### PR TITLE
Redesign fullscreen viewer toolbar

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -713,13 +713,16 @@ body {
   z-index: 10;
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 6px 12px;
-  background: rgba(255, 255, 255, 0.88);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  gap: 2px;
+  padding: 5px 10px;
+  background: var(--window-chrome);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
   border-radius: 9999px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 0 0 1px var(--glass-border),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
   animation: toolbarIn 0.25s ease-out;
   cursor: grab;
   touch-action: none;
@@ -736,12 +739,12 @@ body {
 }
 
 .fullscreen-toolbar-btn {
-  width: 28px;
-  height: 28px;
+  width: 26px;
+  height: 26px;
   border: none;
-  border-radius: 6px;
+  border-radius: 7px;
   background: none;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-dim);
   font-size: 0.85rem;
   cursor: pointer;
   display: flex;
@@ -751,8 +754,8 @@ body {
 }
 
 .fullscreen-toolbar-btn:hover:not(:disabled) {
-  background: rgba(0, 0, 0, 0.08);
-  color: rgba(0, 0, 0, 0.85);
+  background: rgba(124, 107, 255, 0.08);
+  color: var(--text);
 }
 
 .fullscreen-toolbar-btn:disabled {
@@ -761,21 +764,21 @@ body {
 }
 
 .fullscreen-toolbar-close {
-  color: rgba(220, 50, 50, 0.7);
+  color: rgba(239, 68, 68, 0.6);
 }
 
 .fullscreen-toolbar-close:hover {
-  background: rgba(220, 50, 50, 0.1);
-  color: #d32f2f;
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
 }
 
 .fullscreen-toolbar-title {
+  flex: 1;
   font-family: var(--font-mono);
-  font-size: 0.68rem;
+  font-size: 0.65rem;
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.5);
+  color: var(--text-dim);
   padding: 0 8px;
-  max-width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -783,9 +786,9 @@ body {
 
 .fullscreen-toolbar-sep {
   width: 1px;
-  height: 16px;
-  background: rgba(0, 0, 0, 0.12);
-  margin: 0 4px;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 0 3px;
 }
 
 /* ── Viewer ── */

--- a/web/src/components/ViewerWindow.tsx
+++ b/web/src/components/ViewerWindow.tsx
@@ -224,6 +224,18 @@ export function ViewerWindow({
     }
   }, [onFixError, error, title]);
 
+  // Escape key exits fullscreen
+  useEffect(() => {
+    if (!fullscreen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [fullscreen, onClose]);
+
   const onPointerDown = useCallback((e: ReactPointerEvent) => {
     if ((e.target as HTMLElement).closest("button")) return;
     e.preventDefault();
@@ -326,30 +338,30 @@ export function ViewerWindow({
             className="fullscreen-toolbar-btn"
             disabled={!hasPrev}
             onClick={() => onNavigate?.(-1)}
-            title="Previous doc"
+            title="Previous"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M15 18l-6-6 6-6" />
             </svg>
           </button>
-          <span className="fullscreen-toolbar-title">{title}</span>
           <button
             className="fullscreen-toolbar-btn"
             disabled={!hasNext}
             onClick={() => onNavigate?.(1)}
-            title="Next doc"
+            title="Next"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M9 18l6-6-6-6" />
             </svg>
           </button>
+          <span className="fullscreen-toolbar-title">{title}</span>
           <div className="fullscreen-toolbar-sep" />
           <button
             className="fullscreen-toolbar-btn"
             onClick={onToggleFullscreen}
-            title="Exit fullscreen"
+            title="Window"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <polyline points="4 14 10 14 10 20" />
               <polyline points="20 10 14 10 14 4" />
               <line x1="14" y1="10" x2="21" y2="3" />
@@ -361,7 +373,9 @@ export function ViewerWindow({
             onClick={onClose}
             title="Close"
           >
-            ×
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Restyled fullscreen toolbar from white pill to dark glassmorphism matching app design tokens
- Reordered controls to mirror windowed titlebar: `[◂ ▸] [title] [↙ shrink] [×]`
- Replaced text × with SVG close icon
- Added Escape key handler to close fullscreen viewer

## Test plan
- [x] Open artifact fullscreen — toolbar is dark glass pill, not white
- [x] Controls match windowed titlebar order (resize + close on right)
- [x] Press Escape — closes viewer back to desktop
- [x] Prev/next navigation works
- [x] Toolbar is still draggable

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)