### PR TITLE
Phase A: prompt-driven surface control + slash commands

### DIFF
--- a/.opencode/agents/oyster.md
+++ b/.opencode/agents/oyster.md
@@ -27,44 +27,9 @@ You help the user capture, structure, and visualise their thinking. You operate 
 - All files you create go inside this workspace.
 - **Each artifact gets its own directory** at the top level of the workspace (e.g. `snake-game/`). When the user mentions an artifact by name, list the top-level directories and read `manifest.json` in each one to match by the `"name"` field. Folder names are kebab-case IDs that often differ from display names (e.g. `snake-game/` contains `"name": "Zombie Horde"`).
 
-## Knowledge graph (Graphiti) — CRITICAL
+## Memory
 
-You have a persistent knowledge graph via MCP (the `graphiti` server). **You MUST use it.** This is how you remember things across sessions. Without it, you are stateless and forget everything.
-
-### MANDATORY RULES — you MUST follow these
-
-1. **EVERY time the user asks what you know about them, a person, a project, or anything that could be in memory** — you MUST call `search_nodes` and `search_facts` BEFORE responding. Never answer "I don't know" without searching first.
-2. **When the user tells you personal facts, preferences, project info, or anything worth remembering** — IMMEDIATELY call `add_episode` to save it. Do NOT just acknowledge it. Actually call the tool.
-3. **When the user says "remember this"** — call `add_episode`. No exceptions.
-4. **At the start of EVERY new conversation** — call `search_nodes` with a general query to load context before your first response.
-5. **If you're unsure whether something is in the graph** — search anyway. Searching costs nothing. Not searching means you answer blind.
-
-### How to save (add_episode)
-
-```
-add_episode(
-  name="descriptive name",
-  episode_body="the facts to remember",
-  source="text"
-)
-```
-
-- Do NOT pass a group_id for now — let it use the default
-- `source` is "text" for conversation context, "json" for structured data
-
-### How to search
-
-- `search_facts(query="...")` — find relationships between entities
-- `search_nodes(query="...")` — find entity summaries
-- `get_episodes(group_id="default")` — get recent episodes
-- Do NOT filter by group_id when searching — search everything
-
-### Guidelines
-
-- Save meaningful facts: who people are, what they're working on, preferences, decisions, deadlines
-- Do not filter searches by group_id — always search the full graph
-- Entity types are extracted automatically: Preference, Requirement, Procedure, Location, Event, Organization, Document, Topic, Object
-- After saving, confirm briefly: "Saved to memory." — don't write a paragraph about it
+Memory across sessions is not yet available. Focus on the current session's context. If the user asks you to remember something, let them know that persistent memory is coming in a future update.
 
 ## Artifact registry (Oyster MCP)
 
@@ -83,13 +48,19 @@ You have MCP tools (the `oyster` server) for managing the desktop surface direct
 | `remove_artifact` | Remove an artifact from the desktop surface. File and record are preserved — reversible. Use this instead of deleting. |
 | `regenerate_icon` | Regenerate the AI icon for an artifact. Optional `hint` guides what is depicted (e.g. "a chess knight"); geometric style and palette are always preserved. |
 | `register_artifact` | Register a file that **already exists on disk** as a desktop artifact. Only for pre-existing files — for new content, use `create_artifact`. |
+| `open_artifact` | Open an artifact in the user's viewer window by exact ID. Use `list_artifacts(search: ...)` first to find the right ID. |
+| `switch_space` | Switch the user's desktop to a different space by exact ID. Use `list_spaces` first if you need to find available spaces. |
 
 ### Usage
 
+- **At the start of any Oyster task** — call `get_context` first. It gives you the documented workflow for onboarding, artifact creation, and tool sequencing. Do not improvise the flow from scratch.
 - **Creating something new**: call `create_artifact(space_id, label, artifact_kind, content)`. Do not write files manually then register — that is the old flow.
+- **After `create_artifact`**: always call `reveal_artifact(id)` — this switches the user's desktop to the right space and highlights the new icon so they know where it landed.
 - **Editing an existing artifact**: call `read_artifact(id)` to get the current content, edit the file at `source_path` (from `list_artifacts`), surface updates automatically.
 - **Reorganising**: use `update_artifact(id, { space_id, group_name, label })` to move between spaces or groups.
 - Always call `list_spaces` and `list_artifacts` first to understand what exists before creating or modifying.
+- **"Show me X" / "open X"** → call `list_artifacts(search: "...")` to find matching artifacts, then `open_artifact(id)` with the exact ID to open it in the viewer.
+- **"Switch to Y" / "go to Y"** → call `switch_space(id)` directly if you already know the space ID from context. Only call `list_spaces` first if you're unsure what spaces exist.
 - `create_artifact` kind determines file extension: `notes`→`.md`, `diagram`→`.mmd`, all others→`.html`
 - New artifacts appear immediately on the desktop after creation.
 
@@ -98,7 +69,6 @@ You have MCP tools (the `oyster` server) for managing the desktop surface direct
 - Answer questions about the project and codebase
 - Create artifacts: documents, mind maps, presentations, apps, games, diagrams, spreadsheets
 - Structure user input into knowledge (entities, relationships, context)
-- Remember context across sessions via the knowledge graph
 - Help the user think, plan, and build
 
 ## What you cannot do

--- a/.opencode/config.toml
+++ b/.opencode/config.toml
@@ -7,3 +7,8 @@ id = "claude-sonnet-4-20250514"
 [model.edit]
 provider = "anthropic"
 id = "claude-sonnet-4-20250514"
+
+[mcp.oyster]
+type = "remote"
+url = "http://localhost:4200/mcp/"
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,16 @@ Three systems, three responsibilities:
 |---|---|---|
 | Oyster Server | 4200 | Artifact/space registry (SQLite), MCP tool surface, chat proxy |
 | OpenCode | 4096 | AI engine, code execution, filesystem access |
-| Graphiti | 8000 | Knowledge graph, persistent memory, cross-session context (Docker/FalkorDB) |
 
 **SQLite** (`userland/oyster.db`) holds surface state: artifacts and spaces. Fast, local, no infrastructure.
 
-**Graphiti** is the memory layer. Everything is nodes and edges — no separate tables. Episodes are ingested, entities and facts extracted by LLM automatically. The agent calls `search_nodes`/`search_facts` before answering, and `add_episode` to remember things. Configured in `opencode.json`, mandatory rules in `.opencode/agents/oyster.md`.
+**OpenCode** has MCP access to Oyster (surface management). The UI talks only to Oyster Server.
 
-**OpenCode** has MCP access to both Oyster (surface) and Graphiti (memory). The UI talks only to Oyster Server.
+**Graphiti** (knowledge graph / persistent memory) is deferred to v2. The v1 surface works without cross-session memory.
 
 ## Mental Models
 
-**Spaces** — organisational nodes, navigated via `parent_id` hierarchy in SQLite (nav only). Semantic relationships between spaces (client_of, depends_on, shares_pattern) live as edges in the Graphiti graph — not SQL columns. "Tell me about all my client projects" is a graph traversal, not a container space query.
+**Spaces** — organisational nodes, navigated via `parent_id` hierarchy in SQLite (nav only). Semantic relationships between spaces (client_of, depends_on, shares_pattern) are a future feature via knowledge graph — not SQL columns.
 
 **Artifacts** — typed outputs on the surface (app, notes, diagram, deck, wireframe, table, map). Registered in SQLite, files in `userland/`. `source_origin` tracks provenance: `manual` | `discovered` | `ai_generated`.
 
@@ -39,8 +38,8 @@ Three systems, three responsibilities:
 - `server/src/artifact-store.ts` / `artifact-service.ts` — artifact CRUD
 - `server/src/space-store.ts` / `space-service.ts` — space CRUD + repo scanner
 - `server/src/db.ts` — SQLite schema and migrations
-- `.opencode/agents/oyster.md` — agent personality, Graphiti rules, conventions
-- `opencode.json` — MCP server config (Oyster + Graphiti endpoints)
+- `.opencode/agents/oyster.md` — agent personality, conventions
+- `opencode.json` — MCP server config (Oyster endpoint)
 - `web/src/App.tsx` — root, spaces/artifacts state, wizard triggers
 - `web/src/components/Desktop.tsx` — surface grid, topbar, sort/filter/view
 - `web/src/components/ChatBar.tsx` — chat input, space pills, messages panel
@@ -52,7 +51,7 @@ Three systems, three responsibilities:
 - Never write to `userland/oyster.db` directly from agent — use MCP tools
 - `source_origin: 'ai_generated'` on all agent-created artifacts
 - SQLite migrations are additive `ALTER TABLE ... ADD COLUMN` with try/catch (idempotent)
-- Space `parent_id` is nav only — don't encode semantics there, use the graph
+- Space `parent_id` is nav only — semantic relationships are a future feature
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# Oyster OS — Working Context
+
+## Hypothesis
+
+The right interface for knowledge work is a **surface that connects all your systems, accumulates context over time, and synthesises across boundaries** — so you can ask a question that spans Zoho and ProCore and last month's conversation and get one answer, not three logins.
+
+Not just for makers and developers. For anyone whose work is distributed across more than one system and one session.
+
+**The key test:** can the surface join dots that no single tool, dashboard, or LLM session could? A dashboard can't — it's a pre-defined view. ChatGPT can't — it has no live access and forgets. A Zoho report can't — ProCore isn't in scope. Oyster can, because it connects all systems via MCP, holds the relationships between them in a knowledge graph, and accumulates context across every session.
+
+## Architecture
+
+Three systems, three responsibilities:
+
+| System | Port | Responsibility |
+|---|---|---|
+| Oyster Server | 4200 | Artifact/space registry (SQLite), MCP tool surface, chat proxy |
+| OpenCode | 4096 | AI engine, code execution, filesystem access |
+| Graphiti | 8000 | Knowledge graph, persistent memory, cross-session context (Docker/FalkorDB) |
+
+**SQLite** (`userland/oyster.db`) holds surface state: artifacts and spaces. Fast, local, no infrastructure.
+
+**Graphiti** is the memory layer. Everything is nodes and edges — no separate tables. Episodes are ingested, entities and facts extracted by LLM automatically. The agent calls `search_nodes`/`search_facts` before answering, and `add_episode` to remember things. Configured in `opencode.json`, mandatory rules in `.opencode/agents/oyster.md`.
+
+**OpenCode** has MCP access to both Oyster (surface) and Graphiti (memory). The UI talks only to Oyster Server.
+
+## Mental Models
+
+**Spaces** — organisational nodes, navigated via `parent_id` hierarchy in SQLite (nav only). Semantic relationships between spaces (client_of, depends_on, shares_pattern) live as edges in the Graphiti graph — not SQL columns. "Tell me about all my client projects" is a graph traversal, not a container space query.
+
+**Artifacts** — typed outputs on the surface (app, notes, diagram, deck, wireframe, table, map). Registered in SQLite, files in `userland/`. `source_origin` tracks provenance: `manual` | `discovered` | `ai_generated`.
+
+**Groups/folders** — display clustering only (`group_name` on artifacts). Not structural.
+
+## Key Files
+
+- `server/src/index.ts` — HTTP server, all API routes
+- `server/src/mcp-server.ts` — MCP tool surface for agents
+- `server/src/artifact-store.ts` / `artifact-service.ts` — artifact CRUD
+- `server/src/space-store.ts` / `space-service.ts` — space CRUD + repo scanner
+- `server/src/db.ts` — SQLite schema and migrations
+- `.opencode/agents/oyster.md` — agent personality, Graphiti rules, conventions
+- `opencode.json` — MCP server config (Oyster + Graphiti endpoints)
+- `web/src/App.tsx` — root, spaces/artifacts state, wizard triggers
+- `web/src/components/Desktop.tsx` — surface grid, topbar, sort/filter/view
+- `web/src/components/ChatBar.tsx` — chat input, space pills, messages panel
+
+## Conventions
+
+- Prefer editing existing files over creating new ones
+- MCP tools for surface management; direct filesystem for artifact content
+- Never write to `userland/oyster.db` directly from agent — use MCP tools
+- `source_origin: 'ai_generated'` on all agent-created artifacts
+- SQLite migrations are additive `ALTER TABLE ... ADD COLUMN` with try/catch (idempotent)
+- Space `parent_id` is nav only — don't encode semantics there, use the graph
+
+---
+
+## Behavioral Guidelines
+
+Bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+- State your assumptions explicitly before implementing. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+- Minimum code that solves the problem. Nothing speculative.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+- Ask: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+- Touch only what you must. Clean up only your own mess.
+- Don't improve adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove imports/variables/functions that *your* changes made unused.
+- Don't remove pre-existing dead code unless asked.
+- Every changed line should trace directly to the request.
+
+### 4. Goal-Driven Execution
+
+- Transform tasks into verifiable goals before coding:
+  - "Fix the bug" → "Write a test that reproduces it, then make it pass"
+  - "Add validation" → "Write tests for invalid inputs, then make them pass"
+- For multi-step tasks, state a brief plan with verify steps before starting:
+  1. [Step] → verify: [check]
+  2. [Step] → verify: [check]

--- a/docs/plans/oyster-os-design.md
+++ b/docs/plans/oyster-os-design.md
@@ -82,16 +82,14 @@ Prove that Oyster can:
 │  │       └── spaces  (nav hierarchy, scan status)      │ │
 │  └──────────────────────────────────────────────────────┘ │
 │                                                           │
-│  ┌─────────────────┐   ┌──────────────────────────────┐  │
-│  │  OpenCode       │   │  Graphiti  (port 8000)        │  │
-│  │  (port 4096)    │   │  ├── FalkorDB graph store     │  │
-│  │  REST + SSE     │   │  ├── LLM entity extraction    │  │
-│  │  .opencode/     │   │  └── MCP endpoint  (/mcp/)   │  │
-│  │  agents/        │   │       ├── search_nodes        │  │
-│  │  oyster.md      │   │       ├── search_facts        │  │
-│  └─────────────────┘   │       ├── add_episode        │  │
-│                         │       └── get_episodes       │  │
-│                         └──────────────────────────────┘  │
+│  ┌─────────────────┐                                      │
+│  │  OpenCode       │   (Graphiti — deferred to v2)        │
+│  │  (port 4096)    │                                      │
+│  │  REST + SSE     │                                      │
+│  │  .opencode/     │                                      │
+│  │  agents/        │                                      │
+│  │  oyster.md      │                                      │
+│  └─────────────────┘                                      │
 │                                                           │
 │  ┌──────────────────────────────────────────────────────┐ │
 │  │  React UI  (Vite dev server or static)               │ │
@@ -107,9 +105,8 @@ Prove that Oyster can:
 |---|---|---|
 | Oyster Server | 4200 | Artifact/space registry (SQLite), MCP tool surface, chat proxy |
 | OpenCode | 4096 | AI engine, code execution, filesystem access |
-| Graphiti | 8000 | Knowledge graph, persistent memory, cross-session context |
 
-The agent (OpenCode) has MCP access to both Oyster (surface management) and Graphiti (memory). The UI talks only to Oyster Server. Graphiti is invisible to the user.
+The agent (OpenCode) has MCP access to Oyster (surface management). The UI talks only to Oyster Server. Persistent memory (Graphiti) is deferred to v2.
 
 ### The Artifact Contract
 
@@ -230,20 +227,11 @@ spaces (id, display_name, repo_path, color, parent_id,
 `source_origin` tracks how an artifact arrived: `manual` | `discovered` | `ai_generated`.
 `parent_id` on spaces is **navigation only** — where to show the space in the UI hierarchy. Semantic relationships between spaces live in the knowledge graph.
 
-### Knowledge Graph — Graphiti
+### Knowledge Graph — Deferred to v2
 
-Graphiti runs locally via Docker (FalkorDB backend, MCP endpoint at `localhost:8000`). This is where Oyster's memory lives.
+Persistent memory (cross-session context, entity graphs, relationship tracking) is planned but not active in v1. The v1 surface works without it — the agent is stateless between sessions.
 
-**Model:** Everything is nodes and edges — no separate tables for memories vs spaces.
-
-- **Episodes** — raw input ingested via `add_episode` (conversations, onboarding events, documents)
-- **Entity nodes** — extracted by LLM from episodes: `Space`, `Artifact`, `Person`, `Decision`, `Technology`, `Pattern`
-- **Fact edges** — typed relationships: `USES`, `CLIENT_OF`, `DEPENDS_ON`, `SHARES_PATTERN`, `HAS_ARTIFACT`, `DECIDED`
-- **group_id** — namespace mapping to `space_id` for scoped queries
-
-**Key property:** Space relationships are graph edges, not SQL columns. "Tell me about all my client projects" is a graph traversal over `CLIENT_OF` edges — not a query against a container space. There may be no container space. Relationships emerge as the agent observes and records them.
-
-**Temporal facts:** Graphiti invalidates stale facts when state changes. A decision made last month that's been superseded is marked invalid, not deleted. History is preserved.
+**v2 options under evaluation:** Graphiti (FalkorDB, Docker), opencode-plugin-simple-memory, forgetful (SQLite + embeddings), or custom Oyster-native SQLite FTS5. See issue #70 for details.
 
 ### App-Specific Data
 

--- a/docs/plans/oyster-os-design.md
+++ b/docs/plans/oyster-os-design.md
@@ -1,22 +1,39 @@
 # Oyster OS — Design Document
 
-**Status:** Approved
-**Last updated:** 2026-03-27
+**Status:** Living document
+**Last updated:** 2026-03-30
 **Authors:** Matthew Slight, with architectural input from Bharat Mani Prem Sankar
 
 ---
 
+## Hypothesis
+
+> The right interface for knowledge work is a **surface that connects all your systems, accumulates context over time, and synthesises across boundaries** — so you can ask a question that spans Zoho and ProCore and last month's conversation and get one answer, not three logins.
+
+Not just for makers and developers. For anyone whose work is distributed across more than one system and one session.
+
+**The key test:** can the surface join dots that no single tool, dashboard, or LLM session could?
+- A dashboard can't — it's a pre-defined view of one system.
+- ChatGPT can't — it has no live access and forgets between sessions.
+- A Zoho report can't — ProCore isn't in scope.
+
+Oyster can, because it connects all systems via MCP, holds the relationships between them in a knowledge graph, and accumulates context across every session.
+
 ## Problem
 
-People's thinking, work and context are fragmented across ChatGPT, Claude, Notion, email, docs, task tools, whiteboards and CRMs. No single tool captures intent, structures it, and renders it into whatever form is needed. Every tool forces you to choose the format first. This starts with thought first.
+People's work is fragmented across systems, projects, and sessions. A construction company's chairman needs to know the health of the sales pipeline — but the answer spans Zoho CRM and ProCore and decisions made last quarter. No single tool sees all of it. No dashboard was pre-built for exactly that question. No LLM session has access to both systems plus the history.
+
+More broadly: each LLM conversation starts from scratch. No tool knows the auth pattern you built in one project conflicts with what you're building in another. No tool remembers the decision you made six months ago. No tool can answer "what should I focus on this week?" from first principles across all your work.
+
+Oyster's surface accumulates context across all your systems and sessions — so your AI partner gets smarter the longer you use it, not just during a single conversation.
 
 ## Product
 
-Oyster is a hosted web app built around a visual surface. The user sees generated outputs — documents, presentations, mind maps, apps — as icons on an ambient surface, with a unified chat bar for talking to the AI. The bar is the single entry point: chat to build, search to find, type to navigate. Each output replaces a separate tool.
+Oyster is a visual surface where generated outputs — documents, diagrams, apps, notes — appear as artifacts you can open, organise, and build on. A unified chat bar is the single entry point: chat to build, search to find, type to navigate. Each output replaces a separate tool.
 
-The engine for the PoC is OpenCode (`opencode serve`) running inside a hosted user runtime. Product behaviour is primarily steered by `.opencode/agents/oyster.md`. The user never sees OpenCode, terminals, or code — the engine is invisible.
+The engine is OpenCode (`opencode serve`). Persistent memory is Graphiti (a temporal knowledge graph running locally via Docker). Product behaviour is steered by `.opencode/agents/oyster.md`. The user never sees OpenCode or the graph — the engine is invisible.
 
-**One-liner:** Ditch the tools. Use AI like a pro — to write, to present, to build, to visualise.
+**One-liner:** A surface that remembers. An AI that connects the dots.
 
 ---
 
@@ -52,42 +69,47 @@ Prove that Oyster can:
 ### System Overview
 
 ```
-┌─────────────────────────────────────────────────┐
-│            Central (Supabase)                    │
-│                                                  │
-│  oyster schema (all users, RLS)                  │
-│  ├── nodes                                       │
-│  ├── edges                                       │
-│  └── artifacts                                   │
-│                                                  │
-│  Auth (Supabase Auth)                            │
-│  User registry                                   │
-└────────────────────┬────────────────────────────┘
-                     │ DATABASE_URL
-                     │
-┌────────────────────▼────────────────────────────┐
-│           User Container / VM                    │
-│                                                  │
-│  ┌──────────────────────────────────────────┐   │
-│  │  opencode serve (port 4096)              │   │
-│  │  REST API + SSE streaming                │◄──┼── HTTP/SSE ──► Clients
-│  │  ├── POST /session                       │   │
-│  │  ├── POST /session/{id}/message          │   │
-│  │  ├── GET  /event (SSE stream)            │   │
-│  │  └── GET  /file/* (static serving)       │   │
-│  └──────────────┬───────────────────────────┘   │
-│                 │                                │
-│  ┌──────────────▼──┐  ┌───────────┐  ┌────────────┐
-│  │/workspace       │  │/artifacts │  │Local       │
-│  │ .opencode/      │  │ <id>/     │  │Postgres    │
-│  │   agents/       │  │  manifest │  │(app data   │
-│  │ docs/           │  │  src/     │  │ only)      │
-│  │ data/           │  │  data/    │  │            │
-│  └─────────────────┘  └───────────┘  └────────────┘
-└─────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│                    User Machine (local)                   │
+│                                                           │
+│  ┌─────────────────────────────────────────────────────┐ │
+│  │  Oyster Server  (port 4200)                         │ │
+│  │  ├── HTTP API  (/api/artifacts, /api/spaces, etc.)  │ │
+│  │  ├── MCP endpoint  (/mcp/)  ← agent tool surface    │ │
+│  │  ├── Chat proxy  → OpenCode                         │ │
+│  │  └── SQLite  (userland/oyster.db)                   │ │
+│  │       ├── artifacts  (registry, metadata)           │ │
+│  │       └── spaces  (nav hierarchy, scan status)      │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                           │
+│  ┌─────────────────┐   ┌──────────────────────────────┐  │
+│  │  OpenCode       │   │  Graphiti  (port 8000)        │  │
+│  │  (port 4096)    │   │  ├── FalkorDB graph store     │  │
+│  │  REST + SSE     │   │  ├── LLM entity extraction    │  │
+│  │  .opencode/     │   │  └── MCP endpoint  (/mcp/)   │  │
+│  │  agents/        │   │       ├── search_nodes        │  │
+│  │  oyster.md      │   │       ├── search_facts        │  │
+│  └─────────────────┘   │       ├── add_episode        │  │
+│                         │       └── get_episodes       │  │
+│                         └──────────────────────────────┘  │
+│                                                           │
+│  ┌──────────────────────────────────────────────────────┐ │
+│  │  React UI  (Vite dev server or static)               │ │
+│  │  ├── polls /api/artifacts + /api/spaces              │ │
+│  │  └── streams chat via SSE                            │ │
+│  └──────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
 ```
 
-**Implementation note (PoC):** The PoC uses SQLite (`userland/oyster.db`) instead of Supabase for the artifact registry. The Oyster HTTP server (port 4200) handles artifact serving, the chat proxy to OpenCode, and the MCP endpoint — no separate Supabase dependency. The central/local database split described below reflects the production design, not the current implementation.
+**Three systems, three responsibilities:**
+
+| System | Port | Responsibility |
+|---|---|---|
+| Oyster Server | 4200 | Artifact/space registry (SQLite), MCP tool surface, chat proxy |
+| OpenCode | 4096 | AI engine, code execution, filesystem access |
+| Graphiti | 8000 | Knowledge graph, persistent memory, cross-session context |
+
+The agent (OpenCode) has MCP access to both Oyster (surface management) and Graphiti (memory). The UI talks only to Oyster Server. Graphiti is invisible to the user.
 
 ### The Artifact Contract
 
@@ -191,69 +213,41 @@ OpenCode has full filesystem access to the workspace and can read/modify any art
 
 Agents should use MCP tools for surface management and direct filesystem access for reading/modifying artifact source content. Do not touch `userland/oyster.db` directly.
 
-### Central Database (Supabase) — Fixed Schema
+### SQLite — Artifact and Space Registry
 
-The Oyster system data lives centrally. One migration updates all users. UI and clients query this directly without going through OpenCode.
-
-The central schema is a fixed product contract, optimised for reliable UI querying and broad semantic flexibility rather than exhaustive type-specific modelling.
+Oyster Server owns a local SQLite database (`userland/oyster.db`) for surface state. This is fast, local, zero-infrastructure.
 
 ```sql
--- Core knowledge graph
-nodes (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  type text,              -- person, task, idea, project, note, meeting, etc.
-  title text,
-  content text,
-  metadata jsonb,         -- type-specific fields (email, status, due_date, etc.)
-  source_type text,       -- chat, import, connector, system
-  created_at timestamptz,
-  updated_at timestamptz
-)
+artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config,
+           runtime_kind, runtime_config, group_name, source_origin, source_ref,
+           removed_at, created_at, updated_at)
 
--- Relationships between nodes
-edges (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  source_node_id uuid references nodes,
-  target_node_id uuid references nodes,
-  relationship text,      -- works_with, blocked_by, part_of, mentioned_in, etc.
-  metadata jsonb,
-  source_type text,       -- chat, import, connector, system
-  created_at timestamptz
-)
-
--- Registry of generated outputs
-artifacts (
-  id uuid primary key,
-  user_id uuid references auth.users,
-  name text,
-  type text,              -- app, deck, map, notes, diagram, wireframe, table
-  runtime text,           -- static, vite, docker
-  path text,              -- filesystem path on the VM
-  node_id uuid references nodes,  -- optional: linked to a node
-  status text,            -- generating, ready, failed
-  metadata jsonb,         -- storage, capabilities, ports, entrypoint
-  created_at timestamptz
-)
+spaces (id, display_name, repo_path, color, parent_id,
+        scan_status, scan_error, last_scanned_at, last_scan_summary,
+        created_at, updated_at)
 ```
 
-**RLS on all tables:** `user_id = auth.uid()`
+`source_origin` tracks how an artifact arrived: `manual` | `discovered` | `ai_generated`.
+`parent_id` on spaces is **navigation only** — where to show the space in the UI hierarchy. Semantic relationships between spaces live in the knowledge graph.
 
-**PoC simplification:** No user_id columns, no RLS, no auth. Single user.
+### Knowledge Graph — Graphiti
 
-### Local Database (Per-Container Postgres) — App Data Only
+Graphiti runs locally via Docker (FalkorDB backend, MCP endpoint at `localhost:8000`). This is where Oyster's memory lives.
 
-When OpenCode generates an artifact that needs persistent data (e.g. a todo tracker, a CRM), it creates a schema in local Postgres for that artifact. Artifacts with `storage: "none"` don't get a database — they're just files.
+**Model:** Everything is nodes and edges — no separate tables for memories vs spaces.
 
-```
-One Postgres instance, one database
-├── schema: app_kps_todo      ← OpenCode created and manages this
-├── schema: app_deal_tracker  ← OpenCode created and manages this
-└── (no schema for static-only artifacts)
-```
+- **Episodes** — raw input ingested via `add_episode` (conversations, onboarding events, documents)
+- **Entity nodes** — extracted by LLM from episodes: `Space`, `Artifact`, `Person`, `Decision`, `Technology`, `Pattern`
+- **Fact edges** — typed relationships: `USES`, `CLIENT_OF`, `DEPENDS_ON`, `SHARES_PATTERN`, `HAS_ARTIFACT`, `DECIDED`
+- **group_id** — namespace mapping to `space_id` for scoped queries
 
-**Firewall:** OpenCode can access both central and local Postgres. The UI only accesses central Supabase. Local app schemas are only accessed by their generated artifact frontends.
+**Key property:** Space relationships are graph edges, not SQL columns. "Tell me about all my client projects" is a graph traversal over `CLIENT_OF` edges — not a query against a container space. There may be no container space. Relationships emerge as the agent observes and records them.
+
+**Temporal facts:** Graphiti invalidates stale facts when state changes. A decision made last month that's been superseded is marked invalid, not deleted. History is preserved.
+
+### App-Specific Data
+
+Artifacts that need persistence (e.g. a generated todo tracker) use their own local SQLite or browser storage. OpenCode creates and manages this per-artifact. It is separate from Oyster's registry.
 
 ### OpenCode Server (Engine)
 
@@ -281,10 +275,10 @@ Defines a major part of Oyster's behaviour and conventions via `.opencode/agents
 Key sections:
 
 - **Identity:** "You are Oyster. You help the user capture, structure, and visualise their thinking."
-- **Knowledge conventions:** Always structure input into the Oyster system data (nodes + edges in Supabase). Check if a node exists before creating duplicates. Use node types and relationship types flexibly.
-- **Artifact generation:** Generated artifacts go in `/artifacts/<id>/`. Each gets a `manifest.json`. The agent sets `runtime`, `storage`, and `capabilities` based on what the user asked for. Report the served URL after generation.
-- **Output conventions:** Defined per output type. The agent infers the correct artifact type from the user's intent — the user doesn't choose formats, they describe what they need.
-- **Data rules:** Oyster system data is in Supabase (connection string from env). App-specific data is in local Postgres. Never mix them.
+- **Knowledge graph (Graphiti) — MANDATORY:** At session start, call `search_nodes` to load context. When the user shares facts, decisions, or project info, call `add_episode` immediately. Before answering anything about a person, project, or past work, call `search_nodes` + `search_facts` first. The graph is how Oyster remembers across sessions — without it, the agent is stateless.
+- **Artifact generation:** Use `create_artifact` via Oyster MCP. Generated artifacts are registered on the desktop surface automatically. Set `source_origin: 'ai_generated'` for agent-produced content.
+- **Output conventions:** The agent infers the correct artifact type from intent — the user describes what they need, not what format to use.
+- **Surface management:** Prefer Oyster MCP tools (`create_artifact`, `list_artifacts`, `update_artifact`) over direct filesystem manipulation. The MCP tools keep the registry consistent.
 
 OpenCode supports custom agent markdown files natively via `.opencode/agents/`. No special tooling needed.
 
@@ -335,7 +329,7 @@ The UI is a visual surface with an embedded chat bar. Artifacts are icons on the
 **Data model:**
 - Trash is cosmetic — deleting an artifact removes it from the surface, but the underlying data (nodes, edges) stays in the knowledge graph
 
-The UI reads from Supabase directly for the artifact list and knowledge graph. It connects to the OpenCode server via HTTP/SSE for chat.
+The UI polls Oyster Server (`/api/artifacts`, `/api/spaces`) for surface state and streams chat via SSE. It has no direct connection to Graphiti or OpenCode.
 
 **Design origin:** The visual surface pattern emerged organically from the tokinvest-concept prototype. Sprint 1 initially mimicked desktop OS chrome (floating windows, dock, minimize/maximize) but prototyping revealed this was borrowed decoration that didn't serve user intent. The refined direction strips all chrome and embeds chat directly into the surface.
 

--- a/opencode.json
+++ b/opencode.json
@@ -2,10 +2,6 @@
   "$schema": "https://opencode.ai/config.json",
   "model": "openai/gpt-5.4",
   "mcp": {
-    "graphiti": {
-      "type": "remote",
-      "url": "http://localhost:8000/mcp/"
-    },
     "oyster": {
       "type": "remote",
       "url": "http://localhost:4200/mcp/"

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -107,6 +107,7 @@ export class ArtifactService {
       id?: string;
       artifact_kind?: ArtifactKind;
       group_name?: string;
+      source_origin?: "manual" | "discovered" | "ai_generated";
     },
     approvedRoots: string[],
   ): Artifact {
@@ -117,20 +118,36 @@ export class ArtifactService {
       throw new Error(`File does not exist: ${absPath}`);
     }
 
-    // Validate path is under an approved root
-    const normalizedRoots = approvedRoots.map((r) => resolve(r));
-    const isApproved = normalizedRoots.some((root) => absPath.startsWith(root + "/") || absPath === root);
-    if (!isApproved) {
-      throw new Error(
-        `Path is not under an approved root. Allowed roots: ${normalizedRoots.join(", ")}`,
-      );
+    // Validate path is under an approved root (skip if no roots specified — trusted caller)
+    if (approvedRoots.length > 0) {
+      const normalizedRoots = approvedRoots.map((r) => resolve(r));
+      const isApproved = normalizedRoots.some((root) => absPath.startsWith(root + "/") || absPath === root);
+      if (!isApproved) {
+        throw new Error(
+          `Path is not under an approved root. Allowed roots: ${normalizedRoots.join(", ")}`,
+        );
+      }
     }
 
     // Infer ID from filename stem if not provided
     const id = params.id || basename(absPath).replace(/\.[^.]+$/, "");
 
-    // Validate uniqueness
-    if (this.store.getById(id)) {
+    // If a removed record exists with this ID, resurface and update it
+    const existing = this.store.getById(id);
+    if (existing) {
+      if (existing.removed_at) {
+        this.store.resurface(id);
+        const kind = params.artifact_kind || inferKindFromPath(absPath);
+        this.store.update(id, {
+          space_id: params.space_id,
+          label: params.label,
+          artifact_kind: kind,
+          group_name: params.group_name || null,
+          storage_config: JSON.stringify({ path: absPath }),
+          source_origin: params.source_origin ?? "manual",
+        });
+        return this.rowToArtifact(this.store.getById(id)!);
+      }
       throw new Error(`Artifact with id "${id}" already exists`);
     }
 
@@ -148,7 +165,7 @@ export class ArtifactService {
       runtime_kind: "static_file",
       runtime_config: "{}",
       group_name: params.group_name || null,
-      source_origin: "manual",
+      source_origin: params.source_origin ?? "manual",
       source_ref: null,
     });
 
@@ -176,6 +193,7 @@ export class ArtifactService {
       content: string;
       subdir?: string;
       group_name?: string;
+      source_origin?: "manual" | "discovered" | "ai_generated";
     },
     userlandDir: string,
   ): Artifact {
@@ -209,7 +227,7 @@ export class ArtifactService {
     // Register — best-effort rollback on DB failure
     try {
       return this.registerArtifact(
-        { path: absPath, space_id, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id },
+        { path: absPath, space_id, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id, source_origin: params.source_origin },
         [userlandDir],
       );
     } catch (err) {
@@ -245,7 +263,7 @@ export class ArtifactService {
 
   async updateArtifact(
     id: string,
-    fields: { label?: string; space_id?: string; group_name?: string | null },
+    fields: { label?: string; space_id?: string; group_name?: string | null; artifact_kind?: ArtifactKind },
   ): Promise<Artifact> {
     const row = this.store.getById(id);
     if (!row) throw new Error(`Artifact "${id}" not found`);
@@ -261,6 +279,7 @@ export class ArtifactService {
       if (!space_id) throw new Error("space_id must not be empty");
       updateable.space_id = space_id;
     }
+    if (fields.artifact_kind !== undefined) updateable.artifact_kind = fields.artifact_kind;
     if ("group_name" in fields) updateable.group_name = fields.group_name ?? null;
 
     if (Object.keys(updateable).length > 0) {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -45,6 +45,7 @@ export function initDb(userlandDir: string): Database.Database {
     "ALTER TABLE artifacts ADD COLUMN removed_at TEXT",
     "ALTER TABLE artifacts ADD COLUMN source_origin TEXT NOT NULL DEFAULT 'manual'",
     "ALTER TABLE artifacts ADD COLUMN source_ref TEXT",
+    "ALTER TABLE spaces ADD COLUMN parent_id TEXT REFERENCES spaces(id)",
   ]) {
     try { db.exec(sql); } catch { /* already exists */ }
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -161,7 +161,15 @@ const uiClients = new Set<ServerResponse>();
 function broadcastUiEvent(event: UiCommand) {
   const data = `data: ${JSON.stringify(event)}\n\n`;
   for (const client of uiClients) {
-    client.write(data);
+    if (client.writableEnded || client.destroyed) {
+      uiClients.delete(client);
+      continue;
+    }
+    try {
+      client.write(data);
+    } catch {
+      uiClients.delete(client);
+    }
   }
 }
 
@@ -429,8 +437,9 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   if (url === "/oauth/register" && req.method === "POST") {
     let body = "";
     for await (const chunk of req) body += chunk;
-    const { client_name } = JSON.parse(body || "{}");
-    json(res, { client_id: "oyster-local", client_name: client_name || "oyster", client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
+    let parsed: { client_name?: string };
+    try { parsed = JSON.parse(body || "{}"); } catch { json(res, { error: "Invalid JSON body" }, 400); return; }
+    json(res, { client_id: "oyster-local", client_name: parsed.client_name || "oyster", client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
     return;
   }
   if (url?.startsWith("/oauth/authorize")) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -123,6 +123,7 @@ const spaceService = new SpaceService(spaceStore, store);
 // ── Initialize subsystems ──
 
 const iconGenerator = new IconGenerator(updateGeneratedArtifact);
+const pendingReveals = new Set<string>();
 
 spawnSession(SHELL, SHELL_ARGS, WORKSPACE, cleanEnv);
 spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);
@@ -145,6 +146,24 @@ startAutoApprover(OPENCODE_PORT, (file) => handleFileEdited(file, ARTIFACTS_DIR,
 
 process.on("SIGTERM", () => { markShuttingDown(); db.close(); process.exit(0); });
 process.on("SIGINT", () => { markShuttingDown(); db.close(); process.exit(0); });
+
+// ── UI push events (SSE) ──
+
+interface UiCommand {
+  version: 1;
+  command: string;
+  payload: unknown;
+  correlationId?: string;
+}
+
+const uiClients = new Set<ServerResponse>();
+
+function broadcastUiEvent(event: UiCommand) {
+  const data = `data: ${JSON.stringify(event)}\n\n`;
+  for (const client of uiClients) {
+    client.write(data);
+  }
+}
 
 // ── HTTP request handler ──
 
@@ -184,8 +203,23 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // GET /api/artifacts
   if (url === "/api/artifacts") {
     const artifacts = await artifactService.getAllArtifacts((id) => clearSeenArtifact(id));
+    const revealed = new Set(pendingReveals);
+    pendingReveals.clear();
+    const response = artifacts.map((a) => revealed.has(a.id) ? { ...a, pendingReveal: true } : a);
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(artifacts));
+    res.end(JSON.stringify(response));
+    return;
+  }
+
+  // GET /api/ui/events — SSE stream for UI commands
+  if (url === "/api/ui/events") {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    uiClients.add(res);
+    req.on("close", () => uiClients.delete(res));
     return;
   }
 
@@ -367,6 +401,52 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   if (await handleSpacesRequest(url, req, res, spaceService)) return;
 
+  // ── No-op OAuth for MCP SDK (localhost only, no real auth) ──
+
+  const BASE = `http://localhost:${PORT}`;
+  const json = (res: ServerResponse, data: unknown, status = 200) => {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(data));
+  };
+
+  if (url === "/.well-known/oauth-protected-resource/mcp" || url === "/.well-known/oauth-protected-resource/mcp/") {
+    json(res, { resource: `${BASE}/mcp`, authorization_servers: [`${BASE}/`], scopes_supported: [] });
+    return;
+  }
+  if (url === "/.well-known/oauth-authorization-server") {
+    json(res, {
+      issuer: `${BASE}/`,
+      authorization_endpoint: `${BASE}/oauth/authorize`,
+      token_endpoint: `${BASE}/oauth/token`,
+      registration_endpoint: `${BASE}/oauth/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+    });
+    return;
+  }
+  if (url === "/oauth/register" && req.method === "POST") {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    const { client_name } = JSON.parse(body || "{}");
+    json(res, { client_id: "oyster-local", client_name: client_name || "oyster", client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
+    return;
+  }
+  if (url?.startsWith("/oauth/authorize")) {
+    const params = new URL(url, BASE).searchParams;
+    const redirect = params.get("redirect_uri") || `${BASE}/`;
+    const state = params.get("state") || "";
+    const sep = redirect.includes("?") ? "&" : "?";
+    res.writeHead(302, { Location: `${redirect}${sep}code=oyster-local-code&state=${state}` });
+    res.end();
+    return;
+  }
+  if (url === "/oauth/token" && req.method === "POST") {
+    json(res, { access_token: "oyster-local-token", token_type: "bearer", expires_in: 86400 });
+    return;
+  }
+
   // ── MCP server ──
   if (url === "/mcp" || url === "/mcp/") {
     // Localhost-only: reject non-local origins and don't emit wildcard CORS
@@ -378,7 +458,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     // Override the wildcard CORS header set at the top of handleHttpRequest
     res.setHeader("Access-Control-Allow-Origin", origin || "http://localhost:4200");
 
-    const mcpServer = createMcpServer({ store, service: artifactService, userlandDir: USERLAND_DIR, iconGenerator, spaceService });
+    const mcpServer = createMcpServer({ store, service: artifactService, userlandDir: USERLAND_DIR, iconGenerator, spaceService, pendingReveals, broadcastUiEvent });
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => { transport.close(); mcpServer.close(); });
     await mcpServer.connect(transport);
@@ -386,9 +466,9 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     return;
   }
 
-  // Fallback
-  res.writeHead(404);
-  res.end("Not found");
+  // Fallback — JSON body so MCP SDK OAuth discovery doesn't choke on plain text
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Not found" }));
 }
 
 // ── HTTP + WebSocket server ──

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -286,7 +286,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         .optional()
         .describe("Filter by artifact kind"),
       search: z.string().optional().describe("Search term — filters artifacts whose label contains this text (case-insensitive)"),
-      limit: z.number().optional().describe("Max results to return (default 20)"),
+      limit: z.number().int().min(1).max(100).optional().describe("Max results to return (default 20)"),
     },
     async ({ space_id, artifact_kind, search, limit }) => {
       let artifacts = await deps.service.getAllArtifacts();
@@ -502,9 +502,9 @@ export function createMcpServer(deps: McpDeps): McpServer {
     { id: z.string().describe("Space ID to switch to") },
     async ({ id }) => {
       const spaces = deps.spaceService.listSpaces();
-      const space = spaces.find((s: { id: string }) => s.id === id);
+      const space = spaces.find(s => s.id === id);
       if (!space) {
-        return { content: [{ type: "text" as const, text: `Space "${id}" not found. Available: ${spaces.map((s: { id: string }) => s.id).join(", ")}` }], isError: true };
+        return { content: [{ type: "text" as const, text: `Space "${id}" not found. Available: ${spaces.map(s => s.id).join(", ")}` }], isError: true };
       }
       deps.broadcastUiEvent({
         version: 1,

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, mkdirSync } from "node:fs";
-import { extname, dirname, join } from "node:path";
+import { existsSync, readFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { extname, dirname, join, resolve, basename } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ArtifactStore } from "./artifact-store.js";
@@ -16,12 +16,107 @@ const ARTIFACT_KINDS = [
 
 const TEXT_EXTS = new Set([".md", ".mmd", ".mermaid", ".html", ".htm", ".txt", ".json", ".csv"]);
 
+const CONTEXT_PRIORITY_FILES = [
+  "README.md", "CLAUDE.md", "AGENTS.md", "package.json", "tsconfig.json",
+  "pyproject.toml", "Cargo.toml", "go.mod", ".opencode/agents",
+];
+const CONTEXT_SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", "out", "coverage", ".cache"]);
+const CONTEXT_MAX_TOKENS = 30_000;
+const CHARS_PER_TOKEN = 4;
+
+interface RepoFile { path: string; relPath: string; size: number }
+
+function walkRepoFiles(dir: string, root: string, depth = 0, acc: RepoFile[] = []): RepoFile[] {
+  if (depth > 5) return acc;
+  let entries: string[];
+  try { entries = readdirSync(dir); } catch { return acc; }
+  for (const entry of entries) {
+    const abs = join(dir, entry);
+    let st: ReturnType<typeof statSync>;
+    try { st = statSync(abs); } catch { continue; }
+    if (st.isDirectory()) {
+      if (!CONTEXT_SKIP_DIRS.has(entry)) walkRepoFiles(abs, root, depth + 1, acc);
+    } else if (TEXT_EXTS.has(extname(entry).toLowerCase())) {
+      acc.push({ path: abs, relPath: abs.slice(root.length + 1), size: st.size });
+    }
+  }
+  return acc;
+}
+
+function gatherRepoContext(repoPath: string): { content: string; suggestions: Array<{ label: string; kind: string; evidence_paths: string[] }> } {
+  const root = resolve(repoPath);
+  if (!existsSync(root)) return { content: `Repo path not found: ${root}`, suggestions: [] };
+
+  const allFiles = walkRepoFiles(root, root);
+
+  // Sort: priority files first, then by path
+  allFiles.sort((a, b) => {
+    const aPri = CONTEXT_PRIORITY_FILES.findIndex(p => a.relPath === p || a.relPath.startsWith(p + "/")) >= 0 ? 0 : 1;
+    const bPri = CONTEXT_PRIORITY_FILES.findIndex(p => b.relPath === p || b.relPath.startsWith(p + "/")) >= 0 ? 0 : 1;
+    if (aPri !== bPri) return aPri - bPri;
+    return a.relPath.localeCompare(b.relPath);
+  });
+
+  const sections: string[] = [];
+  let tokenBudget = CONTEXT_MAX_TOKENS;
+  const includedPaths: string[] = [];
+
+  for (const file of allFiles) {
+    if (tokenBudget <= 0) break;
+    try {
+      const raw = readFileSync(file.path, "utf8");
+      const tokens = Math.ceil(raw.length / CHARS_PER_TOKEN);
+      if (tokens > tokenBudget) continue;
+      sections.push(`### ${file.relPath}\n\`\`\`\n${raw}\n\`\`\``);
+      includedPaths.push(file.relPath);
+      tokenBudget -= tokens;
+    } catch { /* unreadable */ }
+  }
+
+  // Derive suggestions from what we found
+  const suggestions: Array<{ label: string; kind: string; evidence_paths: string[] }> = [];
+
+  // README → notes
+  const readmePaths = includedPaths.filter(p => basename(p).toLowerCase() === "readme.md");
+  for (const p of readmePaths) suggestions.push({ label: basename(p, ".md"), kind: "notes", evidence_paths: [p] });
+
+  // .mmd / .mermaid → diagram
+  const diagramPaths = includedPaths.filter(p => p.endsWith(".mmd") || p.endsWith(".mermaid"));
+  for (const p of diagramPaths) suggestions.push({ label: basename(p).replace(/\.[^.]+$/, ""), kind: "diagram", evidence_paths: [p] });
+
+  // Directories with package.json + dev/start script → app
+  const pkgPaths = allFiles.filter(f => basename(f.path) === "package.json");
+  for (const pkg of pkgPaths) {
+    try {
+      const parsed = JSON.parse(readFileSync(pkg.path, "utf8"));
+      if (parsed.scripts?.dev || parsed.scripts?.start) {
+        const dir = pkg.path.slice(root.length + 1).replace(/\/package\.json$/, "") || ".";
+        suggestions.push({ label: parsed.name ?? basename(dir), kind: "app", evidence_paths: [pkg.relPath] });
+      }
+    } catch { /* bad json */ }
+  }
+
+  const skippedCount = allFiles.length - includedPaths.length;
+  const header = `# Repo context: ${root}\nFiles included: ${includedPaths.length} / ${allFiles.length} (${skippedCount} skipped — over budget or unreadable)\n\n`;
+
+  return { content: header + sections.join("\n\n"), suggestions };
+}
+
+interface UiCommand {
+  version: 1;
+  command: string;
+  payload: unknown;
+  correlationId?: string;
+}
+
 interface McpDeps {
   store: ArtifactStore;
   service: ArtifactService;
   userlandDir: string;
   iconGenerator: IconGenerator;
   spaceService: SpaceService;
+  pendingReveals: Set<string>;
+  broadcastUiEvent: (event: UiCommand) => void;
 }
 
 function buildContext(userlandDir: string): string {
@@ -70,9 +165,11 @@ scan it for artifacts in one step, or \`scan_space\` to rescan an existing space
 2. Call \`onboard_space\` with the project name and repo path — creates the space and scans for apps, docs, and diagrams in one step.
 3. Call \`list_artifacts\` with the new space_id to see what was discovered.
 4. To rescan later (e.g. after new files are added), call \`scan_space\`.
+5. Call \`gather_repo_context\` to read the repo's key files and get deterministic artifact suggestions — useful before generating summaries or creating new artifacts from repo content.
 
 **Working with artifacts:**
 - Use \`create_artifact\` to write a new file and register it in one step.
+- After \`create_artifact\`, always call \`reveal_artifact\` with the new artifact's id — this switches the user's desktop to the right space and highlights the icon so they know where it landed.
 - Use \`read_artifact\` to read the content of an existing static file artifact.
 - Use \`update_artifact\` to rename, reassign to a different space, or change the group.
 - Use \`remove_artifact\` to hide an artifact from the surface (reversible).
@@ -156,22 +253,50 @@ export function createMcpServer(deps: McpDeps): McpServer {
     },
   );
 
+  // ── gather_repo_context ──
+
+  server.tool(
+    "gather_repo_context",
+    "Read key files from a local repo and return them as a structured context payload, along with deterministic artifact suggestions (READMEs, diagrams, apps detected from package.json). Stays within a ~30k token budget. Does NOT create artifacts — call create_artifact separately if you want to persist any output.",
+    {
+      repo_path: z.string().describe("Absolute local path to the repository root"),
+    },
+    async ({ repo_path }) => {
+      try {
+        const result = gatherRepoContext(repo_path);
+        return {
+          content: [{ type: "text" as const, text: result.content }],
+          structuredContent: { suggestions: result.suggestions },
+        };
+      } catch (err) {
+        return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
+      }
+    },
+  );
+
   // ── list_artifacts ──
 
   server.tool(
     "list_artifacts",
-    "List artifacts (desktop icons) on the Oyster surface, optionally filtered by space or kind. Returns id, label, kind, space, status, url, group, and source_path for each artifact.",
+    "List artifacts (desktop icons) on the Oyster surface, optionally filtered by space, kind, or search term. Returns id, label, kind, space, status, url, group, and source_path for each artifact.",
     {
       space_id: z.string().optional().describe("Filter by space"),
       artifact_kind: z
         .enum(ARTIFACT_KINDS)
         .optional()
         .describe("Filter by artifact kind"),
+      search: z.string().optional().describe("Search term — filters artifacts whose label contains this text (case-insensitive)"),
+      limit: z.number().optional().describe("Max results to return (default 20)"),
     },
-    async ({ space_id, artifact_kind }) => {
+    async ({ space_id, artifact_kind, search, limit }) => {
       let artifacts = await deps.service.getAllArtifacts();
       if (space_id) artifacts = artifacts.filter((a) => a.spaceId === space_id);
       if (artifact_kind) artifacts = artifacts.filter((a) => a.artifactKind === artifact_kind);
+      if (search) {
+        const q = search.toLowerCase();
+        artifacts = artifacts.filter((a) => a.label.toLowerCase().includes(q));
+      }
+      artifacts = artifacts.slice(0, limit ?? 20);
 
       const summary = artifacts.map((a) => ({
         id: a.id,
@@ -210,7 +335,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
       try {
         const artifact = deps.service.registerArtifact(
           { path, space_id, label, id, artifact_kind, group_name },
-          [deps.userlandDir],
+          [], // MCP callers are trusted — no path restriction
         );
         return {
           content: [{ type: "text" as const, text: JSON.stringify(artifact, null, 2) }],
@@ -267,11 +392,12 @@ export function createMcpServer(deps: McpDeps): McpServer {
       content: z.string().describe("File content to write"),
       subdir: z.string().optional().describe("Subdirectory within the space (e.g. 'invoices'). Must be a relative path."),
       group_name: z.string().optional().describe("Visual group on the surface"),
+      source_origin: z.enum(["manual", "ai_generated"]).optional().describe("Provenance of the artifact. Defaults to 'manual'. Use 'ai_generated' when the content was produced by an AI agent."),
     },
-    async ({ space_id, label, artifact_kind, content, subdir, group_name }) => {
+    async ({ space_id, label, artifact_kind, content, subdir, group_name, source_origin }) => {
       try {
         const artifact = deps.service.createArtifact(
-          { space_id, label, artifact_kind, content, subdir, group_name },
+          { space_id, label, artifact_kind, content, subdir, group_name, source_origin },
           deps.userlandDir,
         );
         return {
@@ -288,18 +414,20 @@ export function createMcpServer(deps: McpDeps): McpServer {
 
   server.tool(
     "update_artifact",
-    "Update display metadata only: label, space assignment, or group name. Does not rename or move the file on disk.",
+    "Update display metadata: label, space assignment, group name, or artifact kind. Does not rename or move the file on disk.",
     {
       id: z.string().describe("Artifact ID to update"),
       label: z.string().optional().describe("New display name"),
       space_id: z.string().optional().describe("Reassign to a different space (tab). Does not move the file."),
       group_name: z.string().optional().describe("Change visual group. Pass empty string to remove grouping."),
+      artifact_kind: z.enum(["app", "deck", "map", "notes", "diagram", "wireframe", "table"]).optional().describe("Correct the artifact kind if it was inferred incorrectly."),
     },
-    async ({ id, label, space_id, group_name }) => {
+    async ({ id, label, space_id, group_name, artifact_kind }) => {
       try {
         const updated = await deps.service.updateArtifact(id, {
           label,
           space_id,
+          artifact_kind,
           ...(group_name !== undefined ? { group_name: group_name || null } : {}),
         });
         return {
@@ -325,6 +453,65 @@ export function createMcpServer(deps: McpDeps): McpServer {
       } catch (err) {
         return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
       }
+    },
+  );
+
+  // ── reveal_artifact ──
+
+  server.tool(
+    "reveal_artifact",
+    "Flag an artifact to be revealed on the user's desktop — the UI will switch to its space and briefly highlight the icon on the next poll. Call this after create_artifact so the user knows where to find what you just created.",
+    { id: z.string().describe("Artifact ID to reveal") },
+    async ({ id }) => {
+      const artifact = await deps.service.getArtifactById(id);
+      if (!artifact) {
+        return { content: [{ type: "text" as const, text: `Artifact "${id}" not found` }], isError: true };
+      }
+      deps.pendingReveals.add(id);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ revealed: id, space: artifact.spaceId, label: artifact.label }) }],
+      };
+    },
+  );
+
+  // ── open_artifact ──
+
+  server.tool(
+    "open_artifact",
+    "Open an artifact in the user's viewer window by exact ID. The UI switches to the artifact's space and opens the viewer immediately. Use list_artifacts(search) first to find the right ID.",
+    { id: z.string().describe("Artifact ID to open") },
+    async ({ id }) => {
+      const artifact = await deps.service.getArtifactById(id);
+      if (!artifact) {
+        return { content: [{ type: "text" as const, text: `Artifact "${id}" not found. Use list_artifacts to find available artifacts.` }], isError: true };
+      }
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "open_artifact",
+        payload: { id: artifact.id, spaceId: artifact.spaceId, label: artifact.label, url: artifact.url, artifactKind: artifact.artifactKind },
+      });
+      return { content: [{ type: "text" as const, text: `Opened "${artifact.label}"` }] };
+    },
+  );
+
+  // ── switch_space ──
+
+  server.tool(
+    "switch_space",
+    "Switch the user's desktop to a different space by exact ID. The UI navigates immediately. Use list_spaces first to find available space IDs.",
+    { id: z.string().describe("Space ID to switch to") },
+    async ({ id }) => {
+      const spaces = deps.spaceService.listSpaces();
+      const space = spaces.find((s: { id: string }) => s.id === id);
+      if (!space) {
+        return { content: [{ type: "text" as const, text: `Space "${id}" not found. Available: ${spaces.map((s: { id: string }) => s.id).join(", ")}` }], isError: true };
+      }
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "switch_space",
+        payload: { spaceId: space.id },
+      });
+      return { content: [{ type: "text" as const, text: `Switched to "${space.displayName}"` }] };
     },
   );
 

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -24,6 +24,7 @@ function rowToSpace(row: SpaceRow): Space {
     displayName: row.display_name,
     repoPath: row.repo_path,
     color: row.color,
+    parentId: row.parent_id,
     scanStatus: toScanStatus(row.scan_status),
     scanError: row.scan_error,
     lastScannedAt: row.last_scanned_at,
@@ -73,7 +74,7 @@ export class SpaceService {
 
     const color = SPACE_PALETTE[hashStr(id) % SPACE_PALETTE.length];
     this.spaceStore.insert({
-      id, display_name: displayName, repo_path: repoPath, color,
+      id, display_name: displayName, repo_path: repoPath, color, parent_id: null,
       scan_status: "none", scan_error: null, last_scanned_at: null,
       last_scan_summary: null, ai_job_status: null, ai_job_error: null,
     });

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -5,6 +5,7 @@ export interface SpaceRow {
   display_name: string;
   repo_path: string | null;
   color: string | null;
+  parent_id: string | null;
   scan_status: string;
   scan_error: string | null;
   last_scanned_at: string | null;
@@ -39,11 +40,11 @@ export class SqliteSpaceStore implements SpaceStore {
       getByRepoPath: db.prepare("SELECT * FROM spaces WHERE repo_path = ?"),
       insert: db.prepare(`
         INSERT INTO spaces (
-          id, display_name, repo_path, color, scan_status,
+          id, display_name, repo_path, color, parent_id, scan_status,
           scan_error, last_scanned_at, last_scan_summary,
           ai_job_status, ai_job_error
         ) VALUES (
-          @id, @display_name, @repo_path, @color, @scan_status,
+          @id, @display_name, @repo_path, @color, @parent_id, @scan_status,
           @scan_error, @last_scanned_at, @last_scan_summary,
           @ai_job_status, @ai_job_error
         )
@@ -58,7 +59,7 @@ export class SqliteSpaceStore implements SpaceStore {
   delete(id: string): void { this.db.prepare("DELETE FROM spaces WHERE id = ?").run(id); }
 
   private static readonly UPDATABLE_COLUMNS = new Set([
-    "display_name", "repo_path", "color", "scan_status",
+    "display_name", "repo_path", "color", "parent_id", "scan_status",
     "scan_error", "last_scanned_at", "last_scan_summary",
     "ai_job_status", "ai_job_error",
   ]);

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -32,9 +32,9 @@ export function slugify(str: string): string {
 
 export function inferKindFromPath(filePath: string): ArtifactKind {
   const lower = filePath.toLowerCase();
-  if (lower.includes("dashboard") || lower.includes("diagram")) return "diagram";
+  if (lower.includes("dashboard") || lower.includes("diagram") || lower.includes("analysis") || lower.includes("chart")) return "diagram";
   if (lower.includes("deck") || lower.includes("slide") || lower.includes("present")) return "deck";
-  if (lower.includes("map") || lower.includes("mind")) return "map";
+  if (lower.includes("map") || lower.includes("mind") || lower.includes("segment")) return "map";
   if (lower.includes("note") || lower.includes("readme")) return "notes";
   if (lower.includes("table") || lower.includes("spreadsheet") || lower.includes("tracker")) return "table";
   const ext = extname(lower);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -30,6 +30,7 @@ export interface Artifact {
   iconStatus?: IconStatus;
   createdAt: string;
   groupName?: string;
+  pendingReveal?: boolean;
 }
 
 export type ScanStatus = "none" | "scanning" | "complete" | "error";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -47,6 +47,7 @@ export interface Space {
   displayName: string;
   repoPath: string | null;
   color: string | null;
+  parentId: string | null;
   scanStatus: ScanStatus;
   scanError: string | null;
   lastScannedAt: string | null;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -398,6 +398,16 @@ body {
   animation: fadeUp 0.4s ease forwards, pulse 1.5s ease-in-out infinite;
 }
 
+.artifact-icon.reveal {
+  animation: revealPulse 1.5s ease-out;
+}
+
+@keyframes revealPulse {
+  0% { box-shadow: 0 0 0 0 rgba(124, 107, 255, 0.6); }
+  50% { box-shadow: 0 0 0 12px rgba(124, 107, 255, 0); }
+  100% { box-shadow: none; }
+}
+
 /* Icon thumbnail */
 .icon-thumb {
   width: 72px;
@@ -720,8 +730,15 @@ body {
   text-align: left;
 }
 
-.slash-autocomplete-item:hover {
+.slash-autocomplete-item:hover,
+.slash-autocomplete-item.active {
   background: rgba(255, 255, 255, 0.08);
+}
+
+.chatbar-messages.slash-dimmed {
+  opacity: 0.3;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
 }
 
 .slash-cmd {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1959,7 +1959,7 @@ body {
 
 .list-row-space {
   font-size: 0.65rem;
-  font-weight: 500;
+  font-weight: 300;
   padding: 3px 10px;
   border-radius: 999px;
   justify-self: end;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -687,7 +687,61 @@ body {
 }
 
 
+.slash-autocomplete {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  background: rgba(13, 14, 26, 0.95);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 4px;
+  margin-bottom: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  z-index: 10;
+}
+
+.slash-autocomplete-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 8px;
+  text-align: left;
+}
+
+.slash-autocomplete-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.slash-cmd {
+  color: var(--accent);
+  font-weight: 600;
+  min-width: 24px;
+}
+
+.slash-args {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.slash-desc {
+  color: rgba(255, 255, 255, 0.5);
+  margin-left: auto;
+  font-size: 12px;
+}
+
 .chatbar-bar {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -735,10 +735,14 @@ body {
   background: rgba(255, 255, 255, 0.08);
 }
 
+.chatbar-messages {
+  transition: opacity 0.2s ease, filter 0.2s ease;
+}
+
 .chatbar-messages.slash-dimmed {
-  opacity: 0.3;
+  opacity: 0.25;
   pointer-events: none;
-  transition: opacity 0.15s ease;
+  filter: blur(2px);
 }
 
 .slash-cmd {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,7 @@ export default function App() {
     }
   }, []);
   const [loaded, setLoaded] = useState(false);
+  const [revealId, setRevealId] = useState<string | null>(null);
   const [showHardcoreGate, setShowHardcoreGate] = useState(false);
   const [openGroup, setOpenGroup] = useState<string | null>(() => getUrlState().groupName);
   const [spotlightOpen, setSpotlightOpen] = useState(false);
@@ -81,13 +82,47 @@ export default function App() {
     fetchSpaces().then(setSpaces);
   }, []);
 
-  // Poll for status updates every 5 seconds
+  // Poll for status updates every 5 seconds; handle pending reveals
   useEffect(() => {
     const interval = setInterval(() => {
-      fetchArtifacts().then(setArtifacts);
+      fetchArtifacts().then((arts) => {
+        setArtifacts(arts);
+        const revealed = arts.find((a) => a.pendingReveal);
+        if (revealed) {
+          setActiveSpace(revealed.spaceId);
+          window.history.pushState(null, "", `/s/${revealed.spaceId}`);
+          if (revealed.groupName) setOpenGroup(revealed.groupName);
+          setRevealId(revealed.id);
+          setTimeout(() => setRevealId(null), 3000);
+        }
+      });
       fetchSpaces().then(setSpaces);
     }, 5000);
     return () => clearInterval(interval);
+  }, []);
+
+  // Subscribe to server-pushed UI commands (open artifact, switch space)
+  useEffect(() => {
+    const es = new EventSource("/api/ui/events");
+    es.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data);
+        if (event.command === "open_artifact") {
+          const { spaceId, label, url, artifactKind } = event.payload;
+          setActiveSpace(spaceId);
+          window.history.pushState(null, "", `/s/${spaceId}/a/${event.payload.id}`);
+          dispatch({ type: "CLOSE_ALL_VIEWERS" });
+          dispatch({ type: "OPEN_VIEWER", title: label, path: url, fullscreen: shouldOpenFullscreen(artifactKind) });
+        }
+        if (event.command === "switch_space") {
+          const { spaceId } = event.payload;
+          setActiveSpace(spaceId);
+          window.history.pushState(null, "", `/s/${spaceId}`);
+          dispatch({ type: "CLOSE_ALL_VIEWERS" });
+        }
+      } catch { /* ignore malformed events */ }
+    };
+    return () => es.close();
   }, []);
 
   // Sync state from browser back/forward
@@ -219,6 +254,7 @@ export default function App() {
           window.history.pushState(null, "", `/s/${activeSpace}/g/${encodeURIComponent(name.toLowerCase())}`);
         }}
         onSpaceChange={handleSpaceChange}
+        revealId={revealId}
       />
 
       <div className="windows-layer">

--- a/web/src/components/ArtifactIcon.tsx
+++ b/web/src/components/ArtifactIcon.tsx
@@ -53,16 +53,17 @@ interface Props {
   index: number;
   onClick: () => void;
   onStop?: () => void;
+  reveal?: boolean;
 }
 
-export function ArtifactIcon({ artifact, index, onClick, onStop }: Props) {
+export function ArtifactIcon({ artifact, index, onClick, onStop, reveal }: Props) {
   const config = typeConfig[artifact.artifactKind] || typeConfig.app;
   // Only show status indicators for managed apps (local_process runtime)
   const isManagedApp = artifact.runtimeKind === "local_process";
 
   return (
     <button
-      className={`artifact-icon ${artifact.status === "generating" ? "generating" : ""}`}
+      className={`artifact-icon ${artifact.status === "generating" ? "generating" : ""} ${reveal ? "reveal" : ""}`}
       style={{
         animationDelay: `${index * 0.05 + 0.05}s`,
         ...(artifact.status === "generating" ? { pointerEvents: "none" as const } : {}),

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -78,6 +78,11 @@ function ToolBlock({ tool }: { tool: ToolPart }) {
   );
 }
 
+const SLASH_COMMANDS = [
+  { cmd: "/s", args: "<prefix>", desc: "Switch space", example: "/s bf → blunderfixer" },
+  { cmd: "/o", args: "<search>", desc: "Open artifact", example: "/o competitor analysis" },
+];
+
 interface Props {
   onOpenTerminal: () => void;
   isHero?: boolean;
@@ -124,6 +129,45 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   const handleSend = useCallback(async () => {
     if (!input.trim() || streaming || !sessionId) return;
     const content = input;
+
+    // ── Slash commands — instant, no LLM call ──
+    // Nothing starting with "/" ever reaches the AI.
+    if (content.trim().startsWith("/")) {
+      setInput("");
+      const slashMatch = content.trim().match(/^\/([a-z])\s+(.+)$/i);
+      if (slashMatch) {
+        const [, cmd, arg] = slashMatch;
+        const q = arg.trim().toLowerCase();
+
+        if (cmd === "s" && onSpaceChange) {
+          // Subsequence match: "bf" matches "blunderfixer" (b...f...)
+          const subsequence = (query: string, target: string) => {
+            let qi = 0;
+            for (let ti = 0; ti < target.length && qi < query.length; ti++) {
+              if (target[ti] === query[qi]) qi++;
+            }
+            return qi === query.length;
+          };
+
+          // Try: exact ID, then prefix, then subsequence on ID, then subsequence on display name
+          const match = spaces.find(s => s.id === q)
+            || spaces.find(s => s.id.startsWith(q))
+            || spaces.find(s => s.displayName.toLowerCase().startsWith(q))
+            || spaces.find(s => subsequence(q, s.id))
+            || spaces.find(s => subsequence(q, s.displayName.toLowerCase()));
+
+          if (match) {
+            onSpaceChange(match.id);
+          } else {
+            const available = spaces.map(s => s.id).join(", ");
+            setMessages(prev => [...prev, { role: "assistant", content: `No space matching "${arg.trim()}". Available: ${available}` }]);
+            setExpanded(true);
+          }
+        }
+      }
+      return;
+    }
+
     setInput("");
     setMessages((prev) => [...prev, { role: "user", content }]);
     setStreaming(true);
@@ -143,7 +187,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
       setStreaming(false);
       setStatusText("");
     }
-  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking]);
+  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange]);
 
   function handleCopyChat() {
     const text = messages
@@ -255,6 +299,72 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
 
       {/* Input bar */}
       <div className="chatbar-bar" onClick={() => { if (messages.length > 0 && !expanded) setExpanded(true); }}>
+        {/* Slash command autocomplete — floats above input */}
+        {input.startsWith("/") && (() => {
+          const lower = input.toLowerCase().trim();
+          const spaceArgMatch = lower.match(/^\/s(\s+(.*))?$/);
+
+          // "/s" or "/s " or "/s b..." — show matching spaces
+          if (spaceArgMatch !== null && (lower === "/s" || lower.startsWith("/s "))) {
+            const q = (spaceArgMatch[2] || "").trim();
+            const subseq = (query: string, target: string) => {
+              let qi = 0;
+              for (let ti = 0; ti < target.length && qi < query.length; ti++) {
+                if (target[ti] === query[qi]) qi++;
+              }
+              return qi === query.length;
+            };
+            const matches = spaces.filter(s =>
+              !q || s.id.startsWith(q) || s.displayName.toLowerCase().startsWith(q) || subseq(q, s.id) || subseq(q, s.displayName.toLowerCase())
+            ).slice(0, 8);
+            if (matches.length === 0) return null;
+            return (
+              <div className="slash-autocomplete">
+                {matches.map(s => (
+                  <button
+                    key={s.id}
+                    className="slash-autocomplete-item"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setInput("");
+                      onSpaceChange?.(s.id);
+                    }}
+                  >
+                    <span className="slash-cmd">{s.id}</span>
+                    <span className="slash-desc">{s.displayName}</span>
+                  </button>
+                ))}
+              </div>
+            );
+          }
+
+          // After "/" — show available commands (but not if already showing spaces)
+          if (!input.includes(" ") && lower !== "/s") {
+            const filtered = SLASH_COMMANDS.filter(c => c.cmd.startsWith(lower));
+            if (filtered.length === 0) return null;
+            return (
+              <div className="slash-autocomplete">
+                {filtered.map(c => (
+                  <button
+                    key={c.cmd}
+                    className="slash-autocomplete-item"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setInput(c.cmd + (c.args ? " " : ""));
+                      inputRef.current?.focus();
+                    }}
+                  >
+                    <span className="slash-cmd">{c.cmd}</span>
+                    {c.args && <span className="slash-args">{c.args}</span>}
+                    <span className="slash-desc">{c.desc}</span>
+                  </button>
+                ))}
+              </div>
+            );
+          }
+
+          return null;
+        })()}
         <div
           className="chatbar-oyster"
           onClick={onOpenTerminal}

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -80,7 +80,6 @@ function ToolBlock({ tool }: { tool: ToolPart }) {
 
 const SLASH_COMMANDS = [
   { cmd: "/s", args: "<prefix>", desc: "Switch space", example: "/s bf → blunderfixer" },
-  { cmd: "/o", args: "<search>", desc: "Open artifact", example: "/o competitor analysis" },
 ];
 
 interface Props {
@@ -99,6 +98,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   const [focused, setFocused] = useState(false);
   const [tagline, setTagline] = useState<{ dim: string; bright: string } | null>(null);
   const [copied, setCopied] = useState(false);
+  const [slashIndex, setSlashIndex] = useState(0);
   const taglineIndexRef = useRef(0);
   const bottomRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -107,6 +107,42 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   const isHero = !!isHeroProp;
 
   const { messages, setMessages, sessionId, expanded, setExpanded, pushSessionUrl } = useChatSession();
+
+  // Compute slash autocomplete items
+  const subseq = useCallback((query: string, target: string) => {
+    let qi = 0;
+    for (let ti = 0; ti < target.length && qi < query.length; ti++) {
+      if (target[ti] === query[qi]) qi++;
+    }
+    return qi === query.length;
+  }, []);
+
+  const slashItems = useMemo(() => {
+    if (!input.startsWith("/")) return [];
+    const lower = input.toLowerCase().trim();
+    const spaceArgMatch = lower.match(/^\/s(\s+(.*))?$/);
+
+    if (spaceArgMatch !== null && (lower === "/s" || lower.startsWith("/s "))) {
+      const q = (spaceArgMatch[2] || "").trim();
+      return spaces
+        .filter(s => !q || s.id.startsWith(q) || s.displayName.toLowerCase().startsWith(q) || subseq(q, s.id) || subseq(q, s.displayName.toLowerCase()))
+        .slice(0, 8)
+        .map(s => ({ key: s.id, label: s.id, desc: s.displayName, type: "space" as const }));
+    }
+
+    if (!input.includes(" ") && lower !== "/s") {
+      return SLASH_COMMANDS
+        .filter(c => c.cmd.startsWith(lower))
+        .map(c => ({ key: c.cmd, label: c.cmd, args: c.args, desc: c.desc, type: "command" as const }));
+    }
+
+    return [];
+  }, [input, spaces, subseq]);
+
+  const slashOpen = slashItems.length > 0;
+
+  // Reset index when items change
+  useEffect(() => { setSlashIndex(0); }, [slashItems.length]);
   const { resetTracking } = useChatEvents({ sessionId, setMessages, setStreaming, setStatusText });
 
   useEffect(() => {
@@ -140,21 +176,12 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
         const q = arg.trim().toLowerCase();
 
         if (cmd === "s" && onSpaceChange) {
-          // Subsequence match: "bf" matches "blunderfixer" (b...f...)
-          const subsequence = (query: string, target: string) => {
-            let qi = 0;
-            for (let ti = 0; ti < target.length && qi < query.length; ti++) {
-              if (target[ti] === query[qi]) qi++;
-            }
-            return qi === query.length;
-          };
-
           // Try: exact ID, then prefix, then subsequence on ID, then subsequence on display name
           const match = spaces.find(s => s.id === q)
             || spaces.find(s => s.id.startsWith(q))
             || spaces.find(s => s.displayName.toLowerCase().startsWith(q))
-            || spaces.find(s => subsequence(q, s.id))
-            || spaces.find(s => subsequence(q, s.displayName.toLowerCase()));
+            || spaces.find(s => subseq(q, s.id))
+            || spaces.find(s => subseq(q, s.displayName.toLowerCase()));
 
           if (match) {
             onSpaceChange(match.id);
@@ -187,7 +214,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
       setStreaming(false);
       setStatusText("");
     }
-  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange]);
+  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq]);
 
   function handleCopyChat() {
     const text = messages
@@ -221,7 +248,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
 
       {/* Messages panel — expands upward */}
       {messages.length > 0 && (
-        <div className={`chatbar-messages ${expanded ? "chat-expanded" : "chat-collapsed"}`}>
+        <div className={`chatbar-messages ${expanded ? "chat-expanded" : "chat-collapsed"}${slashOpen ? " slash-dimmed" : ""}`}>
           <div className="chatbar-actions">
             <button
               className={`chatbar-copy ${copied ? "copied" : ""}`}
@@ -300,71 +327,26 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
       {/* Input bar */}
       <div className="chatbar-bar" onClick={() => { if (messages.length > 0 && !expanded) setExpanded(true); }}>
         {/* Slash command autocomplete — floats above input */}
-        {input.startsWith("/") && (() => {
-          const lower = input.toLowerCase().trim();
-          const spaceArgMatch = lower.match(/^\/s(\s+(.*))?$/);
-
-          // "/s" or "/s " or "/s b..." — show matching spaces
-          if (spaceArgMatch !== null && (lower === "/s" || lower.startsWith("/s "))) {
-            const q = (spaceArgMatch[2] || "").trim();
-            const subseq = (query: string, target: string) => {
-              let qi = 0;
-              for (let ti = 0; ti < target.length && qi < query.length; ti++) {
-                if (target[ti] === query[qi]) qi++;
-              }
-              return qi === query.length;
-            };
-            const matches = spaces.filter(s =>
-              !q || s.id.startsWith(q) || s.displayName.toLowerCase().startsWith(q) || subseq(q, s.id) || subseq(q, s.displayName.toLowerCase())
-            ).slice(0, 8);
-            if (matches.length === 0) return null;
-            return (
-              <div className="slash-autocomplete">
-                {matches.map(s => (
-                  <button
-                    key={s.id}
-                    className="slash-autocomplete-item"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      setInput("");
-                      onSpaceChange?.(s.id);
-                    }}
-                  >
-                    <span className="slash-cmd">{s.id}</span>
-                    <span className="slash-desc">{s.displayName}</span>
-                  </button>
-                ))}
-              </div>
-            );
-          }
-
-          // After "/" — show available commands (but not if already showing spaces)
-          if (!input.includes(" ") && lower !== "/s") {
-            const filtered = SLASH_COMMANDS.filter(c => c.cmd.startsWith(lower));
-            if (filtered.length === 0) return null;
-            return (
-              <div className="slash-autocomplete">
-                {filtered.map(c => (
-                  <button
-                    key={c.cmd}
-                    className="slash-autocomplete-item"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      setInput(c.cmd + (c.args ? " " : ""));
-                      inputRef.current?.focus();
-                    }}
-                  >
-                    <span className="slash-cmd">{c.cmd}</span>
-                    {c.args && <span className="slash-args">{c.args}</span>}
-                    <span className="slash-desc">{c.desc}</span>
-                  </button>
-                ))}
-              </div>
-            );
-          }
-
-          return null;
-        })()}
+        {slashOpen && (
+          <div className="slash-autocomplete">
+            {slashItems.map((item, i) => (
+              <button
+                key={item.key}
+                className={`slash-autocomplete-item${i === slashIndex ? " active" : ""}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  if (item.type === "space") { setInput(""); onSpaceChange?.(item.key); }
+                  else { setInput(item.label + ("args" in item && item.args ? " " : "")); inputRef.current?.focus(); }
+                }}
+                onMouseEnter={() => setSlashIndex(i)}
+              >
+                <span className="slash-cmd">{item.label}</span>
+                {"args" in item && item.args && <span className="slash-args">{item.args}</span>}
+                <span className="slash-desc">{item.desc}</span>
+              </button>
+            ))}
+          </div>
+        )}
         <div
           className="chatbar-oyster"
           onClick={onOpenTerminal}
@@ -387,7 +369,21 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && handleSend()}
+          onKeyDown={(e) => {
+            if (slashOpen) {
+              if (e.key === "ArrowDown") { e.preventDefault(); setSlashIndex(i => Math.min(i + 1, slashItems.length - 1)); return; }
+              if (e.key === "ArrowUp") { e.preventDefault(); setSlashIndex(i => Math.max(i - 1, 0)); return; }
+              if (e.key === "Tab" || (e.key === "Enter" && slashItems[slashIndex])) {
+                e.preventDefault();
+                const item = slashItems[slashIndex];
+                if (item.type === "space") { setInput(""); onSpaceChange?.(item.key); }
+                else { setInput(item.label + ("args" in item && item.args ? " " : "")); }
+                return;
+              }
+              if (e.key === "Escape") { setInput(""); return; }
+            }
+            if (e.key === "Enter") handleSend();
+          }}
           onFocus={() => {
             setFocused(true);
             if (messages.length > 0) setExpanded(true);

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -240,7 +240,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
                     {(!isAllSpace || groupBy !== "kind") && <span className="list-row-badge">{a.artifactKind}</span>}
                     {isAllSpace && groupBy !== "space" && (() => {
                       const c = spaceColor(a.spaceId);
-                      return <span className="list-row-space" style={{ color: c, background: `${c}28` }}>{a.spaceId}</span>;
+                      return <span className="list-row-space" style={{ color: "rgba(255,255,255,0.7)", background: `${c}40` }}>{a.spaceId}</span>;
                     })()}
                   </div>
                 ))}

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -18,9 +18,10 @@ interface Props {
   onArtifactStop?: (artifact: Artifact) => void;
   onGroupClick: (groupName: string) => void;
   onSpaceChange: (space: string) => void;
+  revealId?: string | null;
 }
 
-export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick }: Props) {
+export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, revealId }: Props) {
   const isAllSpace = space === "__all__";
 
   // ── Topbar auto-hide ──
@@ -263,6 +264,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
                         index={i}
                         onClick={() => onArtifactClick(item.artifact)}
                         onStop={onArtifactStop ? () => onArtifactStop(item.artifact) : undefined}
+                        reveal={item.artifact.id === revealId}
                       />
                     )
                   ))}
@@ -290,6 +292,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
                       index={i}
                       onClick={() => onArtifactClick(item.artifact)}
                       onStop={onArtifactStop ? () => onArtifactStop(item.artifact) : undefined}
+                      reveal={item.artifact.id === revealId}
                     />
                   )}
                 </div>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,8 +4,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
+    port: 5555,
     proxy: {
       '/api/chat/events': {
+        target: 'http://localhost:4200',
+        headers: { Accept: 'text/event-stream' },
+      },
+      '/api/ui/events': {
         target: 'http://localhost:4200',
         headers: { Accept: 'text/event-stream' },
       },


### PR DESCRIPTION
## Summary

- **Drop Graphiti** — memory deferred to v2. Removes Docker dependency, cleans up agent instructions. (#66)
- **SSE command channel** — `GET /api/ui/events` pushes typed `UiCommand` events to the browser instantly, replacing the 5s poll for navigation actions. (#67)
- **Prompt-driven nav** — two new MCP tools (`open_artifact`, `switch_space`) let the AI control the surface. `list_artifacts` gains `search`/`limit` params so the LLM can find artifacts by name before opening by exact ID. (#68)
- **Slash commands** — `/s <prefix>` for instant space switching (no LLM call). Subsequence matching so `/s bf` → blunderfixer. Autocomplete dropdown on `/` with space picker on `/s`.
- **Supporting changes** — design doc refresh, `source_origin` threading, artifact kind inference, `reveal` prop on ArtifactIcon, CLAUDE.md project instructions.

## Test plan

- [ ] `npm run dev` — server starts without Graphiti errors (no port 8000 connection attempts)
- [ ] Type "show me snake game" in chat → viewer opens immediately (not 5s delayed)
- [ ] Type "switch to home" in chat → space changes immediately
- [ ] Type `/s bf` → instant switch to blunderfixer (no LLM call)
- [ ] Type `/` → autocomplete dropdown appears above input bar
- [ ] Type `/s` → space picker appears with all spaces
- [ ] Onboard a real project, type "show me the competitor analysis" → correct artifact opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)