### PR TITLE
Phase B: CLI packaging — npm install -g oyster-os

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,8 @@
       "Bash(git commit:*)",
       "Bash(git checkout:*)",
       "Bash(git push:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(npm run:*)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 node_modules/
-dist/
 .env
 .env.local
 .superpowers/
 .claude/
+*.tgz
 
-# User data (not project source)
+# Build output
+server/dist/
+shared/types.js
+
+# User data
 userland/
 server/registry.json
-shared/types.js
-server/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 # User data (not project source)
 userland/
 server/registry.json
+shared/types.js
+server/dist/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ANTHROPIC_API_KEY=your-key    # or OPENAI_API_KEY, etc.
 FAL_KEY=your-key              # optional — AI-generated icons
 ```
 
-Oyster uses OpenCode under the hood, which supports Anthropic, OpenAI, Gemini, Groq, and Ollama. Bring whichever AI you prefer.
+Anthropic (Claude) is the default. Other providers (OpenAI, Gemini, Groq, Ollama) can be configured in `.opencode/config.toml`.
 
 ## Core commands
 

--- a/README.md
+++ b/README.md
@@ -28,57 +28,69 @@ Oyster puts that work on one surface and lets you control it with simple command
 - **Bring your own AI**  
   Oyster speaks MCP — the open standard that lets AI tools talk to each other. Connect the AI you already use and it can control your workspace directly.
 
+## Quick start
+
+### Install and run
+
+```bash
+npm install -g oyster-os
+oyster
+```
+
+That's it. Oyster starts, your browser opens to **http://localhost:4200**, and you're on the surface.
+
+On first run, Oyster will ask for your API key. Paste it and it's saved to `~/.oyster/.env`.
+
+### Connect your AI
+
+Oyster is an MCP server. Any MCP-compatible tool can control your workspace.
+
+**Claude Code:**
+
+```bash
+claude mcp add --transport http oyster http://localhost:4200/mcp/
+```
+
+**Cursor / VS Code / other MCP clients** — add to your MCP config:
+
+```json
+{
+  "oyster": {
+    "type": "http",
+    "url": "http://localhost:4200/mcp/"
+  }
+}
+```
+
+Once connected, your AI can list spaces, open artefacts, create documents, onboard projects, and manage the surface directly.
+
+### Onboard a project
+
+From the Oyster chat bar:
+
+```
+onboard my project at ~/Dev/my-project
+```
+
+Or from Claude Code / any connected AI:
+
+```
+> onboard_space(name: "My Project", repo_path: "/path/to/my-project")
+```
+
+Oyster scans the folder for documents, apps, and diagrams and adds them to the surface automatically.
+
 ## What works today
 
 - Prompt-driven navigation
 - Space switching
 - Artefact desktop with icons
 - Local repo onboarding
-- MCP-powered agent actions (works with Claude Code, Cursor, any MCP client)
+- MCP server with 12 tools (works with Claude Code, Cursor, any MCP client)
 - Instant UI updates via SSE
+- Slash commands (`/s`, `/o`, `#`)
 
-## Example
-
-Things you can type into Oyster:
-
-```text
-show me the competitor analysis
-switch to blunderfixer
-/o competitor analysis
-/s home
-#bf
-#1
-```
-
-## Quick start
-
-### Requirements
-
-Node.js 22+
-
-### Install
-
-```bash
-git clone https://github.com/mattslight/oyster.git
-cd oyster
-npm install
-npm run dev
-```
-
-Open:
-
-**http://localhost:7337** 😎
-
-Create a `.env` file at the project root with your preferred AI provider key:
-
-```
-ANTHROPIC_API_KEY=your-key    # or OPENAI_API_KEY, etc.
-FAL_KEY=your-key              # optional — AI-generated icons
-```
-
-Anthropic (Claude) is the default. Other providers (OpenAI, Gemini, Groq, Ollama) can be configured in `.opencode/config.toml`.
-
-## Core commands
+## Commands
 
 | Command | What it does |
 |---|---|
@@ -95,6 +107,34 @@ Examples:
 /o pricing deck
 #home
 #2
+```
+
+## The full loop
+
+Here's what it looks like end to end:
+
+```bash
+# 1. Install Oyster
+npm install -g oyster-os
+
+# 2. Start it
+oyster
+# → browser opens to http://localhost:4200
+
+# 3. Connect Claude Code (or any MCP client)
+claude mcp add --transport http oyster http://localhost:4200/mcp/
+
+# 4. From Claude Code, onboard a project
+> onboard_space(name: "My App", repo_path: "~/Dev/my-app")
+# → Oyster scans for docs, apps, diagrams
+
+# 5. From the Oyster chat bar
+show me the architecture diagram
+# → artifact opens in the viewer
+
+# 6. Switch spaces
+#1
+# → instant switch to your first project
 ```
 
 ## Who it is for
@@ -117,6 +157,7 @@ Local-first. Single-user. Built for fast iteration.
 - artefact management
 - repo onboarding
 - visual workspace
+- MCP server
 
 **Planned later**
 - dynamic UI — interfaces that adapt to the task at hand, not static layouts
@@ -127,17 +168,14 @@ Local-first. Single-user. Built for fast iteration.
 ## Architecture
 
 ```
-Web UI (React + Vite)
-        |
-        v
-Oyster Server
-  - SQLite
-  - MCP tools
-  - SSE updates
-  - chat proxy
-        |
-        v
-OpenCode / LLM
+Browser → http://localhost:4200
+              |
+        Oyster Server
+         - SQLite (artefacts, spaces)
+         - MCP server (/mcp/)
+         - SSE push (instant UI updates)
+         - Static web UI
+         - Chat proxy → OpenCode → LLM
 ```
 
 ## Contributing
@@ -150,7 +188,7 @@ Good areas to help with:
 - slash commands
 - artefact search and ranking
 - UI polish
-- packaging and distribution
+- MCP connectors
 
 If you want to contribute:
 
@@ -158,18 +196,27 @@ If you want to contribute:
 2. Keep the scope tight
 3. Send a focused PR with a clear before and after
 
+### Development
+
+```bash
+git clone https://github.com/mattslight/oyster.git
+cd oyster
+cd web && npm install && cd ../server && npm install && cd ..
+npm run dev
+# → dev server at http://localhost:7337 (proxies to server at 4200)
+```
+
 ## Roadmap
 
-**Short term priorities:**
+**Short term:**
 
 - smoother onboarding
-- stronger packaging and distribution
 - faster artefact opening and navigation
 - better repo import experience
 
 **Longer term:**
 
-- dynamic UI — surfaces that reshape to fit the job, not one-size-fits-all layouts
+- dynamic UI — surfaces that reshape to fit the job
 - cloud and hybrid hosting
 - persistent memory
 - plugin ecosystem

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { spawn, execSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(__dirname, "..");
+const OYSTER_HOME = join(process.env.HOME || "~", ".oyster");
+const ENV_FILE = join(OYSTER_HOME, ".env");
+
+// ── Resolve API key ──
+
+function loadEnvFile(path, env) {
+  if (!existsSync(path)) return;
+  const lines = readFileSync(path, "utf8").split("\n");
+  for (const line of lines) {
+    const match = line.match(/^([A-Z_]+)=(.+)$/);
+    if (match && !env[match[1]]) env[match[1]] = match[2];
+  }
+}
+
+function getEnvVars() {
+  const env = { ...process.env };
+  // Check project root .env, then ~/.oyster/.env
+  loadEnvFile(join(PACKAGE_ROOT, ".env"), env);
+  loadEnvFile(ENV_FILE, env);
+  return env;
+}
+
+async function ensureApiKey(env) {
+  // Check for any supported provider key
+  const keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
+  if (keys.some((k) => env[k])) return env;
+
+  console.log("\n  🦪 Welcome to Oyster\n");
+  console.log("  You need an API key to power the AI engine.");
+  console.log("  Supports: Anthropic, OpenAI, Gemini, Groq, Ollama\n");
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise((resolve) => {
+    rl.question("  Enter your Anthropic API key: ", resolve);
+  });
+  rl.close();
+
+  const key = answer.trim();
+  if (!key) {
+    console.log("\n  No key provided. Set ANTHROPIC_API_KEY in your environment or ~/.oyster/.env\n");
+    process.exit(1);
+  }
+
+  // Save to ~/.oyster/.env
+  mkdirSync(OYSTER_HOME, { recursive: true });
+  const envContent = existsSync(ENV_FILE) ? readFileSync(ENV_FILE, "utf8") : "";
+  writeFileSync(ENV_FILE, envContent + `ANTHROPIC_API_KEY=${key}\n`);
+  console.log(`\n  Saved to ${ENV_FILE}\n`);
+
+  env.ANTHROPIC_API_KEY = key;
+  return env;
+}
+
+// ── Main ──
+
+async function main() {
+  const env = await ensureApiKey(getEnvVars());
+
+  // Set workspace to cwd
+  env.OYSTER_WORKSPACE = env.OYSTER_WORKSPACE || PACKAGE_ROOT;
+
+  const serverEntry = join(PACKAGE_ROOT, "server", "dist", "server", "src", "index.js");
+
+  if (!existsSync(serverEntry)) {
+    console.error("  Error: Server not built. Run `npm run build` first.");
+    process.exit(1);
+  }
+
+  console.log("\n  🦪 Starting Oyster...\n");
+
+  const child = spawn("node", [serverEntry], {
+    stdio: "inherit",
+    env,
+    cwd: PACKAGE_ROOT,
+  });
+
+  // Wait a moment then open browser
+  setTimeout(() => {
+    const url = "http://localhost:4200";
+    console.log(`\n  Open: ${url}\n`);
+    try {
+      const platform = process.platform;
+      if (platform === "darwin") execSync(`open ${url}`);
+      else if (platform === "linux") execSync(`xdg-open ${url}`);
+      else if (platform === "win32") execSync(`start ${url}`);
+    } catch {
+      // Browser open is best-effort
+    }
+  }, 3000);
+
+  // Forward signals
+  process.on("SIGINT", () => { child.kill("SIGINT"); process.exit(0); });
+  process.on("SIGTERM", () => { child.kill("SIGTERM"); process.exit(0); });
+
+  child.on("exit", (code) => process.exit(code || 0));
+}
+
+main();

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -32,7 +32,7 @@ function getEnvVars() {
 
 async function ensureApiKey(env) {
   // Check for any supported provider key
-  const keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"];
+  const keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY"];
   if (keys.some((k) => env[k])) return env;
 
   console.log("\n  🦪 Welcome to Oyster\n");
@@ -40,21 +40,32 @@ async function ensureApiKey(env) {
   console.log("  Supports: Anthropic, OpenAI, Gemini, Groq, Ollama\n");
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  const provider = await new Promise((resolve) => {
+    rl.question("  Provider [1] Anthropic  [2] OpenAI  [3] Other: ", resolve);
+  });
+
+  const providerMap = {
+    "1": { name: "ANTHROPIC_API_KEY", label: "Anthropic" },
+    "2": { name: "OPENAI_API_KEY", label: "OpenAI" },
+  };
+  const choice = providerMap[provider.trim()] || { name: "ANTHROPIC_API_KEY", label: "API" };
+
   const answer = await new Promise((resolve) => {
-    rl.question("  Enter your Anthropic API key: ", resolve);
+    rl.question(`  Enter your ${choice.label} API key: `, resolve);
   });
   rl.close();
 
   const key = answer.trim();
   if (!key) {
-    console.log("\n  No key provided. Set ANTHROPIC_API_KEY in your environment or ~/.oyster/.env\n");
+    console.log("\n  No key provided. Set your API key in ~/.oyster/.env\n");
     process.exit(1);
   }
 
   // Save to ~/.oyster/.env
   mkdirSync(OYSTER_HOME, { recursive: true });
   const envContent = existsSync(ENV_FILE) ? readFileSync(ENV_FILE, "utf8") : "";
-  writeFileSync(ENV_FILE, envContent + `ANTHROPIC_API_KEY=${key}\n`);
+  writeFileSync(ENV_FILE, envContent + `${choice.name}=${key}\n`);
   console.log(`\n  Saved to ${ENV_FILE}\n`);
 
   env.ANTHROPIC_API_KEY = key;

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -36,23 +36,11 @@ async function ensureApiKey(env) {
   if (keys.some((k) => env[k])) return env;
 
   console.log("\n  🦪 Welcome to Oyster\n");
-  console.log("  You need an API key to power the AI engine.");
-  console.log("  Supports: Anthropic, OpenAI, Gemini, Groq, Ollama\n");
+  console.log("  You need an API key to power the AI engine.\n");
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-
-  const provider = await new Promise((resolve) => {
-    rl.question("  Provider [1] Anthropic  [2] OpenAI  [3] Other: ", resolve);
-  });
-
-  const providerMap = {
-    "1": { name: "ANTHROPIC_API_KEY", label: "Anthropic" },
-    "2": { name: "OPENAI_API_KEY", label: "OpenAI" },
-  };
-  const choice = providerMap[provider.trim()] || { name: "ANTHROPIC_API_KEY", label: "API" };
-
   const answer = await new Promise((resolve) => {
-    rl.question(`  Enter your ${choice.label} API key: `, resolve);
+    rl.question("  Paste your API key: ", resolve);
   });
   rl.close();
 
@@ -62,11 +50,17 @@ async function ensureApiKey(env) {
     process.exit(1);
   }
 
+  // Detect provider from key prefix
+  let envVar = "ANTHROPIC_API_KEY";
+  if (key.startsWith("sk-ant-")) envVar = "ANTHROPIC_API_KEY";
+  else if (key.startsWith("sk-")) envVar = "OPENAI_API_KEY";
+  else if (key.startsWith("gsk_")) envVar = "GROQ_API_KEY";
+
   // Save to ~/.oyster/.env
   mkdirSync(OYSTER_HOME, { recursive: true });
   const envContent = existsSync(ENV_FILE) ? readFileSync(ENV_FILE, "utf8") : "";
-  writeFileSync(ENV_FILE, envContent + `${choice.name}=${key}\n`);
-  console.log(`\n  Saved to ${ENV_FILE}\n`);
+  writeFileSync(ENV_FILE, envContent + `${envVar}=${key}\n`);
+  console.log(`\n  Saved as ${envVar} to ${ENV_FILE}\n`);
 
   env.ANTHROPIC_API_KEY = key;
   return env;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oyster-os",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A modern workspace OS with AI at its core",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oyster-os",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A modern workspace OS with AI at its core",
   "type": "module",
   "bin": {
@@ -16,7 +16,7 @@
     "prepublishOnly": "npm run build",
     "build:web": "cd web && npx vite build",
     "build:server": "cd server && npm run build",
-    "build": "npm run build:web && npm run build:server && cp -r web/dist server/dist/public",
+    "build": "npm run build:web && npm run build:server && node -e \"const fs=require('fs');fs.cpSync('web/dist','server/dist/public',{recursive:true})\"",
     "dev": "npx concurrently -n web,server -c blue,green \"cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oyster-os",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A modern workspace OS with AI at its core",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,15 +9,14 @@
   "files": [
     "bin/",
     "server/dist/",
-    "web/dist/",
-    "shared/",
     "builtins/",
     ".opencode/"
   ],
   "scripts": {
-    "postinstall": "cd web && npm install && cd ../server && npm install",
     "prepublishOnly": "npm run build",
-    "build": "cd web && npm run build && cd ../server && npm run build",
+    "build:web": "cd web && npx vite build",
+    "build:server": "cd server && npm run build",
+    "build": "npm run build:web && npm run build:server && cp -r web/dist server/dist/public",
     "dev": "npx concurrently -n web,server -c blue,green \"cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,44 @@
 {
   "name": "oyster-os",
-  "private": true,
+  "version": "0.1.0",
+  "description": "A modern workspace OS with AI at its core",
+  "type": "module",
+  "bin": {
+    "oyster": "./bin/oyster.mjs"
+  },
+  "files": [
+    "bin/",
+    "server/dist/",
+    "web/dist/",
+    "shared/",
+    "builtins/",
+    ".opencode/"
+  ],
   "scripts": {
     "postinstall": "cd web && npm install && cd ../server && npm install",
+    "prepublishOnly": "npm run build",
+    "build": "cd web && npm run build && cd ../server && npm run build",
     "dev": "npx concurrently -n web,server -c blue,green \"cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev"
+  },
+  "keywords": ["ai", "mcp", "workspace", "os", "knowledge-management"],
+  "author": "Matthew Slight",
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mattslight/oyster.git"
+  },
+  "dependencies": {
+    "@fal-ai/client": "^1.9.4",
+    "@modelcontextprotocol/sdk": "^1.28.0",
+    "better-sqlite3": "^12.8.0",
+    "marked": "^17.0.4",
+    "opencode-ai": "^1.2.26",
+    "ws": "^8.18.0"
+  },
+  "optionalDependencies": {
+    "node-pty": "1.0.0"
   },
   "devDependencies": {
     "concurrently": "^9.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oyster-os",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A modern workspace OS with AI at its core",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oyster-os",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A modern workspace OS with AI at its core",
   "type": "module",
   "bin": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,7 +20,8 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.0",
-        "tsx": "^4.19.0"
+        "tsx": "^4.19.0",
+        "typescript": "^6.0.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2329,6 +2330,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "node --env-file=../.env node_modules/.bin/tsx watch src/index.ts",
-    "start": "node --env-file=../.env node_modules/.bin/tsx src/index.ts"
+    "start": "node --env-file=../.env node_modules/.bin/tsx src/index.ts",
+    "build": "tsc"
   },
   "dependencies": {
     "@fal-ai/client": "^1.9.4",
@@ -20,6 +21,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.0",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "typescript": "^6.0.2"
   }
 }

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -99,7 +99,7 @@ export class ArtifactService {
 
   // ── Registration ──
 
-  registerArtifact(
+  async registerArtifact(
     params: {
       path: string;
       space_id: string;
@@ -110,7 +110,7 @@ export class ArtifactService {
       source_origin?: "manual" | "discovered" | "ai_generated";
     },
     approvedRoots: string[],
-  ): Artifact {
+  ): Promise<Artifact> {
     const absPath = resolve(params.path);
 
     // Validate file exists
@@ -146,7 +146,7 @@ export class ArtifactService {
           storage_config: JSON.stringify({ path: absPath }),
           source_origin: params.source_origin ?? "manual",
         });
-        return this.rowToArtifact(this.store.getById(id)!);
+        return await this.rowToArtifact(this.store.getById(id)!);
       }
       throw new Error(`Artifact with id "${id}" already exists`);
     }
@@ -185,7 +185,7 @@ export class ArtifactService {
 
   // ── Creation ──
 
-  createArtifact(
+  async createArtifact(
     params: {
       space_id: string;
       label: string;
@@ -196,7 +196,7 @@ export class ArtifactService {
       source_origin?: "manual" | "discovered" | "ai_generated";
     },
     userlandDir: string,
-  ): Artifact {
+  ): Promise<Artifact> {
     const label = params.label.trim();
     const space_id = params.space_id.trim();
     if (!label) throw new Error("label must not be empty");
@@ -226,7 +226,7 @@ export class ArtifactService {
 
     // Register — best-effort rollback on DB failure
     try {
-      return this.registerArtifact(
+      return await this.registerArtifact(
         { path: absPath, space_id, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id, source_origin: params.source_origin },
         [userlandDir],
       );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { readFileSync, existsSync, mkdirSync, statSync, copyFileSync, readdirSync, cpSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, statSync, copyFileSync, readdirSync, cpSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { extname, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { renderMarkdown, renderMermaid } from "./renderers.js";
@@ -50,7 +51,7 @@ function findPackageRoot(): string {
     if (existsSync(join(dir, ".opencode", "agents"))) return dir;
     dir = dirname(dir);
   }
-  return process.cwd().replace(/\/server\/?$/, "");
+  return process.cwd().replace(/[\\/]server[\\/]?$/, "");
 }
 
 const PACKAGE_ROOT = findPackageRoot();
@@ -81,7 +82,7 @@ const SHELL = process.env.OYSTER_SHELL || OPENCODE_BIN;
 const SHELL_ARGS = SHELL.endsWith("opencode") ? ["."] : [];
 const WORKSPACE = process.env.OYSTER_WORKSPACE || PACKAGE_ROOT;
 const PROJECT_ROOT = PACKAGE_ROOT;
-const USERLAND_DIR = process.env.OYSTER_USERLAND || `${PROJECT_ROOT}/userland`;
+const USERLAND_DIR = process.env.OYSTER_USERLAND || join(homedir(), ".oyster", "userland");
 const ARTIFACTS_DIR = `${USERLAND_DIR}/`;
 
 // ── MIME types ──
@@ -515,13 +516,20 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     ? join(__dirname, "..", "..", "public")
     : join(PROJECT_ROOT, "web", "dist");
   if (existsSync(webDistDir)) {
-    const urlPath = (url || "/").split("?")[0];
+    const urlPath = decodeURIComponent((url || "/").split("?")[0]).replace(/^\/+/, "");
+    const resolved = join(webDistDir, urlPath);
+    // Security: prevent path traversal
+    if (!resolved.startsWith(webDistDir)) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return;
+    }
     const candidates = [
-      join(webDistDir, urlPath),
+      resolved,
       join(webDistDir, "index.html"), // SPA fallback
     ];
     for (const candidate of candidates) {
-      if (existsSync(candidate) && statSync(candidate).isFile()) {
+      if (candidate.startsWith(webDistDir) && existsSync(candidate) && statSync(candidate).isFile()) {
         const ext = extname(candidate);
         const mime = MIME[ext] || "application/octet-stream";
         res.writeHead(200, { "Content-Type": mime });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,7 +54,24 @@ function findPackageRoot(): string {
 }
 
 const PACKAGE_ROOT = findPackageRoot();
-const OPENCODE_BIN = join(PACKAGE_ROOT, "server", "node_modules", ".bin", "opencode");
+// OpenCode binary: walk up from PACKAGE_ROOT to find node_modules/.bin/opencode (handles npm hoisting)
+function findOpenCodeBin(): string {
+  const candidates = [
+    join(PACKAGE_ROOT, "server", "node_modules", ".bin", "opencode"),
+    join(PACKAGE_ROOT, "node_modules", ".bin", "opencode"),
+  ];
+  // Walk up for hoisted installs (npx, global)
+  let dir = PACKAGE_ROOT;
+  for (let i = 0; i < 5; i++) {
+    candidates.push(join(dir, "node_modules", ".bin", "opencode"));
+    dir = dirname(dir);
+  }
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return "opencode"; // fallback to PATH
+}
+const OPENCODE_BIN = findOpenCodeBin();
 const SHELL = process.env.OYSTER_SHELL || OPENCODE_BIN;
 const SHELL_ARGS = SHELL.endsWith("opencode") ? ["."] : [];
 const WORKSPACE = process.env.OYSTER_WORKSPACE || PACKAGE_ROOT;
@@ -488,7 +505,10 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   }
 
   // ── Static web UI (production mode) ──
-  const webDistDir = join(PROJECT_ROOT, "web", "dist");
+  // Check dist/public (published package) first, then web/dist (dev with build)
+  const webDistDir = existsSync(join(__dirname, "..", "..", "public"))
+    ? join(__dirname, "..", "..", "public")
+    : join(PROJECT_ROOT, "web", "dist");
   if (existsSync(webDistDir)) {
     const urlPath = (url || "/").split("?")[0];
     const candidates = [

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -56,18 +56,23 @@ function findPackageRoot(): string {
 const PACKAGE_ROOT = findPackageRoot();
 // OpenCode binary: walk up from PACKAGE_ROOT to find node_modules/.bin/opencode (handles npm hoisting)
 function findOpenCodeBin(): string {
-  const candidates = [
-    join(PACKAGE_ROOT, "server", "node_modules", ".bin", "opencode"),
-    join(PACKAGE_ROOT, "node_modules", ".bin", "opencode"),
+  const isWin = process.platform === "win32";
+  const names = isWin ? ["opencode.cmd", "opencode.ps1", "opencode"] : ["opencode"];
+  const roots = [
+    join(PACKAGE_ROOT, "server", "node_modules", ".bin"),
+    join(PACKAGE_ROOT, "node_modules", ".bin"),
   ];
   // Walk up for hoisted installs (npx, global)
   let dir = PACKAGE_ROOT;
   for (let i = 0; i < 5; i++) {
-    candidates.push(join(dir, "node_modules", ".bin", "opencode"));
+    roots.push(join(dir, "node_modules", ".bin"));
     dir = dirname(dir);
   }
-  for (const c of candidates) {
-    if (existsSync(c)) return c;
+  for (const root of roots) {
+    for (const name of names) {
+      const candidate = join(root, name);
+      if (existsSync(candidate)) return candidate;
+    }
   }
   return "opencode"; // fallback to PATH
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,11 +42,23 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 const PORT = 4200;
 const OPENCODE_PORT = 4096;
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const OPENCODE_BIN = join(__dirname, "..", "node_modules", ".bin", "opencode");
+
+// Find the package root by walking up from __dirname until we find .opencode/agents/
+function findPackageRoot(): string {
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, ".opencode", "agents"))) return dir;
+    dir = dirname(dir);
+  }
+  return process.cwd().replace(/\/server\/?$/, "");
+}
+
+const PACKAGE_ROOT = findPackageRoot();
+const OPENCODE_BIN = join(PACKAGE_ROOT, "server", "node_modules", ".bin", "opencode");
 const SHELL = process.env.OYSTER_SHELL || OPENCODE_BIN;
 const SHELL_ARGS = SHELL.endsWith("opencode") ? ["."] : [];
-const WORKSPACE = process.env.OYSTER_WORKSPACE || process.cwd();
-const PROJECT_ROOT = WORKSPACE.replace(/\/server\/?$/, "");
+const WORKSPACE = process.env.OYSTER_WORKSPACE || PACKAGE_ROOT;
+const PROJECT_ROOT = PACKAGE_ROOT;
 const USERLAND_DIR = process.env.OYSTER_USERLAND || `${PROJECT_ROOT}/userland`;
 const ARTIFACTS_DIR = `${USERLAND_DIR}/`;
 
@@ -473,6 +485,25 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     await mcpServer.connect(transport);
     await transport.handleRequest(req, res);
     return;
+  }
+
+  // ── Static web UI (production mode) ──
+  const webDistDir = join(PROJECT_ROOT, "web", "dist");
+  if (existsSync(webDistDir)) {
+    const urlPath = (url || "/").split("?")[0];
+    const candidates = [
+      join(webDistDir, urlPath),
+      join(webDistDir, "index.html"), // SPA fallback
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate) && statSync(candidate).isFile()) {
+        const ext = extname(candidate);
+        const mime = MIME[ext] || "application/octet-stream";
+        res.writeHead(200, { "Content-Type": mime });
+        res.end(readFileSync(candidate));
+        return;
+      }
+    }
   }
 
   // Fallback — JSON body so MCP SDK OAuth discovery doesn't choke on plain text

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -16,6 +16,7 @@ export function spawnOpenCodeServe(
     cwd: userlandDir,
     env: cleanEnv,
     stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
   });
 
   child.stdout?.on("data", (data: Buffer) => {

--- a/server/src/pty-manager.ts
+++ b/server/src/pty-manager.ts
@@ -1,12 +1,21 @@
 import { WebSocketServer, WebSocket } from "ws";
-import pty from "node-pty";
 import type { Server } from "node:http";
 
 const SCROLLBACK_LIMIT = 50_000; // chars to replay on reconnect
 
 let scrollback = "";
 const clients = new Set<WebSocket>();
-let proc: pty.IPty;
+let proc: any;
+let ptyAvailable = false;
+let ptyModule: any;
+
+// Dynamic import — node-pty is optional (native module, may not build on all platforms)
+try {
+  ptyModule = await import("node-pty");
+  ptyAvailable = true;
+} catch {
+  console.log("[pty] node-pty not available — terminal disabled");
+}
 
 export function spawnSession(
   shell: string,
@@ -14,8 +23,10 @@ export function spawnSession(
   cwd: string,
   env: Record<string, string>,
 ) {
+  if (!ptyAvailable) return;
+
   console.log(`Spawning ${shell} in ${cwd}`);
-  proc = pty.spawn(shell, shellArgs, {
+  proc = ptyModule.default.spawn(shell, shellArgs, {
     name: "xterm-256color",
     cols: 120,
     rows: 40,
@@ -35,7 +46,7 @@ export function spawnSession(
     }
   });
 
-  proc.onExit(({ exitCode }) => {
+  proc.onExit(({ exitCode }: { exitCode: number }) => {
     console.log(`Session exited with code ${exitCode}`);
     for (const client of clients) {
       if (client.readyState === WebSocket.OPEN) {
@@ -54,6 +65,11 @@ export function attachWebSocket(httpServer: Server) {
     console.log(`Client connected (${clients.size + 1} total)`);
     clients.add(ws);
 
+    if (!ptyAvailable) {
+      ws.send("\r\n\x1b[90m[terminal not available — node-pty not installed]\x1b[0m\r\n");
+      return;
+    }
+
     // Replay scrollback so reconnecting clients see current state
     if (scrollback.length > 0) {
       ws.send(scrollback);
@@ -61,6 +77,7 @@ export function attachWebSocket(httpServer: Server) {
 
     // Client → PTY
     ws.on("message", (msg: Buffer | string) => {
+      if (!proc) return;
       const data = typeof msg === "string" ? msg : msg.toString("utf-8");
 
       // Handle resize messages

--- a/server/src/pty-manager.ts
+++ b/server/src/pty-manager.ts
@@ -67,6 +67,7 @@ export function attachWebSocket(httpServer: Server) {
 
     if (!ptyAvailable) {
       ws.send("\r\n\x1b[90m[terminal not available — node-pty not installed]\x1b[0m\r\n");
+      ws.on("close", () => { clients.delete(ws); });
       return;
     }
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,7 +6,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "..",
+    "declaration": false
   },
-  "include": ["src"]
+  "include": ["src", "../shared"]
 }


### PR DESCRIPTION
## Summary

Oyster is now installable from npm. One command to install, one command to run.

```bash
npm install -g oyster-os
oyster
```

### What's in this PR

- **Compiled server** — tsc builds to `server/dist/`, no tsx at runtime
- **CLI entry point** (`bin/oyster.mjs`) — API key prompt, browser open, signal handling
- **Static web serving** — web assets built into `server/dist/public/`, served from port 4200
- **Package root detection** — works from compiled output, hoisted node_modules, global installs
- **Windows support** — node-pty graceful fallback, opencode.cmd detection, shell:true for spawn
- **Provider-agnostic key detection** — auto-detects Anthropic/OpenAI/Groq from key prefix
- **577KB package** — 65 files, no node_modules shipped
- **README rewrite** — full loop from install → connect AI → onboard project

### Tested on

- macOS (dev mode + tarball install)
- Windows (npm install -g from npm registry, Claude Code MCP connection, project onboarding)

### The full loop works

1. `npm install -g oyster-os` ✓
2. `oyster` → server starts, browser opens ✓
3. `claude mcp add --transport http oyster http://localhost:4200/mcp/` ✓
4. Claude Code discovers all 12 Oyster tools ✓
5. Onboard a project → artefacts appear on surface ✓

Closes #69

## Test plan

- [ ] `npm install -g oyster-os` on a clean machine
- [ ] `oyster` starts server, opens browser at localhost:4200
- [ ] Web UI loads with builtins (Zombie Horde, demo deck)
- [ ] API key prompt works on first run
- [ ] MCP server accessible at /mcp/
- [ ] Claude Code can connect and call tools
- [ ] Works on Windows (node-pty disabled gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)