### PR TITLE
feat: auto-discovery, broader scanner, multi-folder spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## 2026-04-12
 
+### Multi-folder spaces and broader scanning
+
+**Multi-folder spaces**
+- A space can now have multiple folders (repos, project dirs, any folder)
+- New `space_paths` table — migrates existing `repo_path` values automatically
+- Add Space wizard: toggle between "New space" and "Existing space"
+- Drop multiple folders onto one space
+- API: `GET/POST/DELETE /api/spaces/:id/paths`
+
+**Broader scanner**
+- Finds artifacts in Go, Rust, Python, Ruby, Java projects (not just JS frameworks)
+- Root-level projects detected (single-repo projects, not just monorepo sub-dirs)
+- Any `.md` file discovered as notes (not just root README and `docs/`)
+- More JS frameworks: Angular, Nuxt, Astro, Remix, Solid
+- Non-JS projects stored correctly (no broken package.json references)
+- Apps grouped under "Apps", all notes/diagrams under "Docs"
+- Hidden dirs and tool dirs skipped to reduce noise
+- Folder resolution searches Dropbox, OneDrive, iCloud Drive, Downloads
+
+**Auth flow**
+- Removed API key prompt — runs `opencode providers login` inline on first run
+- Uses bundled OpenCode binary, no separate install step
+
+**Renamed builtin:** `snake-game` → `zombie-horde` (game was already Zombie Horde)
+
 ### Phase B: CLI packaging — `npm install -g oyster-os`
 
 Oyster is now a published npm package. One command to install, one command to run.

--- a/README.md
+++ b/README.md
@@ -98,20 +98,12 @@ Oyster scans the folder for documents, apps, and diagrams and adds them to the s
 
 | Command | What it does |
 |---|---|
-| `/s <space>` | Switch to a space |
-| `/o <query>` | Open an artefact by name |
-| `#<space>` | Quick space switch |
-| `#<number>` | Jump to a numbered space |
-| normal chat | Ask Oyster to navigate or organise work |
-
-Examples:
-
-```
-/s blunderfixer
-/o pricing deck
-#home
-#2
-```
+| `/s <space>` | Switch to a space — `/s blunderfixer` opens that space |
+| `/o <query>` | Open an artefact by name — `/o pricing deck` finds and opens it |
+| `#<space>` | Quick space switch — `#home` goes home, `#bf` matches blunderfixer |
+| `#<number>` | Jump to a numbered space — `#1` switches to first space |
+| `#.` | Go to the home screen |
+| normal chat | Ask Oyster anything — navigate, organise, or create work |
 
 ## The full loop
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -50,6 +50,23 @@ export function initDb(userlandDir: string): Database.Database {
     try { db.exec(sql); } catch { /* already exists */ }
   }
 
+  // space_paths — a space can have multiple folders
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS space_paths (
+      space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+      path     TEXT NOT NULL,
+      label    TEXT,
+      added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (space_id, path)
+    )
+  `);
+
+  // Migrate: move existing repo_path values into space_paths
+  db.exec(`
+    INSERT OR IGNORE INTO space_paths (space_id, path)
+    SELECT id, repo_path FROM spaces WHERE repo_path IS NOT NULL
+  `);
+
   try {
     db.exec(`
       CREATE UNIQUE INDEX IF NOT EXISTS artifacts_space_source_ref_uq

--- a/server/src/discovery.ts
+++ b/server/src/discovery.ts
@@ -1,0 +1,309 @@
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const PROJECT_MARKERS = [
+  ".git", "package.json", "go.mod", "Cargo.toml",
+  "pyproject.toml", "setup.py", "requirements.txt",
+  "Gemfile", "pom.xml", "build.gradle", "Makefile",
+];
+
+export interface Candidate {
+  name: string;
+  path: string;
+  markers: string[];
+  framework?: string;
+}
+
+export interface SuggestedSpace {
+  name: string;
+  folders: string[];
+}
+
+/**
+ * Check if a dropped folder is a container of projects (like ~/Dev)
+ * vs a single project (like ~/Dev/blunderfixer).
+ */
+export function isContainer(dirPath: string): boolean {
+  let entries: string[];
+  try { entries = readdirSync(dirPath); } catch { return false; }
+
+  const hasOwnMarkers = PROJECT_MARKERS.some(m => entries.includes(m));
+  if (hasOwnMarkers) return false;
+
+  let projectCount = 0;
+  for (const entry of entries) {
+    if (entry.startsWith(".")) continue;
+    const sub = join(dirPath, entry);
+    try {
+      if (!statSync(sub).isDirectory()) continue;
+    } catch { continue; }
+    const subEntries = readdirSync(sub);
+    if (PROJECT_MARKERS.some(m => subEntries.includes(m))) {
+      projectCount++;
+    }
+  }
+
+  return projectCount >= 2;
+}
+
+/**
+ * Scan a container folder and return candidate projects.
+ */
+export function discoverCandidates(containerPath: string): Candidate[] {
+  const candidates: Candidate[] = [];
+  let entries: string[];
+  try { entries = readdirSync(containerPath); } catch { return []; }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".")) continue;
+    const sub = join(containerPath, entry);
+    try {
+      if (!statSync(sub).isDirectory()) continue;
+    } catch { continue; }
+
+    const subEntries = readdirSync(sub);
+    const markers = PROJECT_MARKERS.filter(m => subEntries.includes(m));
+    if (markers.length === 0) continue;
+
+    let framework: string | undefined;
+    if (subEntries.includes("package.json")) {
+      try {
+        const pkg = JSON.parse(readFileSync(join(sub, "package.json"), "utf8"));
+        const deps = Object.keys({ ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) });
+        const frameworks = ["react", "vue", "next", "vite", "svelte", "angular", "nuxt", "astro"];
+        framework = frameworks.find(f => deps.some(d => d.includes(f)));
+      } catch {}
+    } else if (markers.includes("go.mod")) {
+      framework = "go";
+    } else if (markers.includes("Cargo.toml")) {
+      framework = "rust";
+    } else if (markers.includes("pyproject.toml") || markers.includes("setup.py")) {
+      framework = "python";
+    } else if (markers.includes("Gemfile")) {
+      framework = "ruby";
+    } else if (markers.includes("pom.xml") || markers.includes("build.gradle")) {
+      framework = "java";
+    }
+
+    candidates.push({ name: entry, path: sub, markers, framework });
+  }
+
+  return candidates;
+}
+
+// ── LLM provider abstraction ──
+
+interface AuthConfig {
+  provider: string;
+  key: string;
+}
+
+// Provider → { baseUrl, model } for OpenAI-compatible APIs
+const OPENAI_COMPAT: Record<string, { baseUrl: string; model: string }> = {
+  openai:     { baseUrl: "https://api.openai.com/v1",               model: "gpt-4o-mini" },
+  perplexity: { baseUrl: "https://api.perplexity.ai",               model: "sonar" },
+  openrouter: { baseUrl: "https://openrouter.ai/api/v1",            model: "anthropic/claude-haiku-4-5-20251001" },
+  groq:       { baseUrl: "https://api.groq.com/openai/v1",          model: "llama-3.3-70b-versatile" },
+  copilot:    { baseUrl: "https://api.githubcopilot.com",            model: "gpt-4o-mini" },
+  together:   { baseUrl: "https://api.together.xyz/v1",              model: "meta-llama/Llama-3.3-70B-Instruct-Turbo" },
+};
+
+function readAuth(): AuthConfig | null {
+  const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
+
+  if (existsSync(authPath)) {
+    try {
+      const auth = JSON.parse(readFileSync(authPath, "utf8"));
+      // Check all providers in auth.json — use the first one with a key
+      for (const [provider, creds] of Object.entries(auth)) {
+        const c = creds as Record<string, string>;
+        const key = c.key ?? c.access;
+        if (key) return { provider, key };
+      }
+    } catch {}
+  }
+
+  // Fall back to env vars
+  if (process.env.ANTHROPIC_API_KEY) return { provider: "anthropic", key: process.env.ANTHROPIC_API_KEY };
+  if (process.env.OPENAI_API_KEY) return { provider: "openai", key: process.env.OPENAI_API_KEY };
+  if (process.env.GEMINI_API_KEY) return { provider: "google", key: process.env.GEMINI_API_KEY };
+  if (process.env.PERPLEXITY_API_KEY) return { provider: "perplexity", key: process.env.PERPLEXITY_API_KEY };
+  if (process.env.GROQ_API_KEY) return { provider: "groq", key: process.env.GROQ_API_KEY };
+
+  return null;
+}
+
+async function callLLM(auth: AuthConfig, prompt: string): Promise<string | null> {
+  try {
+    // Anthropic has a different API format
+    if (auth.provider === "anthropic") {
+      const res = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": auth.key,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: "claude-haiku-4-5-20251001",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: prompt }],
+        }),
+      });
+      if (!res.ok) return null;
+      const data = await res.json() as { content: Array<{ text: string }> };
+      return data.content[0]?.text ?? null;
+    }
+
+    // Google has its own format
+    if (auth.provider === "google") {
+      const res = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${auth.key}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+          }),
+        },
+      );
+      if (!res.ok) return null;
+      const data = await res.json() as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> };
+      return data.candidates?.[0]?.content?.parts?.[0]?.text ?? null;
+    }
+
+    // Everything else: OpenAI-compatible (OpenAI, Perplexity, Groq, OpenRouter, etc.)
+    const compat = OPENAI_COMPAT[auth.provider];
+    if (!compat) return null; // handled by callViaOpenCode fallback
+    const res = await fetch(`${compat.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${auth.key}`,
+      },
+      body: JSON.stringify({
+        model: compat.model,
+        max_tokens: 1024,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { choices: Array<{ message: { content: string } }> };
+    return data.choices[0]?.message?.content ?? null;
+
+  } catch (err) {
+    console.log(`[discovery] LLM call error: ${err}`);
+  }
+
+  return null;
+}
+
+/**
+ * Fallback: send prompt through the running OpenCode instance.
+ * Works with any provider the user authenticated with.
+ */
+async function callViaOpenCode(prompt: string, port = 4096): Promise<string | null> {
+  try {
+    // Create a throwaway session
+    const sessionRes = await fetch(`http://127.0.0.1:${port}/session`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    if (!sessionRes.ok) return null;
+    const session = await sessionRes.json() as { id: string };
+
+    // Send the message
+    const msgRes = await fetch(`http://127.0.0.1:${port}/session/${session.id}/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ parts: [{ type: "text", text: prompt }] }),
+    });
+    if (!msgRes.ok) return null;
+    const msg = await msgRes.json() as { parts: Array<{ type: string; text?: string }> };
+
+    // Extract text from response parts
+    return msg.parts?.filter(p => p.type === "text").map(p => p.text).join("") ?? null;
+  } catch (err) {
+    console.log(`[discovery] OpenCode fallback error: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * Call LLM to group candidates into suggested spaces.
+ * Uses whatever provider the user authenticated with via OpenCode.
+ */
+export async function groupWithLLM(candidates: Candidate[]): Promise<SuggestedSpace[]> {
+  const auth = readAuth();
+  if (!auth) {
+    console.log("[discovery] No auth found, using fallback grouping");
+    return fallbackGrouping(candidates);
+  }
+
+  console.log(`[discovery] Using ${auth.provider} for grouping`);
+
+  const candidateList = candidates.map(c => {
+    let desc = c.name;
+    if (c.framework) desc += ` (${c.framework})`;
+    return desc;
+  });
+
+  const prompt = `You are organising a developer's workspace. Given these project folder names found in their dev directory, group them into logical workspaces/spaces.
+
+Project folders:
+${candidateList.map(c => `- ${c}`).join("\n")}
+
+Rules:
+- Related repos (same product/project) should be grouped into one space
+- Look for naming patterns: shared prefixes, suffixes like -api, -web, -portal, -docs
+- Standalone projects get their own space
+- Use clean, lowercase names for spaces (e.g. "tokinvest" not "tokinvest-drc" or "Tokinvest")
+- Every folder must appear in exactly one space
+
+Return ONLY valid JSON, no markdown, no explanation:
+[{"name": "Space Name", "folders": ["folder1", "folder2"]}, ...]`;
+
+  let text = await callLLM(auth, prompt);
+
+  // If direct API call failed, try via OpenCode (handles any provider)
+  if (!text) {
+    console.log("[discovery] Direct LLM call failed, trying via OpenCode");
+    text = await callViaOpenCode(prompt);
+  }
+
+  if (!text) {
+    console.log("[discovery] All LLM attempts failed, using fallback");
+    return fallbackGrouping(candidates);
+  }
+
+  try {
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) return fallbackGrouping(candidates);
+
+    const groups = JSON.parse(jsonMatch[0]) as SuggestedSpace[];
+
+    // Map folder names back to full paths
+    return groups.map(g => ({
+      name: g.name,
+      folders: g.folders.map(f => {
+        const candidate = candidates.find(c => c.name === f);
+        return candidate?.path ?? f;
+      }),
+    }));
+  } catch {
+    console.log("[discovery] Failed to parse LLM response, using fallback");
+    return fallbackGrouping(candidates);
+  }
+}
+
+/**
+ * Simple fallback: each candidate becomes its own space.
+ */
+function fallbackGrouping(candidates: Candidate[]): SuggestedSpace[] {
+  return candidates.map(c => ({
+    name: c.name.replace(/[-_]/g, " "),
+    folders: [c.path],
+  }));
+}

--- a/server/src/discovery.ts
+++ b/server/src/discovery.ts
@@ -258,9 +258,11 @@ ${candidateList.map(c => `- ${c}`).join("\n")}
 Rules:
 - Related repos (same product/project) should be grouped into one space
 - Look for naming patterns: shared prefixes, suffixes like -api, -web, -portal, -docs
-- Standalone projects get their own space
+- Standalone projects that look like real products/apps get their own space
+- Small utilities, configs, forks, or miscellaneous repos should go in a catch-all space called "other"
 - Use clean, lowercase names for spaces (e.g. "tokinvest" not "tokinvest-drc" or "Tokinvest")
 - Every folder must appear in exactly one space
+- Aim for fewer spaces rather than more — group aggressively
 
 Return ONLY valid JSON, no markdown, no explanation:
 [{"name": "Space Name", "folders": ["folder1", "folder2"]}, ...]`;

--- a/server/src/discovery.ts
+++ b/server/src/discovery.ts
@@ -13,6 +13,7 @@ export interface Candidate {
   path: string;
   markers: string[];
   framework?: string;
+  subProjects?: string[];
 }
 
 export interface SuggestedSpace {
@@ -86,7 +87,39 @@ export function discoverCandidates(containerPath: string): Candidate[] {
       framework = "java";
     }
 
-    candidates.push({ name: entry, path: sub, markers, framework });
+    // Detect monorepo — sub-dirs (depth 1-2) with their own project markers
+    const subProjects: string[] = [];
+    const WORKSPACE_DIRS = new Set(["apps", "packages", "services", "libs", "modules", "tools"]);
+    for (const subEntry of subEntries) {
+      if (subEntry.startsWith(".") || subEntry === "node_modules" || subEntry === "dist" || subEntry === "build") continue;
+      const subSub = join(sub, subEntry);
+      try {
+        if (!statSync(subSub).isDirectory()) continue;
+        const subSubEntries = readdirSync(subSub);
+        if (PROJECT_MARKERS.some(m => subSubEntries.includes(m))) {
+          subProjects.push(subEntry);
+        }
+        // Check one level deeper for workspace patterns (apps/web, packages/shared)
+        if (WORKSPACE_DIRS.has(subEntry)) {
+          for (const nested of subSubEntries) {
+            const nestedPath = join(subSub, nested);
+            try {
+              if (!statSync(nestedPath).isDirectory()) continue;
+              const nestedEntries = readdirSync(nestedPath);
+              if (PROJECT_MARKERS.some(m => nestedEntries.includes(m))) {
+                subProjects.push(`${subEntry}/${nested}`);
+              }
+            } catch { continue; }
+          }
+        }
+      } catch { continue; }
+    }
+
+    // Also flag pnpm/yarn/lerna workspaces as monorepos even if sub-project scan missed them
+    const isWorkspace = subEntries.includes("pnpm-workspace.yaml") || subEntries.includes("lerna.json");
+    const hasSubProjects = subProjects.length > 0 || isWorkspace;
+
+    candidates.push({ name: entry, path: sub, markers, framework, subProjects: hasSubProjects ? (subProjects.length > 0 ? subProjects : ["(workspace)"]) : undefined });
   }
 
   return candidates;
@@ -247,10 +280,11 @@ export async function groupWithLLM(candidates: Candidate[]): Promise<SuggestedSp
   const candidateList = candidates.map(c => {
     let desc = c.name;
     if (c.framework) desc += ` (${c.framework})`;
+    if (c.subProjects?.length) desc += ` [monorepo: ${c.subProjects.join(", ")}]`;
     return desc;
   });
 
-  const prompt = `You are organising a developer's workspace. Given these project folder names found in their dev directory, group them into logical workspaces/spaces.
+  const prompt = `You are organising a developer's workspace. Given these project folders found in their dev directory, group them into logical spaces.
 
 Project folders:
 ${candidateList.map(c => `- ${c}`).join("\n")}
@@ -258,11 +292,11 @@ ${candidateList.map(c => `- ${c}`).join("\n")}
 Rules:
 - Related repos (same product/project) should be grouped into one space
 - Look for naming patterns: shared prefixes, suffixes like -api, -web, -portal, -docs
-- Standalone projects that look like real products/apps get their own space
-- Small utilities, configs, forks, or miscellaneous repos should go in a catch-all space called "other"
-- Use clean, lowercase names for spaces (e.g. "tokinvest" not "tokinvest-drc" or "Tokinvest")
+- Monorepos (marked with [monorepo:]) are already self-contained — they should get their own space, not go in "other"
+- Projects that look like real products or apps should get their own space
+- Only put genuinely miscellaneous things (tiny configs, forks, one-off scripts) in "other"
+- Use clean, lowercase names for spaces (e.g. "tokinvest" not "tokinvest-drc")
 - Every folder must appear in exactly one space
-- Aim for fewer spaces rather than more — group aggressively
 
 Return ONLY valid JSON, no markdown, no explanation:
 [{"name": "Space Name", "folders": ["folder1", "folder2"]}, ...]`;

--- a/server/src/pty-manager.ts
+++ b/server/src/pty-manager.ts
@@ -26,7 +26,8 @@ export function spawnSession(
   if (!ptyAvailable) return;
 
   console.log(`Spawning ${shell} in ${cwd}`);
-  proc = ptyModule.default.spawn(shell, shellArgs, {
+  const pty = ptyModule.default ?? ptyModule;
+  proc = pty.spawn(shell, shellArgs, {
     name: "xterm-256color",
     cols: 120,
     rows: 40,

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -56,30 +56,48 @@ export class SpaceService {
     if (!id) throw new Error("name must contain at least one alphanumeric character");
     if (this.spaceStore.getById(id)) throw new Error(`Space "${id}" already exists`);
 
-    let repoPath: string | null = null;
-    if (params.repoPath) {
-      const raw = params.repoPath.startsWith("~/")
-        ? join(process.env.HOME ?? "", params.repoPath.slice(2))
-        : params.repoPath;
-      repoPath = resolve(raw);
-      // Note: resolve() does not follow symlinks. Two symlinked paths to the
-      // same repo will produce different normalised strings and bypass this check.
-      // This is a known limitation — document it; Phase 4 can add fs.realpath().
-
-      // Friendly duplicate check before hitting the UNIQUE constraint
-      const existing = this.spaceStore.getByRepoPath(repoPath);
-      if (existing) {
-        throw new Error(`Repo path is already attached to space "${existing.id}"`);
-      }
-    }
-
     const color = SPACE_PALETTE[hashStr(id) % SPACE_PALETTE.length];
     this.spaceStore.insert({
-      id, display_name: displayName, repo_path: repoPath, color, parent_id: null,
+      id, display_name: displayName, repo_path: null, color, parent_id: null,
       scan_status: "none", scan_error: null, last_scanned_at: null,
       last_scan_summary: null, ai_job_status: null, ai_job_error: null,
     });
+
+    // If a path was provided, add it to space_paths
+    if (params.repoPath) {
+      this.addPath(id, params.repoPath);
+    }
+
     return rowToSpace(this.spaceStore.getById(id)!);
+  }
+
+  addPath(spaceId: string, rawPath: string): string {
+    const row = this.spaceStore.getById(spaceId);
+    if (!row) throw new Error(`Space "${spaceId}" not found`);
+
+    const resolved = rawPath.startsWith("~/")
+      ? resolve(join(process.env.HOME ?? "", rawPath.slice(2)))
+      : resolve(rawPath);
+
+    if (!existsSync(resolved)) throw new Error(`Path does not exist: ${resolved}`);
+    if (!statSync(resolved).isDirectory()) throw new Error(`Path is not a directory: ${resolved}`);
+
+    // Check if this path is already attached to another space
+    const existing = this.spaceStore.getSpaceByPath(resolved);
+    if (existing && existing.id !== spaceId) {
+      throw new Error(`Path is already attached to space "${existing.display_name}"`);
+    }
+
+    this.spaceStore.addPath(spaceId, resolved);
+    return resolved;
+  }
+
+  removePath(spaceId: string, path: string): void {
+    this.spaceStore.removePath(spaceId, path);
+  }
+
+  getPaths(spaceId: string): string[] {
+    return this.spaceStore.getPaths(spaceId).map(p => p.path);
   }
 
   listSpaces(): Space[] { return this.spaceStore.getAll().map(rowToSpace); }
@@ -95,10 +113,12 @@ export class SpaceService {
   async scanSpace(spaceId: string): Promise<ScanResult> {
     const row = this.spaceStore.getById(spaceId);
     if (!row) throw new Error(`Space "${spaceId}" not found`);
-    if (!row.repo_path) throw new Error(`Space "${spaceId}" has no repo_path`);
-    const repoPath = row.repo_path;
-    if (!existsSync(repoPath)) throw new Error(`repo_path does not exist: ${repoPath}`);
-    if (!statSync(repoPath).isDirectory()) throw new Error(`repo_path is not a directory: ${repoPath}`);
+
+    const paths = this.spaceStore.getPaths(spaceId).map(p => p.path);
+    // Fall back to legacy repo_path if no space_paths yet
+    if (paths.length === 0 && row.repo_path) paths.push(row.repo_path);
+    if (paths.length === 0) throw new Error(`Space "${spaceId}" has no folders`);
+
     if (this.scanning.has(spaceId)) throw new Error(`Scan already in progress for space "${spaceId}"`);
 
     this.scanning.add(spaceId);
@@ -106,8 +126,14 @@ export class SpaceService {
 
     const result: ScanResult = { discovered: 0, skipped: 0, resurfaced: 0, errors: [], artifacts: [] };
     try {
-      const candidates = this.walk(repoPath);
-      for (const c of candidates) this.upsertCandidate(spaceId, c, result);
+      for (const folderPath of paths) {
+        if (!existsSync(folderPath) || !statSync(folderPath).isDirectory()) {
+          result.errors.push(`Skipped missing folder: ${folderPath}`);
+          continue;
+        }
+        const candidates = this.walk(folderPath);
+        for (const c of candidates) this.upsertCandidate(spaceId, c, result);
+      }
       this.spaceStore.update(spaceId, {
         scan_status: "complete",
         last_scanned_at: new Date().toISOString(),

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -162,8 +162,9 @@ export class SpaceService {
     const relDir = relative(root, dir);
     const posixRelDir = relDir.replace(/\\/g, "/");
 
-    // Directory-level app detection (depth > 0 only — skip root itself)
-    if (depth > 0 && entries.includes("package.json")) {
+    // Directory-level app detection — including root (the project itself can be an app)
+    let isAppDir = false;
+    if (entries.includes("package.json")) {
       try {
         const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
         const scripts = pkg.scripts ?? {};
@@ -172,16 +173,20 @@ export class SpaceService {
         const deps = Object.keys({ ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) });
         const hasFramework = APP_DEP_KEYWORDS.some((kw) => deps.some((d) => d.includes(kw)));
         if (hasDev && (APP_DIR_NAMES.has(dirName) || hasFramework)) {
-          results.push({ absPath: dir, sourceRef: `${posixRelDir}/:app`, kind: "app" });
+          const ref = posixRelDir ? `${posixRelDir}/:app` : ":app";
+          results.push({ absPath: dir, sourceRef: ref, kind: "app" });
+          isAppDir = true;
         }
       } catch { /* malformed package.json */ }
     }
 
-    // Non-JS project detection (depth > 0)
-    if (depth > 0) {
+    // Non-JS project detection — including root
+    if (!isAppDir && !entries.includes("package.json")) {
       for (const marker of PROJECT_MARKERS) {
         if (entries.includes(marker)) {
-          results.push({ absPath: dir, sourceRef: `${posixRelDir}/:app`, kind: "app" });
+          const ref = posixRelDir ? `${posixRelDir}/:app` : ":app";
+          results.push({ absPath: dir, sourceRef: ref, kind: "app" });
+          isAppDir = true;
           break;
         }
       }
@@ -200,7 +205,7 @@ export class SpaceService {
 
       const posixRelFile = (posixRelDir ? posixRelDir + "/" : "") + entry;
 
-      // Markdown files — any .md anywhere
+      // Markdown files
       if (entry.endsWith(".md")) {
         results.push({ absPath, sourceRef: `${posixRelFile}:notes`, kind: "notes" });
       // Diagrams — mermaid files
@@ -214,15 +219,9 @@ export class SpaceService {
     return results;
   }
 
-  private deriveGroup(sourceRef: string, kind: "app" | "notes" | "diagram"): string | null {
+  private deriveGroup(_sourceRef: string, kind: "app" | "notes" | "diagram"): string | null {
     if (kind === "app") return "Apps";
-    const pathPart = sourceRef.split(":")[0];
-    const parts = pathPart.split("/").filter(Boolean);
-    // Root-level files (README.md, CHANGELOG.md) — no group
-    if (parts.length <= 1) return null;
-    // Use the top-level directory as the group, capitalised
-    const topDir = parts[0];
-    return topDir.charAt(0).toUpperCase() + topDir.slice(1);
+    return "Docs";
   }
 
   private upsertCandidate(
@@ -247,7 +246,8 @@ export class SpaceService {
     // Derive label from path stem
     const pathPart = sourceRef.split(":")[0];
     const stem = pathPart.replace(/\/$/, "").split("/").pop() ?? pathPart;
-    const label = stem.replace(/\.[^.]+$/, "");
+    // For root-level artifacts (sourceRef = ":app"), use the folder name
+    const label = stem ? stem.replace(/\.[^.]+$/, "") : absPath.split(sep).pop() ?? "project";
 
     let runtimeKind = "static_file";
     let storageConfig: Record<string, unknown> = { path: absPath };

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -211,9 +211,9 @@ export class SpaceService {
       // Diagrams — mermaid files
       } else if (entry.endsWith(".mmd") || entry.endsWith(".mermaid")) {
         results.push({ absPath, sourceRef: `${posixRelFile}:diagram`, kind: "diagram" });
-      // Standalone HTML files in src/ or root — potential apps/pages
+      // Standalone HTML files in non-root directories without package.json
       } else if (entry === "index.html" && depth > 0 && !entries.includes("package.json")) {
-        results.push({ absPath, sourceRef: `${posixRelFile}:app`, kind: "app" });
+        results.push({ absPath: dir, sourceRef: `${posixRelFile}:app`, kind: "app" });
       }
     }
     return results;
@@ -254,22 +254,26 @@ export class SpaceService {
     let runtimeConfig: Record<string, unknown> = {};
 
     if (kind === "app") {
-      // Always point storage at package.json (a real file), not the directory itself.
-      // Detection guarantees scripts.dev || scripts.start exists — use whichever is present.
       const pkgPath = join(absPath, "package.json");
-      storageConfig = { path: pkgPath };
-      try {
-        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
-        const startCmd = pkg.scripts?.dev
-          ? "npm run dev"
-          : pkg.scripts?.start
-          ? "npm start"
-          : null;
-        if (startCmd) {
-          runtimeKind = "local_process";
-          runtimeConfig = { command: startCmd, cwd: absPath };
-        }
-      } catch { /* package.json unreadable — stay static_file, path already set */ }
+      if (existsSync(pkgPath)) {
+        // JS/TS project — use package.json for runtime config
+        storageConfig = { path: pkgPath };
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+          const startCmd = pkg.scripts?.dev
+            ? "npm run dev"
+            : pkg.scripts?.start
+            ? "npm start"
+            : null;
+          if (startCmd) {
+            runtimeKind = "local_process";
+            runtimeConfig = { command: startCmd, cwd: absPath };
+          }
+        } catch { /* package.json unreadable — stay static_file */ }
+      } else {
+        // Non-JS project (Go, Rust, Python, etc.) or standalone HTML
+        storageConfig = { path: absPath };
+      }
     }
 
     const group_name = this.deriveGroup(sourceRef, kind);

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, relative, sep } from "node:path";
+import { homedir } from "node:os";
 import crypto from "node:crypto";
 import type { SpaceStore, SpaceRow } from "./space-store.js";
 import type { ArtifactStore } from "./artifact-store.js";
@@ -76,7 +77,7 @@ export class SpaceService {
     if (!row) throw new Error(`Space "${spaceId}" not found`);
 
     const resolved = rawPath.startsWith("~/")
-      ? resolve(join(process.env.HOME ?? "", rawPath.slice(2)))
+      ? resolve(join(homedir(), rawPath.slice(2)))
       : resolve(rawPath);
 
     if (!existsSync(resolved)) throw new Error(`Path does not exist: ${resolved}`);
@@ -131,8 +132,13 @@ export class SpaceService {
           result.errors.push(`Skipped missing folder: ${folderPath}`);
           continue;
         }
+        const folderSlug = folderPath.split(sep).pop() ?? folderPath;
         const candidates = this.walk(folderPath);
-        for (const c of candidates) this.upsertCandidate(spaceId, c, result);
+        for (const c of candidates) {
+          // Namespace sourceRef with folder name to avoid collisions across multiple paths
+          c.sourceRef = `${folderSlug}/${c.sourceRef}`;
+          this.upsertCandidate(spaceId, c, result);
+        }
       }
       this.spaceStore.update(spaceId, {
         scan_status: "complete",
@@ -271,8 +277,11 @@ export class SpaceService {
           }
         } catch { /* package.json unreadable — stay static_file */ }
       } else {
-        // Non-JS project (Go, Rust, Python, etc.) or standalone HTML
-        storageConfig = { path: absPath };
+        // Non-JS project or standalone HTML — point at a real file, not the directory
+        const candidateFiles = ["index.html", "go.mod", "Cargo.toml", "pyproject.toml",
+          "setup.py", "requirements.txt", "Gemfile", "pom.xml", "build.gradle", "Makefile"];
+        const storagePath = candidateFiles.map(f => join(absPath, f)).find(f => existsSync(f)) ?? absPath;
+        storageConfig = { path: storagePath };
       }
     }
 

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -34,11 +34,12 @@ function rowToSpace(row: SpaceRow): Space {
   };
 }
 
-const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", "out", "coverage", ".cache"]);
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next", "out", "coverage", ".cache", ".claude", ".opencode", ".vscode", ".idea", "__pycache__", ".tox", "venv", ".venv", "target", "vendor"]);
 const SKIP_FILE_PATTERNS = [/\.lock$/, /\.log$/];
 const MAX_DEPTH = 4;
-const APP_DIR_NAMES = new Set(["web", "admin", "app", "client", "frontend"]);
-const APP_DEP_KEYWORDS = ["react", "vue", "next", "vite", "svelte"];
+const APP_DIR_NAMES = new Set(["web", "admin", "app", "client", "frontend", "ui", "dashboard", "portal", "site"]);
+const APP_DEP_KEYWORDS = ["react", "vue", "next", "vite", "svelte", "angular", "nuxt", "astro", "remix", "solid"];
+const PROJECT_MARKERS = ["go.mod", "Cargo.toml", "pyproject.toml", "setup.py", "requirements.txt", "Gemfile", "pom.xml", "build.gradle"];
 
 export class SpaceService {
   private scanning = new Set<string>();
@@ -150,27 +151,38 @@ export class SpaceService {
       } catch { /* malformed package.json */ }
     }
 
+    // Non-JS project detection (depth > 0)
+    if (depth > 0) {
+      for (const marker of PROJECT_MARKERS) {
+        if (entries.includes(marker)) {
+          results.push({ absPath: dir, sourceRef: `${posixRelDir}/:app`, kind: "app" });
+          break;
+        }
+      }
+    }
+
     for (const entry of entries) {
       const absPath = join(dir, entry);
       let stat: ReturnType<typeof statSync>;
       try { stat = statSync(absPath); } catch { continue; }
 
       if (stat.isDirectory()) {
-        if (!SKIP_DIRS.has(entry)) results.push(...this.walk(absPath, depth + 1, root));
+        if (!SKIP_DIRS.has(entry) && !entry.startsWith(".")) results.push(...this.walk(absPath, depth + 1, root));
         continue;
       }
       if (SKIP_FILE_PATTERNS.some((p) => p.test(entry))) continue;
 
       const posixRelFile = (posixRelDir ? posixRelDir + "/" : "") + entry;
 
-      if (depth === 0 && entry === "README.md") {
-        results.push({ absPath, sourceRef: "README.md:notes", kind: "notes" });
-      } else if (depth === 0 && entry === "CHANGELOG.md") {
-        results.push({ absPath, sourceRef: "CHANGELOG.md:notes", kind: "notes" });
-      } else if (posixRelDir.startsWith("docs") && entry.endsWith(".md")) {
+      // Markdown files — any .md anywhere
+      if (entry.endsWith(".md")) {
         results.push({ absPath, sourceRef: `${posixRelFile}:notes`, kind: "notes" });
+      // Diagrams — mermaid files
       } else if (entry.endsWith(".mmd") || entry.endsWith(".mermaid")) {
         results.push({ absPath, sourceRef: `${posixRelFile}:diagram`, kind: "diagram" });
+      // Standalone HTML files in src/ or root — potential apps/pages
+      } else if (entry === "index.html" && depth > 0 && !entries.includes("package.json")) {
+        results.push({ absPath, sourceRef: `${posixRelFile}:app`, kind: "app" });
       }
     }
     return results;

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -16,6 +16,13 @@ export interface SpaceRow {
   updated_at: string;
 }
 
+export interface SpacePath {
+  space_id: string;
+  path: string;
+  label: string | null;
+  added_at: string;
+}
+
 export interface SpaceStore {
   getAll(): SpaceRow[];
   getById(id: string): SpaceRow | undefined;
@@ -23,6 +30,10 @@ export interface SpaceStore {
   insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void;
   update(id: string, fields: Partial<Omit<SpaceRow, "id" | "created_at">>): void;
   delete(id: string): void;
+  getPaths(spaceId: string): SpacePath[];
+  addPath(spaceId: string, path: string, label?: string): void;
+  removePath(spaceId: string, path: string): void;
+  getSpaceByPath(path: string): SpaceRow | undefined;
 }
 
 export class SqliteSpaceStore implements SpaceStore {
@@ -31,6 +42,10 @@ export class SqliteSpaceStore implements SpaceStore {
     getById: Database.Statement;
     getByRepoPath: Database.Statement;
     insert: Database.Statement;
+    getPaths: Database.Statement;
+    addPath: Database.Statement;
+    removePath: Database.Statement;
+    getSpaceByPath: Database.Statement;
   };
 
   constructor(private db: Database.Database) {
@@ -49,6 +64,10 @@ export class SqliteSpaceStore implements SpaceStore {
           @ai_job_status, @ai_job_error
         )
       `),
+      getPaths: db.prepare("SELECT * FROM space_paths WHERE space_id = ? ORDER BY added_at"),
+      addPath: db.prepare("INSERT OR IGNORE INTO space_paths (space_id, path, label) VALUES (?, ?, ?)"),
+      removePath: db.prepare("DELETE FROM space_paths WHERE space_id = ? AND path = ?"),
+      getSpaceByPath: db.prepare("SELECT s.* FROM spaces s JOIN space_paths sp ON s.id = sp.space_id WHERE sp.path = ?"),
     };
   }
 
@@ -56,7 +75,14 @@ export class SqliteSpaceStore implements SpaceStore {
   getById(id: string): SpaceRow | undefined { return this.stmts.getById.get(id) as SpaceRow | undefined; }
   getByRepoPath(repoPath: string): SpaceRow | undefined { return this.stmts.getByRepoPath.get(repoPath) as SpaceRow | undefined; }
   insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void { this.stmts.insert.run(row); }
-  delete(id: string): void { this.db.prepare("DELETE FROM spaces WHERE id = ?").run(id); }
+  delete(id: string): void {
+    this.db.prepare("DELETE FROM space_paths WHERE space_id = ?").run(id);
+    this.db.prepare("DELETE FROM spaces WHERE id = ?").run(id);
+  }
+  getPaths(spaceId: string): SpacePath[] { return this.stmts.getPaths.all(spaceId) as SpacePath[]; }
+  addPath(spaceId: string, path: string, label?: string): void { this.stmts.addPath.run(spaceId, path, label ?? null); }
+  removePath(spaceId: string, path: string): void { this.stmts.removePath.run(spaceId, path); }
+  getSpaceByPath(path: string): SpaceRow | undefined { return this.stmts.getSpaceByPath.get(path) as SpaceRow | undefined; }
 
   private static readonly UPDATABLE_COLUMNS = new Set([
     "display_name", "repo_path", "color", "parent_id", "scan_status",

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -184,6 +184,12 @@ export async function handleSpacesRequest(
 
   // POST /api/discover — scan a folder, detect if container, return candidates + suggestions
   if (url === "/api/discover" && req.method === "POST") {
+    const discoverOrigin = req.headers.origin;
+    if (discoverOrigin && !discoverOrigin.startsWith("http://localhost") && !discoverOrigin.startsWith("http://127.0.0.1")) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return true;
+    }
     let body = "";
     req.on("data", (chunk: Buffer | string) => (body += chunk));
     req.on("end", () => {

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -1,4 +1,5 @@
 import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { SpaceService } from "./space-service.js";
 
@@ -28,7 +29,12 @@ export async function handleSpacesRequest(
       res.end(JSON.stringify({ error: "name is required" }));
       return true;
     }
-    const home = process.env.HOME ?? "";
+    const home = process.env.HOME || homedir();
+    if (!home) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Cannot determine home directory" }));
+      return true;
+    }
     const searchRoots = [
       // Home
       home,

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -108,6 +108,58 @@ export async function handleSpacesRequest(
     return true;
   }
 
+  // GET /api/spaces/:id/paths — list folders for a space
+  const spacePathsMatch = url.match(/^\/api\/spaces\/([^/]+)\/paths$/);
+  if (spacePathsMatch && req.method === "GET") {
+    try {
+      const paths = spaceService.getPaths(spacePathsMatch[1]);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ paths }));
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: (err as Error).message }));
+    }
+    return true;
+  }
+
+  // POST /api/spaces/:id/paths — add a folder to a space
+  if (spacePathsMatch && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => (body += chunk));
+    req.on("end", () => {
+      try {
+        const { path } = JSON.parse(body);
+        if (!path) throw new Error("path is required");
+        const resolved = spaceService.addPath(spacePathsMatch[1], path);
+        res.writeHead(201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ path: resolved }));
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return true;
+  }
+
+  // DELETE /api/spaces/:id/paths — remove a folder from a space
+  if (spacePathsMatch && req.method === "DELETE") {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => (body += chunk));
+    req.on("end", () => {
+      try {
+        const { path } = JSON.parse(body);
+        if (!path) throw new Error("path is required");
+        spaceService.removePath(spacePathsMatch[1], path);
+        res.writeHead(204);
+        res.end();
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return true;
+  }
+
   // POST /api/spaces/:id/scan
   const spaceScanMatch = url.match(/^\/api\/spaces\/([^/]+)\/scan$/);
   if (spaceScanMatch && req.method === "POST") {

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -237,28 +237,40 @@ export async function handleSpacesRequest(
         const results: Array<{ spaceId: string; name: string; scanned: number }> = [];
 
         for (const s of spaceList) {
-          // Create or find existing space
-          let space;
-          try {
-            space = spaceService.createSpace({ name: s.name });
-          } catch {
-            // Space might already exist
-            space = spaceService.getSpace(s.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""));
-            if (!space) throw new Error(`Could not create or find space "${s.name}"`);
-          }
+          // "__home__" = import without a space, scan into home
+          const isHome = s.name === "__home__";
+          let spaceId = "home";
 
-          // Add folders
-          for (const folder of s.folders) {
+          if (!isHome) {
+            let space;
             try {
-              spaceService.addPath(space.id, folder);
-            } catch { /* path might already be added */ }
+              space = spaceService.createSpace({ name: s.name });
+            } catch {
+              space = spaceService.getSpace(s.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""));
+              if (!space) throw new Error(`Could not create or find space "${s.name}"`);
+            }
+            spaceId = space.id;
+
+            for (const folder of s.folders) {
+              try {
+                spaceService.addPath(spaceId, folder);
+              } catch { /* path might already be added */ }
+            }
           }
 
-          // Scan
-          const scanResult = await spaceService.scanSpace(space.id);
+          // Scan — for home, add paths temporarily then scan
+          if (isHome) {
+            // Ensure home space exists
+            try { spaceService.createSpace({ name: "home" }); } catch {}
+            for (const folder of s.folders) {
+              try { spaceService.addPath("home", folder); } catch {}
+            }
+          }
+
+          const scanResult = await spaceService.scanSpace(spaceId);
           results.push({
-            spaceId: space.id,
-            name: s.name,
+            spaceId,
+            name: isHome ? "home" : s.name,
             scanned: scanResult.discovered + scanResult.resurfaced,
           });
         }

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -29,8 +29,22 @@ export async function handleSpacesRequest(
       return true;
     }
     const home = process.env.HOME ?? "";
-    const searchRoots = [home, `${home}/Dev`, `${home}/dev`, `${home}/Projects`, `${home}/projects`,
-      `${home}/code`, `${home}/Code`, `${home}/repos`, `${home}/Repos`, `${home}/Documents`, `${home}/Desktop`];
+    const searchRoots = [
+      // Home
+      home,
+      // Dev folders
+      `${home}/Dev`, `${home}/dev`, `${home}/Projects`, `${home}/projects`,
+      `${home}/code`, `${home}/Code`, `${home}/repos`, `${home}/Repos`,
+      `${home}/src`, `${home}/workspace`, `${home}/Workspace`,
+      // OS folders
+      `${home}/Documents`, `${home}/Desktop`, `${home}/Downloads`, `${home}/Sites`,
+      // Cloud sync
+      `${home}/Dropbox`, `${home}/OneDrive`, `${home}/OneDrive - Personal`,
+      `${home}/Library/Mobile Documents/com~apple~CloudDocs`, // iCloud Drive
+      `${home}/Google Drive`, `${home}/My Drive`,
+      // Go
+      `${home}/go/src`,
+    ];
     const seenInodes = new Set<number>();
     const matches: string[] = [];
     for (const root of searchRoots) {

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -1,7 +1,9 @@
 import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
+import { resolve, join } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { SpaceService } from "./space-service.js";
+import { isContainer, discoverCandidates, groupWithLLM } from "./discovery.js";
 
 /**
  * Handle all /api/resolve-folder and /api/spaces/* routes.
@@ -176,6 +178,97 @@ export async function handleSpacesRequest(
       const status = err.message.includes("already in progress") ? 409 : 400;
       res.writeHead(status, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: err.message }));
+    });
+    return true;
+  }
+
+  // POST /api/discover — scan a folder, detect if container, return candidates + suggestions
+  if (url === "/api/discover" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => (body += chunk));
+    req.on("end", () => {
+      try {
+        const { path: rawPath } = JSON.parse(body);
+        if (!rawPath) throw new Error("path is required");
+        const folderPath = rawPath.startsWith("~/")
+          ? resolve(join(homedir(), rawPath.slice(2)))
+          : resolve(rawPath);
+
+        if (!existsSync(folderPath) || !statSync(folderPath).isDirectory()) {
+          throw new Error("Path does not exist or is not a directory");
+        }
+
+        const container = isContainer(folderPath);
+        if (!container) {
+          // Single project — return as-is, no grouping needed
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ container: false, path: folderPath }));
+          return;
+        }
+
+        const candidates = discoverCandidates(folderPath);
+        // Start LLM grouping
+        groupWithLLM(candidates).then(suggestions => {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ container: true, candidates, suggestions }));
+        }).catch(err => {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: (err as Error).message }));
+        });
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return true;
+  }
+
+  // POST /api/discover/import — batch create spaces from confirmed suggestions
+  if (url === "/api/discover/import" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => (body += chunk));
+    req.on("end", async () => {
+      try {
+        const { spaces: spaceList } = JSON.parse(body) as {
+          spaces: Array<{ name: string; folders: string[] }>
+        };
+        if (!spaceList?.length) throw new Error("spaces array is required");
+
+        const results: Array<{ spaceId: string; name: string; scanned: number }> = [];
+
+        for (const s of spaceList) {
+          // Create or find existing space
+          let space;
+          try {
+            space = spaceService.createSpace({ name: s.name });
+          } catch {
+            // Space might already exist
+            space = spaceService.getSpace(s.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""));
+            if (!space) throw new Error(`Could not create or find space "${s.name}"`);
+          }
+
+          // Add folders
+          for (const folder of s.folders) {
+            try {
+              spaceService.addPath(space.id, folder);
+            } catch { /* path might already be added */ }
+          }
+
+          // Scan
+          const scanResult = await spaceService.scanSpace(space.id);
+          results.push({
+            spaceId: space.id,
+            name: s.name,
+            scanned: scanResult.discovered + scanResult.resurfaced,
+          });
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ imported: results }));
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
     });
     return true;
   }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2183,6 +2183,16 @@ body {
   border-bottom-color: rgba(124, 107, 255, 0.5);
 }
 .discovery-group-count { display: none; }
+.discovery-loose {
+  background: transparent;
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.06);
+}
+.discovery-loose-label {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.2);
+  font-style: italic;
+}
 .discovery-new-group {
   border: 1px dashed rgba(255, 255, 255, 0.1);
   border-radius: 10px;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2156,6 +2156,7 @@ body {
   box-sizing: border-box;
 }
 .add-space-input::placeholder { color: rgba(255, 255, 255, 0.2); }
+select.add-space-input { appearance: none; cursor: pointer; }
 .add-space-input--mono { font-family: "SF Mono", monospace; font-size: 11px; }
 .add-space-folder-card {
   display: flex;
@@ -2269,13 +2270,55 @@ body {
   letter-spacing: 0.01em;
 }
 .add-space-drop-zone--filled {
-  flex-direction: row;
-  height: 44px;
-  padding: 0 14px;
-  gap: 10px;
+  flex-direction: column;
+  height: auto;
+  min-height: 44px;
+  padding: 8px 14px;
+  gap: 4px;
   border-style: solid;
   border-color: rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.05);
+}
+.add-space-mode-toggle {
+  display: flex;
+  gap: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.add-space-mode-btn {
+  flex: 1;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: none;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.add-space-mode-btn.active {
+  background: rgba(124, 107, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+.add-space-mode-btn:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.06);
+}
+.add-space-folder-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+.add-space-folder-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.add-space-drop-more {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.2);
+  text-align: center;
+  padding-top: 4px;
 }
 .add-space-drop-path {
   flex: 1;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2130,6 +2130,122 @@ body {
   gap: 18px;
   animation: scaleIn 0.15s ease;
 }
+.add-space-modal--wide { width: 440px; max-height: 80vh; }
+.add-space-subtitle {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: -12px;
+}
+.discovery-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  max-height: 50vh;
+  padding-right: 4px;
+}
+.discovery-group {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+.discovery-group--disabled { opacity: 0.35; }
+.discovery-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.discovery-checkbox input {
+  accent-color: #7c6bff;
+  cursor: pointer;
+}
+.discovery-group--drop {
+  outline: 1px solid rgba(124, 107, 255, 0.4);
+  background: rgba(124, 107, 255, 0.06);
+}
+.discovery-group-name {
+  flex: 1;
+  background: none;
+  border: none;
+  border-bottom: 1px dashed transparent;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  outline: none;
+  padding: 2px 0;
+  cursor: text;
+}
+.discovery-group-name:hover {
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+.discovery-group-name:focus {
+  border-bottom-color: rgba(124, 107, 255, 0.5);
+}
+.discovery-group-count { display: none; }
+.discovery-new-group {
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.2);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.discovery-new-group:hover {
+  border-color: rgba(124, 107, 255, 0.3);
+  color: rgba(255, 255, 255, 0.4);
+}
+.discovery-new-group--drop {
+  border-color: rgba(124, 107, 255, 0.5);
+  background: rgba(124, 107, 255, 0.08);
+  color: rgba(255, 255, 255, 0.5);
+}
+.discovery-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+  padding-left: 24px;
+  min-height: 20px;
+}
+.discovery-chip {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: grab;
+  user-select: none;
+  transition: all 0.12s ease;
+}
+.discovery-chip:hover {
+  background: rgba(124, 107, 255, 0.1);
+  border-color: rgba(124, 107, 255, 0.25);
+  color: rgba(255, 255, 255, 0.7);
+}
+.discovery-chip:active {
+  cursor: grabbing;
+  opacity: 0.6;
+}
+.discovery-actions {
+  display: flex;
+  gap: 8px;
+}
+.add-space-btn-secondary {
+  flex: 0;
+  padding: 12px 20px;
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 14px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.add-space-btn-secondary:hover { background: rgba(255, 255, 255, 0.1); }
 .add-space-header { display: flex; flex-direction: column; gap: 4px; }
 .add-space-title {
   font-size: 18px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -396,6 +396,7 @@ export default function App() {
 
       {showAddSpaceWizard && (
         <AddSpaceWizard
+          spaces={spaces}
           onClose={() => setShowAddSpaceWizard(false)}
           onComplete={() => {
             setShowAddSpaceWizard(false);

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -30,8 +30,9 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [discovering, setDiscovering] = useState(false);
   const [importResult, setImportResult] = useState<Array<{ name: string; scanned: number }> | null>(null);
-  const [dragItem, setDragItem] = useState<{ fromIdx: number; folder: string } | null>(null);
-  const [dropTarget, setDropTarget] = useState<number | null>(null);
+  const [dragItem, setDragItem] = useState<{ fromIdx: number | "loose"; folder: string } | null>(null);
+  const [dropTarget, setDropTarget] = useState<number | "loose" | "new" | null>(null);
+  const [looseFolders, setLooseFolders] = useState<string[]>([]);
 
   const resolveFolder = useCallback(async (folderName: string) => {
     if (mode === "new" && !name.trim()) setName(folderName);
@@ -101,41 +102,41 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
     setSuggestions(prev => prev.map((s, i) => i === idx ? { ...s, name: newName } : s));
   }
 
-  function moveFolder(fromIdx: number, folder: string, target: string) {
-    setSuggestions(prev => {
-      let toIdx = parseInt(target);
+  function moveFolderTo(from: number | "loose", folder: string, target: number | "loose" | "new") {
+    // Remove from source
+    if (from === "loose") {
+      setLooseFolders(prev => prev.filter(f => f !== folder));
+    } else {
+      setSuggestions(prev => {
+        const next = prev.map((s, i) => i === from ? { ...s, folders: s.folders.filter(f => f !== folder) } : s);
+        return next.filter(s => s.folders.length > 0);
+      });
+    }
 
-      // "new" = create a new group
-      if (target === "new") {
-        const newGroup: Suggestion = { name: "Other", folders: [folder], enabled: true };
-        const next = prev.map((s, i) => ({
-          ...s,
-          folders: i === fromIdx ? s.folders.filter(f => f !== folder) : s.folders,
-        }));
-        return [...next.filter(s => s.folders.length > 0), newGroup];
-      }
-
-      if (isNaN(toIdx)) return prev;
-
-      const next = prev.map((s, i) => ({
-        ...s,
-        folders: i === fromIdx ? s.folders.filter(f => f !== folder)
-               : i === toIdx ? [...s.folders, folder]
-               : s.folders,
-      }));
-      return next.filter(s => s.folders.length > 0);
-    });
+    // Add to target
+    if (target === "loose") {
+      setLooseFolders(prev => [...prev, folder]);
+    } else if (target === "new") {
+      setSuggestions(prev => [...prev, { name: "new space", folders: [folder], enabled: true }]);
+    } else {
+      setSuggestions(prev => prev.map((s, i) => i === target ? { ...s, folders: [...s.folders, folder] } : s));
+    }
   }
 
   async function handleImportDiscovery() {
     setScanning(true);
     setError(null);
     try {
-      const enabled = suggestions.filter(s => s.enabled);
+      const enabled = suggestions.filter(s => s.enabled && s.folders.length > 0);
+      // Include loose folders as "home" (no space name — server handles as home)
+      const allSpaces = [
+        ...enabled.map(s => ({ name: s.name, folders: s.folders })),
+        ...(looseFolders.length > 0 ? [{ name: "__home__", folders: looseFolders }] : []),
+      ];
       const res = await fetch("/api/discover/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ spaces: enabled.map(s => ({ name: s.name, folders: s.folders })) }),
+        body: JSON.stringify({ spaces: allSpaces }),
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({})) as { error?: string };
@@ -191,8 +192,8 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
 
   // ── Discovery preview step ──
   if (step === "discovery") {
-    const enabledCount = suggestions.filter(s => s.enabled).length;
-    const totalFolders = suggestions.filter(s => s.enabled).reduce((n, s) => n + s.folders.length, 0);
+    const enabledCount = suggestions.filter(s => s.enabled && s.folders.length > 0).length;
+    const totalFolders = suggestions.filter(s => s.enabled).reduce((n, s) => n + s.folders.length, 0) + looseFolders.length;
 
     return (
       <div className="add-space-overlay" onClick={handleBackdrop}>
@@ -220,8 +221,8 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
                 onDrop={e => {
                   e.preventDefault();
                   setDropTarget(null);
-                  if (dragItem && dragItem.fromIdx !== idx) {
-                    moveFolder(dragItem.fromIdx, dragItem.folder, String(idx));
+                  if (dragItem && !(dragItem.fromIdx === idx)) {
+                    moveFolderTo(dragItem.fromIdx, dragItem.folder, idx);
                   }
                   setDragItem(null);
                 }}
@@ -260,21 +261,58 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
                 </div>
               </div>
             ))}
+
+            {/* Import without a space — lands on home */}
             <div
-              className={`discovery-new-group ${dropTarget === -1 ? "discovery-new-group--drop" : ""}`}
-              onDragOver={e => { e.preventDefault(); setDropTarget(-1); }}
+              className={`discovery-group discovery-loose ${dropTarget === "loose" ? "discovery-group--drop" : ""}`}
+              onDragOver={e => { e.preventDefault(); setDropTarget("loose"); }}
               onDragLeave={() => setDropTarget(null)}
               onDrop={e => {
                 e.preventDefault();
                 setDropTarget(null);
                 if (dragItem) {
-                  moveFolder(dragItem.fromIdx, dragItem.folder, "new");
+                  moveFolderTo(dragItem.fromIdx, dragItem.folder, "loose");
                   setDragItem(null);
                 }
               }}
-              onClick={() => {
-                setSuggestions(prev => [...prev, { name: "other", folders: [], enabled: true }]);
+            >
+              <div className="discovery-group-header">
+                <span className="discovery-loose-label">import without a space</span>
+              </div>
+              {looseFolders.length > 0 && (
+                <div className="discovery-chips">
+                  {looseFolders.map(f => {
+                    const folderName = f.split("/").pop() ?? f;
+                    return (
+                      <div
+                        key={f}
+                        className="discovery-chip"
+                        draggable
+                        onDragStart={() => setDragItem({ fromIdx: "loose", folder: f })}
+                        onDragEnd={() => { setDragItem(null); setDropTarget(null); }}
+                      >
+                        {folderName}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Create a brand new space */}
+            <div
+              className={`discovery-new-group ${dropTarget === "new" ? "discovery-new-group--drop" : ""}`}
+              onDragOver={e => { e.preventDefault(); setDropTarget("new"); }}
+              onDragLeave={() => setDropTarget(null)}
+              onDrop={e => {
+                e.preventDefault();
+                setDropTarget(null);
+                if (dragItem) {
+                  moveFolderTo(dragItem.fromIdx, dragItem.folder, "new");
+                  setDragItem(null);
+                }
               }}
+              onClick={() => setSuggestions(prev => [...prev, { name: "new space", folders: [], enabled: true }])}
             >
               + new space
             </div>

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -48,7 +48,7 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
         await checkAndAddFolder(`~/${folderName}`);
       }
     } catch {
-      setFolders(prev => [...prev, `~/${folderName}`]);
+      await checkAndAddFolder(`~/${folderName}`);
     }
   }, [name, mode]);
 
@@ -77,7 +77,7 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
         setFolders(prev => prev.includes(data.path!) ? prev : [...prev, data.path!]);
       }
     } catch (err) {
-      setFolders(prev => [...prev, path]);
+      setFolders(prev => prev.includes(path) ? prev : [...prev, path]);
     } finally {
       setDiscovering(false);
     }

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -1,16 +1,19 @@
 import { useState, useCallback } from "react";
-import type { ScanResult } from "../../../shared/types";
-import { createSpace, triggerScan, deleteSpace } from "../data/spaces-api";
+import type { Space, ScanResult } from "../../../shared/types";
+import { createSpace, addPath, triggerScan, deleteSpace } from "../data/spaces-api";
 
 interface Props {
+  spaces: Space[];
   onClose: () => void;
   onComplete: () => void;
 }
 
-export function AddSpaceWizard({ onClose, onComplete }: Props) {
+export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
   const [step, setStep] = useState<"name-path" | "results">("name-path");
+  const [mode, setMode] = useState<"new" | "existing">("new");
   const [name, setName] = useState("");
-  const [repoPath, setRepoPath] = useState("");
+  const [existingSpaceId, setExistingSpaceId] = useState("");
+  const [folders, setFolders] = useState<string[]>([]);
   const [pathAmbiguous, setPathAmbiguous] = useState<string[]>([]);
   const [scanning, setScanning] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -18,40 +21,63 @@ export function AddSpaceWizard({ onClose, onComplete }: Props) {
   const [dragging, setDragging] = useState(false);
 
   const resolveFolder = useCallback(async (folderName: string) => {
-    if (!name.trim()) setName(folderName);
+    if (mode === "new" && !name.trim()) setName(folderName);
     setPathAmbiguous([]);
     try {
       const res = await fetch(`/api/resolve-folder?name=${encodeURIComponent(folderName)}`);
       const data = await res.json() as { matches: string[] };
       if (data.matches.length === 1) {
-        setRepoPath(data.matches[0]);
+        setFolders(prev => prev.includes(data.matches[0]) ? prev : [...prev, data.matches[0]]);
       } else if (data.matches.length > 1) {
         setPathAmbiguous(data.matches);
       } else {
-        setRepoPath(`~/${folderName}`);
+        setFolders(prev => [...prev, `~/${folderName}`]);
       }
     } catch {
-      setRepoPath(`~/${folderName}`);
+      setFolders(prev => [...prev, `~/${folderName}`]);
     }
-  }, [name]);
+  }, [name, mode]);
 
   function handleBackdrop(e: React.MouseEvent) {
     if (e.target === e.currentTarget) onClose();
   }
 
+  function removeFolder(path: string) {
+    setFolders(prev => prev.filter(p => p !== path));
+  }
+
   async function handleScan() {
-    if (!name.trim()) { setError("Name is required"); return; }
     setError(null);
     setScanning(true);
-    let createdSpaceId: string | null = null;
+
+    let spaceId: string;
+    let createdNew = false;
+
     try {
-      const space = await createSpace({ name: name.trim(), repoPath: repoPath.trim() || undefined });
-      createdSpaceId = space.id;
-      const result = await triggerScan(space.id);
+      if (mode === "existing") {
+        if (!existingSpaceId) { setError("Pick a space"); setScanning(false); return; }
+        spaceId = existingSpaceId;
+      } else {
+        if (!name.trim()) { setError("Name is required"); setScanning(false); return; }
+        const space = await createSpace({ name: name.trim() });
+        spaceId = space.id;
+        createdNew = true;
+      }
+
+      // Add all folders to the space
+      for (const folder of folders) {
+        await addPath(spaceId, folder);
+      }
+
+      // Scan
+      const result = await triggerScan(spaceId);
       setScanResult(result);
       setStep("results");
     } catch (err) {
-      if (createdSpaceId) await deleteSpace(createdSpaceId);
+      if (createdNew && mode === "new") {
+        const id = name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+        await deleteSpace(id);
+      }
       setError((err as Error).message);
     } finally {
       setScanning(false);
@@ -61,6 +87,8 @@ export function AddSpaceWizard({ onClose, onComplete }: Props) {
   const appItems = scanResult?.artifacts.filter(a => a.kind === "app") ?? [];
   const docItems = scanResult?.artifacts.filter(a => a.kind !== "app") ?? [];
   const totalFound = (scanResult?.discovered ?? 0) + (scanResult?.resurfaced ?? 0);
+
+  const existingSpaces = spaces.filter(s => s.id !== "__all__");
 
   return (
     <div className="add-space-overlay" onClick={handleBackdrop}>
@@ -78,43 +106,77 @@ export function AddSpaceWizard({ onClose, onComplete }: Props) {
           <>
             <div className="add-space-title">Add space</div>
             <div className="add-space-fields">
-              <input
-                className="add-space-input"
-                placeholder="Name"
-                value={name}
-                onChange={e => setName(e.target.value)}
-                onKeyDown={e => e.key === "Enter" && !scanning && handleScan()}
-                autoFocus
-              />
+
+              {/* Toggle: new vs existing */}
+              {existingSpaces.length > 0 && (
+                <div className="add-space-mode-toggle">
+                  <button
+                    className={`add-space-mode-btn ${mode === "new" ? "active" : ""}`}
+                    onClick={() => setMode("new")}
+                  >New space</button>
+                  <button
+                    className={`add-space-mode-btn ${mode === "existing" ? "active" : ""}`}
+                    onClick={() => setMode("existing")}
+                  >Existing space</button>
+                </div>
+              )}
+
+              {mode === "new" ? (
+                <input
+                  className="add-space-input"
+                  placeholder="Name"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  onKeyDown={e => e.key === "Enter" && !scanning && handleScan()}
+                  autoFocus
+                />
+              ) : (
+                <select
+                  className="add-space-input"
+                  value={existingSpaceId}
+                  onChange={e => setExistingSpaceId(e.target.value)}
+                >
+                  <option value="">Pick a space…</option>
+                  {existingSpaces.map(s => (
+                    <option key={s.id} value={s.id}>{s.displayName}</option>
+                  ))}
+                </select>
+              )}
+
               <div
-                className={`add-space-drop-zone${dragging ? " add-space-drop-zone--over" : ""}${repoPath ? " add-space-drop-zone--filled" : ""}`}
+                className={`add-space-drop-zone${dragging ? " add-space-drop-zone--over" : ""}${folders.length > 0 ? " add-space-drop-zone--filled" : ""}`}
                 onDragOver={e => { e.preventDefault(); setDragging(true); }}
                 onDragLeave={() => setDragging(false)}
                 onDrop={e => {
                   e.preventDefault();
                   setDragging(false);
-                  const item = e.dataTransfer.items[0];
-                  if (!item) return;
-                  const entry = item.webkitGetAsEntry?.();
-                  if (entry?.isDirectory) {
-                    resolveFolder(entry.name);
+                  for (let i = 0; i < e.dataTransfer.items.length; i++) {
+                    const entry = e.dataTransfer.items[i].webkitGetAsEntry?.();
+                    if (entry?.isDirectory) {
+                      resolveFolder(entry.name);
+                    }
                   }
                 }}
               >
-                {repoPath ? (
-                  <>
-                    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: 0, opacity: 0.7 }}>
-                      <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
-                    </svg>
-                    <span className="add-space-drop-path">{repoPath}</span>
-                    <button className="add-space-drop-clear" onClick={() => { setRepoPath(""); setPathAmbiguous([]); }}>×</button>
-                  </>
+                {folders.length > 0 ? (
+                  <div className="add-space-folder-list">
+                    {folders.map(f => (
+                      <div key={f} className="add-space-folder-item">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: 0, opacity: 0.7 }}>
+                          <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
+                        </svg>
+                        <span className="add-space-drop-path">{f}</span>
+                        <button className="add-space-drop-clear" onClick={() => removeFolder(f)}>×</button>
+                      </div>
+                    ))}
+                    <div className="add-space-drop-more">Drop another folder to add</div>
+                  </div>
                 ) : (
                   <div className="add-space-drop-empty">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style={{ opacity: 0.2 }}>
                       <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
                     </svg>
-                    <span>Drop project or repo folder to import</span>
+                    <span>Drop project folder to import</span>
                   </div>
                 )}
               </div>
@@ -122,7 +184,10 @@ export function AddSpaceWizard({ onClose, onComplete }: Props) {
                 <div className="add-space-ambiguous">
                   <div className="add-space-ambiguous-label">Multiple matches — pick one:</div>
                   {pathAmbiguous.map(p => (
-                    <button key={p} className="add-space-ambiguous-option" onClick={() => { setRepoPath(p); setPathAmbiguous([]); }}>
+                    <button key={p} className="add-space-ambiguous-option" onClick={() => {
+                      setFolders(prev => prev.includes(p) ? prev : [...prev, p]);
+                      setPathAmbiguous([]);
+                    }}>
                       {p}
                     </button>
                   ))}
@@ -133,9 +198,9 @@ export function AddSpaceWizard({ onClose, onComplete }: Props) {
             <button
               className="add-space-btn-primary"
               onClick={handleScan}
-              disabled={scanning || !name.trim()}
+              disabled={scanning || (mode === "new" ? !name.trim() : !existingSpaceId)}
             >
-              {scanning ? (repoPath ? "Scanning…" : "Adding…") : repoPath ? "Scan" : "Add"}
+              {scanning ? "Scanning…" : folders.length > 0 ? "Scan" : "Add"}
             </button>
           </>
         )}

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -8,8 +8,14 @@ interface Props {
   onComplete: () => void;
 }
 
+interface Suggestion {
+  name: string;
+  folders: string[];
+  enabled: boolean;
+}
+
 export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
-  const [step, setStep] = useState<"name-path" | "results">("name-path");
+  const [step, setStep] = useState<"name-path" | "discovery" | "results">("name-path");
   const [mode, setMode] = useState<"new" | "existing">("new");
   const [name, setName] = useState("");
   const [existingSpaceId, setExistingSpaceId] = useState("");
@@ -20,6 +26,13 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
   const [dragging, setDragging] = useState(false);
 
+  // Discovery state
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [discovering, setDiscovering] = useState(false);
+  const [importResult, setImportResult] = useState<Array<{ name: string; scanned: number }> | null>(null);
+  const [dragItem, setDragItem] = useState<{ fromIdx: number; folder: string } | null>(null);
+  const [dropTarget, setDropTarget] = useState<number | null>(null);
+
   const resolveFolder = useCallback(async (folderName: string) => {
     if (mode === "new" && !name.trim()) setName(folderName);
     setPathAmbiguous([]);
@@ -27,23 +40,115 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
       const res = await fetch(`/api/resolve-folder?name=${encodeURIComponent(folderName)}`);
       const data = await res.json() as { matches: string[] };
       if (data.matches.length === 1) {
-        setFolders(prev => prev.includes(data.matches[0]) ? prev : [...prev, data.matches[0]]);
+        await checkAndAddFolder(data.matches[0]);
       } else if (data.matches.length > 1) {
         setPathAmbiguous(data.matches);
       } else {
-        setFolders(prev => [...prev, `~/${folderName}`]);
+        await checkAndAddFolder(`~/${folderName}`);
       }
     } catch {
       setFolders(prev => [...prev, `~/${folderName}`]);
     }
   }, [name, mode]);
 
+  async function checkAndAddFolder(path: string) {
+    // Check if this is a container (like ~/Dev) with multiple projects
+    setDiscovering(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/discover", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path }),
+      });
+      const data = await res.json() as {
+        container: boolean;
+        path?: string;
+        suggestions?: Array<{ name: string; folders: string[] }>;
+      };
+
+      if (data.container && data.suggestions) {
+        // Switch to discovery flow
+        setSuggestions(data.suggestions.map(s => ({ ...s, enabled: true })));
+        setStep("discovery");
+      } else {
+        // Single project — add to folders list
+        setFolders(prev => prev.includes(data.path!) ? prev : [...prev, data.path!]);
+      }
+    } catch (err) {
+      setFolders(prev => [...prev, path]);
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
   function handleBackdrop(e: React.MouseEvent) {
-    if (e.target === e.currentTarget) onClose();
+    // Only close on backdrop click if we're on the first step with no progress
+    if (e.target === e.currentTarget && step === "name-path" && folders.length === 0 && suggestions.length === 0) {
+      onClose();
+    }
   }
 
   function removeFolder(path: string) {
     setFolders(prev => prev.filter(p => p !== path));
+  }
+
+  function toggleSuggestion(idx: number) {
+    setSuggestions(prev => prev.map((s, i) => i === idx ? { ...s, enabled: !s.enabled } : s));
+  }
+
+  function renameSuggestion(idx: number, newName: string) {
+    setSuggestions(prev => prev.map((s, i) => i === idx ? { ...s, name: newName } : s));
+  }
+
+  function moveFolder(fromIdx: number, folder: string, target: string) {
+    setSuggestions(prev => {
+      let toIdx = parseInt(target);
+
+      // "new" = create a new group
+      if (target === "new") {
+        const newGroup: Suggestion = { name: "Other", folders: [folder], enabled: true };
+        const next = prev.map((s, i) => ({
+          ...s,
+          folders: i === fromIdx ? s.folders.filter(f => f !== folder) : s.folders,
+        }));
+        return [...next.filter(s => s.folders.length > 0), newGroup];
+      }
+
+      if (isNaN(toIdx)) return prev;
+
+      const next = prev.map((s, i) => ({
+        ...s,
+        folders: i === fromIdx ? s.folders.filter(f => f !== folder)
+               : i === toIdx ? [...s.folders, folder]
+               : s.folders,
+      }));
+      return next.filter(s => s.folders.length > 0);
+    });
+  }
+
+  async function handleImportDiscovery() {
+    setScanning(true);
+    setError(null);
+    try {
+      const enabled = suggestions.filter(s => s.enabled);
+      const res = await fetch("/api/discover/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ spaces: enabled.map(s => ({ name: s.name, folders: s.folders })) }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const data = await res.json() as { imported: Array<{ name: string; scanned: number }> };
+      setImportResult(data.imported);
+      setStep("results");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setScanning(false);
+    }
   }
 
   async function handleScan() {
@@ -64,12 +169,10 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
         createdNew = true;
       }
 
-      // Add all folders to the space
       for (const folder of folders) {
         await addPath(spaceId, folder);
       }
 
-      // Scan
       const result = await triggerScan(spaceId);
       setScanResult(result);
       setStep("results");
@@ -84,171 +187,313 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
     }
   }
 
-  const appItems = scanResult?.artifacts.filter(a => a.kind === "app") ?? [];
-  const docItems = scanResult?.artifacts.filter(a => a.kind !== "app") ?? [];
-  const totalFound = (scanResult?.discovered ?? 0) + (scanResult?.resurfaced ?? 0);
-
   const existingSpaces = spaces.filter(s => s.id !== "__all__");
 
+  // ── Discovery preview step ──
+  if (step === "discovery") {
+    const enabledCount = suggestions.filter(s => s.enabled).length;
+    const totalFolders = suggestions.filter(s => s.enabled).reduce((n, s) => n + s.folders.length, 0);
+
+    return (
+      <div className="add-space-overlay" onClick={handleBackdrop}>
+        <div className="add-space-modal add-space-modal--wide">
+          <div className="add-space-stepper">
+            {[1, 2, 3].map(n => (
+              <div key={n} className={`add-space-step-bar ${n === 2 ? "active" : n < 2 ? "done" : "future"}`} />
+            ))}
+          </div>
+
+          <div className="add-space-title">
+            Create {suggestions.length} spaces
+          </div>
+          <div className="add-space-subtitle">
+            {suggestions.reduce((n, s) => n + s.folders.length, 0)} folders grouped into spaces. Edit, move, or untick to skip.
+          </div>
+
+          <div className="discovery-list">
+            {suggestions.map((s, idx) => (
+              <div
+                key={idx}
+                className={`discovery-group ${s.enabled ? "" : "discovery-group--disabled"} ${dropTarget === idx ? "discovery-group--drop" : ""}`}
+                onDragOver={e => { e.preventDefault(); setDropTarget(idx); }}
+                onDragLeave={() => setDropTarget(null)}
+                onDrop={e => {
+                  e.preventDefault();
+                  setDropTarget(null);
+                  if (dragItem && dragItem.fromIdx !== idx) {
+                    moveFolder(dragItem.fromIdx, dragItem.folder, String(idx));
+                  }
+                  setDragItem(null);
+                }}
+              >
+                <div className="discovery-group-header">
+                  <label className="discovery-checkbox">
+                    <input
+                      type="checkbox"
+                      checked={s.enabled}
+                      onChange={() => toggleSuggestion(idx)}
+                    />
+                  </label>
+                  <input
+                    className="discovery-group-name"
+                    value={s.name}
+                    onChange={e => renameSuggestion(idx, e.target.value)}
+                    disabled={!s.enabled}
+                    placeholder="space name"
+                  />
+                </div>
+                <div className="discovery-chips">
+                  {s.folders.map(f => {
+                    const folderName = f.split("/").pop() ?? f;
+                    return (
+                      <div
+                        key={f}
+                        className="discovery-chip"
+                        draggable
+                        onDragStart={() => setDragItem({ fromIdx: idx, folder: f })}
+                        onDragEnd={() => { setDragItem(null); setDropTarget(null); }}
+                      >
+                        {folderName}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+            <div
+              className={`discovery-new-group ${dropTarget === -1 ? "discovery-new-group--drop" : ""}`}
+              onDragOver={e => { e.preventDefault(); setDropTarget(-1); }}
+              onDragLeave={() => setDropTarget(null)}
+              onDrop={e => {
+                e.preventDefault();
+                setDropTarget(null);
+                if (dragItem) {
+                  moveFolder(dragItem.fromIdx, dragItem.folder, "new");
+                  setDragItem(null);
+                }
+              }}
+              onClick={() => {
+                setSuggestions(prev => [...prev, { name: "other", folders: [], enabled: true }]);
+              }}
+            >
+              + new space
+            </div>
+          </div>
+
+          {error && <div className="add-space-error">{error}</div>}
+          <div className="discovery-actions">
+            <button className="add-space-btn-secondary" onClick={() => { setStep("name-path"); setSuggestions([]); }}>
+              Back
+            </button>
+            <button
+              className="add-space-btn-primary"
+              onClick={handleImportDiscovery}
+              disabled={scanning || enabledCount === 0}
+            >
+              {scanning ? "Importing…" : `Import ${enabledCount} space${enabledCount !== 1 ? "s" : ""} (${totalFolders} folders)`}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Results step ──
+  if (step === "results") {
+    // Discovery import results
+    if (importResult) {
+      const totalScanned = importResult.reduce((n, r) => n + r.scanned, 0);
+      return (
+        <div className="add-space-overlay" onClick={handleBackdrop}>
+          <div className="add-space-modal">
+            <div className="add-space-stepper">
+              {[1, 2, 3].map(n => (
+                <div key={n} className={`add-space-step-bar ${n <= 3 ? "done" : "future"}`} />
+              ))}
+            </div>
+            <div className="add-space-found-count">{importResult.length} spaces created</div>
+            <div className="add-space-found-label">{totalScanned} artifacts discovered</div>
+            <div className="add-space-found-list">
+              {importResult.map(r => (
+                <div key={r.name} className="add-space-found-item">
+                  <div className="add-space-item-dot add-space-item-dot--app" />
+                  <span className="add-space-item-name">{r.name}</span>
+                  <span className="add-space-item-kind">{r.scanned} items</span>
+                </div>
+              ))}
+            </div>
+            <button className="add-space-btn-primary" onClick={onComplete}>Done</button>
+          </div>
+        </div>
+      );
+    }
+
+    // Single space scan results
+    const appItems = scanResult?.artifacts.filter(a => a.kind === "app") ?? [];
+    const docItems = scanResult?.artifacts.filter(a => a.kind !== "app") ?? [];
+    const totalFound = (scanResult?.discovered ?? 0) + (scanResult?.resurfaced ?? 0);
+
+    return (
+      <div className="add-space-overlay" onClick={handleBackdrop}>
+        <div className="add-space-modal">
+          <div className="add-space-stepper">
+            {[1, 2, 3].map(n => (
+              <div key={n} className={`add-space-step-bar ${n <= 2 ? "done" : "future"}`} />
+            ))}
+          </div>
+          <div className="add-space-found-count">{totalFound} {totalFound === 1 ? "item" : "items"}</div>
+          <div className="add-space-found-label">
+            {totalFound === 0
+              ? "Nothing detected — add artifacts manually from the desktop."
+              : "Added to your surface"}
+          </div>
+          {totalFound > 0 && (
+            <div className="add-space-found-list">
+              {appItems.length > 0 && (
+                <>
+                  <div className="add-space-section-label">Apps</div>
+                  {appItems.map(a => (
+                    <div key={a.id} className="add-space-found-item">
+                      <div className="add-space-item-dot add-space-item-dot--app" />
+                      <span className="add-space-item-name">{a.label}</span>
+                      <span className="add-space-item-kind">App</span>
+                    </div>
+                  ))}
+                </>
+              )}
+              {docItems.length > 0 && (
+                <>
+                  <div className="add-space-section-label">Docs</div>
+                  {docItems.map(a => (
+                    <div key={a.id} className="add-space-found-item">
+                      <div className="add-space-item-dot add-space-item-dot--doc" />
+                      <span className="add-space-item-name">{a.label}</span>
+                      <span className="add-space-item-kind">
+                        {a.kind === "diagram" ? "Diagram" : "Notes"}
+                      </span>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+          <button className="add-space-btn-primary" onClick={onComplete}>Done</button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Name/path step ──
   return (
     <div className="add-space-overlay" onClick={handleBackdrop}>
       <div className="add-space-modal">
         <div className="add-space-stepper">
-          {[1, 2, 3].map((n) => {
-            const currentStep = step === "name-path" ? 1 : 2;
-            const active = n === currentStep;
-            const done = n < currentStep;
-            return <div key={n} className={`add-space-step-bar ${active ? "active" : done ? "done" : "future"}`} />;
-          })}
+          {[1, 2, 3].map((n) => (
+            <div key={n} className={`add-space-step-bar ${n === 1 ? "active" : "future"}`} />
+          ))}
         </div>
 
-        {step === "name-path" && (
-          <>
-            <div className="add-space-title">Add space</div>
-            <div className="add-space-fields">
+        <div className="add-space-title">Add space</div>
+        <div className="add-space-fields">
 
-              {/* Toggle: new vs existing */}
-              {existingSpaces.length > 0 && (
-                <div className="add-space-mode-toggle">
-                  <button
-                    className={`add-space-mode-btn ${mode === "new" ? "active" : ""}`}
-                    onClick={() => setMode("new")}
-                  >New space</button>
-                  <button
-                    className={`add-space-mode-btn ${mode === "existing" ? "active" : ""}`}
-                    onClick={() => setMode("existing")}
-                  >Existing space</button>
-                </div>
-              )}
+          {existingSpaces.length > 0 && (
+            <div className="add-space-mode-toggle">
+              <button
+                className={`add-space-mode-btn ${mode === "new" ? "active" : ""}`}
+                onClick={() => setMode("new")}
+              >New space</button>
+              <button
+                className={`add-space-mode-btn ${mode === "existing" ? "active" : ""}`}
+                onClick={() => setMode("existing")}
+              >Existing space</button>
+            </div>
+          )}
 
-              {mode === "new" ? (
-                <input
-                  className="add-space-input"
-                  placeholder="Name"
-                  value={name}
-                  onChange={e => setName(e.target.value)}
-                  onKeyDown={e => e.key === "Enter" && !scanning && handleScan()}
-                  autoFocus
-                />
-              ) : (
-                <select
-                  className="add-space-input"
-                  value={existingSpaceId}
-                  onChange={e => setExistingSpaceId(e.target.value)}
-                >
-                  <option value="">Pick a space…</option>
-                  {existingSpaces.map(s => (
-                    <option key={s.id} value={s.id}>{s.displayName}</option>
-                  ))}
-                </select>
-              )}
+          {mode === "new" ? (
+            <input
+              className="add-space-input"
+              placeholder="Name"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && !scanning && !discovering && handleScan()}
+              autoFocus
+            />
+          ) : (
+            <select
+              className="add-space-input"
+              value={existingSpaceId}
+              onChange={e => setExistingSpaceId(e.target.value)}
+            >
+              <option value="">Pick a space…</option>
+              {existingSpaces.map(s => (
+                <option key={s.id} value={s.id}>{s.displayName}</option>
+              ))}
+            </select>
+          )}
 
-              <div
-                className={`add-space-drop-zone${dragging ? " add-space-drop-zone--over" : ""}${folders.length > 0 ? " add-space-drop-zone--filled" : ""}`}
-                onDragOver={e => { e.preventDefault(); setDragging(true); }}
-                onDragLeave={() => setDragging(false)}
-                onDrop={e => {
-                  e.preventDefault();
-                  setDragging(false);
-                  for (let i = 0; i < e.dataTransfer.items.length; i++) {
-                    const entry = e.dataTransfer.items[i].webkitGetAsEntry?.();
-                    if (entry?.isDirectory) {
-                      resolveFolder(entry.name);
-                    }
-                  }
-                }}
-              >
-                {folders.length > 0 ? (
-                  <div className="add-space-folder-list">
-                    {folders.map(f => (
-                      <div key={f} className="add-space-folder-item">
-                        <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: 0, opacity: 0.7 }}>
-                          <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
-                        </svg>
-                        <span className="add-space-drop-path">{f}</span>
-                        <button className="add-space-drop-clear" onClick={() => removeFolder(f)}>×</button>
-                      </div>
-                    ))}
-                    <div className="add-space-drop-more">Drop another folder to add</div>
-                  </div>
-                ) : (
-                  <div className="add-space-drop-empty">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style={{ opacity: 0.2 }}>
+          <div
+            className={`add-space-drop-zone${dragging ? " add-space-drop-zone--over" : ""}${folders.length > 0 ? " add-space-drop-zone--filled" : ""}`}
+            onDragOver={e => { e.preventDefault(); setDragging(true); }}
+            onDragLeave={() => setDragging(false)}
+            onDrop={e => {
+              e.preventDefault();
+              setDragging(false);
+              for (let i = 0; i < e.dataTransfer.items.length; i++) {
+                const entry = e.dataTransfer.items[i].webkitGetAsEntry?.();
+                if (entry?.isDirectory) {
+                  resolveFolder(entry.name);
+                }
+              }
+            }}
+          >
+            {discovering ? (
+              <div className="add-space-drop-empty">
+                <span>Analysing folder…</span>
+              </div>
+            ) : folders.length > 0 ? (
+              <div className="add-space-folder-list">
+                {folders.map(f => (
+                  <div key={f} className="add-space-folder-item">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: 0, opacity: 0.7 }}>
                       <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
                     </svg>
-                    <span>Drop project folder to import</span>
+                    <span className="add-space-drop-path">{f}</span>
+                    <button className="add-space-drop-clear" onClick={() => removeFolder(f)}>×</button>
                   </div>
-                )}
+                ))}
+                <div className="add-space-drop-more">Drop another folder to add</div>
               </div>
-              {pathAmbiguous.length > 1 && (
-                <div className="add-space-ambiguous">
-                  <div className="add-space-ambiguous-label">Multiple matches — pick one:</div>
-                  {pathAmbiguous.map(p => (
-                    <button key={p} className="add-space-ambiguous-option" onClick={() => {
-                      setFolders(prev => prev.includes(p) ? prev : [...prev, p]);
-                      setPathAmbiguous([]);
-                    }}>
-                      {p}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-            {error && <div className="add-space-error">{error}</div>}
-            <button
-              className="add-space-btn-primary"
-              onClick={handleScan}
-              disabled={scanning || (mode === "new" ? !name.trim() : !existingSpaceId)}
-            >
-              {scanning ? "Scanning…" : folders.length > 0 ? "Scan" : "Add"}
-            </button>
-          </>
-        )}
-
-        {step === "results" && scanResult && (
-          <>
-            <div className="add-space-found-count">{totalFound} {totalFound === 1 ? "item" : "items"}</div>
-            <div className="add-space-found-label">
-              {totalFound === 0
-                ? "Nothing detected — add artifacts manually from the desktop."
-                : "Added to your surface"}
-            </div>
-            {totalFound > 0 && (
-              <div className="add-space-found-list">
-                {appItems.length > 0 && (
-                  <>
-                    <div className="add-space-section-label">Apps</div>
-                    {appItems.map(a => (
-                      <div key={a.id} className="add-space-found-item">
-                        <div className="add-space-item-dot add-space-item-dot--app" />
-                        <span className="add-space-item-name">{a.label}</span>
-                        <span className="add-space-item-kind">App</span>
-                      </div>
-                    ))}
-                  </>
-                )}
-                {docItems.length > 0 && (
-                  <>
-                    <div className="add-space-section-label">Docs</div>
-                    {docItems.map(a => (
-                      <div key={a.id} className="add-space-found-item">
-                        <div className="add-space-item-dot add-space-item-dot--doc" />
-                        <span className="add-space-item-name">{a.label}</span>
-                        <span className="add-space-item-kind">
-                          {a.kind === "diagram" ? "Diagram" : "Notes"}
-                        </span>
-                      </div>
-                    ))}
-                  </>
-                )}
+            ) : (
+              <div className="add-space-drop-empty">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style={{ opacity: 0.2 }}>
+                  <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
+                </svg>
+                <span>Drop project folder to import</span>
               </div>
             )}
-            <button className="add-space-btn-primary" onClick={onComplete}>
-              Done
-            </button>
-          </>
-        )}
-
+          </div>
+          {pathAmbiguous.length > 1 && (
+            <div className="add-space-ambiguous">
+              <div className="add-space-ambiguous-label">Multiple matches — pick one:</div>
+              {pathAmbiguous.map(p => (
+                <button key={p} className="add-space-ambiguous-option" onClick={() => {
+                  checkAndAddFolder(p);
+                  setPathAmbiguous([]);
+                }}>
+                  {p}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        {error && <div className="add-space-error">{error}</div>}
+        <button
+          className="add-space-btn-primary"
+          onClick={handleScan}
+          disabled={scanning || discovering || (mode === "new" ? !name.trim() : !existingSpaceId) || folders.length === 0}
+        >
+          {scanning ? "Scanning…" : folders.length > 0 ? "Scan" : "Add"}
+        </button>
       </div>
     </div>
   );

--- a/web/src/data/spaces-api.ts
+++ b/web/src/data/spaces-api.ts
@@ -32,3 +32,17 @@ export async function deleteSpace(spaceId: string): Promise<void> {
   await fetch(`/api/spaces/${spaceId}`, { method: "DELETE" });
   // best-effort — ignore errors (wizard uses this only for cleanup)
 }
+
+export async function addPath(spaceId: string, path: string): Promise<string> {
+  const res = await fetch(`/api/spaces/${spaceId}/paths`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ path }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  const data = await res.json() as { path: string };
+  return data.path;
+}


### PR DESCRIPTION
## Summary

- **Auto-discovery**: drop ~/Dev (or any container folder) and Oyster detects multiple projects, sends to LLM for grouping, presents editable preview with draggable chips
- **Multi-folder spaces**: a space can have multiple folders via `space_paths` table. Add Space wizard supports "Existing space" mode
- **Broader scanner**: finds Go, Rust, Python, Ruby, Java projects. Root-level projects detected. Any `.md` file discovered
- **Monorepo detection**: scans `apps/`, `packages/`, detects pnpm workspaces — monorepos get their own space
- **Multi-provider LLM**: works with Anthropic (Haiku), OpenAI (4o-mini), Perplexity (Sonar), Groq, OpenRouter, Google (Gemini Flash). Falls back to OpenCode API for unknown providers
- **Three import states**: assign to space, import to home (no space), or skip
- **Non-JS app handling**: Go/Rust/Python projects stored correctly (no broken package.json references)
- **README commands table** updated with inline examples

## New files

- `server/src/discovery.ts` — container detection, candidate scanning, LLM grouping, multi-provider support

## API

- `POST /api/discover` — scan folder, detect container vs project, return LLM-grouped suggestions
- `POST /api/discover/import` — batch create spaces from confirmed suggestions
- `GET/POST/DELETE /api/spaces/:id/paths` — manage folders per space

## Test plan

- [ ] Drop ~/Dev → discovery preview with grouped spaces, drag chips to reorganise, import
- [ ] Drop a single project folder → normal single-space flow (no discovery)
- [ ] Monorepo (pnpm workspace) gets its own space, not "other"
- [ ] Move chips between groups, create new group, drag to "import without a space"
- [ ] Unticked spaces don't get imported
- [ ] Non-JS project (Go/Python) scanned without errors
- [ ] Works with Anthropic auth, falls back gracefully without auth

Closes #89, #90, #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)