### PR TITLE
feat: persistent memory system (#70)

### DIFF
--- a/.opencode/agents/oyster.md
+++ b/.opencode/agents/oyster.md
@@ -30,7 +30,21 @@ You help the user capture, structure, and visualise their thinking. You operate 
 
 ## Memory
 
-Memory across sessions is not yet available. Focus on the current session's context. If the user asks you to remember something, let them know that persistent memory is coming in a future update.
+You have persistent memory across sessions. Use it to store facts, preferences, and decisions the user explicitly asks you to remember.
+
+| Tool | When to use |
+|------|-------------|
+| `remember` | User says "remember this", shares a preference, or makes a durable decision. Provide `content` (freeform text), optional `space_id` to scope it, optional `tags` for categorisation. |
+| `recall` | Search memories by natural language. Use at session start to load relevant context, or when the user asks what you remember. |
+| `forget` | Remove a memory by ID when the user says it's no longer relevant. |
+| `list_memories` | List all active memories, optionally filtered by space. |
+
+### Memory guidelines
+
+- **Explicit writes only.** Only call `remember` when the user asks you to, or when they share something clearly durable (a preference, a decision, a constraint). Do not auto-remember transient information.
+- **Always check memory before saying "I don't know".** If the user asks about themselves, their preferences, or anything you might have been told before — you MUST call `recall` or `list_memories` first. Never answer "I don't have that information" without checking. Examples: "how old am I?", "what do you know about me?", "what are my preferences?" — all require a memory lookup before responding.
+- Use tags to categorise: `["preference"]`, `["decision"]`, `["context"]`.
+- Do not store what file is open, the current time, or session-specific state.
 
 ## Artifact registry (Oyster MCP)
 
@@ -51,6 +65,10 @@ You have MCP tools (the `oyster` server) for managing the desktop surface direct
 | `register_artifact` | Register a file that **already exists on disk** as a desktop artifact. Only for pre-existing files — for new content, use `create_artifact`. |
 | `open_artifact` | Open an artifact in the user's viewer window by exact ID. Use `list_artifacts(search: ...)` first to find the right ID. |
 | `switch_space` | Switch the user's desktop to a different space by exact ID. Use `list_spaces` first if you need to find available spaces. |
+| `remember` | Store a memory. Only when the user explicitly asks or shares a durable fact. |
+| `recall` | Search memories by natural language query. Use at session start for relevant context. |
+| `forget` | Remove a memory from active recall by ID. |
+| `list_memories` | List all active memories, optionally filtered by space. |
 
 ### Usage
 

--- a/.opencode/config.toml
+++ b/.opencode/config.toml
@@ -8,7 +8,5 @@ id = "claude-sonnet-4-20250514"
 provider = "anthropic"
 id = "claude-sonnet-4-20250514"
 
-[mcp.oyster]
-type = "remote"
-url = "http://localhost:4200/mcp/"
+# MCP config is written dynamically by the server with the actual port
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -583,12 +583,9 @@ const opencodeConfig = readFileSync(join(PROJECT_ROOT, ".opencode", "config.toml
 writeFileSync(join(USERLAND_DIR, ".opencode", "config.toml"), opencodeConfig);
 
 // Also write opencode.json (OpenCode reads this from cwd)
-const opencodeJson = {
-  "$schema": "https://opencode.ai/config.json",
-  model: "anthropic/claude-sonnet-4-20250514",
-  mcp: { oyster: { type: "remote", url: `http://localhost:${port}/mcp/` } },
-};
-writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(opencodeJson, null, 2) + "\n");
+const sourceOpencode = JSON.parse(readFileSync(join(PROJECT_ROOT, "opencode.json"), "utf8"));
+sourceOpencode.mcp = { oyster: { type: "remote", url: `http://localhost:${port}/mcp/` } };
+writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(sourceOpencode, null, 2) + "\n");
 
 const httpServer = createServer(handleHttpRequest);
 attachWebSocket(httpServer);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./opencode-manager.js";
 import { spawnSession, attachWebSocket } from "./pty-manager.js";
 import { createMcpServer } from "./mcp-server.js";
+import { SqliteFtsMemoryProvider } from "./memory-store.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
 // ── Config ──
@@ -155,6 +156,8 @@ const store = new SqliteArtifactStore(db);
 const artifactService = new ArtifactService(store, USERLAND_DIR);
 const spaceStore = new SqliteSpaceStore(db);
 const spaceService = new SpaceService(spaceStore, store);
+const memoryProvider = new SqliteFtsMemoryProvider(USERLAND_DIR);
+await memoryProvider.init();
 
 // ── Initialize subsystems ──
 
@@ -163,7 +166,7 @@ const pendingReveals = new Set<string>();
 
 spawnSession(SHELL, SHELL_ARGS, WORKSPACE, cleanEnv);
 
-spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);
+// OpenCode spawn is deferred until after port resolution (see below)
 scanExistingArtifacts(ARTIFACTS_DIR, iconGenerator);
 
 // Reconcile non-builtin ready gen: artifacts into DB (idempotent — dedupes by canonical path)
@@ -181,8 +184,8 @@ startGenerationTimer(iconGenerator, (id, filePath, builtin) => {
 });
 startAutoApprover(getOpenCodePort, (file) => handleFileEdited(file, ARTIFACTS_DIR, iconGenerator));
 
-process.on("SIGTERM", () => { markShuttingDown(); db.close(); process.exit(0); });
-process.on("SIGINT", () => { markShuttingDown(); db.close(); process.exit(0); });
+process.on("SIGTERM", () => { markShuttingDown(); db.close(); memoryProvider.close(); process.exit(0); });
+process.on("SIGINT", () => { markShuttingDown(); db.close(); memoryProvider.close(); process.exit(0); });
 
 // ── UI push events (SSE) ──
 
@@ -504,7 +507,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     // Override the wildcard CORS header set at the top of handleHttpRequest
     res.setHeader("Access-Control-Allow-Origin", origin || `http://localhost:${PREFERRED_PORT}`);
 
-    const mcpServer = createMcpServer({ store, service: artifactService, userlandDir: USERLAND_DIR, iconGenerator, spaceService, pendingReveals, broadcastUiEvent });
+    const mcpServer = createMcpServer({ store, service: artifactService, userlandDir: USERLAND_DIR, iconGenerator, spaceService, memoryProvider, pendingReveals, broadcastUiEvent });
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => { transport.close(); mcpServer.close(); });
     await mcpServer.connect(transport);
@@ -571,10 +574,29 @@ function findPort(preferred: number, maxAttempts = 10): Promise<number> {
 }
 
 const port = await findPort(PREFERRED_PORT);
+
+// Write OpenCode config with the actual port so MCP URL is always correct
+const opencodeConfig = readFileSync(join(PROJECT_ROOT, ".opencode", "config.toml"), "utf8")
+  .replace(/# MCP config is written dynamically.*/, "")
+  .trimEnd()
+  + `\n\n[mcp.oyster]\ntype = "remote"\nurl = "http://localhost:${port}/mcp/"\n`;
+writeFileSync(join(USERLAND_DIR, ".opencode", "config.toml"), opencodeConfig);
+
+// Also write opencode.json (OpenCode reads this from cwd)
+const opencodeJson = {
+  "$schema": "https://opencode.ai/config.json",
+  model: "anthropic/claude-sonnet-4-20250514",
+  mcp: { oyster: { type: "remote", url: `http://localhost:${port}/mcp/` } },
+};
+writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(opencodeJson, null, 2) + "\n");
+
 const httpServer = createServer(handleHttpRequest);
 attachWebSocket(httpServer);
 httpServer.listen(port, () => {
   console.log(`Oyster server listening on http://localhost:${port}`);
   console.log(`  WebSocket: ws://localhost:${port}`);
   console.log(`  API:       http://localhost:${port}/api/artifacts`);
+
+  // Spawn OpenCode AFTER server is listening so MCP connection succeeds
+  spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);
 });

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -6,6 +6,8 @@ import type { ArtifactStore } from "./artifact-store.js";
 import type { ArtifactService } from "./artifact-service.js";
 import type { IconGenerator } from "./icon-generator.js";
 import type { SpaceService } from "./space-service.js";
+import type { MemoryProvider } from "./memory-store.js";
+import { registerMemoryTools } from "./memory-store.js";
 import type { ArtifactKind } from "../../shared/types.js";
 
 // Kept local — value imports from shared/ don't transpile in tsx (include: ["src"] only).
@@ -115,6 +117,7 @@ interface McpDeps {
   userlandDir: string;
   iconGenerator: IconGenerator;
   spaceService: SpaceService;
+  memoryProvider: MemoryProvider;
   pendingReveals: Set<string>;
   broadcastUiEvent: (event: UiCommand) => void;
 }
@@ -559,6 +562,9 @@ export function createMcpServer(deps: McpDeps): McpServer {
       };
     },
   );
+
+  // ── Memory tools ──
+  registerMemoryTools(server, deps.memoryProvider);
 
   return server;
 }

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -35,6 +35,7 @@ export interface MemoryProvider {
   list(space_id?: string): Promise<Memory[]>;
   exportMemories(): Promise<Memory[]>;
   importMemories(memories: Memory[]): Promise<void>;
+  close(): void;
 }
 
 // ── SQLite FTS5 provider ──────────────────────────────────────

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -1,0 +1,338 @@
+import Database from "better-sqlite3";
+import crypto from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// ── Contract ──────────────────────────────────────────────────
+
+export interface Memory {
+  id: string;
+  content: string;
+  space_id: string | null;
+  tags: string[];
+  created_at: string;
+}
+
+export interface RememberInput {
+  content: string;
+  space_id?: string;
+  tags?: string[];
+}
+
+export interface RecallInput {
+  query: string;
+  space_id?: string;
+  limit?: number;
+}
+
+export interface MemoryProvider {
+  init(): Promise<void>;
+  remember(input: RememberInput): Promise<Memory>;
+  recall(input: RecallInput): Promise<Memory[]>;
+  forget(id: string): Promise<void>;
+  list(space_id?: string): Promise<Memory[]>;
+  exportMemories(): Promise<Memory[]>;
+  importMemories(memories: Memory[]): Promise<void>;
+}
+
+// ── SQLite FTS5 provider ──────────────────────────────────────
+
+interface MemoryRow {
+  id: string;
+  space_id: string | null;
+  content: string;
+  tags: string;          // JSON array stored as text
+  access_count: number;
+  superseded_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToMemory(row: MemoryRow): Memory {
+  return {
+    id: row.id,
+    content: row.content,
+    space_id: row.space_id,
+    tags: JSON.parse(row.tags),
+    created_at: row.created_at,
+  };
+}
+
+export class SqliteFtsMemoryProvider implements MemoryProvider {
+  private db!: Database.Database;
+  private stmts!: {
+    insert: Database.Statement;
+    findExact: Database.Statement;
+    supersede: Database.Statement;
+    listActive: Database.Statement;
+    listActiveBySpace: Database.Statement;
+    getById: Database.Statement;
+    incrementAccess: Database.Statement;
+    exportAll: Database.Statement;
+  };
+  private storagePath: string;
+
+  constructor(storagePath: string) {
+    this.storagePath = storagePath;
+  }
+
+  async init(): Promise<void> {
+    mkdirSync(this.storagePath, { recursive: true });
+    const dbPath = join(this.storagePath, "memory.db");
+    this.db = new Database(dbPath);
+    this.db.pragma("journal_mode = WAL");
+
+    // Schema
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memories (
+        id            TEXT PRIMARY KEY,
+        space_id      TEXT,
+        content       TEXT NOT NULL,
+        tags          TEXT NOT NULL DEFAULT '[]',
+        access_count  INTEGER NOT NULL DEFAULT 0,
+        superseded_by TEXT,
+        created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    this.db.exec(`CREATE INDEX IF NOT EXISTS memories_space_id ON memories(space_id)`);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS memories_active ON memories(superseded_by) WHERE superseded_by IS NULL`);
+
+    // FTS5 virtual table
+    this.db.exec(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+        content,
+        tags,
+        content=memories,
+        content_rowid=rowid
+      )
+    `);
+
+    // Triggers to keep FTS in sync
+    for (const sql of [
+      `CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+        INSERT INTO memories_fts(rowid, content, tags) VALUES (new.rowid, new.content, new.tags);
+      END`,
+      `CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+        INSERT INTO memories_fts(memories_fts, rowid, content, tags) VALUES('delete', old.rowid, old.content, old.tags);
+      END`,
+      `CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+        INSERT INTO memories_fts(memories_fts, rowid, content, tags) VALUES('delete', old.rowid, old.content, old.tags);
+        INSERT INTO memories_fts(rowid, content, tags) VALUES (new.rowid, new.content, new.tags);
+      END`,
+    ]) {
+      this.db.exec(sql);
+    }
+
+    // Prepared statements
+    this.stmts = {
+      insert: this.db.prepare(
+        `INSERT INTO memories (id, space_id, content, tags, created_at, updated_at)
+         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      ),
+      findExact: this.db.prepare(
+        `SELECT * FROM memories
+         WHERE content = ? AND (space_id = ? OR (space_id IS NULL AND ? IS NULL))
+           AND superseded_by IS NULL`,
+      ),
+      supersede: this.db.prepare(
+        `UPDATE memories SET superseded_by = ?, updated_at = datetime('now') WHERE id = ?`,
+      ),
+      listActive: this.db.prepare(
+        `SELECT * FROM memories WHERE superseded_by IS NULL ORDER BY updated_at DESC`,
+      ),
+      listActiveBySpace: this.db.prepare(
+        `SELECT * FROM memories WHERE superseded_by IS NULL AND (space_id = ? OR space_id IS NULL)
+         ORDER BY updated_at DESC`,
+      ),
+      getById: this.db.prepare(`SELECT * FROM memories WHERE id = ?`),
+      incrementAccess: this.db.prepare(
+        `UPDATE memories SET access_count = access_count + 1 WHERE id = ?`,
+      ),
+      exportAll: this.db.prepare(
+        `SELECT * FROM memories WHERE superseded_by IS NULL ORDER BY created_at ASC`,
+      ),
+    };
+  }
+
+  async remember(input: RememberInput): Promise<Memory> {
+    const spaceId = input.space_id ?? null;
+    const tags = JSON.stringify(input.tags ?? []);
+
+    // Conservative dedupe: exact content match in same scope
+    const existing = this.stmts.findExact.get(input.content, spaceId, spaceId) as MemoryRow | undefined;
+    if (existing) {
+      return rowToMemory(existing);
+    }
+
+    const id = crypto.randomUUID();
+    this.stmts.insert.run(id, spaceId, input.content, tags);
+    const row = this.stmts.getById.get(id) as MemoryRow;
+    return rowToMemory(row);
+  }
+
+  async recall(input: RecallInput): Promise<Memory[]> {
+    const limit = input.limit ?? 10;
+    const spaceId = input.space_id ?? null;
+
+    // Convert query to OR-joined terms so partial matches work
+    // "how old am I" → "how OR old OR am OR I"
+    const terms = input.query
+      .replace(/[^\w\s]/g, "")
+      .split(/\s+/)
+      .filter((t) => t.length > 1);
+    if (terms.length === 0) return this.list(spaceId ?? undefined);
+    const ftsQuery = terms.join(" OR ");
+
+    let sql: string;
+    let params: unknown[];
+
+    if (spaceId) {
+      sql = `SELECT m.* FROM memories m
+             JOIN memories_fts fts ON m.rowid = fts.rowid
+             WHERE memories_fts MATCH ? AND m.superseded_by IS NULL
+               AND (m.space_id = ? OR m.space_id IS NULL)
+             ORDER BY fts.rank
+             LIMIT ?`;
+      params = [ftsQuery, spaceId, limit];
+    } else {
+      sql = `SELECT m.* FROM memories m
+             JOIN memories_fts fts ON m.rowid = fts.rowid
+             WHERE memories_fts MATCH ? AND m.superseded_by IS NULL
+             ORDER BY fts.rank
+             LIMIT ?`;
+      params = [ftsQuery, limit];
+    }
+
+    const rows = this.db.prepare(sql).all(...params) as MemoryRow[];
+
+    // Increment access counts
+    for (const row of rows) {
+      this.stmts.incrementAccess.run(row.id);
+    }
+
+    return rows.map(rowToMemory);
+  }
+
+  async forget(id: string): Promise<void> {
+    const row = this.stmts.getById.get(id) as MemoryRow | undefined;
+    if (!row) return;
+    this.stmts.supersede.run("forgotten", id);
+  }
+
+  async list(space_id?: string): Promise<Memory[]> {
+    const rows = space_id
+      ? (this.stmts.listActiveBySpace.all(space_id) as MemoryRow[])
+      : (this.stmts.listActive.all() as MemoryRow[]);
+    return rows.map(rowToMemory);
+  }
+
+  async exportMemories(): Promise<Memory[]> {
+    const rows = this.stmts.exportAll.all() as MemoryRow[];
+    return rows.map(rowToMemory);
+  }
+
+  async importMemories(memories: Memory[]): Promise<void> {
+    const insertOrIgnore = this.db.prepare(
+      `INSERT OR IGNORE INTO memories (id, space_id, content, tags, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+    );
+    const tx = this.db.transaction((items: Memory[]) => {
+      for (const m of items) {
+        insertOrIgnore.run(m.id, m.space_id, m.content, JSON.stringify(m.tags), m.created_at);
+      }
+    });
+    tx(memories);
+  }
+
+  close(): void {
+    this.db?.close();
+  }
+}
+
+// ── MCP tool registration ─────────────────────────────────────
+
+export function registerMemoryTools(server: McpServer, provider: MemoryProvider): void {
+  server.tool(
+    "remember",
+    "Store a memory for future sessions. Use when the user says 'remember this', shares a preference, or makes a decision worth preserving. Do not auto-remember — only store when explicitly asked or when the fact is clearly durable.",
+    {
+      content: z.string().describe("The memory content — freeform text describing what to remember"),
+      space_id: z.string().optional().describe("Scope to a space (e.g. 'tokinvest'). Omit for global memory."),
+      tags: z.array(z.string()).optional().describe("Categorisation tags (e.g. ['preference'], ['decision', 'project:tokinvest'])"),
+    },
+    async ({ content, space_id, tags }) => {
+      try {
+        const memory = await provider.remember({ content, space_id, tags });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(memory, null, 2) }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "recall",
+    "Search memories by natural language query. Returns ranked matches from this space and global memories. Use at session start to load relevant context, or when the user asks what you remember.",
+    {
+      query: z.string().describe("Natural language search query"),
+      space_id: z.string().optional().describe("Scope search to a space plus global memories. Omit to search everything."),
+      limit: z.number().int().min(1).max(50).optional().describe("Max results (default 10)"),
+    },
+    async ({ query, space_id, limit }) => {
+      try {
+        const memories = await provider.recall({ query, space_id, limit });
+        if (memories.length === 0) {
+          return { content: [{ type: "text" as const, text: "No memories found." }] };
+        }
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(memories, null, 2) }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "forget",
+    "Remove a memory from active recall by ID. The user will no longer see this memory in searches or lists.",
+    {
+      id: z.string().describe("Memory ID to forget"),
+    },
+    async ({ id }) => {
+      try {
+        await provider.forget(id);
+        return { content: [{ type: "text" as const, text: `Memory "${id}" forgotten.` }] };
+      } catch (err) {
+        return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
+      }
+    },
+  );
+
+  server.tool(
+    "list_memories",
+    "List all active memories, optionally filtered by space. Returns memories ordered by most recently updated.",
+    {
+      space_id: z.string().optional().describe("Filter by space. Omit to list all memories."),
+    },
+    async ({ space_id }) => {
+      try {
+        const memories = await provider.list(space_id);
+        if (memories.length === 0) {
+          return { content: [{ type: "text" as const, text: "No memories stored yet." }] };
+        }
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(memories, null, 2) }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
+      }
+    },
+  );
+}

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -185,7 +185,7 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       .replace(/[^\w\s]/g, "")
       .split(/\s+/)
       .filter((t) => t.length > 1);
-    if (terms.length === 0) return this.list(spaceId ?? undefined);
+    if (terms.length === 0) return [];
     const ftsQuery = terms.join(" OR ");
 
     let sql: string;

--- a/web/src/data/chat-api.ts
+++ b/web/src/data/chat-api.ts
@@ -16,6 +16,7 @@ export async function createSession(): Promise<ChatSession> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       title: "oyster",
+      agent: "oyster",
       permission: [
         { permission: "read", pattern: "*", action: "allow" },
         { permission: "write", pattern: "*", action: "allow" },
@@ -57,6 +58,7 @@ export async function sendMessage(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       parts: [{ type: "text", text }],
+      agent: "oyster",
     }),
   });
   if (!res.ok) throw new Error(`sendMessage failed: ${res.status}`);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,22 +1,25 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const serverPort = process.env.OYSTER_PORT ?? '4444'
+const target = `http://localhost:${serverPort}`
+
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 7337,
     proxy: {
       '/api/chat/events': {
-        target: 'http://localhost:4444',
+        target,
         headers: { Accept: 'text/event-stream' },
       },
       '/api/ui/events': {
-        target: 'http://localhost:4444',
+        target,
         headers: { Accept: 'text/event-stream' },
       },
-      '/api': 'http://localhost:4444',
-      '/docs': 'http://localhost:4444',
-      '/artifacts': 'http://localhost:4444',
+      '/api': target,
+      '/docs': target,
+      '/artifacts': target,
     }
   }
 })


### PR DESCRIPTION
## Summary

- Adds cross-session memory for the AI agent via an async `MemoryProvider` interface
- First provider: `SqliteFtsMemoryProvider` — own `memory.db`, FTS5 full-text search, supersession model for soft-delete
- 4 new MCP tools: `remember`, `recall`, `forget`, `list_memories`
- Fixes OpenCode MCP connection race — server now listens before spawning OpenCode
- Dynamic config writing — MCP URL uses actual resolved port, not hardcoded value

## Architecture

```
MemoryProvider (async contract)
    └── SqliteFtsMemoryProvider   ← ships with Oyster
    └── RemoteMemoryProvider      ← later
    └── McpMemoryProvider         ← later
```

- `memory.db` is separate from `oyster.db` — different concerns
- Contract is async, storage-agnostic, includes `exportMemories()`/`importMemories()` for provider migration
- Agent writes memory only when explicitly asked (no auto-memory)

## Files

| File | Change |
|------|--------|
| `server/src/memory-store.ts` | **NEW** — interface, provider, MCP tool registration |
| `server/src/index.ts` | Wire provider, dynamic config, spawn ordering fix |
| `server/src/mcp-server.ts` | Add memoryProvider to McpDeps |
| `.opencode/agents/oyster.md` | Memory tool docs + recall-first guidelines |
| `.opencode/config.toml` | Remove hardcoded MCP URL |
| `web/src/data/chat-api.ts` | Add agent field to sessions/messages |

## Test plan

- [x] Smoke test: remember/recall/forget/list/export/import via direct provider calls
- [x] FTS5 OR-joined query: "how old am I?" matches "User is 44 years old"
- [x] Dedupe: same content returns existing memory, no duplicate
- [x] Cross-session recall: memory stored in session 1, recalled in session 2
- [x] Space-scoped + global memory coexist
- [x] `memory.db` created separately from `oyster.db`
- [x] Dynamic port: MCP URL matches actual server port
- [x] Agent checks memory before saying "I don't know"

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)