### PR TITLE
feat: full-page drop-to-import with electric feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 2026-04-13
 
+### Drop-to-import
+
+- Drop a folder anywhere on the surface to import projects
+- Full-page drop zone — works on the chat bar, icons, anywhere
+- Background animates on drag (Grainient speeds up)
+- Icons and chat dim during drag to focus attention
+- Wizard skips straight to scanning when folder is dropped
+- Browser no longer navigates away on accidental file drops
+
+### Dev / prod separation
+
+- Dev server uses port 3333, prod uses 4444 — can run side by side
+- Dev uses `./userland`, prod uses `~/.oyster/userland`
+- `OYSTER_INSTALLED` flag from CLI controls which environment
+- Version badge on surface shows version + env (dev/prod)
+- Icon resolution fix: checks artifact root dir for `icon.png`
+
 ### Persistent memory
 
 - AI agent remembers across sessions — preferences, decisions, context

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2141,11 +2141,16 @@ body {
   box-shadow: inset 0 0 120px rgba(124, 107, 255, 0.08);
 }
 
+.icon-grid,
+.list-view,
+.chatbar-wrapper {
+  transition: opacity 0.15s;
+}
+
 .shell-drag-over .icon-grid,
 .shell-drag-over .list-view,
 .shell-drag-over .chatbar-wrapper {
   opacity: 0.3;
-  transition: opacity 0.15s;
 }
 
 /* ── Add Space Wizard ── */

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2134,10 +2134,18 @@ body {
 
 /* ── Surface drop highlight ── */
 
-.desktop-scroll--drop {
-  outline: 2px dashed var(--accent);
+.shell-drag-over .desktop {
+  outline: 2px solid var(--accent);
   outline-offset: -8px;
-  border-radius: 12px;
+  background: rgba(124, 107, 255, 0.04);
+  box-shadow: inset 0 0 120px rgba(124, 107, 255, 0.08);
+}
+
+.shell-drag-over .icon-grid,
+.shell-drag-over .list-view,
+.shell-drag-over .chatbar-wrapper {
+  opacity: 0.3;
+  transition: opacity 0.15s;
 }
 
 /* ── Add Space Wizard ── */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,14 +59,16 @@ export default function App() {
       }
     }
     document.addEventListener("keydown", handleKeyDown);
-    // Prevent browser from opening dropped files/folders
-    function preventDrop(e: DragEvent) { e.preventDefault(); }
-    document.addEventListener("dragover", preventDrop);
-    document.addEventListener("drop", preventDrop);
+    // Prevent browser from opening dropped files/folders (but allow text drops)
+    function preventFileDrop(e: DragEvent) {
+      if (e.dataTransfer?.types.includes("Files")) e.preventDefault();
+    }
+    document.addEventListener("dragover", preventFileDrop);
+    document.addEventListener("drop", preventFileDrop);
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
-      document.removeEventListener("dragover", preventDrop);
-      document.removeEventListener("drop", preventDrop);
+      document.removeEventListener("dragover", preventFileDrop);
+      document.removeEventListener("drop", preventFileDrop);
     };
   }, []);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,9 @@ export default function App() {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [showAddSpaceWizard, setShowAddSpaceWizard] = useState(false);
+  const [droppedFolder, setDroppedFolder] = useState<string | undefined>();
+  const [shellDragOver, setShellDragOver] = useState(false);
+  const dragCounter = useRef(0);
   const getUrlState = useCallback((): { space: string; artifactId: string | null; groupName: string | null; hash: string } => {
     const artifactMatch = window.location.pathname.match(/^\/s\/([^/]+)\/a\/([^/]+)$/);
     if (artifactMatch) {
@@ -56,7 +59,15 @@ export default function App() {
       }
     }
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    // Prevent browser from opening dropped files/folders
+    function preventDrop(e: DragEvent) { e.preventDefault(); }
+    document.addEventListener("dragover", preventDrop);
+    document.addEventListener("drop", preventDrop);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("dragover", preventDrop);
+      document.removeEventListener("drop", preventDrop);
+    };
   }, []);
 
   // Redirect bare `/` to `/s/home` so every space has a uniform URL
@@ -252,7 +263,35 @@ export default function App() {
   }
 
   return (
-    <div className="oyster-shell">
+    <div
+      className={`oyster-shell${shellDragOver ? " shell-drag-over" : ""}`}
+      onDragEnter={(e) => {
+        if (e.dataTransfer.types.includes("Files")) {
+          dragCounter.current++;
+          setShellDragOver(true);
+        }
+      }}
+      onDragLeave={() => {
+        dragCounter.current--;
+        if (dragCounter.current <= 0) {
+          dragCounter.current = 0;
+          setShellDragOver(false);
+        }
+      }}
+      onDragOver={(e) => {
+        if (e.dataTransfer.types.includes("Files")) e.preventDefault();
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        dragCounter.current = 0;
+        setShellDragOver(false);
+        const entry = e.dataTransfer.items[0]?.webkitGetAsEntry?.();
+        if (entry?.isDirectory) {
+          setDroppedFolder(entry.name);
+          setShowAddSpaceWizard(true);
+        }
+      }}
+    >
       {!connected && (
         <div className="connection-banner">
           <span>Oyster server not connected</span>
@@ -271,8 +310,9 @@ export default function App() {
           window.history.pushState(null, "", `/s/${activeSpace}/g/${encodeURIComponent(name.toLowerCase())}`);
         }}
         onSpaceChange={handleSpaceChange}
-        onAddSpace={() => setShowAddSpaceWizard(true)}
+        onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         isFirstRun={isFirstRun}
+        dragOver={shellDragOver}
         revealId={revealId}
       />
 
@@ -401,9 +441,11 @@ export default function App() {
       {showAddSpaceWizard && (
         <AddSpaceWizard
           spaces={spaces}
-          onClose={() => setShowAddSpaceWizard(false)}
+          initialFolder={droppedFolder}
+          onClose={() => { setShowAddSpaceWizard(false); setDroppedFolder(undefined); }}
           onComplete={() => {
             setShowAddSpaceWizard(false);
+            setDroppedFolder(undefined);
             fetchSpaces().then(setSpaces);
             fetchArtifacts().then(setArtifacts);
           }}

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -1,9 +1,10 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { Space, ScanResult } from "../../../shared/types";
 import { createSpace, addPath, triggerScan, deleteSpace } from "../data/spaces-api";
 
 interface Props {
   spaces: Space[];
+  initialFolder?: string;
   onClose: () => void;
   onComplete: () => void;
 }
@@ -14,8 +15,8 @@ interface Suggestion {
   enabled: boolean;
 }
 
-export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
-  const [step, setStep] = useState<"name-path" | "discovery" | "results">("name-path");
+export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: Props) {
+  const [step, setStep] = useState<"name-path" | "discovery" | "results">(initialFolder ? "discovery" : "name-path");
   const [mode, setMode] = useState<"new" | "existing">("new");
   const [name, setName] = useState("");
   const [existingSpaceId, setExistingSpaceId] = useState("");
@@ -28,7 +29,7 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
 
   // Discovery state
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
-  const [discovering, setDiscovering] = useState(false);
+  const [discovering, setDiscovering] = useState(!!initialFolder);
   const [importResult, setImportResult] = useState<Array<{ name: string; scanned: number }> | null>(null);
   const [dragItem, setDragItem] = useState<{ fromIdx: number | "loose"; folder: string } | null>(null);
   const [dropTarget, setDropTarget] = useState<number | "loose" | "new" | null>(null);
@@ -51,6 +52,11 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
       await checkAndAddFolder(`~/${folderName}`);
     }
   }, [name, mode]);
+
+  // Auto-resolve folder dropped on the surface
+  useEffect(() => {
+    if (initialFolder) resolveFolder(initialFolder);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function checkAndAddFolder(path: string) {
     // Check if this is a container (like ~/Dev) with multiple projects
@@ -205,13 +211,18 @@ export function AddSpaceWizard({ spaces, onClose, onComplete }: Props) {
           </div>
 
           <div className="add-space-title">
-            Create {suggestions.length} spaces
+            {discovering ? "Scanning…" : `Create ${enabledCount} spaces`}
           </div>
           <div className="add-space-subtitle">
-            {suggestions.reduce((n, s) => n + s.folders.length, 0)} folders grouped into spaces. Edit, move, or untick to skip.
+            {discovering ? "Looking for projects in your folder" : `${totalFolders} folders grouped into spaces. Edit, move, or untick to skip.`}
           </div>
 
           <div className="discovery-list">
+            {discovering && suggestions.length === 0 && (
+              <div style={{ textAlign: "center", padding: "40px 0", color: "var(--text-dim)", fontSize: "13px" }}>
+                Scanning for projects…
+              </div>
+            )}
             {suggestions.map((s, idx) => (
               <div
                 key={idx}

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { Space, ScanResult } from "../../../shared/types";
 import { createSpace, addPath, triggerScan, deleteSpace } from "../data/spaces-api";
 
@@ -54,9 +54,13 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
   }, [name, mode]);
 
   // Auto-resolve folder dropped on the surface
+  const resolved = useRef(false);
   useEffect(() => {
-    if (initialFolder) resolveFolder(initialFolder);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (initialFolder && !resolved.current) {
+      resolved.current = true;
+      resolveFolder(initialFolder);
+    }
+  }, [initialFolder, resolveFolder]);
 
   async function checkAndAddFolder(path: string) {
     // Check if this is a container (like ~/Dev) with multiple projects
@@ -79,11 +83,13 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
         setSuggestions(data.suggestions.map(s => ({ ...s, enabled: true })));
         setStep("discovery");
       } else {
-        // Single project — add to folders list
+        // Single project — go back to name-path step with folder loaded
         setFolders(prev => prev.includes(data.path!) ? prev : [...prev, data.path!]);
+        setStep("name-path");
       }
     } catch (err) {
       setFolders(prev => prev.includes(path) ? prev : [...prev, path]);
+      setStep("name-path");
     } finally {
       setDiscovering(false);
     }

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -18,16 +18,14 @@ interface Props {
   onArtifactStop?: (artifact: Artifact) => void;
   onGroupClick: (groupName: string) => void;
   onSpaceChange: (space: string) => void;
-  onAddSpace?: () => void;
+  onAddSpace?: (folderName?: string) => void;
   isFirstRun?: boolean;
+  dragOver?: boolean;
   revealId?: string | null;
 }
 
-export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, revealId }: Props) {
+export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, dragOver, revealId }: Props) {
   const isAllSpace = space === "__all__";
-
-  // ── Surface drop-to-import ──
-  const [surfaceDragOver, setSurfaceDragOver] = useState(false);
 
   // ── Topbar auto-hide ──
   const [topbarVisible, setTopbarVisible] = useState(true);
@@ -78,7 +76,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
           color1="#07060f"
           color2="#7c6bff"
           color3="#5227FF"
-          timeSpeed={0.15}
+          timeSpeed={dragOver ? 2 : 0.15}
           colorBalance={0}
           warpStrength={2}
           warpFrequency={6.5}
@@ -168,26 +166,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
         <div className="topbar-right" />
       </div>
 
-      <div
-        className={`desktop-scroll${isHero ? " desktop-scroll--hero" : ""}${surfaceDragOver ? " desktop-scroll--drop" : ""}`}
-        onDragOver={(e) => {
-          if (onAddSpace && e.dataTransfer.types.includes("Files")) {
-            e.preventDefault();
-            setSurfaceDragOver(true);
-          }
-        }}
-        onDragLeave={(e) => {
-          const related = e.relatedTarget as Node | null;
-          if (related && e.currentTarget.contains(related)) return;
-          setSurfaceDragOver(false);
-        }}
-        onDrop={(e) => {
-          setSurfaceDragOver(false);
-          if (!e.dataTransfer.types.includes("Files")) return;
-          e.preventDefault();
-          if (onAddSpace) onAddSpace();
-        }}
-      >
+      <div className={`desktop-scroll${isHero ? " desktop-scroll--hero" : ""}`}>
         <div className="filter-bar">
           {activeKind && (
             <div className="filter-notice">


### PR DESCRIPTION
## Summary

- Drop a folder anywhere on the page to trigger the discovery wizard
- Grainient background speeds up on drag — electric visual feedback
- Icons and chat bar dim during drag to focus attention
- Wizard skips step 1 and goes straight to scanning when folder is dropped
- Prevents browser from navigating away on accidental file drops

## Files

| File | Change |
|------|--------|
| `web/src/App.tsx` | Full-page drag/drop handlers, droppedFolder state |
| `web/src/App.css` | Shell drag-over styles (glow, dim) |
| `web/src/components/Desktop.tsx` | dragOver prop controls Grainient speed |
| `web/src/components/AddSpaceWizard.tsx` | initialFolder prop, auto-resolve, skip step 1 |
| `CHANGELOG.md` | Drop-to-import + dev/prod separation entries |

## Test plan

- [x] Drop folder on surface → wizard opens at scanning step
- [x] Drop folder on chat bar → same result, no browser navigation
- [x] Drag hover → background speeds up, icons dim
- [x] Release drag without dropping → reverts to normal
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)