### PR TITLE
feat: cloud AI import — paste from ChatGPT/Claude/Gemini (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-04-15
+
+### Cloud AI import
+
+- Import projects, context, and memories from ChatGPT, Claude, or Gemini
+- 3-step wizard: select provider, paste AI output, preview and import
+- Server converts any format to structured JSON via OpenCode
+- Merge-based: detects existing spaces, skips duplicates on re-import
+- First-run onboarding banner with "Import from AI" CTA
+
+### Builtin redesign
+
+- All builtins (Quick Start, Connect Your AI, Import from AI) redesigned with consistent design language
+- Glass cards, ambient glow, pill selectors, smooth animations
+- Iframe close support via postMessage
+
 ## 2026-04-14
 
 ### MCP onboarding

--- a/builtins/connect-your-ai/src/index.html
+++ b/builtins/connect-your-ai/src/index.html
@@ -4,149 +4,185 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bring Your Own AI</title>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --accent: #7c6bff;
+      --accent-bright: #a597ff;
+      --green: #4ade80;
+      --text: #f0f0f5;
+      --text-dim: rgba(232,233,240,0.45);
+      --text-muted: rgba(232,233,240,0.2);
+      --surface: rgba(12,13,28,0.85);
+      --border: rgba(124,107,255,0.15);
+      --font-body: 'Space Grotesk', -apple-system, sans-serif;
+      --font-mono: 'IBM Plex Mono', monospace;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: 'Space Grotesk', -apple-system, sans-serif;
-      background: #0a0b14;
-      color: #c8c8d0;
+      font-family: var(--font-body);
+      color: var(--text);
+      background: rgba(30, 31, 54, 1);
       min-height: 100vh;
-      padding: 60px 24px;
-      line-height: 1.6;
+      display: flex;
+      justify-content: center;
+      padding: 60px 24px 80px;
+      overflow-x: hidden;
     }
-    .page { max-width: 640px; margin: 0 auto; }
 
-    h1 {
-      font-size: 28px;
-      font-weight: 600;
-      color: #fff;
-      margin-bottom: 8px;
+    .glow {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% -10%, rgba(124,107,255,0.10) 0%, transparent 60%),
+        radial-gradient(ellipse 50% 35% at 80% 90%, rgba(165,151,255,0.04) 0%, transparent 50%);
     }
-    .subtitle {
-      font-size: 15px;
-      color: rgba(255,255,255,0.45);
+
+    .page {
+      max-width: 600px;
+      width: 100%;
+      position: relative;
+      z-index: 1;
+      animation: fadeUp 0.5s cubic-bezier(0.16,1,0.3,1);
+    }
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(16px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .page-header {
+      text-align: center;
       margin-bottom: 48px;
     }
-
-    h2 {
-      font-size: 16px;
-      font-weight: 600;
-      color: #fff;
-      margin-bottom: 16px;
-      margin-top: 48px;
+    .page-header h1 {
+      font-size: clamp(1.6rem, 4vw, 2.2rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 8px;
     }
-    h2:first-of-type { margin-top: 0; }
+    .page-header p {
+      font-size: 15px;
+      color: var(--text-dim);
+    }
+
+    .section-label {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--accent);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 16px;
+      margin-top: 40px;
+    }
+    .section-label:first-of-type { margin-top: 0; }
 
     /* Tabs */
-    .tabs {
+    .tab-track {
       display: flex;
       gap: 2px;
-      background: rgba(255,255,255,0.04);
-      border-radius: 10px 10px 0 0;
-      padding: 4px 4px 0;
-      overflow-x: auto;
+      padding: 3px 4px;
+      border-radius: 9999px;
+      background: rgba(13,14,26,0.6);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid rgba(255,255,255,0.06);
+      margin-bottom: 0;
+      display: inline-flex;
     }
-    .tab {
-      padding: 10px 18px;
-      font-size: 13px;
-      font-family: inherit;
-      font-weight: 500;
-      color: rgba(255,255,255,0.4);
+    .tab-btn {
       background: none;
       border: none;
+      color: var(--text-dim);
+      font-family: var(--font-body);
+      font-size: 13px;
+      font-weight: 500;
+      padding: 7px 18px;
+      border-radius: 9999px;
       cursor: pointer;
-      border-radius: 8px 8px 0 0;
+      transition: color 0.2s, background 0.2s;
       white-space: nowrap;
-      transition: color 0.15s, background 0.15s;
     }
-    .tab:hover { color: rgba(255,255,255,0.7); }
-    .tab.active {
-      color: #fff;
-      background: rgba(124,107,255,0.15);
+    .tab-btn:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+    .tab-btn.active { background: rgba(124,107,255,0.25); color: #fff; }
+
+    /* Code card */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      overflow: hidden;
+      margin-bottom: 12px;
     }
 
-    /* Code panels */
-    .panels {
-      background: rgba(30,32,50,0.6);
-      border: 1px solid rgba(255,255,255,0.06);
-      border-top: none;
-      border-radius: 0 0 10px 10px;
+    .code-header {
+      padding: 12px 20px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--text-muted);
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .code-body {
       padding: 20px;
       position: relative;
     }
-    .panel { display: none; }
-    .panel.active { display: block; }
-
-    .panel-label {
-      font-size: 11px;
-      color: rgba(255,255,255,0.3);
-      margin-bottom: 8px;
-      font-family: 'IBM Plex Mono', monospace;
-    }
-
-    pre {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 13px;
-      line-height: 1.5;
-      color: #e0e0e8;
+    .code-body pre {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.6;
+      color: rgba(255,255,255,0.75);
       white-space: pre-wrap;
       word-break: break-all;
     }
 
     .copy-btn {
-      position: absolute;
-      top: 12px;
-      right: 12px;
       background: rgba(124,107,255,0.15);
       border: 1px solid rgba(124,107,255,0.2);
-      color: rgba(255,255,255,0.6);
+      color: var(--text-dim);
       font-size: 11px;
-      font-family: 'IBM Plex Mono', monospace;
-      padding: 4px 10px;
-      border-radius: 6px;
+      font-family: var(--font-mono);
+      padding: 4px 12px;
+      border-radius: 9999px;
       cursor: pointer;
       transition: all 0.15s;
     }
-    .copy-btn:hover {
-      background: rgba(124,107,255,0.3);
-      color: #fff;
-    }
-    .copy-btn.copied {
-      background: rgba(80,200,120,0.2);
-      border-color: rgba(80,200,120,0.3);
-      color: rgba(80,200,120,0.8);
-    }
+    .copy-btn:hover { background: rgba(124,107,255,0.3); color: #fff; }
+    .copy-btn.copied { background: rgba(74,222,128,0.15); border-color: rgba(74,222,128,0.2); color: var(--green); }
+
+    .panel { display: none; }
+    .panel.active { display: block; }
 
     /* Examples */
     .examples {
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 10px;
       margin-top: 16px;
     }
     .example {
       display: flex;
       align-items: baseline;
       gap: 12px;
-      font-size: 14px;
+      font-size: 13px;
     }
     .example-prompt {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 13px;
-      color: rgba(124,107,255,0.8);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--accent-bright);
       flex-shrink: 0;
     }
-    .example-arrow {
-      color: rgba(255,255,255,0.2);
-      flex-shrink: 0;
-    }
-    .example-result {
-      color: rgba(255,255,255,0.5);
-      font-size: 13px;
-    }
+    .example-arrow { color: var(--text-muted); flex-shrink: 0; }
+    .example-result { color: var(--text-dim); font-size: 13px; }
 
-    /* Tools grid */
+    /* Tools */
     .tools {
       display: flex;
       flex-wrap: wrap;
@@ -154,61 +190,55 @@
       margin-top: 16px;
     }
     .tool {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--font-mono);
       font-size: 11px;
       padding: 5px 12px;
-      border-radius: 6px;
+      border-radius: 9999px;
       background: rgba(124,107,255,0.08);
-      color: rgba(255,255,255,0.5);
+      color: var(--text-dim);
     }
 
-    .note {
-      font-size: 13px;
-      color: rgba(255,255,255,0.3);
+    .desc {
+      font-size: 14px;
+      color: var(--text-dim);
+      line-height: 1.7;
       margin-top: 12px;
     }
-
-    .accent { color: #7c6bff; }
   </style>
 </head>
 <body>
+  <div class="glow"></div>
   <div class="page">
-    <h1>Bring Your Own AI</h1>
-    <p class="subtitle">Oyster is an MCP server. Any AI that speaks the protocol can control your workspace.</p>
-
-    <h2>Quick start</h2>
-
-    <div class="tabs">
-      <button class="tab active" onclick="showTab('claude')">Claude Code</button>
-      <button class="tab" onclick="showTab('cursor')">Cursor</button>
-      <button class="tab" onclick="showTab('vscode')">VS Code</button>
-      <button class="tab" onclick="showTab('windsurf')">Windsurf</button>
+    <div class="page-header">
+      <h1>Bring Your Own AI.</h1>
+      <p>Oyster is an MCP server. Any AI that speaks the protocol can control your workspace.</p>
     </div>
-    <div class="panels">
-      <button class="copy-btn" onclick="copyCode(this)">copy</button>
 
-      <div id="panel-claude" class="panel active">
-        <div class="panel-label">run in your terminal</div>
-        <pre id="code-claude"></pre>
-      </div>
+    <div class="section-label">Quick start</div>
 
-      <div id="panel-cursor" class="panel">
-        <div class="panel-label">.cursor/mcp.json</div>
-        <pre id="code-cursor"></pre>
-      </div>
-
-      <div id="panel-vscode" class="panel">
-        <div class="panel-label">.vscode/mcp.json</div>
-        <pre id="code-vscode"></pre>
-      </div>
-
-      <div id="panel-windsurf" class="panel">
-        <div class="panel-label">~/.codeium/windsurf/mcp_config.json</div>
-        <pre id="code-windsurf"></pre>
+    <div style="margin-bottom:12px">
+      <div class="tab-track">
+        <button class="tab-btn active" onclick="showTab('claude')">Claude Code</button>
+        <button class="tab-btn" onclick="showTab('cursor')">Cursor</button>
+        <button class="tab-btn" onclick="showTab('vscode')">VS Code</button>
+        <button class="tab-btn" onclick="showTab('windsurf')">Windsurf</button>
       </div>
     </div>
 
-    <h2>What you can do</h2>
+    <div class="card">
+      <div class="code-header">
+        <span id="panel-label">run in your terminal</span>
+        <button class="copy-btn" onclick="copyCode(this)">copy</button>
+      </div>
+      <div class="code-body">
+        <div id="panel-claude" class="panel active"><pre id="code-claude"></pre></div>
+        <div id="panel-cursor" class="panel"><pre id="code-cursor"></pre></div>
+        <div id="panel-vscode" class="panel"><pre id="code-vscode"></pre></div>
+        <div id="panel-windsurf" class="panel"><pre id="code-windsurf"></pre></div>
+      </div>
+    </div>
+
+    <div class="section-label">What you can do</div>
     <div class="examples">
       <div class="example">
         <span class="example-prompt">"Create a deck about Q2 results"</span>
@@ -218,7 +248,7 @@
       <div class="example">
         <span class="example-prompt">"Scan ~/Dev/my-project"</span>
         <span class="example-arrow">&rarr;</span>
-        <span class="example-result">new space with apps, docs, and diagrams discovered</span>
+        <span class="example-result">new space with apps, docs, and diagrams</span>
       </div>
       <div class="example">
         <span class="example-prompt">"Open the competitor analysis"</span>
@@ -226,7 +256,7 @@
         <span class="example-result">opens it in the viewer</span>
       </div>
       <div class="example">
-        <span class="example-prompt">"Move the pitch deck to the clients space"</span>
+        <span class="example-prompt">"Move the pitch deck to clients"</span>
         <span class="example-arrow">&rarr;</span>
         <span class="example-result">reassigned instantly</span>
       </div>
@@ -237,7 +267,7 @@
       </div>
     </div>
 
-    <h2>Available tools</h2>
+    <div class="section-label">Available tools</div>
     <div class="tools">
       <span class="tool">create_artifact</span>
       <span class="tool">list_artifacts</span>
@@ -254,18 +284,25 @@
       <span class="tool">gather_repo_context</span>
       <span class="tool">regenerate_icon</span>
     </div>
-    <p class="note">Your AI can chain these together. Ask it to onboard a project, scan for artifacts, create a summary, and organise everything into spaces — all from one prompt.</p>
+    <p class="desc">Your AI can chain these together. Ask it to onboard a project, scan for artifacts, create a summary, and organise everything into spaces — all from one prompt.</p>
   </div>
 
   <script>
     const origin = window.location.origin;
     const mcpUrl = origin + '/mcp/';
 
+    const labels = {
+      claude: 'run in your terminal',
+      cursor: '.cursor/mcp.json',
+      vscode: '.vscode/mcp.json',
+      windsurf: '~/.codeium/windsurf/mcp_config.json',
+    };
+
     document.getElementById('code-claude').textContent =
       `claude mcp add --transport http oyster ${mcpUrl}`;
 
     document.getElementById('code-cursor').textContent =
-      `{
+`{
   "mcpServers": {
     "oyster": {
       "url": "${mcpUrl}"
@@ -274,7 +311,7 @@
 }`;
 
     document.getElementById('code-vscode').textContent =
-      `{
+`{
   "servers": {
     "oyster": {
       "type": "http",
@@ -284,7 +321,7 @@
 }`;
 
     document.getElementById('code-windsurf').textContent =
-      `{
+`{
   "mcpServers": {
     "oyster": {
       "serverUrl": "${mcpUrl}"
@@ -293,11 +330,11 @@
 }`;
 
     function showTab(name) {
-      document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-      document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+      document.querySelectorAll('.tab-btn').forEach(t => t.classList.remove('active'));
       event.target.classList.add('active');
+      document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
       document.getElementById('panel-' + name).classList.add('active');
-      // Reset copy button
+      document.getElementById('panel-label').textContent = labels[name];
       const btn = document.querySelector('.copy-btn');
       btn.textContent = 'copy';
       btn.classList.remove('copied');

--- a/builtins/connect-your-ai/src/index.html
+++ b/builtins/connect-your-ai/src/index.html
@@ -218,10 +218,10 @@
 
     <div style="margin-bottom:12px">
       <div class="tab-track">
-        <button class="tab-btn active" onclick="showTab('claude')">Claude Code</button>
-        <button class="tab-btn" onclick="showTab('cursor')">Cursor</button>
-        <button class="tab-btn" onclick="showTab('vscode')">VS Code</button>
-        <button class="tab-btn" onclick="showTab('windsurf')">Windsurf</button>
+        <button class="tab-btn active" onclick="showTab('claude',this)">Claude Code</button>
+        <button class="tab-btn" onclick="showTab('cursor',this)">Cursor</button>
+        <button class="tab-btn" onclick="showTab('vscode',this)">VS Code</button>
+        <button class="tab-btn" onclick="showTab('windsurf',this)">Windsurf</button>
       </div>
     </div>
 
@@ -329,9 +329,9 @@
   }
 }`;
 
-    function showTab(name) {
+    function showTab(name, el) {
       document.querySelectorAll('.tab-btn').forEach(t => t.classList.remove('active'));
-      event.target.classList.add('active');
+      el.classList.add('active');
       document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
       document.getElementById('panel-' + name).classList.add('active');
       document.getElementById('panel-label').textContent = labels[name];

--- a/builtins/import-from-ai/manifest.json
+++ b/builtins/import-from-ai/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "import-from-ai",
   "name": "Import from AI",
-  "type": "notes",
+  "type": "app",
   "runtime": "static",
   "entrypoint": "src/index.html",
   "ports": [],

--- a/builtins/import-from-ai/manifest.json
+++ b/builtins/import-from-ai/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "import-from-ai",
+  "name": "Import from AI",
+  "type": "notes",
+  "runtime": "static",
+  "entrypoint": "src/index.html",
+  "ports": [],
+  "storage": "none",
+  "capabilities": [],
+  "status": "ready",
+  "builtin": true,
+  "created_at": "2026-04-14T00:00:00.000Z",
+  "updated_at": "2026-04-14T00:00:00.000Z"
+}

--- a/builtins/import-from-ai/src/index.html
+++ b/builtins/import-from-ai/src/index.html
@@ -1,0 +1,496 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Import from AI</title>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Space Grotesk', -apple-system, sans-serif;
+      background: #0a0b14;
+      color: #c8c8d0;
+      min-height: 100vh;
+      padding: 60px 24px;
+      line-height: 1.6;
+    }
+    .page { max-width: 640px; margin: 0 auto; }
+
+    h1 { font-size: 28px; font-weight: 600; color: #fff; margin-bottom: 8px; }
+    .subtitle { font-size: 15px; color: rgba(255,255,255,0.45); margin-bottom: 40px; }
+
+    /* Steps indicator */
+    .steps {
+      display: flex;
+      gap: 24px;
+      margin-bottom: 32px;
+    }
+    .step-dot {
+      font-size: 13px;
+      font-weight: 500;
+      color: rgba(255,255,255,0.25);
+      cursor: default;
+    }
+    .step-dot.active { color: #7c6bff; }
+    .step-dot.done { color: rgba(124,107,255,0.5); }
+    .step-dot .num {
+      display: inline-flex;
+      width: 22px; height: 22px;
+      align-items: center; justify-content: center;
+      border-radius: 50%;
+      border: 1px solid rgba(255,255,255,0.1);
+      font-size: 11px;
+      margin-right: 6px;
+    }
+    .step-dot.active .num {
+      border-color: #7c6bff;
+      background: rgba(124,107,255,0.15);
+    }
+    .step-dot.done .num {
+      border-color: rgba(124,107,255,0.3);
+      background: rgba(124,107,255,0.1);
+    }
+
+    /* Panels */
+    .panel { display: none; }
+    .panel.active { display: block; }
+
+    /* Provider selector */
+    .providers {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 24px;
+      flex-wrap: wrap;
+    }
+    .provider-btn {
+      padding: 8px 16px;
+      border-radius: 8px;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: rgba(255,255,255,0.03);
+      color: rgba(255,255,255,0.5);
+      font-family: inherit;
+      font-size: 13px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .provider-btn:hover {
+      border-color: rgba(124,107,255,0.3);
+      color: rgba(255,255,255,0.8);
+    }
+    .provider-btn.selected {
+      border-color: #7c6bff;
+      background: rgba(124,107,255,0.12);
+      color: #fff;
+    }
+
+    /* Prompt display */
+    .prompt-box {
+      background: rgba(30,32,50,0.6);
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 10px;
+      padding: 20px;
+      position: relative;
+      margin-bottom: 16px;
+    }
+    .prompt-box pre {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #e0e0e8;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+    .prompt-loading {
+      color: rgba(255,255,255,0.3);
+      font-size: 13px;
+      padding: 40px;
+      text-align: center;
+    }
+
+    /* Buttons */
+    .btn {
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-family: inherit;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: all 0.15s;
+    }
+    .btn-primary {
+      background: #7c6bff;
+      color: #fff;
+    }
+    .btn-primary:hover { background: #6b5ce6; }
+    .btn-primary:disabled {
+      background: rgba(124,107,255,0.3);
+      cursor: not-allowed;
+    }
+    .btn-secondary {
+      background: rgba(255,255,255,0.06);
+      color: rgba(255,255,255,0.6);
+    }
+    .btn-secondary:hover { background: rgba(255,255,255,0.1); }
+    .btn-success {
+      background: #4ade80;
+      color: #000;
+      font-weight: 600;
+    }
+    .btn-success:hover { background: #3bc96e; }
+    .btn-row { display: flex; gap: 8px; margin-top: 16px; }
+
+    .copy-btn {
+      position: absolute;
+      top: 12px; right: 12px;
+      background: rgba(124,107,255,0.15);
+      border: 1px solid rgba(124,107,255,0.2);
+      color: rgba(255,255,255,0.6);
+      font-size: 11px;
+      font-family: 'IBM Plex Mono', monospace;
+      padding: 4px 10px;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    .copy-btn:hover { background: rgba(124,107,255,0.3); color: #fff; }
+    .copy-btn.copied { background: rgba(80,200,120,0.2); border-color: rgba(80,200,120,0.3); color: rgba(80,200,120,0.8); }
+
+    /* Textarea */
+    .paste-area {
+      width: 100%;
+      min-height: 200px;
+      background: rgba(30,32,50,0.6);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 10px;
+      padding: 16px;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 12px;
+      color: #e0e0e8;
+      resize: vertical;
+      line-height: 1.5;
+    }
+    .paste-area:focus {
+      outline: none;
+      border-color: rgba(124,107,255,0.4);
+    }
+    .paste-area::placeholder { color: rgba(255,255,255,0.2); }
+
+    /* Error / warning */
+    .error { color: #f87171; font-size: 13px; margin-top: 8px; }
+    .warning { color: #fbbf24; font-size: 13px; margin-bottom: 12px; }
+
+    /* Counts */
+    .counts {
+      display: flex;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+    .count-badge {
+      font-size: 13px;
+      padding: 4px 12px;
+      border-radius: 6px;
+    }
+    .count-new { background: rgba(74,222,128,0.12); color: #4ade80; }
+    .count-merge { background: rgba(251,191,36,0.12); color: #fbbf24; }
+    .count-skip { background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.4); }
+
+    /* Action list */
+    .action-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+    .action-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 8px 12px;
+      border-radius: 8px;
+      background: rgba(255,255,255,0.02);
+      font-size: 13px;
+    }
+    .action-item.indent { margin-left: 28px; }
+    .action-item input[type="checkbox"] { accent-color: #7c6bff; margin-top: 3px; flex-shrink: 0; }
+    .action-type {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      color: rgba(124,107,255,0.7);
+      min-width: 90px;
+      flex-shrink: 0;
+    }
+    .action-label { color: rgba(255,255,255,0.7); flex: 1; }
+    .action-status {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      flex-shrink: 0;
+    }
+    .status-new { background: rgba(74,222,128,0.1); color: #4ade80; }
+    .status-merge { background: rgba(251,191,36,0.1); color: #fbbf24; }
+    .status-skip { background: rgba(255,255,255,0.05); color: rgba(255,255,255,0.3); }
+
+    /* Success */
+    .success-msg {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .success-msg h2 { font-size: 22px; color: #4ade80; margin-bottom: 8px; }
+    .success-msg p { color: rgba(255,255,255,0.5); font-size: 14px; margin-bottom: 24px; }
+
+    .spinner {
+      display: inline-block;
+      width: 16px; height: 16px;
+      border: 2px solid rgba(124,107,255,0.3);
+      border-top-color: #7c6bff;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .hint { font-size: 12px; color: rgba(255,255,255,0.3); margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <h1>Import from AI</h1>
+    <p class="subtitle">Bring your projects and context from ChatGPT, Claude, or Gemini.</p>
+
+    <div class="steps">
+      <span class="step-dot active" id="step1-dot"><span class="num">1</span>Copy prompt</span>
+      <span class="step-dot" id="step2-dot"><span class="num">2</span>Paste response</span>
+      <span class="step-dot" id="step3-dot"><span class="num">3</span>Review</span>
+    </div>
+
+    <!-- Step 1: Provider + Copy -->
+    <div class="panel active" id="panel-step1">
+      <div class="providers">
+        <button class="provider-btn selected" onclick="selectProvider('chatgpt', this)">ChatGPT</button>
+        <button class="provider-btn" onclick="selectProvider('claude', this)">Claude</button>
+        <button class="provider-btn" onclick="selectProvider('gemini', this)">Gemini</button>
+        <button class="provider-btn" onclick="selectProvider('other', this)">Other</button>
+      </div>
+
+      <div class="prompt-box">
+        <button class="copy-btn" onclick="copyPrompt(this)">copy</button>
+        <div id="prompt-content"><div class="prompt-loading">Loading prompt...</div></div>
+      </div>
+      <p class="hint">This prompt is tailored to your workspace. Paste it into your AI of choice.</p>
+
+      <div class="btn-row">
+        <button class="btn btn-primary" onclick="goToStep(2)">Next</button>
+      </div>
+    </div>
+
+    <!-- Step 2: Paste -->
+    <div class="panel" id="panel-step2">
+      <textarea class="paste-area" id="paste-input" placeholder="Paste your AI's response here..."></textarea>
+      <div id="parse-error" class="error" style="display:none"></div>
+
+      <div class="btn-row">
+        <button class="btn btn-secondary" onclick="goToStep(1)">Back</button>
+        <button class="btn btn-primary" id="preview-btn" onclick="previewImport()">Preview import</button>
+      </div>
+    </div>
+
+    <!-- Step 3: Review -->
+    <div class="panel" id="panel-step3">
+      <div id="plan-warnings"></div>
+      <div id="plan-counts" class="counts"></div>
+      <div id="plan-actions" class="action-list"></div>
+
+      <div class="btn-row">
+        <button class="btn btn-secondary" onclick="goToStep(2)">Back</button>
+        <button class="btn btn-success" id="import-btn" onclick="executeImport()">Import selected</button>
+      </div>
+    </div>
+
+    <!-- Success -->
+    <div class="panel" id="panel-success">
+      <div class="success-msg">
+        <h2>Import complete</h2>
+        <p id="success-detail"></p>
+        <button class="btn btn-primary" onclick="window.location.reload()">Import more</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const origin = window.location.origin;
+    let selectedProvider = 'chatgpt';
+    let currentPrompt = '';
+    let currentPlan = null;
+
+    // Load prompt on page load
+    loadPrompt();
+
+    function selectProvider(provider, btn) {
+      selectedProvider = provider;
+      document.querySelectorAll('.provider-btn').forEach(b => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      loadPrompt();
+    }
+
+    async function loadPrompt() {
+      const el = document.getElementById('prompt-content');
+      el.innerHTML = '<div class="prompt-loading">Loading prompt...</div>';
+      try {
+        const res = await fetch(`${origin}/api/import/prompt?provider=${selectedProvider}`);
+        currentPrompt = await res.text();
+        el.innerHTML = `<pre>${escapeHtml(currentPrompt)}</pre>`;
+      } catch (err) {
+        el.innerHTML = `<div class="prompt-loading">Failed to load prompt</div>`;
+      }
+    }
+
+    function copyPrompt(btn) {
+      navigator.clipboard.writeText(currentPrompt).then(() => {
+        btn.textContent = 'copied';
+        btn.classList.add('copied');
+        setTimeout(() => { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
+      });
+    }
+
+    function goToStep(step) {
+      document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+      document.getElementById(`panel-step${step}`).classList.add('active');
+
+      for (let i = 1; i <= 3; i++) {
+        const dot = document.getElementById(`step${i}-dot`);
+        dot.className = 'step-dot';
+        if (i < step) dot.classList.add('done');
+        if (i === step) dot.classList.add('active');
+      }
+    }
+
+    async function previewImport() {
+      const raw = document.getElementById('paste-input').value.trim();
+      if (!raw) return;
+
+      const btn = document.getElementById('preview-btn');
+      const errEl = document.getElementById('parse-error');
+      btn.innerHTML = '<span class="spinner"></span>Previewing...';
+      btn.disabled = true;
+      errEl.style.display = 'none';
+
+      try {
+        const res = await fetch(`${origin}/api/import/preview`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ raw, provider: selectedProvider }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) {
+          errEl.textContent = data.error || 'Preview failed';
+          errEl.style.display = 'block';
+          return;
+        }
+
+        currentPlan = data;
+        renderPlan(data);
+        goToStep(3);
+      } catch (err) {
+        errEl.textContent = 'Network error: ' + err.message;
+        errEl.style.display = 'block';
+      } finally {
+        btn.innerHTML = 'Preview import';
+        btn.disabled = false;
+      }
+    }
+
+    function renderPlan(plan) {
+      // Warnings
+      const warnEl = document.getElementById('plan-warnings');
+      warnEl.innerHTML = plan.warnings.map(w => `<div class="warning">${escapeHtml(w)}</div>`).join('');
+
+      // Counts
+      const countsEl = document.getElementById('plan-counts');
+      countsEl.innerHTML = `
+        <span class="count-badge count-new">${plan.counts.new} new</span>
+        <span class="count-badge count-merge">${plan.counts.merge} merge</span>
+        <span class="count-badge count-skip">${plan.counts.skipped} skipped</span>
+      `;
+
+      // Actions
+      const actionsEl = document.getElementById('plan-actions');
+      actionsEl.innerHTML = plan.actions.map(a => {
+        const checked = a.status !== 'duplicate_skipped' ? 'checked' : '';
+        const indent = a.depends_on ? ' indent' : '';
+        const statusClass = a.status === 'new' ? 'status-new' : a.status === 'exists_will_merge' ? 'status-merge' : 'status-skip';
+        const statusLabel = a.status === 'new' ? 'new' : a.status === 'exists_will_merge' ? 'merge' : 'skip';
+        const label = a.name || a.title || a.content?.slice(0, 60) || '';
+        const typeLabel = a.type.replace(/_/g, ' ');
+
+        return `<div class="action-item${indent}">
+          <input type="checkbox" ${checked} data-id="${a.action_id}" data-depends="${a.depends_on || ''}" onchange="handleCheck(this)">
+          <span class="action-type">${typeLabel}</span>
+          <span class="action-label">${escapeHtml(label)}</span>
+          <span class="action-status ${statusClass}">${statusLabel}</span>
+        </div>`;
+      }).join('');
+    }
+
+    function handleCheck(cb) {
+      const id = cb.dataset.id;
+      if (!cb.checked) {
+        // Untick children
+        document.querySelectorAll(`input[data-depends="${id}"]`).forEach(child => {
+          child.checked = false;
+        });
+      }
+    }
+
+    async function executeImport() {
+      if (!currentPlan) return;
+
+      const approved = [];
+      document.querySelectorAll('#plan-actions input[type="checkbox"]:checked').forEach(cb => {
+        approved.push(cb.dataset.id);
+      });
+
+      const btn = document.getElementById('import-btn');
+      btn.innerHTML = '<span class="spinner"></span>Importing...';
+      btn.disabled = true;
+
+      try {
+        const res = await fetch(`${origin}/api/import/execute`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ plan_id: currentPlan.plan_id, approved_action_ids: approved }),
+        });
+
+        const data = await res.json();
+
+        // Show success
+        document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+        document.getElementById('panel-success').classList.add('active');
+
+        const detail = document.getElementById('success-detail');
+        const failed = data.counts.failed;
+        detail.textContent = `${data.counts.created} items created${failed ? `, ${failed} failed` : ''}.`;
+
+        // Find first created space to switch to
+        const createdSpace = data.results.find(r => r.status === 'created' && currentPlan.actions.find(a => a.action_id === r.action_id && a.type === 'create_space'));
+        if (createdSpace) {
+          const action = currentPlan.actions.find(a => a.action_id === createdSpace.action_id);
+          if (action?.name) {
+            const slug = action.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+            // Navigate parent to the new space
+            try { window.parent.postMessage({ type: 'switch_space', space: slug }, '*'); } catch {}
+          }
+        }
+      } catch (err) {
+        btn.innerHTML = 'Import failed - try again';
+        btn.disabled = false;
+      }
+    }
+
+    function escapeHtml(str) {
+      const div = document.createElement('div');
+      div.textContent = str;
+      return div.innerHTML;
+    }
+  </script>
+</body>
+</html>

--- a/builtins/import-from-ai/src/index.html
+++ b/builtins/import-from-ai/src/index.html
@@ -272,13 +272,13 @@
       </div>
 
       <div class="prompt-box">
-        <button class="copy-btn" onclick="copyPrompt(this)">copy</button>
         <div id="prompt-content"><div class="prompt-loading">Loading prompt...</div></div>
       </div>
       <p class="hint">This prompt is tailored to your workspace. Paste it into your AI of choice.</p>
 
       <div class="btn-row">
-        <button class="btn btn-primary" onclick="goToStep(2)">Next</button>
+        <button class="btn btn-primary" onclick="copyPromptAndAdvance()">Copy prompt</button>
+        <button class="btn btn-secondary" onclick="goToStep(2)" style="font-size:13px">Next &rarr;</button>
       </div>
     </div>
 
@@ -343,11 +343,11 @@
       }
     }
 
-    function copyPrompt(btn) {
+    function copyPromptAndAdvance() {
+      const btn = document.querySelector('.btn-primary');
       navigator.clipboard.writeText(currentPrompt).then(() => {
-        btn.textContent = 'copied';
-        btn.classList.add('copied');
-        setTimeout(() => { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
+        btn.textContent = 'Copied!';
+        setTimeout(() => goToStep(2), 800);
       });
     }
 

--- a/builtins/import-from-ai/src/index.html
+++ b/builtins/import-from-ai/src/index.html
@@ -4,243 +4,386 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Import from AI</title>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --accent: #7c6bff;
+      --accent-bright: #a597ff;
+      --green: #4ade80;
+      --amber: #fbbf24;
+      --text: #f0f0f5;
+      --text-dim: rgba(232,233,240,0.45);
+      --text-muted: rgba(232,233,240,0.2);
+      --surface: rgba(12,13,28,0.85);
+      --border: rgba(124,107,255,0.15);
+      --font-body: 'Space Grotesk', -apple-system, sans-serif;
+      --font-mono: 'IBM Plex Mono', monospace;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: 'Space Grotesk', -apple-system, sans-serif;
-      background: #0a0b14;
-      color: #c8c8d0;
+      font-family: var(--font-body);
+      color: var(--text);
+      background: rgba(30, 31, 54, 1);
       min-height: 100vh;
-      padding: 60px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 40px 24px;
+      overflow-x: hidden;
+    }
+
+    /* ── Ambient glow ── */
+    .glow {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% -10%, rgba(124,107,255,0.12) 0%, transparent 60%),
+        radial-gradient(ellipse 60% 40% at 20% 100%, rgba(124,107,255,0.06) 0%, transparent 50%),
+        radial-gradient(ellipse 50% 35% at 80% 90%, rgba(165,151,255,0.04) 0%, transparent 50%);
+    }
+
+    .wizard {
+      width: 100%;
+      max-width: 560px;
+      position: relative;
+      z-index: 1;
+      animation: fadeUp 0.5s cubic-bezier(0.16,1,0.3,1);
+    }
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(16px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* ── Header ── */
+    .wizard-header {
+      text-align: center;
+      margin-bottom: 48px;
+    }
+    .wizard-header h1 {
+      font-size: clamp(1.6rem, 4vw, 2.2rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 8px;
+    }
+    .wizard-header p {
+      font-size: 15px;
+      color: var(--text-dim);
       line-height: 1.6;
     }
-    .page { max-width: 640px; margin: 0 auto; }
 
-    h1 { font-size: 28px; font-weight: 600; color: #fff; margin-bottom: 8px; }
-    .subtitle { font-size: 15px; color: rgba(255,255,255,0.45); margin-bottom: 40px; }
-
-    /* Steps indicator */
+    /* ── Steps ── */
     .steps {
       display: flex;
-      gap: 24px;
-      margin-bottom: 32px;
+      justify-content: center;
+      align-items: center;
+      gap: 0;
+      margin-bottom: 40px;
     }
-    .step-dot {
-      font-size: 13px;
-      font-weight: 500;
-      color: rgba(255,255,255,0.25);
-      cursor: default;
+    .step-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
     }
-    .step-dot.active { color: #7c6bff; }
-    .step-dot.done { color: rgba(124,107,255,0.5); }
-    .step-dot .num {
-      display: inline-flex;
-      width: 22px; height: 22px;
-      align-items: center; justify-content: center;
+    .step-num {
+      width: 24px; height: 24px;
       border-radius: 50%;
-      border: 1px solid rgba(255,255,255,0.1);
+      border: 1.5px solid var(--text-muted);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-mono);
       font-size: 11px;
-      margin-right: 6px;
+      color: var(--text-muted);
+      transition: all 0.3s;
+      flex-shrink: 0;
     }
-    .step-dot.active .num {
-      border-color: #7c6bff;
+    .step-label {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      transition: color 0.3s;
+    }
+    .step-line {
+      width: 32px;
+      height: 1px;
+      background: var(--text-muted);
+      margin: 0 12px;
+      transition: background 0.3s;
+    }
+    .step-item.active .step-num {
+      border-color: var(--accent);
       background: rgba(124,107,255,0.15);
+      color: var(--accent-bright);
     }
-    .step-dot.done .num {
-      border-color: rgba(124,107,255,0.3);
-      background: rgba(124,107,255,0.1);
+    .step-item.active .step-label { color: var(--accent-bright); }
+    .step-item.done .step-num {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: #fff;
     }
+    .step-item.done .step-label { color: var(--text-dim); }
+    .step-line.done { background: var(--accent); }
 
-    /* Panels */
-    .panel { display: none; }
+    /* ── Panels ── */
+    .panel { display: none; animation: fadeUp 0.4s cubic-bezier(0.16,1,0.3,1); }
     .panel.active { display: block; }
 
-    /* Provider selector */
+    /* ── Glass card ── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      overflow: hidden;
+    }
+
+    /* ── Provider pills (matches space-pills) ── */
     .providers {
       display: flex;
-      gap: 8px;
+      justify-content: center;
       margin-bottom: 24px;
-      flex-wrap: wrap;
     }
-    .provider-btn {
-      padding: 8px 16px;
-      border-radius: 8px;
-      border: 1px solid rgba(255,255,255,0.08);
-      background: rgba(255,255,255,0.03);
-      color: rgba(255,255,255,0.5);
-      font-family: inherit;
+    .providers-track {
+      display: flex;
+      gap: 2px;
+      padding: 3px 4px;
+      border-radius: 9999px;
+      background: rgba(13,14,26,0.6);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid rgba(255,255,255,0.06);
+    }
+    .provider-pill {
+      background: none;
+      border: none;
+      color: var(--text-dim);
+      font-family: var(--font-body);
       font-size: 13px;
+      font-weight: 500;
+      padding: 7px 18px;
+      border-radius: 9999px;
       cursor: pointer;
-      transition: all 0.15s;
+      transition: color 0.2s, background 0.2s;
+      white-space: nowrap;
     }
-    .provider-btn:hover {
-      border-color: rgba(124,107,255,0.3);
-      color: rgba(255,255,255,0.8);
-    }
-    .provider-btn.selected {
-      border-color: #7c6bff;
-      background: rgba(124,107,255,0.12);
+    .provider-pill:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+    .provider-pill.selected {
+      background: rgba(124,107,255,0.25);
       color: #fff;
     }
 
-    /* Prompt display */
-    .prompt-box {
-      background: rgba(30,32,50,0.6);
-      border: 1px solid rgba(255,255,255,0.06);
-      border-radius: 10px;
-      padding: 20px;
-      position: relative;
-      margin-bottom: 16px;
+    /* ── Prompt code area ── */
+    .prompt-scroll {
+      max-height: 280px;
+      overflow-y: auto;
+      padding: 24px;
     }
-    .prompt-box pre {
-      font-family: 'IBM Plex Mono', monospace;
+    .prompt-scroll pre {
+      font-family: var(--font-mono);
       font-size: 12px;
-      line-height: 1.5;
-      color: #e0e0e8;
+      line-height: 1.6;
+      color: rgba(255,255,255,0.75);
       white-space: pre-wrap;
       word-break: break-word;
-      max-height: 300px;
-      overflow-y: auto;
     }
     .prompt-loading {
-      color: rgba(255,255,255,0.3);
-      font-size: 13px;
-      padding: 40px;
+      padding: 60px 24px;
       text-align: center;
+      color: var(--text-muted);
+      font-size: 13px;
     }
 
-    /* Buttons */
+    /* ── Buttons ── */
+    .btn-row {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-top: 28px;
+    }
     .btn {
-      padding: 10px 20px;
-      border-radius: 8px;
-      font-family: inherit;
-      font-size: 14px;
-      font-weight: 500;
-      cursor: pointer;
+      font-family: var(--font-body);
+      font-weight: 600;
       border: none;
-      transition: all 0.15s;
+      border-radius: 12px;
+      cursor: pointer;
+      transition: all 0.2s;
     }
     .btn-primary {
-      background: #7c6bff;
+      background: var(--accent);
       color: #fff;
+      padding: 14px 36px;
+      font-size: 15px;
+      border-radius: 999px;
     }
-    .btn-primary:hover { background: #6b5ce6; }
-    .btn-primary:disabled {
-      background: rgba(124,107,255,0.3);
-      cursor: not-allowed;
+    .btn-primary:hover { background: #6b5ce6; transform: translateY(-1px); }
+    .btn-primary:disabled { opacity: 0.4; cursor: not-allowed; transform: none; }
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-dim);
+      padding: 14px 20px;
+      font-size: 13px;
     }
-    .btn-secondary {
-      background: rgba(255,255,255,0.06);
-      color: rgba(255,255,255,0.6);
+    .btn-ghost:hover { color: var(--text); }
+    .btn-import {
+      background: var(--green);
+      color: #050510;
+      padding: 16px 48px;
+      font-size: 16px;
+      border-radius: 9999px;
     }
-    .btn-secondary:hover { background: rgba(255,255,255,0.1); }
-    .btn-success {
-      background: #4ade80;
-      color: #000;
-      font-weight: 600;
-    }
-    .btn-success:hover { background: #3bc96e; }
-    .btn-row { display: flex; gap: 8px; margin-top: 16px; }
+    .btn-import:hover { background: #3bc96e; transform: translateY(-1px); }
 
-    .copy-btn {
-      position: absolute;
-      top: 12px; right: 12px;
-      background: rgba(124,107,255,0.15);
-      border: 1px solid rgba(124,107,255,0.2);
-      color: rgba(255,255,255,0.6);
-      font-size: 11px;
-      font-family: 'IBM Plex Mono', monospace;
-      padding: 4px 10px;
-      border-radius: 6px;
-      cursor: pointer;
-    }
-    .copy-btn:hover { background: rgba(124,107,255,0.3); color: #fff; }
-    .copy-btn.copied { background: rgba(80,200,120,0.2); border-color: rgba(80,200,120,0.3); color: rgba(80,200,120,0.8); }
-
-    /* Textarea */
+    /* ── Textarea ── */
     .paste-area {
       width: 100%;
-      min-height: 200px;
-      background: rgba(30,32,50,0.6);
-      border: 1px solid rgba(255,255,255,0.08);
-      border-radius: 10px;
-      padding: 16px;
-      font-family: 'IBM Plex Mono', monospace;
+      min-height: 240px;
+      background: transparent;
+      border: none;
+      padding: 24px;
+      font-family: var(--font-mono);
       font-size: 12px;
-      color: #e0e0e8;
-      resize: vertical;
-      line-height: 1.5;
+      color: var(--text);
+      resize: none;
+      line-height: 1.6;
     }
-    .paste-area:focus {
-      outline: none;
-      border-color: rgba(124,107,255,0.4);
-    }
-    .paste-area::placeholder { color: rgba(255,255,255,0.2); }
+    .paste-area:focus { outline: none; }
+    .paste-area::placeholder { color: var(--text-muted); }
 
-    /* Error / warning */
-    .error { color: #f87171; font-size: 13px; margin-top: 8px; }
-    .warning { color: #fbbf24; font-size: 13px; margin-bottom: 12px; }
-
-    /* Counts */
-    .counts {
-      display: flex;
-      gap: 16px;
-      margin-bottom: 16px;
-    }
-    .count-badge {
+    /* ── Error ── */
+    .error {
+      color: #f87171;
       font-size: 13px;
-      padding: 4px 12px;
-      border-radius: 6px;
+      padding: 12px 24px;
+      display: none;
     }
-    .count-new { background: rgba(74,222,128,0.12); color: #4ade80; }
-    .count-merge { background: rgba(251,191,36,0.12); color: #fbbf24; }
-    .count-skip { background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.4); }
 
-    /* Action list */
-    .action-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
-    .action-item {
-      display: flex;
-      align-items: flex-start;
-      gap: 10px;
-      padding: 8px 12px;
-      border-radius: 8px;
-      background: rgba(255,255,255,0.02);
-      font-size: 13px;
+    /* ── Review summary ── */
+    .review-summary {
+      padding: 32px 28px;
     }
-    .action-item.indent { margin-left: 28px; }
-    .action-item input[type="checkbox"] { accent-color: #7c6bff; margin-top: 3px; flex-shrink: 0; }
-    .action-type {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 11px;
-      color: rgba(124,107,255,0.7);
-      min-width: 90px;
-      flex-shrink: 0;
-    }
-    .action-label { color: rgba(255,255,255,0.7); flex: 1; }
-    .action-status {
-      font-size: 11px;
-      padding: 2px 8px;
-      border-radius: 4px;
-      flex-shrink: 0;
-    }
-    .status-new { background: rgba(74,222,128,0.1); color: #4ade80; }
-    .status-merge { background: rgba(251,191,36,0.1); color: #fbbf24; }
-    .status-skip { background: rgba(255,255,255,0.05); color: rgba(255,255,255,0.3); }
-
-    /* Success */
-    .success-msg {
+    .review-title {
+      font-size: clamp(1.2rem, 3vw, 1.6rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 8px;
       text-align: center;
-      padding: 40px 20px;
     }
-    .success-msg h2 { font-size: 22px; color: #4ade80; margin-bottom: 8px; }
-    .success-msg p { color: rgba(255,255,255,0.5); font-size: 14px; margin-bottom: 24px; }
+    .review-sub {
+      font-size: 14px;
+      color: var(--text-dim);
+      text-align: center;
+      margin-bottom: 28px;
+    }
+    .review-spaces {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .review-space {
+      background: rgba(255,255,255,0.03);
+      border-radius: 12px;
+      padding: 16px;
+      border: none;
+    }
+    .review-space-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 10px;
+    }
+    .review-space-dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .review-space-name {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text);
+      flex: 1;
+    }
+    .review-space-badge {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      font-weight: 500;
+      padding: 3px 10px;
+      border-radius: 9999px;
+      letter-spacing: 0.02em;
+    }
+    .badge-new { background: rgba(74,222,128,0.1); color: var(--green); }
+    .badge-merge { background: rgba(251,191,36,0.1); color: var(--amber); }
+    .review-projects {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding-left: 18px;
+    }
+    .review-project {
+      font-size: 12px;
+      color: var(--text-dim);
+      background: rgba(255,255,255,0.05);
+      padding: 5px 12px;
+      border-radius: 9999px;
+    }
+    .review-bottom {
+      display: flex;
+      justify-content: center;
+      gap: 24px;
+      margin-top: 24px;
+      padding-top: 20px;
+      border-top: 1px solid rgba(255,255,255,0.04);
+    }
+    .review-bottom-stat {
+      text-align: center;
+    }
+    .review-bottom-num {
+      font-family: var(--font-mono);
+      font-size: 20px;
+      font-weight: 700;
+    }
+    .review-bottom-label {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-top: 2px;
+    }
 
+    /* ── Success ── */
+    .success-panel {
+      text-align: center;
+      padding: 64px 32px;
+    }
+    .success-icon {
+      width: 56px; height: 56px;
+      border-radius: 50%;
+      background: rgba(74,222,128,0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 20px;
+      font-size: 24px;
+    }
+    .success-panel h2 {
+      font-size: 22px;
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+    .success-panel p {
+      color: var(--text-dim);
+      font-size: 14px;
+      margin-bottom: 28px;
+    }
+
+    /* ── Spinner ── */
     .spinner {
       display: inline-block;
       width: 16px; height: 16px;
-      border: 2px solid rgba(124,107,255,0.3);
-      border-top-color: #7c6bff;
+      border: 2px solid rgba(255,255,255,0.2);
+      border-top-color: #fff;
       border-radius: 50%;
       animation: spin 0.6s linear infinite;
       margin-right: 8px;
@@ -248,249 +391,242 @@
     }
     @keyframes spin { to { transform: rotate(360deg); } }
 
-    .hint { font-size: 12px; color: rgba(255,255,255,0.3); margin-top: 8px; }
+    .hint {
+      font-size: 12px;
+      color: var(--text-muted);
+      text-align: center;
+      margin-top: 12px;
+    }
   </style>
 </head>
 <body>
-  <div class="page">
-    <h1>Import from AI</h1>
-    <p class="subtitle">Bring your projects and context from ChatGPT, Claude, or Gemini.</p>
+  <div class="glow"></div>
+  <div class="wizard">
+    <div class="wizard-header">
+      <h1>Import from AI.</h1>
+      <p>Bring your projects, context, and memories from any AI.</p>
+    </div>
 
     <div class="steps">
-      <span class="step-dot active" id="step1-dot"><span class="num">1</span>Copy prompt</span>
-      <span class="step-dot" id="step2-dot"><span class="num">2</span>Paste response</span>
-      <span class="step-dot" id="step3-dot"><span class="num">3</span>Review</span>
+      <div class="step-item active" id="s1"><span class="step-num">1</span><span class="step-label">Copy</span></div>
+      <div class="step-line" id="line1"></div>
+      <div class="step-item" id="s2"><span class="step-num">2</span><span class="step-label">Paste</span></div>
+      <div class="step-line" id="line2"></div>
+      <div class="step-item" id="s3"><span class="step-num">3</span><span class="step-label">Import</span></div>
     </div>
 
-    <!-- Step 1: Provider + Copy -->
-    <div class="panel active" id="panel-step1">
+    <!-- Step 1 -->
+    <div class="panel active" id="p1">
       <div class="providers">
-        <button class="provider-btn selected" onclick="selectProvider('chatgpt', this)">ChatGPT</button>
-        <button class="provider-btn" onclick="selectProvider('claude', this)">Claude</button>
-        <button class="provider-btn" onclick="selectProvider('gemini', this)">Gemini</button>
-        <button class="provider-btn" onclick="selectProvider('other', this)">Other</button>
+        <div class="providers-track">
+          <button class="provider-pill selected" onclick="pickProvider('chatgpt',this)">ChatGPT</button>
+          <button class="provider-pill" onclick="pickProvider('claude',this)">Claude</button>
+          <button class="provider-pill" onclick="pickProvider('gemini',this)">Gemini</button>
+          <button class="provider-pill" onclick="pickProvider('other',this)">Other</button>
+        </div>
       </div>
-
-      <div class="prompt-box">
-        <div id="prompt-content"><div class="prompt-loading">Loading prompt...</div></div>
+      <div class="card">
+        <div id="prompt-area"><div class="prompt-loading">Loading prompt...</div></div>
       </div>
-      <p class="hint">This prompt is tailored to your workspace. Paste it into your AI of choice.</p>
-
       <div class="btn-row">
-        <button class="btn btn-primary" onclick="copyPromptAndAdvance()">Copy prompt</button>
-        <button class="btn btn-secondary" onclick="goToStep(2)" style="font-size:13px">Next &rarr;</button>
+        <button class="btn btn-primary" onclick="copyAndNext()">Copy prompt</button>
+        <button class="btn btn-ghost" onclick="go(2)">Next &rarr;</button>
+      </div>
+      <p class="hint">Tailored to your workspace. Paste it into your AI.</p>
+    </div>
+
+    <!-- Step 2 -->
+    <div class="panel" id="p2">
+      <div class="card">
+        <textarea class="paste-area" id="paste" placeholder="Paste your AI's response here..."></textarea>
+        <div id="err" class="error"></div>
+      </div>
+      <div class="btn-row">
+        <button class="btn btn-ghost" onclick="go(1)">&larr; Back</button>
+        <button class="btn btn-primary" id="previewBtn" onclick="preview()">Preview import</button>
       </div>
     </div>
 
-    <!-- Step 2: Paste -->
-    <div class="panel" id="panel-step2">
-      <textarea class="paste-area" id="paste-input" placeholder="Paste your AI's response here..."></textarea>
-      <div id="parse-error" class="error" style="display:none"></div>
-
-      <div class="btn-row">
-        <button class="btn btn-secondary" onclick="goToStep(1)">Back</button>
-        <button class="btn btn-primary" id="preview-btn" onclick="previewImport()">Preview import</button>
+    <!-- Step 3 -->
+    <div class="panel" id="p3">
+      <div class="card">
+        <div class="review-summary">
+          <div class="review-title">Ready to import</div>
+          <div class="review-sub"></div>
+          <div class="review-stats" id="stats"></div>
+        </div>
       </div>
-    </div>
-
-    <!-- Step 3: Review -->
-    <div class="panel" id="panel-step3">
-      <div id="plan-warnings"></div>
-      <div id="plan-counts" class="counts"></div>
-      <div id="plan-actions" class="action-list"></div>
-
       <div class="btn-row">
-        <button class="btn btn-secondary" onclick="goToStep(2)">Back</button>
-        <button class="btn btn-success" id="import-btn" onclick="executeImport()">Import selected</button>
+        <button class="btn btn-ghost" onclick="go(2)">&larr; Back</button>
+        <button class="btn btn-import" id="importBtn" onclick="run()">Import everything</button>
       </div>
     </div>
 
     <!-- Success -->
-    <div class="panel" id="panel-success">
-      <div class="success-msg">
-        <h2>Import complete</h2>
-        <p id="success-detail"></p>
-        <button class="btn btn-primary" onclick="window.location.reload()">Import more</button>
+    <div class="panel" id="p4">
+      <div class="card">
+        <div class="success-panel">
+          <div class="success-icon">&#10003;</div>
+          <h2>You're all set</h2>
+          <p id="successDetail"></p>
+          <button class="btn btn-primary" onclick="window.parent.postMessage({type:'oyster-close'},'*')">Done</button>
+          <div style="margin-top:16px"><button class="btn btn-ghost" onclick="location.reload()">Import more &rarr;</button></div>
+        </div>
       </div>
     </div>
   </div>
 
   <script>
-    const origin = window.location.origin;
-    let selectedProvider = 'chatgpt';
-    let currentPrompt = '';
-    let currentPlan = null;
+    const O = window.location.origin;
+    let provider = 'chatgpt', prompt = '', plan = null;
 
-    // Load prompt on page load
     loadPrompt();
 
-    function selectProvider(provider, btn) {
-      selectedProvider = provider;
-      document.querySelectorAll('.provider-btn').forEach(b => b.classList.remove('selected'));
-      btn.classList.add('selected');
+    async function loadPrompt() {
+      const el = document.getElementById('prompt-area');
+      el.innerHTML = '<div class="prompt-loading">Loading prompt...</div>';
+      try {
+        const r = await fetch(`${O}/api/import/prompt?provider=${provider}`);
+        prompt = await r.text();
+        el.innerHTML = `<div class="prompt-scroll"><pre>${esc(prompt)}</pre></div>`;
+      } catch { el.innerHTML = '<div class="prompt-loading">Failed to load</div>'; }
+    }
+
+    function pickProvider(p, el) {
+      provider = p;
+      document.querySelectorAll('.provider-pill').forEach(b => b.classList.remove('selected'));
+      el.classList.add('selected');
       loadPrompt();
     }
 
-    async function loadPrompt() {
-      const el = document.getElementById('prompt-content');
-      el.innerHTML = '<div class="prompt-loading">Loading prompt...</div>';
-      try {
-        const res = await fetch(`${origin}/api/import/prompt?provider=${selectedProvider}`);
-        currentPrompt = await res.text();
-        el.innerHTML = `<pre>${escapeHtml(currentPrompt)}</pre>`;
-      } catch (err) {
-        el.innerHTML = `<div class="prompt-loading">Failed to load prompt</div>`;
-      }
-    }
-
-    function copyPromptAndAdvance() {
+    function copyAndNext() {
       const btn = document.querySelector('.btn-primary');
-      navigator.clipboard.writeText(currentPrompt).then(() => {
+      navigator.clipboard.writeText(prompt).then(() => {
         btn.textContent = 'Copied!';
-        setTimeout(() => goToStep(2), 800);
+        setTimeout(() => go(2), 600);
       });
     }
 
-    function goToStep(step) {
-      document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
-      document.getElementById(`panel-step${step}`).classList.add('active');
-
-      for (let i = 1; i <= 3; i++) {
-        const dot = document.getElementById(`step${i}-dot`);
-        dot.className = 'step-dot';
-        if (i < step) dot.classList.add('done');
-        if (i === step) dot.classList.add('active');
-      }
+    function go(step) {
+      for (let i = 1; i <= 4; i++) document.getElementById('p' + i).classList.remove('active');
+      document.getElementById('p' + step).classList.add('active');
+      ['s1','s2','s3'].forEach((id, idx) => {
+        const el = document.getElementById(id);
+        el.className = 'step-item' + (idx + 1 === step ? ' active' : idx + 1 < step ? ' done' : '');
+      });
+      ['line1','line2'].forEach((id, idx) => {
+        const el = document.getElementById(id);
+        el.className = 'step-line' + (idx + 1 < step ? ' done' : '');
+      });
     }
 
-    async function previewImport() {
-      const raw = document.getElementById('paste-input').value.trim();
+    async function preview() {
+      const raw = document.getElementById('paste').value.trim();
       if (!raw) return;
-
-      const btn = document.getElementById('preview-btn');
-      const errEl = document.getElementById('parse-error');
-      btn.innerHTML = '<span class="spinner"></span>Previewing...';
+      const btn = document.getElementById('previewBtn');
+      const err = document.getElementById('err');
+      btn.innerHTML = '<span class="spinner"></span>Processing...';
       btn.disabled = true;
-      errEl.style.display = 'none';
-
+      err.style.display = 'none';
       try {
-        const res = await fetch(`${origin}/api/import/preview`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ raw, provider: selectedProvider }),
+        const r = await fetch(`${O}/api/import/preview`, {
+          method: 'POST', headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ raw, provider }),
         });
-
-        const data = await res.json();
-        if (!res.ok) {
-          errEl.textContent = data.error || 'Preview failed';
-          errEl.style.display = 'block';
-          return;
-        }
-
-        currentPlan = data;
-        renderPlan(data);
-        goToStep(3);
-      } catch (err) {
-        errEl.textContent = 'Network error: ' + err.message;
-        errEl.style.display = 'block';
+        const d = await r.json();
+        if (!r.ok) { err.textContent = d.error; err.style.display = 'block'; return; }
+        plan = d;
+        renderStats(d);
+        go(3);
+      } catch (e) {
+        err.textContent = 'Connection error'; err.style.display = 'block';
       } finally {
-        btn.innerHTML = 'Preview import';
-        btn.disabled = false;
+        btn.innerHTML = 'Preview import'; btn.disabled = false;
       }
     }
 
-    function renderPlan(plan) {
-      // Warnings
-      const warnEl = document.getElementById('plan-warnings');
-      warnEl.innerHTML = plan.warnings.map(w => `<div class="warning">${escapeHtml(w)}</div>`).join('');
+    const SPACE_COLORS = ['#7c6bff','#4ade80','#fbbf24','#60a5fa','#f472b6','#a78bfa','#22d3ee','#fb923c'];
 
-      // Counts
-      const countsEl = document.getElementById('plan-counts');
-      countsEl.innerHTML = `
-        <span class="count-badge count-new">${plan.counts.new} new</span>
-        <span class="count-badge count-merge">${plan.counts.merge} merge</span>
-        <span class="count-badge count-skip">${plan.counts.skipped} skipped</span>
-      `;
+    function renderStats(p) {
+      const a = p.actions;
+      const spaces = a.filter(x => x.type === 'create_space');
+      const projects = a.filter(x => x.type === 'create_project_summary');
+      const memories = a.filter(x => x.type === 'create_memory' && x.status !== 'duplicate_skipped').length;
+      const overviews = a.filter(x => x.type === 'create_space_overview').length;
 
-      // Actions
-      const actionsEl = document.getElementById('plan-actions');
-      actionsEl.innerHTML = plan.actions.map(a => {
-        const checked = a.status !== 'duplicate_skipped' ? 'checked' : '';
-        const indent = a.depends_on ? ' indent' : '';
-        const statusClass = a.status === 'new' ? 'status-new' : a.status === 'exists_will_merge' ? 'status-merge' : 'status-skip';
-        const statusLabel = a.status === 'new' ? 'new' : a.status === 'exists_will_merge' ? 'merge' : 'skip';
-        const label = a.name || a.title || a.content?.slice(0, 60) || '';
-        const typeLabel = a.type.replace(/_/g, ' ');
+      // Build space cards with their projects
+      let spacesHtml = '<div class="review-spaces">';
+      spaces.forEach((sp, i) => {
+        const color = SPACE_COLORS[i % SPACE_COLORS.length];
+        const badge = sp.status === 'new'
+          ? '<span class="review-space-badge badge-new">new</span>'
+          : '<span class="review-space-badge badge-merge">update</span>';
+        const spProjects = projects.filter(pr => pr.space === sp.name);
 
-        return `<div class="action-item${indent}">
-          <input type="checkbox" ${checked} data-id="${a.action_id}" data-depends="${a.depends_on || ''}" onchange="handleCheck(this)">
-          <span class="action-type">${typeLabel}</span>
-          <span class="action-label">${escapeHtml(label)}</span>
-          <span class="action-status ${statusClass}">${statusLabel}</span>
+        spacesHtml += `<div class="review-space">
+          <div class="review-space-header">
+            <div class="review-space-dot" style="background:${color}"></div>
+            <span class="review-space-name">${esc(sp.name)}</span>
+            ${badge}
+          </div>
+          ${spProjects.length ? '<div class="review-projects">' + spProjects.map(pr =>
+            `<span class="review-project">${esc(pr.name)}</span>`
+          ).join('') + '</div>' : ''}
         </div>`;
-      }).join('');
-    }
-
-    function handleCheck(cb) {
-      const id = cb.dataset.id;
-      if (!cb.checked) {
-        // Untick children
-        document.querySelectorAll(`input[data-depends="${id}"]`).forEach(child => {
-          child.checked = false;
-        });
-      }
-    }
-
-    async function executeImport() {
-      if (!currentPlan) return;
-
-      const approved = [];
-      document.querySelectorAll('#plan-actions input[type="checkbox"]:checked').forEach(cb => {
-        approved.push(cb.dataset.id);
       });
+      spacesHtml += '</div>';
 
-      const btn = document.getElementById('import-btn');
+      // Bottom stats — only show non-zero
+      const bottomParts = [];
+      if (overviews) bottomParts.push(`<div class="review-bottom-stat"><div class="review-bottom-num" style="color:var(--text)">${overviews}</div><div class="review-bottom-label">overview${overviews !== 1 ? 's' : ''}</div></div>`);
+      if (memories) bottomParts.push(`<div class="review-bottom-stat"><div class="review-bottom-num" style="color:var(--accent-bright)">${memories}</div><div class="review-bottom-label">new memor${memories !== 1 ? 'ies' : 'y'}</div></div>`);
+
+      const skippedMemories = a.filter(x => x.type === 'create_memory' && x.status === 'duplicate_skipped').length;
+      if (skippedMemories) bottomParts.push(`<div class="review-bottom-stat"><div class="review-bottom-num" style="color:var(--text-muted)">${skippedMemories}</div><div class="review-bottom-label">already saved</div></div>`);
+
+      if (bottomParts.length) spacesHtml += `<div class="review-bottom">${bottomParts.join('')}</div>`;
+
+      const newItems = a.filter(x => x.status !== 'duplicate_skipped').length;
+      document.getElementById('stats').innerHTML = spacesHtml;
+      document.querySelector('.review-sub').textContent = newItems > 0
+        ? `${newItems} new items from ${provider} ready to import.`
+        : `Everything from ${provider} is already imported.`;
+    }
+
+    async function run() {
+      if (!plan) return;
+      const approved = plan.actions.filter(a => a.status !== 'duplicate_skipped').map(a => a.action_id);
+      const btn = document.getElementById('importBtn');
       btn.innerHTML = '<span class="spinner"></span>Importing...';
       btn.disabled = true;
-
       try {
-        const res = await fetch(`${origin}/api/import/execute`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ plan_id: currentPlan.plan_id, approved_action_ids: approved }),
+        const r = await fetch(`${O}/api/import/execute`, {
+          method: 'POST', headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ plan_id: plan.plan_id, approved_action_ids: approved }),
         });
-
-        const data = await res.json();
-
-        // Show success
-        document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
-        document.getElementById('panel-success').classList.add('active');
-
-        const detail = document.getElementById('success-detail');
-        const failed = data.counts.failed;
-        detail.textContent = `${data.counts.created} items created${failed ? `, ${failed} failed` : ''}.`;
-
-        // Find first created space to switch to
-        const createdSpace = data.results.find(r => r.status === 'created' && currentPlan.actions.find(a => a.action_id === r.action_id && a.type === 'create_space'));
-        if (createdSpace) {
-          const action = currentPlan.actions.find(a => a.action_id === createdSpace.action_id);
-          if (action?.name) {
-            const slug = action.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-            // Navigate parent to the new space
+        const d = await r.json();
+        const skipped = d.results.filter(r => r.status === 'skipped').length;
+        let detail = '';
+        if (d.counts.created > 0) detail += `${d.counts.created} imported`;
+        if (skipped > 0) detail += (detail ? ', ' : '') + `${skipped} already existed`;
+        if (d.counts.failed > 0) detail += (detail ? ', ' : '') + `${d.counts.failed} failed`;
+        if (!detail) detail = 'Everything was already imported';
+        document.getElementById('successDetail').textContent = detail + '.';
+        go(4);
+        // Switch to first new space
+        const created = d.results.find(r => r.status === 'created' && plan.actions.find(a => a.action_id === r.action_id && a.type === 'create_space'));
+        if (created) {
+          const act = plan.actions.find(a => a.action_id === created.action_id);
+          if (act?.name) {
+            const slug = act.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
             try { window.parent.postMessage({ type: 'switch_space', space: slug }, '*'); } catch {}
           }
         }
-      } catch (err) {
-        btn.innerHTML = 'Import failed - try again';
-        btn.disabled = false;
-      }
+      } catch { btn.innerHTML = 'Retry'; btn.disabled = false; }
     }
 
-    function escapeHtml(str) {
-      const div = document.createElement('div');
-      div.textContent = str;
-      return div.innerHTML;
-    }
+    function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
   </script>
+
 </body>
 </html>

--- a/builtins/import-from-ai/src/index.html
+++ b/builtins/import-from-ai/src/index.html
@@ -613,15 +613,6 @@
         if (!detail) detail = 'Everything was already imported';
         document.getElementById('successDetail').textContent = detail + '.';
         go(4);
-        // Switch to first new space
-        const created = d.results.find(r => r.status === 'created' && plan.actions.find(a => a.action_id === r.action_id && a.type === 'create_space'));
-        if (created) {
-          const act = plan.actions.find(a => a.action_id === created.action_id);
-          if (act?.name) {
-            const slug = act.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-            try { window.parent.postMessage({ type: 'switch_space', space: slug }, '*'); } catch {}
-          }
-        }
       } catch { btn.innerHTML = 'Retry'; btn.disabled = false; }
     }
 

--- a/builtins/quick-start/src/index.html
+++ b/builtins/quick-start/src/index.html
@@ -4,152 +4,209 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Quick Start</title>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --accent: #7c6bff;
+      --accent-bright: #a597ff;
+      --green: #4ade80;
+      --text: #f0f0f5;
+      --text-dim: rgba(232,233,240,0.45);
+      --text-muted: rgba(232,233,240,0.2);
+      --surface: rgba(12,13,28,0.85);
+      --border: rgba(124,107,255,0.15);
+      --font-body: 'Space Grotesk', -apple-system, sans-serif;
+      --font-mono: 'IBM Plex Mono', monospace;
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: 'Space Grotesk', -apple-system, sans-serif;
-      background: #0a0b14;
-      color: #c8c8d0;
+      font-family: var(--font-body);
+      color: var(--text);
+      background: rgba(30, 31, 54, 1);
       min-height: 100vh;
-      padding: 60px 24px;
-      line-height: 1.6;
+      display: flex;
+      justify-content: center;
+      padding: 60px 24px 80px;
+      overflow-x: hidden;
     }
-    .page { max-width: 640px; margin: 0 auto; }
 
-    h1 {
-      font-size: 28px;
-      font-weight: 600;
-      color: #fff;
-      margin-bottom: 8px;
+    /* Ambient glow */
+    .glow {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(ellipse 80% 50% at 50% -10%, rgba(124,107,255,0.10) 0%, transparent 60%),
+        radial-gradient(ellipse 50% 35% at 80% 90%, rgba(165,151,255,0.04) 0%, transparent 50%);
     }
-    .subtitle {
-      font-size: 15px;
-      color: rgba(255,255,255,0.45);
+
+    .page {
+      max-width: 600px;
+      width: 100%;
+      position: relative;
+      z-index: 1;
+      animation: fadeUp 0.5s cubic-bezier(0.16,1,0.3,1);
+    }
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(16px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .page-header {
+      text-align: center;
       margin-bottom: 48px;
     }
+    .page-header h1 {
+      font-size: clamp(1.6rem, 4vw, 2.2rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 8px;
+    }
+    .page-header p {
+      font-size: 15px;
+      color: var(--text-dim);
+    }
 
-    h2 {
-      font-size: 14px;
-      font-weight: 600;
-      color: #7c6bff;
-      letter-spacing: 1px;
+    /* Section labels */
+    .section-label {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--accent);
+      letter-spacing: 0.08em;
       text-transform: uppercase;
       margin-bottom: 16px;
-      margin-top: 48px;
+      margin-top: 40px;
     }
-    h2:first-of-type { margin-top: 0; }
+    .section-label:first-of-type { margin-top: 0; }
 
-    p {
-      font-size: 14px;
-      color: rgba(255,255,255,0.55);
-      margin-bottom: 16px;
-      line-height: 1.7;
+    /* Glass cards */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      padding: 20px 24px;
+      margin-bottom: 12px;
     }
 
-    /* Shortcuts table */
+    .card-title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 6px;
+    }
+    .card p {
+      font-size: 13px;
+      color: var(--text-dim);
+      line-height: 1.6;
+    }
+    .card a {
+      color: var(--accent-bright);
+      text-decoration: none;
+    }
+    .card a:hover { text-decoration: underline; }
+
+    code {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      background: rgba(124,107,255,0.1);
+      padding: 2px 7px;
+      border-radius: 5px;
+      color: var(--accent-bright);
+    }
+
+    /* Shortcut rows */
     .shortcuts {
       display: flex;
       flex-direction: column;
-      gap: 0;
     }
     .shortcut {
       display: flex;
       align-items: baseline;
       gap: 16px;
-      padding: 10px 0;
-      border-bottom: 1px solid rgba(255,255,255,0.04);
+      padding: 12px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.03);
     }
     .shortcut:last-child { border-bottom: none; }
     .shortcut-key {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--font-mono);
       font-size: 13px;
-      color: #a99eff;
-      min-width: 140px;
+      font-weight: 500;
+      color: var(--accent-bright);
+      min-width: 120px;
       flex-shrink: 0;
     }
     .shortcut-desc {
       font-size: 13px;
-      color: rgba(255,255,255,0.45);
+      color: var(--text-dim);
+      line-height: 1.5;
     }
 
-    /* Cards */
-    .card {
-      background: rgba(13, 14, 26, 0.9);
-      border: 1px solid rgba(255,255,255,0.06);
-      border-radius: 12px;
-      padding: 20px;
-      margin-bottom: 12px;
-    }
-    .card-title {
+    /* Description text */
+    .desc {
       font-size: 14px;
-      font-weight: 600;
-      color: #fff;
-      margin-bottom: 8px;
+      color: var(--text-dim);
+      line-height: 1.7;
+      margin-bottom: 16px;
     }
-    .card p { margin-bottom: 0; }
-
-    code {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 12px;
-      background: rgba(124,107,255,0.1);
-      padding: 2px 6px;
-      border-radius: 4px;
-      color: #a99eff;
-    }
-
-    .link {
-      color: #7c6bff;
-      text-decoration: none;
-      font-size: 14px;
-    }
-    .link:hover { text-decoration: underline; }
 
     @media (max-width: 500px) {
-      .shortcut { flex-direction: column; gap: 2px; }
+      .shortcut { flex-direction: column; gap: 3px; }
       .shortcut-key { min-width: 0; }
     }
   </style>
 </head>
 <body>
+  <div class="glow"></div>
   <div class="page">
-    <h1>Quick Start</h1>
-    <p class="subtitle">Everything you need to know in 60 seconds.</p>
+    <div class="page-header">
+      <h1>Quick Start.</h1>
+      <p>Everything you need to know in 60 seconds.</p>
+    </div>
 
-    <h2>The prompt bar</h2>
-    <p>Type anything into the prompt bar to talk to Oyster. Ask it to create documents, organise your work, or answer questions about your projects. Any printable key focuses the prompt bar automatically.</p>
+    <div class="section-label">The prompt bar</div>
+    <p class="desc">Type anything into the prompt bar to talk to Oyster. Ask it to create documents, organise your work, or answer questions about your projects. Any printable key focuses the prompt bar automatically.</p>
 
-    <h2>Slash commands</h2>
-    <div class="shortcuts">
-      <div class="shortcut">
-        <span class="shortcut-key">/s &lt;name&gt;</span>
-        <span class="shortcut-desc">Switch space. Fuzzy matches. <code>/s bf</code> finds "blunderfixer".</span>
-      </div>
-      <div class="shortcut">
-        <span class="shortcut-key">/o &lt;search&gt;</span>
-        <span class="shortcut-desc">Open an artifact by name. <code>/o pitch</code> opens your pitch deck.</span>
-      </div>
-      <div class="shortcut">
-        <span class="shortcut-key">#1 #2 #3</span>
-        <span class="shortcut-desc">Jump to a space by position. <code>#.</code> for home, <code>#0</code> for all.</span>
-      </div>
-      <div class="shortcut">
-        <span class="shortcut-key">Cmd+K</span>
-        <span class="shortcut-desc">Spotlight search across all artifacts.</span>
+    <div class="section-label">Slash commands</div>
+    <div class="card">
+      <div class="shortcuts">
+        <div class="shortcut">
+          <span class="shortcut-key">/s &lt;name&gt;</span>
+          <span class="shortcut-desc">Switch space. Fuzzy matches. <code>/s bf</code> finds "blunderfixer".</span>
+        </div>
+        <div class="shortcut">
+          <span class="shortcut-key">/o &lt;search&gt;</span>
+          <span class="shortcut-desc">Open an artifact by name. <code>/o pitch</code> opens your pitch deck.</span>
+        </div>
+        <div class="shortcut">
+          <span class="shortcut-key">#1 #2 #3</span>
+          <span class="shortcut-desc">Jump to a space by position. <code>#.</code> for home, <code>#0</code> for all.</span>
+        </div>
+        <div class="shortcut">
+          <span class="shortcut-key">Cmd+K</span>
+          <span class="shortcut-desc">Spotlight search across all artifacts.</span>
+        </div>
       </div>
     </div>
 
-    <h2>Spaces</h2>
-    <p>Spaces are workspaces — one per project, client, or topic. Switch between them using the pills below the prompt bar, or with <code>#name</code> and <code>/s name</code>.</p>
-    <p>Click <code>+</code> to add a new space, or drop a folder anywhere on the surface to import a project automatically.</p>
+    <div class="section-label">Spaces</div>
+    <p class="desc">Spaces are workspaces — one per project, client, or topic. Switch between them using the pills below the prompt bar, or with <code>#name</code> and <code>/s name</code>.</p>
+    <p class="desc">Click <code>+</code> to add a new space, or drop a folder anywhere on the surface to import a project automatically.</p>
 
-    <h2>Artifacts</h2>
-    <p>Everything on the surface is an artifact — notes, decks, diagrams, apps, tables, wireframes. Click an icon to open it. The topbar (hover near the top) has sort, filter, and view controls.</p>
+    <div class="section-label">Artifacts</div>
+    <p class="desc">Everything on the surface is an artifact — notes, decks, diagrams, apps, tables, wireframes. Click an icon to open it. The topbar (hover near the top) has sort, filter, and view controls.</p>
 
-    <h2>Get more from Oyster</h2>
+    <div class="section-label">Get more from Oyster</div>
     <div class="card">
       <div class="card-title">Bring Your Own AI</div>
-      <p>Oyster is an MCP server. Connect Claude Code, Cursor, or VS Code and control your surface from any AI. <a class="link" href="/artifacts/connect-your-ai/src/index.html">Read the guide</a></p>
+      <p>Oyster is an MCP server. Connect Claude Code, Cursor, or VS Code and control your surface from any AI. <a href="/artifacts/connect-your-ai/src/index.html">Read the guide</a></p>
+    </div>
+    <div class="card">
+      <div class="card-title">Import from AI</div>
+      <p>Bring your projects, context, and memories from ChatGPT, Claude, or Gemini. <a href="/artifacts/import-from-ai/src/index.html">Start importing</a></p>
     </div>
     <div class="card">
       <div class="card-title">Drop to import</div>

--- a/docs/superpowers/plans/2026-04-14-cloud-ai-import.md
+++ b/docs/superpowers/plans/2026-04-14-cloud-ai-import.md
@@ -1,0 +1,1139 @@
+# Cloud AI Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users import structured context from cloud AIs (ChatGPT, Claude, Gemini) into Oyster via a copy-prompt → paste-response → preview → approve flow.
+
+**Architecture:** Server generates a context-aware prompt, user pastes it into their AI, pastes the JSON response back. Server builds an import plan (merge-based dedup), client shows checkboxes, server executes approved actions. Three endpoints: `/api/import/prompt`, `/api/import/preview`, `/api/import/execute`.
+
+**Tech Stack:** TypeScript (server), vanilla HTML/CSS/JS (builtin wizard), React (onboarding banner)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `server/src/import.ts` | **NEW** — All import logic: types, prompt template, JSON parsing/recovery, plan building, plan store, execution |
+| `server/src/index.ts` | **MODIFY** — Add 3 API routes, wire up import module |
+| `builtins/import-from-ai/manifest.json` | **NEW** — Builtin manifest |
+| `builtins/import-from-ai/src/index.html` | **NEW** — 3-step wizard (provider select, paste, preview/approve) |
+| `web/src/components/OnboardingBanner.tsx` | **NEW** — First-run banner with "Import from AI" CTA |
+| `web/src/components/Desktop.tsx` | **MODIFY** — Render banner when `isFirstRun` |
+| `web/src/App.tsx` | **MODIFY** — Pass `isFirstRun` to Desktop (already computed at line 185) |
+| `web/src/App.css` | **MODIFY** — Banner styles |
+
+---
+
+### Task 1: Import types and plan store
+
+**Files:**
+- Create: `server/src/import.ts`
+
+- [ ] **Step 1: Create import.ts with types and plan store**
+
+```typescript
+// server/src/import.ts
+import { randomUUID } from "node:crypto";
+
+// ── Types ──
+
+export interface ImportPayload {
+  schema_version: number;
+  mode?: "fresh" | "augment";
+  source?: {
+    provider?: string;
+    generated_at?: string;
+  };
+  spaces?: Array<{
+    name: string;
+    projects?: Array<{ name: string; summary: string }>;
+  }>;
+  summaries?: Array<{
+    space: string;
+    title: string;
+    content: string;
+  }>;
+  memories?: Array<{
+    content: string;
+    tags?: string[];
+    space?: string;
+  }>;
+}
+
+export type ActionType = "create_space" | "create_project_summary" | "create_space_overview" | "create_memory";
+export type ActionStatus = "new" | "exists_will_merge" | "duplicate_skipped";
+
+export interface ImportAction {
+  action_id: string;
+  type: ActionType;
+  status: ActionStatus;
+  name?: string;
+  space?: string;
+  summary?: string;
+  title?: string;
+  content?: string;
+  tags?: string[];
+  depends_on?: string;
+}
+
+export interface ImportPlan {
+  plan_id: string;
+  provider: string;
+  generated_at: string;
+  counts: { new: number; merge: number; skipped: number };
+  warnings: string[];
+  actions: ImportAction[];
+}
+
+export interface ExecuteResult {
+  results: Array<{ action_id: string; status: "created" | "skipped" | "failed"; error?: string }>;
+  counts: { created: number; failed: number };
+}
+
+// ── Plan Store (in-memory, TTL 10 min) ──
+
+const plans = new Map<string, { plan: ImportPlan; payload: ImportPayload; expires: number }>();
+const PLAN_TTL = 10 * 60 * 1000;
+
+export function storePlan(plan: ImportPlan, payload: ImportPayload): void {
+  plans.set(plan.plan_id, { plan, payload, expires: Date.now() + PLAN_TTL });
+}
+
+export function getPlan(planId: string): { plan: ImportPlan; payload: ImportPayload } | null {
+  const entry = plans.get(planId);
+  if (!entry) return null;
+  if (Date.now() > entry.expires) {
+    plans.delete(planId);
+    return null;
+  }
+  return { plan: entry.plan, payload: entry.payload };
+}
+
+export function deletePlan(planId: string): void {
+  plans.delete(planId);
+}
+
+// Clean expired plans periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, entry] of plans) {
+    if (now > entry.expires) plans.delete(id);
+  }
+}, 60_000);
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/import.ts
+git commit -m "feat(import): add types and in-memory plan store"
+```
+
+---
+
+### Task 2: Prompt generation
+
+**Files:**
+- Modify: `server/src/import.ts`
+
+- [ ] **Step 1: Add prompt generation function**
+
+Append to `server/src/import.ts`:
+
+```typescript
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ── Import State ──
+
+const IMPORT_STATE_PATH = join(homedir(), ".oyster", "import-state.json");
+
+interface ImportState {
+  [provider: string]: { last_import_date: string };
+}
+
+function readImportState(): ImportState {
+  try {
+    if (existsSync(IMPORT_STATE_PATH)) {
+      return JSON.parse(readFileSync(IMPORT_STATE_PATH, "utf8"));
+    }
+  } catch {}
+  return {};
+}
+
+export function writeImportDate(provider: string): void {
+  const state = readImportState();
+  state[provider] = { last_import_date: new Date().toISOString() };
+  const { writeFileSync, mkdirSync } = require("node:fs") as typeof import("node:fs");
+  mkdirSync(join(homedir(), ".oyster"), { recursive: true });
+  writeFileSync(IMPORT_STATE_PATH, JSON.stringify(state, null, 2) + "\n");
+}
+
+// ── Prompt Generation ──
+
+const JSON_SCHEMA_EXAMPLE = `{
+  "schema_version": 1,
+  "mode": "fresh",
+  "source": {
+    "provider": "chatgpt",
+    "generated_at": "2026-04-14T18:00:00Z"
+  },
+  "spaces": [
+    {
+      "name": "Work",
+      "projects": [
+        { "name": "Project Name", "summary": "One sentence about this project." }
+      ]
+    }
+  ],
+  "summaries": [
+    {
+      "space": "Work",
+      "title": "Work overview",
+      "content": "2-3 sentences summarising this space."
+    }
+  ],
+  "memories": [
+    {
+      "content": "A durable fact, preference, or constraint worth remembering.",
+      "tags": ["preference"],
+      "space": "Work"
+    }
+  ]
+}`;
+
+export interface PromptContext {
+  provider: string;
+  spaces: Array<{ id: string; displayName: string }>;
+  knownProjects: Map<string, string[]>; // spaceId → project names
+}
+
+export function generatePrompt(ctx: PromptContext): string {
+  const state = readImportState();
+  const lastImport = state[ctx.provider]?.last_import_date;
+  const hasSpaces = ctx.spaces.length > 0;
+
+  const mode = hasSpaces ? "augment" : "fresh";
+
+  let prompt = `Based on our past conversations, identify durable workstreams, projects, and long-lived personal contexts that should be organised in a workspace tool.\n\n`;
+
+  if (hasSpaces) {
+    prompt += `I already have these spaces set up:\n`;
+    for (const s of ctx.spaces) {
+      const projects = ctx.knownProjects.get(s.id) || [];
+      if (projects.length > 0) {
+        prompt += `- ${s.displayName} (projects: ${projects.join(", ")})\n`;
+      } else {
+        prompt += `- ${s.displayName}\n`;
+      }
+    }
+    prompt += `\nMap into existing spaces where possible. Only suggest new spaces when needed. Do not reorganise what already exists.\n\n`;
+  }
+
+  if (lastImport) {
+    prompt += `My last import was on ${lastImport}. Only include items that are new or changed since then.\n\n`;
+  }
+
+  prompt += `RULES:
+- Only include durable items worth keeping: ongoing projects, recurring themes, stable preferences, important decisions.
+- Exclude one-off conversational details, temporary questions, or ephemeral topics.
+- Every project belongs to exactly one space.
+- Summaries: one per space, 2-3 sentences describing what the space is about.
+- Memories: durable facts, preferences, or constraints. Not opinions or emotional colour from a single conversation.
+
+OUTPUT FORMAT:
+- Output one valid JSON object only.
+- No markdown fences. No prose before or after. No explanation.
+- Set mode to "${mode}".
+- Set source.provider to "${ctx.provider}".
+- Set source.generated_at to the current time in ISO 8601 format.
+
+JSON SCHEMA:
+${JSON_SCHEMA_EXAMPLE}`;
+
+  return prompt;
+}
+```
+
+Note: the `writeImportDate` function uses `require` for the write imports to avoid adding them to the top-level import when they're only needed at write time. Alternatively, move the `writeFileSync` and `mkdirSync` imports to the top — either approach works. For cleanliness, move them to the top-level import on line 1 alongside the existing `readFileSync`, `existsSync`.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/import.ts
+git commit -m "feat(import): add prompt generation with context-aware template"
+```
+
+---
+
+### Task 3: JSON parsing and recovery
+
+**Files:**
+- Modify: `server/src/import.ts`
+
+- [ ] **Step 1: Add JSON parsing with three-stage recovery**
+
+Append to `server/src/import.ts`:
+
+```typescript
+// ── JSON Parsing & Recovery ──
+
+function stripMarkdownFences(raw: string): string {
+  // Remove ```json ... ``` or ``` ... ```
+  let s = raw.trim();
+  s = s.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/, "");
+  // Remove leading/trailing prose (anything before first { or after last })
+  const firstBrace = s.indexOf("{");
+  const lastBrace = s.lastIndexOf("}");
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    s = s.slice(firstBrace, lastBrace + 1);
+  }
+  // Remove BOM
+  s = s.replace(/^\uFEFF/, "");
+  return s;
+}
+
+export interface ParseResult {
+  success: boolean;
+  payload?: ImportPayload;
+  error?: string;
+  recovered?: boolean;
+}
+
+export async function parseImportJSON(
+  raw: string,
+  aiRepairFn?: (broken: string) => Promise<string | null>,
+): Promise<ParseResult> {
+  // Stage 1: regex cleanup
+  const cleaned = stripMarkdownFences(raw);
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    return { success: true, payload: parsed as ImportPayload };
+  } catch (e1) {
+    // Stage 2: AI repair
+    if (aiRepairFn) {
+      try {
+        const repaired = await aiRepairFn(cleaned);
+        if (repaired) {
+          const repairedCleaned = stripMarkdownFences(repaired);
+          const parsed = JSON.parse(repairedCleaned);
+          return { success: true, payload: parsed as ImportPayload, recovered: true };
+        }
+      } catch {}
+    }
+
+    // Stage 3: error
+    return {
+      success: false,
+      error: `Invalid JSON: ${(e1 as Error).message}`,
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/import.ts
+git commit -m "feat(import): add three-stage JSON parsing with regex cleanup and AI repair hook"
+```
+
+---
+
+### Task 4: Preview — plan building with merge rules
+
+**Files:**
+- Modify: `server/src/import.ts`
+
+- [ ] **Step 1: Add the buildImportPlan function**
+
+This is the core merge logic. Append to `server/src/import.ts`:
+
+```typescript
+import { slugify } from "./utils.js";
+
+// ── Preview (Plan Building) ──
+
+export interface PreviewDeps {
+  getSpaceBySlug: (slug: string) => { id: string; displayName: string } | null;
+  getArtifactsBySpace: (spaceId: string) => Array<{ source_ref: string | null; label: string }>;
+  findMemory: (content: string, spaceId: string | null) => boolean;
+}
+
+export function buildImportPlan(
+  payload: ImportPayload,
+  provider: string,
+  generatedAt: string,
+  deps: PreviewDeps,
+): ImportPlan {
+  const planId = `imp_${randomUUID().slice(0, 12)}`;
+  const actions: ImportAction[] = [];
+  const warnings: string[] = [];
+  let actCounter = 0;
+  const nextId = () => `act_${++actCounter}`;
+
+  const sourceRef = (kind: string, name: string) =>
+    `import:${provider}:${generatedAt}:${kind}:${slugify(name)}`;
+
+  // ── Spaces ──
+  const spaceActionIds = new Map<string, string>(); // space name → action_id
+
+  for (const space of payload.spaces ?? []) {
+    if (!space.name) continue;
+    const slug = slugify(space.name);
+    const existing = deps.getSpaceBySlug(slug);
+    const actionId = nextId();
+    spaceActionIds.set(space.name, actionId);
+
+    if (existing) {
+      actions.push({
+        action_id: actionId,
+        type: "create_space",
+        name: space.name,
+        status: "exists_will_merge",
+      });
+      warnings.push(`Space '${space.name}' already exists and will be merged.`);
+    } else {
+      actions.push({
+        action_id: actionId,
+        type: "create_space",
+        name: space.name,
+        status: "new",
+      });
+    }
+
+    // ── Projects within this space ──
+    for (const project of space.projects ?? []) {
+      if (!project.name) continue;
+      const spaceId = existing?.id ?? slug;
+      const projRef = sourceRef("project", project.name);
+      const existingArtifacts = deps.getArtifactsBySpace(spaceId);
+      const isDupe = existingArtifacts.some(
+        (a) => a.source_ref?.startsWith("import:") && slugify(a.label) === slugify(project.name),
+      );
+
+      actions.push({
+        action_id: nextId(),
+        type: "create_project_summary",
+        space: space.name,
+        name: project.name,
+        summary: project.summary,
+        status: isDupe ? "duplicate_skipped" : "new",
+        depends_on: existing ? undefined : actionId,
+      });
+    }
+  }
+
+  // ── Space overviews (from summaries[]) ──
+  for (const summary of payload.summaries ?? []) {
+    if (!summary.space || !summary.content) continue;
+    const slug = slugify(summary.space);
+    const existing = deps.getSpaceBySlug(slug);
+    const spaceId = existing?.id ?? slug;
+    const existingArtifacts = deps.getArtifactsBySpace(spaceId);
+    const hasOverview = existingArtifacts.some(
+      (a) => a.source_ref?.includes("overview"),
+    );
+    const parentActionId = spaceActionIds.get(summary.space);
+
+    actions.push({
+      action_id: nextId(),
+      type: "create_space_overview",
+      space: summary.space,
+      title: summary.title || `${summary.space} overview`,
+      content: summary.content,
+      status: hasOverview ? "exists_will_merge" : "new",
+      depends_on: existing ? undefined : parentActionId,
+    });
+  }
+
+  // ── Memories ──
+  for (const memory of payload.memories ?? []) {
+    if (!memory.content) continue;
+    const spaceSlug = memory.space ? slugify(memory.space) : null;
+    const existingSpace = spaceSlug ? deps.getSpaceBySlug(spaceSlug) : null;
+    const spaceId = existingSpace?.id ?? spaceSlug;
+    const isDupe = deps.findMemory(memory.content, spaceId);
+
+    actions.push({
+      action_id: nextId(),
+      type: "create_memory",
+      content: memory.content,
+      tags: memory.tags,
+      space: memory.space,
+      status: isDupe ? "duplicate_skipped" : "new",
+    });
+  }
+
+  const counts = {
+    new: actions.filter((a) => a.status === "new").length,
+    merge: actions.filter((a) => a.status === "exists_will_merge").length,
+    skipped: actions.filter((a) => a.status === "duplicate_skipped").length,
+  };
+
+  const plan: ImportPlan = { plan_id: planId, provider, generated_at: generatedAt, counts, warnings, actions };
+  storePlan(plan, payload);
+  return plan;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/import.ts
+git commit -m "feat(import): add plan building with merge rules and dependency tracking"
+```
+
+---
+
+### Task 5: Execute — action execution
+
+**Files:**
+- Modify: `server/src/import.ts`
+
+- [ ] **Step 1: Add the executeImportPlan function**
+
+Append to `server/src/import.ts`:
+
+```typescript
+// ── Execute ──
+
+export interface ExecuteDeps {
+  createSpace: (name: string) => { id: string };
+  createArtifact: (params: {
+    space_id: string;
+    label: string;
+    artifact_kind: "notes";
+    content: string;
+    source_origin: "ai_generated";
+    source_ref: string;
+  }) => Promise<{ id: string }>;
+  remember: (input: { content: string; space_id?: string; tags?: string[] }) => Promise<{ id: string }>;
+  getSpaceBySlug: (slug: string) => { id: string } | null;
+}
+
+export async function executeImportPlan(
+  planId: string,
+  approvedIds: string[],
+  deps: ExecuteDeps,
+): Promise<ExecuteResult> {
+  const entry = getPlan(planId);
+  if (!entry) {
+    return { results: [], counts: { created: 0, failed: 0 } };
+  }
+
+  const { plan } = entry;
+  const approved = new Set(approvedIds);
+  const results: ExecuteResult["results"] = [];
+  const createdSpaces = new Map<string, string>(); // space name → space id
+
+  // Validate: reject orphaned actions (depends_on a non-approved, non-merge action)
+  for (const action of plan.actions) {
+    if (!approved.has(action.action_id)) continue;
+    if (action.depends_on) {
+      const parent = plan.actions.find((a) => a.action_id === action.depends_on);
+      if (parent && parent.status === "new" && !approved.has(parent.action_id)) {
+        results.push({
+          action_id: action.action_id,
+          status: "failed",
+          error: `Depends on ${action.depends_on} which was not approved`,
+        });
+        approved.delete(action.action_id);
+      }
+    }
+  }
+
+  // Execute in order: spaces first, then artifacts, then memories
+  const ordered = plan.actions.filter((a) => approved.has(a.action_id));
+
+  for (const action of ordered) {
+    try {
+      switch (action.type) {
+        case "create_space": {
+          if (action.status === "exists_will_merge") {
+            // Space already exists, just record its ID
+            const existing = deps.getSpaceBySlug(slugify(action.name!));
+            if (existing) createdSpaces.set(action.name!, existing.id);
+            results.push({ action_id: action.action_id, status: "skipped" });
+          } else {
+            const space = deps.createSpace(action.name!);
+            createdSpaces.set(action.name!, space.id);
+            results.push({ action_id: action.action_id, status: "created" });
+          }
+          break;
+        }
+        case "create_project_summary": {
+          const spaceId = resolveSpaceId(action.space!, createdSpaces, deps);
+          const ref = `import:${plan.provider}:${plan.generated_at}:project:${slugify(action.name!)}`;
+          await deps.createArtifact({
+            space_id: spaceId,
+            label: action.name!,
+            artifact_kind: "notes",
+            content: `# ${action.name}\n\n${action.summary || ""}`,
+            source_origin: "ai_generated",
+            source_ref: ref,
+          });
+          results.push({ action_id: action.action_id, status: "created" });
+          break;
+        }
+        case "create_space_overview": {
+          const spaceId = resolveSpaceId(action.space!, createdSpaces, deps);
+          const ref = `import:${plan.provider}:${plan.generated_at}:overview:${slugify(action.space!)}`;
+          await deps.createArtifact({
+            space_id: spaceId,
+            label: action.title || `${action.space} overview`,
+            artifact_kind: "notes",
+            content: `# ${action.title || action.space}\n\n${action.content || ""}`,
+            source_origin: "ai_generated",
+            source_ref: ref,
+          });
+          results.push({ action_id: action.action_id, status: "created" });
+          break;
+        }
+        case "create_memory": {
+          const spaceSlug = action.space ? slugify(action.space) : undefined;
+          const spaceId = spaceSlug
+            ? resolveSpaceId(action.space!, createdSpaces, deps)
+            : undefined;
+          const importTag = `_import:${plan.provider}:${plan.generated_at.slice(0, 10)}`;
+          const tags = [...(action.tags || []), importTag];
+          await deps.remember({
+            content: action.content!,
+            space_id: spaceId,
+            tags,
+          });
+          results.push({ action_id: action.action_id, status: "created" });
+          break;
+        }
+      }
+    } catch (err) {
+      results.push({
+        action_id: action.action_id,
+        status: "failed",
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  // Write import date only after successful execute
+  const created = results.filter((r) => r.status === "created").length;
+  if (created > 0) {
+    writeImportDate(plan.provider);
+  }
+
+  deletePlan(planId);
+
+  return {
+    results,
+    counts: {
+      created,
+      failed: results.filter((r) => r.status === "failed").length,
+    },
+  };
+}
+
+function resolveSpaceId(
+  spaceName: string,
+  createdSpaces: Map<string, string>,
+  deps: ExecuteDeps,
+): string {
+  const fromCreated = createdSpaces.get(spaceName);
+  if (fromCreated) return fromCreated;
+  const existing = deps.getSpaceBySlug(slugify(spaceName));
+  if (existing) return existing.id;
+  return slugify(spaceName);
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/import.ts
+git commit -m "feat(import): add plan execution with best-effort per-action results"
+```
+
+---
+
+### Task 6: API routes
+
+**Files:**
+- Modify: `server/src/index.ts`
+
+- [ ] **Step 1: Add import to index.ts**
+
+At the top of `server/src/index.ts`, add to the imports (after the existing import block around line 30):
+
+```typescript
+import {
+  generatePrompt,
+  parseImportJSON,
+  buildImportPlan,
+  executeImportPlan,
+  getPlan,
+  type PromptContext,
+  type PreviewDeps,
+  type ExecuteDeps,
+} from "./import.js";
+```
+
+- [ ] **Step 2: Add the three routes**
+
+In `server/src/index.ts`, inside the `handleHttpRequest` function, add before the existing `// ── Static files ──` section (which is the fallback). Find the section where other API routes are defined and add:
+
+```typescript
+  // ── Import routes ──
+
+  if (url.startsWith("/api/import/prompt") && req.method === "GET") {
+    const params = new URL(url, "http://localhost").searchParams;
+    const provider = params.get("provider") || "chatgpt";
+
+    const allSpaces = spaceStore.getAll()
+      .filter((s) => s.id !== "home" && s.id !== "__all__")
+      .map((s) => ({ id: s.id, displayName: s.display_name }));
+
+    const knownProjects = new Map<string, string[]>();
+    for (const s of allSpaces) {
+      const artifacts = store.getBySpaceId(s.id)
+        .filter((a) => a.source_ref?.startsWith("import:") && !a.removed_at);
+      if (artifacts.length > 0) {
+        knownProjects.set(s.id, artifacts.map((a) => a.label));
+      }
+    }
+
+    const prompt = generatePrompt({ provider, spaces: allSpaces, knownProjects });
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(prompt);
+    return;
+  }
+
+  if (url === "/api/import/preview" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", async () => {
+      try {
+        const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
+
+        const parseResult = await parseImportJSON(raw);
+        if (!parseResult.success || !parseResult.payload) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: parseResult.error }));
+          return;
+        }
+
+        const generatedAt = parseResult.payload.source?.generated_at || new Date().toISOString();
+
+        const previewDeps: PreviewDeps = {
+          getSpaceBySlug: (slug) => {
+            const row = spaceStore.getAll().find((s) => s.id === slug);
+            return row ? { id: row.id, displayName: row.display_name } : null;
+          },
+          getArtifactsBySpace: (spaceId) => {
+            return store.getBySpaceId(spaceId)
+              .filter((a) => !a.removed_at)
+              .map((a) => ({ source_ref: a.source_ref, label: a.label }));
+          },
+          findMemory: (content, spaceId) => {
+            try {
+              return memoryProvider.findExact(content, spaceId ?? undefined);
+            } catch {
+              return false;
+            }
+          },
+        };
+
+        const plan = buildImportPlan(parseResult.payload, provider, generatedAt, previewDeps);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(plan));
+      } catch (err) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return;
+  }
+
+  if (url === "/api/import/execute" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", async () => {
+      try {
+        const { plan_id, approved_action_ids } = JSON.parse(body) as {
+          plan_id: string;
+          approved_action_ids: string[];
+        };
+
+        if (!getPlan(plan_id)) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Plan not found or expired" }));
+          return;
+        }
+
+        const executeDeps: ExecuteDeps = {
+          createSpace: (name) => spaceService.createSpace({ name }),
+          createArtifact: (params) => artifactService.createArtifact(params, USERLAND_DIR),
+          remember: (input) => memoryProvider.remember(input),
+          getSpaceBySlug: (slug) => {
+            const row = spaceStore.getAll().find((s) => s.id === slug);
+            return row ? { id: row.id } : null;
+          },
+        };
+
+        const result = await executeImportPlan(plan_id, approved_action_ids, executeDeps);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return;
+  }
+```
+
+- [ ] **Step 3: Add `findExact` to memory provider if not exposed**
+
+The preview route uses `memoryProvider.findExact()`. Check if `SqliteFtsMemoryProvider` exposes this. If not, add a public method in `server/src/memory-store.ts`:
+
+```typescript
+findExact(content: string, spaceId?: string): boolean {
+  const row = this.stmts.findExact.get(content, spaceId ?? null, spaceId ?? null);
+  return !!row;
+}
+```
+
+The prepared statement already exists (line 137 in memory-store.ts).
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd server && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/index.ts server/src/import.ts server/src/memory-store.ts
+git commit -m "feat(import): add /api/import/prompt, preview, execute routes"
+```
+
+---
+
+### Task 7: Builtin wizard — Import from AI
+
+**Files:**
+- Create: `builtins/import-from-ai/manifest.json`
+- Create: `builtins/import-from-ai/src/index.html`
+
+- [ ] **Step 1: Create manifest**
+
+```json
+{
+  "id": "import-from-ai",
+  "name": "Import from AI",
+  "type": "notes",
+  "runtime": "static",
+  "entrypoint": "src/index.html",
+  "ports": [],
+  "storage": "none",
+  "capabilities": [],
+  "status": "ready",
+  "builtin": true,
+  "created_at": "2026-04-14T00:00:00.000Z",
+  "updated_at": "2026-04-14T00:00:00.000Z"
+}
+```
+
+- [ ] **Step 2: Create the wizard HTML**
+
+Create `builtins/import-from-ai/src/index.html` — a self-contained HTML page with inline CSS and JS. Must match the Oyster dark theme (bg: `#0a0b14`, fonts: Space Grotesk + IBM Plex Mono, accent: `#7c6bff`).
+
+The page has three steps controlled by JS state:
+
+**Step 1 — Provider select + copy prompt:**
+- Four radio buttons: ChatGPT, Claude, Gemini, Other
+- On provider select, fetch `GET /api/import/prompt?provider={provider}`
+- Display prompt in a scrollable `<pre>` block
+- "Copy to clipboard" button
+- "Next" button to advance to step 2
+
+**Step 2 — Paste response:**
+- Large `<textarea>` with placeholder "Paste your AI's response here"
+- "Preview import" button
+- On click: POST `/api/import/preview` with `{ raw: textarea.value, provider }`
+- Show spinner while loading
+- On error: show error message inline (red text below textarea)
+- On success: advance to step 3 with plan data
+
+**Step 3 — Review & approve:**
+- Show `counts` summary at top: "X new, Y merge, Z skipped"
+- Show `warnings` if any (amber text)
+- List each action as a checkbox row:
+  - Pre-checked for `new` and `exists_will_merge`
+  - Unchecked for `duplicate_skipped`
+  - Indented for actions with `depends_on`
+  - Unticking a parent auto-unticks children
+- "Import selected" button
+- On click: POST `/api/import/execute` with `{ plan_id, approved_action_ids }`
+- On success: show counts, then redirect to first new space via `/api/ui/command` or `window.location`
+
+The HTML should be ~300-400 lines. Follow the style patterns from `builtins/connect-your-ai/src/index.html` and `builtins/quick-start/src/index.html` (dark theme, same fonts, same spacing).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add builtins/import-from-ai/
+git commit -m "feat(import): add Import from AI builtin wizard"
+```
+
+---
+
+### Task 8: Onboarding banner
+
+**Files:**
+- Create: `web/src/components/OnboardingBanner.tsx`
+- Modify: `web/src/components/Desktop.tsx`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/App.css`
+
+- [ ] **Step 1: Create OnboardingBanner component**
+
+```tsx
+// web/src/components/OnboardingBanner.tsx
+import { useState } from "react";
+
+interface Props {
+  onImportFromAI: () => void;
+  onDismiss: () => void;
+}
+
+export function OnboardingBanner({ onImportFromAI, onDismiss }: Props) {
+  return (
+    <div className="onboarding-banner">
+      <div className="onboarding-banner-content">
+        <h2>Set up your workspace</h2>
+        <p>Bring in your projects and context from other tools.</p>
+        <div className="onboarding-banner-actions">
+          <button className="onboarding-btn-primary" onClick={onImportFromAI}>
+            Import from AI
+          </button>
+          <button className="onboarding-btn-secondary" disabled title="Coming soon">
+            Scan my machine
+          </button>
+        </div>
+        <button className="onboarding-dismiss" onClick={onDismiss}>
+          skip for now
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add banner styles to App.css**
+
+Add to `web/src/App.css`:
+
+```css
+.onboarding-banner {
+  display: flex;
+  justify-content: center;
+  padding: 32px 16px 0;
+}
+.onboarding-banner-content {
+  max-width: 440px;
+  background: rgba(124, 107, 255, 0.06);
+  border: 1px solid rgba(124, 107, 255, 0.15);
+  border-radius: 16px;
+  padding: 28px 32px;
+  text-align: center;
+}
+.onboarding-banner-content h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 6px;
+}
+.onboarding-banner-content p {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 20px;
+}
+.onboarding-banner-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+.onboarding-btn-primary {
+  background: #7c6bff;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+.onboarding-btn-primary:hover {
+  background: #6b5ce6;
+}
+.onboarding-btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.4);
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: not-allowed;
+  font-family: inherit;
+}
+.onboarding-dismiss {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.onboarding-dismiss:hover {
+  color: rgba(255, 255, 255, 0.5);
+}
+```
+
+- [ ] **Step 3: Wire up in Desktop.tsx**
+
+In `web/src/components/Desktop.tsx`:
+
+1. Add import at top:
+```typescript
+import { OnboardingBanner } from "./OnboardingBanner";
+```
+
+2. Add dismissed state:
+```typescript
+const [bannerDismissed, setBannerDismissed] = useState(
+  () => localStorage.getItem("oyster-onboarding-dismissed") === "true"
+);
+```
+
+3. Add dismiss handler:
+```typescript
+const handleDismiss = () => {
+  localStorage.setItem("oyster-onboarding-dismissed", "true");
+  setBannerDismissed(true);
+};
+```
+
+4. Render banner before the filter bar (inside desktop-scroll, before the first child):
+```tsx
+{isFirstRun && !bannerDismissed && (
+  <OnboardingBanner
+    onImportFromAI={() => {
+      // Open the import-from-ai builtin artifact
+      const importArtifact = artifacts.find((a) => a.id === "import-from-ai");
+      if (importArtifact) onArtifactClick(importArtifact);
+    }}
+    onDismiss={handleDismiss}
+  />
+)}
+```
+
+- [ ] **Step 4: Ensure isFirstRun is passed to Desktop in App.tsx**
+
+Check `web/src/App.tsx` line 185 — `isFirstRun` is already computed. Verify it's passed to the `<Desktop>` component in the JSX. If not, add `isFirstRun={isFirstRun}` to the Desktop props.
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/OnboardingBanner.tsx web/src/components/Desktop.tsx web/src/App.tsx web/src/App.css
+git commit -m "feat(import): add first-run onboarding banner with Import from AI CTA"
+```
+
+---
+
+### Task 9: Integration test — end-to-end manual verification
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Test fresh install flow**
+
+Clear localStorage in browser and delete all user-created spaces. Verify:
+- Onboarding banner appears on surface
+- Click "Import from AI" → wizard opens
+- Provider selector works, prompt loads
+- Prompt contains no existing spaces (fresh mode)
+
+- [ ] **Step 3: Test import flow**
+
+Copy the prompt, paste into ChatGPT/Claude. Paste the response back:
+- Preview shows plan with checkboxes, counts, warnings
+- Untick a space → children auto-untick
+- Click "Import selected" → spaces, project summaries, space overviews, memories created
+- Post-import: switches to first new space
+
+- [ ] **Step 4: Test re-import dedup**
+
+Run the import again with the same data:
+- Prompt now includes existing spaces (augment mode)
+- Preview shows duplicates as `duplicate_skipped`
+- Approve → no new items created
+
+- [ ] **Step 5: Test error handling**
+
+Paste invalid JSON:
+- Regex cleanup strips fences
+- If still broken, shows error inline
+- Server doesn't crash
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git commit -m "feat(import): cloud AI import complete (#107)"
+```
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-14-cloud-ai-import.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
+++ b/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
@@ -59,8 +59,11 @@ Self-contained HTML at `builtins/import-from-ai/src/index.html`. Three steps:
 - Textarea for the AI's JSON response
 - "Preview import" button
 - Sends `POST /api/import/preview` with the raw pasted text and selected provider
-- Strips markdown fences (```json ... ```) if present — AIs frequently wrap JSON despite being told not to
-- Shows validation errors inline if JSON is malformed
+- Server attempts three-stage JSON recovery before failing:
+  1. **Regex cleanup** (no tokens): strip markdown fences, leading/trailing prose, BOM
+  2. **AI repair** (cheap call): if still invalid, send to OpenCode with "Fix this JSON, return only valid JSON"
+  3. **Error**: if repair fails, show the parse error inline with the problematic section highlighted
+- The user almost never sees a parse failure
 
 ### Step 3: Review & approve
 

--- a/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
+++ b/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
@@ -32,7 +32,7 @@ Three API endpoints:
 Banner appears on the surface with two CTAs:
 - "Import from AI" → opens the import wizard artifact
 - "Scan my machine" → placeholder for future local discovery (#108), disabled in V1
-- "skip for now" → dismisses, doesn't return
+- "skip for now" → dismisses banner (persisted in localStorage). The builtin "Import from AI" card remains on the surface for later use.
 
 Banner component: `web/src/components/OnboardingBanner.tsx` (new).
 Rendered by Desktop when `isFirstRun && !dismissed`.
@@ -45,18 +45,21 @@ Rendered by Desktop when `isFirstRun && !dismissed`.
 
 Self-contained HTML at `builtins/import-from-ai/src/index.html`. Three steps:
 
-### Step 1: Copy prompt
+### Step 1: Select provider & copy prompt
 
-- Page loads, fetches `GET /api/import/prompt`
-- Displays the generated prompt in a code block
+- User selects their AI provider: ChatGPT, Claude, Gemini, Other
+- Page fetches `GET /api/import/prompt?provider={provider}`
+- Displays the generated prompt in a code block (prompt includes provider-specific wording and demands raw JSON only — no markdown fences, no prose before or after)
 - "Copy to clipboard" button
-- Instruction: "Paste this into ChatGPT, Claude, or Gemini"
+- Instruction: "Paste this into {provider}"
+- Selected provider is carried through to Step 2 for provenance
 
 ### Step 2: Paste response
 
 - Textarea for the AI's JSON response
 - "Preview import" button
-- Sends `POST /api/import/preview` with the raw pasted text
+- Sends `POST /api/import/preview` with the raw pasted text and selected provider
+- Strips markdown fences (```json ... ```) if present — AIs frequently wrap JSON despite being told not to
 - Shows validation errors inline if JSON is malformed
 
 ### Step 3: Review & approve
@@ -111,8 +114,9 @@ What the user's AI outputs:
 
 Rules:
 - `schema_version`: always `1` for now
-- `mode`: `"fresh"` or `"augment"` — set by the prompt, informs merge behaviour
-- `source`: provider name and when the AI generated the response
+- `mode`: advisory only — the AI outputs `"fresh"` or `"augment"` but the server derives the real mode from Oyster state (has spaces → augment, no spaces → fresh). The payload value is ignored for logic; it exists so the AI's intent is visible in the raw data.
+- `source.provider`: set by the wizard based on user's selection in Step 1, not trusted from the AI output
+- `source.generated_at`: when the AI generated the response
 - `spaces[].projects`: nested inside spaces, every project belongs to exactly one space
 - `summaries[].space`: must reference a space name from the `spaces` array or an existing space
 - `memories[].space`: optional — global if omitted
@@ -120,29 +124,39 @@ Rules:
 
 ## Prompt Generation
 
-`GET /api/import/prompt` returns a plain text prompt built from a deterministic template + live Oyster context.
+`GET /api/import/prompt?provider={provider}` returns a plain text prompt built from a deterministic template + live Oyster context. The server derives the real mode from state — the AI's `mode` field in the response is advisory only.
 
 ### Template logic
 
-- **Fresh install** (no spaces): blank-slate prompt asking the AI to suggest full organisation
+- **Fresh install** (no user-created spaces): blank-slate prompt asking the AI to suggest full organisation
 - **Existing workspace**: augment prompt listing current spaces and known projects, asking AI to map into existing spaces and suggest additions
-- **Re-import**: includes `last_import_date` (stored as a key in SQLite `metadata` table or a simple JSON file at `~/.oyster/import-state.json`), asks AI to only include items newer than that date
+- **Re-import**: includes `last_import_date` (stored in `~/.oyster/import-state.json` per provider), asks AI to only include items newer than that date
 
 ### What the template includes
 
-- The JSON schema (so the AI knows the exact output format)
+- The exact JSON schema (so the AI knows the output format)
 - Existing space names (if any)
-- Existing project names per space (if any)
-- Last import timestamp (if any)
+- Existing project names per space (from previous imports — artifacts with `source_ref` matching `import:*`)
+- Last import timestamp for this provider (if any)
 - Instructions: durable items only, no prose, no one-off conversational details
+- Explicit instruction: output one valid JSON object only, no markdown fences, no prose before or after
+- Provider-specific wording where relevant
 
 ## Import Plan
 
-`POST /api/import/preview` accepts the raw pasted text and returns:
+`POST /api/import/preview` accepts the raw pasted text and selected provider, and returns:
 
 ```json
 {
   "plan_id": "imp_abc123",
+  "counts": {
+    "new": 4,
+    "merge": 1,
+    "skipped": 1
+  },
+  "warnings": [
+    "Space 'Build' already exists and will be merged."
+  ],
   "actions": [
     {
       "action_id": "act_1",
@@ -162,15 +176,17 @@ Rules:
       "space": "Work",
       "name": "KPS",
       "summary": "Main operating work.",
-      "status": "new"
+      "status": "new",
+      "depends_on": "act_1"
     },
     {
       "action_id": "act_4",
-      "type": "create_summary",
+      "type": "create_space_overview",
       "space": "Work",
       "title": "Work overview",
       "content": "Active focus is KPS and Digital Mart.",
-      "status": "new"
+      "status": "new",
+      "depends_on": "act_1"
     },
     {
       "action_id": "act_5",
@@ -190,12 +206,30 @@ Rules:
 }
 ```
 
-Action statuses:
+### Action types
+
+- `create_space` — create a new space
+- `create_project_summary` — create a notes artifact summarising a project within a space
+- `create_space_overview` — one per space, replaces if exists. The canonical summary of what a space is about.
+- `create_memory` — store a durable memory, optionally scoped to a space
+
+### Action statuses
+
 - `new` — will be created
-- `exists_will_merge` — space exists, projects/summaries will be added to it
+- `exists_will_merge` — space exists, projects/overviews will be added to it
 - `duplicate_skipped` — already exists, recommended to skip
 
-The plan is held in memory on the server (keyed by `plan_id`), valid for a short TTL (e.g. 10 minutes).
+### Action dependencies
+
+Actions can have a `depends_on` field referencing another action's `action_id`. This creates parent-child relationships:
+
+- If a user unticks a `create_space` action, the UI auto-unticks all actions that depend on it
+- The server rejects orphaned actions on execute (e.g. a project summary for a space that wasn't approved)
+- Exception: `exists_will_merge` spaces don't need to be ticked — the space already exists, so children are valid regardless
+
+### Plan TTL
+
+The plan is held in memory on the server (keyed by `plan_id`), valid for 10 minutes.
 
 ## Merge Rules
 
@@ -204,19 +238,23 @@ Every import is a merge. Rules per type:
 | Type | Match key | Behaviour |
 |------|-----------|-----------|
 | Space | Slug (normalised name) | If exists: merge projects into it. If new: create. |
-| Project summary | Space slug + project name | If exists in space: skip. If new: create notes artifact. |
-| Summary | Space slug + "summary" | One per space. If exists: replace content. If new: create. |
+| Project summary | Space slug + project name slug | If exists in space: skip. If new: create notes artifact. |
+| Space overview | Space slug + `source_ref` containing `overview` | One per space. If exists: replace content. If new: create. |
 | Memory | Exact content match in same scope | If exact match: skip. If new: create. |
+
+### "Known projects" definition
+
+The prompt includes existing project names per space. In V1, "known projects" = notes artifacts with `source_ref` matching `import:*` within the space. These are the project summaries created by previous imports. Not arbitrary artifacts.
 
 ## Provenance
 
 Every created item carries import provenance for dedup on re-import:
 
 - **Artifacts**: `source_origin: "ai_generated"`, `source_ref: "import:{provider}:{generated_at}"` (e.g. `import:chatgpt:2026-04-14T18:00:00Z`)
-- **Memories**: tagged with `import:{provider}:{generated_at}` (e.g. `import:chatgpt:2026-04-14`)
+- **Memories**: tagged with reserved prefix `_import:{provider}:{generated_at}` (e.g. `_import:chatgpt:2026-04-14`). The `_` prefix marks these as system tags — not displayed in the UI alongside semantic user tags.
 - **All items**: `imported_at` timestamp set at creation time (uses existing `created_at` field)
 
-On re-import, merge logic checks `source_ref` / tags before creating to avoid duplicates across import runs.
+On re-import, merge logic checks `source_ref` / `_import:*` tags before creating to avoid duplicates across import runs.
 
 ## Execution
 
@@ -249,9 +287,9 @@ Execution is best-effort:
 ### What gets created
 
 - **Spaces** → `spaceService.createSpace({ name })` (existing code)
-- **Project summaries** → `artifactService.createArtifact({ space_id, label: name, artifact_kind: "notes", content: summary, source_origin: "ai_generated" })`
-- **Summaries** → same as project summaries but with the summary title as label
-- **Memories** → `memoryProvider.remember({ content, tags, space_id })`
+- **Project summaries** → `artifactService.createArtifact({ space_id, label: name, artifact_kind: "notes", content: summary, source_origin: "ai_generated", source_ref: "import:{provider}:{generated_at}" })`
+- **Space overviews** → same as project summaries but with overview title as label, `source_ref` includes `overview` marker for dedup
+- **Memories** → `memoryProvider.remember({ content, tags: [...userTags, "_import:{provider}:{generated_at}"], space_id })`
 
 ## Privacy
 

--- a/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
+++ b/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
@@ -67,10 +67,9 @@ Self-contained HTML at `builtins/import-from-ai/src/index.html`. Three steps:
 
 ### Step 3: Review & approve
 
-- Renders the import plan as a checklist
-- Each action has a checkbox (pre-checked for `new` and `exists_will_merge`, unchecked for `duplicate_skipped`)
-- "Import selected" button
-- Sends `POST /api/import/execute` with `plan_id` and `approved_action_ids`
+- Shows a summary: spaces with their projects, overview and memory counts
+- "Import everything" button (imports all non-skipped actions)
+- Sends `POST /api/import/execute` with `plan_id` and all non-skipped `action_ids`
 
 ### Post-import
 
@@ -143,7 +142,7 @@ Rules:
 - Existing project names per space (from previous imports — artifacts with `source_ref` matching `import:*`)
 - Last import timestamp for this provider (if any)
 - Instructions: durable items only, no prose, no one-off conversational details
-- Explicit instruction: output one valid JSON object only, no markdown fences, no prose before or after
+- Explicit instruction: output YAML only, no markdown fences, no prose before or after (YAML saves output tokens; the server converts to JSON via OpenCode)
 - Provider-specific wording where relevant
 
 ## Import Plan
@@ -233,7 +232,7 @@ Actions can have a `depends_on` field referencing another action's `action_id`. 
 
 ### Plan TTL
 
-The plan is held in memory on the server (keyed by `plan_id`), valid for 10 minutes.
+The plan is held in memory on the server (keyed by `plan_id`), valid for 30 minutes.
 
 ## Merge Rules
 

--- a/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
+++ b/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
@@ -1,0 +1,293 @@
+# Cloud AI Import — Design Spec
+
+## Problem
+
+Users have months/years of AI conversation history in ChatGPT, Claude.ai, Gemini etc. containing project context, decisions, and life domains that don't exist on disk. Oyster can scan local files but can't access cloud AI history.
+
+## Solution
+
+A merge-based import flow where the user copies a prompt from Oyster, pastes it into their cloud AI, and pastes the structured response back. Oyster previews what will be created and the user approves.
+
+Every import is a merge operation. The first run is a merge into an empty workspace. Subsequent runs merge new items and skip duplicates.
+
+## Architecture
+
+```
+Server builds prompt → User copies to AI → AI responds with JSON
+→ User pastes back → Server builds plan → Client approves plan
+→ Server executes plan
+```
+
+Three API endpoints:
+- `GET /api/import/prompt` — generates a context-aware prompt
+- `POST /api/import/preview` — validates JSON, dedupes, returns an import plan
+- `POST /api/import/execute` — applies the approved plan
+
+## Entry Points
+
+### First run (onboarding banner)
+
+`isFirstRun` = no user-created spaces (exclude `home` and `__all__`). Dismissed state persisted in localStorage.
+
+Banner appears on the surface with two CTAs:
+- "Import from AI" → opens the import wizard artifact
+- "Scan my machine" → placeholder for future local discovery (#108), disabled in V1
+- "skip for now" → dismisses, doesn't return
+
+Banner component: `web/src/components/OnboardingBanner.tsx` (new).
+Rendered by Desktop when `isFirstRun && !dismissed`.
+
+### Builtin artifact (permanent)
+
+"Import from AI" card lives on the home surface as a builtin. Available for re-imports. Contains the 3-step wizard.
+
+## The Wizard (builtin artifact)
+
+Self-contained HTML at `builtins/import-from-ai/src/index.html`. Three steps:
+
+### Step 1: Copy prompt
+
+- Page loads, fetches `GET /api/import/prompt`
+- Displays the generated prompt in a code block
+- "Copy to clipboard" button
+- Instruction: "Paste this into ChatGPT, Claude, or Gemini"
+
+### Step 2: Paste response
+
+- Textarea for the AI's JSON response
+- "Preview import" button
+- Sends `POST /api/import/preview` with the raw pasted text
+- Shows validation errors inline if JSON is malformed
+
+### Step 3: Review & approve
+
+- Renders the import plan as a checklist
+- Each action has a checkbox (pre-checked for `new` and `exists_will_merge`, unchecked for `duplicate_skipped`)
+- "Import selected" button
+- Sends `POST /api/import/execute` with `plan_id` and `approved_action_ids`
+
+### Post-import
+
+- Close/reset wizard
+- Switch to the first space that received new content (new space or existing space that was merged into)
+- Show success message with counts
+
+## Import JSON Schema
+
+What the user's AI outputs:
+
+```json
+{
+  "schema_version": 1,
+  "mode": "augment",
+  "source": {
+    "provider": "chatgpt",
+    "generated_at": "2026-04-14T18:00:00Z"
+  },
+  "spaces": [
+    {
+      "name": "Work",
+      "projects": [
+        { "name": "KPS", "summary": "Main operating work." }
+      ]
+    }
+  ],
+  "summaries": [
+    {
+      "space": "Work",
+      "title": "Work overview",
+      "content": "Active focus is KPS and Digital Mart."
+    }
+  ],
+  "memories": [
+    {
+      "content": "User prefers organising by life domain first.",
+      "tags": ["preference"],
+      "space": "Work"
+    }
+  ]
+}
+```
+
+Rules:
+- `schema_version`: always `1` for now
+- `mode`: `"fresh"` or `"augment"` — set by the prompt, informs merge behaviour
+- `source`: provider name and when the AI generated the response
+- `spaces[].projects`: nested inside spaces, every project belongs to exactly one space
+- `summaries[].space`: must reference a space name from the `spaces` array or an existing space
+- `memories[].space`: optional — global if omitted
+- Parser must be forgiving: skip malformed items, don't reject the whole payload
+
+## Prompt Generation
+
+`GET /api/import/prompt` returns a plain text prompt built from a deterministic template + live Oyster context.
+
+### Template logic
+
+- **Fresh install** (no spaces): blank-slate prompt asking the AI to suggest full organisation
+- **Existing workspace**: augment prompt listing current spaces and known projects, asking AI to map into existing spaces and suggest additions
+- **Re-import**: includes `last_import_date` (stored as a key in SQLite `metadata` table or a simple JSON file at `~/.oyster/import-state.json`), asks AI to only include items newer than that date
+
+### What the template includes
+
+- The JSON schema (so the AI knows the exact output format)
+- Existing space names (if any)
+- Existing project names per space (if any)
+- Last import timestamp (if any)
+- Instructions: durable items only, no prose, no one-off conversational details
+
+## Import Plan
+
+`POST /api/import/preview` accepts the raw pasted text and returns:
+
+```json
+{
+  "plan_id": "imp_abc123",
+  "actions": [
+    {
+      "action_id": "act_1",
+      "type": "create_space",
+      "name": "Work",
+      "status": "new"
+    },
+    {
+      "action_id": "act_2",
+      "type": "create_space",
+      "name": "Build",
+      "status": "exists_will_merge"
+    },
+    {
+      "action_id": "act_3",
+      "type": "create_project_summary",
+      "space": "Work",
+      "name": "KPS",
+      "summary": "Main operating work.",
+      "status": "new"
+    },
+    {
+      "action_id": "act_4",
+      "type": "create_summary",
+      "space": "Work",
+      "title": "Work overview",
+      "content": "Active focus is KPS and Digital Mart.",
+      "status": "new"
+    },
+    {
+      "action_id": "act_5",
+      "type": "create_memory",
+      "content": "User prefers organising by life domain first.",
+      "tags": ["preference"],
+      "space": "Work",
+      "status": "new"
+    },
+    {
+      "action_id": "act_6",
+      "type": "create_memory",
+      "content": "Deadline is Friday",
+      "status": "duplicate_skipped"
+    }
+  ]
+}
+```
+
+Action statuses:
+- `new` — will be created
+- `exists_will_merge` — space exists, projects/summaries will be added to it
+- `duplicate_skipped` — already exists, recommended to skip
+
+The plan is held in memory on the server (keyed by `plan_id`), valid for a short TTL (e.g. 10 minutes).
+
+## Merge Rules
+
+Every import is a merge. Rules per type:
+
+| Type | Match key | Behaviour |
+|------|-----------|-----------|
+| Space | Slug (normalised name) | If exists: merge projects into it. If new: create. |
+| Project summary | Space slug + project name | If exists in space: skip. If new: create notes artifact. |
+| Summary | Space slug + "summary" | One per space. If exists: replace content. If new: create. |
+| Memory | Exact content match in same scope | If exact match: skip. If new: create. |
+
+## Provenance
+
+Every created item carries import provenance for dedup on re-import:
+
+- **Artifacts**: `source_origin: "ai_generated"`, `source_ref: "import:{provider}:{generated_at}"` (e.g. `import:chatgpt:2026-04-14T18:00:00Z`)
+- **Memories**: tagged with `import:{provider}:{generated_at}` (e.g. `import:chatgpt:2026-04-14`)
+- **All items**: `imported_at` timestamp set at creation time (uses existing `created_at` field)
+
+On re-import, merge logic checks `source_ref` / tags before creating to avoid duplicates across import runs.
+
+## Execution
+
+`POST /api/import/execute` accepts:
+
+```json
+{
+  "plan_id": "imp_abc123",
+  "approved_action_ids": ["act_1", "act_3", "act_4", "act_5"]
+}
+```
+
+Execution is best-effort:
+- Each action is attempted independently
+- No rollback on partial failure
+- Returns per-action results:
+
+```json
+{
+  "results": [
+    { "action_id": "act_1", "status": "created" },
+    { "action_id": "act_3", "status": "created" },
+    { "action_id": "act_4", "status": "failed", "error": "disk full" },
+    { "action_id": "act_5", "status": "created" }
+  ],
+  "counts": { "created": 3, "failed": 1 }
+}
+```
+
+### What gets created
+
+- **Spaces** → `spaceService.createSpace({ name })` (existing code)
+- **Project summaries** → `artifactService.createArtifact({ space_id, label: name, artifact_kind: "notes", content: summary, source_origin: "ai_generated" })`
+- **Summaries** → same as project summaries but with the summary title as label
+- **Memories** → `memoryProvider.remember({ content, tags, space_id })`
+
+## Privacy
+
+- Pasted JSON is processed locally by Oyster only
+- Never re-sent to another LLM
+- Not stored raw — only the created artifacts and memories persist
+- The import plan is held in memory with a short TTL, then discarded
+
+## Files
+
+| File | Action |
+|------|--------|
+| `server/src/import.ts` | **NEW** — prompt template, preview logic, execute logic, plan store |
+| `server/src/index.ts` | Add 3 routes |
+| `builtins/import-from-ai/manifest.json` | **NEW** — builtin manifest |
+| `builtins/import-from-ai/src/index.html` | **NEW** — 3-step wizard |
+| `web/src/components/OnboardingBanner.tsx` | **NEW** — first-run banner |
+| `web/src/components/Desktop.tsx` | Render banner when `isFirstRun` |
+| `web/src/App.tsx` | Compute `isFirstRun`, pass to Desktop |
+
+## Future (not V1)
+
+- Prompt bar auto-detect as fallback (hybrid mode)
+- Incremental re-import with "only items newer than X" in prompt
+- Confidence scoring in schema v2
+- Cross-space projects in schema v2
+- Auto-sync when ChatGPT exposes MCP
+
+## Verify
+
+1. Fresh install → onboarding banner shows → click "Import from AI" → wizard opens
+2. Copy prompt → includes no existing spaces (fresh mode)
+3. Paste valid JSON → preview shows plan with checkboxes
+4. Approve → spaces, project summaries, summaries, memories created
+5. Post-import → switches to first new space
+6. Run import again with same data → duplicates detected and skipped
+7. Existing user → prompt includes current spaces (augment mode)
+8. Malformed JSON → preview shows inline error, doesn't crash
+9. Partial failure → results show which actions failed

--- a/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
+++ b/docs/superpowers/specs/2026-04-14-cloud-ai-import-design.md
@@ -119,8 +119,9 @@ Rules:
 - `schema_version`: always `1` for now
 - `mode`: advisory only — the AI outputs `"fresh"` or `"augment"` but the server derives the real mode from Oyster state (has spaces → augment, no spaces → fresh). The payload value is ignored for logic; it exists so the AI's intent is visible in the raw data.
 - `source.provider`: set by the wizard based on user's selection in Step 1, not trusted from the AI output
-- `source.generated_at`: when the AI generated the response
+- `source.generated_at`: best-effort — if missing or invalid, server falls back to import time for provenance and state tracking
 - `spaces[].projects`: nested inside spaces, every project belongs to exactly one space
+- `summaries[]`: maps to `create_space_overview` actions in the import plan. Each summary becomes the canonical overview artifact for its space.
 - `summaries[].space`: must reference a space name from the `spaces` array or an existing space
 - `memories[].space`: optional — global if omitted
 - Parser must be forgiving: skip malformed items, don't reject the whole payload
@@ -133,7 +134,7 @@ Rules:
 
 - **Fresh install** (no user-created spaces): blank-slate prompt asking the AI to suggest full organisation
 - **Existing workspace**: augment prompt listing current spaces and known projects, asking AI to map into existing spaces and suggest additions
-- **Re-import**: includes `last_import_date` (stored in `~/.oyster/import-state.json` per provider), asks AI to only include items newer than that date
+- **Re-import**: includes `last_import_date` (stored in `~/.oyster/import-state.json` per provider, written only after successful execute — not after preview), asks AI to only include items newer than that date
 
 ### What the template includes
 
@@ -326,7 +327,7 @@ Execution is best-effort:
 1. Fresh install → onboarding banner shows → click "Import from AI" → wizard opens
 2. Copy prompt → includes no existing spaces (fresh mode)
 3. Paste valid JSON → preview shows plan with checkboxes
-4. Approve → spaces, project summaries, summaries, memories created
+4. Approve → spaces, project summaries, space overviews, memories created
 5. Post-import → switches to first new space
 6. Run import again with same data → duplicates detected and skipped
 7. Existing user → prompt includes current spaces (augment mode)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,9 +13,8 @@
         "better-sqlite3": "^12.8.0",
         "marked": "^17.0.4",
         "node-pty": "1.0.0",
-        "opencode-ai": "^1.2.26",
-        "ws": "^8.18.0",
-        "yaml": "^2.8.3"
+        "opencode-ai": "^1.4.3",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -1633,33 +1632,33 @@
       }
     },
     "node_modules/opencode-ai": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.2.26.tgz",
-      "integrity": "sha512-dcBNK/wD5Z7bRp/MHlyHf195gkP5gxm7271C3YTS/HhavjEr1f5kVtlOvwGbm0Mmvw/ukQMi0xGHuf/RwWKrfg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.4.3.tgz",
+      "integrity": "sha512-WwCSrLgJiS+sLIWoi9pa62vAw3l6VI3a+ShhjDDMUJBBG2FxU18xEhk8xhEedLMKyHo1p0nwD41+iKZ1y+rdAw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "opencode": "bin/opencode"
       },
       "optionalDependencies": {
-        "opencode-darwin-arm64": "1.2.26",
-        "opencode-darwin-x64": "1.2.26",
-        "opencode-darwin-x64-baseline": "1.2.26",
-        "opencode-linux-arm64": "1.2.26",
-        "opencode-linux-arm64-musl": "1.2.26",
-        "opencode-linux-x64": "1.2.26",
-        "opencode-linux-x64-baseline": "1.2.26",
-        "opencode-linux-x64-baseline-musl": "1.2.26",
-        "opencode-linux-x64-musl": "1.2.26",
-        "opencode-windows-arm64": "1.2.26",
-        "opencode-windows-x64": "1.2.26",
-        "opencode-windows-x64-baseline": "1.2.26"
+        "opencode-darwin-arm64": "1.4.3",
+        "opencode-darwin-x64": "1.4.3",
+        "opencode-darwin-x64-baseline": "1.4.3",
+        "opencode-linux-arm64": "1.4.3",
+        "opencode-linux-arm64-musl": "1.4.3",
+        "opencode-linux-x64": "1.4.3",
+        "opencode-linux-x64-baseline": "1.4.3",
+        "opencode-linux-x64-baseline-musl": "1.4.3",
+        "opencode-linux-x64-musl": "1.4.3",
+        "opencode-windows-arm64": "1.4.3",
+        "opencode-windows-x64": "1.4.3",
+        "opencode-windows-x64-baseline": "1.4.3"
       }
     },
     "node_modules/opencode-darwin-arm64": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.2.26.tgz",
-      "integrity": "sha512-8gKkjPfqg2o86kZhgmDe4CSD1Se56uZNHXquWrp0J+vi6ZbCX9tM6aPcJtj1iSlaHe8KAq6yI6L/aHcVKgGncw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.4.3.tgz",
+      "integrity": "sha512-d/MT28Is5yhdFY+36AqKc5r31zx8lXTQIYblfn5R8kdhamXijZVGdD0pHl3eJc1ZolUHNwzg2B+IqV22uyU9GQ==",
       "cpu": [
         "arm64"
       ],
@@ -1669,9 +1668,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.2.26.tgz",
-      "integrity": "sha512-FHZL0EF5e30DuqWEejiFJ6sy8f/uaiPBVrzhVjmS3GhTqeJHJwOhJ/1KanzRtTmLwp3PoTx0NkQ055J61E5WDQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.4.3.tgz",
+      "integrity": "sha512-8FUHeybVmaCYt4S2YmWcf32o/xa/ahCfI258bpWssrzs7Xg51JgUB/Csoble0I1mH7RpW39SKy/hHUtHGuJfJg==",
       "cpu": [
         "x64"
       ],
@@ -1681,9 +1680,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64-baseline": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.2.26.tgz",
-      "integrity": "sha512-pRv3qHj9rnflony9eQOgVFnrDZXW/XMozZ3MZx2hb4bzG33RY6t9DQ+AW3Dv+lHz2I2iMA+OYEKr6RXyxZiusw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.4.3.tgz",
+      "integrity": "sha512-WTqf7WBNRZcv6pClqnN4F7X/T/osgcPGikNHkHUSLszKWg9flqz7Z68kHR4i9ae8Bn3ke9MQRgzRdOt2PgLL0w==",
       "cpu": [
         "x64"
       ],
@@ -1693,9 +1692,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.2.26.tgz",
-      "integrity": "sha512-GTXwn0u1flhAOSFNEY8SZmYSLmhBCfeBPE3+9TtWfznri7tWdXtJIrfcodYtQ+7C03uK1tHJSyFBJ/8TmyD2CQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.4.3.tgz",
+      "integrity": "sha512-9jpVSOEF7TX3gPPAHVAsBT9XEO3LgYafI+IUmOzbBB9CDiVVNJw6JmEffmSpSxY4nkAh322xnMbNjVGEyXQBRA==",
       "cpu": [
         "arm64"
       ],
@@ -1705,9 +1704,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64-musl": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.2.26.tgz",
-      "integrity": "sha512-WB/aDSQX+S5XkKXfkKl7AmIePC2kGoKatdsxBEtpg1EgC/3llqHKZXxrFA5ulzlxEt7VongiyfzFFAxIzo8o1w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.4.3.tgz",
+      "integrity": "sha512-3Ej2klaep8+fxcc44UyEuRpb/UFiNkwfzIDLIST83hFUtjzprjpTRqg6zHmOfzyfjNAaNpB4VZw6e9y3mGBpiQ==",
       "cpu": [
         "arm64"
       ],
@@ -1717,9 +1716,9 @@
       ]
     },
     "node_modules/opencode-linux-x64": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.2.26.tgz",
-      "integrity": "sha512-8PvGk4tQ6VlG0Csiz6Er/h0QIrdkbCqSHfLf7vU+JtlscjST2z2NTOfG4aC+yJQkm0PZ9ZB8V4xsGkpye9u4wQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.4.3.tgz",
+      "integrity": "sha512-RS6TsDqTUrW5sefxD1KD9Xy9mSYGXAlr2DlGrdi8vNm9e/Bt4r4u557VB7f/Uj2CxTt2Gf7OWl08ZoPlxMJ5Gg==",
       "cpu": [
         "x64"
       ],
@@ -1729,9 +1728,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.2.26.tgz",
-      "integrity": "sha512-VDfR2o2FRwAP4x/LkgmfwDlSPUKSVTMRb+9w9eKhu7gTdGEzmjAkAt4rfgL7lo/K+WmwJiVY7r0IZncRU3fZIA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.4.3.tgz",
+      "integrity": "sha512-HpzdgYaI90qqt0WokcyBhadgFQ0EYMhq4TZ4EcaSPuZTssS2Drb6kp70Si54uOJL/MUAdc9+E0BYYIAdOJ6h1g==",
       "cpu": [
         "x64"
       ],
@@ -1741,9 +1740,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline-musl": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.2.26.tgz",
-      "integrity": "sha512-al/kb5hN7YpYSz4NpAar8fZpjTLwTT+vsjTm8lgYRLxQATmHZtN1BCD6GQAuH6a4EisVDZwgYZgYIOEXL0nAwQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.4.3.tgz",
+      "integrity": "sha512-aned/3FQTHXXQv2PPKDprJwQaQkoadriQ6AByGhRl6/bHhSkhkiVl6cHHvYMKxYEwN4bVOydWhasfgm/xru/xw==",
       "cpu": [
         "x64"
       ],
@@ -1753,9 +1752,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-musl": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.2.26.tgz",
-      "integrity": "sha512-mFy4v/H3B+CsujYdqAgD91SVoxg42cyQkOgZqGuAqvlB1kxvpyGt6NqeKSRIkUZNO9XoF5wSZ8S/CiWrN0Z0uA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.4.3.tgz",
+      "integrity": "sha512-ibUevyDxVrwkp6FWu8UBCBsrzlKDT/uEug2NHCKaHIwo9uwVf5zsL/0ueHYqmH14SHK+M6wzWewYk6WuW9f0zQ==",
       "cpu": [
         "x64"
       ],
@@ -1765,9 +1764,9 @@
       ]
     },
     "node_modules/opencode-windows-arm64": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.2.26.tgz",
-      "integrity": "sha512-x5UPLsjenGbpJT6rzi+c01ojfp5UrM6XxqSHDfH4+ALGDz1ojBJkKtdmHMhn7NYTlmGlZpVIgIdr0Exg5OVguQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.4.3.tgz",
+      "integrity": "sha512-2ViH17WpIQbRVfQaOBMi49pu73gqTQYT/4/WxFjShmRagX40/KkG18fhvyDAZrBKfkhPtdwgFsFxMSYP9F6QCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1777,9 +1776,9 @@
       ]
     },
     "node_modules/opencode-windows-x64": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.2.26.tgz",
-      "integrity": "sha512-/KIuzoYja+fS/HrIZBiO7vMnPFjAyp0nZVV5XZtA5LyJ0M3+WrsCFwcG1DN3qslEeBqTzW1YOondeU5OJNcTrQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.4.3.tgz",
+      "integrity": "sha512-UxmKDIw3t4XHST6JSUWHmSrCGIEK1LRTAOpO82HBC3XkIjH78gVIeauRR6RULjWAApmy9I1C3TukO2sDUi7Gvw==",
       "cpu": [
         "x64"
       ],
@@ -1789,9 +1788,9 @@
       ]
     },
     "node_modules/opencode-windows-x64-baseline": {
-      "version": "1.2.26",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.2.26.tgz",
-      "integrity": "sha512-murif0cXJm7vLQXPJwf793H5PH5izK3xQR/Y5Bhn3UiVso2Xsy85QPYB2Ut4O+cU1T6IbRwXtbcN+f6c4j7hHA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.4.3.tgz",
+      "integrity": "sha512-SWYDli9SAKQd/pS/hVfuq1KEsc+gnAJdv+YtBmxaHOw57y0euqLwbGFUYFq78GAMGt/RnTYWZIEUbRK/ZiX3UA==",
       "cpu": [
         "x64"
       ],
@@ -2418,21 +2417,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,8 @@
         "marked": "^17.0.4",
         "node-pty": "1.0.0",
         "opencode-ai": "^1.2.26",
-        "ws": "^8.18.0"
+        "ws": "^8.18.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
@@ -2417,6 +2418,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/server/package.json
+++ b/server/package.json
@@ -14,9 +14,8 @@
     "better-sqlite3": "^12.8.0",
     "marked": "^17.0.4",
     "node-pty": "1.0.0",
-    "opencode-ai": "^1.2.26",
-    "ws": "^8.18.0",
-    "yaml": "^2.8.3"
+    "opencode-ai": "^1.4.3",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "marked": "^17.0.4",
     "node-pty": "1.0.0",
     "opencode-ai": "^1.2.26",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -1,0 +1,512 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ── Types ──
+
+export interface ImportPayload {
+  schema_version: number;
+  mode?: "fresh" | "augment";
+  source?: {
+    provider?: string;
+    generated_at?: string;
+  };
+  spaces?: Array<{
+    name: string;
+    projects?: Array<{ name: string; summary: string }>;
+  }>;
+  summaries?: Array<{
+    space: string;
+    title: string;
+    content: string;
+  }>;
+  memories?: Array<{
+    content: string;
+    tags?: string[];
+    space?: string;
+  }>;
+}
+
+export type ActionType = "create_space" | "create_project_summary" | "create_space_overview" | "create_memory";
+export type ActionStatus = "new" | "exists_will_merge" | "duplicate_skipped";
+
+export interface ImportAction {
+  action_id: string;
+  type: ActionType;
+  status: ActionStatus;
+  name?: string;
+  space?: string;
+  summary?: string;
+  title?: string;
+  content?: string;
+  tags?: string[];
+  depends_on?: string;
+}
+
+export interface ImportPlan {
+  plan_id: string;
+  provider: string;
+  generated_at: string;
+  counts: { new: number; merge: number; skipped: number };
+  warnings: string[];
+  actions: ImportAction[];
+}
+
+export interface ExecuteResult {
+  results: Array<{ action_id: string; status: "created" | "skipped" | "failed"; error?: string }>;
+  counts: { created: number; failed: number };
+}
+
+// ── Plan Store (in-memory, TTL 10 min) ──
+
+const plans = new Map<string, { plan: ImportPlan; payload: ImportPayload; expires: number }>();
+const PLAN_TTL = 10 * 60 * 1000;
+
+export function storePlan(plan: ImportPlan, payload: ImportPayload): void {
+  plans.set(plan.plan_id, { plan, payload, expires: Date.now() + PLAN_TTL });
+}
+
+export function getPlan(planId: string): { plan: ImportPlan; payload: ImportPayload } | null {
+  const entry = plans.get(planId);
+  if (!entry) return null;
+  if (Date.now() > entry.expires) {
+    plans.delete(planId);
+    return null;
+  }
+  return { plan: entry.plan, payload: entry.payload };
+}
+
+export function deletePlan(planId: string): void {
+  plans.delete(planId);
+}
+
+// Clean expired plans periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, entry] of plans) {
+    if (now > entry.expires) plans.delete(id);
+  }
+}, 60_000);
+
+// ── Import State ──
+
+const IMPORT_STATE_PATH = join(homedir(), ".oyster", "import-state.json");
+
+interface ImportState {
+  [provider: string]: { last_import_date: string };
+}
+
+function readImportState(): ImportState {
+  try {
+    if (existsSync(IMPORT_STATE_PATH)) {
+      return JSON.parse(readFileSync(IMPORT_STATE_PATH, "utf8"));
+    }
+  } catch {}
+  return {};
+}
+
+export function writeImportDate(provider: string): void {
+  const state = readImportState();
+  state[provider] = { last_import_date: new Date().toISOString() };
+  mkdirSync(join(homedir(), ".oyster"), { recursive: true });
+  writeFileSync(IMPORT_STATE_PATH, JSON.stringify(state, null, 2) + "\n");
+}
+
+// ── Prompt Generation ──
+
+const JSON_SCHEMA_EXAMPLE = `{
+  "schema_version": 1,
+  "mode": "fresh",
+  "source": {
+    "provider": "chatgpt",
+    "generated_at": "2026-04-14T18:00:00Z"
+  },
+  "spaces": [
+    {
+      "name": "Work",
+      "projects": [
+        { "name": "Project Name", "summary": "One sentence about this project." }
+      ]
+    }
+  ],
+  "summaries": [
+    {
+      "space": "Work",
+      "title": "Work overview",
+      "content": "2-3 sentences summarising this space."
+    }
+  ],
+  "memories": [
+    {
+      "content": "A durable fact, preference, or constraint worth remembering.",
+      "tags": ["preference"],
+      "space": "Work"
+    }
+  ]
+}`;
+
+export interface PromptContext {
+  provider: string;
+  spaces: Array<{ id: string; displayName: string }>;
+  knownProjects: Map<string, string[]>;
+}
+
+export function generatePrompt(ctx: PromptContext): string {
+  const state = readImportState();
+  const lastImport = state[ctx.provider]?.last_import_date;
+  const hasSpaces = ctx.spaces.length > 0;
+  const mode = hasSpaces ? "augment" : "fresh";
+
+  let prompt = `Based on our past conversations, identify durable workstreams, projects, and long-lived personal contexts that should be organised in a workspace tool.\n\n`;
+
+  if (hasSpaces) {
+    prompt += `I already have these spaces set up:\n`;
+    for (const s of ctx.spaces) {
+      const projects = ctx.knownProjects.get(s.id) || [];
+      if (projects.length > 0) {
+        prompt += `- ${s.displayName} (projects: ${projects.join(", ")})\n`;
+      } else {
+        prompt += `- ${s.displayName}\n`;
+      }
+    }
+    prompt += `\nMap into existing spaces where possible. Only suggest new spaces when needed. Do not reorganise what already exists.\n\n`;
+  }
+
+  if (lastImport) {
+    prompt += `My last import was on ${lastImport}. Only include items that are new or changed since then.\n\n`;
+  }
+
+  prompt += `RULES:
+- Only include durable items worth keeping: ongoing projects, recurring themes, stable preferences, important decisions.
+- Exclude one-off conversational details, temporary questions, or ephemeral topics.
+- Every project belongs to exactly one space.
+- Summaries: one per space, 2-3 sentences describing what the space is about.
+- Memories: durable facts, preferences, or constraints. Not opinions or emotional colour from a single conversation.
+
+OUTPUT FORMAT:
+- Output one valid JSON object only.
+- No markdown fences. No prose before or after. No explanation.
+- Set mode to "${mode}".
+- Set source.provider to "${ctx.provider}".
+- Set source.generated_at to the current time in ISO 8601 format.
+
+JSON SCHEMA:
+${JSON_SCHEMA_EXAMPLE}`;
+
+  return prompt;
+}
+
+// ── JSON Parsing & Recovery ──
+
+function stripMarkdownFences(raw: string): string {
+  let s = raw.trim();
+  s = s.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/, "");
+  const firstBrace = s.indexOf("{");
+  const lastBrace = s.lastIndexOf("}");
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    s = s.slice(firstBrace, lastBrace + 1);
+  }
+  s = s.replace(/^\uFEFF/, "");
+  return s;
+}
+
+export interface ParseResult {
+  success: boolean;
+  payload?: ImportPayload;
+  error?: string;
+  recovered?: boolean;
+}
+
+export async function parseImportJSON(
+  raw: string,
+  aiRepairFn?: (broken: string) => Promise<string | null>,
+): Promise<ParseResult> {
+  const cleaned = stripMarkdownFences(raw);
+
+  try {
+    const parsed = JSON.parse(cleaned);
+    return { success: true, payload: parsed as ImportPayload };
+  } catch (e1) {
+    if (aiRepairFn) {
+      try {
+        const repaired = await aiRepairFn(cleaned);
+        if (repaired) {
+          const repairedCleaned = stripMarkdownFences(repaired);
+          const parsed = JSON.parse(repairedCleaned);
+          return { success: true, payload: parsed as ImportPayload, recovered: true };
+        }
+      } catch {}
+    }
+
+    return {
+      success: false,
+      error: `Invalid JSON: ${(e1 as Error).message}`,
+    };
+  }
+}
+
+// ── Preview (Plan Building) ──
+
+export interface PreviewDeps {
+  getSpaceBySlug: (slug: string) => { id: string; displayName: string } | null;
+  getArtifactsBySpace: (spaceId: string) => Array<{ source_ref: string | null; label: string }>;
+  findMemory: (content: string, spaceId: string | null) => boolean;
+}
+
+function slugify(str: string): string {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+export function buildImportPlan(
+  payload: ImportPayload,
+  provider: string,
+  generatedAt: string,
+  deps: PreviewDeps,
+): ImportPlan {
+  const planId = `imp_${randomUUID().slice(0, 12)}`;
+  const actions: ImportAction[] = [];
+  const warnings: string[] = [];
+  let actCounter = 0;
+  const nextId = () => `act_${++actCounter}`;
+
+  const spaceActionIds = new Map<string, string>();
+
+  for (const space of payload.spaces ?? []) {
+    if (!space.name) continue;
+    const slug = slugify(space.name);
+    const existing = deps.getSpaceBySlug(slug);
+    const actionId = nextId();
+    spaceActionIds.set(space.name, actionId);
+
+    if (existing) {
+      actions.push({
+        action_id: actionId,
+        type: "create_space",
+        name: space.name,
+        status: "exists_will_merge",
+      });
+      warnings.push(`Space '${space.name}' already exists and will be merged.`);
+    } else {
+      actions.push({
+        action_id: actionId,
+        type: "create_space",
+        name: space.name,
+        status: "new",
+      });
+    }
+
+    for (const project of space.projects ?? []) {
+      if (!project.name) continue;
+      const spaceId = existing?.id ?? slug;
+      const existingArtifacts = deps.getArtifactsBySpace(spaceId);
+      const isDupe = existingArtifacts.some(
+        (a) => a.source_ref?.startsWith("import:") && slugify(a.label) === slugify(project.name),
+      );
+
+      actions.push({
+        action_id: nextId(),
+        type: "create_project_summary",
+        space: space.name,
+        name: project.name,
+        summary: project.summary,
+        status: isDupe ? "duplicate_skipped" : "new",
+        depends_on: existing ? undefined : actionId,
+      });
+    }
+  }
+
+  for (const summary of payload.summaries ?? []) {
+    if (!summary.space || !summary.content) continue;
+    const slug = slugify(summary.space);
+    const existing = deps.getSpaceBySlug(slug);
+    const spaceId = existing?.id ?? slug;
+    const existingArtifacts = deps.getArtifactsBySpace(spaceId);
+    const hasOverview = existingArtifacts.some(
+      (a) => a.source_ref?.includes("overview"),
+    );
+    const parentActionId = spaceActionIds.get(summary.space);
+
+    actions.push({
+      action_id: nextId(),
+      type: "create_space_overview",
+      space: summary.space,
+      title: summary.title || `${summary.space} overview`,
+      content: summary.content,
+      status: hasOverview ? "exists_will_merge" : "new",
+      depends_on: existing ? undefined : parentActionId,
+    });
+  }
+
+  for (const memory of payload.memories ?? []) {
+    if (!memory.content) continue;
+    const spaceSlug = memory.space ? slugify(memory.space) : null;
+    const existingSpace = spaceSlug ? deps.getSpaceBySlug(spaceSlug) : null;
+    const spaceId = existingSpace?.id ?? spaceSlug;
+    const isDupe = deps.findMemory(memory.content, spaceId);
+
+    actions.push({
+      action_id: nextId(),
+      type: "create_memory",
+      content: memory.content,
+      tags: memory.tags,
+      space: memory.space,
+      status: isDupe ? "duplicate_skipped" : "new",
+    });
+  }
+
+  const counts = {
+    new: actions.filter((a) => a.status === "new").length,
+    merge: actions.filter((a) => a.status === "exists_will_merge").length,
+    skipped: actions.filter((a) => a.status === "duplicate_skipped").length,
+  };
+
+  const plan: ImportPlan = { plan_id: planId, provider, generated_at: generatedAt, counts, warnings, actions };
+  storePlan(plan, payload);
+  return plan;
+}
+
+// ── Execute ──
+
+export interface ExecuteDeps {
+  createSpace: (name: string) => { id: string };
+  createArtifact: (params: {
+    space_id: string;
+    label: string;
+    artifact_kind: "notes";
+    content: string;
+    source_origin: "ai_generated";
+    source_ref: string;
+  }) => Promise<{ id: string }>;
+  remember: (input: { content: string; space_id?: string; tags?: string[] }) => Promise<{ id: string }>;
+  getSpaceBySlug: (slug: string) => { id: string } | null;
+}
+
+function resolveSpaceId(
+  spaceName: string,
+  createdSpaces: Map<string, string>,
+  deps: ExecuteDeps,
+): string {
+  const fromCreated = createdSpaces.get(spaceName);
+  if (fromCreated) return fromCreated;
+  const existing = deps.getSpaceBySlug(slugify(spaceName));
+  if (existing) return existing.id;
+  return slugify(spaceName);
+}
+
+export async function executeImportPlan(
+  planId: string,
+  approvedIds: string[],
+  deps: ExecuteDeps,
+): Promise<ExecuteResult> {
+  const entry = getPlan(planId);
+  if (!entry) {
+    return { results: [], counts: { created: 0, failed: 0 } };
+  }
+
+  const { plan } = entry;
+  const approved = new Set(approvedIds);
+  const results: ExecuteResult["results"] = [];
+  const createdSpaces = new Map<string, string>();
+
+  // Validate: reject orphaned actions
+  for (const action of plan.actions) {
+    if (!approved.has(action.action_id)) continue;
+    if (action.depends_on) {
+      const parent = plan.actions.find((a) => a.action_id === action.depends_on);
+      if (parent && parent.status === "new" && !approved.has(parent.action_id)) {
+        results.push({
+          action_id: action.action_id,
+          status: "failed",
+          error: `Depends on ${action.depends_on} which was not approved`,
+        });
+        approved.delete(action.action_id);
+      }
+    }
+  }
+
+  const ordered = plan.actions.filter((a) => approved.has(a.action_id));
+
+  for (const action of ordered) {
+    try {
+      switch (action.type) {
+        case "create_space": {
+          if (action.status === "exists_will_merge") {
+            const existing = deps.getSpaceBySlug(slugify(action.name!));
+            if (existing) createdSpaces.set(action.name!, existing.id);
+            results.push({ action_id: action.action_id, status: "skipped" });
+          } else {
+            const space = deps.createSpace(action.name!);
+            createdSpaces.set(action.name!, space.id);
+            results.push({ action_id: action.action_id, status: "created" });
+          }
+          break;
+        }
+        case "create_project_summary": {
+          const spaceId = resolveSpaceId(action.space!, createdSpaces, deps);
+          const ref = `import:${plan.provider}:${plan.generated_at}:project:${slugify(action.name!)}`;
+          await deps.createArtifact({
+            space_id: spaceId,
+            label: action.name!,
+            artifact_kind: "notes",
+            content: `# ${action.name}\n\n${action.summary || ""}`,
+            source_origin: "ai_generated",
+            source_ref: ref,
+          });
+          results.push({ action_id: action.action_id, status: "created" });
+          break;
+        }
+        case "create_space_overview": {
+          const spaceId = resolveSpaceId(action.space!, createdSpaces, deps);
+          const ref = `import:${plan.provider}:${plan.generated_at}:overview:${slugify(action.space!)}`;
+          await deps.createArtifact({
+            space_id: spaceId,
+            label: action.title || `${action.space} overview`,
+            artifact_kind: "notes",
+            content: `# ${action.title || action.space}\n\n${action.content || ""}`,
+            source_origin: "ai_generated",
+            source_ref: ref,
+          });
+          results.push({ action_id: action.action_id, status: "created" });
+          break;
+        }
+        case "create_memory": {
+          const spaceSlug = action.space ? slugify(action.space) : undefined;
+          const spaceId = spaceSlug
+            ? resolveSpaceId(action.space!, createdSpaces, deps)
+            : undefined;
+          const importTag = `_import:${plan.provider}:${plan.generated_at.slice(0, 10)}`;
+          const tags = [...(action.tags || []), importTag];
+          await deps.remember({
+            content: action.content!,
+            space_id: spaceId,
+            tags,
+          });
+          results.push({ action_id: action.action_id, status: "created" });
+          break;
+        }
+      }
+    } catch (err) {
+      results.push({
+        action_id: action.action_id,
+        status: "failed",
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  const created = results.filter((r) => r.status === "created").length;
+  if (created > 0) {
+    writeImportDate(plan.provider);
+  }
+
+  deletePlan(planId);
+
+  return {
+    results,
+    counts: {
+      created,
+      failed: results.filter((r) => r.status === "failed").length,
+    },
+  };
+}

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -58,7 +58,7 @@ export interface ExecuteResult {
   counts: { created: number; failed: number };
 }
 
-// ── Plan Store (in-memory, TTL 10 min) ──
+// ── Plan Store (in-memory, TTL 30 min) ──
 
 const plans = new Map<string, { plan: ImportPlan; payload: ImportPayload; expires: number }>();
 const PLAN_TTL = 30 * 60 * 1000;
@@ -208,7 +208,7 @@ export async function parseImportPayload(
   // Fast path: already valid JSON
   try {
     const parsed = JSON.parse(cleaned);
-    if (parsed && Array.isArray(parsed.spaces)) {
+    if (parsed && typeof parsed === "object" && (Array.isArray(parsed.spaces) || Array.isArray(parsed.summaries) || Array.isArray(parsed.memories))) {
       return { success: true, payload: parsed as ImportPayload };
     }
   } catch (err) {
@@ -224,7 +224,7 @@ export async function parseImportPayload(
         console.log("[import] AI returned:", converted.slice(0, 200));
         const json = stripFences(converted);
         const parsed = JSON.parse(json);
-        if (parsed && Array.isArray(parsed.spaces)) {
+        if (parsed && typeof parsed === "object" && (Array.isArray(parsed.spaces) || Array.isArray(parsed.summaries) || Array.isArray(parsed.memories))) {
           return { success: true, payload: parsed as ImportPayload };
         }
         console.log("[import] AI response parsed but spaces is not an array");
@@ -315,12 +315,14 @@ export function buildImportPlan(
     if (!summary.space || !summary.content) continue;
     const slug = slugify(summary.space);
     const existing = deps.getSpaceBySlug(slug);
+    const parentActionId = spaceActionIds.get(summary.space);
+    // Skip if space doesn't exist and isn't being created in this import
+    if (!existing && !parentActionId) continue;
     const spaceId = existing?.id ?? slug;
     const existingArtifacts = deps.getArtifactsBySpace(spaceId);
     const hasOverview = existingArtifacts.some(
       (a) => a.source_ref?.includes("overview"),
     );
-    const parentActionId = spaceActionIds.get(summary.space);
 
     actions.push({
       action_id: nextId(),

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { parse as parseYAML } from "yaml";
 
 // ── Types ──
 
@@ -62,7 +61,7 @@ export interface ExecuteResult {
 // ── Plan Store (in-memory, TTL 10 min) ──
 
 const plans = new Map<string, { plan: ImportPlan; payload: ImportPayload; expires: number }>();
-const PLAN_TTL = 10 * 60 * 1000;
+const PLAN_TTL = 30 * 60 * 1000;
 
 export function storePlan(plan: ImportPlan, payload: ImportPayload): void {
   plans.set(plan.plan_id, { plan, payload, expires: Date.now() + PLAN_TTL });
@@ -202,42 +201,44 @@ export interface ParseResult {
 
 export async function parseImportPayload(
   raw: string,
-  aiRepairFn?: (broken: string) => Promise<string | null>,
+  convertFn?: (text: string) => Promise<string | null>,
 ): Promise<ParseResult> {
   const cleaned = stripFences(raw);
 
-  // Try JSON first, then YAML
+  // Fast path: already valid JSON
   try {
-    return { success: true, payload: JSON.parse(cleaned) as ImportPayload };
-  } catch {}
-
-  try {
-    const parsed = parseYAML(cleaned);
-    if (parsed && typeof parsed === "object" && (parsed as ImportPayload).spaces) {
+    const parsed = JSON.parse(cleaned);
+    if (parsed && Array.isArray(parsed.spaces)) {
       return { success: true, payload: parsed as ImportPayload };
     }
-  } catch {}
-
-  // Hand off to AI for repair — this is the expected path for most real AI output
-  if (aiRepairFn) {
-    try {
-      const repaired = await aiRepairFn(cleaned);
-      if (repaired) {
-        const repairedCleaned = stripFences(repaired);
-        try {
-          return { success: true, payload: JSON.parse(repairedCleaned) as ImportPayload, recovered: true };
-        } catch {}
-        try {
-          const parsed = parseYAML(repairedCleaned);
-          if (parsed && typeof parsed === "object") {
-            return { success: true, payload: parsed as ImportPayload, recovered: true };
-          }
-        } catch {}
-      }
-    } catch {}
+  } catch (err) {
+    console.log("[import] JSON parse failed:", (err as Error).message);
   }
 
-  return { success: false, error: "Could not parse the response. Check the format and try again." };
+  // Convert through AI — the expected path for most real AI output
+  if (convertFn) {
+    try {
+      console.log("[import] Sending to AI for conversion...");
+      const converted = await convertFn(cleaned);
+      if (converted) {
+        console.log("[import] AI returned:", converted.slice(0, 200));
+        const json = stripFences(converted);
+        const parsed = JSON.parse(json);
+        if (parsed && Array.isArray(parsed.spaces)) {
+          return { success: true, payload: parsed as ImportPayload };
+        }
+        console.log("[import] AI response parsed but spaces is not an array");
+      } else {
+        console.log("[import] AI conversion returned null");
+      }
+    } catch (err) {
+      console.error("[import] AI conversion error:", err);
+    }
+  } else {
+    console.log("[import] No convertFn provided");
+  }
+
+  return { success: false, error: "Could not parse the response. Try pasting the full output from your AI." };
 }
 
 // ── Preview (Plan Building) ──
@@ -481,11 +482,12 @@ export async function executeImportPlan(
         }
       }
     } catch (err) {
-      results.push({
-        action_id: action.action_id,
-        status: "failed",
-        error: (err as Error).message,
-      });
+      const msg = (err as Error).message;
+      if (msg.includes("already exists")) {
+        results.push({ action_id: action.action_id, status: "skipped" });
+      } else {
+        results.push({ action_id: action.action_id, status: "failed", error: msg });
+      }
     }
   }
 

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -270,6 +270,7 @@ export function buildImportPlan(
   for (const space of payload.spaces ?? []) {
     if (!space.name) continue;
     const slug = slugify(space.name);
+    if (!slug) continue;
     const existing = deps.getSpaceBySlug(slug);
     const actionId = nextId();
     spaceActionIds.set(space.name, actionId);
@@ -376,6 +377,7 @@ export interface ExecuteDeps {
     source_ref: string;
   }) => Promise<{ id: string }>;
   remember: (input: { content: string; space_id?: string; tags?: string[] }) => Promise<{ id: string }>;
+  findMemory: (content: string, spaceId: string | null) => boolean;
   getSpaceBySlug: (slug: string) => { id: string } | null;
 }
 
@@ -472,14 +474,19 @@ export async function executeImportPlan(
           const spaceId = spaceSlug
             ? resolveSpaceId(action.space!, createdSpaces, deps)
             : undefined;
-          const importTag = `_import:${plan.provider}:${plan.generated_at.slice(0, 10)}`;
-          const tags = [...(action.tags || []), importTag];
-          await deps.remember({
-            content: action.content!,
-            space_id: spaceId,
-            tags,
-          });
-          results.push({ action_id: action.action_id, status: "created" });
+          // Check if already exists before creating
+          if (deps.findMemory && deps.findMemory(action.content!, spaceId ?? null)) {
+            results.push({ action_id: action.action_id, status: "skipped" });
+          } else {
+            const importTag = `_import:${plan.provider}:${plan.generated_at.slice(0, 10)}`;
+            const tags = [...(action.tags || []), importTag];
+            await deps.remember({
+              content: action.content!,
+              space_id: spaceId,
+              tags,
+            });
+            results.push({ action_id: action.action_id, status: "created" });
+          }
           break;
         }
       }

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { parse as parseYAML } from "yaml";
 
 // ── Types ──
 
@@ -115,36 +116,24 @@ export function writeImportDate(provider: string): void {
 
 // ── Prompt Generation ──
 
-const JSON_SCHEMA_EXAMPLE = `{
-  "schema_version": 1,
-  "mode": "fresh",
-  "source": {
-    "provider": "chatgpt",
-    "generated_at": "2026-04-14T18:00:00Z"
-  },
-  "spaces": [
-    {
-      "name": "Work",
-      "projects": [
-        { "name": "Project Name", "summary": "One sentence about this project." }
-      ]
-    }
-  ],
-  "summaries": [
-    {
-      "space": "Work",
-      "title": "Work overview",
-      "content": "2-3 sentences summarising this space."
-    }
-  ],
-  "memories": [
-    {
-      "content": "A durable fact, preference, or constraint worth remembering.",
-      "tags": ["preference"],
-      "space": "Work"
-    }
-  ]
-}`;
+const SCHEMA_EXAMPLE = `schema_version: 1
+mode: fresh
+source:
+  provider: chatgpt
+  generated_at: "2026-04-14T18:00:00Z"
+spaces:
+  - name: Work
+    projects:
+      - name: Project Name
+        summary: One sentence about this project.
+summaries:
+  - space: Work
+    title: Work overview
+    content: 2-3 sentences summarising this space.
+memories:
+  - content: A durable fact, preference, or constraint worth remembering.
+    tags: [preference]
+    space: Work`;
 
 export interface PromptContext {
   provider: string;
@@ -185,30 +174,23 @@ export function generatePrompt(ctx: PromptContext): string {
 - Memories: durable facts, preferences, or constraints. Not opinions or emotional colour from a single conversation.
 
 OUTPUT FORMAT:
-- Output one valid JSON object only.
-- No markdown fences. No prose before or after. No explanation.
+- Output YAML only. No markdown fences. No prose before or after. No explanation.
 - Set mode to "${mode}".
 - Set source.provider to "${ctx.provider}".
 - Set source.generated_at to the current time in ISO 8601 format.
 
-JSON SCHEMA:
-${JSON_SCHEMA_EXAMPLE}`;
+SCHEMA:
+${SCHEMA_EXAMPLE}`;
 
   return prompt;
 }
 
-// ── JSON Parsing & Recovery ──
+// ── Parsing (YAML/JSON + AI fallback) ──
 
-function stripMarkdownFences(raw: string): string {
-  let s = raw.trim();
-  s = s.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/, "");
-  const firstBrace = s.indexOf("{");
-  const lastBrace = s.lastIndexOf("}");
-  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
-    s = s.slice(firstBrace, lastBrace + 1);
-  }
-  s = s.replace(/^\uFEFF/, "");
-  return s;
+function stripFences(raw: string): string {
+  let s = raw.trim().replace(/^\uFEFF/, "");
+  s = s.replace(/^```(?:json|yaml|yml)?\s*\n?/i, "").replace(/\n?```\s*$/, "");
+  return s.trim();
 }
 
 export interface ParseResult {
@@ -218,32 +200,44 @@ export interface ParseResult {
   recovered?: boolean;
 }
 
-export async function parseImportJSON(
+export async function parseImportPayload(
   raw: string,
   aiRepairFn?: (broken: string) => Promise<string | null>,
 ): Promise<ParseResult> {
-  const cleaned = stripMarkdownFences(raw);
+  const cleaned = stripFences(raw);
+
+  // Try JSON first, then YAML (YAML is a superset of JSON so this order is safe)
+  try {
+    return { success: true, payload: JSON.parse(cleaned) as ImportPayload };
+  } catch {}
 
   try {
-    const parsed = JSON.parse(cleaned);
-    return { success: true, payload: parsed as ImportPayload };
-  } catch (e1) {
-    if (aiRepairFn) {
-      try {
-        const repaired = await aiRepairFn(cleaned);
-        if (repaired) {
-          const repairedCleaned = stripMarkdownFences(repaired);
-          const parsed = JSON.parse(repairedCleaned);
-          return { success: true, payload: parsed as ImportPayload, recovered: true };
-        }
-      } catch {}
+    const parsed = parseYAML(cleaned);
+    if (parsed && typeof parsed === "object") {
+      return { success: true, payload: parsed as ImportPayload };
     }
+  } catch {}
 
-    return {
-      success: false,
-      error: `Invalid JSON: ${(e1 as Error).message}`,
-    };
+  // Hand off to AI for repair
+  if (aiRepairFn) {
+    try {
+      const repaired = await aiRepairFn(cleaned);
+      if (repaired) {
+        const repairedCleaned = stripFences(repaired);
+        try {
+          return { success: true, payload: JSON.parse(repairedCleaned) as ImportPayload, recovered: true };
+        } catch {}
+        try {
+          const parsed = parseYAML(repairedCleaned);
+          if (parsed && typeof parsed === "object") {
+            return { success: true, payload: parsed as ImportPayload, recovered: true };
+          }
+        } catch {}
+      }
+    } catch {}
   }
+
+  return { success: false, error: "Could not parse the response. Check the format and try again." };
 }
 
 // ── Preview (Plan Building) ──

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -206,19 +206,19 @@ export async function parseImportPayload(
 ): Promise<ParseResult> {
   const cleaned = stripFences(raw);
 
-  // Try JSON first, then YAML (YAML is a superset of JSON so this order is safe)
+  // Try JSON first, then YAML
   try {
     return { success: true, payload: JSON.parse(cleaned) as ImportPayload };
   } catch {}
 
   try {
     const parsed = parseYAML(cleaned);
-    if (parsed && typeof parsed === "object") {
+    if (parsed && typeof parsed === "object" && (parsed as ImportPayload).spaces) {
       return { success: true, payload: parsed as ImportPayload };
     }
   } catch {}
 
-  // Hand off to AI for repair
+  // Hand off to AI for repair — this is the expected path for most real AI output
   if (aiRepairFn) {
     try {
       const repaired = await aiRepairFn(cleaned);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -30,7 +30,7 @@ import {
 import { runStartupBackup } from "./backup.js";
 import {
   generatePrompt,
-  parseImportJSON,
+  parseImportPayload,
   buildImportPlan,
   executeImportPlan,
   getPlan,
@@ -497,7 +497,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       try {
         const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
 
-        const parseResult = await parseImportJSON(raw);
+        const parseResult = await parseImportPayload(raw);
         if (!parseResult.success || !parseResult.payload) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: parseResult.error }));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,6 +29,16 @@ import {
 } from "./artifact-detector.js";
 import { runStartupBackup } from "./backup.js";
 import {
+  generatePrompt,
+  parseImportJSON,
+  buildImportPlan,
+  executeImportPlan,
+  getPlan,
+  type PromptContext,
+  type PreviewDeps,
+  type ExecuteDeps,
+} from "./import.js";
+import {
   spawnOpenCodeServe,
   getOpenCodePort,
   markShuttingDown,
@@ -454,6 +464,110 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // ── Spaces API ──
 
   if (await handleSpacesRequest(url, req, res, spaceService)) return;
+
+  // ── Import routes ──
+
+  if (url.startsWith("/api/import/prompt") && req.method === "GET") {
+    const params = new URL(url, "http://localhost").searchParams;
+    const provider = params.get("provider") || "chatgpt";
+
+    const allSpaces = spaceStore.getAll()
+      .filter((s) => s.id !== "home" && s.id !== "__all__")
+      .map((s) => ({ id: s.id, displayName: s.display_name }));
+
+    const knownProjects = new Map<string, string[]>();
+    for (const s of allSpaces) {
+      const artifacts = store.getBySpaceId(s.id)
+        .filter((a) => a.source_ref?.startsWith("import:") && !a.removed_at);
+      if (artifacts.length > 0) {
+        knownProjects.set(s.id, artifacts.map((a) => a.label));
+      }
+    }
+
+    const prompt = generatePrompt({ provider, spaces: allSpaces, knownProjects });
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(prompt);
+    return;
+  }
+
+  if (url === "/api/import/preview" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk: Buffer) => (body += chunk));
+    req.on("end", async () => {
+      try {
+        const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
+
+        const parseResult = await parseImportJSON(raw);
+        if (!parseResult.success || !parseResult.payload) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: parseResult.error }));
+          return;
+        }
+
+        const generatedAt = parseResult.payload.source?.generated_at || new Date().toISOString();
+
+        const previewDeps: PreviewDeps = {
+          getSpaceBySlug: (slug) => {
+            const row = spaceStore.getAll().find((s) => s.id === slug);
+            return row ? { id: row.id, displayName: row.display_name } : null;
+          },
+          getArtifactsBySpace: (spaceId) => {
+            return store.getBySpaceId(spaceId)
+              .filter((a) => !a.removed_at)
+              .map((a) => ({ source_ref: a.source_ref, label: a.label }));
+          },
+          findMemory: (content, spaceId) => {
+            return memoryProvider.findExact(content, spaceId ?? undefined);
+          },
+        };
+
+        const plan = buildImportPlan(parseResult.payload, provider, generatedAt, previewDeps);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(plan));
+      } catch (err) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return;
+  }
+
+  if (url === "/api/import/execute" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk: Buffer) => (body += chunk));
+    req.on("end", async () => {
+      try {
+        const { plan_id, approved_action_ids } = JSON.parse(body) as {
+          plan_id: string;
+          approved_action_ids: string[];
+        };
+
+        if (!getPlan(plan_id)) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Plan not found or expired" }));
+          return;
+        }
+
+        const executeDeps: ExecuteDeps = {
+          createSpace: (name) => spaceService.createSpace({ name }),
+          createArtifact: (params) => artifactService.createArtifact(params, USERLAND_DIR),
+          remember: (input) => memoryProvider.remember(input),
+          getSpaceBySlug: (slug) => {
+            const row = spaceStore.getAll().find((s) => s.id === slug);
+            return row ? { id: row.id } : null;
+          },
+        };
+
+        const result = await executeImportPlan(plan_id, approved_action_ids, executeDeps);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return;
+  }
 
   // ── No-op OAuth for MCP SDK (localhost only, no real auth) ──
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -497,38 +497,54 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       try {
         const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
 
-        const aiRepair = async (broken: string): Promise<string | null> => {
+        const convertFn = async (text: string): Promise<string | null> => {
           try {
             const port = getOpenCodePort();
-            // Create a session
-            const sessRes = await fetch(`http://localhost:${port}/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+            if (!port) {
+              console.log("[import] OpenCode not ready yet");
+              return null;
+            }
+
+            const sessRes = await fetch(`http://localhost:${port}/session`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: "{}",
+            });
             const sess = await sessRes.json() as { id: string };
-            // Send repair message
+            console.log("[import] OpenCode session:", sess.id);
+
+            const prompt = `Convert this text into valid JSON. Output ONLY the raw JSON object, nothing else. No markdown fences. No explanation.\n\nRequired schema:\n{\n  "schema_version": 1,\n  "mode": "fresh" | "augment",\n  "source": { "provider": "string", "generated_at": "ISO string" },\n  "spaces": [{ "name": "string", "projects": [{ "name": "string", "summary": "string" }] }],\n  "summaries": [{ "space": "string", "title": "string", "content": "string" }],\n  "memories": [{ "content": "string", "tags": ["string"], "space": "string" }]\n}\n\nText to convert:\n${text.slice(0, 12000)}`;
+
             const msgRes = await fetch(`http://localhost:${port}/session/${sess.id}/message`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ content: `Convert this text into valid JSON matching the Oyster import schema. Output ONLY the JSON, nothing else.\n\nThe schema has: schema_version (number), mode (string), source (object with provider and generated_at), spaces (array of {name, projects: [{name, summary}]}), summaries (array of {space, title, content}), memories (array of {content, tags, space}).\n\nText to convert:\n${broken.slice(0, 8000)}` }),
+              body: JSON.stringify({ parts: [{ type: "text", text: prompt }], agent: "oyster" }),
             });
-            // Read the streamed response
-            const text = await msgRes.text();
-            // Extract assistant content from the SSE stream
-            const lines = text.split("\n").filter(l => l.startsWith("data: "));
-            for (const line of lines.reverse()) {
-              try {
-                const evt = JSON.parse(line.slice(6));
-                if (evt.type === "message.completed" || evt.type === "text") {
-                  const content = evt.content || evt.text || "";
-                  if (content.includes("{")) return content;
-                }
-              } catch {}
+
+            const resBody = await msgRes.json() as {
+              info?: { error?: unknown };
+              parts?: Array<{ type: string; text?: string }>;
+            };
+
+            if (resBody.info?.error) {
+              console.error("[import] OpenCode error:", JSON.stringify(resBody.info.error).slice(0, 300));
+              return null;
             }
+
+            for (const part of resBody.parts ?? []) {
+              if (part.type === "text" && part.text?.includes("{")) {
+                console.log("[import] AI conversion succeeded, length:", part.text.length);
+                return part.text;
+              }
+            }
+            console.log("[import] OpenCode returned", resBody.parts?.length ?? 0, "parts, none with JSON");
           } catch (err) {
-            console.error("[import] AI repair failed:", err);
+            console.error("[import] AI conversion failed:", err);
           }
           return null;
         };
 
-        const parseResult = await parseImportPayload(raw, aiRepair);
+        const parseResult = await parseImportPayload(raw, convertFn);
         if (!parseResult.success || !parseResult.payload) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: parseResult.error }));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -605,6 +605,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           createSpace: (name) => spaceService.createSpace({ name }),
           createArtifact: (params) => artifactService.createArtifact(params, USERLAND_DIR),
           remember: (input) => memoryProvider.remember(input),
+          findMemory: (content, spaceId) => memoryProvider.findExact(content, spaceId ?? undefined),
           getSpaceBySlug: (slug) => {
             const row = spaceStore.getAll().find((s) => s.id === slug);
             return row ? { id: row.id } : null;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -492,7 +492,10 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   if (url === "/api/import/preview" && req.method === "POST") {
     let body = "";
-    req.on("data", (chunk: Buffer) => (body += chunk));
+    req.on("data", (chunk: Buffer) => {
+      body += chunk;
+      if (body.length > 500_000) { res.writeHead(413); res.end("Payload too large"); req.destroy(); }
+    });
     req.on("end", async () => {
       try {
         const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
@@ -581,7 +584,10 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   if (url === "/api/import/execute" && req.method === "POST") {
     let body = "";
-    req.on("data", (chunk: Buffer) => (body += chunk));
+    req.on("data", (chunk: Buffer) => {
+      body += chunk;
+      if (body.length > 100_000) { res.writeHead(413); res.end("Payload too large"); req.destroy(); }
+    });
     req.on("end", async () => {
       try {
         const { plan_id, approved_action_ids } = JSON.parse(body) as {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -497,7 +497,38 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       try {
         const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
 
-        const parseResult = await parseImportPayload(raw);
+        const aiRepair = async (broken: string): Promise<string | null> => {
+          try {
+            const port = getOpenCodePort();
+            // Create a session
+            const sessRes = await fetch(`http://localhost:${port}/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+            const sess = await sessRes.json() as { id: string };
+            // Send repair message
+            const msgRes = await fetch(`http://localhost:${port}/session/${sess.id}/message`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ content: `Convert this text into valid JSON matching the Oyster import schema. Output ONLY the JSON, nothing else.\n\nThe schema has: schema_version (number), mode (string), source (object with provider and generated_at), spaces (array of {name, projects: [{name, summary}]}), summaries (array of {space, title, content}), memories (array of {content, tags, space}).\n\nText to convert:\n${broken.slice(0, 8000)}` }),
+            });
+            // Read the streamed response
+            const text = await msgRes.text();
+            // Extract assistant content from the SSE stream
+            const lines = text.split("\n").filter(l => l.startsWith("data: "));
+            for (const line of lines.reverse()) {
+              try {
+                const evt = JSON.parse(line.slice(6));
+                if (evt.type === "message.completed" || evt.type === "text") {
+                  const content = evt.content || evt.text || "";
+                  if (content.includes("{")) return content;
+                }
+              } catch {}
+            }
+          } catch (err) {
+            console.error("[import] AI repair failed:", err);
+          }
+          return null;
+        };
+
+        const parseResult = await parseImportPayload(raw, aiRepair);
         if (!parseResult.success || !parseResult.payload) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: parseResult.error }));

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -159,6 +159,11 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     };
   }
 
+  findExact(content: string, spaceId?: string): boolean {
+    const sid = spaceId ?? null;
+    return !!(this.stmts.findExact.get(content, sid, sid) as MemoryRow | undefined);
+  }
+
   async remember(input: RememberInput): Promise<Memory> {
     const spaceId = input.space_id ?? null;
     const tags = JSON.stringify(input.tags ?? []);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2543,3 +2543,67 @@ select.add-space-input { appearance: none; cursor: pointer; }
   text-align: left;
 }
 .add-space-ambiguous-option:hover { background: rgba(255,255,255,0.1); color: #fff; }
+
+/* ── Onboarding Banner ── */
+
+.onboarding-banner {
+  display: flex;
+  justify-content: center;
+  padding: 32px 16px 0;
+}
+.onboarding-banner-content {
+  max-width: 440px;
+  background: rgba(124, 107, 255, 0.06);
+  border: 1px solid rgba(124, 107, 255, 0.15);
+  border-radius: 16px;
+  padding: 28px 32px;
+  text-align: center;
+}
+.onboarding-banner-content h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 6px;
+}
+.onboarding-banner-content p {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 20px;
+}
+.onboarding-banner-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+.onboarding-btn-primary {
+  background: #7c6bff;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+.onboarding-btn-primary:hover { background: #6b5ce6; }
+.onboarding-btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.4);
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: not-allowed;
+  font-family: inherit;
+}
+.onboarding-dismiss {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.onboarding-dismiss:hover { color: rgba(255, 255, 255, 0.5); }

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -8,6 +8,7 @@ import { spaceColor } from "../utils/spaceColor";
 import { useDesktopPreferences } from "../hooks/useDesktopPreferences";
 import { useDesktopSections, kindLabel } from "../hooks/useDesktopSections";
 import { useDragOrder } from "../hooks/useDragOrder";
+import { OnboardingBanner } from "./OnboardingBanner";
 
 interface Props {
   space: string;
@@ -24,8 +25,17 @@ interface Props {
   revealId?: string | null;
 }
 
-export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, dragOver, revealId }: Props) {
+export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, dragOver, revealId, isFirstRun }: Props) {
   const isAllSpace = space === "__all__";
+
+  // ── Onboarding banner ──
+  const [bannerDismissed, setBannerDismissed] = useState(
+    () => localStorage.getItem("oyster-onboarding-dismissed") === "true"
+  );
+  const handleDismiss = () => {
+    localStorage.setItem("oyster-onboarding-dismissed", "true");
+    setBannerDismissed(true);
+  };
 
   // ── Topbar auto-hide ──
   const [topbarVisible, setTopbarVisible] = useState(true);
@@ -167,6 +177,15 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
       </div>
 
       <div className={`desktop-scroll${isHero ? " desktop-scroll--hero" : ""}`}>
+        {isFirstRun && !bannerDismissed && (
+          <OnboardingBanner
+            onImportFromAI={() => {
+              const importArtifact = artifacts.find((a) => a.id === "import-from-ai");
+              if (importArtifact) onArtifactClick(importArtifact);
+            }}
+            onDismiss={handleDismiss}
+          />
+        )}
         <div className="filter-bar">
           {activeKind && (
             <div className="filter-notice">

--- a/web/src/components/OnboardingBanner.tsx
+++ b/web/src/components/OnboardingBanner.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 interface Props {
   onImportFromAI: () => void;
   onDismiss: () => void;

--- a/web/src/components/OnboardingBanner.tsx
+++ b/web/src/components/OnboardingBanner.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+interface Props {
+  onImportFromAI: () => void;
+  onDismiss: () => void;
+}
+
+export function OnboardingBanner({ onImportFromAI, onDismiss }: Props) {
+  return (
+    <div className="onboarding-banner">
+      <div className="onboarding-banner-content">
+        <h2>Set up your workspace</h2>
+        <p>Bring in your projects and context from other tools.</p>
+        <div className="onboarding-banner-actions">
+          <button className="onboarding-btn-primary" onClick={onImportFromAI}>
+            Import from AI
+          </button>
+          <button className="onboarding-btn-secondary" disabled title="Coming soon">
+            Scan my machine
+          </button>
+        </div>
+        <button className="onboarding-dismiss" onClick={onDismiss}>
+          skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ViewerWindow.tsx
+++ b/web/src/components/ViewerWindow.tsx
@@ -134,6 +134,7 @@ export function ViewerWindow({
     function handleMessage(event: MessageEvent) {
       if (event.origin !== window.location.origin) return;
       if (event.source !== iframeRef.current?.contentWindow) return;
+      if (event.data?.type === "oyster-close") { onClose(); return; }
       if (event.data?.type !== "oyster-error") return;
       setError({
         message: event.data.error?.message || "Unknown error",
@@ -145,7 +146,7 @@ export function ViewerWindow({
     }
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [fullscreen, onToggleFullscreen]);
+  }, [fullscreen, onToggleFullscreen, onClose]);
 
   // Track hash changes inside iframe (e.g., Reveal.js slide navigation)
   // Injects a MutationObserver + polling script into the iframe to detect


### PR DESCRIPTION
## Summary

- **Cloud AI Import wizard** — 3-step builtin: select provider → paste AI output → preview → import
- Server converts any text format to structured JSON via OpenCode (no strict format required from the AI)
- Merge-based import: detects existing spaces, skips duplicates on re-import
- Plan/execute architecture with per-action results and "already exists" handling
- First-run onboarding banner with "Import from AI" CTA
- **Builtin redesign** — Quick Start, Connect Your AI, and Import from AI all share consistent design language (glass cards, ambient glow, pill selectors)
- Iframe `oyster-close` postMessage for viewer close from within builtins

## New files

- `server/src/import.ts` — types, plan store, prompt gen, parsing, plan building, execution
- `builtins/import-from-ai/` — manifest + wizard HTML
- `web/src/components/OnboardingBanner.tsx` — first-run banner

## Modified files

- `server/src/index.ts` — 3 new routes + OpenCode conversion function
- `server/src/memory-store.ts` — `findExact()` for dedup
- `web/src/components/Desktop.tsx` — onboarding banner integration
- `web/src/components/ViewerWindow.tsx` — `oyster-close` message handler
- `builtins/quick-start/src/index.html` — redesigned
- `builtins/connect-your-ai/src/index.html` — redesigned

## Test plan

- [ ] Fresh install — onboarding banner shows with "Import from AI" CTA
- [ ] Click "Import from AI" — wizard opens fullscreen
- [ ] Copy prompt — includes existing spaces in augment mode
- [ ] Paste ChatGPT/Claude output — OpenCode converts to JSON, preview shows spaces + projects
- [ ] Import — spaces, project summaries, space overviews, memories created
- [ ] Re-import same data — duplicates skipped, "already existed" shown
- [ ] Done button — closes viewer, returns to surface
- [ ] Quick Start and Connect Your AI — redesigned, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)