### PR TITLE
fix: pin fullscreen toolbar by default, auto-hide after first use

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1279,10 +1279,9 @@ body {
   border-radius: 9999px;
   box-shadow:
     0 4px 24px rgba(0, 0, 0, 0.4),
-    0 0 0 1px var(--glass-border),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    0 0 0 1px rgba(255, 255, 255, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
   user-select: none;
-  transform: translateY(0);
   opacity: 1;
   transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -1291,6 +1290,18 @@ body {
   transform: translateY(calc(-100% - 8px));
 }
 
+.fullscreen-toolbar-hint {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 48px;
+  height: 14px;
+  border: 1.5px solid rgba(255, 255, 255, 0.25);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
 
 .fullscreen-toolbar-btn {
   width: 26px;

--- a/web/src/components/ViewerWindow.tsx
+++ b/web/src/components/ViewerWindow.tsx
@@ -110,7 +110,6 @@ export function ViewerWindow({
   onHashChange,
   initialHash,
 }: Props) {
-  const toolbarRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [error, setError] = useState<ArtifactError | null>(null);
   const [iframeKey, setIframeKey] = useState(0);
@@ -347,13 +346,16 @@ export function ViewerWindow({
     }
   }, [onFixError, error, title]);
 
-  // Fullscreen toolbar auto-hide
+  // Toolbar: visible until first use, then auto-hides with subtle hint (#102)
+  const [discovered, setDiscovered] = useState(
+    () => localStorage.getItem("oyster-toolbar-discovered") === "true",
+  );
   const [toolbarVisible, setToolbarVisible] = useState(true);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const scheduleHide = useCallback(() => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
-    hideTimer.current = setTimeout(() => setToolbarVisible(false), 150);
+    hideTimer.current = setTimeout(() => setToolbarVisible(false), 1500);
   }, []);
 
   const showToolbar = useCallback(() => {
@@ -362,16 +364,22 @@ export function ViewerWindow({
   }, []);
 
   const leaveToolbar = useCallback(() => {
-    scheduleHide();
-  }, [scheduleHide]);
+    if (discovered) scheduleHide();
+  }, [discovered, scheduleHide]);
 
-  // Start auto-hide timer when entering fullscreen
+  const markDiscovered = useCallback(() => {
+    if (!discovered) {
+      setDiscovered(true);
+      localStorage.setItem("oyster-toolbar-discovered", "true");
+    }
+  }, [discovered]);
+
   useEffect(() => {
     if (!fullscreen) return;
     setToolbarVisible(true);
-    scheduleHide();
+    if (discovered) scheduleHide();
     return () => { if (hideTimer.current) clearTimeout(hideTimer.current); };
-  }, [fullscreen, scheduleHide]);
+  }, [fullscreen, discovered, scheduleHide]);
 
   // Escape key exits fullscreen
   useEffect(() => {
@@ -477,14 +485,12 @@ export function ViewerWindow({
           onMouseEnter={showToolbar}
           onMouseLeave={leaveToolbar}
         >
-        <div
-          ref={toolbarRef}
-          className={`fullscreen-toolbar ${toolbarVisible ? "" : "fullscreen-toolbar-hidden"}`}
-        >
+        {!toolbarVisible && <div className="fullscreen-toolbar-hint" />}
+        <div className={`fullscreen-toolbar ${toolbarVisible ? "" : "fullscreen-toolbar-hidden"}`}>
           <button
             className="fullscreen-toolbar-btn"
             disabled={!hasPrev}
-            onClick={() => onNavigate?.(-1)}
+            onClick={() => { markDiscovered(); onNavigate?.(-1); }}
             title="Previous"
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -494,7 +500,7 @@ export function ViewerWindow({
           <button
             className="fullscreen-toolbar-btn"
             disabled={!hasNext}
-            onClick={() => onNavigate?.(1)}
+            onClick={() => { markDiscovered(); onNavigate?.(1); }}
             title="Next"
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -505,7 +511,7 @@ export function ViewerWindow({
           <div className="fullscreen-toolbar-sep" />
           <button
             className="fullscreen-toolbar-btn"
-            onClick={onToggleFullscreen}
+            onClick={() => { markDiscovered(); onToggleFullscreen?.(); }}
             title="Window"
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -517,7 +523,7 @@ export function ViewerWindow({
           </button>
           <button
             className="fullscreen-toolbar-btn fullscreen-toolbar-close"
-            onClick={onClose}
+            onClick={() => { markDiscovered(); onClose(); }}
             title="Close"
           >
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">


### PR DESCRIPTION
## Summary
- Toolbar stays visible on first fullscreen open until user clicks any button (close, nav, resize)
- After first interaction, auto-hides with 1.5s delay, leaving a subtle `\____/` tab hint at top center
- Preference stored in localStorage (`oyster-toolbar-discovered`)
- Toolbar border visibility improved

Closes #102

## Test plan
- [ ] Open any artifact fullscreen — toolbar should stay pinned
- [ ] Click any toolbar button — toolbar should auto-hide on next open
- [ ] Hover the tab hint at top — toolbar slides back down
- [ ] Clear `localStorage.removeItem("oyster-toolbar-discovered")` to re-test first-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)