### PR TITLE
feat: space management UI — rename, recolor, remove (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 From prompt to workspace.
 
-A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.
+The desktop that understands what you're working on.
 
 ```bash
 npm install -g oyster-os && oyster

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ Browser → http://localhost:4444
 
 Early v1. Local-first. Single-user. Built for fast iteration.
 
-**Now:** prompt-driven navigation, space switching, artefact desktop, repo onboarding, MCP server with 12 tools, slash commands, instant UI updates via SSE.
+**Now:** MCP powered workspace, bring your own AI, prompt-driven navigation, space switching, artefact desktop, repo onboarding, 12 MCP tools, slash commands, instant UI updates via SSE.
 
 **Next:** smoother onboarding, faster artefact navigation, better repo import.
 
-**Later:** dynamic UI that reshapes to fit the task, cloud hosting, persistent memory, plugin ecosystem.
+**Vision:** persistent memory, plugins, dynamic UI that reshapes to fit the task, build & share apps.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 # Oyster
 
-[![npm version](https://img.shields.io/npm/v/oyster-os)](https://www.npmjs.com/package/oyster-os)
-[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
-[![npm downloads](https://img.shields.io/npm/dm/oyster-os)](https://www.npmjs.com/package/oyster-os)
-[![Platform: macOS | Linux | Windows](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)]()
+[![Release](https://img.shields.io/github/v/release/mattslight/oyster?color=7c6bff)](https://github.com/mattslight/oyster/releases)
+[![npm](https://img.shields.io/npm/v/oyster-os?color=7c6bff)](https://www.npmjs.com/package/oyster-os)
+[![Downloads](https://img.shields.io/npm/dm/oyster-os?color=7c6bff)](https://www.npmjs.com/package/oyster-os)
+[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-7c6bff)]()
+[![License](https://img.shields.io/badge/License-AGPL--3.0-7c6bff)](LICENSE)
 
 A modern OS for knowledge work powered by MCP — connect your projects, control everything from a prompt. Bring your own LLM. Install as easy as `npm install oyster-os`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-7c6bff)]()
 [![License](https://img.shields.io/badge/License-AGPL--3.0-7c6bff)](LICENSE)
 
-One surface for all your work. Chat to navigate, organise, and create — powered by MCP so any AI can control it.
+One surface. All your work.
+
+A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.
 
 ```bash
 npm install -g oyster-os && oyster

--- a/README.md
+++ b/README.md
@@ -8,42 +8,31 @@
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-7c6bff)]()
 [![License](https://img.shields.io/badge/License-AGPL--3.0-7c6bff)](LICENSE)
 
-A modern OS for knowledge work powered by MCP — connect your projects, control everything from a prompt. Bring your own LLM. Install as easy as `npm install oyster-os`
+One surface for all your work. Chat to navigate, organise, and create — powered by MCP so any AI can control it.
 
-Open the right thing, switch context quickly, and organise work from one chat bar.  
-Oyster is local, AI-first, visual, and built for people juggling multiple projects, tools, and sessions.
+```bash
+npm install -g oyster-os && oyster
+```
 
 ![Oyster desktop](docs/screenshots/desktop.png)
 
 ## Why Oyster
 
-Most work is scattered across folders, repos, docs, tabs, and chat threads.
+Your work is scattered across folders, repos, docs, tabs, and chat threads. Oyster puts it all on one visual surface and lets you control it from a chat bar.
 
-Oyster puts that work on one surface and lets you control it with simple commands.
+- **Open things fast** — type `/o competitor analysis` and it opens, no folder hunting
+- **Switch context instantly** — `#blunderfixer` or `#1` to jump between projects
+- **See everything at once** — docs, diagrams, apps, decks, and spreadsheets on one desktop
+- **Any AI can control it** — Oyster speaks MCP, the open standard for AI tools. Connect Claude Code, Cursor, or any MCP client and your AI can manage the surface directly
 
-- **Open things fast**  
-  Type `/o competitor analysis` and open the right artefact without digging through folders.
-
-- **Switch context quickly**  
-  Jump between spaces with `/s blunderfixer` or `#bf`.
-
-- **Keep work visible**  
-  Docs, diagrams, apps, decks, and spreadsheets live together on a visual desktop.
-
-- **Let the agent act on the surface**  
-  Oyster can open artefacts, switch spaces, and organise the workspace through MCP tools.
-
-- **Bring your own AI**  
-  Oyster speaks MCP — the open standard that lets AI tools talk to each other. Connect the AI you already use and it can control your workspace directly.
-
-## Quick start
-
-### Install and run
+## Quick Start
 
 ```bash
 npm install -g oyster-os
 oyster
 ```
+
+That's it. On first run, Oyster connects you to an AI provider (opens your browser to sign in). Then your workspace opens at **http://localhost:4444**.
 
 Or try without installing:
 
@@ -51,11 +40,9 @@ Or try without installing:
 npx oyster-os
 ```
 
-That's it. On first run, Oyster connects you to an AI provider (opens your browser to sign in). Then your workspace opens at **http://localhost:4444**.
+## Connect Your AI
 
-### Connect your AI
-
-Oyster is an MCP server. Any MCP-compatible tool can control your workspace.
+Oyster is an MCP server. Any MCP-compatible tool can connect and control your workspace.
 
 **Claude Code:**
 
@@ -76,7 +63,7 @@ claude mcp add --transport http oyster http://localhost:4444/mcp/
 
 Once connected, your AI can list spaces, open artefacts, create documents, onboard projects, and manage the surface directly.
 
-### Onboard a project
+## Onboard a Project
 
 From the Oyster chat bar:
 
@@ -84,23 +71,7 @@ From the Oyster chat bar:
 onboard my project at ~/Dev/my-project
 ```
 
-Or from Claude Code / any connected AI:
-
-```
-> onboard_space(name: "My Project", repo_path: "/path/to/my-project")
-```
-
 Oyster scans the folder for documents, apps, and diagrams and adds them to the surface automatically.
-
-## What works today
-
-- Prompt-driven navigation
-- Space switching
-- Artefact desktop with icons
-- Local repo onboarding
-- MCP server with 12 tools (works with Claude Code, Cursor, any MCP client)
-- Instant UI updates via SSE
-- Slash commands (`/s`, `/o`, `#`)
 
 ## Commands
 
@@ -112,62 +83,6 @@ Oyster scans the folder for documents, apps, and diagrams and adds them to the s
 | `#<number>` | Jump to a numbered space — `#1` switches to first space |
 | `#.` | Go to the home screen |
 | normal chat | Ask Oyster anything — navigate, organise, or create work |
-
-## The full loop
-
-Here's what it looks like end to end:
-
-```bash
-# 1. Install Oyster
-npm install -g oyster-os
-
-# 2. Start it
-oyster
-# → browser opens to http://localhost:4444
-
-# 3. Connect Claude Code (or any MCP client)
-claude mcp add --transport http oyster http://localhost:4444/mcp/
-
-# 4. From Claude Code, onboard a project
-> onboard_space(name: "My App", repo_path: "~/Dev/my-app")
-# → Oyster scans for docs, apps, diagrams
-
-# 5. From the Oyster chat bar
-show me the architecture diagram
-# → artifact opens in the viewer
-
-# 6. Switch spaces
-#1
-# → instant switch to your first project
-```
-
-## Who it is for
-
-Oyster is for people working across more than one project, repo, or tool at a time, especially:
-
-- founders
-- builders
-- consultants
-- product teams
-- anyone tired of folder hunting and tab overload
-
-## Current status
-
-Early v1.  
-Local-first. Single-user. Built for fast iteration.
-
-**In scope now**
-- prompt-driven surface control
-- artefact management
-- repo onboarding
-- visual workspace
-- MCP server
-
-**Planned later**
-- dynamic UI — interfaces that adapt to the task at hand, not static layouts
-- cloud hosting
-- persistent memory
-- richer plugins and integrations
 
 ## Architecture
 
@@ -182,19 +97,19 @@ Browser → http://localhost:4444
          - Chat proxy → OpenCode → LLM
 ```
 
+## Status
+
+Early v1. Local-first. Single-user. Built for fast iteration.
+
+**Now:** prompt-driven navigation, space switching, artefact desktop, repo onboarding, MCP server with 12 tools, slash commands, instant UI updates via SSE.
+
+**Next:** smoother onboarding, faster artefact navigation, better repo import.
+
+**Later:** dynamic UI that reshapes to fit the task, cloud hosting, persistent memory, plugin ecosystem.
+
 ## Contributing
 
-Oyster is still early, but focused contributions are welcome.
-
-Good areas to help with:
-
-- onboarding and setup
-- slash commands
-- artefact search and ranking
-- UI polish
-- MCP connectors
-
-If you want to contribute:
+Oyster is early, but focused contributions are welcome.
 
 1. Open an issue first
 2. Keep the scope tight
@@ -209,22 +124,6 @@ cd web && npm install && cd ../server && npm install && cd ..
 npm run dev
 # → dev server at http://localhost:7337 (proxies to server at 4200)
 ```
-
-## Roadmap
-
-**Short term:**
-
-- smoother onboarding
-- faster artefact opening and navigation
-- better repo import experience
-
-**Longer term:**
-
-- dynamic UI — surfaces that reshape to fit the job
-- cloud and hybrid hosting
-- persistent memory
-- plugin ecosystem
-- richer cross-space search and automation
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 # Oyster
 
+[![npm version](https://img.shields.io/npm/v/oyster-os)](https://www.npmjs.com/package/oyster-os)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/oyster-os)](https://www.npmjs.com/package/oyster-os)
+[![Platform: macOS | Linux | Windows](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)]()
+
 A modern OS for knowledge work powered by MCP — connect your projects, control everything from a prompt. Bring your own LLM. Install as easy as `npm install oyster-os`
 
 Open the right thing, switch context quickly, and organise work from one chat bar.  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux%20%7C%20Windows-7c6bff)]()
 [![License](https://img.shields.io/badge/License-AGPL--3.0-7c6bff)](LICENSE)
 
-One surface. All your work.
+From prompt to workspace.
 
 A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 From prompt to workspace.
 
-The desktop that understands what you're working on.
+A workspace OS that understands your projects, remembers your work, and acts from one prompt. Powered by MCP — bring any AI.
 
 ```bash
 npm install -g oyster-os && oyster

--- a/builtins/import-from-ai/src/index.html
+++ b/builtins/import-from-ai/src/index.html
@@ -516,7 +516,16 @@
 
   <script>
     const O = window.location.origin;
+    const urlParams = new URLSearchParams(window.location.search);
+    const targetSpaceId = urlParams.get('spaceId');
+    const targetSpaceName = urlParams.get('spaceName');
     let provider = 'chatgpt', prompt = '', plan = null;
+
+    // Update title if space-scoped
+    if (targetSpaceName) {
+      document.querySelector('.wizard-header h1').textContent = `Import to ${targetSpaceName}.`;
+      document.querySelector('.wizard-header p').textContent = `Bring context and memories about ${targetSpaceName} from any AI.`;
+    }
 
     loadPrompt();
 
@@ -524,7 +533,9 @@
       const el = document.getElementById('prompt-area');
       el.innerHTML = '<div class="prompt-loading">Loading prompt...</div>';
       try {
-        const r = await fetch(`${O}/api/import/prompt?provider=${provider}`);
+        let url = `${O}/api/import/prompt?provider=${provider}`;
+        if (targetSpaceId) url += `&spaceId=${encodeURIComponent(targetSpaceId)}`;
+        const r = await fetch(url);
         prompt = await r.text();
         el.innerHTML = `<div class="prompt-scroll"><pre>${esc(prompt)}</pre></div>`;
       } catch { el.innerHTML = '<div class="prompt-loading">Failed to load</div>'; }
@@ -577,7 +588,7 @@
       try {
         const r = await fetch(`${O}/api/import/preview`, {
           method: 'POST', headers: {'Content-Type':'application/json'},
-          body: JSON.stringify({ raw, provider }),
+          body: JSON.stringify({ raw, provider, targetSpaceId }),
         });
         const d = await r.json();
         if (!r.ok) { err.textContent = d.error; err.style.display = 'block'; return; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -471,7 +471,7 @@
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
     </div>
-    <p class="hero-features">MCP Powered <span class="hero-dot"></span> Bring Your Own AI <span class="hero-dot"></span> Memory <span class="hero-dot"></span> Plugins <span class="hero-dot"></span> Dynamic UI <span class="hero-dot"></span> Build &amp; Share Apps</p>
+    <p class="hero-features">MCP Powered <span class="hero-dot"></span> Bring Your Own AI <span class="hero-dot"></span> Persistent Memory <span class="hero-dot"></span> Plugins <span class="hero-dot"></span> Dynamic UI <span class="hero-dot"></span> Build &amp; Share Apps</p>
     <img src="screenshots/desktop.png" alt="Oyster desktop" class="hero-img">
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@
       line-height: 1.7;
       color: rgba(255, 255, 255, 0.7);
       max-width: 480px;
-      margin: 0 auto 32px;
+      margin: 0 auto 48px;
     }
 
     .hero-features {
@@ -61,17 +61,8 @@
       text-transform: uppercase;
       letter-spacing: 1.5px;
       font-family: 'IBM Plex Mono', monospace;
+      margin-top: 40px;
       margin-bottom: 48px;
-    }
-
-    .hero-features-label {
-      font-size: 10px;
-      font-weight: 600;
-      color: rgba(255, 255, 255, 0.35);
-      text-transform: uppercase;
-      letter-spacing: 2px;
-      margin-bottom: 10px;
-      font-family: 'IBM Plex Mono', monospace;
     }
 
     .hero-dot {
@@ -471,12 +462,11 @@
     <p class="subtitle">
       Your AI-native desktop. It understands your work and acts on it.
     </p>
-    <p class="hero-features-label">Key Features</p>
-    <p class="hero-features">MCP Powered <span class="hero-dot">●</span> Bring Your Own AI <span class="hero-dot hero-dot-soon">●</span> <span class="hero-features-soon">Memory <span class="hero-dot hero-dot-soon">●</span> Plugins <span class="hero-dot hero-dot-soon">●</span> Dynamic UI <span class="hero-dot hero-dot-soon">●</span> Build &amp; Share Apps</span></p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
     </div>
+    <p class="hero-features">MCP Powered <span class="hero-dot">●</span> Bring Your Own AI <span class="hero-dot hero-dot-soon">●</span> <span class="hero-features-soon">Memory <span class="hero-dot hero-dot-soon">●</span> Plugins <span class="hero-dot hero-dot-soon">●</span> Dynamic UI <span class="hero-dot hero-dot-soon">●</span> Build &amp; Share Apps</span></p>
     <img src="screenshots/desktop.png" alt="Oyster desktop" class="hero-img">
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,10 @@
       margin-bottom: 48px;
     }
 
+    .hero-features-soon {
+      opacity: 0.45;
+    }
+
     .cta-row {
       display: flex;
       gap: 16px;
@@ -446,7 +450,7 @@
     <p class="subtitle">
       Your AI-native desktop. It understands your work and acts on it.
     </p>
-    <p class="hero-features">MCP Powered · Memory · Plugins · Dynamic UI · Build &amp; Share Apps</p>
+    <p class="hero-features">MCP Powered · <span class="hero-features-soon">Memory · Plugins · Dynamic UI · Build &amp; Share Apps</span></p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,9 +55,12 @@
     }
 
     .hero-features {
-      font-size: 14px;
-      color: rgba(255, 255, 255, 0.45);
-      letter-spacing: 0.03em;
+      font-size: 11px;
+      font-weight: 600;
+      color: #a99eff;
+      text-transform: uppercase;
+      letter-spacing: 1.5px;
+      font-family: 'IBM Plex Mono', monospace;
       margin-bottom: 48px;
     }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,37 +54,6 @@
       margin: 0 auto 48px;
     }
 
-    .hero-features {
-      font-size: 13px;
-      font-weight: 600;
-      color: #a99eff;
-      text-transform: uppercase;
-      letter-spacing: 1.5px;
-      font-family: 'IBM Plex Mono', monospace;
-      margin-top: 40px;
-      margin-bottom: 48px;
-    }
-
-    .hero-dot {
-      display: inline-block;
-      width: 6px;
-      height: 6px;
-      background: #fff;
-      border-radius: 50%;
-      vertical-align: middle;
-      margin: 0 8px;
-      position: relative;
-      top: -1px;
-    }
-
-    .hero-dot-soon {
-      opacity: 0.45;
-    }
-
-    .hero-features-soon {
-      opacity: 0.45;
-    }
-
     .cta-row {
       display: flex;
       gap: 16px;
@@ -471,7 +440,6 @@
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
     </div>
-    <p class="hero-features">MCP Powered <span class="hero-dot"></span> Bring Your Own AI <span class="hero-dot"></span> Persistent Memory <span class="hero-dot"></span> Plugins <span class="hero-dot"></span> Dynamic UI <span class="hero-dot"></span> Build &amp; Share Apps</p>
     <img src="screenshots/desktop.png" alt="Oyster desktop" class="hero-img">
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
     }
 
     .hero-features {
-      font-size: 11px;
+      font-size: 13px;
       font-weight: 600;
       color: #a99eff;
       text-transform: uppercase;
@@ -67,8 +67,8 @@
 
     .hero-dot {
       display: inline-block;
-      width: 5px;
-      height: 5px;
+      width: 6px;
+      height: 6px;
       background: #fff;
       border-radius: 50%;
       vertical-align: middle;

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Oyster — From prompt to workspace.</title>
-  <meta name="description" content="From prompt to workspace. The desktop that understands what you're working on — powered by MCP so any AI can control it.">
+  <meta name="description" content="From prompt to workspace. A workspace OS that understands your projects, remembers your work, and acts from one prompt. Powered by MCP — bring any AI.">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -465,7 +465,7 @@
   <div class="hero">
     <h1>From prompt to workspace.</h1>
     <p class="subtitle">
-      The desktop that understands what you're working on.
+      A workspace OS that understands your projects, remembers your work, and acts from one prompt. Powered by MCP — bring any AI.
     </p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Oyster — From prompt to workspace.</title>
-  <meta name="description" content="From prompt to workspace. Your AI-native desktop that understands your work and acts on it — powered by MCP so any AI can control it.">
+  <meta name="description" content="From prompt to workspace. The desktop that understands what you're working on — powered by MCP so any AI can control it.">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -465,7 +465,7 @@
   <div class="hero">
     <h1>From prompt to workspace.</h1>
     <p class="subtitle">
-      Your AI-native desktop. It understands your work and acts on it.
+      The desktop that understands what you're working on.
     </p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Oyster — One surface. All your work.</title>
-  <meta name="description" content="One surface. All your work. A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.">
+  <title>Oyster — From prompt to workspace.</title>
+  <meta name="description" content="From prompt to workspace. Your AI-native desktop that understands your work and acts on it — powered by MCP so any AI can control it.">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -463,7 +463,7 @@
 
   <!-- Hero -->
   <div class="hero">
-    <h1>One surface. All your work.</h1>
+    <h1>From prompt to workspace.</h1>
     <p class="subtitle">
       Your AI-native desktop. It understands your work and acts on it.
     </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Oyster — The world's your oyster</title>
-  <meta name="description" content="A prompt-controlled workspace for files, projects, and artefacts. Local-first, visual, AI-native.">
+  <meta name="description" content="One surface. All your work. A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -434,7 +434,7 @@
   <div class="hero">
     <h1><span class="dim">The World's your</span> Oyster.</h1>
     <p class="subtitle">
-      A modern workspace OS with AI at its core. Open the right thing, switch context, create documents, and organise work — all from one prompt. Oyster doesn't just hold your files. It understands them.
+      A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.
     </p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -450,7 +450,7 @@
     <p class="subtitle">
       Your AI-native desktop. It understands your work and acts on it.
     </p>
-    <p class="hero-features">MCP Powered · <span class="hero-features-soon">Memory · Plugins · Dynamic UI · Build &amp; Share Apps</span></p>
+    <p class="hero-features">MCP Powered · Bring Your Own AI · <span class="hero-features-soon">Memory · Plugins · Dynamic UI · Build &amp; Share Apps</span></p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,10 +66,15 @@
     }
 
     .hero-dot {
-      color: #fff;
-      font-size: 6px;
+      display: inline-block;
+      width: 5px;
+      height: 5px;
+      background: #fff;
+      border-radius: 50%;
       vertical-align: middle;
-      margin: 0 4px;
+      margin: 0 8px;
+      position: relative;
+      top: -1px;
     }
 
     .hero-dot-soon {
@@ -466,7 +471,7 @@
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
     </div>
-    <p class="hero-features">MCP Powered <span class="hero-dot">●</span> Bring Your Own AI <span class="hero-dot">●</span> Memory <span class="hero-dot">●</span> Plugins <span class="hero-dot">●</span> Dynamic UI <span class="hero-dot">●</span> Build &amp; Share Apps</p>
+    <p class="hero-features">MCP Powered <span class="hero-dot"></span> Bring Your Own AI <span class="hero-dot"></span> Memory <span class="hero-dot"></span> Plugins <span class="hero-dot"></span> Dynamic UI <span class="hero-dot"></span> Build &amp; Share Apps</p>
     <img src="screenshots/desktop.png" alt="Oyster desktop" class="hero-img">
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -481,24 +481,21 @@
     </div>
   </div>
 
-  <!-- Feature 2: Find what you need. Fast. -->
+  <!-- Feature 2: Work with full context. -->
   <div class="feature-section reverse">
     <div class="feature-text">
-      <h3>Find what you need. Fast.</h3>
-      <p>Type what you're looking for and Oyster finds it. No folders, no tabs, no hunting. The right artefact opens instantly.</p>
+      <h3>Work with full context.</h3>
+      <p>Your AI sees every space, project, and artefact. Ask it to summarise across projects, find connections, or act on something specific — it has the full picture.</p>
     </div>
     <div class="feature-mock">
-      <div class="mock-panel" id="mock-open">
+      <div class="mock-panel" id="mock-context">
         <div class="mock-chatbar">
           <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
-          <div class="mock-chatbar-text"><code><span class="typing-text" data-text="/o competitor analysis"></span></code></div>
+          <div class="mock-chatbar-text"><code><span class="typing-text" data-text="summarise progress across all projects"></span></code></div>
         </div>
         <div class="mock-autocomplete">
           <div class="mock-autocomplete-item active fade-in fade-in-1">
-            <span class="name">Competitor Analysis</span>
-          </div>
-          <div class="mock-autocomplete-item fade-in fade-in-2">
-            <span class="name">Competitor Landscape</span>
+            <span class="name">3 spaces · 12 artefacts · full context</span>
           </div>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,26 @@
       line-height: 1.7;
       color: rgba(255, 255, 255, 0.7);
       max-width: 480px;
-      margin: 0 auto 56px;
+      margin: 0 auto 32px;
+    }
+
+    .hero-badges {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-bottom: 48px;
+    }
+
+    .hero-badge {
+      padding: 6px 16px;
+      border-radius: 9999px;
+      font-size: 13px;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.8);
+      border: 1px solid rgba(124, 107, 255, 0.35);
+      background: rgba(124, 107, 255, 0.1);
+      letter-spacing: 0.02em;
     }
 
     .cta-row {
@@ -434,8 +453,15 @@
   <div class="hero">
     <h1>One surface. All your work.</h1>
     <p class="subtitle">
-      A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.
+      A workspace with AI at the core. It understands your work and acts on it.
     </p>
+    <div class="hero-badges">
+      <span class="hero-badge">MCP Powered</span>
+      <span class="hero-badge">Memory</span>
+      <span class="hero-badge">Plugins</span>
+      <span class="hero-badge">Dynamic UI</span>
+      <span class="hero-badge">Build &amp; Share Apps</span>
+    </div>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -466,7 +466,7 @@
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
     </div>
-    <p class="hero-features">MCP Powered <span class="hero-dot">●</span> Bring Your Own AI <span class="hero-dot hero-dot-soon">●</span> <span class="hero-features-soon">Memory <span class="hero-dot hero-dot-soon">●</span> Plugins <span class="hero-dot hero-dot-soon">●</span> Dynamic UI <span class="hero-dot hero-dot-soon">●</span> Build &amp; Share Apps</span></p>
+    <p class="hero-features">MCP Powered <span class="hero-dot">●</span> Bring Your Own AI <span class="hero-dot">●</span> Memory <span class="hero-dot">●</span> Plugins <span class="hero-dot">●</span> Dynamic UI <span class="hero-dot">●</span> Build &amp; Share Apps</p>
     <img src="screenshots/desktop.png" alt="Oyster desktop" class="hero-img">
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Oyster — The world's your oyster</title>
+  <title>Oyster — One surface. All your work.</title>
   <meta name="description" content="One surface. All your work. A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.">
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
@@ -432,7 +432,7 @@
 
   <!-- Hero -->
   <div class="hero">
-    <h1><span class="dim">The World's your</span> Oyster.</h1>
+    <h1>One surface. All your work.</h1>
     <p class="subtitle">
       A workspace that understands your files and acts from one prompt — powered by MCP so any AI can control it.
     </p>
@@ -446,7 +446,7 @@
   <!-- Feature 1: One surface. All your work. -->
   <div class="feature-section" id="features">
     <div class="feature-text">
-      <h3>One surface. All your work.</h3>
+      <h3>Your work, not your folders.</h3>
       <p>Docs, apps, diagrams, decks, and spreadsheets live together on a visual desktop. Everything is visible, searchable, and launchable.</p>
     </div>
     <div class="feature-mock">

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,23 +54,11 @@
       margin: 0 auto 32px;
     }
 
-    .hero-badges {
-      display: flex;
-      gap: 10px;
-      justify-content: center;
-      flex-wrap: wrap;
+    .hero-features {
+      font-size: 14px;
+      color: rgba(255, 255, 255, 0.45);
+      letter-spacing: 0.03em;
       margin-bottom: 48px;
-    }
-
-    .hero-badge {
-      padding: 6px 16px;
-      border-radius: 9999px;
-      font-size: 13px;
-      font-weight: 500;
-      color: rgba(255, 255, 255, 0.8);
-      border: 1px solid rgba(124, 107, 255, 0.35);
-      background: rgba(124, 107, 255, 0.1);
-      letter-spacing: 0.02em;
     }
 
     .cta-row {
@@ -453,15 +441,9 @@
   <div class="hero">
     <h1>One surface. All your work.</h1>
     <p class="subtitle">
-      A workspace with AI at the core. It understands your work and acts on it.
+      Your AI-native desktop. It understands your work and acts on it.
     </p>
-    <div class="hero-badges">
-      <span class="hero-badge">MCP Powered</span>
-      <span class="hero-badge">Memory</span>
-      <span class="hero-badge">Plugins</span>
-      <span class="hero-badge">Dynamic UI</span>
-      <span class="hero-badge">Build &amp; Share Apps</span>
-    </div>
+    <p class="hero-features">MCP Powered · Memory · Plugins · Dynamic UI · Build &amp; Share Apps</p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,27 @@
       margin-bottom: 48px;
     }
 
+    .hero-features-label {
+      font-size: 10px;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.35);
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      margin-bottom: 10px;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+
+    .hero-dot {
+      color: #fff;
+      font-size: 6px;
+      vertical-align: middle;
+      margin: 0 4px;
+    }
+
+    .hero-dot-soon {
+      opacity: 0.45;
+    }
+
     .hero-features-soon {
       opacity: 0.45;
     }
@@ -450,7 +471,8 @@
     <p class="subtitle">
       Your AI-native desktop. It understands your work and acts on it.
     </p>
-    <p class="hero-features">MCP Powered · Bring Your Own AI · <span class="hero-features-soon">Memory · Plugins · Dynamic UI · Build &amp; Share Apps</span></p>
+    <p class="hero-features-label">Key Features</p>
+    <p class="hero-features">MCP Powered <span class="hero-dot">●</span> Bring Your Own AI <span class="hero-dot hero-dot-soon">●</span> <span class="hero-features-soon">Memory <span class="hero-dot hero-dot-soon">●</span> Plugins <span class="hero-dot hero-dot-soon">●</span> Dynamic UI <span class="hero-dot hero-dot-soon">●</span> Build &amp; Share Apps</span></p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oyster-os",
-  "version": "0.2.4",
+  "version": "0.2.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oyster-os",
-      "version": "0.2.4",
+      "version": "0.2.5-beta.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fal-ai/client": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oyster-os",
-  "version": "0.2.4",
+  "version": "0.2.5-beta.0",
   "description": "A modern workspace OS with AI at its core",
   "type": "module",
   "bin": {

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -48,6 +48,7 @@ export interface ImportPlan {
   plan_id: string;
   provider: string;
   generated_at: string;
+  target_space_id?: string;
   counts: { new: number; merge: number; skipped: number };
   warnings: string[];
   actions: ImportAction[];
@@ -141,9 +142,37 @@ export interface PromptContext {
   provider: string;
   spaces: Array<{ id: string; displayName: string }>;
   knownProjects: Map<string, string[]>;
+  targetSpace?: { id: string; displayName: string };
 }
 
 export function generatePrompt(ctx: PromptContext): string {
+  // Space-scoped prompt — focused on one topic
+  if (ctx.targetSpace) {
+    const name = ctx.targetSpace.displayName;
+    const projects = ctx.knownProjects.get(ctx.targetSpace.id) || [];
+    let prompt = `Based on our past conversations, tell me everything you know about "${name}".\n\n`;
+    if (projects.length > 0) {
+      prompt += `I already have these projects tracked: ${projects.join(", ")}. Include any new ones.\n\n`;
+    }
+    prompt += `RULES:
+- Include: projects, key decisions, preferences, recurring themes, important context.
+- Exclude: one-off questions, ephemeral chat, anything not durable.
+- Use ONLY this one space: "${name}". Do not create other spaces.
+- Summaries: one for the space, 2-3 sentences.
+- Memories: durable facts and preferences related to ${name}.
+
+OUTPUT FORMAT:
+- Output YAML only. No markdown fences. No prose before or after.
+- Set mode to "augment".
+- Set source.provider to "${ctx.provider}".
+- Set source.generated_at to the current time in ISO 8601 format.
+
+SCHEMA:
+${SCHEMA_EXAMPLE}`;
+    return prompt;
+  }
+
+  // Global prompt — all workstreams
   const state = readImportState();
   const lastImport = state[ctx.provider]?.last_import_date;
   const hasSpaces = ctx.spaces.length > 0;
@@ -261,6 +290,7 @@ export function buildImportPlan(
   provider: string,
   generatedAt: string,
   deps: PreviewDeps,
+  targetSpaceId?: string,
 ): ImportPlan {
   const planId = `imp_${randomUUID().slice(0, 12)}`;
   const actions: ImportAction[] = [];
@@ -268,10 +298,35 @@ export function buildImportPlan(
   let actCounter = 0;
   const nextId = () => `act_${++actCounter}`;
 
+  // When scoped to a target space, resolve the display name for remapping
+  const targetSpaceRow = targetSpaceId ? deps.getSpaceBySlug(targetSpaceId) : null;
+  const targetSpaceName = targetSpaceRow?.displayName ?? targetSpaceId;
+
   const spaceActionIds = new Map<string, string>();
 
   for (const space of payload.spaces ?? []) {
     if (!space.name) continue;
+
+    if (targetSpaceId) {
+      // Space-scoped: skip create_space, remap projects into target
+      for (const project of space.projects ?? []) {
+        if (!project.name) continue;
+        const existingArtifacts = deps.getArtifactsBySpace(targetSpaceId);
+        const isDupe = existingArtifacts.some(
+          (a) => a.source_ref?.startsWith("import:") && slugify(a.label) === slugify(project.name),
+        );
+        actions.push({
+          action_id: nextId(),
+          type: "create_project_summary",
+          space: targetSpaceName!,
+          name: project.name,
+          summary: project.summary,
+          status: isDupe ? "duplicate_skipped" : "new",
+        });
+      }
+      continue;
+    }
+
     const slug = slugify(space.name);
     if (!slug) continue;
     const existing = deps.getSpaceBySlug(slug);
@@ -317,10 +372,24 @@ export function buildImportPlan(
 
   for (const summary of payload.summaries ?? []) {
     if (!summary.space || !summary.content) continue;
+
+    if (targetSpaceId) {
+      const existingArtifacts = deps.getArtifactsBySpace(targetSpaceId);
+      const hasOverview = existingArtifacts.some((a) => a.source_ref?.includes("overview"));
+      actions.push({
+        action_id: nextId(),
+        type: "create_space_overview",
+        space: targetSpaceName!,
+        title: summary.title || `${targetSpaceName} overview`,
+        content: summary.content,
+        status: hasOverview ? "exists_will_merge" : "new",
+      });
+      continue;
+    }
+
     const slug = slugify(summary.space);
     const existing = deps.getSpaceBySlug(slug);
     const parentActionId = spaceActionIds.get(summary.space);
-    // Skip if space doesn't exist and isn't being created in this import
     if (!existing && !parentActionId) continue;
     const spaceId = existing?.id ?? slug;
     const existingArtifacts = deps.getArtifactsBySpace(spaceId);
@@ -341,9 +410,7 @@ export function buildImportPlan(
 
   for (const memory of payload.memories ?? []) {
     if (!memory.content) continue;
-    const spaceSlug = memory.space ? slugify(memory.space) : null;
-    const existingSpace = spaceSlug ? deps.getSpaceBySlug(spaceSlug) : null;
-    const spaceId = existingSpace?.id ?? spaceSlug;
+    const spaceId = targetSpaceId ?? (memory.space ? (deps.getSpaceBySlug(slugify(memory.space))?.id ?? slugify(memory.space)) : null);
     const isDupe = deps.findMemory(memory.content, spaceId);
 
     actions.push({
@@ -351,7 +418,7 @@ export function buildImportPlan(
       type: "create_memory",
       content: memory.content,
       tags: memory.tags,
-      space: memory.space,
+      space: targetSpaceName ?? memory.space,
       status: isDupe ? "duplicate_skipped" : "new",
     });
   }
@@ -362,7 +429,7 @@ export function buildImportPlan(
     skipped: actions.filter((a) => a.status === "duplicate_skipped").length,
   };
 
-  const plan: ImportPlan = { plan_id: planId, provider, generated_at: generatedAt, counts, warnings, actions };
+  const plan: ImportPlan = { plan_id: planId, provider, generated_at: generatedAt, target_space_id: targetSpaceId, counts, warnings, actions };
   storePlan(plan, payload);
   return plan;
 }
@@ -410,6 +477,12 @@ export async function executeImportPlan(
   const approved = new Set(approvedIds);
   const results: ExecuteResult["results"] = [];
   const createdSpaces = new Map<string, string>();
+
+  // When scoped to a target space, all space references resolve to it
+  if (plan.target_space_id) {
+    const targetName = plan.actions.find(a => a.space)?.space;
+    if (targetName) createdSpaces.set(targetName, plan.target_space_id);
+  }
 
   // Validate: reject orphaned actions
   for (const action of plan.actions) {

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -480,8 +480,9 @@ export async function executeImportPlan(
 
   // When scoped to a target space, all space references resolve to it
   if (plan.target_space_id) {
-    const targetName = plan.actions.find(a => a.space)?.space;
-    if (targetName) createdSpaces.set(targetName, plan.target_space_id);
+    for (const action of plan.actions) {
+      if (action.space) createdSpaces.set(action.space, plan.target_space_id);
+    }
   }
 
   // Validate: reject orphaned actions

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -309,9 +309,9 @@ export function buildImportPlan(
 
     if (targetSpaceId) {
       // Space-scoped: skip create_space, remap projects into target
+      const existingArtifacts = deps.getArtifactsBySpace(targetSpaceId);
       for (const project of space.projects ?? []) {
         if (!project.name) continue;
-        const existingArtifacts = deps.getArtifactsBySpace(targetSpaceId);
         const isDupe = existingArtifacts.some(
           (a) => a.source_ref?.startsWith("import:") && slugify(a.label) === slugify(project.name),
         );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -472,6 +472,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   if (url.startsWith("/api/import/prompt") && req.method === "GET") {
     const params = new URL(url, "http://localhost").searchParams;
     const provider = params.get("provider") || "chatgpt";
+    const spaceId = params.get("spaceId");
 
     const allSpaces = spaceStore.getAll()
       .filter((s) => s.id !== "home" && s.id !== "__all__")
@@ -486,7 +487,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       }
     }
 
-    const prompt = generatePrompt({ provider, spaces: allSpaces, knownProjects });
+    const targetSpace = spaceId
+      ? allSpaces.find((s) => s.id === spaceId) ?? undefined
+      : undefined;
+
+    const prompt = generatePrompt({ provider, spaces: allSpaces, knownProjects, targetSpace });
     res.writeHead(200, { "Content-Type": "text/plain" });
     res.end(prompt);
     return;
@@ -500,7 +505,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     });
     req.on("end", async () => {
       try {
-        const { raw, provider } = JSON.parse(body) as { raw: string; provider: string };
+        const { raw, provider, targetSpaceId } = JSON.parse(body) as { raw: string; provider: string; targetSpaceId?: string };
 
         const convertFn = async (text: string): Promise<string | null> => {
           try {
@@ -573,7 +578,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           },
         };
 
-        const plan = buildImportPlan(parseResult.payload, provider, generatedAt, previewDeps);
+        const plan = buildImportPlan(parseResult.payload, provider, generatedAt, previewDeps, targetSpaceId);
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify(plan));
       } catch (err) {

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -110,8 +110,15 @@ export class SpaceService {
     const row = this.spaceStore.getById(id);
     if (!row) throw new Error(`Space "${id}" not found`);
     const dbFields: Record<string, string> = {};
-    if (fields.displayName !== undefined) dbFields.display_name = fields.displayName;
-    if (fields.color !== undefined) dbFields.color = fields.color;
+    if (fields.displayName !== undefined) {
+      const trimmed = fields.displayName.trim();
+      if (!trimmed) throw new Error("displayName must not be empty");
+      dbFields.display_name = trimmed;
+    }
+    if (fields.color !== undefined) {
+      if (!/^#[0-9a-fA-F]{6}$/.test(fields.color)) throw new Error("color must be a 6-digit hex string");
+      dbFields.color = fields.color;
+    }
     this.spaceStore.update(id, dbFields);
     return rowToSpace(this.spaceStore.getById(id)!);
   }
@@ -120,7 +127,7 @@ export class SpaceService {
     const artifacts = this.artifactStore.getBySpaceId(sourceSpaceId)
       .filter(a => a.group_name === folderName);
     for (const a of artifacts) {
-      this.artifactStore.update(a.id, { space_id: targetSpaceId, group_name: null as unknown as string });
+      this.artifactStore.update(a.id, { space_id: targetSpaceId, group_name: null });
     }
   }
 

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -106,8 +106,32 @@ export class SpaceService {
     const row = this.spaceStore.getById(id);
     return row ? rowToSpace(row) : null;
   }
-  deleteSpace(id: string): void {
-    this.artifactStore.getBySpaceId(id).forEach(a => this.artifactStore.delete(a.id));
+  updateSpace(id: string, fields: { displayName?: string; color?: string }): Space {
+    const row = this.spaceStore.getById(id);
+    if (!row) throw new Error(`Space "${id}" not found`);
+    const dbFields: Record<string, string> = {};
+    if (fields.displayName !== undefined) dbFields.display_name = fields.displayName;
+    if (fields.color !== undefined) dbFields.color = fields.color;
+    this.spaceStore.update(id, dbFields);
+    return rowToSpace(this.spaceStore.getById(id)!);
+  }
+
+  convertFolderToSpace(sourceSpaceId: string, folderName: string, targetSpaceId: string): void {
+    const artifacts = this.artifactStore.getBySpaceId(sourceSpaceId)
+      .filter(a => a.group_name === folderName);
+    for (const a of artifacts) {
+      this.artifactStore.update(a.id, { space_id: targetSpaceId, group_name: null as unknown as string });
+    }
+  }
+
+  deleteSpace(id: string, folderNameOverride?: string): void {
+    const row = this.spaceStore.getById(id);
+    const folderName = folderNameOverride ?? row?.display_name ?? id;
+    const artifacts = this.artifactStore.getBySpaceId(id);
+    // Move orphaned artifacts to home in a folder named after the deleted space
+    for (const a of artifacts) {
+      this.artifactStore.update(a.id, { space_id: "home", group_name: folderName });
+    }
     this.spaceStore.delete(id);
   }
 

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -132,7 +132,9 @@ export class SpaceService {
   }
 
   deleteSpace(id: string, folderNameOverride?: string): void {
+    if (id === "home" || id === "__all__") throw new Error(`Cannot delete reserved space "${id}"`);
     const row = this.spaceStore.getById(id);
+    if (!row) throw new Error(`Space "${id}" not found`);
     const folderName = folderNameOverride ?? row?.display_name ?? id;
     const artifacts = this.artifactStore.getBySpaceId(id);
     // Move orphaned artifacts to home in a folder named after the deleted space

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -77,17 +77,19 @@ export async function handleSpacesRequest(
     req.on("data", (chunk: Buffer | string) => (body += chunk));
     req.on("end", () => {
       try {
-        const { folderName, sourceSpaceId } = JSON.parse(body);
+        const { folderName, sourceSpaceId, merge } = JSON.parse(body);
         if (!folderName) throw new Error("folderName is required");
         let space: ReturnType<typeof spaceService.getSpace>;
         const existing = spaceService.getSpace(slugify(folderName));
-        if (existing) {
+        if (existing && merge) {
           space = existing;
+        } else if (existing && !merge) {
+          space = spaceService.createSpace({ name: folderName });
         } else {
           space = spaceService.createSpace({ name: folderName });
         }
         spaceService.convertFolderToSpace(sourceSpaceId ?? "home", folderName, space!.id);
-        res.writeHead(existing ? 200 : 201, { "Content-Type": "application/json" });
+        res.writeHead(existing && merge ? 200 : 201, { "Content-Type": "application/json" });
         res.end(JSON.stringify(space));
       } catch (err) {
         res.writeHead(400, { "Content-Type": "application/json" });

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { SpaceService } from "./space-service.js";
+import { slugify } from "./utils.js";
 import { isContainer, discoverCandidates, groupWithLLM } from "./discovery.js";
 
 /**
@@ -70,6 +71,32 @@ export async function handleSpacesRequest(
     return true;
   }
 
+  // POST /api/spaces/from-folder — convert a folder group into a space
+  if (url === "/api/spaces/from-folder" && req.method === "POST") {
+    let body = "";
+    req.on("data", (chunk: Buffer | string) => (body += chunk));
+    req.on("end", () => {
+      try {
+        const { folderName, sourceSpaceId } = JSON.parse(body);
+        if (!folderName) throw new Error("folderName is required");
+        let space: ReturnType<typeof spaceService.getSpace>;
+        const existing = spaceService.getSpace(slugify(folderName));
+        if (existing) {
+          space = existing;
+        } else {
+          space = spaceService.createSpace({ name: folderName });
+        }
+        spaceService.convertFolderToSpace(sourceSpaceId ?? "home", folderName, space!.id);
+        res.writeHead(existing ? 200 : 201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(space));
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
+    return true;
+  }
+
   // POST /api/spaces — create space
   if (url === "/api/spaces" && req.method === "POST") {
     let body = "";
@@ -104,15 +131,38 @@ export async function handleSpacesRequest(
     res.end(JSON.stringify(space));
     return true;
   }
+  if (spaceIdMatch && req.method === "PATCH") {
+    return new Promise<boolean>((resolve) => {
+      let body = "";
+      req.on("data", (c: Buffer) => { body += c.toString(); });
+      req.on("end", () => {
+        try {
+          const { displayName, color } = JSON.parse(body);
+          const updated = spaceService.updateSpace(spaceIdMatch[1], { displayName, color });
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(updated));
+        } catch (err) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: (err as Error).message }));
+        }
+        resolve(true);
+      });
+    });
+  }
   if (spaceIdMatch && req.method === "DELETE") {
-    try {
-      spaceService.deleteSpace(spaceIdMatch[1]);
-      res.writeHead(204);
-      res.end();
-    } catch (err) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: (err as Error).message }));
-    }
+    let body = "";
+    req.on("data", (c: Buffer) => { body += c.toString(); });
+    req.on("end", () => {
+      try {
+        const parsed = body ? JSON.parse(body) : {};
+        spaceService.deleteSpace(spaceIdMatch[1], parsed.folderName);
+        res.writeHead(204);
+        res.end();
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+    });
     return true;
   }
 

--- a/server/src/spaces-routes.ts
+++ b/server/src/spaces-routes.ts
@@ -83,8 +83,6 @@ export async function handleSpacesRequest(
         const existing = spaceService.getSpace(slugify(folderName));
         if (existing && merge) {
           space = existing;
-        } else if (existing && !merge) {
-          space = spaceService.createSpace({ name: folderName });
         } else {
           space = spaceService.createSpace({ name: folderName });
         }
@@ -152,20 +150,22 @@ export async function handleSpacesRequest(
     });
   }
   if (spaceIdMatch && req.method === "DELETE") {
-    let body = "";
-    req.on("data", (c: Buffer) => { body += c.toString(); });
-    req.on("end", () => {
-      try {
-        const parsed = body ? JSON.parse(body) : {};
-        spaceService.deleteSpace(spaceIdMatch[1], parsed.folderName);
-        res.writeHead(204);
-        res.end();
-      } catch (err) {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: (err as Error).message }));
-      }
+    return new Promise<boolean>((resolve) => {
+      let body = "";
+      req.on("data", (c: Buffer) => { body += c.toString(); });
+      req.on("end", () => {
+        try {
+          const parsed = body ? JSON.parse(body) : {};
+          spaceService.deleteSpace(spaceIdMatch[1], parsed.folderName);
+          res.writeHead(204);
+          res.end();
+        } catch (err) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: (err as Error).message }));
+        }
+        resolve(true);
+      });
     });
-    return true;
   }
 
   // GET /api/spaces/:id/paths — list folders for a space

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -170,6 +170,45 @@ body {
   z-index: 1;
 }
 
+/* ── Empty space state ── */
+.empty-space-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 20px;
+  gap: 20px;
+}
+.empty-space-hint {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  opacity: 0.5;
+}
+.empty-space-actions {
+  display: flex;
+  gap: 10px;
+}
+.empty-space-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.empty-space-action:hover {
+  background: rgba(124, 107, 255, 0.08);
+  border-color: rgba(124, 107, 255, 0.25);
+  color: var(--text);
+}
+
 .topbar-hover-zone {
   position: absolute;
   top: 0;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2479,6 +2479,81 @@ body {
 /* + pill */
 .space-pill--add { opacity: 0.4; font-size: 16px; line-height: 1; padding: 0 10px; min-width: 28px; }
 .space-pill--add:hover { opacity: 0.8; }
+
+/* Space context menu */
+.space-ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 140px;
+  padding: 4px;
+  background: var(--window-chrome);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.12);
+  transform: translate(-50%, -100%);
+  margin-top: -8px;
+}
+.space-ctx-item {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.space-ctx-item:hover { background: rgba(124, 107, 255, 0.12); }
+.space-ctx-delete { color: #ef4444; }
+.space-ctx-delete:hover { background: rgba(239, 68, 68, 0.12); }
+.space-ctx-sep {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 3px 8px;
+}
+.space-ctx-colors {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+  padding: 8px;
+}
+.space-ctx-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.space-ctx-swatch:hover { border-color: rgba(255, 255, 255, 0.5); transform: scale(1.15); }
+.space-ctx-confirm {
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+.space-ctx-confirm-actions {
+  display: flex;
+  gap: 4px;
+  margin-top: 6px;
+}
+.space-pill-rename {
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--accent);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0 2px;
+  width: 80px;
+  outline: none;
+  position: relative;
+  z-index: 1;
+}
 .add-space-drop-zone {
   display: flex;
   flex-direction: column;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -200,9 +200,9 @@ export default function App() {
     }
   }, [activeSpace, handleSpaceChange]);
 
-  const handleConvertToSpace = useCallback(async (groupName: string, merge?: boolean) => {
+  const handleConvertToSpace = useCallback(async (groupName: string, merge?: boolean, sourceSpaceId?: string) => {
     try {
-      const newSpace = await convertFolderToSpace(groupName, activeSpace, merge);
+      const newSpace = await convertFolderToSpace(groupName, sourceSpaceId ?? activeSpace, merge);
       setSpaces((prev) => prev.some(s => s.id === newSpace.id) ? prev : [...prev, newSpace]);
       handleSpaceChange(newSpace.id);
     } catch (err) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -343,9 +343,17 @@ export default function App() {
         onSpaceChange={handleSpaceChange}
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         onConvertToSpace={handleConvertToSpace}
-        onImportFromAI={() => {
-          const importArtifact = artifacts.find((a) => a.id === "import-from-ai");
-          if (importArtifact) handleArtifactClick(importArtifact);
+        onImportFromAI={(spaceId) => {
+          const importArtifact = artifacts.find((a) => a.id.endsWith("import-from-ai"));
+          if (!importArtifact) return;
+          if (spaceId) {
+            const sp = spaces.find((s) => s.id === spaceId);
+            const params = `?spaceId=${encodeURIComponent(spaceId)}&spaceName=${encodeURIComponent(sp?.displayName ?? spaceId)}`;
+            const scoped = { ...importArtifact, url: importArtifact.url + params };
+            handleArtifactClick(scoped);
+          } else {
+            handleArtifactClick(importArtifact);
+          }
         }}
         isFirstRun={isFirstRun}
         dragOver={shellDragOver}
@@ -481,11 +489,12 @@ export default function App() {
           spaces={spaces}
           initialFolder={droppedFolder}
           onClose={() => { setShowAddSpaceWizard(false); setDroppedFolder(undefined); }}
-          onComplete={() => {
+          onComplete={(newSpaceId) => {
             setShowAddSpaceWizard(false);
             setDroppedFolder(undefined);
             fetchSpaces().then(setSpaces);
             fetchArtifacts().then(setArtifacts);
+            if (newSpaceId) handleSpaceChange(newSpaceId);
           }}
         />
       )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,7 @@ import {
   stopApp as stopAppApi,
 } from "./data/artifacts-api";
 import { shouldOpenFullscreen } from "../../shared/types";
-import { fetchSpaces } from "./data/spaces-api";
+import { fetchSpaces, createSpace, updateSpace, deleteSpace, convertFolderToSpace } from "./data/spaces-api";
 import type { Space } from "../../shared/types";
 import { createSession, sendMessage } from "./data/chat-api";
 import "./App.css";
@@ -181,6 +181,35 @@ export default function App() {
     setOpenGroup(null);
   }, []);
 
+  const handleSpaceUpdate = useCallback(async (id: string, fields: { displayName?: string; color?: string }) => {
+    try {
+      const updated = await updateSpace(id, fields);
+      setSpaces((prev) => prev.map((s) => s.id === id ? updated : s));
+    } catch (err) {
+      console.error("[space] update failed:", err);
+    }
+  }, []);
+
+  const handleSpaceDelete = useCallback(async (id: string, folderName?: string) => {
+    try {
+      await deleteSpace(id, folderName);
+      setSpaces((prev) => prev.filter((s) => s.id !== id));
+      if (activeSpace === id) handleSpaceChange("home");
+    } catch (err) {
+      console.error("[space] delete failed:", err);
+    }
+  }, [activeSpace, handleSpaceChange]);
+
+  const handleConvertToSpace = useCallback(async (groupName: string) => {
+    try {
+      const newSpace = await convertFolderToSpace(groupName, activeSpace);
+      setSpaces((prev) => [...prev, newSpace]);
+      handleSpaceChange(newSpace.id);
+    } catch (err) {
+      console.error("[space] convert folder failed:", err);
+    }
+  }, [activeSpace, handleSpaceChange]);
+
   const isHero = activeSpace === "home";
   const isFirstRun = spaces.filter(s => s.id !== "home" && s.id !== "__all__").length === 0;
 
@@ -313,6 +342,7 @@ export default function App() {
         }}
         onSpaceChange={handleSpaceChange}
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
+        onConvertToSpace={handleConvertToSpace}
         isFirstRun={isFirstRun}
         dragOver={shellDragOver}
         revealId={revealId}
@@ -435,6 +465,8 @@ export default function App() {
         onSpaceChange={handleSpaceChange}
         inputRef={chatInputRef}
         onAddSpace={() => setShowAddSpaceWizard(true)}
+        onSpaceUpdate={handleSpaceUpdate}
+        onSpaceDelete={handleSpaceDelete}
         artifacts={artifacts}
         onArtifactOpen={handleArtifactClick}
         isFirstRun={isFirstRun}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -343,6 +343,10 @@ export default function App() {
         onSpaceChange={handleSpaceChange}
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         onConvertToSpace={handleConvertToSpace}
+        onImportFromAI={() => {
+          const importArtifact = artifacts.find((a) => a.id === "import-from-ai");
+          if (importArtifact) handleArtifactClick(importArtifact);
+        }}
         isFirstRun={isFirstRun}
         dragOver={shellDragOver}
         revealId={revealId}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,7 @@ import {
   stopApp as stopAppApi,
 } from "./data/artifacts-api";
 import { shouldOpenFullscreen } from "../../shared/types";
-import { fetchSpaces, createSpace, updateSpace, deleteSpace, convertFolderToSpace } from "./data/spaces-api";
+import { fetchSpaces, updateSpace, deleteSpace, convertFolderToSpace } from "./data/spaces-api";
 import type { Space } from "../../shared/types";
 import { createSession, sendMessage } from "./data/chat-api";
 import "./App.css";
@@ -200,10 +200,10 @@ export default function App() {
     }
   }, [activeSpace, handleSpaceChange]);
 
-  const handleConvertToSpace = useCallback(async (groupName: string) => {
+  const handleConvertToSpace = useCallback(async (groupName: string, merge?: boolean) => {
     try {
-      const newSpace = await convertFolderToSpace(groupName, activeSpace);
-      setSpaces((prev) => [...prev, newSpace]);
+      const newSpace = await convertFolderToSpace(groupName, activeSpace, merge);
+      setSpaces((prev) => prev.some(s => s.id === newSpace.id) ? prev : [...prev, newSpace]);
       handleSpaceChange(newSpace.id);
     } catch (err) {
       console.error("[space] convert folder failed:", err);

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -182,6 +182,12 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
         createdNew = true;
       }
 
+      if (folders.length === 0) {
+        // Empty space — no scan needed
+        onComplete();
+        return;
+      }
+
       for (const folder of folders) {
         await addPath(spaceId, folder);
       }
@@ -541,9 +547,9 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
         <button
           className="add-space-btn-primary"
           onClick={handleScan}
-          disabled={scanning || discovering || (mode === "new" ? !name.trim() : !existingSpaceId) || folders.length === 0}
+          disabled={scanning || discovering || (mode === "new" ? !name.trim() : !existingSpaceId || folders.length === 0)}
         >
-          {scanning ? "Scanning…" : folders.length > 0 ? "Scan" : "Add"}
+          {scanning ? "Scanning…" : folders.length > 0 ? "Scan" : "Create"}
         </button>
       </div>
     </div>

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -166,6 +166,19 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
 
   async function handleScan() {
     setError(null);
+
+    // Empty space — just create and close, no scan
+    if (mode === "new" && folders.length === 0) {
+      if (!name.trim()) { setError("Name is required"); return; }
+      try {
+        await createSpace({ name: name.trim() });
+        onComplete();
+      } catch (err) {
+        setError((err as Error).message);
+      }
+      return;
+    }
+
     setScanning(true);
 
     let spaceId: string;
@@ -180,12 +193,6 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
         const space = await createSpace({ name: name.trim() });
         spaceId = space.id;
         createdNew = true;
-      }
-
-      if (folders.length === 0) {
-        // Empty space — no scan needed
-        onComplete();
-        return;
       }
 
       for (const folder of folders) {

--- a/web/src/components/AddSpaceWizard.tsx
+++ b/web/src/components/AddSpaceWizard.tsx
@@ -6,7 +6,7 @@ interface Props {
   spaces: Space[];
   initialFolder?: string;
   onClose: () => void;
-  onComplete: () => void;
+  onComplete: (newSpaceId?: string) => void;
 }
 
 interface Suggestion {
@@ -171,8 +171,8 @@ export function AddSpaceWizard({ spaces, initialFolder, onClose, onComplete }: P
     if (mode === "new" && folders.length === 0) {
       if (!name.trim()) { setError("Name is required"); return; }
       try {
-        await createSpace({ name: name.trim() });
-        onComplete();
+        const space = await createSpace({ name: name.trim() });
+        onComplete(space.id);
       } catch (err) {
         setError((err as Error).message);
       }

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion";
 import { spaceColor } from "../utils/spaceColor";
 import { marked } from "marked";
@@ -92,13 +93,20 @@ interface Props {
   activeSpace?: string;
   onSpaceChange?: (space: string) => void;
   onAddSpace?: () => void;
+  onSpaceUpdate?: (id: string, fields: { displayName?: string; color?: string }) => void;
+  onSpaceDelete?: (id: string, folderName?: string) => void;
   inputRef?: React.RefObject<HTMLInputElement | null>;
   artifacts?: Artifact[];
   onArtifactOpen?: (artifact: Artifact) => void;
   isFirstRun?: boolean;
 }
 
-export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activeSpace, onSpaceChange, onAddSpace, inputRef: externalInputRef, artifacts = [], onArtifactOpen, isFirstRun }: Props) {
+const SPACE_PALETTE = [
+  "#6057c4", "#3d8aaa", "#3a8f64", "#b06840",
+  "#8f5a9e", "#3a8a7a", "#9e7c2a", "#8f4a5a",
+];
+
+export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activeSpace, onSpaceChange, onAddSpace, onSpaceUpdate, onSpaceDelete, inputRef: externalInputRef, artifacts = [], onArtifactOpen, isFirstRun }: Props) {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [statusText, setStatusText] = useState("");
@@ -114,6 +122,31 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   const [placeholder, setPlaceholder] = useState(() => placeholders[Math.floor(Math.random() * placeholders.length)]);
   const placeholderIndexRef = useRef(0);
   const isHero = !!isHeroProp;
+
+  // Space context menu
+  const [ctxMenu, setCtxMenu] = useState<{ spaceId: string; rect: DOMRect } | null>(null);
+  const [renaming, setRenaming] = useState<{ spaceId: string; name: string } | null>(null);
+  const [showColors, setShowColors] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const ctxRef = useRef<HTMLDivElement>(null);
+  const renameRef = useRef<HTMLInputElement>(null);
+
+  // Close context menu on outside click
+  useEffect(() => {
+    if (!ctxMenu) return;
+    function handleClick(e: MouseEvent) {
+      if (ctxRef.current && !ctxRef.current.contains(e.target as Node)) {
+        setCtxMenu(null);
+        setShowColors(false);
+        setConfirmDelete(false);
+      }
+    }
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [ctxMenu]);
+
+  // Focus rename input when it appears
+  useEffect(() => { renameRef.current?.focus(); }, [renaming]);
 
   const { messages, setMessages, sessionId, expanded, setExpanded, pushSessionUrl } = useChatSession();
 
@@ -563,19 +596,56 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
               {activeSpace === "__all__" && (
                 <motion.span layoutId="space-pill-bg" className="space-pill-bg" style={{ background: "#7c6bff" }} transition={{ type: "spring", stiffness: 400, damping: 35 }} />
               )}
-              <span style={{ position: "relative", zIndex: 1 }}>all</span>
+              <span style={{ position: "relative", zIndex: 1 }}>All</span>
             </button>
 
             {/* Named spaces */}
             {spaces.filter(s => s.id !== "home").map((s) => {
               const color = s.color ?? spaceColor(s.id);
               const isActive = activeSpace === s.id;
+              const isRenaming = renaming?.spaceId === s.id;
               return (
-                <button key={s.id} className={`space-pill${isActive ? " active" : ""}`} onClick={() => onSpaceChange(s.id)} style={{ position: "relative" }}>
+                <button
+                  key={s.id}
+                  className={`space-pill${isActive ? " active" : ""}`}
+                  onClick={() => !isRenaming && onSpaceChange?.(s.id)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                    setCtxMenu({ spaceId: s.id, rect });
+                    setShowColors(false);
+                    setConfirmDelete(false);
+                    setRenaming(null);
+                  }}
+                  style={{ position: "relative" }}
+                >
                   {isActive && (
                     <motion.span layoutId="space-pill-bg" className="space-pill-bg" style={{ background: color }} transition={{ type: "spring", stiffness: 400, damping: 35 }} />
                   )}
-                  <span style={{ position: "relative", zIndex: 1 }}>{s.displayName}</span>
+                  {isRenaming ? (
+                    <input
+                      ref={renameRef}
+                      className="space-pill-rename"
+                      value={renaming.name}
+                      onChange={(e) => setRenaming({ ...renaming, name: e.target.value })}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && renaming.name.trim()) {
+                          onSpaceUpdate?.(s.id, { displayName: renaming.name.trim() });
+                          setRenaming(null);
+                        }
+                        if (e.key === "Escape") setRenaming(null);
+                      }}
+                      onBlur={() => {
+                        if (renaming.name.trim() && renaming.name.trim() !== s.displayName) {
+                          onSpaceUpdate?.(s.id, { displayName: renaming.name.trim() });
+                        }
+                        setRenaming(null);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ) : (
+                    <span style={{ position: "relative", zIndex: 1 }}>{s.displayName}</span>
+                  )}
                 </button>
               );
             })}
@@ -601,6 +671,88 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
         <div className="chatbar-onboarding-hint">
           or click <code>+</code> to add your projects
         </div>
+      )}
+
+      {/* Space context menu — portaled to body to escape transforms */}
+      {ctxMenu && createPortal(
+        <div
+          ref={ctxRef}
+          className="space-ctx-menu"
+          style={{ left: ctxMenu.rect.left + ctxMenu.rect.width / 2, top: ctxMenu.rect.top }}
+        >
+          {!showColors && !confirmDelete && (
+            <>
+              <button className="space-ctx-item" onClick={() => {
+                const s = spaces.find(sp => sp.id === ctxMenu.spaceId);
+                if (s) setRenaming({ spaceId: s.id, name: s.displayName });
+                setCtxMenu(null);
+              }}>
+                Rename
+              </button>
+              <button className="space-ctx-item" onClick={() => setShowColors(true)}>
+                Color
+              </button>
+              <div className="space-ctx-sep" />
+              <button className="space-ctx-item space-ctx-delete" onClick={() => setConfirmDelete(true)}>
+                Remove
+              </button>
+            </>
+          )}
+          {showColors && (
+            <div className="space-ctx-colors">
+              {SPACE_PALETTE.map((c) => (
+                <button
+                  key={c}
+                  className="space-ctx-swatch"
+                  style={{ background: c }}
+                  onClick={() => {
+                    onSpaceUpdate?.(ctxMenu.spaceId, { color: c });
+                    setCtxMenu(null);
+                    setShowColors(false);
+                  }}
+                />
+              ))}
+            </div>
+          )}
+          {confirmDelete && (() => {
+            const sp = spaces.find(s => s.id === ctxMenu.spaceId);
+            const folderName = sp?.displayName ?? ctxMenu.spaceId;
+            const hasConflict = artifacts.some(a => a.spaceId === "home" && a.groupName === folderName);
+            const altName = folderName + " (2)";
+            return (
+              <div className="space-ctx-confirm">
+                {hasConflict ? (
+                  <>
+                    <span>"{folderName}" folder exists on Home.</span>
+                    <div className="space-ctx-confirm-actions">
+                      <button className="space-ctx-item" onClick={() => { setConfirmDelete(false); setCtxMenu(null); }}>Cancel</button>
+                      <button className="space-ctx-item" onClick={() => {
+                        onSpaceDelete?.(ctxMenu.spaceId);
+                        setCtxMenu(null); setConfirmDelete(false);
+                      }}>Merge</button>
+                      <button className="space-ctx-item" onClick={() => {
+                        onSpaceDelete?.(ctxMenu.spaceId, altName);
+                        setCtxMenu(null); setConfirmDelete(false);
+                      }}>Keep "{altName}"</button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <span>Moves to a folder on Home.</span>
+                    <div className="space-ctx-confirm-actions">
+                      <button className="space-ctx-item" onClick={() => { setConfirmDelete(false); setCtxMenu(null); }}>Cancel</button>
+                      <button className="space-ctx-item space-ctx-delete" onClick={() => {
+                        onSpaceDelete?.(ctxMenu.spaceId);
+                        setCtxMenu(null); setConfirmDelete(false);
+                      }}>Remove</button>
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })()}
+        </div>,
+        document.body,
       )}
 
     </div>

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -716,11 +716,24 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
           {confirmDelete && (() => {
             const sp = spaces.find(s => s.id === ctxMenu.spaceId);
             const folderName = sp?.displayName ?? ctxMenu.spaceId;
-            const hasConflict = artifacts.some(a => a.spaceId === "home" && a.groupName === folderName);
+            const spaceArtifacts = artifacts.filter(a => a.spaceId === ctxMenu.spaceId);
+            const isEmpty = spaceArtifacts.length === 0;
+            const hasConflict = !isEmpty && artifacts.some(a => a.spaceId === "home" && a.groupName === folderName);
             const altName = folderName + " (2)";
             return (
               <div className="space-ctx-confirm">
-                {hasConflict ? (
+                {isEmpty ? (
+                  <>
+                    <span>Remove this space?</span>
+                    <div className="space-ctx-confirm-actions">
+                      <button className="space-ctx-item" onClick={() => { setConfirmDelete(false); setCtxMenu(null); }}>Cancel</button>
+                      <button className="space-ctx-item space-ctx-delete" onClick={() => {
+                        onSpaceDelete?.(ctxMenu.spaceId);
+                        setCtxMenu(null); setConfirmDelete(false);
+                      }}>Remove</button>
+                    </div>
+                  </>
+                ) : hasConflict ? (
                   <>
                     <span>"{folderName}" folder exists on Home.</span>
                     <div className="space-ctx-confirm-actions">

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -632,15 +632,14 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
                         if (e.key === "Enter" && renaming.name.trim()) {
                           onSpaceUpdate?.(s.id, { displayName: renaming.name.trim() });
                           setRenaming(null);
+                          e.currentTarget.blur();
                         }
-                        if (e.key === "Escape") setRenaming(null);
-                      }}
-                      onBlur={() => {
-                        if (renaming.name.trim() && renaming.name.trim() !== s.displayName) {
-                          onSpaceUpdate?.(s.id, { displayName: renaming.name.trim() });
+                        if (e.key === "Escape") {
+                          setRenaming(null);
+                          e.currentTarget.blur();
                         }
-                        setRenaming(null);
                       }}
+                      onBlur={() => setRenaming(null)}
                       onClick={(e) => e.stopPropagation()}
                     />
                   ) : (

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -21,7 +21,7 @@ interface Props {
   onGroupClick: (groupName: string) => void;
   onSpaceChange: (space: string) => void;
   onAddSpace?: (folderName?: string) => void;
-  onConvertToSpace?: (groupName: string, merge?: boolean) => void;
+  onConvertToSpace?: (groupName: string, merge?: boolean, sourceSpaceId?: string) => void;
   onImportFromAI?: (spaceId?: string) => void;
   isFirstRun?: boolean;
   dragOver?: boolean;
@@ -41,7 +41,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
   };
 
   // ── Folder context menu ──
-  const [folderCtx, setFolderCtx] = useState<{ name: string; x: number; y: number } | null>(null);
+  const [folderCtx, setFolderCtx] = useState<{ name: string; sourceSpaceId?: string; x: number; y: number } | null>(null);
   const folderCtxRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!folderCtx) return;
@@ -316,7 +316,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                 <div className="icon-grid icon-grid--inline" style={{ justifyContent: headerAlign === "left" ? "start" : headerAlign === "right" ? "end" : "center" }}>
                   {section.items.map((item, i) => (
                     item.type === "group" ? (
-                      <GroupIcon key={item.key} name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }} />
+                      <GroupIcon key={item.key} name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setFolderCtx({ name: item.name, sourceSpaceId: section.spaceId, x: e.clientX, y: e.clientY }); }} />
                     ) : (
                       <ArtifactIcon
                         key={item.key}
@@ -376,17 +376,17 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
               return (
                 <>
                   <span className="space-ctx-confirm" style={{ padding: "6px 12px" }}>"{folderCtx.name}" space exists.</span>
-                  <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name, true); setFolderCtx(null); }}>
+                  <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name, true, folderCtx.sourceSpaceId); setFolderCtx(null); }}>
                     Merge
                   </button>
-                  <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name + " (2)"); setFolderCtx(null); }}>
+                  <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name + " (2)", false, folderCtx.sourceSpaceId); setFolderCtx(null); }}>
                     Create "{folderCtx.name} (2)"
                   </button>
                 </>
               );
             }
             return (
-              <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name); setFolderCtx(null); }}>
+              <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name, false, folderCtx.sourceSpaceId); setFolderCtx(null); }}>
                 Convert to Space
               </button>
             );

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -22,7 +22,7 @@ interface Props {
   onSpaceChange: (space: string) => void;
   onAddSpace?: (folderName?: string) => void;
   onConvertToSpace?: (groupName: string, merge?: boolean) => void;
-  onImportFromAI?: () => void;
+  onImportFromAI?: (spaceId?: string) => void;
   isFirstRun?: boolean;
   dragOver?: boolean;
   revealId?: string | null;
@@ -195,7 +195,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
         {isFirstRun && !bannerDismissed && (
           <OnboardingBanner
             onImportFromAI={() => {
-              const importArtifact = artifacts.find((a) => a.id === "import-from-ai");
+              const importArtifact = artifacts.find((a) => a.id.endsWith("import-from-ai"));
               if (importArtifact) onArtifactClick(importArtifact);
             }}
             onDismiss={handleDismiss}
@@ -252,7 +252,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
             <div className="empty-space-hint">This space is empty</div>
             <div className="empty-space-actions">
               {onImportFromAI && (
-                <button className="empty-space-action" onClick={onImportFromAI}>
+                <button className="empty-space-action" onClick={() => onImportFromAI(space)}>
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                     <polyline points="7 10 12 15 17 10" />
@@ -265,7 +265,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style={{ opacity: 0.7 }}>
                   <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
                 </svg>
-                Add a folder
+                Import folder
               </button>
             </div>
           </div>

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -22,12 +22,13 @@ interface Props {
   onSpaceChange: (space: string) => void;
   onAddSpace?: (folderName?: string) => void;
   onConvertToSpace?: (groupName: string, merge?: boolean) => void;
+  onImportFromAI?: () => void;
   isFirstRun?: boolean;
   dragOver?: boolean;
   revealId?: string | null;
 }
 
-export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, dragOver, revealId, isFirstRun }: Props) {
+export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, onImportFromAI, dragOver, revealId, isFirstRun }: Props) {
   const isAllSpace = space === "__all__";
 
   // ── Onboarding banner ──
@@ -244,6 +245,31 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
             </button>
           </div>
         </div>
+
+        {/* Empty space state */}
+        {!isHero && !isAllSpace && artifacts.length === 0 && (
+          <div className="empty-space-state">
+            <div className="empty-space-hint">This space is empty</div>
+            <div className="empty-space-actions">
+              {onImportFromAI && (
+                <button className="empty-space-action" onClick={onImportFromAI}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                  Import from AI
+                </button>
+              )}
+              <button className="empty-space-action" onClick={() => onAddSpace?.()}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style={{ opacity: 0.7 }}>
+                  <path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/>
+                </svg>
+                Add a folder
+              </button>
+            </div>
+          </div>
+        )}
 
         {viewMode === "list" ? (
           <div className={`list-view${isAllSpace && groupBy === "kind" ? " list-view--no-badge" : ""}${!isAllSpace || groupBy === "space" ? " list-view--no-space" : ""}`}>

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { LayoutGrid, List, ArrowDownAZ, Tag, Clock, Folder, AlignLeft, AlignCenter, AlignRight } from "lucide-react";
 import type { Artifact } from "../data/artifacts-api";
 import { ArtifactIcon, typeConfig } from "./ArtifactIcon";
@@ -20,12 +21,13 @@ interface Props {
   onGroupClick: (groupName: string) => void;
   onSpaceChange: (space: string) => void;
   onAddSpace?: (folderName?: string) => void;
+  onConvertToSpace?: (groupName: string, merge?: boolean) => void;
   isFirstRun?: boolean;
   dragOver?: boolean;
   revealId?: string | null;
 }
 
-export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, dragOver, revealId, isFirstRun }: Props) {
+export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, dragOver, revealId, isFirstRun }: Props) {
   const isAllSpace = space === "__all__";
 
   // ── Onboarding banner ──
@@ -36,6 +38,18 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
     localStorage.setItem("oyster-onboarding-dismissed", "true");
     setBannerDismissed(true);
   };
+
+  // ── Folder context menu ──
+  const [folderCtx, setFolderCtx] = useState<{ name: string; x: number; y: number } | null>(null);
+  const folderCtxRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!folderCtx) return;
+    function handleClick(e: MouseEvent) {
+      if (folderCtxRef.current && !folderCtxRef.current.contains(e.target as Node)) setFolderCtx(null);
+    }
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [folderCtx]);
 
   // ── Topbar auto-hide ──
   const [topbarVisible, setTopbarVisible] = useState(true);
@@ -276,7 +290,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
                 <div className="icon-grid icon-grid--inline" style={{ justifyContent: headerAlign === "left" ? "start" : headerAlign === "right" ? "end" : "center" }}>
                   {section.items.map((item, i) => (
                     item.type === "group" ? (
-                      <GroupIcon key={item.key} name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} />
+                      <GroupIcon key={item.key} name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }} />
                     ) : (
                       <ArtifactIcon
                         key={item.key}
@@ -305,7 +319,7 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
                   style={isDragged ? undefined : { transition: "transform 0.25s ease" }}
                 >
                   {item.type === "group" ? (
-                    <GroupIcon name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} />
+                    <GroupIcon name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }} />
                   ) : (
                     <ArtifactIcon
                       artifact={item.artifact}
@@ -322,6 +336,38 @@ export function Desktop({ space, artifacts, isHero, onArtifactClick, onArtifactS
         )}
       </div>
       <div className="version-badge">v{__APP_VERSION__} · {__APP_ENV__}</div>
+
+      {folderCtx && createPortal(
+        <div
+          ref={folderCtxRef}
+          className="space-ctx-menu"
+          style={{ left: folderCtx.x, top: folderCtx.y, transform: "translateY(-100%)", marginTop: -8 }}
+        >
+          {onConvertToSpace && (() => {
+            const slug = folderCtx.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+            const hasConflict = spaces.includes(slug);
+            if (hasConflict) {
+              return (
+                <>
+                  <span className="space-ctx-confirm" style={{ padding: "6px 12px" }}>"{folderCtx.name}" space exists.</span>
+                  <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name, true); setFolderCtx(null); }}>
+                    Merge
+                  </button>
+                  <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name + " (2)"); setFolderCtx(null); }}>
+                    Create "{folderCtx.name} (2)"
+                  </button>
+                </>
+              );
+            }
+            return (
+              <button className="space-ctx-item" onClick={() => { onConvertToSpace(folderCtx.name); setFolderCtx(null); }}>
+                Convert to Space
+              </button>
+            );
+          })()}
+        </div>,
+        document.body,
+      )}
     </div>
   );
 }

--- a/web/src/components/GroupIcon.tsx
+++ b/web/src/components/GroupIcon.tsx
@@ -6,9 +6,10 @@ interface Props {
   artifacts: Artifact[];
   index: number;
   onClick: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
 }
 
-export function GroupIcon({ name, artifacts, index, onClick }: Props) {
+export function GroupIcon({ name, artifacts, index, onClick, onContextMenu }: Props) {
   // Take first 4 artifacts for the 2x2 preview
   const previews = artifacts.slice(0, 4);
 
@@ -16,7 +17,8 @@ export function GroupIcon({ name, artifacts, index, onClick }: Props) {
     <button
       className="artifact-icon"
       style={{ animationDelay: `${index * 0.05 + 0.05}s` }}
-      onClick={onClick}
+      onClick={(e) => { if (e.button === 0 && !e.ctrlKey) onClick(); }}
+      onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); onContextMenu?.(e); }}
     >
       <div className="group-thumb">
         <div className="group-grid">

--- a/web/src/components/ViewerWindow.tsx
+++ b/web/src/components/ViewerWindow.tsx
@@ -119,7 +119,7 @@ export function ViewerWindow({
   const [fixLogOpen, setFixLogOpen] = useState(false);
   const fixLogEndRef = useRef<HTMLDivElement>(null);
   const unsubRef = useRef<(() => void) | null>(null);
-  const iframeSrc = useMemo(() => `${path}?t=${Date.now()}${initialHash ? initialHash : ""}`, [path, iframeKey]);
+  const iframeSrc = useMemo(() => `${path}${path.includes("?") ? "&" : "?"}t=${Date.now()}${initialHash ? initialHash : ""}`, [path, iframeKey]);
 
   // Auto-scroll fix log
   useEffect(() => {

--- a/web/src/data/spaces-api.ts
+++ b/web/src/data/spaces-api.ts
@@ -41,11 +41,11 @@ export async function updateSpace(spaceId: string, fields: { displayName?: strin
   return res.json();
 }
 
-export async function convertFolderToSpace(folderName: string, sourceSpaceId: string = "home"): Promise<Space> {
+export async function convertFolderToSpace(folderName: string, sourceSpaceId: string = "home", merge?: boolean): Promise<Space> {
   const res = await fetch("/api/spaces/from-folder", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ folderName, sourceSpaceId }),
+    body: JSON.stringify({ folderName, sourceSpaceId, merge }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({})) as { error?: string };
@@ -60,7 +60,11 @@ export async function deleteSpace(spaceId: string, folderName?: string): Promise
     opts.headers = { "Content-Type": "application/json" };
     opts.body = JSON.stringify({ folderName });
   }
-  await fetch(`/api/spaces/${spaceId}`, opts);
+  const res = await fetch(`/api/spaces/${spaceId}`, opts);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
 }
 
 export async function addPath(spaceId: string, path: string): Promise<string> {

--- a/web/src/data/spaces-api.ts
+++ b/web/src/data/spaces-api.ts
@@ -28,9 +28,39 @@ export async function triggerScan(spaceId: string): Promise<ScanResult> {
   return res.json();
 }
 
-export async function deleteSpace(spaceId: string): Promise<void> {
-  await fetch(`/api/spaces/${spaceId}`, { method: "DELETE" });
-  // best-effort — ignore errors (wizard uses this only for cleanup)
+export async function updateSpace(spaceId: string, fields: { displayName?: string; color?: string }): Promise<Space> {
+  const res = await fetch(`/api/spaces/${spaceId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(fields),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function convertFolderToSpace(folderName: string, sourceSpaceId: string = "home"): Promise<Space> {
+  const res = await fetch("/api/spaces/from-folder", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ folderName, sourceSpaceId }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({})) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function deleteSpace(spaceId: string, folderName?: string): Promise<void> {
+  const opts: RequestInit = { method: "DELETE" };
+  if (folderName) {
+    opts.headers = { "Content-Type": "application/json" };
+    opts.body = JSON.stringify({ folderName });
+  }
+  await fetch(`/api/spaces/${spaceId}`, opts);
 }
 
 export async function addPath(spaceId: string, path: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Right-click any space pill → context menu with **Rename**, **Color**, **Remove**
- Rename: inline text edit on the pill (Enter to save, Esc to cancel)
- Color: 8-swatch palette picker
- Remove: moves artifacts to a folder on Home (not deleted), with merge/keep-separate on name conflicts
- Right-click folders → **Convert to Space** (with merge option if space name exists)
- New endpoints: `PATCH /api/spaces/:id`, `POST /api/spaces/from-folder`
- Also: "all" → "All" capitalization

## Open questions
- Orphaned artifacts on space removal: current approach (folder on Home) vs alternatives — see [comment](https://github.com/mattslight/oyster/issues/64#issuecomment-4250641330)
- Pill reorder via drag-and-drop tracked separately in #111

## Test plan
- [ ] Right-click a space pill — context menu appears centered above pill
- [ ] Rename a space — pill updates inline
- [ ] Change color — pill background updates
- [ ] Remove a space — artifacts appear in a folder on Home (enable "By folder" view)
- [ ] Right-click a folder on Home → "Convert to Space" creates space and moves artifacts
- [ ] Remove a space when folder name already exists on Home — merge/keep-separate prompt
- [ ] Convert folder when space name exists — merge/create-new prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)