### PR TITLE
fix: kill OpenCode subprocess on shutdown and reset port on restart

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -43,6 +43,7 @@ import {
   spawnOpenCodeServe,
   getOpenCodePort,
   markShuttingDown,
+  killOpenCode,
   startAutoApprover,
   proxyToOpenCode,
   proxySSE,
@@ -202,8 +203,8 @@ startGenerationTimer(iconGenerator, (id, filePath, builtin) => {
 });
 startAutoApprover(getOpenCodePort, (file) => handleFileEdited(file, ARTIFACTS_DIR, iconGenerator));
 
-process.on("SIGTERM", () => { markShuttingDown(); db.close(); memoryProvider.close(); process.exit(0); });
-process.on("SIGINT", () => { markShuttingDown(); db.close(); memoryProvider.close(); process.exit(0); });
+process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); process.exit(0); });
+process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); process.exit(0); });
 
 // ── UI push events (SSE) ──
 

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -15,7 +15,9 @@ export function getOpenCodePort(): number {
 export function killOpenCode() {
   if (opencodeChild) {
     if (process.platform === "win32" && opencodeChild.pid) {
-      try { execSync(`taskkill /PID ${opencodeChild.pid} /T /F`, { stdio: "ignore" }); } catch {}
+      try { execSync(`taskkill /PID ${opencodeChild.pid} /T /F`, { stdio: "ignore" }); } catch (err) {
+        console.warn(`[opencode-serve] taskkill failed: ${err instanceof Error ? err.message : err}`);
+      }
     } else {
       opencodeChild.kill("SIGTERM");
     }
@@ -29,11 +31,10 @@ export function spawnOpenCodeServe(
   userlandDir: string,
   cleanEnv: Record<string, string>,
 ) {
-  // Use port 0 to let the OS pick an available port
   console.log(`Spawning opencode serve in ${userlandDir}`);
-  // Reset port so the new instance's port is captured
   resolvedPort = 0;
-  const child = spawn(opencodeBin, ["serve", "--port", "0"], {
+  const portArg = opencodePort > 0 ? String(opencodePort) : "0";
+  const child = spawn(opencodeBin, ["serve", "--port", portArg], {
     cwd: userlandDir,
     env: cleanEnv,
     stdio: ["ignore", "pipe", "pipe"],
@@ -58,7 +59,7 @@ export function spawnOpenCodeServe(
 
   child.on("error", (err) => {
     console.error(`[opencode-serve] spawn error: ${err.message}`);
-    if (opencodeChild === child) opencodeChild = null;
+    if (opencodeChild === child) { opencodeChild = null; resolvedPort = 0; }
     if (shuttingDown) return;
     opencodeRestarts++;
     if (opencodeRestarts > MAX_RESTARTS) {
@@ -71,7 +72,7 @@ export function spawnOpenCodeServe(
   });
 
   child.on("exit", (code) => {
-    if (opencodeChild === child) opencodeChild = null;
+    if (opencodeChild === child) { opencodeChild = null; resolvedPort = 0; }
     if (shuttingDown) return;
     opencodeRestarts++;
     if (opencodeRestarts > MAX_RESTARTS) {

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -49,6 +49,7 @@ export function spawnOpenCodeServe(
     const match = text.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/);
     if (match && !resolvedPort) {
       resolvedPort = parseInt(match[1], 10);
+      opencodeRestarts = 0;
       console.log(`[opencode-serve] resolved to port ${resolvedPort}`);
     }
   });
@@ -57,9 +58,10 @@ export function spawnOpenCodeServe(
     console.error(`[opencode-serve] ${data.toString().trim()}`);
   });
 
-  child.on("error", (err) => {
-    console.error(`[opencode-serve] spawn error: ${err.message}`);
-    if (opencodeChild === child) { opencodeChild = null; resolvedPort = 0; }
+  function scheduleRestart(reason: string) {
+    if (opencodeChild !== child) return; // already handled by other event
+    opencodeChild = null;
+    resolvedPort = 0;
     if (shuttingDown) return;
     opencodeRestarts++;
     if (opencodeRestarts > MAX_RESTARTS) {
@@ -67,21 +69,17 @@ export function spawnOpenCodeServe(
       return;
     }
     const delay = Math.min(2000 * opencodeRestarts, 30000);
-    console.log(`[opencode-serve] restarting in ${delay}ms...`);
+    console.log(`[opencode-serve] ${reason}, restarting in ${delay}ms...`);
     setTimeout(() => spawnOpenCodeServe(opencodeBin, opencodePort, userlandDir, cleanEnv), delay);
+  }
+
+  child.on("error", (err) => {
+    console.error(`[opencode-serve] spawn error: ${err.message}`);
+    scheduleRestart(`spawn error: ${err.message}`);
   });
 
   child.on("exit", (code) => {
-    if (opencodeChild === child) { opencodeChild = null; resolvedPort = 0; }
-    if (shuttingDown) return;
-    opencodeRestarts++;
-    if (opencodeRestarts > MAX_RESTARTS) {
-      console.error("[opencode-serve] too many restarts, giving up");
-      return;
-    }
-    const delay = Math.min(2000 * opencodeRestarts, 30000);
-    console.log(`[opencode-serve] exited (code ${code}), restarting in ${delay}ms...`);
-    setTimeout(() => spawnOpenCodeServe(opencodeBin, opencodePort, userlandDir, cleanEnv), delay);
+    scheduleRestart(`exited (code ${code})`);
   });
 
   return child;

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -1,5 +1,5 @@
 import { type IncomingMessage, type ServerResponse } from "node:http";
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
 
 let shuttingDown = false;
 let opencodeRestarts = 0;
@@ -14,7 +14,11 @@ export function getOpenCodePort(): number {
 
 export function killOpenCode() {
   if (opencodeChild) {
-    opencodeChild.kill("SIGTERM");
+    if (process.platform === "win32" && opencodeChild.pid) {
+      try { execSync(`taskkill /PID ${opencodeChild.pid} /T /F`, { stdio: "ignore" }); } catch {}
+    } else {
+      opencodeChild.kill("SIGTERM");
+    }
     opencodeChild = null;
   }
 }
@@ -50,6 +54,20 @@ export function spawnOpenCodeServe(
 
   child.stderr?.on("data", (data: Buffer) => {
     console.error(`[opencode-serve] ${data.toString().trim()}`);
+  });
+
+  child.on("error", (err) => {
+    console.error(`[opencode-serve] spawn error: ${err.message}`);
+    if (opencodeChild === child) opencodeChild = null;
+    if (shuttingDown) return;
+    opencodeRestarts++;
+    if (opencodeRestarts > MAX_RESTARTS) {
+      console.error("[opencode-serve] too many restarts, giving up");
+      return;
+    }
+    const delay = Math.min(2000 * opencodeRestarts, 30000);
+    console.log(`[opencode-serve] restarting in ${delay}ms...`);
+    setTimeout(() => spawnOpenCodeServe(opencodeBin, opencodePort, userlandDir, cleanEnv), delay);
   });
 
   child.on("exit", (code) => {

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -6,9 +6,17 @@ let opencodeRestarts = 0;
 const MAX_RESTARTS = 10;
 
 let resolvedPort = 0;
+let opencodeChild: ReturnType<typeof spawn> | null = null;
 
 export function getOpenCodePort(): number {
   return resolvedPort;
+}
+
+export function killOpenCode() {
+  if (opencodeChild) {
+    opencodeChild.kill("SIGTERM");
+    opencodeChild = null;
+  }
 }
 
 export function spawnOpenCodeServe(
@@ -19,12 +27,15 @@ export function spawnOpenCodeServe(
 ) {
   // Use port 0 to let the OS pick an available port
   console.log(`Spawning opencode serve in ${userlandDir}`);
+  // Reset port so the new instance's port is captured
+  resolvedPort = 0;
   const child = spawn(opencodeBin, ["serve", "--port", "0"], {
     cwd: userlandDir,
     env: cleanEnv,
     stdio: ["ignore", "pipe", "pipe"],
     shell: process.platform === "win32",
   });
+  opencodeChild = child;
 
   child.stdout?.on("data", (data: Buffer) => {
     const text = data.toString().trim();
@@ -42,6 +53,7 @@ export function spawnOpenCodeServe(
   });
 
   child.on("exit", (code) => {
+    if (opencodeChild === child) opencodeChild = null;
     if (shuttingDown) return;
     opencodeRestarts++;
     if (opencodeRestarts > MAX_RESTARTS) {


### PR DESCRIPTION
## Summary
- **Kill OpenCode on shutdown**: The child process reference was being discarded, so OpenCode survived every server restart — leading to 254 zombie processes and a load average of 510
- **Reset port on restart**: `resolvedPort` was never cleared when OpenCode crashed and restarted, so the new instance's port was never captured and all proxy requests went to the dead port

## Test plan
- [ ] Start Oyster, verify OpenCode spawns and port resolves
- [ ] Kill Oyster server (Ctrl+C), verify the OpenCode process is also terminated
- [ ] Simulate OpenCode crash, verify it restarts and the new port is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)