### PR TITLE
fix: chat user bubble conflates with assistant response

### DIFF
--- a/web/src/hooks/useChatEvents.ts
+++ b/web/src/hooks/useChatEvents.ts
@@ -138,16 +138,19 @@ export function useChatEvents({
         }
 
         case "message.part.updated": {
-          const partMsgId = props.messageID as string;
           const part = props.part as {
             type: string;
             text?: string;
             id: string;
+            messageID?: string;
             toolName?: string;
             name?: string;
             tool?: string;
             state?: { input?: Record<string, unknown>; output?: unknown; status?: string };
           };
+          // OpenCode 1.4+ nests messageID inside part; older versions put it at props.messageID
+          const partMsgId = part.messageID || (props.messageID as string);
+          if (!partMsgId) break;
           // Skip non-content part types
           if (part.type === "step-start" || part.type === "step-finish") break;
           if (part.type === "reasoning") {

--- a/web/src/hooks/useChatEvents.ts
+++ b/web/src/hooks/useChatEvents.ts
@@ -149,7 +149,8 @@ export function useChatEvents({
             state?: { input?: Record<string, unknown>; output?: unknown; status?: string };
           };
           // OpenCode 1.4+ nests messageID inside part; older versions put it at props.messageID
-          const partMsgId = part.messageID || (props.messageID as string);
+          const fallbackMessageID = typeof props.messageID === "string" ? props.messageID : undefined;
+          const partMsgId = part.messageID ?? fallbackMessageID;
           if (!partMsgId) break;
           // Skip non-content part types
           if (part.type === "step-start" || part.type === "step-finish") break;


### PR DESCRIPTION
## Summary

User bubble in chat was appearing with the assistant's response appended: "ok make tetris" → "ok make tetrisI'll create a Tetris game for you". All previous user bubbles would also show the latest conflated text.

## Root cause

OpenCode 1.4 moved `messageID` inside the `part` payload for `message.part.updated` events:

```
// 1.4+
{ type: "message.part.updated", properties: { part: { messageID, id, type, text, ... } } }
```

The handler still read `props.messageID` which is now `undefined`. When a tool event fired, the update path used `partMsgId === undefined` and matched any state message with `id === undefined` — which is always the optimistic user bubble. The assistant's streamed text (stored under `textPartsMap[undefined]`) got written onto the user bubble's content.

## Fix

Read `part.messageID` first, fall back to `props.messageID` for older OpenCode versions, and bail if both are missing.

## Test plan

- [x] Reproduced against live OpenCode 1.4.3 SSE events → user bubble conflated
- [x] Applied fix in simulation against same captured events → user bubble stays as typed
- [x] `tsc --noEmit` passes
- [ ] Manual verification: send 2 messages in dev, confirm user bubbles stay intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)