### PR TITLE
docs: align with shipped v1 (port 4444, 19 MCP tools, FTS5 memory)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,13 @@ Browser → http://localhost:4444
          - Chat proxy → OpenCode (spawned internally) → LLM
 ```
 
-**Oyster Server** (port 4200) — HTTP API, artifact/space registry (SQLite), MCP tool surface, static web serving, chat proxy to OpenCode. This is the only user-facing port.
+**Oyster Server** (port 4444 when installed, 3333 in dev) — HTTP API, artifact/space registry (SQLite), MCP tool surface, static web serving, chat proxy to OpenCode. This is the only user-facing port.
 
 **OpenCode** — AI engine, spawned as a subprocess by the server. Not user-facing. Configured via `.opencode/agents/oyster.md` and `.opencode/config.toml`.
 
 **SQLite** (`~/.oyster/userland/oyster.db`) — artefact and space registry. Fast, local, no infrastructure.
 
-**No persistent memory in v1.** Cross-session memory (Graphiti / knowledge graph) is deferred to v2. The agent is stateless between sessions.
+**Memory (v1)** — SQLite FTS5-backed `remember` / `recall` / `forget` / `list_memories` tools in `server/src/memory-store.ts`. Richer cross-session / graph-based memory is future work.
 
 ## Mental Models
 
@@ -33,7 +33,7 @@ Browser → http://localhost:4444
 
 **Artefacts** — typed outputs on the surface (app, notes, diagram, deck, wireframe, table, map). Registered in SQLite, files in `~/.oyster/userland/`. `source_origin` tracks provenance: `manual` | `discovered` | `ai_generated`.
 
-**MCP** — the server exposes 15 tools at `/mcp/`. Any MCP client (Claude Code, Cursor, etc.) can connect and control the surface.
+**MCP** — the server exposes 19 tools at `/mcp/` (15 artifact/space + 4 memory). Any MCP client (Claude Code, Cursor, etc.) can connect and control the surface.
 
 ## Key Files
 
@@ -54,7 +54,7 @@ Browser → http://localhost:4444
 ```bash
 # Development
 cd web && npm install && cd ../server && npm install && cd ..
-npm run dev              # Vite dev server at 7337, proxies to server at 4200
+npm run dev              # Vite dev server at 7337, proxies to server at 3333
 
 # Production build
 npm run build            # Builds web + server + copies web into server/dist/public/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Browser → http://localhost:4444
          - Chat proxy → OpenCode (spawned internally) → LLM
 ```
 
-**Oyster Server** (port 4444 when installed, 3333 in dev) — HTTP API, artifact/space registry (SQLite), MCP tool surface, static web serving, chat proxy to OpenCode. This is the only user-facing port.
+**Oyster Server** (port 4444 when installed, 3333 in dev) — HTTP API, artifact/space registry (SQLite), MCP tool surface, static web serving, chat proxy to OpenCode. In the installed package, this is the only user-facing port; in dev, Vite serves the UI at 7337 and proxies to the server.
 
 **OpenCode** — AI engine, spawned as a subprocess by the server. Not user-facing. Configured via `.opencode/agents/oyster.md` and `.opencode/config.toml`.
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ Browser → http://localhost:4444
 
 Early v1. Local-first. Single-user. Built for fast iteration.
 
-**Now:** MCP powered workspace, bring your own AI, prompt-driven navigation, space switching, artefact desktop, repo onboarding, 12 MCP tools, slash commands, instant UI updates via SSE.
+**Now:** MCP powered workspace, bring your own AI, prompt-driven navigation, space switching, artefact desktop, repo onboarding, persistent memory (remember/recall), 19 MCP tools, slash commands, instant UI updates via SSE.
 
 **Next:** smoother onboarding, faster artefact navigation, better repo import.
 
-**Vision:** persistent memory, plugins, dynamic UI that reshapes to fit the task, build & share apps.
+**Vision:** plugins, dynamic UI that reshapes to fit the task, build & share apps.
 
 ## Contributing
 
@@ -128,7 +128,7 @@ git clone https://github.com/mattslight/oyster.git
 cd oyster
 cd web && npm install && cd ../server && npm install && cd ..
 npm run dev
-# → dev server at http://localhost:7337 (proxies to server at 4200)
+# → dev server at http://localhost:7337 (proxies to server at 3333)
 ```
 
 ## Licence

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -431,20 +431,25 @@
 
     <div class="section-label">Available tools</div>
     <div class="tools">
-      <span class="tool">create_artifact</span>
-      <span class="tool">list_artifacts</span>
-      <span class="tool">read_artifact</span>
-      <span class="tool">update_artifact</span>
-      <span class="tool">open_artifact</span>
-      <span class="tool">remove_artifact</span>
-      <span class="tool">onboard_space</span>
-      <span class="tool">scan_space</span>
+      <span class="tool">get_context</span>
       <span class="tool">list_spaces</span>
       <span class="tool">switch_space</span>
+      <span class="tool">onboard_space</span>
+      <span class="tool">scan_space</span>
+      <span class="tool">gather_repo_context</span>
+      <span class="tool">list_artifacts</span>
+      <span class="tool">create_artifact</span>
+      <span class="tool">register_artifact</span>
+      <span class="tool">read_artifact</span>
+      <span class="tool">update_artifact</span>
+      <span class="tool">remove_artifact</span>
+      <span class="tool">open_artifact</span>
+      <span class="tool">reveal_artifact</span>
+      <span class="tool">regenerate_icon</span>
       <span class="tool">remember</span>
       <span class="tool">recall</span>
-      <span class="tool">gather_repo_context</span>
-      <span class="tool">regenerate_icon</span>
+      <span class="tool">forget</span>
+      <span class="tool">list_memories</span>
     </div>
     <p class="note">Your AI can chain these together. Ask it to onboard a project, scan for artifacts, create a summary, and organise everything into spaces — all from one prompt.</p>
   </div>

--- a/docs/plans/oyster-os-design.md
+++ b/docs/plans/oyster-os-design.md
@@ -1,7 +1,7 @@
 # Oyster OS — Design Document
 
 **Status:** Living document
-**Last updated:** 2026-03-30
+**Last updated:** 2026-04-18
 **Authors:** Matthew Slight, with architectural input from Bharat Mani Prem Sankar
 
 ---
@@ -17,7 +17,7 @@ Not just for makers and developers. For anyone whose work is distributed across 
 - ChatGPT can't — it has no live access and forgets between sessions.
 - A Zoho report can't — ProCore isn't in scope.
 
-Oyster can, because it connects all systems via MCP, holds the relationships between them in a knowledge graph, and accumulates context across every session.
+Oyster can, because it connects all systems via MCP, holds the relationships between them, and accumulates context across every session.
 
 ## Problem
 
@@ -58,7 +58,7 @@ The engine is OpenCode (`opencode serve`), spawned internally by the server. Pro
 Prove that Oyster can:
 
 1. Present a visual surface where generated outputs appear as typed icons.
-2. Accept chat input via an embedded bar and structure it into persistent Oyster system data (nodes, edges).
+2. Accept chat input via an embedded bar and structure it into persistent Oyster system data (spaces, artifacts, memories).
 3. Generate usable outputs that appear on the surface without the user touching code.
 4. Feel like a workspace you return to, not a chat thread you scroll.
 
@@ -106,7 +106,7 @@ Prove that Oyster can:
 | OpenCode (internal) | AI engine, spawned as subprocess, not user-facing |
 | SQLite (~/.oyster/userland/oyster.db) | Artefact and space registry |
 
-The UI, API, and MCP server all run on port 4444. OpenCode is spawned internally. Memory ships in v1 (SQLite FTS5).
+The UI, API, and MCP server all run on port 4444 (3333 in dev, overridable via `OYSTER_PORT`). OpenCode is spawned internally. Memory ships in v1 (SQLite FTS5).
 
 ### The Artifact Contract
 

--- a/docs/plans/oyster-os-design.md
+++ b/docs/plans/oyster-os-design.md
@@ -106,7 +106,7 @@ Prove that Oyster can:
 | OpenCode (internal) | AI engine, spawned as subprocess, not user-facing |
 | SQLite (~/.oyster/userland/oyster.db) | Artefact and space registry |
 
-The UI, API, and MCP server all run on port 4444 (3333 in dev, overridable via `OYSTER_PORT`). OpenCode is spawned internally. Memory ships in v1 (SQLite FTS5).
+In the installed package the server serves API, MCP, and static UI on port 4444. In dev the server runs on 3333 and Vite serves the UI at 7337 (proxying API/MCP to the server). `OYSTER_PORT` overrides the server port. OpenCode is spawned internally. Memory ships in v1 (SQLite FTS5).
 
 ### The Artifact Contract
 

--- a/docs/plans/oyster-os-design.md
+++ b/docs/plans/oyster-os-design.md
@@ -31,7 +31,7 @@ Oyster's surface accumulates context across all your systems and sessions — so
 
 Oyster is a visual surface where generated outputs — documents, diagrams, apps, notes — appear as artifacts you can open, organise, and build on. A unified chat bar is the single entry point: chat to build, search to find, type to navigate. Each output replaces a separate tool.
 
-The engine is OpenCode (`opencode serve`), spawned internally by the server. Persistent memory is deferred to v2. Product behaviour is steered by `.opencode/agents/oyster.md`. The user never sees OpenCode — the engine is invisible.
+The engine is OpenCode (`opencode serve`), spawned internally by the server. Product behaviour is steered by `.opencode/agents/oyster.md`. The user never sees OpenCode — the engine is invisible.
 
 **One-liner:** A surface that remembers. An AI that connects the dots.
 
@@ -73,7 +73,7 @@ Prove that Oyster can:
 │                    User Machine (local)                   │
 │                                                           │
 │  ┌─────────────────────────────────────────────────────┐ │
-│  │  Oyster Server  (port 4200)                         │ │
+│  │  Oyster Server  (port 4444)                         │ │
 │  │  ├── HTTP API  (/api/artifacts, /api/spaces, etc.)  │ │
 │  │  ├── MCP endpoint  (/mcp/)  ← agent tool surface    │ │
 │  │  ├── Chat proxy  → OpenCode                         │ │
@@ -102,11 +102,11 @@ Prove that Oyster can:
 
 | Component | Role |
 |---|---|
-| Oyster Server (port 4200) | Everything: API, SQLite, MCP server, static web UI, chat proxy |
+| Oyster Server (port 4444) | Everything: API, SQLite, MCP server, static web UI, chat proxy |
 | OpenCode (internal) | AI engine, spawned as subprocess, not user-facing |
 | SQLite (~/.oyster/userland/oyster.db) | Artefact and space registry |
 
-The UI, API, and MCP server all run on port 4200. OpenCode is spawned internally. No persistent memory in v1.
+The UI, API, and MCP server all run on port 4444. OpenCode is spawned internally. Memory ships in v1 (SQLite FTS5).
 
 ### The Artifact Contract
 
@@ -195,16 +195,9 @@ This is additive. Tier 1 artifacts continue working unchanged when Tier 2 is add
 
 OpenCode has full filesystem access to the workspace and can read/modify any artifact's manifest, source files, and data. This is tenant-scoped visibility — the agent sees everything for one user, nothing for other users. This cross-artifact visibility is Oyster's core differentiator: "take the data from the sales dashboard and reference it in the presentation" works because both artifacts are in the same filesystem scope.
 
-**MCP tool surface:** In addition to filesystem access, agents interact with the desktop surface via the Oyster MCP server (`localhost:4200/mcp/`). This is the preferred interface for surface management — it enforces approved paths, maintains the artifact registry, and makes agent intent legible to the system.
+**MCP tool surface:** In addition to filesystem access, agents interact with the desktop surface via the Oyster MCP server (`localhost:4444/mcp/`). This is the preferred interface for surface management — it enforces approved paths, maintains the artifact registry, and makes agent intent legible to the system.
 
-| Tool | What it does |
-|------|-------------|
-| `get_context` | Returns a full description of Oyster OS, artifact kinds, and the userland path |
-| `list_spaces` / `list_artifacts` | Discover what exists on the surface |
-| `create_artifact` | Write content + register on the surface in one step (opaque UUID id, slug-based filename) |
-| `read_artifact` | Read the raw text of a static file artifact |
-| `update_artifact` | Update display metadata (label, space, group) without touching the file |
-| `register_artifact` | Register a pre-existing file as a desktop artifact |
+See `server/src/mcp-server.ts` and `server/src/memory-store.ts` for the current tool surface (19 tools: 15 artifact/space + 4 memory).
 
 Agents should use MCP tools for surface management and direct filesystem access for reading/modifying artifact source content. Do not touch `userland/oyster.db` directly.
 
@@ -225,11 +218,9 @@ spaces (id, display_name, repo_path, color, parent_id,
 `source_origin` tracks how an artifact arrived: `manual` | `discovered` | `ai_generated`.
 `parent_id` on spaces is **navigation only** — where to show the space in the UI hierarchy. Semantic relationships between spaces are a v2 feature.
 
-### Knowledge Graph — Deferred to v2
+### Memory (v1)
 
-Persistent memory (cross-session context, entity graphs, relationship tracking) is planned but not active in v1. The v1 surface works without it — the agent is stateless between sessions.
-
-**v2 options under evaluation:** Graphiti (FalkorDB), opencode-plugin-simple-memory, forgetful (SQLite + embeddings), or custom Oyster-native SQLite FTS5. See issue #70 for details and [`docs/research/memory-layer-evaluation.md`](../research/memory-layer-evaluation.md) for the full evaluation.
+Persistent memory ships in v1 via SQLite FTS5 (`server/src/memory-store.ts`), exposed as four MCP tools: `remember`, `recall`, `forget`, `list_memories`. Memories are scoped per space, with global memories also supported. Richer graph-based memory (entity extraction, relationship tracking, temporal awareness) is future work — see [`docs/research/memory-layer-evaluation.md`](../research/memory-layer-evaluation.md) for earlier options analysis.
 
 ### App-Specific Data
 
@@ -237,7 +228,7 @@ Artifacts that need persistence (e.g. a generated todo tracker) use their own lo
 
 ### OpenCode Server (Engine)
 
-`opencode serve` is spawned internally by Oyster Server as a subprocess. It's not user-facing — the user only sees port 4200. OpenCode powers the chat and tool calling behind the scenes.
+`opencode serve` is spawned internally by Oyster Server as a subprocess. It's not user-facing — the user only sees port 4444. OpenCode powers the chat and tool calling behind the scenes.
 
 Key endpoints:
 - `POST /session` — create a new session
@@ -313,9 +304,9 @@ The UI is a visual surface with an embedded chat bar. Artifacts are icons on the
 - The viewer is the only remaining "window" — it makes sense because you're viewing a specific document
 
 **Data model:**
-- Trash is cosmetic — deleting an artifact removes it from the surface, but the underlying data (nodes, edges) stays in the knowledge graph
+- Trash is cosmetic — deleting an artifact removes it from the surface, but the underlying file and record are preserved
 
-The UI polls Oyster Server (`/api/artifacts`, `/api/spaces`) for surface state and streams chat via SSE. It has no direct connection to Graphiti or OpenCode.
+The UI polls Oyster Server (`/api/artifacts`, `/api/spaces`) for surface state and streams chat via SSE.
 
 **Design origin:** The visual surface pattern emerged organically from the tokinvest-concept prototype. Sprint 1 initially mimicked desktop OS chrome (floating windows, dock, minimize/maximize) but prototyping revealed this was borrowed decoration that didn't serve user intent. The refined direction strips all chrome and embeds chat directly into the surface.
 
@@ -471,7 +462,7 @@ On import, Oyster can auto-generate starter artifacts (summaries, knowledge maps
 
 PoC input is chat only. Imports are sprint 2+. Live connectors are later.
 
-**Note:** OpenCode has native MCP support. Connectors can be implemented as MCP servers, managed via the REST API (`GET /mcp`, `POST /mcp/{name}/connect`). The Oyster server itself exposes an MCP endpoint (`localhost:4200/mcp/`) that any agent — not just OpenCode — can use to manage the desktop surface. This is how Claude Code, Cursor, or any other agent with MCP support can create artifacts and navigate spaces without touching the filesystem directly.
+**Note:** OpenCode has native MCP support. Connectors can be implemented as MCP servers, managed via the REST API (`GET /mcp`, `POST /mcp/{name}/connect`). The Oyster server itself exposes an MCP endpoint (`localhost:4444/mcp/`) that any agent — not just OpenCode — can use to manage the desktop surface. This is how Claude Code, Cursor, or any other agent with MCP support can create artifacts and navigate spaces without touching the filesystem directly.
 
 ---
 
@@ -529,9 +520,9 @@ TBD. Cloud hosting and multi-tenant provisioning are future concerns. The import
 - [~] Supabase realtime subscriptions — superseded: SQLite + polling via `/api/artifacts`
 - [x] Real artifact generation + appearance on surface (auto-detected from userland/ via file watcher)
 - [x] Artifact manifest schema (folder + manifest.json per artifact)
-- [x] MCP server at `localhost:4200/mcp/` — agent tool surface for surface management (Phase 1: discover + register; Phase 2: create, read, update)
+- [x] MCP server at `localhost:4444/mcp/` — agent tool surface for surface management (Phase 1: discover + register; Phase 2: create, read, update)
 - [x] AI-generated artifact icons (GPT-4o-mini + fal.ai Flux Schnell)
-- [x] Knowledge graph memory layer (Graphiti, localhost:8000)
+- [x] Memory layer (SQLite FTS5, server-side) — `remember` / `recall` / `forget` / `list_memories`
 - [x] Drag-to-reorder desktop icons with localStorage persistence
 - [x] Fullscreen preference persistence per artifact
 

--- a/docs/research/memory-layer-evaluation.md
+++ b/docs/research/memory-layer-evaluation.md
@@ -1,6 +1,6 @@
 # Memory Layer Evaluation — March 2026
 
-> **STATUS (2026-03): Decision made (Graphiti) but deferred to v2.** Current v1 has no persistent memory. The agent is stateless between sessions. See issue #70 for v2 options. Revisit when persistent memory moves from "planned" to "in progress."
+> **STATUS (2026-04): Superseded.** v1 shipped with a simple SQLite FTS5 memory layer (see `server/src/memory-store.ts`). The evaluation below is preserved as research for a future richer / graph-based memory layer.
 
 ## Context
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -126,7 +126,7 @@ function buildContext(userlandDir: string): string {
   return `
 # Oyster OS
 
-Oyster is a personal AI-native desktop OS that runs in the browser (localhost:4200).
+Oyster is a personal AI-native desktop OS that runs in the browser (localhost:4444).
 It is NOT a chat interface or a file browser — it is a spatial desktop surface where
 artifacts (interactive documents, apps, diagrams, etc.) live as launchable icons.
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -126,7 +126,7 @@ function buildContext(userlandDir: string): string {
   return `
 # Oyster OS
 
-Oyster is a personal AI-native desktop OS that runs in the browser (localhost:4444).
+Oyster is a personal AI-native desktop OS that runs in your browser.
 It is NOT a chat interface or a file browser — it is a spatial desktop surface where
 artifacts (interactive documents, apps, diagrams, etc.) live as launchable icons.
 


### PR DESCRIPTION
## Summary

Docs drifted from the code. This PR realigns them.

- **Port 4200 → 4444** (server listens on `4444` when installed, `3333` in dev — no `4200` exists in code)
- **MCP tool count:** README said `12`, CLAUDE.md said `15`, mcp.html listed `14` — reality is **19** (15 artifact/space in `server/src/mcp-server.ts` + 4 memory in `server/src/memory-store.ts`)
- **Memory ships in v1** via SQLite FTS5 (`remember` / `recall` / `forget` / `list_memories`). Docs previously said memory was deferred to v2.
- Cuts stale Graphiti / knowledge-graph references (Graphiti is never referenced in code; FTS5 shipped instead). Preserved as historical research in `docs/research/memory-layer-evaluation.md` and the speculative `docs/future/architecture-graphiti-v2.html`.
- Replaces the outdated 6-tool table in `oyster-os-design.md` with a pointer to `server/src/mcp-server.ts`.

## Files

- `CLAUDE.md` — port, tool count, memory block, dev proxy port
- `README.md` — tool count in Now, memory moved from Vision → Now, dev proxy port
- `docs/plans/oyster-os-design.md` — port references, MCP tool table cut, "Knowledge Graph — Deferred" rewritten as "Memory (v1)", stale graph references removed
- `docs/mcp.html` — tool list now reflects all 19
- `docs/research/memory-layer-evaluation.md` — status banner updated to "Superseded; v1 shipped with SQLite FTS5"

## Test plan

- [ ] `grep -rn "4200" CLAUDE.md README.md docs/plans docs/mcp.html docs/research` returns no hits
- [ ] `grep -rEn "12 MCP tools|15 tools at|14 tools" CLAUDE.md README.md docs/` returns no hits
- [ ] `grep -rEn "No persistent memory in v1|deferred to v2" CLAUDE.md README.md docs/plans docs/mcp.html` returns no hits
- [ ] Spot-check rendered `docs/plans/oyster-os-design.md` reads cleanly around the memory/MCP sections
- [ ] Open `docs/mcp.html` in a browser — tool list shows 19 items

Historical superpowers/plans and specs referencing `:4200` are left untouched — they're records of completed work at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)