### PR TITLE
docs: add /plugins catalog page + plugin system design

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -428,6 +428,7 @@
     <a href="#features">Features</a>
     <a href="#install">Install</a>
     <a href="/mcp">MCP</a>
+    <a href="/plugins">Plugins</a>
   </nav>
 
   <!-- Hero -->

--- a/docs/plans/plugin-system.md
+++ b/docs/plans/plugin-system.md
@@ -1,0 +1,166 @@
+# Oyster Plugin & App System — Design Notes
+
+> **Status (2026-04):** Exploratory design. Tier 1 install flow (manual drop-in) works today via the existing artifact detector. Tiers 2 and 3 are future work. The `builtins/` apps (zombie-horde, quick-start, etc.) are effectively first-party plugins with `builtin: true`. Third-party plugins live in their own repos — **the Oyster monorepo does not contain example plugins.**
+
+## Core Insight
+
+**Apps and plugins are the same concern.** The existing `builtins/<name>/manifest.json` shape already *is* a plugin manifest. The only difference between a shipped-in-package app (zombie-horde) and a user-installed plugin is provenance — `builtin: true` vs `false` — and the folder they live in. One loader, one manifest schema.
+
+```json
+{
+  "id": "pomodoro",
+  "name": "Pomodoro",
+  "type": "app",
+  "runtime": "static",
+  "entrypoint": "src/index.html",
+  "ports": [],
+  "storage": "none",
+  "capabilities": [],
+  "builtin": false
+}
+```
+
+The `runtime` field is the forward-looking lever — it lets new plugin kinds land without re-architecting the loader.
+
+## Runtime Taxonomy
+
+| `runtime` | What it loads | Status |
+|---|---|---|
+| `static` | folder with `entrypoint` HTML, served as an iframe artifact | ✅ shipped (zombie-horde, pomodoro) |
+| `bundle` | `main.js` bundled with esbuild, runs in sandboxed iframe, talks to host via `postMessage` | next |
+| `mcp` | server-side Node module that registers tools at `/mcp/` alongside the built-in 19 | after `bundle` |
+| `panel` | React component mounted into `Desktop.tsx` shell (Obsidian's native model) | eventually |
+
+Pomodoro (`mattslight/oyster-pomodoro`, separate repo) uses `runtime: "static"` and is the reference demonstration for Tier 1 install.
+
+## What We Learned From Obsidian
+
+Obsidian's sample plugin (`obsidianmd/obsidian-sample-plugin`) and its install model are the clearest prior art. Key patterns worth adopting:
+
+### Plugin class + lifecycle hooks
+Plugins extend a `Plugin` base class and implement `onload()` / `onunload()`. The host provides auto-cleanup registration helpers — `addCommand`, `addRibbonIcon`, `addStatusBarItem`, `addSettingTab`, `registerEvent`, `registerDomEvent`, `registerInterval`. Anything registered through these is automatically torn down on unload. **Plugins never manage their own listener lifecycles.** This is the single most important architectural lever — it prevents leak hell as the plugin ecosystem grows.
+
+For Oyster's future `bundle` / `panel` runtimes, mirror this: `api.registerCommand(...)`, `api.registerArtifactType(...)`, `api.registerMCPTool(...)`, `api.registerSurfacePanel(...)`.
+
+### Host as external at build time
+Obsidian's `esbuild.config.mjs` marks `obsidian`, `electron`, `@codemirror/*` as externals. Plugins bundle their own deps but never the host. Oyster's equivalent: ship `@oyster/plugin-sdk` (types + runtime shims), mark it external at plugin build time.
+
+### `loadData()` / `saveData()` for settings
+Flat JSON persistence the host owns. Plugin never touches disk directly. For Oyster, plugins get a scoped SQLite namespace — same "host owns storage" rule.
+
+### Stable IDs post-release
+Command IDs and plugin `id` must never change once published. They become keys in user config. Non-negotiable for Oyster's slash commands and artifact types.
+
+### Compatibility matrix via `versions.json`
+Maps plugin versions → min host versions so old hosts can still pull a compatible plugin build. Matters more for Oyster than it first appears: MCP tool schemas will evolve. Need a `minOysterVersion` in manifest *before* Tier 2 ships.
+
+### No runtime sandbox; trust via community review
+Plugins run with full host access. Safety is norms-based (AGENTS.md): "local/offline default, no RCE, no hidden telemetry, explicit opt-in for network."
+
+**Oyster should diverge here.** Oyster's natural security boundary is MCP. Force plugins to do workspace mutations through the same MCP surface external AIs already use — then you get an audit log, permission scope, and no raw SQLite access, for free. The `capabilities` manifest field becomes the explicit opt-in: `["mcp:read", "mcp:write", "network", "storage"]`.
+
+## Three-Tier Install Flow (Obsidian's Model)
+
+All three tiers are layered on top of GitHub Releases. The technical primitive is always "download release assets into a folder."
+
+### Tier 1 — Manual drop-in (no infrastructure)
+User creates `<vault>/.obsidian/plugins/<id>/` with `manifest.json` + `main.js` + optional `styles.css`. Enables in settings.
+
+**Oyster equivalent today:** drop a folder into `~/.oyster/userland/<id>/`. The existing artifact detector (`server/src/artifact-detector.ts`) picks up the manifest and registers the artifact. Works without any new code.
+
+```bash
+git clone https://github.com/mattslight/oyster-pomodoro ~/.oyster/userland/pomodoro
+# restart oyster
+```
+
+**Small improvement needed:** scan a dedicated `~/.oyster/plugins/` directory so installed plugins don't mix with user-created artifacts. Tiny patch to the bootstrap loop.
+
+### Tier 2 — Paste a GitHub URL (BRAT-style)
+Obsidian: user installs BRAT plugin, pastes `<owner>/<repo>`, BRAT fetches the latest GitHub Release (which must have `manifest.json` + `main.js` as binary attachments), drops them into `.obsidian/plugins/<id>/`, auto-updates on new releases.
+
+**Oyster equivalent:**
+```bash
+oyster install mattslight/oyster-pomodoro
+oyster update pomodoro
+oyster uninstall pomodoro
+```
+Implementation: ~50 lines. `gh api` or raw HTTPS → fetch release assets → validate `manifest.json` → write to `~/.oyster/plugins/<id>/` → signal the server to re-scan. Plus a matching slash command in chat (`/install <repo>`).
+
+### Tier 3 — Curated community directory
+Obsidian: author submits a PR to `obsidianmd/obsidian-releases` adding one entry to `community-plugins.json`:
+```json
+{ "id": "pomodoro", "name": "Pomodoro", "author": "mattslight",
+  "description": "…", "repo": "mattslight/oyster-pomodoro" }
+```
+Obsidian's in-app UI reads that JSON, fetches each plugin's manifest + release assets from GitHub, renders browse/search/install.
+
+**Oyster equivalent:** an `oyster-community-plugins` repo with the same JSON shape, surfaced in the Oyster UI as a browsable gallery. Not needed until there are plugins worth browsing.
+
+### Launch sequencing
+- **Tier 1** → ship now. Pomodoro proves it. No code changes required beyond adding `~/.oyster/plugins/` to the scan paths.
+- **Tier 2** → ship when there's a second third-party plugin to validate against. `oyster install` CLI + `/install` slash command.
+- **Tier 3** → ship when the community is real. Until then it's over-engineering.
+
+## First Use Case: Pomodoro (separate repo: `mattslight/oyster-pomodoro`)
+
+A classic 25/5/15 focus timer. Single-file `runtime: "static"` app, no dependencies, no network, no storage capability declared (uses `localStorage` which the iframe manages itself — scoped to the iframe origin, invisible to Oyster).
+
+**Lives in its own GitHub repo** — not in the Oyster monorepo. This is intentional: the whole point of validating the install flow is that plugins live *outside* Oyster. Bundling examples inside would side-step the very thing we're testing.
+
+Why this is the right first use case:
+- Exercises the whole Tier 1 loop (manifest → detector → registered artifact → iframe render)
+- Trivially safe (static HTML, no host API calls)
+- Utilitarian — proves "any developer can ship a useful artifact to Oyster in 30 minutes"
+- Not a game — games are too self-contained; they don't stress host integration
+
+What pomodoro *doesn't* exercise (future test cases for richer runtimes):
+- Talking to Oyster MCP tools (wait for `bundle` runtime + SDK)
+- Reading artifacts / writing notes (needs MCP capabilities)
+- Registering slash commands (needs `panel` or `bundle` runtime)
+
+## Manifest Schema (extensions needed before Tier 2)
+
+Current shape (from `builtins/zombie-horde/manifest.json`):
+```json
+{ "id", "name", "type", "runtime", "entrypoint",
+  "ports", "storage", "capabilities", "status", "builtin",
+  "created_at", "updated_at" }
+```
+
+Additions required before Tier 2 (GitHub install):
+- **`version`** — semver. User-visible, used for update comparisons.
+- **`minOysterVersion`** — min host version the plugin expects. Lets the loader reject incompatibly new/old plugins cleanly.
+- **`author`**, **`authorUrl`**, **`description`** — surfaced in the Tier 3 gallery.
+- **`repo`** — `owner/name` on GitHub. Enables `oyster update` to find new releases.
+
+Additions worth considering at the same time:
+- **`permissions`** — explicit capability opt-in (`mcp:read`, `mcp:write`, `network`, `storage`). Prompted to the user on install.
+- **`fundingUrl`** — Obsidian has this; low cost, high goodwill.
+
+## Open Questions
+
+1. **Separate `~/.oyster/plugins/` vs single userland?** Obsidian keeps them together with other vault content (`.obsidian/plugins/`), which is fine because the folder is the plugin ID. Oyster could do the same under `~/.oyster/userland/` but a split feels cleaner for install/uninstall scripting. Lean: split.
+2. **Sandbox boundary for `bundle` runtime?** Sandboxed iframe with postMessage is the safe default. The plugin gets a proxied SDK that translates calls to MCP requests. Cleaner than Obsidian's "full host access" model.
+3. **Plugin updates — auto or opt-in?** Obsidian defaults to prompting. Lean: same.
+4. **MCP tool plugins — in-process vs spawned?** Spawned subprocesses are safer but slower. In-process with capability gating is faster. Defer until needed.
+
+## Planned External Repos
+
+The Oyster monorepo stays focused on the host. Plugins and their ecosystem live in separate repos, following Obsidian's model:
+
+| Repo | Purpose | Equivalent to |
+|---|---|---|
+| `mattslight/oyster-sample-plugin` | **Template repo** (GitHub "Use this template"). Minimal hello-world showing manifest + lifecycle + settings + build. How new plugin authors start. | `obsidianmd/obsidian-sample-plugin` |
+| `mattslight/oyster-pomodoro` | First real third-party plugin. Own releases, own README with screenshots. Validates Tier 1 → Tier 2 install flow. | individual community plugin repos |
+| `mattslight/oyster-community-plugins` | Registry repo containing `community-plugins.json`. Single source of truth for both `oyster.to/plugins` page and the in-app browser (Tier 3). Authors submit a PR to list. | `obsidianmd/obsidian-releases` |
+
+**oyster.to/plugins** — static page generated from `community-plugins.json`. Discovery only; install still happens via CLI/in-app. Zero backend.
+
+## References
+
+- Obsidian sample plugin: https://github.com/obsidianmd/obsidian-sample-plugin
+- Obsidian plugin docs: https://docs.obsidian.md/Plugins/
+- Obsidian community plugins directory: https://obsidian.md/plugins
+- BRAT (community install tool): https://github.com/TfTHacker/obsidian42-brat
+- Oyster artifact detector: `server/src/artifact-detector.ts`
+- Oyster builtins bootstrap: `server/src/index.ts:144-154`

--- a/docs/plans/plugin-system.md
+++ b/docs/plans/plugin-system.md
@@ -26,12 +26,12 @@ The `runtime` field is the forward-looking lever — it lets new plugin kinds la
 
 | `runtime` | What it loads | Status |
 |---|---|---|
-| `static` | folder with `entrypoint` HTML, served as an iframe artifact | ✅ shipped (zombie-horde, pomodoro) |
+| `static` | folder with `entrypoint` HTML, served as an iframe artifact | ✅ supported (builtin: zombie-horde; 3p: pomodoro) |
 | `bundle` | `main.js` bundled with esbuild, runs in sandboxed iframe, talks to host via `postMessage` | next |
 | `mcp` | server-side Node module that registers tools at `/mcp/` alongside the built-in 19 | after `bundle` |
 | `panel` | React component mounted into `Desktop.tsx` shell (Obsidian's native model) | eventually |
 
-Pomodoro (`mattslight/oyster-pomodoro`, separate repo) uses `runtime: "static"` and is the reference demonstration for Tier 1 install.
+Pomodoro (`mattslight/oyster-sample-plugin`, separate repo) uses `runtime: "static"` and is the reference demonstration for Tier 1 install.
 
 ## What We Learned From Obsidian
 
@@ -69,7 +69,7 @@ User creates `<vault>/.obsidian/plugins/<id>/` with `manifest.json` + `main.js` 
 **Oyster equivalent today:** drop a folder into `~/.oyster/userland/<id>/`. The existing artifact detector (`server/src/artifact-detector.ts`) picks up the manifest and registers the artifact. Works without any new code.
 
 ```bash
-git clone https://github.com/mattslight/oyster-pomodoro ~/.oyster/userland/pomodoro
+git clone https://github.com/mattslight/oyster-sample-plugin ~/.oyster/userland/pomodoro
 # restart oyster
 ```
 
@@ -80,7 +80,7 @@ Obsidian: user installs BRAT plugin, pastes `<owner>/<repo>`, BRAT fetches the l
 
 **Oyster equivalent:**
 ```bash
-oyster install mattslight/oyster-pomodoro
+oyster install mattslight/oyster-sample-plugin
 oyster update pomodoro
 oyster uninstall pomodoro
 ```
@@ -90,7 +90,7 @@ Implementation: ~50 lines. `gh api` or raw HTTPS → fetch release assets → va
 Obsidian: author submits a PR to `obsidianmd/obsidian-releases` adding one entry to `community-plugins.json`:
 ```json
 { "id": "pomodoro", "name": "Pomodoro", "author": "mattslight",
-  "description": "…", "repo": "mattslight/oyster-pomodoro" }
+  "description": "…", "repo": "mattslight/oyster-sample-plugin" }
 ```
 Obsidian's in-app UI reads that JSON, fetches each plugin's manifest + release assets from GitHub, renders browse/search/install.
 
@@ -101,7 +101,7 @@ Obsidian's in-app UI reads that JSON, fetches each plugin's manifest + release a
 - **Tier 2** → ship when there's a second third-party plugin to validate against. `oyster install` CLI + `/install` slash command.
 - **Tier 3** → ship when the community is real. Until then it's over-engineering.
 
-## First Use Case: Pomodoro (separate repo: `mattslight/oyster-pomodoro`)
+## First Use Case: Pomodoro (separate repo: `mattslight/oyster-sample-plugin`)
 
 A classic 25/5/15 focus timer. Single-file `runtime: "static"` app, no dependencies, no network, no storage capability declared (uses `localStorage` which the iframe manages itself — scoped to the iframe origin, invisible to Oyster).
 
@@ -150,8 +150,7 @@ The Oyster monorepo stays focused on the host. Plugins and their ecosystem live 
 
 | Repo | Purpose | Equivalent to |
 |---|---|---|
-| `mattslight/oyster-sample-plugin` | **Template repo** (GitHub "Use this template"). Minimal hello-world showing manifest + lifecycle + settings + build. How new plugin authors start. | `obsidianmd/obsidian-sample-plugin` |
-| `mattslight/oyster-pomodoro` | First real third-party plugin. Own releases, own README with screenshots. Validates Tier 1 → Tier 2 install flow. | individual community plugin repos |
+| `mattslight/oyster-sample-plugin` | **Template repo** (GitHub "Use this template") that currently hosts the Pomodoro plugin as the reference third-party implementation. May split later into a minimal hello-world template + a dedicated pomodoro repo; for now one repo serves both roles. | `obsidianmd/obsidian-sample-plugin` |
 | `mattslight/oyster-community-plugins` | Registry repo containing `community-plugins.json`. Single source of truth for both `oyster.to/plugins` page and the in-app browser (Tier 3). Authors submit a PR to list. | `obsidianmd/obsidian-releases` |
 
 **oyster.to/plugins** — static-hosted page that fetches `community-plugins.json` at runtime. Discovery only; install still happens via CLI/in-app. Zero backend.

--- a/docs/plans/plugin-system.md
+++ b/docs/plans/plugin-system.md
@@ -154,7 +154,7 @@ The Oyster monorepo stays focused on the host. Plugins and their ecosystem live 
 | `mattslight/oyster-pomodoro` | First real third-party plugin. Own releases, own README with screenshots. Validates Tier 1 → Tier 2 install flow. | individual community plugin repos |
 | `mattslight/oyster-community-plugins` | Registry repo containing `community-plugins.json`. Single source of truth for both `oyster.to/plugins` page and the in-app browser (Tier 3). Authors submit a PR to list. | `obsidianmd/obsidian-releases` |
 
-**oyster.to/plugins** — static page generated from `community-plugins.json`. Discovery only; install still happens via CLI/in-app. Zero backend.
+**oyster.to/plugins** — static-hosted page that fetches `community-plugins.json` at runtime. Discovery only; install still happens via CLI/in-app. Zero backend.
 
 ## References
 

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -467,12 +467,16 @@
     }
 
     function setCopyState(btn, label, cls) {
+      if (btn._copyTimeoutId) {
+        clearTimeout(btn._copyTimeoutId);
+      }
       btn.textContent = label;
       btn.classList.remove("copied", "error");
       if (cls) btn.classList.add(cls);
-      setTimeout(() => {
+      btn._copyTimeoutId = setTimeout(() => {
         btn.textContent = "copy";
         btn.classList.remove("copied", "error");
+        btn._copyTimeoutId = null;
       }, 2000);
     }
 
@@ -515,15 +519,25 @@
       });
     }
 
+    const FETCH_TIMEOUT_MS = 10000;
+
+    async function fetchJson(url) {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(url, { cache: "no-cache", signal: controller.signal });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }
+
     async function fetchRegistry() {
       try {
-        const res = await fetch(REGISTRY_URL, { cache: "no-cache" });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return await res.json();
+        return await fetchJson(REGISTRY_URL);
       } catch {
-        const res = await fetch(FALLBACK_URL, { cache: "no-cache" });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return await res.json();
+        return await fetchJson(FALLBACK_URL);
       }
     }
 
@@ -532,12 +546,17 @@
         const raw = await fetchRegistry();
         if (!Array.isArray(raw)) throw new Error("registry not an array");
         const plugins = raw.filter(isValidPlugin);
-        if (plugins.length === 0) {
-          renderState(`No plugins listed yet. <a href="https://github.com/mattslight/oyster-community-plugins">Submit the first one</a>.`);
-          return;
+        const invalidCount = raw.length - plugins.length;
+        if (invalidCount > 0) {
+          console.warn(`[plugins] filtered ${invalidCount} invalid registry entries`);
         }
-        if (plugins.length < raw.length) {
-          console.warn(`[plugins] filtered ${raw.length - plugins.length} invalid registry entries`);
+        if (plugins.length === 0) {
+          if (raw.length === 0) {
+            renderState(`No plugins listed yet. <a href="https://github.com/mattslight/oyster-community-plugins">Submit the first one</a>.`);
+          } else {
+            renderState(`The registry has ${raw.length} ${raw.length === 1 ? "entry" : "entries"} but none passed validation. <a href="https://github.com/mattslight/oyster-community-plugins/issues">Report an issue</a>.`);
+          }
+          return;
         }
         root.innerHTML = plugins.map(renderCard).join("");
         bindCopyButtons();

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -1,0 +1,482 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plugins — Oyster</title>
+  <meta name="description" content="Community plugins for Oyster. Static apps, tools, and widgets that run on your workspace surface.">
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0b14;
+      color: #e0e0e0;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+
+    .bg {
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
+                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
+                  #0a0b14;
+      z-index: 0;
+    }
+
+    /* Back nav */
+    .back-nav {
+      position: fixed;
+      top: 16px;
+      left: 0;
+      right: 0;
+      z-index: 10;
+      display: flex;
+      justify-content: center;
+    }
+    .back-bar {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 20px;
+      background: rgba(13, 14, 26, 0.8);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 9999px;
+    }
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 500;
+      color: rgba(255,255,255,0.5);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .back-link:hover { color: #fff; }
+
+    /* Hero */
+    .hero {
+      position: relative;
+      z-index: 1;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 120px 24px 0;
+      text-align: center;
+    }
+    h1 {
+      font-size: clamp(32px, 5vw, 48px);
+      font-weight: 700;
+      line-height: 1.15;
+      color: #fff;
+      margin-bottom: 16px;
+    }
+    .subtitle {
+      font-size: 18px;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.5);
+      max-width: 560px;
+      margin: 0 auto;
+    }
+
+    /* Section */
+    .section {
+      position: relative;
+      z-index: 1;
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+    .section-label {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 1.5px;
+      text-transform: uppercase;
+      color: #7c6bff;
+      margin-bottom: 20px;
+      margin-top: 80px;
+    }
+
+    /* Plugin grid */
+    .plugins {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: 16px;
+    }
+    .plugin-card {
+      background: rgba(13, 14, 26, 0.7);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 16px;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .plugin-card:hover {
+      border-color: rgba(124, 107, 255, 0.3);
+      transform: translateY(-2px);
+    }
+    .plugin-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .plugin-name {
+      font-size: 18px;
+      font-weight: 600;
+      color: #fff;
+    }
+    .plugin-author {
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.4);
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .plugin-author a {
+      color: inherit;
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .plugin-author a:hover { color: #a99eff; }
+    .plugin-desc {
+      font-size: 14px;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.55);
+      flex-grow: 1;
+    }
+    .plugin-install {
+      position: relative;
+      background: rgba(13, 14, 26, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 8px;
+      padding: 10px 44px 10px 12px;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      color: #a99eff;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .copy-inline {
+      position: absolute;
+      top: 50%;
+      right: 6px;
+      transform: translateY(-50%);
+      background: rgba(124, 107, 255, 0.12);
+      border: 1px solid rgba(124, 107, 255, 0.2);
+      color: rgba(255, 255, 255, 0.5);
+      font-size: 10px;
+      font-family: 'IBM Plex Mono', monospace;
+      padding: 4px 8px;
+      border-radius: 5px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .copy-inline:hover {
+      background: rgba(124, 107, 255, 0.25);
+      color: #fff;
+    }
+    .copy-inline.copied {
+      background: rgba(80, 200, 120, 0.15);
+      border-color: rgba(80, 200, 120, 0.3);
+      color: rgba(80, 200, 120, 0.9);
+    }
+    .plugin-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .plugin-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: rgba(255, 255, 255, 0.4);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .plugin-link:hover { color: #a99eff; }
+
+    /* Empty / error / loading states */
+    .state {
+      text-align: center;
+      padding: 40px 24px;
+      color: rgba(255, 255, 255, 0.4);
+      font-size: 14px;
+    }
+    .state a {
+      color: #a99eff;
+      text-decoration: none;
+    }
+    .state a:hover { color: #fff; }
+
+    /* Submit CTA */
+    .submit-section {
+      position: relative;
+      z-index: 1;
+      max-width: 640px;
+      margin: 80px auto 0;
+      padding: 0 24px;
+      text-align: center;
+    }
+    .submit-card {
+      background: rgba(13, 14, 26, 0.7);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 16px;
+      padding: 32px 24px;
+    }
+    .submit-title {
+      font-size: 20px;
+      font-weight: 600;
+      color: #fff;
+      margin-bottom: 8px;
+    }
+    .submit-desc {
+      font-size: 14px;
+      color: rgba(255, 255, 255, 0.5);
+      line-height: 1.7;
+      margin-bottom: 20px;
+    }
+    .submit-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 20px;
+      background: rgba(124, 107, 255, 0.15);
+      border: 1px solid rgba(124, 107, 255, 0.3);
+      color: #fff;
+      font-size: 13px;
+      font-weight: 500;
+      border-radius: 9999px;
+      text-decoration: none;
+      transition: all 0.15s;
+    }
+    .submit-cta:hover {
+      background: rgba(124, 107, 255, 0.25);
+      border-color: rgba(124, 107, 255, 0.5);
+    }
+
+    /* Install CTA */
+    .install-section {
+      position: relative;
+      z-index: 1;
+      max-width: 640px;
+      margin: 60px auto 0;
+      padding: 0 24px 100px;
+      text-align: center;
+    }
+    .install-label {
+      font-size: 16px;
+      font-weight: 600;
+      color: #fff;
+      margin-bottom: 24px;
+    }
+    .terminal {
+      background: rgba(13, 14, 26, 0.95);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 12px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      overflow: hidden;
+      text-align: left;
+    }
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      padding: 12px 16px;
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      position: relative;
+    }
+    .terminal-dots { display: flex; gap: 6px; }
+    .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
+    .terminal-title {
+      position: absolute; left: 0; right: 0; text-align: center;
+      font-size: 11px; color: rgba(255,255,255,0.25);
+      font-family: 'IBM Plex Mono', monospace; pointer-events: none;
+    }
+    .terminal-body {
+      padding: 20px 24px 24px;
+      display: flex; flex-direction: column; gap: 10px;
+    }
+    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
+    .terminal-line code { font-family: 'IBM Plex Mono', monospace; font-size: clamp(16px, 2.5vw, 20px); color: #a99eff; }
+
+    /* Footer */
+    .footer {
+      position: relative;
+      z-index: 1;
+      text-align: center;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.3);
+      padding: 0 24px 60px;
+    }
+    .footer .heart { color: #e25555; }
+    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
+    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
+
+    @media (max-width: 600px) {
+      .hero { padding-top: 100px; }
+      .plugins { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="bg"></div>
+
+  <div class="back-nav">
+    <div class="back-bar">
+      <a class="back-link" href="/">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
+        </svg>
+        oyster.to
+      </a>
+    </div>
+  </div>
+
+  <div class="hero">
+    <h1>Plugins.</h1>
+    <p class="subtitle">Community-built apps, tools, and widgets that run on your Oyster surface. Install any with a single command.</p>
+  </div>
+
+  <div class="section">
+    <div class="section-label">Available</div>
+    <div id="plugins" class="plugins">
+      <div class="state">Loading plugins&hellip;</div>
+    </div>
+  </div>
+
+  <div class="submit-section">
+    <div class="submit-card">
+      <div class="submit-title">Built a plugin?</div>
+      <p class="submit-desc">The registry is an open repo. Submit a PR adding one entry to <code style="font-family:'IBM Plex Mono', monospace; color:#a99eff;">community-plugins.json</code> and your plugin lands here.</p>
+      <a class="submit-cta" href="https://github.com/mattslight/oyster-community-plugins">
+        Submit a plugin
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M7 17l10-10"/><path d="M7 7h10v10"/>
+        </svg>
+      </a>
+    </div>
+  </div>
+
+  <div class="install-section">
+    <div class="install-label">Don't have Oyster yet?</div>
+    <div class="terminal">
+      <div class="terminal-bar">
+        <div class="terminal-dots">
+          <span style="background: #ff5f57;"></span>
+          <span style="background: #febc2e;"></span>
+          <span style="background: #28c840;"></span>
+        </div>
+        <span class="terminal-title">terminal</span>
+      </div>
+      <div class="terminal-body">
+        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
+  </div>
+
+  <script>
+    const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-community-plugins/main/community-plugins.json";
+    const FALLBACK_URL = "https://cdn.jsdelivr.net/gh/mattslight/oyster-community-plugins@main/community-plugins.json";
+
+    const root = document.getElementById("plugins");
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, (c) => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+      }[c]));
+    }
+
+    function installCommand(plugin) {
+      return `git clone https://github.com/${plugin.repo} ~/.oyster/userland/${plugin.id}`;
+    }
+
+    function renderCard(plugin) {
+      const cmd = installCommand(plugin);
+      const authorHtml = plugin.authorUrl
+        ? `<a href="${escapeHtml(plugin.authorUrl)}" target="_blank" rel="noopener">${escapeHtml(plugin.author)}</a>`
+        : escapeHtml(plugin.author);
+      return `
+        <div class="plugin-card">
+          <div class="plugin-header">
+            <div class="plugin-name">${escapeHtml(plugin.name)}</div>
+            <div class="plugin-author">by ${authorHtml}</div>
+          </div>
+          <div class="plugin-desc">${escapeHtml(plugin.description)}</div>
+          <div class="plugin-install">
+            <span>${escapeHtml(cmd)}</span>
+            <button class="copy-inline" data-cmd="${escapeHtml(cmd)}">copy</button>
+          </div>
+          <div class="plugin-footer">
+            <a class="plugin-link" href="https://github.com/${escapeHtml(plugin.repo)}" target="_blank" rel="noopener">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56 0-.27-.01-1-.02-1.96-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.68-1.28-1.68-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.29 1.2-3.1-.12-.29-.52-1.47.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.58.23 2.76.11 3.05.75.81 1.2 1.84 1.2 3.1 0 4.42-2.69 5.38-5.25 5.67.41.36.78 1.06.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z"/></svg>
+              View on GitHub
+            </a>
+          </div>
+        </div>
+      `;
+    }
+
+    function renderState(html) {
+      root.innerHTML = `<div class="state">${html}</div>`;
+    }
+
+    function bindCopyButtons() {
+      root.querySelectorAll(".copy-inline").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          navigator.clipboard.writeText(btn.dataset.cmd).then(() => {
+            btn.textContent = "copied";
+            btn.classList.add("copied");
+            setTimeout(() => {
+              btn.textContent = "copy";
+              btn.classList.remove("copied");
+            }, 2000);
+          });
+        });
+      });
+    }
+
+    async function fetchRegistry() {
+      try {
+        const res = await fetch(REGISTRY_URL, { cache: "no-cache" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      } catch {
+        const res = await fetch(FALLBACK_URL, { cache: "no-cache" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      }
+    }
+
+    async function load() {
+      try {
+        const plugins = await fetchRegistry();
+        if (!Array.isArray(plugins) || plugins.length === 0) {
+          renderState(`No plugins listed yet. <a href="https://github.com/mattslight/oyster-community-plugins">Submit the first one</a>.`);
+          return;
+        }
+        root.innerHTML = plugins.map(renderCard).join("");
+        bindCopyButtons();
+      } catch (err) {
+        renderState(`Couldn't load the plugin registry. <a href="https://github.com/mattslight/oyster-community-plugins">View on GitHub</a>.`);
+        console.error(err);
+      }
+    }
+
+    load();
+  </script>
+</body>
+</html>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -188,6 +188,11 @@
       border-color: rgba(80, 200, 120, 0.3);
       color: rgba(80, 200, 120, 0.9);
     }
+    .copy-inline.error {
+      background: rgba(248, 113, 113, 0.15);
+      border-color: rgba(248, 113, 113, 0.35);
+      color: rgba(248, 113, 113, 0.9);
+    }
     .plugin-footer {
       display: flex;
       align-items: center;
@@ -392,6 +397,12 @@
     const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-community-plugins/main/community-plugins.json";
     const FALLBACK_URL = "https://cdn.jsdelivr.net/gh/mattslight/oyster-community-plugins@main/community-plugins.json";
 
+    // Strict patterns — the registry is user-submitted via PR, and the
+    // install command is copied into a user's shell. Reject anything that
+    // could smuggle shell metacharacters through `id` / `repo`.
+    const ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+    const REPO_PATTERN = /^[A-Za-z0-9_.-]{1,64}\/[A-Za-z0-9_.-]{1,64}$/;
+
     const root = document.getElementById("plugins");
 
     function escapeHtml(s) {
@@ -400,14 +411,35 @@
       }[c]));
     }
 
+    function sanitizeHttpUrl(url) {
+      if (!url) return null;
+      try {
+        const p = new URL(String(url));
+        return (p.protocol === "http:" || p.protocol === "https:") ? p.toString() : null;
+      } catch {
+        return null;
+      }
+    }
+
+    function isValidPlugin(p) {
+      return p && typeof p === "object"
+        && typeof p.id === "string" && ID_PATTERN.test(p.id)
+        && typeof p.repo === "string" && REPO_PATTERN.test(p.repo)
+        && typeof p.name === "string" && p.name.length > 0
+        && typeof p.author === "string" && p.author.length > 0
+        && typeof p.description === "string";
+    }
+
     function installCommand(plugin) {
+      // id and repo have been validated against strict patterns; safe to interpolate.
       return `git clone https://github.com/${plugin.repo} ~/.oyster/userland/${plugin.id}`;
     }
 
     function renderCard(plugin) {
       const cmd = installCommand(plugin);
-      const authorHtml = plugin.authorUrl
-        ? `<a href="${escapeHtml(plugin.authorUrl)}" target="_blank" rel="noopener">${escapeHtml(plugin.author)}</a>`
+      const authorUrl = sanitizeHttpUrl(plugin.authorUrl);
+      const authorHtml = authorUrl
+        ? `<a href="${escapeHtml(authorUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(plugin.author)}</a>`
         : escapeHtml(plugin.author);
       return `
         <div class="plugin-card">
@@ -421,7 +453,7 @@
             <button class="copy-inline" data-cmd="${escapeHtml(cmd)}">copy</button>
           </div>
           <div class="plugin-footer">
-            <a class="plugin-link" href="https://github.com/${escapeHtml(plugin.repo)}" target="_blank" rel="noopener">
+            <a class="plugin-link" href="https://github.com/${escapeHtml(plugin.repo)}" target="_blank" rel="noopener noreferrer">
               <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56 0-.27-.01-1-.02-1.96-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.68-1.28-1.68-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.29 1.2-3.1-.12-.29-.52-1.47.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.78 0c2.21-1.49 3.18-1.18 3.18-1.18.63 1.58.23 2.76.11 3.05.75.81 1.2 1.84 1.2 3.1 0 4.42-2.69 5.38-5.25 5.67.41.36.78 1.06.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z"/></svg>
               View on GitHub
             </a>
@@ -434,17 +466,51 @@
       root.innerHTML = `<div class="state">${html}</div>`;
     }
 
+    function setCopyState(btn, label, cls) {
+      btn.textContent = label;
+      btn.classList.remove("copied", "error");
+      if (cls) btn.classList.add(cls);
+      setTimeout(() => {
+        btn.textContent = "copy";
+        btn.classList.remove("copied", "error");
+      }, 2000);
+    }
+
+    function fallbackCopyText(text) {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "absolute";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        return document.execCommand("copy");
+      } catch {
+        return false;
+      } finally {
+        document.body.removeChild(ta);
+      }
+    }
+
+    async function copyToClipboard(text) {
+      if (!text) return false;
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        try {
+          await navigator.clipboard.writeText(text);
+          return true;
+        } catch {
+          return fallbackCopyText(text);
+        }
+      }
+      return fallbackCopyText(text);
+    }
+
     function bindCopyButtons() {
       root.querySelectorAll(".copy-inline").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          navigator.clipboard.writeText(btn.dataset.cmd).then(() => {
-            btn.textContent = "copied";
-            btn.classList.add("copied");
-            setTimeout(() => {
-              btn.textContent = "copy";
-              btn.classList.remove("copied");
-            }, 2000);
-          });
+        btn.addEventListener("click", async () => {
+          const ok = await copyToClipboard(btn.dataset.cmd || "");
+          setCopyState(btn, ok ? "copied" : "copy failed", ok ? "copied" : "error");
         });
       });
     }
@@ -463,10 +529,15 @@
 
     async function load() {
       try {
-        const plugins = await fetchRegistry();
-        if (!Array.isArray(plugins) || plugins.length === 0) {
+        const raw = await fetchRegistry();
+        if (!Array.isArray(raw)) throw new Error("registry not an array");
+        const plugins = raw.filter(isValidPlugin);
+        if (plugins.length === 0) {
           renderState(`No plugins listed yet. <a href="https://github.com/mattslight/oyster-community-plugins">Submit the first one</a>.`);
           return;
+        }
+        if (plugins.length < raw.length) {
+          console.warn(`[plugins] filtered ${raw.length - plugins.length} invalid registry entries`);
         }
         root.innerHTML = plugins.map(renderCard).join("");
         bindCopyButtons();


### PR DESCRIPTION
## Summary

- Adds `/plugins` to oyster.to — a community plugin discovery page that renders [`community-plugins.json`](https://github.com/mattslight/oyster-community-plugins) at runtime (GitHub raw, with jsDelivr fallback). Card grid, copy-install-command, View-on-GitHub per plugin.
- Adds a **Plugins** nav link on the home page.
- Adds `docs/plans/plugin-system.md` documenting the plugin/app system: three-tier install model (manual drop-in → CLI install → curated directory), runtime taxonomy (`static` / `bundle` / `mcp` / `panel`), and lessons from Obsidian's plugin architecture.

## Related repos (not in this PR)

- [`mattslight/oyster-sample-plugin`](https://github.com/mattslight/oyster-sample-plugin) — starter template, Pomodoro timer, v0.1.0 released
- [`mattslight/oyster-community-plugins`](https://github.com/mattslight/oyster-community-plugins) — registry repo seeded with pomodoro

## Tier 1 install (works today)

```bash
git clone https://github.com/mattslight/oyster-sample-plugin ~/.oyster/userland/pomodoro
# restart oyster
```

## Test plan

- [ ] Merge → GitHub Pages rebuilds → visit https://oyster.to/plugins — pomodoro card should render
- [ ] Copy-install-command button works, hover states render, GitHub link opens correct repo
- [ ] Nav link on home page navigates to /plugins
- [ ] Page degrades gracefully if registry fetch fails (shows "Couldn't load…" state)

## Note

Couldn't visually verify in a browser this session — Chrome extension unavailable. Confirmed non-visually: HTML structure parses, registry JSON fetches successfully from the public URL the page will call, fallback CDN resolves. Recommend a visual spot-check after deploy before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)