### PR TITLE
feat(cli): oyster install <id> resolves via community registry

### DIFF
--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -14,6 +14,7 @@ import { pipeline } from "node:stream/promises";
 const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB cap on plugin bundles
 const DOWNLOAD_TIMEOUT_MS = 60_000;
 const API_TIMEOUT_MS = 10_000;
+const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-community-plugins/main/community-plugins.json";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = join(__dirname, "..");
@@ -57,18 +58,44 @@ function printHelp() {
 
   Usage:
     oyster                            Start the server (default)
-    oyster install <owner>/<repo>     Install a plugin from its latest GitHub release
+    oyster install <id|owner/repo>    Install a plugin by registry id, or directly from a repo
     oyster uninstall <id>             Remove an installed plugin
     oyster list                       List installed plugins
     oyster --version                  Print version
     oyster --help                     Show this help
+
+  Examples:
+    oyster install pomodoro                           # resolved via community registry
+    oyster install mattslight/oyster-sample-plugin    # explicit repo path
 `);
 }
 
-async function cmdInstall(repo) {
-  if (!repo || !REPO_PATTERN.test(repo)) {
-    throw new Error("install expects <owner>/<repo>, e.g. 'oyster install mattslight/oyster-sample-plugin'");
+async function resolvePluginArg(arg) {
+  if (!arg) {
+    throw new Error("install expects a plugin id or <owner>/<repo>, e.g. 'oyster install pomodoro'");
   }
+  if (REPO_PATTERN.test(arg)) return arg;
+  if (!PLUGIN_ID_PATTERN.test(arg)) {
+    throw new Error(`'${arg}' is neither a valid plugin id nor an <owner>/<repo> path.`);
+  }
+  console.log(`\n  Looking up '${arg}' in the community registry...`);
+  const registry = await fetchJson(REGISTRY_URL);
+  if (!Array.isArray(registry)) {
+    throw new Error("Registry response was not a JSON array — ask the registry maintainer.");
+  }
+  const entry = registry.find((p) => p && p.id === arg);
+  if (!entry) {
+    throw new Error(`'${arg}' is not listed in the community registry. Try 'oyster install <owner>/<repo>' for plugins that aren't listed, or browse https://oyster.to/plugins.`);
+  }
+  if (!entry.repo || !REPO_PATTERN.test(entry.repo)) {
+    throw new Error(`Registry entry for '${arg}' has an invalid 'repo' field: '${entry.repo}'.`);
+  }
+  console.log(`  → ${entry.repo}`);
+  return entry.repo;
+}
+
+async function cmdInstall(arg) {
+  const repo = await resolvePluginArg(arg);
 
   console.log(`\n  Fetching latest release of ${repo}...`);
   const release = await fetchJson(`https://api.github.com/repos/${repo}/releases/latest`);

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -14,6 +14,10 @@ import { pipeline } from "node:stream/promises";
 const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB cap on plugin bundles
 const DOWNLOAD_TIMEOUT_MS = 60_000;
 const API_TIMEOUT_MS = 10_000;
+// The community registry is the trust root for `oyster install <id>`. A merged
+// PR to that repo can redirect any id to any repo — delegation is to the
+// registry maintainer, not verified here. Direct `oyster install <owner>/<repo>`
+// bypasses the registry entirely.
 const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-community-plugins/main/community-plugins.json";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -70,11 +74,15 @@ function printHelp() {
 `);
 }
 
+// Returns { repo, expectedId } — expectedId is set only when arg was resolved
+// via the registry, letting the caller assert the downloaded manifest.id
+// matches what the user typed. For direct <owner>/<repo> installs there's
+// nothing to cross-check against, so expectedId is null.
 async function resolvePluginArg(arg) {
   if (!arg) {
     throw new Error("install expects a plugin id or <owner>/<repo>, e.g. 'oyster install pomodoro'");
   }
-  if (REPO_PATTERN.test(arg)) return arg;
+  if (REPO_PATTERN.test(arg)) return { repo: arg, expectedId: null };
   if (!PLUGIN_ID_PATTERN.test(arg)) {
     throw new Error(`'${arg}' is neither a valid plugin id nor an <owner>/<repo> path.`);
   }
@@ -83,19 +91,23 @@ async function resolvePluginArg(arg) {
   if (!Array.isArray(registry)) {
     throw new Error("Registry response was not a JSON array — ask the registry maintainer.");
   }
-  const entry = registry.find((p) => p && p.id === arg);
-  if (!entry) {
+  const matches = registry.filter((p) => p && p.id === arg);
+  if (matches.length === 0) {
     throw new Error(`'${arg}' is not listed in the community registry. Try 'oyster install <owner>/<repo>' for plugins that aren't listed, or browse https://oyster.to/plugins.`);
   }
+  if (matches.length > 1) {
+    throw new Error(`Registry has ${matches.length} entries with id '${arg}' — report this to the registry maintainer.`);
+  }
+  const entry = matches[0];
   if (!entry.repo || !REPO_PATTERN.test(entry.repo)) {
     throw new Error(`Registry entry for '${arg}' has an invalid 'repo' field: '${entry.repo}'.`);
   }
   console.log(`  → ${entry.repo}`);
-  return entry.repo;
+  return { repo: entry.repo, expectedId: arg };
 }
 
 async function cmdInstall(arg) {
-  const repo = await resolvePluginArg(arg);
+  const { repo, expectedId } = await resolvePluginArg(arg);
 
   console.log(`\n  Fetching latest release of ${repo}...`);
   const release = await fetchJson(`https://api.github.com/repos/${repo}/releases/latest`);
@@ -121,6 +133,9 @@ async function cmdInstall(arg) {
     const manifest = JSON.parse(readFileSync(join(manifestRoot, "manifest.json"), "utf8"));
     if (!manifest.id || !PLUGIN_ID_PATTERN.test(manifest.id)) {
       throw new Error(`Invalid plugin id in manifest: '${manifest.id}'. Must match ${PLUGIN_ID_PATTERN}.`);
+    }
+    if (expectedId && manifest.id !== expectedId) {
+      throw new Error(`Registry mismatch: '${expectedId}' points to ${repo}, but that plugin declares id '${manifest.id}'. Refusing install so 'oyster uninstall ${expectedId}' stays honest. Report to the registry maintainer.`);
     }
 
     const userlandDir = join(OYSTER_HOME, "userland");


### PR DESCRIPTION
## Summary

Makes \`oyster install pomodoro\` work — the CLI now resolves a bare id via \`community-plugins.json\` before fetching the GitHub release. The explicit \`<owner>/<repo>\` form still works for plugins not yet in the registry.

## Why

Without this, users had to know the full repo path to install anything, which defeats the purpose of having a community registry. The registry was already the source of truth for discovery; making it the resolver too is the natural move. Matches how Obsidian, Homebrew, npm, and apt all work.

## Design decision: single canonical identifier

Considered introducing a separate \`slug\` / \`shortname\` field on registry entries. Rejected:

- Two namespaces doubles uniqueness enforcement + disambiguation overhead
- The manifest \`id\` regex (\`^[a-z0-9][a-z0-9-]{0,63}$\`) already produces slug-friendly ids
- No major package manager does this

So: one \`id\` per plugin — used as registry key, install folder name, CLI argument, and human-facing short name.

## Resolution order in the CLI

1. If arg matches \`<owner>/<repo>\` → treat as explicit repo, skip registry
2. Else if arg matches \`PLUGIN_ID_PATTERN\` → GET \`community-plugins.json\`, find entry by \`id\`, use its \`repo\`
3. Else → reject with clear usage

## Error UX

- \`oyster install nosuchplugin\` → *\"'nosuchplugin' is not listed in the community registry. Try 'oyster install <owner>/<repo>' for plugins that aren't listed, or browse https://oyster.to/plugins.\"*
- Registry unreachable → existing API-timeout error
- Registry entry with malformed \`repo\` → clear error

## Tested end-to-end

- \`oyster install pomodoro\` → ✓ resolves via registry, installs
- \`oyster install mattslight/oyster-sample-plugin\` → ✓ direct form still works
- \`oyster install nosuchplugin\` → ✓ clean error pointing to registry + explicit-form escape hatch
- Round-trip (uninstall → install) still clean

## Test plan

- [ ] \`oyster install pomodoro\` works without knowing the repo path
- [ ] \`oyster install mattslight/oyster-sample-plugin\` continues to work
- [ ] \`oyster install unknown-plugin\` gives helpful error
- [ ] Behaviour unchanged when the registry is temporarily unavailable (errors clearly, doesn't proceed with a bad repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)