### PR TITLE
docs(plugins): copy button uses 'oyster install <id>'

### DIFF
--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -450,8 +450,8 @@
     }
 
     function installCommand(plugin) {
-      // id and repo have been validated against strict patterns; safe to interpolate.
-      return `git clone https://github.com/${plugin.repo} ~/.oyster/userland/${plugin.id}`;
+      // id has been validated against strict patterns; safe to interpolate.
+      return `oyster install ${plugin.id}`;
     }
 
     function renderCard(plugin) {


### PR DESCRIPTION
## Summary

oyster-os 0.3.3 ships the install CLI with community-registry resolution. The copy button on each plugin card can now give the real one-liner.

**Before:** \`git clone https://github.com/mattslight/oyster-sample-plugin ~/.oyster/userland/pomodoro\`
**After:** \`oyster install pomodoro\`

One-line change in \`installCommand()\`.

## Test plan

- [ ] Merge → Pages rebuild → visit https://oyster.to/plugins
- [ ] Copy button on the Pomodoro card copies \`oyster install pomodoro\`
- [ ] Paste into a terminal → CLI installs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)