### PR TITLE
ci: bump release workflow actions for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: npm
+    # Third-party action versions are pinned to exact tags (not floating @vN majors)
+    # so that a compromised or accidentally-published bad release on the same major
+    # branch does not land in our CI automatically. Manual bumps for now; revisit
+    # once Dependabot/Renovate is configured for this repo.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -50,7 +54,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v3.0.0
         with:
           name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -50,7 +50,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.notes }}


### PR DESCRIPTION
## Summary

GitHub Actions deprecated Node.js 20 — actions pinned to it will be force-upgraded to Node 24 on **2026-06-02**. Bump to current majors that already support Node 24. On review, also pin to exact tags rather than floating majors, to avoid pulling a compromised or mistakenly-published release on the same major branch.

| Action | From | To | Reason |
|---|---|---|---|
| \`actions/checkout\` | \`@v4\` (Node 20) | \`@v6.0.2\` | current latest; Node 24 ready |
| \`actions/setup-node\` | \`@v4\` (Node 20) | \`@v6.3.0\` | current latest; Node 24 ready |
| \`softprops/action-gh-release\` | \`@v2\` (Node 20) | \`@v3.0.0\` | current latest |

## Pinning strategy

**Exact tags, not floating majors.** A floating \`@v6\` would pull whatever lands on the major branch next — including any compromised or bad release. Exact tags mean manual bumps for now, which is fine at three actions.

**Full commit SHAs** are GitHub's strongest recommendation, but SHA pins go stale fast without automation. Tracked as #139 — once Dependabot is configured, the actions should move to SHA pins.

## Verification

The release workflow only fires on \`v*\` tags, so this PR can't be tested in isolation. It'll be exercised on the next \`npm run release\`. Revert is trivial if anything breaks.

## Test plan

- [ ] Merge
- [ ] On next \`npm run release\`, CI completes cleanly with no Node 20 deprecation warnings
- [ ] npm package publishes correctly
- [ ] GitHub release is created with correct changelog notes

## Related

- #139 — Dependabot follow-up (unblocks SHA pinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)