### PR TITLE
fix(surface): stale tiles linger after oyster uninstall <id>

### DIFF
--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, unlinkSync, statSync } from "node:fs";
 import { resolve, basename, dirname, join, sep } from "node:path";
 import crypto from "node:crypto";
 import type { ArtifactStore, ArtifactRow } from "./artifact-store.js";
@@ -30,6 +30,27 @@ function parseJson(raw: string): Record<string, unknown> {
   }
 }
 
+function storagePathOf(row: ArtifactRow): string | undefined {
+  if (row.storage_kind !== "filesystem") return undefined;
+  const parsed = parseJson(row.storage_config);
+  return typeof parsed.path === "string" ? parsed.path : undefined;
+}
+
+// Returns true if the path exists, false only on ENOENT/ENOTDIR, and rethrows
+// on any other error (permissions, transient IO). Narrower than existsSync,
+// which would swallow those and let us wipe DB rows whose backing files are
+// temporarily inaccessible (e.g. synced drive offline, permission glitch).
+function pathExistsOrThrow(path: string): boolean {
+  try {
+    statSync(path);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    throw err;
+  }
+}
+
 const KIND_EXT: Record<ArtifactKind, string> = {
   notes: ".md", diagram: ".mmd",
   app: ".html", deck: ".html", wireframe: ".html", table: ".html", map: ".html",
@@ -43,21 +64,26 @@ export class ArtifactService {
   async getAllArtifacts(onArtifactRemoved?: (id: string, filePath: string) => void): Promise<Artifact[]> {
     const allRows = this.store.getAll();
 
-    // Self-heal: drop DB rows whose filesystem backing no longer exists.
+    // Self-heal: drop DB rows whose filesystem backing is definitively gone.
     // Happens after `oyster uninstall <id>`, manual folder removal, or a
     // crashed install. The in-memory map already self-heals; this closes
     // the same loop for persisted rows so the surface doesn't show ghosts.
+    //
+    // Rows with a filesystem path get their existence checked via
+    // pathExistsOrThrow (narrower than existsSync — only ENOENT/ENOTDIR
+    // counts as "gone", so a temporary permission blip doesn't wipe data).
+    // Parsed paths are cached to avoid re-parsing storage_config below.
     const rows: ArtifactRow[] = [];
+    const pathByRowIdx = new Map<number, string>();
     for (const row of allRows) {
-      if (row.storage_kind === "filesystem") {
-        try {
-          const path = (JSON.parse(row.storage_config) as { path?: string }).path;
-          if (path && !existsSync(path)) {
-            this.store.remove(row.id);
-            onArtifactRemoved?.(row.id, path);
-            continue;
-          }
-        } catch { /* malformed storage_config — leave row alone */ }
+      const storagePath = storagePathOf(row);
+      if (storagePath) {
+        if (!pathExistsOrThrow(storagePath)) {
+          this.store.remove(row.id);
+          onArtifactRemoved?.(row.id, storagePath);
+          continue;
+        }
+        pathByRowIdx.set(rows.length, storagePath);
       }
       rows.push(row);
     }
@@ -66,11 +92,8 @@ export class ArtifactService {
 
     // Map of filePath → persisted artifact index — used to suppress and merge gen: twins
     const dbPathToIdx = new Map<string, number>();
-    for (let i = 0; i < rows.length; i++) {
-      try {
-        const p = (JSON.parse(rows[i].storage_config) as { path?: string }).path;
-        if (p) dbPathToIdx.set(p, i);
-      } catch {}
+    for (const [idx, storagePath] of pathByRowIdx) {
+      dbPathToIdx.set(storagePath, idx);
     }
 
     const entries = getGeneratedArtifactEntries(onArtifactRemoved);

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -41,7 +41,27 @@ export class ArtifactService {
   constructor(private store: ArtifactStore, private userlandDir?: string) {}
 
   async getAllArtifacts(onArtifactRemoved?: (id: string, filePath: string) => void): Promise<Artifact[]> {
-    const rows = this.store.getAll();
+    const allRows = this.store.getAll();
+
+    // Self-heal: drop DB rows whose filesystem backing no longer exists.
+    // Happens after `oyster uninstall <id>`, manual folder removal, or a
+    // crashed install. The in-memory map already self-heals; this closes
+    // the same loop for persisted rows so the surface doesn't show ghosts.
+    const rows: ArtifactRow[] = [];
+    for (const row of allRows) {
+      if (row.storage_kind === "filesystem") {
+        try {
+          const path = (JSON.parse(row.storage_config) as { path?: string }).path;
+          if (path && !existsSync(path)) {
+            this.store.remove(row.id);
+            onArtifactRemoved?.(row.id, path);
+            continue;
+          }
+        } catch { /* malformed storage_config — leave row alone */ }
+      }
+      rows.push(row);
+    }
+
     const persisted = await Promise.all(rows.map((row) => this.rowToArtifact(row)));
 
     // Map of filePath → persisted artifact index — used to suppress and merge gen: twins


### PR DESCRIPTION
## Bug

After \`oyster uninstall <id>\`, the plugin's icon stayed on the desktop indefinitely — even across browser refreshes.

## Root cause

The in-memory generated-artifact map self-heals (\`getGeneratedArtifactEntries\` removes entries whose filePath no longer exists). But plugins installed via manifest get reconciled into SQLite at boot (\`server/src/index.ts:192\`), and the persisted row was never checked for filesystem backing. \`getAllArtifacts\` returned the row every poll, the UI rendered the tile.

## Fix

One ~15-line addition in \`getAllArtifacts\`: before building the response, iterate rows with \`storage_kind: filesystem\`, check \`existsSync(path)\`, and call \`store.remove\` for any whose backing file is gone. The existing \`onArtifactRemoved\` callback now fires for both in-memory and persisted cases.

Web client already polls \`/api/artifacts\` every 5 s, so ghost tiles clear within one poll of the uninstall — no CLI→server ping, no new endpoint, no file watcher.

## Out of scope

Install-side hot-reload (tracked as #136) is a different problem with a different fix. This PR only closes the uninstall ghost-tile loop.

## Test plan

- [ ] Build + run updated server
- [ ] \`oyster install pomodoro\` — tile appears after restart (expected, separate issue)
- [ ] \`oyster uninstall pomodoro\` — tile disappears within ~5 s, no restart, no refresh needed
- [ ] Folders that never had a DB row (in-memory only) continue to clean up via the existing path
- [ ] \`getAllArtifacts\` still returns builtins correctly (they are filesystem-backed but only live in the in-memory map, not the DB; the check is a no-op for them)
- [ ] Rows with malformed \`storage_config\` JSON are left alone rather than spuriously removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)