### PR TITLE
chore(cli): 🦪 in oyster --help header

### DIFF
--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -58,7 +58,7 @@ if (cmd && !cmd.startsWith("-")) {
 
 function printHelp() {
   console.log(`
-  Oyster — prompt-controlled workspace OS
+  🦪 Oyster — prompt-controlled workspace OS
 
   Usage:
     oyster                            Start the server (default)


### PR DESCRIPTION
Matches the emoji the server already prints in its startup banner. Drive-by visual consistency.