### PR TITLE
docs: swap to Barlow, rename /plugins hero to 'Pearls'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Oyster — From prompt to workspace.</title>
   <meta name="description" content="From prompt to workspace. The OS that understands your projects, remembers your work, and acts from one prompt. Powered by MCP — bring any AI.">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { scroll-padding-top: 60px; }
 
     body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: 'Barlow', -apple-system, BlinkMacSystemFont, sans-serif;
       background: #0a0b14;
       color: #e0e0e0;
       min-height: 100vh;
@@ -593,10 +593,10 @@
     <div class="feature-mock">
       <div class="mock-panel" style="padding: 0; overflow: hidden;">
         <div style="display: flex; gap: 2px; padding: 6px 6px 0; background: rgba(255,255,255,0.02);">
-          <button onclick="showMcpTab('claude-code')" class="mcp-tab mcp-tab-active" style="padding: 8px 14px; font-size: 11px; font-family: 'Space Grotesk', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Claude Code</button>
-          <button onclick="showMcpTab('cursor')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Space Grotesk', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Cursor</button>
-          <button onclick="showMcpTab('vscode')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Space Grotesk', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">VS Code</button>
-          <button onclick="showMcpTab('windsurf')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Space Grotesk', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Windsurf</button>
+          <button onclick="showMcpTab('claude-code')" class="mcp-tab mcp-tab-active" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Claude Code</button>
+          <button onclick="showMcpTab('cursor')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Cursor</button>
+          <button onclick="showMcpTab('vscode')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">VS Code</button>
+          <button onclick="showMcpTab('windsurf')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Windsurf</button>
         </div>
         <div style="padding: 16px;">
           <div id="mcp-claude-code" class="mcp-panel" style="display: block;">
@@ -660,24 +660,24 @@
           <!-- View 1: Kanban -->
           <div class="dui-view dui-active" data-view="0" style="display: flex; gap: 8px;">
             <div style="flex: 1;">
-              <div style="font-size: 9px; font-weight: 600; color: #a99eff; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px;">To Do</div>
+              <div style="font-size: 11px; font-weight: 600; color: #a99eff; text-transform: uppercase; letter-spacing: 2px; margin-bottom: 8px;">To Do</div>
               <div style="display: flex; flex-direction: column; gap: 6px;">
                 <div style="padding: 8px 10px; background: rgba(255,255,255,0.04); border-radius: 8px; font-size: 11px; color: rgba(255,255,255,0.6); border-left: 2px solid #fb7185;">Review proposal</div>
                 <div style="padding: 8px 10px; background: rgba(255,255,255,0.04); border-radius: 8px; font-size: 11px; color: rgba(255,255,255,0.6); border-left: 2px solid #fbbf24;">Chase invoice</div>
               </div>
             </div>
             <div style="flex: 1;">
-              <div style="font-size: 9px; font-weight: 600; color: #36d399; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px;">In Progress</div>
+              <div style="font-size: 11px; font-weight: 600; color: #36d399; text-transform: uppercase; letter-spacing: 2px; margin-bottom: 8px;">In Progress</div>
               <div style="padding: 8px 10px; background: rgba(255,255,255,0.04); border-radius: 8px; font-size: 11px; color: rgba(255,255,255,0.6); border-left: 2px solid #4dc9f6;">Client onboarding</div>
             </div>
             <div style="flex: 1;">
-              <div style="font-size: 9px; font-weight: 600; color: rgba(255,255,255,0.3); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px;">Done</div>
+              <div style="font-size: 11px; font-weight: 600; color: rgba(255,255,255,0.3); text-transform: uppercase; letter-spacing: 2px; margin-bottom: 8px;">Done</div>
               <div style="padding: 8px 10px; background: rgba(255,255,255,0.04); border-radius: 8px; font-size: 11px; color: rgba(255,255,255,0.35); border-left: 2px solid rgba(255,255,255,0.15);">Send contract</div>
             </div>
           </div>
           <!-- View 2: Chart/Report -->
           <div class="dui-view" data-view="1">
-            <div style="font-size: 10px; font-weight: 600; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px;">Q1 Progress</div>
+            <div style="font-size: 12px; font-weight: 600; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 2px; margin-bottom: 12px;">Q1 Progress</div>
             <div style="display: flex; align-items: flex-end; gap: 8px; height: 100px; padding-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,0.06);">
               <div style="flex: 1; background: rgba(124,107,255,0.3); border-radius: 4px 4px 0 0; height: 40%;"></div>
               <div style="flex: 1; background: rgba(124,107,255,0.4); border-radius: 4px 4px 0 0; height: 55%;"></div>
@@ -697,7 +697,7 @@
           </div>
           <!-- View 3: List/Table -->
           <div class="dui-view" data-view="2">
-            <div style="font-size: 10px; font-weight: 600; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 10px;">Recent Activity</div>
+            <div style="font-size: 12px; font-weight: 600; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 2px; margin-bottom: 10px;">Recent Activity</div>
             <div style="display: flex; flex-direction: column; gap: 1px;">
               <div style="display: flex; justify-content: space-between; padding: 8px 10px; background: rgba(255,255,255,0.03); border-radius: 6px; font-size: 11px;">
                 <span style="color: rgba(255,255,255,0.6);">Competitor Analysis updated</span>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bring Your Own AI — Oyster</title>
   <meta name="description" content="Bring your own AI — connect Claude Code, Cursor, VS Code, Windsurf or any MCP-compatible tool to Oyster.">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: 'Barlow', -apple-system, BlinkMacSystemFont, sans-serif;
       background: #0a0b14;
       color: #e0e0e0;
       min-height: 100vh;
@@ -96,9 +96,9 @@
     }
 
     .section-label {
-      font-size: 11px;
+      font-size: 13px;
       font-weight: 600;
-      letter-spacing: 1.5px;
+      letter-spacing: 2.5px;
       text-transform: uppercase;
       color: #7c6bff;
       margin-bottom: 20px;
@@ -255,7 +255,7 @@
       text-align: center;
     }
     .install-label {
-      font-size: 16px;
+      font-size: 22px;
       font-weight: 600;
       color: #fff;
       margin-bottom: 24px;

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Plugins — Oyster</title>
   <meta name="description" content="Community plugins for Oyster. Static apps, tools, and widgets that run on your workspace surface.">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: 'Barlow', -apple-system, BlinkMacSystemFont, sans-serif;
       background: #0a0b14;
       color: #e0e0e0;
       min-height: 100vh;
@@ -76,6 +76,14 @@
       color: #fff;
       margin-bottom: 16px;
     }
+    .rename-strike {
+      color: rgba(255, 255, 255, 0.32);
+      text-decoration: line-through;
+      text-decoration-thickness: 4px;
+      text-decoration-color: rgba(255, 255, 255, 0.6);
+      font-weight: 500;
+      margin-right: 0.25em;
+    }
     .subtitle {
       font-size: 18px;
       line-height: 1.7;
@@ -93,9 +101,9 @@
       padding: 0 24px;
     }
     .section-label {
-      font-size: 11px;
+      font-size: 13px;
       font-weight: 600;
-      letter-spacing: 1.5px;
+      letter-spacing: 2.5px;
       text-transform: uppercase;
       color: #7c6bff;
       margin-bottom: 20px;
@@ -242,7 +250,7 @@
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
     }
     .submit-title {
-      font-size: 20px;
+      font-size: 22px;
       font-weight: 600;
       color: #fff;
       margin-bottom: 8px;
@@ -298,7 +306,7 @@
       text-align: center;
     }
     .install-label {
-      font-size: 16px;
+      font-size: 22px;
       font-weight: 600;
       color: #fff;
       margin-bottom: 24px;
@@ -366,8 +374,8 @@
   </div>
 
   <div class="hero">
-    <h1>Plugins.</h1>
-    <p class="subtitle">Community-built apps, tools, and widgets that run on your Oyster surface. Install any with a single command.</p>
+    <h1><span class="rename-strike">Plugins.</span> Pearls.</h1>
+    <p class="subtitle">Apps, tools, and widgets the community drops inside your shell. Install any with a single command.</p>
   </div>
 
   <div class="section">

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -374,7 +374,7 @@
   </div>
 
   <div class="hero">
-    <h1><span class="rename-strike">Plugins.</span> Pearls.</h1>
+    <h1><span class="rename-strike" aria-hidden="true">Plugins.</span> Pearls.</h1>
     <p class="subtitle">Apps, tools, and widgets the community drops inside your shell. Install any with a single command.</p>
   </div>
 


### PR DESCRIPTION
## Summary

Site-wide font swap (Space Grotesk → Barlow) plus a voice-giving rename on \`/plugins\` (H1 now reads **~~Plugins.~~ Pearls.**).

### Fonts
- Body and headings: \`Space Grotesk\` → \`Barlow\` (400/500/600/700)
- Code font: \`IBM Plex Mono\` unchanged
- Eyebrows stay in regular Barlow (tried Barlow Condensed briefly, didn't land)

### Type tweaks to match Barlow's optical size
Barlow reads a shade smaller than Space Grotesk at the same numeric px, and tracked-uppercase eyebrows were feeling cramped. Nudged across the board:

| Element | Before | After |
|---|---|---|
| \`.section-label\` on /mcp and /plugins | 11px, 1.5px tracking | 13px, 2.5px tracking |
| Inline eyebrow labels inside the home-page mock | 9px/10px, 1px tracking | 11px/12px, 2px tracking |
| \`.install-label\` ("Don't have Oyster yet?") on /mcp and /plugins | 16px | 22px |
| \`.submit-title\` ("Built a plugin?") on /plugins | 20px | 22px |

### /plugins rename: Plugins → Pearls

The H1 is now \`<span class="rename-strike">Plugins.</span> Pearls.\` — a literal rename reveal. SEO, nav, URL, and page copy all still say "Plugins" so nothing breaks for search or muscle memory; the hero just gives the page its own voice and ties into the oyster metaphor.

Subtitle reworded: *"Apps, tools, and widgets the community drops inside your shell. Install any with a single command."*

\`.rename-strike\`: muted white (0.32), 4px-thick line-through at 0.6 alpha, regular (500) weight so "Pearls." carries the visual weight.

## Preview

Once merged + Pages rebuild: https://oyster.to, https://oyster.to/mcp, https://oyster.to/plugins

## Test plan

- [ ] Merge → Pages deploys → visit all three pages, compare against cached copies
- [ ] Font renders as Barlow (check DevTools computed font-family)
- [ ] /plugins hero renders the strike correctly in Chrome, Safari, Firefox (text-decoration-thickness support is universal in modern browsers)
- [ ] Eyebrows on home page mock don't clip / overflow
- [ ] Nav pill and buttons still legible at the new sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)