### PR TITLE
feat(desktop): right-click artifact / folder actions + Archived view

### DIFF
--- a/server/src/artifact-detector.ts
+++ b/server/src/artifact-detector.ts
@@ -122,6 +122,9 @@ function registerArtifactFromManifest(
   seenArtifacts.add(id);
 
   const builtin = manifest.builtin === true;
+  // Manifest-based non-builtin entries are third-party plugins installed
+  // via `oyster install`. The UI branches on this for Uninstall vs Archive.
+  const plugin = !builtin;
 
   if (generating) {
     console.log(`[artifact-detect] generating: ${manifest.name} (${manifest.type})`);
@@ -135,7 +138,7 @@ function registerArtifactFromManifest(
       runtimeKind: "static_file",
       runtimeConfig: {},
       createdAt: manifest.created_at,
-    }, undefined, builtin); // No filePath — prevents self-healing deletion while entrypoint doesn't exist
+    }, undefined, builtin, plugin); // No filePath — prevents self-healing deletion while entrypoint doesn't exist
     generatingArtifacts.set(id, {
       name: manifest.name,
       type: manifest.type,
@@ -156,7 +159,7 @@ function registerArtifactFromManifest(
       runtimeConfig: {},
       createdAt: manifest.created_at,
       ...detectExistingIcon(artifactDir),
-    }, entrypointPath, builtin);
+    }, entrypointPath, builtin, plugin);
     iconGenerator.enqueue(id, manifest.name, manifest.type, artifactDir);
   }
 }

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -59,6 +59,13 @@ const KIND_EXT: Record<ArtifactKind, string> = {
 // ── Service ──
 
 export class ArtifactService {
+  // Archived-paths cache: /api/artifacts polls every 5s and each hit used
+  // to re-run the archived-rows SQL + Set construction. Cache the Set in
+  // memory, invalidate on any call that mutates removed_at. Stays O(active
+  // artifacts) in steady state instead of O(archived).
+  private archivedPathsCache: Set<string> | null = null;
+  private invalidateArchivedPaths(): void { this.archivedPathsCache = null; }
+
   constructor(private store: ArtifactStore, private userlandDir?: string) {}
 
   async getAllArtifacts(onArtifactRemoved?: (id: string, filePath: string) => void): Promise<Artifact[]> {
@@ -80,6 +87,7 @@ export class ArtifactService {
       if (storagePath) {
         if (!pathExistsOrThrow(storagePath)) {
           this.store.remove(row.id);
+          this.invalidateArchivedPaths();
           onArtifactRemoved?.(row.id, storagePath);
           continue;
         }
@@ -207,6 +215,7 @@ export class ArtifactService {
     if (existing) {
       if (existing.removed_at) {
         this.store.resurface(id);
+        this.invalidateArchivedPaths();
         const kind = params.artifact_kind || inferKindFromPath(absPath);
         this.store.update(id, {
           space_id: params.space_id,
@@ -312,6 +321,7 @@ export class ArtifactService {
     const row = this.store.getById(id);
     if (!row) throw new Error(`Artifact "${id}" not found`);
     this.store.remove(id);
+    this.invalidateArchivedPaths();
   }
 
   // ── Reconciliation ──
@@ -346,9 +356,13 @@ export class ArtifactService {
     }
   }
 
-  // Exposed so callers running a reconcile pass can query once.
+  // Exposed so callers running a reconcile pass can query once. Cached
+  // in-memory and invalidated whenever a mutation touches removed_at.
   getArchivedFilePaths(): Set<string> {
-    return this.store.getArchivedFilePaths();
+    if (!this.archivedPathsCache) {
+      this.archivedPathsCache = this.store.getArchivedFilePaths();
+    }
+    return this.archivedPathsCache;
   }
 
   // ── Update ──
@@ -393,6 +407,7 @@ export class ArtifactService {
     if (!row) throw new Error(`Artifact "${id}" not found`);
     if (!row.removed_at) throw new Error(`Artifact "${id}" is not archived`);
     this.store.resurface(id);
+    this.invalidateArchivedPaths();
   }
 
   // ── Group (folder) bulk operations ──
@@ -414,6 +429,7 @@ export class ArtifactService {
     if (!name) throw new Error("group name must not be empty");
     const rows = this.store.getBySpaceId(spaceId).filter((r) => r.group_name === name);
     for (const row of rows) this.store.remove(row.id);
+    if (rows.length > 0) this.invalidateArchivedPaths();
     return rows.length;
   }
 

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -105,22 +105,36 @@ export class ArtifactService {
 
     for (const e of entries) {
       if (e.filePath && archivedPaths.has(e.filePath)) continue;
+      // Manifest-based gen ids are "gen:<plugin-folder>"; strip the prefix
+      // to get the folder name under ~/.oyster/userland/. Used as pluginId
+      // so Uninstall has a stable handle even after the DB reconciles the
+      // artifact to a UUID.
+      const pluginFolderId = e.plugin && e.id.startsWith("gen:") ? e.id.slice(4) : undefined;
+
       const idx = e.filePath ? dbPathToIdx.get(e.filePath) : undefined;
       if (idx !== undefined) {
         // Suppressed twin — forward icon onto the DB artifact so it isn't lost.
-        // The presence of a manifest-based gen twin on a non-builtin entry
-        // means this DB row is a third-party plugin (installed via `oyster install`).
+        // Non-builtin scan entries also have builtin=false, so the plugin
+        // flag must come from the detector's explicit `plugin` marker, not
+        // `!e.builtin` (which would misclassify regular scan-backed notes).
         const dbArtifact = persisted[idx];
         if (e.icon && !dbArtifact.icon) dbArtifact.icon = e.icon;
         if (e.iconStatus && !dbArtifact.iconStatus) dbArtifact.iconStatus = e.iconStatus;
-        if (!e.builtin) dbArtifact.plugin = true;
+        if (e.plugin) {
+          dbArtifact.plugin = true;
+          if (pluginFolderId) dbArtifact.pluginId = pluginFolderId;
+        }
       } else {
         // No DB twin: either a builtin (never reconciled to DB) or a manifest
         // plugin whose DB row hasn't been reconciled yet. Carry through the
-        // builtin flag so the UI can gate destructive actions.
-        const { filePath: _f, builtin, ...a } = e;
+        // builtin / plugin flags so the UI can gate destructive actions.
+        const { filePath: _f, builtin, plugin, ...a } = e;
         const artifact = a as Artifact;
         if (builtin) artifact.builtin = true;
+        if (plugin) {
+          artifact.plugin = true;
+          if (pluginFolderId) artifact.pluginId = pluginFolderId;
+        }
         gen.push(artifact);
       }
     }
@@ -302,7 +316,12 @@ export class ArtifactService {
 
   // ── Reconciliation ──
 
-  reconcileGeneratedArtifact(artifact: Artifact, filePath: string, userlandDir: string): void {
+  reconcileGeneratedArtifact(
+    artifact: Artifact,
+    filePath: string,
+    userlandDir: string,
+    archivedPaths?: Set<string>,
+  ): void {
     if (this.store.getByPath(filePath)) return; // already registered (active row)
     // If the user archived this path previously, the scanner will keep
     // seeing the file on disk and a naive reconcile would create a fresh
@@ -310,7 +329,12 @@ export class ArtifactService {
     // archive. Skip reconciliation when an archived row already claims
     // this path; the user has to restore (#archived → Restore) to bring
     // it back.
-    if (this.store.getArchivedFilePaths().has(filePath)) return;
+    //
+    // Callers that reconcile many artifacts in one pass (e.g. the boot
+    // loop) should pass a pre-loaded `archivedPaths` set to avoid re-
+    // querying for every artifact.
+    const archived = archivedPaths ?? this.store.getArchivedFilePaths();
+    if (archived.has(filePath)) return;
     console.log(`[reconcile] ${artifact.label} → DB`);
     try {
       this.registerArtifact(
@@ -320,6 +344,11 @@ export class ArtifactService {
     } catch (err) {
       console.error(`[reconcile] failed for ${artifact.label}:`, err);
     }
+  }
+
+  // Exposed so callers running a reconcile pass can query once.
+  getArchivedFilePaths(): Set<string> {
+    return this.store.getArchivedFilePaths();
   }
 
   // ── Update ──

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -98,17 +98,30 @@ export class ArtifactService {
 
     const entries = getGeneratedArtifactEntries(onArtifactRemoved);
     const gen: Artifact[] = [];
+    // Paths of archived filesystem-backed rows — used to suppress in-memory
+    // scanner shadows so a soft-deleted artifact doesn't reappear on the
+    // surface just because its backing file still exists on disk.
+    const archivedPaths = this.store.getArchivedFilePaths();
 
     for (const e of entries) {
+      if (e.filePath && archivedPaths.has(e.filePath)) continue;
       const idx = e.filePath ? dbPathToIdx.get(e.filePath) : undefined;
       if (idx !== undefined) {
-        // Suppressed twin — forward icon onto the DB artifact so it isn't lost
+        // Suppressed twin — forward icon onto the DB artifact so it isn't lost.
+        // The presence of a manifest-based gen twin on a non-builtin entry
+        // means this DB row is a third-party plugin (installed via `oyster install`).
         const dbArtifact = persisted[idx];
         if (e.icon && !dbArtifact.icon) dbArtifact.icon = e.icon;
         if (e.iconStatus && !dbArtifact.iconStatus) dbArtifact.iconStatus = e.iconStatus;
+        if (!e.builtin) dbArtifact.plugin = true;
       } else {
-        const { filePath: _f, builtin: _b, ...a } = e;
-        gen.push(a as Artifact);
+        // No DB twin: either a builtin (never reconciled to DB) or a manifest
+        // plugin whose DB row hasn't been reconciled yet. Carry through the
+        // builtin flag so the UI can gate destructive actions.
+        const { filePath: _f, builtin, ...a } = e;
+        const artifact = a as Artifact;
+        if (builtin) artifact.builtin = true;
+        gen.push(artifact);
       }
     }
 
@@ -290,7 +303,14 @@ export class ArtifactService {
   // ── Reconciliation ──
 
   reconcileGeneratedArtifact(artifact: Artifact, filePath: string, userlandDir: string): void {
-    if (this.store.getByPath(filePath)) return; // already registered
+    if (this.store.getByPath(filePath)) return; // already registered (active row)
+    // If the user archived this path previously, the scanner will keep
+    // seeing the file on disk and a naive reconcile would create a fresh
+    // active row next to the archived one — effectively ignoring the
+    // archive. Skip reconciliation when an archived row already claims
+    // this path; the user has to restore (#archived → Restore) to bring
+    // it back.
+    if (this.store.getArchivedFilePaths().has(filePath)) return;
     console.log(`[reconcile] ${artifact.label} → DB`);
     try {
       this.registerArtifact(
@@ -330,6 +350,42 @@ export class ArtifactService {
     }
 
     return this.rowToArtifact(this.store.getById(id)!);
+  }
+
+  // ── Archived-view helpers ──
+
+  async getArchivedArtifacts(): Promise<Artifact[]> {
+    const rows = this.store.getAllArchived();
+    return Promise.all(rows.map((row) => this.rowToArtifact(row)));
+  }
+
+  restoreArtifact(id: string): void {
+    const row = this.store.getById(id);
+    if (!row) throw new Error(`Artifact "${id}" not found`);
+    if (!row.removed_at) throw new Error(`Artifact "${id}" is not archived`);
+    this.store.resurface(id);
+  }
+
+  // ── Group (folder) bulk operations ──
+  // group_name is just a string on each artifact — no separate groups table.
+  // Renaming a group = bulk-update group_name on every artifact in the space
+  // that currently matches the old name. Archiving a group = bulk soft-delete
+  // everything in it.
+
+  renameGroup(spaceId: string, oldName: string, newName: string): number {
+    const trimmed = newName.trim();
+    if (!trimmed) throw new Error("new group name must not be empty");
+    if (!oldName) throw new Error("old group name must not be empty");
+    const rows = this.store.getBySpaceId(spaceId).filter((r) => r.group_name === oldName);
+    for (const row of rows) this.store.update(row.id, { group_name: trimmed });
+    return rows.length;
+  }
+
+  archiveGroup(spaceId: string, name: string): number {
+    if (!name) throw new Error("group name must not be empty");
+    const rows = this.store.getBySpaceId(spaceId).filter((r) => r.group_name === name);
+    for (const row of rows) this.store.remove(row.id);
+    return rows.length;
   }
 
   // ── Private ──

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -154,17 +154,13 @@ export class SqliteArtifactStore implements ArtifactStore {
   // file-backed artifact archived from the UI would still appear because the
   // scanner re-detects the underlying file each scan cycle).
   getArchivedFilePaths(): Set<string> {
+    // Use SQLite's json_extract in-query instead of JSON.parse'ing each row
+    // in JS. Matches the getByPath pattern above and scales better as the
+    // archive grows.
     const rows = this.db.prepare(
-      "SELECT storage_config FROM artifacts WHERE removed_at IS NOT NULL AND storage_kind = 'filesystem'"
-    ).all() as { storage_config: string }[];
-    const paths = new Set<string>();
-    for (const row of rows) {
-      try {
-        const p = (JSON.parse(row.storage_config) as { path?: string }).path;
-        if (p) paths.add(p);
-      } catch { /* malformed — skip */ }
-    }
-    return paths;
+      "SELECT json_extract(storage_config, '$.path') AS path FROM artifacts WHERE removed_at IS NOT NULL AND storage_kind = 'filesystem' AND json_extract(storage_config, '$.path') IS NOT NULL"
+    ).all() as { path: string | null }[];
+    return new Set(rows.map((r) => r.path).filter((p): p is string => typeof p === "string" && p.length > 0));
   }
 
   delete(id: string): void {

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -39,6 +39,8 @@ export interface ArtifactStore {
   resurface(id: string): void;
   remove(id: string): void;
   delete(id: string): void;
+  getAllArchived(): ArtifactRow[];
+  getArchivedFilePaths(): Set<string>;
 }
 
 // ── SQLite implementation ──
@@ -138,6 +140,31 @@ export class SqliteArtifactStore implements ArtifactStore {
 
   remove(id: string): void {
     this.db.prepare("UPDATE artifacts SET removed_at = datetime('now') WHERE id = ?").run(id);
+  }
+
+  // All rows that have been soft-deleted — newest first, for the Archived view.
+  getAllArchived(): ArtifactRow[] {
+    return this.db.prepare(
+      "SELECT * FROM artifacts WHERE removed_at IS NOT NULL ORDER BY removed_at DESC"
+    ).all() as ArtifactRow[];
+  }
+
+  // Paths of soft-deleted filesystem-backed artifacts. Used by getAllArtifacts
+  // to suppress in-memory scanner shadows of archived rows (without this, a
+  // file-backed artifact archived from the UI would still appear because the
+  // scanner re-detects the underlying file each scan cycle).
+  getArchivedFilePaths(): Set<string> {
+    const rows = this.db.prepare(
+      "SELECT storage_config FROM artifacts WHERE removed_at IS NOT NULL AND storage_kind = 'filesystem'"
+    ).all() as { storage_config: string }[];
+    const paths = new Set<string>();
+    for (const row of rows) {
+      try {
+        const p = (JSON.parse(row.storage_config) as { path?: string }).path;
+        if (p) paths.add(p);
+      } catch { /* malformed — skip */ }
+    }
+    return paths;
   }
 
   delete(id: string): void {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { readFileSync, existsSync, mkdirSync, statSync, copyFileSync, readdirSync, cpSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, statSync, copyFileSync, readdirSync, cpSync, writeFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { extname, join, dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -281,6 +281,144 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     const response = artifacts.map((a) => revealed.has(a.id) ? { ...a, pendingReveal: true } : a);
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(response));
+    return;
+  }
+
+  // ── Artifact mutations (context-menu actions on the desktop) ──
+  // PATCH /api/artifacts/:id   — rename and/or move to/from a group
+  // POST  /api/artifacts/:id/archive — soft-delete (removed_at set)
+  // PATCH /api/groups          — rename a group across all artifacts in a space
+  // POST  /api/groups/archive  — archive all artifacts in a group
+
+  const sendJson = (data: unknown, status = 200) => {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(data));
+  };
+  async function readJsonBody(): Promise<Record<string, unknown>> {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    if (!body) return {};
+    try { return JSON.parse(body) as Record<string, unknown>; }
+    catch { throw new Error("Invalid JSON body"); }
+  }
+
+  const artifactMatch = url.match(/^\/api\/artifacts\/([^/]+)$/);
+  if (artifactMatch && req.method === "PATCH") {
+    const id = decodeURIComponent(artifactMatch[1]);
+    try {
+      const body = await readJsonBody();
+      const fields: { label?: string; group_name?: string | null } = {};
+      if (typeof body.label === "string") fields.label = body.label;
+      if ("group_name" in body) {
+        const v = body.group_name;
+        fields.group_name = v === null ? null : (typeof v === "string" ? v.trim() || null : null);
+      }
+      const updated = await artifactService.updateArtifact(id, fields);
+      sendJson(updated);
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 400);
+    }
+    return;
+  }
+
+  // GET /api/artifacts/archived — list soft-deleted rows for the Archived view.
+  // Must match before the :id-scoped routes below so "archived" isn't
+  // interpreted as an id.
+  if (url === "/api/artifacts/archived" && req.method === "GET") {
+    try {
+      const archived = await artifactService.getArchivedArtifacts();
+      sendJson(archived);
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 500);
+    }
+    return;
+  }
+
+  const restoreMatch = url.match(/^\/api\/artifacts\/([^/]+)\/restore$/);
+  if (restoreMatch && req.method === "POST") {
+    const id = decodeURIComponent(restoreMatch[1]);
+    try {
+      artifactService.restoreArtifact(id);
+      sendJson({ id, restored: true });
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 400);
+    }
+    return;
+  }
+
+  const archiveMatch = url.match(/^\/api\/artifacts\/([^/]+)\/archive$/);
+  if (archiveMatch && req.method === "POST") {
+    const id = decodeURIComponent(archiveMatch[1]);
+    try {
+      artifactService.removeArtifact(id);
+      sendJson({ id, archived: true });
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 400);
+    }
+    return;
+  }
+
+  if (url === "/api/groups" && req.method === "PATCH") {
+    try {
+      const body = await readJsonBody();
+      const spaceId = typeof body.space_id === "string" ? body.space_id : null;
+      const oldName = typeof body.old_name === "string" ? body.old_name : null;
+      const newName = typeof body.new_name === "string" ? body.new_name : null;
+      if (!spaceId || !oldName || !newName) {
+        sendJson({ error: "space_id, old_name, new_name are required" }, 400);
+        return;
+      }
+      const updated = artifactService.renameGroup(spaceId, oldName, newName);
+      sendJson({ space_id: spaceId, old_name: oldName, new_name: newName.trim(), updated });
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 400);
+    }
+    return;
+  }
+
+  // POST /api/plugins/:id/uninstall — remove the plugin folder from userland.
+  // The artifact detector + getAllArtifacts self-heal the in-memory and DB
+  // entries; no separate cleanup needed here. Mirrors `oyster uninstall <id>`.
+  const pluginUninstallMatch = url.match(/^\/api\/plugins\/([^/]+)\/uninstall$/);
+  if (pluginUninstallMatch && req.method === "POST") {
+    const id = decodeURIComponent(pluginUninstallMatch[1]);
+    if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(id)) {
+      sendJson({ error: `Invalid plugin id '${id}'` }, 400);
+      return;
+    }
+    const dir = join(USERLAND_DIR, id);
+    if (!existsSync(dir)) {
+      sendJson({ error: `'${id}' is not installed` }, 404);
+      return;
+    }
+    const manifestPath = join(dir, "manifest.json");
+    if (!existsSync(manifestPath)) {
+      sendJson({ error: `${dir} has no manifest.json — refusing to remove a non-plugin folder` }, 400);
+      return;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+      sendJson({ id, uninstalled: true });
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 500);
+    }
+    return;
+  }
+
+  if (url === "/api/groups/archive" && req.method === "POST") {
+    try {
+      const body = await readJsonBody();
+      const spaceId = typeof body.space_id === "string" ? body.space_id : null;
+      const name = typeof body.name === "string" ? body.name : null;
+      if (!spaceId || !name) {
+        sendJson({ error: "space_id and name are required" }, 400);
+        return;
+      }
+      const archived = artifactService.archiveGroup(spaceId, name);
+      sendJson({ space_id: spaceId, name, archived });
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 400);
+    }
     return;
   }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -335,8 +335,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // GET /api/artifacts/archived — list soft-deleted rows for the Archived view.
   // Must match BEFORE the :id-scoped routes below so "archived" is never
   // interpreted as an artifact id (e.g. PATCH /api/artifacts/archived
-  // would otherwise hit the rename handler with id="archived").
+  // would otherwise hit the rename handler with id="archived"). Locked to
+  // local origins for the same reason the mutation endpoints are — the
+  // list contains user-private artifact metadata.
   if (url === "/api/artifacts/archived" && req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return;
     try {
       const archived = await artifactService.getArchivedArtifacts();
       sendJson(archived);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -332,6 +332,20 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     return false;
   };
 
+  // GET /api/artifacts/archived — list soft-deleted rows for the Archived view.
+  // Must match BEFORE the :id-scoped routes below so "archived" is never
+  // interpreted as an artifact id (e.g. PATCH /api/artifacts/archived
+  // would otherwise hit the rename handler with id="archived").
+  if (url === "/api/artifacts/archived" && req.method === "GET") {
+    try {
+      const archived = await artifactService.getArchivedArtifacts();
+      sendJson(archived);
+    } catch (err) {
+      sendJson({ error: (err as Error).message }, 500);
+    }
+    return;
+  }
+
   const artifactMatch = url.match(/^\/api\/artifacts\/([^/]+)$/);
   if (artifactMatch && req.method === "PATCH") {
     if (rejectIfNonLocalOrigin()) return;
@@ -360,19 +374,6 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       sendJson(updated);
     } catch (err) {
       sendJson({ error: (err as Error).message }, 400);
-    }
-    return;
-  }
-
-  // GET /api/artifacts/archived — list soft-deleted rows for the Archived view.
-  // Must match before the :id-scoped routes below so "archived" isn't
-  // interpreted as an id.
-  if (url === "/api/artifacts/archived" && req.method === "GET") {
-    try {
-      const archived = await artifactService.getArchivedArtifacts();
-      sendJson(archived);
-    } catch (err) {
-      sendJson({ error: (err as Error).message }, 500);
     }
     return;
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -313,7 +313,13 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     try {
       const body = await readJsonBody();
       const fields: { label?: string; group_name?: string | null } = {};
-      if (typeof body.label === "string") fields.label = body.label;
+      if ("label" in body) {
+        if (typeof body.label === "string") {
+          fields.label = body.label;
+        } else {
+          throw new Error("label must be a string");
+        }
+      }
       if ("group_name" in body) {
         const v = body.group_name;
         if (v === null) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -188,10 +188,15 @@ spawnSession(SHELL, SHELL_ARGS, WORKSPACE, cleanEnv);
 // OpenCode spawn is deferred until after port resolution (see below)
 scanExistingArtifacts(ARTIFACTS_DIR, iconGenerator);
 
-// Reconcile non-builtin ready gen: artifacts into DB (idempotent — dedupes by canonical path)
-for (const entry of getGeneratedArtifactEntries()) {
-  if (!entry.builtin && entry.filePath && entry.status === "ready") {
-    artifactService.reconcileGeneratedArtifact(entry, entry.filePath, USERLAND_DIR);
+// Reconcile non-builtin ready gen: artifacts into DB (idempotent — dedupes by canonical path).
+// Load the archived-paths set once and pass it through; otherwise every
+// reconcile call would re-run the same SQL + JSON.parse over every archived row.
+{
+  const archivedPaths = artifactService.getArchivedFilePaths();
+  for (const entry of getGeneratedArtifactEntries()) {
+    if (!entry.builtin && entry.filePath && entry.status === "ready") {
+      artifactService.reconcileGeneratedArtifact(entry, entry.filePath, USERLAND_DIR, archivedPaths);
+    }
   }
 }
 
@@ -311,7 +316,13 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       if (typeof body.label === "string") fields.label = body.label;
       if ("group_name" in body) {
         const v = body.group_name;
-        fields.group_name = v === null ? null : (typeof v === "string" ? v.trim() || null : null);
+        if (v === null) {
+          fields.group_name = null;
+        } else if (typeof v === "string") {
+          fields.group_name = v.trim() || null;
+        } else {
+          throw new Error("group_name must be a string or null");
+        }
       }
       const updated = await artifactService.updateArtifact(id, fields);
       sendJson(updated);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -299,16 +299,42 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     res.writeHead(status, { "Content-Type": "application/json" });
     res.end(JSON.stringify(data));
   };
+  // Mutation endpoints below only accept tiny config bodies ({label, group_name}
+  // etc). Cap at 64 KB to prevent memory/CPU abuse from an oversized payload.
+  const MAX_MUTATION_BODY = 64_000;
   async function readJsonBody(): Promise<Record<string, unknown>> {
     let body = "";
-    for await (const chunk of req) body += chunk;
+    for await (const chunk of req) {
+      body += chunk;
+      if (body.length > MAX_MUTATION_BODY) {
+        res.writeHead(413);
+        res.end("Payload too large");
+        req.destroy();
+        throw new Error("Payload too large");
+      }
+    }
     if (!body) return {};
     try { return JSON.parse(body) as Record<string, unknown>; }
     catch { throw new Error("Invalid JSON body"); }
   }
+  // Mutation endpoints are localhost-only. A browser tab on some other site
+  // could otherwise POST to http://localhost:<port>/api/… and trigger
+  // destructive actions (localhost CSRF). Mirrors the /mcp handler pattern:
+  // reject non-local origins outright; echo the origin back for local ones
+  // to override the wildcard CORS header set at the top of this handler.
+  const rejectIfNonLocalOrigin = (): boolean => {
+    const origin = req.headers.origin;
+    if (origin && !/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+      sendJson({ error: "Forbidden origin" }, 403);
+      return true;
+    }
+    if (origin) res.setHeader("Access-Control-Allow-Origin", origin);
+    return false;
+  };
 
   const artifactMatch = url.match(/^\/api\/artifacts\/([^/]+)$/);
   if (artifactMatch && req.method === "PATCH") {
+    if (rejectIfNonLocalOrigin()) return;
     const id = decodeURIComponent(artifactMatch[1]);
     try {
       const body = await readJsonBody();
@@ -353,6 +379,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   const restoreMatch = url.match(/^\/api\/artifacts\/([^/]+)\/restore$/);
   if (restoreMatch && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return;
     const id = decodeURIComponent(restoreMatch[1]);
     try {
       artifactService.restoreArtifact(id);
@@ -365,6 +392,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   const archiveMatch = url.match(/^\/api\/artifacts\/([^/]+)\/archive$/);
   if (archiveMatch && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return;
     const id = decodeURIComponent(archiveMatch[1]);
     try {
       artifactService.removeArtifact(id);
@@ -376,6 +404,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   }
 
   if (url === "/api/groups" && req.method === "PATCH") {
+    if (rejectIfNonLocalOrigin()) return;
     try {
       const body = await readJsonBody();
       const spaceId = typeof body.space_id === "string" ? body.space_id : null;
@@ -398,6 +427,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // entries; no separate cleanup needed here. Mirrors `oyster uninstall <id>`.
   const pluginUninstallMatch = url.match(/^\/api\/plugins\/([^/]+)\/uninstall$/);
   if (pluginUninstallMatch && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return;
     const id = decodeURIComponent(pluginUninstallMatch[1]);
     if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(id)) {
       sendJson({ error: `Invalid plugin id '${id}'` }, 400);
@@ -423,6 +453,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   }
 
   if (url === "/api/groups/archive" && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return;
     try {
       const body = await readJsonBody();
       const spaceId = typeof body.space_id === "string" ? body.space_id : null;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -260,6 +260,17 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     res.end(JSON.stringify(data));
   };
 
+  // Throwable that carries an HTTP status — lets readJsonBody and others
+  // surface a specific status (e.g. 413) without writing the response
+  // themselves, which would race the caller's own catch-block response.
+  class HttpError extends Error {
+    constructor(message: string, public status: number) { super(message); this.name = "HttpError"; }
+  }
+  const sendError = (err: unknown, fallback = 400) => {
+    if (err instanceof HttpError) sendJson({ error: err.message }, err.status);
+    else sendJson({ error: (err as Error).message }, fallback);
+  };
+
   // Mutation endpoints only accept tiny config bodies ({label, group_name}
   // etc). Cap at 64 KB to prevent memory/CPU abuse from an oversized payload.
   const MAX_MUTATION_BODY = 64_000;
@@ -268,15 +279,12 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     for await (const chunk of req) {
       body += chunk;
       if (body.length > MAX_MUTATION_BODY) {
-        res.writeHead(413);
-        res.end("Payload too large");
-        req.destroy();
-        throw new Error("Payload too large");
+        throw new HttpError("Payload too large", 413);
       }
     }
     if (!body) return {};
     try { return JSON.parse(body) as Record<string, unknown>; }
-    catch { throw new Error("Invalid JSON body"); }
+    catch { throw new HttpError("Invalid JSON body", 400); }
   }
 
   // Artifact endpoints (both reads and mutations) are localhost-only. A
@@ -355,7 +363,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       const archived = await artifactService.getArchivedArtifacts();
       sendJson(archived);
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 500);
+      sendError(err, 500);
     }
     return;
   }
@@ -387,7 +395,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       const updated = await artifactService.updateArtifact(id, fields);
       sendJson(updated);
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 400);
+      sendError(err);
     }
     return;
   }
@@ -400,7 +408,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       artifactService.restoreArtifact(id);
       sendJson({ id, restored: true });
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 400);
+      sendError(err);
     }
     return;
   }
@@ -413,7 +421,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       artifactService.removeArtifact(id);
       sendJson({ id, archived: true });
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 400);
+      sendError(err);
     }
     return;
   }
@@ -432,7 +440,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       const updated = artifactService.renameGroup(spaceId, oldName, newName);
       sendJson({ space_id: spaceId, old_name: oldName, new_name: newName.trim(), updated });
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 400);
+      sendError(err);
     }
     return;
   }
@@ -462,7 +470,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       rmSync(dir, { recursive: true, force: true });
       sendJson({ id, uninstalled: true });
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 500);
+      sendError(err, 500);
     }
     return;
   }
@@ -480,7 +488,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       const archived = artifactService.archiveGroup(spaceId, name);
       sendJson({ space_id: spaceId, name, archived });
     } catch (err) {
-      sendJson({ error: (err as Error).message }, 400);
+      sendError(err);
     }
     return;
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -268,7 +268,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   }
   const sendError = (err: unknown, fallback = 400) => {
     if (err instanceof HttpError) sendJson({ error: err.message }, err.status);
-    else sendJson({ error: (err as Error).message }, fallback);
+    else sendJson({ error: err instanceof Error ? err.message : String(err) }, fallback);
   };
 
   // Mutation endpoints only accept tiny config bodies ({label, group_name}
@@ -279,6 +279,10 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     for await (const chunk of req) {
       body += chunk;
       if (body.length > MAX_MUTATION_BODY) {
+        // Destroy the socket so we stop reading further bytes from an
+        // oversized payload — unlike a plain throw, which lets the rest
+        // of the stream keep draining. Matches the /api/import/* pattern.
+        req.destroy();
         throw new HttpError("Payload too large", 413);
       }
     }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -251,6 +251,50 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   const url = req.url || "/";
 
+  // ── Shared helpers ──
+  // Defined near the top so early routes (e.g. GET /api/artifacts) can use
+  // them too, not just the later mutation routes.
+
+  const sendJson = (data: unknown, status = 200) => {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(data));
+  };
+
+  // Mutation endpoints only accept tiny config bodies ({label, group_name}
+  // etc). Cap at 64 KB to prevent memory/CPU abuse from an oversized payload.
+  const MAX_MUTATION_BODY = 64_000;
+  async function readJsonBody(): Promise<Record<string, unknown>> {
+    let body = "";
+    for await (const chunk of req) {
+      body += chunk;
+      if (body.length > MAX_MUTATION_BODY) {
+        res.writeHead(413);
+        res.end("Payload too large");
+        req.destroy();
+        throw new Error("Payload too large");
+      }
+    }
+    if (!body) return {};
+    try { return JSON.parse(body) as Record<string, unknown>; }
+    catch { throw new Error("Invalid JSON body"); }
+  }
+
+  // Artifact endpoints (both reads and mutations) are localhost-only. A
+  // browser tab on some other site could otherwise fetch user data or
+  // trigger destructive actions via http://localhost:<port>/api/…. Mirrors
+  // the /mcp handler pattern: reject non-local origins outright; echo the
+  // origin back for local ones to override the wildcard CORS header set
+  // above.
+  const rejectIfNonLocalOrigin = (): boolean => {
+    const origin = req.headers.origin;
+    if (origin && !/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+      sendJson({ error: "Forbidden origin" }, 403);
+      return true;
+    }
+    if (origin) res.setHeader("Access-Control-Allow-Origin", origin);
+    return false;
+  };
+
   // GET /api/resolve-path?url=...  — resolve a serving URL to a filesystem path
   if (url.startsWith("/api/resolve-path")) {
     const params = new URL(url, "http://localhost").searchParams;
@@ -278,8 +322,12 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     return;
   }
 
-  // GET /api/artifacts
+  // GET /api/artifacts — the full live artifact list. Local-origin-only for
+  // the same reason /api/artifacts/archived is: it contains user-private
+  // artifact metadata that a malicious cross-origin site could otherwise
+  // enumerate against a running local Oyster.
   if (url === "/api/artifacts") {
+    if (rejectIfNonLocalOrigin()) return;
     const artifacts = await artifactService.getAllArtifacts((id) => clearSeenArtifact(id));
     const revealed = new Set(pendingReveals);
     pendingReveals.clear();
@@ -294,43 +342,6 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // POST  /api/artifacts/:id/archive — soft-delete (removed_at set)
   // PATCH /api/groups          — rename a group across all artifacts in a space
   // POST  /api/groups/archive  — archive all artifacts in a group
-
-  const sendJson = (data: unknown, status = 200) => {
-    res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(data));
-  };
-  // Mutation endpoints below only accept tiny config bodies ({label, group_name}
-  // etc). Cap at 64 KB to prevent memory/CPU abuse from an oversized payload.
-  const MAX_MUTATION_BODY = 64_000;
-  async function readJsonBody(): Promise<Record<string, unknown>> {
-    let body = "";
-    for await (const chunk of req) {
-      body += chunk;
-      if (body.length > MAX_MUTATION_BODY) {
-        res.writeHead(413);
-        res.end("Payload too large");
-        req.destroy();
-        throw new Error("Payload too large");
-      }
-    }
-    if (!body) return {};
-    try { return JSON.parse(body) as Record<string, unknown>; }
-    catch { throw new Error("Invalid JSON body"); }
-  }
-  // Mutation endpoints are localhost-only. A browser tab on some other site
-  // could otherwise POST to http://localhost:<port>/api/… and trigger
-  // destructive actions (localhost CSRF). Mirrors the /mcp handler pattern:
-  // reject non-local origins outright; echo the origin back for local ones
-  // to override the wildcard CORS header set at the top of this handler.
-  const rejectIfNonLocalOrigin = (): boolean => {
-    const origin = req.headers.origin;
-    if (origin && !/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
-      sendJson({ error: "Forbidden origin" }, 403);
-      return true;
-    }
-    if (origin) res.setHeader("Access-Control-Allow-Origin", origin);
-    return false;
-  };
 
   // GET /api/artifacts/archived — list soft-deleted rows for the Archived view.
   // Must match BEFORE the :id-scoped routes below so "archived" is never

--- a/server/src/process-manager.ts
+++ b/server/src/process-manager.ts
@@ -20,12 +20,17 @@ export function clearStarting(name: string): void {
 
 // ── Generated artifacts (in-memory, transitional) ──
 
-type GeneratedEntry = Artifact & { filePath?: string; builtin?: boolean };
+type GeneratedEntry = Artifact & { filePath?: string; builtin?: boolean; plugin?: boolean };
 
 const generatedArtifacts = new Map<string, GeneratedEntry>();
 
-export function registerGeneratedArtifact(artifact: Artifact, filePath?: string, builtin = false): void {
-  generatedArtifacts.set(artifact.id, { ...artifact, filePath, builtin });
+export function registerGeneratedArtifact(
+  artifact: Artifact,
+  filePath?: string,
+  builtin = false,
+  plugin = false,
+): void {
+  generatedArtifacts.set(artifact.id, { ...artifact, filePath, builtin, plugin });
 }
 
 export function updateGeneratedArtifact(id: string, fields: Partial<Artifact>, filePath?: string): void {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -31,6 +31,10 @@ export interface Artifact {
   createdAt: string;
   groupName?: string;
   pendingReveal?: boolean;
+  /** First-party app bundled with Oyster (builtins/*). Read-only — cannot be renamed or archived from the UI. */
+  builtin?: boolean;
+  /** Third-party plugin installed via `oyster install <id>`. Removal means uninstall (delete folder), not archive. */
+  plugin?: boolean;
 }
 
 export type ScanStatus = "none" | "scanning" | "complete" | "error";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -35,6 +35,8 @@ export interface Artifact {
   builtin?: boolean;
   /** Third-party plugin installed via `oyster install <id>`. Removal means uninstall (delete folder), not archive. */
   plugin?: boolean;
+  /** For plugin artifacts: the folder-name id under ~/.oyster/userland/ (e.g. "pomodoro"). Used by Uninstall since `id` is a UUID that doesn't map to a directory. */
+  pluginId?: string;
 }
 
 export type ScanStatus = "none" | "scanning" | "complete" | "error";

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,6 +1,6 @@
 /* ── Oyster OS — Desktop Shell ── */
 
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap');
 
 :root {
   --desktop-bg: #1a1b2e;
@@ -569,6 +569,26 @@ body {
   text-shadow: 0 1px 6px rgba(0,0,0,0.7);
 }
 
+/* Inline rename input — visually matches .icon-label but editable */
+.icon-label-input {
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 400;
+  text-align: center;
+  line-height: 1.35;
+  color: var(--text);
+  max-width: 110px;
+  width: 110px;
+  padding: 2px 6px;
+  background: rgba(13, 14, 26, 0.85);
+  border: 1px solid rgba(124, 107, 255, 0.5);
+  border-radius: 4px;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(124, 107, 255, 0.15);
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 /* ── Status dot (app artifacts) ── */
 .status-dot {
   width: 10px;
@@ -761,10 +781,10 @@ body {
   position: relative;
   text-align: center;
   margin-bottom: 20px;
-  font-family: var(--font-body);
+  font-family: 'Barlow', sans-serif;
   font-size: 1.5rem;
-  font-weight: 500;
-  letter-spacing: -0.03em;
+  font-weight: 600;
+  letter-spacing: -0.02em;
   line-height: 1.3;
   opacity: 1;
   transform: translateY(0);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -101,9 +101,12 @@ export default function App() {
 
   // Refetch whenever the mode toggles (archive ↔ normal) so the view flips
   // to the right dataset instantly rather than waiting for the next poll.
-  // Mirrors the error handling used by the mount fetch and poller so a
-  // failure here doesn't leave `connected` stale.
+  // Skip the initial mount — the separate mount effect below handles that
+  // fetch, and firing both racing fetches at startup would waste a round-
+  // trip and leave the faster result under-written by the slower one.
+  const didMountRef = useRef(false);
   useEffect(() => {
+    if (!didMountRef.current) { didMountRef.current = true; return; }
     loadArtifacts()
       .then((a) => { setArtifacts(a); setConnected(true); })
       .catch((err) => { console.warn("[oyster] failed to refetch on mode toggle:", err.message); setConnected(false); });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -361,7 +361,7 @@ export default function App() {
         onSpaceChange={handleSpaceChange}
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         onConvertToSpace={handleConvertToSpace}
-        onRefresh={() => loadArtifacts().then(setArtifacts)}
+        onRefresh={() => loadArtifacts().then(setArtifacts).catch(() => setConnected(false))}
         onArtifactUpdate={(id, fields) => setArtifacts((prev) => prev.map((a) => (a.id === id ? { ...a, ...fields } : a)))}
         onArtifactRemove={(id) => setArtifacts((prev) => prev.filter((a) => a.id !== id))}
         onImportFromAI={(spaceId) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -101,7 +101,13 @@ export default function App() {
 
   // Refetch whenever the mode toggles (archive ↔ normal) so the view flips
   // to the right dataset instantly rather than waiting for the next poll.
-  useEffect(() => { loadArtifacts().then(setArtifacts).catch(() => {}); }, [isArchivedView, loadArtifacts]);
+  // Mirrors the error handling used by the mount fetch and poller so a
+  // failure here doesn't leave `connected` stale.
+  useEffect(() => {
+    loadArtifacts()
+      .then((a) => { setArtifacts(a); setConnected(true); })
+      .catch((err) => { console.warn("[oyster] failed to refetch on mode toggle:", err.message); setConnected(false); });
+  }, [isArchivedView, loadArtifacts]);
 
   // Fetch artifacts + spaces on mount; auto-open artifact if URL contains one
   useEffect(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -370,7 +370,11 @@ export default function App() {
         onSpaceChange={handleSpaceChange}
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         onConvertToSpace={handleConvertToSpace}
-        onRefresh={() => loadArtifacts().then(setArtifacts).catch(() => setConnected(false))}
+        onRefresh={() =>
+          loadArtifacts()
+            .then((nextArtifacts) => { setArtifacts(nextArtifacts); setConnected(true); })
+            .catch(() => setConnected(false))
+        }
         onArtifactUpdate={(id, fields) => setArtifacts((prev) => prev.map((a) => (a.id === id ? { ...a, ...fields } : a)))}
         onArtifactRemove={(id) => setArtifacts((prev) => prev.filter((a) => a.id !== id))}
         onImportFromAI={(spaceId) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { windowsReducer } from "./stores/windows";
 import {
   type Artifact,
   fetchArtifacts,
+  listArchivedArtifacts,
   startApp as startAppApi,
   stopApp as stopAppApi,
 } from "./data/artifacts-api";
@@ -86,9 +87,25 @@ export default function App() {
   const [viewerHash, setViewerHash] = useState<string>(() => getUrlState().hash);
   const [connected, setConnected] = useState(true);
 
+  // Active-space-aware artifact loader. Mirrors current activeSpace via a ref
+  // so callers don't have to thread it through every closure (polling,
+  // onRefresh, mutation handlers all call loadArtifacts with no args).
+  const isArchivedView = activeSpace === "__archived__";
+  const activeSpaceRef = useRef(activeSpace);
+  useEffect(() => { activeSpaceRef.current = activeSpace; }, [activeSpace]);
+  const loadArtifacts = useCallback(() => {
+    return activeSpaceRef.current === "__archived__"
+      ? listArchivedArtifacts()
+      : fetchArtifacts();
+  }, []);
+
+  // Refetch whenever the mode toggles (archive ↔ normal) so the view flips
+  // to the right dataset instantly rather than waiting for the next poll.
+  useEffect(() => { loadArtifacts().then(setArtifacts).catch(() => {}); }, [isArchivedView, loadArtifacts]);
+
   // Fetch artifacts + spaces on mount; auto-open artifact if URL contains one
   useEffect(() => {
-    fetchArtifacts().then((a) => {
+    loadArtifacts().then((a) => {
       setArtifacts(a);
       setLoaded(true);
       setConnected(true);
@@ -107,7 +124,7 @@ export default function App() {
   // Poll for status updates every 5 seconds; handle pending reveals
   useEffect(() => {
     const interval = setInterval(() => {
-      fetchArtifacts().then((arts) => {
+      loadArtifacts().then((arts) => {
         setArtifacts(arts);
         setConnected(true);
         const revealed = arts.find((a) => a.pendingReveal);
@@ -333,7 +350,8 @@ export default function App() {
         space={activeSpace}
         spaces={spaces.map(s => s.id)}
         isHero={isHero}
-        artifacts={activeSpace === "__all__" ? artifacts : artifacts.filter((a) => a.spaceId === activeSpace)}
+        artifacts={(activeSpace === "__all__" || activeSpace === "__archived__") ? artifacts : artifacts.filter((a) => a.spaceId === activeSpace)}
+        isArchivedView={isArchivedView}
         onArtifactClick={handleArtifactClick}
         onArtifactStop={handleArtifactStop}
         onGroupClick={(name) => {
@@ -343,6 +361,7 @@ export default function App() {
         onSpaceChange={handleSpaceChange}
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         onConvertToSpace={handleConvertToSpace}
+        onRefresh={() => loadArtifacts().then(setArtifacts)}
         onImportFromAI={(spaceId) => {
           const importArtifact = artifacts.find((a) => a.id.endsWith("import-from-ai"));
           if (!importArtifact) return;
@@ -493,7 +512,7 @@ export default function App() {
             setShowAddSpaceWizard(false);
             setDroppedFolder(undefined);
             fetchSpaces().then(setSpaces);
-            fetchArtifacts().then(setArtifacts);
+            loadArtifacts().then(setArtifacts);
             if (newSpaceId) handleSpaceChange(newSpaceId);
           }}
         />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -121,7 +121,11 @@ export default function App() {
     if (!didMountRef.current) { didMountRef.current = true; return; }
     loadArtifacts()
       .then((a) => { setArtifacts(a); setConnected(true); })
-      .catch((err) => { console.warn("[oyster] failed to refetch on mode toggle:", err.message); setConnected(false); });
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn("[oyster] failed to refetch on mode toggle:", msg);
+        setConnected(false);
+      });
   }, [isArchivedView, loadArtifacts]);
 
   // Fetch artifacts + spaces on mount; auto-open artifact if URL contains one

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -84,6 +84,18 @@ export default function App() {
   const [revealId, setRevealId] = useState<string | null>(null);
   const [showHardcoreGate, setShowHardcoreGate] = useState(false);
   const [openGroup, setOpenGroup] = useState<string | null>(() => getUrlState().groupName);
+  // Auto-close the group popup when the group goes empty (e.g. the user
+  // archived the last artifact from within it). Without this, the popup
+  // keeps rendering an empty shell until the user manually dismisses.
+  useEffect(() => {
+    if (!openGroup) return;
+    const stillHas = artifacts.some(
+      (a) =>
+        a.groupName?.toLowerCase() === openGroup.toLowerCase() &&
+        (activeSpace === "__all__" || activeSpace === "__archived__" || a.spaceId === activeSpace),
+    );
+    if (!stillHas) setOpenGroup(null);
+  }, [artifacts, openGroup, activeSpace]);
   const [viewerHash, setViewerHash] = useState<string>(() => getUrlState().hash);
   const [connected, setConnected] = useState(true);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -362,6 +362,8 @@ export default function App() {
         onAddSpace={(folder) => { setDroppedFolder(folder); setShowAddSpaceWizard(true); }}
         onConvertToSpace={handleConvertToSpace}
         onRefresh={() => loadArtifacts().then(setArtifacts)}
+        onArtifactUpdate={(id, fields) => setArtifacts((prev) => prev.map((a) => (a.id === id ? { ...a, ...fields } : a)))}
+        onArtifactRemove={(id) => setArtifacts((prev) => prev.filter((a) => a.id !== id))}
         onImportFromAI={(spaceId) => {
           const importArtifact = artifacts.find((a) => a.id.endsWith("import-from-ai"));
           if (!importArtifact) return;

--- a/web/src/components/ArtifactIcon.tsx
+++ b/web/src/components/ArtifactIcon.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { Artifact, ArtifactKind } from "../data/artifacts-api";
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -54,13 +55,25 @@ interface Props {
   index: number;
   onClick: () => void;
   onStop?: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
   reveal?: boolean;
+  isRenaming?: boolean;
+  onRenameCommit?: (label: string) => void;
+  onRenameCancel?: () => void;
 }
 
-export function ArtifactIcon({ artifact, index, onClick, onStop, reveal }: Props) {
+export function ArtifactIcon({ artifact, index, onClick, onStop, onContextMenu, reveal, isRenaming, onRenameCommit, onRenameCancel }: Props) {
   const config = typeConfig[artifact.artifactKind] || typeConfig.app;
   // Only show status indicators for managed apps (local_process runtime)
   const isManagedApp = artifact.runtimeKind === "local_process";
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (isRenaming) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isRenaming]);
 
   return (
     <button
@@ -69,7 +82,8 @@ export function ArtifactIcon({ artifact, index, onClick, onStop, reveal }: Props
         animationDelay: `${index * 0.05 + 0.05}s`,
         ...(artifact.status === "generating" ? { pointerEvents: "none" as const } : {}),
       }}
-      onClick={onClick}
+      onClick={isRenaming ? (e) => e.preventDefault() : onClick}
+      onContextMenu={onContextMenu}
     >
       <div className={`icon-thumb ${artifact.icon ? "icon-thumb-ai" : ""}`} style={artifact.icon ? undefined : { background: config.gradient }}>
         {artifact.icon ? (
@@ -113,7 +127,23 @@ export function ArtifactIcon({ artifact, index, onClick, onStop, reveal }: Props
           </span>
         )}
       </div>
-      <span className="icon-label">{artifact.label}</span>
+      {isRenaming ? (
+        <input
+          ref={inputRef}
+          className="icon-label-input"
+          defaultValue={artifact.label}
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") { e.preventDefault(); onRenameCommit?.(e.currentTarget.value); }
+            else if (e.key === "Escape") { e.preventDefault(); onRenameCancel?.(); }
+          }}
+          onBlur={(e) => onRenameCommit?.(e.currentTarget.value)}
+        />
+      ) : (
+        <span className="icon-label">{artifact.label}</span>
+      )}
     </button>
   );
 }

--- a/web/src/components/ArtifactIcon.tsx
+++ b/web/src/components/ArtifactIcon.tsx
@@ -68,8 +68,15 @@ export function ArtifactIcon({ artifact, index, onClick, onStop, onContextMenu, 
   const isManagedApp = artifact.runtimeKind === "local_process";
 
   const inputRef = useRef<HTMLInputElement>(null);
+  // Guard against the double-commit race: Enter or Esc call commit/cancel
+  // directly, but then the state flip unmounts the <input> which fires blur,
+  // which would call commit a second time. For Esc that undoes the cancel
+  // entirely (the rename still happens). Track "already handled" in a ref
+  // and skip the blur-triggered commit when set.
+  const keyHandledRef = useRef(false);
   useEffect(() => {
     if (isRenaming) {
+      keyHandledRef.current = false;
       inputRef.current?.focus();
       inputRef.current?.select();
     }
@@ -136,10 +143,20 @@ export function ArtifactIcon({ artifact, index, onClick, onStop, onContextMenu, 
           onMouseDown={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
-            if (e.key === "Enter") { e.preventDefault(); onRenameCommit?.(e.currentTarget.value); }
-            else if (e.key === "Escape") { e.preventDefault(); onRenameCancel?.(); }
+            if (e.key === "Enter") {
+              e.preventDefault();
+              keyHandledRef.current = true;
+              onRenameCommit?.(e.currentTarget.value);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              keyHandledRef.current = true;
+              onRenameCancel?.();
+            }
           }}
-          onBlur={(e) => onRenameCommit?.(e.currentTarget.value)}
+          onBlur={(e) => {
+            if (keyHandledRef.current) return;
+            onRenameCommit?.(e.currentTarget.value);
+          }}
         />
       ) : (
         <span className="icon-label">{artifact.label}</span>

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -83,7 +83,7 @@ function ToolBlock({ tool }: { tool: ToolPart }) {
 const SLASH_COMMANDS = [
   { cmd: "/s", args: "<prefix>", desc: "Switch space", example: "/s bf → blunderfixer" },
   { cmd: "/o", args: "<search>", desc: "Open artifact", example: "/o competitor analysis" },
-  { cmd: "#", args: "<space>", desc: "Quick switch", example: "#bf or #1" },
+  { cmd: "#", args: "<space>", desc: "Quick switch", example: "#bf · #all · #archived" },
 ];
 
 interface Props {
@@ -189,11 +189,14 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
         { id: "home", displayName: "Home", hint: "#." },
         { id: "__all__", displayName: "All", hint: "#0" },
         ...userSpaces.map((s, i) => ({ ...s, hint: `#${i + 1}` })),
+        { id: "__archived__", displayName: "Archived", hint: "#archived" },
       ];
+      const labelFor = (id: string) =>
+        id === "__all__" ? "all" : id === "__archived__" ? "archived" : id;
       return ordered
-        .filter(s => !q || s.id.startsWith(q) || s.displayName.toLowerCase().startsWith(q) || (q === "all" && s.id === "__all__") || subseq(q, s.id) || subseq(q, s.displayName.toLowerCase()))
+        .filter(s => !q || s.id.startsWith(q) || s.displayName.toLowerCase().startsWith(q) || (q === "all" && s.id === "__all__") || (q.startsWith("arch") && s.id === "__archived__") || subseq(q, s.id) || subseq(q, s.displayName.toLowerCase()))
         .slice(0, 8)
-        .map(s => ({ key: s.id, label: `#${s.id === "__all__" ? "all" : s.id}`, desc: s.hint, type: "space" as const }));
+        .map(s => ({ key: s.id, label: `#${labelFor(s.id)}`, desc: s.hint, type: "space" as const }));
     }
 
     if (!input.startsWith("/")) return [];
@@ -281,8 +284,9 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
         }
       }
 
-      // Named: #all → __all__, #bf → blunderfixer
+      // Named: #all → __all__, #archived → __archived__, #bf → blunderfixer
       if (q === "all") { onSpaceChange("__all__"); return; }
+      if (q === "archived") { onSpaceChange("__archived__"); return; }
       const match = spaces.find(s => s.id === q)
         || spaces.find(s => s.id.startsWith(q))
         || spaces.find(s => s.displayName.toLowerCase().startsWith(q))
@@ -539,7 +543,25 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
             if (slashOpen) {
               if (e.key === "ArrowDown") { e.preventDefault(); setSlashIndex(i => Math.min(i + 1, slashItems.length - 1)); return; }
               if (e.key === "ArrowUp") { e.preventDefault(); setSlashIndex(i => Math.max(i - 1, 0)); return; }
-              if (e.key === "Tab" || (e.key === "Enter" && slashItems[slashIndex])) {
+              if (e.key === "Tab") {
+                // Tab = complete the current text to the highlighted item,
+                // don't execute. User can inspect what it expanded to and
+                // then hit Enter to run it. Mirrors shell behaviour.
+                e.preventDefault();
+                const item = slashItems[slashIndex];
+                if (item.type === "space") {
+                  const label = item.key === "__all__" ? "all" : item.key === "__archived__" ? "archived" : item.key;
+                  setInput(`#${label}`);
+                } else if (item.type === "artifact") {
+                  const a = artifacts.find((x) => x.id === item.key);
+                  if (a) setInput(`/o ${a.label}`);
+                } else {
+                  setInput(item.label + ("args" in item && item.args ? " " : ""));
+                }
+                return;
+              }
+              if (e.key === "Enter" && slashItems[slashIndex]) {
+                // Enter = execute: switch space / open artifact / begin command
                 e.preventDefault();
                 const item = slashItems[slashIndex];
                 if (item.type === "space") { setInput(""); onSpaceChange?.(item.key); }

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -32,7 +32,7 @@ interface Props {
   isFirstRun?: boolean;
   dragOver?: boolean;
   revealId?: string | null;
-  /** When true, render the archived-items view: context menu shows Restore / Delete permanently. */
+  /** When true, render the archived-items view: context menu shows Restore. */
   isArchivedView?: boolean;
 }
 
@@ -105,9 +105,13 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
   }
   async function handleUninstallPlugin(artifact: Artifact) {
     setArtifactCtx(null);
-    if (!window.confirm(`Uninstall "${artifact.label}"? This removes the plugin folder from ~/.oyster/userland/${artifact.id}.`)) return;
+    // `artifact.id` is a DB UUID once reconciled; the plugin folder is named
+    // by manifest id, exposed as `pluginId`. Fall back to id only as a last
+    // resort (pre-reconcile or mis-tagged entries).
+    const folderId = artifact.pluginId ?? artifact.id;
+    if (!window.confirm(`Uninstall "${artifact.label}"? This removes the plugin folder from ~/.oyster/userland/${folderId}.`)) return;
     onArtifactRemove?.(artifact.id);
-    try { await uninstallPlugin(artifact.id); }
+    try { await uninstallPlugin(folderId); }
     catch (err) { onRefresh?.(); alert(`Uninstall failed: ${(err as Error).message}`); }
   }
   async function handleRestoreArtifact(artifact: Artifact) {

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -25,6 +25,10 @@ interface Props {
   onConvertToSpace?: (groupName: string, merge?: boolean, sourceSpaceId?: string) => void;
   onImportFromAI?: (spaceId?: string) => void;
   onRefresh?: () => void;
+  /** Patch a single artifact in the parent's state — used for optimistic UI on rename so the label swap is instant, not a fetch round-trip later. */
+  onArtifactUpdate?: (id: string, fields: Partial<Artifact>) => void;
+  /** Remove a single artifact from the parent's state — used for optimistic archive / uninstall / restore so the tile disappears instantly. */
+  onArtifactRemove?: (id: string) => void;
   isFirstRun?: boolean;
   dragOver?: boolean;
   revealId?: string | null;
@@ -32,7 +36,7 @@ interface Props {
   isArchivedView?: boolean;
 }
 
-export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, onImportFromAI, onRefresh, dragOver, revealId, isFirstRun, isArchivedView }: Props) {
+export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, onImportFromAI, onRefresh, onArtifactUpdate, onArtifactRemove, dragOver, revealId, isFirstRun, isArchivedView }: Props) {
   const isAllSpace = space === "__all__";
 
   // ── Onboarding banner ──
@@ -78,27 +82,41 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
     setRenamingId(artifact.id);
   }
   async function commitArtifactRename(artifact: Artifact, nextLabel: string) {
-    setRenamingId(null);
     const trimmed = nextLabel.trim();
+    setRenamingId(null);
     if (!trimmed || trimmed === artifact.label) return;
-    try { await updateArtifact(artifact.id, { label: trimmed }); onRefresh?.(); }
-    catch (err) { alert(`Rename failed: ${(err as Error).message}`); }
+    // Optimistic: flip the label immediately so there's no flicker between
+    // the input disappearing and the server round-trip completing. The next
+    // poll (or onRefresh below) converges the state.
+    onArtifactUpdate?.(artifact.id, { label: trimmed });
+    try {
+      await updateArtifact(artifact.id, { label: trimmed });
+    } catch (err) {
+      // Revert the optimistic change on failure.
+      onArtifactUpdate?.(artifact.id, { label: artifact.label });
+      alert(`Rename failed: ${(err as Error).message}`);
+    }
   }
   async function handleArchiveArtifact(artifact: Artifact) {
     setArtifactCtx(null);
-    try { await archiveArtifact(artifact.id); onRefresh?.(); }
-    catch (err) { alert(`Archive failed: ${(err as Error).message}`); }
+    onArtifactRemove?.(artifact.id);
+    try { await archiveArtifact(artifact.id); }
+    catch (err) { onRefresh?.(); alert(`Archive failed: ${(err as Error).message}`); }
   }
   async function handleUninstallPlugin(artifact: Artifact) {
     setArtifactCtx(null);
     if (!window.confirm(`Uninstall "${artifact.label}"? This removes the plugin folder from ~/.oyster/userland/${artifact.id}.`)) return;
-    try { await uninstallPlugin(artifact.id); onRefresh?.(); }
-    catch (err) { alert(`Uninstall failed: ${(err as Error).message}`); }
+    onArtifactRemove?.(artifact.id);
+    try { await uninstallPlugin(artifact.id); }
+    catch (err) { onRefresh?.(); alert(`Uninstall failed: ${(err as Error).message}`); }
   }
   async function handleRestoreArtifact(artifact: Artifact) {
     setArtifactCtx(null);
-    try { await restoreArtifact(artifact.id); onRefresh?.(); }
-    catch (err) { alert(`Restore failed: ${(err as Error).message}`); }
+    // Optimistically remove from the archived view; the next refresh
+    // refetches the archived list and confirms.
+    onArtifactRemove?.(artifact.id);
+    try { await restoreArtifact(artifact.id); }
+    catch (err) { onRefresh?.(); alert(`Restore failed: ${(err as Error).message}`); }
   }
   async function handleRenameGroup(oldName: string, sourceSpaceId?: string) {
     setFolderCtx(null);

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -442,12 +442,18 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                       index={i}
                       onClick={() => onGroupClick(item.name)}
                       // Folder actions (Rename folder / Archive folder) are
-                      // scoped to a space_id. In the archived view, `space`
-                      // is "__archived__" which archived rows don't belong to,
-                      // so those bulk ops would silently no-op. Suppress the
-                      // menu entirely here.
+                      // scoped to a space_id. In the special views the group
+                      // tiles don't map cleanly:
+                      // - __archived__: rows keep their original spaceId so
+                      //   calling the bulk endpoints with "__archived__"
+                      //   no-ops silently.
+                      // - __all__: group tiles can be space-groupings
+                      //   (groupBy="space"), not user folders — same
+                      //   silent-no-op problem, plus Rename folder makes
+                      //   no semantic sense on a whole space.
+                      // Suppress the menu entirely in both cases.
                       onContextMenu={
-                        isArchivedView
+                        isArchivedView || isAllSpace
                           ? (e) => e.preventDefault()
                           : (e) => { e.preventDefault(); setArtifactCtx(null); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }
                       }

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -436,7 +436,22 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                   style={isDragged ? undefined : { transition: "transform 0.25s ease" }}
                 >
                   {item.type === "group" ? (
-                    <GroupIcon name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setArtifactCtx(null); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }} />
+                    <GroupIcon
+                      name={item.name}
+                      artifacts={item.artifacts}
+                      index={i}
+                      onClick={() => onGroupClick(item.name)}
+                      // Folder actions (Rename folder / Archive folder) are
+                      // scoped to a space_id. In the archived view, `space`
+                      // is "__archived__" which archived rows don't belong to,
+                      // so those bulk ops would silently no-op. Suppress the
+                      // menu entirely here.
+                      onContextMenu={
+                        isArchivedView
+                          ? (e) => e.preventDefault()
+                          : (e) => { e.preventDefault(); setArtifactCtx(null); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }
+                      }
+                    />
                   ) : (
                     <ArtifactIcon
                       artifact={item.artifact}

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -76,7 +76,10 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
   const [renamingId, setRenamingId] = useState<string | null>(null);
 
   // ── Context-menu action handlers ──
-  // Every mutation calls onRefresh so the parent refetches fresh state.
+  // Optimistic updates go first via onArtifactUpdate / onArtifactRemove so
+  // the UI responds instantly; onRefresh is called only on failure (to
+  // revert by refetching) or for bulk folder ops where per-artifact
+  // bookkeeping isn't worth it.
   function handleRenameArtifact(artifact: Artifact) {
     setArtifactCtx(null);
     setRenamingId(artifact.id);
@@ -109,7 +112,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
     // by manifest id, exposed as `pluginId`. Fall back to id only as a last
     // resort (pre-reconcile or mis-tagged entries).
     const folderId = artifact.pluginId ?? artifact.id;
-    if (!window.confirm(`Uninstall "${artifact.label}"? This removes the plugin folder from ~/.oyster/userland/${folderId}.`)) return;
+    if (!window.confirm(`Uninstall "${artifact.label}"? This removes the plugin folder "~/.oyster/userland/${folderId}".`)) return;
     onArtifactRemove?.(artifact.id);
     try { await uninstallPlugin(folderId); }
     catch (err) { onRefresh?.(); alert(`Uninstall failed: ${(err as Error).message}`); }

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { LayoutGrid, List, ArrowDownAZ, Tag, Clock, Folder, AlignLeft, AlignCenter, AlignRight } from "lucide-react";
 import type { Artifact } from "../data/artifacts-api";
+import { archiveArtifact, archiveGroup, renameGroup, restoreArtifact, uninstallPlugin, updateArtifact } from "../data/artifacts-api";
 import { ArtifactIcon, typeConfig } from "./ArtifactIcon";
 import { GroupIcon } from "./GroupIcon";
 import Grainient from "./reactbits/Grainient";
@@ -23,12 +24,15 @@ interface Props {
   onAddSpace?: (folderName?: string) => void;
   onConvertToSpace?: (groupName: string, merge?: boolean, sourceSpaceId?: string) => void;
   onImportFromAI?: (spaceId?: string) => void;
+  onRefresh?: () => void;
   isFirstRun?: boolean;
   dragOver?: boolean;
   revealId?: string | null;
+  /** When true, render the archived-items view: context menu shows Restore / Delete permanently. */
+  isArchivedView?: boolean;
 }
 
-export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, onImportFromAI, dragOver, revealId, isFirstRun }: Props) {
+export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onAddSpace, onConvertToSpace, onImportFromAI, onRefresh, dragOver, revealId, isFirstRun, isArchivedView }: Props) {
   const isAllSpace = space === "__all__";
 
   // ── Onboarding banner ──
@@ -51,6 +55,68 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
     window.addEventListener("mousedown", handleClick);
     return () => window.removeEventListener("mousedown", handleClick);
   }, [folderCtx]);
+
+  // ── Artifact context menu (right-click on a tile) ──
+  const [artifactCtx, setArtifactCtx] = useState<{ artifact: Artifact; x: number; y: number } | null>(null);
+  const artifactCtxRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!artifactCtx) return;
+    function handleClick(e: MouseEvent) {
+      if (artifactCtxRef.current && !artifactCtxRef.current.contains(e.target as Node)) setArtifactCtx(null);
+    }
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [artifactCtx]);
+
+  // ── Inline rename state — when set, the matching tile swaps its label for an input ──
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+
+  // ── Context-menu action handlers ──
+  // Every mutation calls onRefresh so the parent refetches fresh state.
+  function handleRenameArtifact(artifact: Artifact) {
+    setArtifactCtx(null);
+    setRenamingId(artifact.id);
+  }
+  async function commitArtifactRename(artifact: Artifact, nextLabel: string) {
+    setRenamingId(null);
+    const trimmed = nextLabel.trim();
+    if (!trimmed || trimmed === artifact.label) return;
+    try { await updateArtifact(artifact.id, { label: trimmed }); onRefresh?.(); }
+    catch (err) { alert(`Rename failed: ${(err as Error).message}`); }
+  }
+  async function handleArchiveArtifact(artifact: Artifact) {
+    setArtifactCtx(null);
+    try { await archiveArtifact(artifact.id); onRefresh?.(); }
+    catch (err) { alert(`Archive failed: ${(err as Error).message}`); }
+  }
+  async function handleUninstallPlugin(artifact: Artifact) {
+    setArtifactCtx(null);
+    if (!window.confirm(`Uninstall "${artifact.label}"? This removes the plugin folder from ~/.oyster/userland/${artifact.id}.`)) return;
+    try { await uninstallPlugin(artifact.id); onRefresh?.(); }
+    catch (err) { alert(`Uninstall failed: ${(err as Error).message}`); }
+  }
+  async function handleRestoreArtifact(artifact: Artifact) {
+    setArtifactCtx(null);
+    try { await restoreArtifact(artifact.id); onRefresh?.(); }
+    catch (err) { alert(`Restore failed: ${(err as Error).message}`); }
+  }
+  async function handleRenameGroup(oldName: string, sourceSpaceId?: string) {
+    setFolderCtx(null);
+    const next = window.prompt("Rename folder", oldName);
+    if (next === null) return;
+    const trimmed = next.trim();
+    if (!trimmed || trimmed === oldName) return;
+    const targetSpace = sourceSpaceId ?? space;
+    try { await renameGroup(targetSpace, oldName, trimmed); onRefresh?.(); }
+    catch (err) { alert(`Rename folder failed: ${(err as Error).message}`); }
+  }
+  async function handleArchiveGroup(name: string, sourceSpaceId?: string) {
+    setFolderCtx(null);
+    const targetSpace = sourceSpaceId ?? space;
+    if (!window.confirm(`Archive folder "${name}" and all its artifacts?`)) return;
+    try { await archiveGroup(targetSpace, name); onRefresh?.(); }
+    catch (err) { alert(`Archive folder failed: ${(err as Error).message}`); }
+  }
 
   // ── Topbar auto-hide ──
   const [topbarVisible, setTopbarVisible] = useState(true);
@@ -345,14 +411,18 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                   style={isDragged ? undefined : { transition: "transform 0.25s ease" }}
                 >
                   {item.type === "group" ? (
-                    <GroupIcon name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }} />
+                    <GroupIcon name={item.name} artifacts={item.artifacts} index={i} onClick={() => onGroupClick(item.name)} onContextMenu={(e) => { e.preventDefault(); setArtifactCtx(null); setFolderCtx({ name: item.name, x: e.clientX, y: e.clientY }); }} />
                   ) : (
                     <ArtifactIcon
                       artifact={item.artifact}
                       index={i}
                       onClick={() => onArtifactClick(item.artifact)}
                       onStop={onArtifactStop ? () => onArtifactStop(item.artifact) : undefined}
+                      onContextMenu={(e) => { e.preventDefault(); setFolderCtx(null); setArtifactCtx({ artifact: item.artifact, x: e.clientX, y: e.clientY }); }}
                       reveal={item.artifact.id === revealId}
+                      isRenaming={renamingId === item.artifact.id}
+                      onRenameCommit={(label) => commitArtifactRename(item.artifact, label)}
+                      onRenameCancel={() => setRenamingId(null)}
                     />
                   )}
                 </div>
@@ -369,6 +439,9 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
           className="space-ctx-menu"
           style={{ left: folderCtx.x, top: folderCtx.y, transform: "translateY(-100%)", marginTop: -8 }}
         >
+          <button className="space-ctx-item" onClick={() => handleRenameGroup(folderCtx.name, folderCtx.sourceSpaceId)}>
+            Rename folder
+          </button>
           {onConvertToSpace && (() => {
             const slug = folderCtx.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
             const hasConflict = spaces.includes(slug);
@@ -391,6 +464,52 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
               </button>
             );
           })()}
+          <div className="space-ctx-sep" />
+          <button className="space-ctx-item space-ctx-delete" onClick={() => handleArchiveGroup(folderCtx.name, folderCtx.sourceSpaceId)}>
+            Archive folder
+          </button>
+        </div>,
+        document.body,
+      )}
+
+      {artifactCtx && createPortal(
+        <div
+          ref={artifactCtxRef}
+          className="space-ctx-menu"
+          style={{ left: artifactCtx.x, top: artifactCtx.y, transform: "translateY(-100%)", marginTop: -8 }}
+        >
+          {isArchivedView ? (
+            // In the Archived view the only supported action is Restore
+            // (store.resurface clears removed_at). Hard-delete was cut for
+            // v1 because we'd either leave orphan files on disk or risk
+            // deleting onboarded files Oyster doesn't own.
+            <button className="space-ctx-item" onClick={() => handleRestoreArtifact(artifactCtx.artifact)}>
+              Restore
+            </button>
+          ) : artifactCtx.artifact.builtin ? (
+            // Builtins are re-seeded from the package on every boot — the
+            // menu is a no-op read-only marker rather than surfacing actions
+            // that would either fail or be reverted on next start.
+            <span className="space-ctx-confirm" style={{ padding: "6px 12px" }}>
+              Read-only (built-in)
+            </span>
+          ) : (
+            <>
+              <button className="space-ctx-item" onClick={() => handleRenameArtifact(artifactCtx.artifact)}>
+                Rename
+              </button>
+              <div className="space-ctx-sep" />
+              {artifactCtx.artifact.plugin ? (
+                <button className="space-ctx-item space-ctx-delete" onClick={() => handleUninstallPlugin(artifactCtx.artifact)}>
+                  Uninstall
+                </button>
+              ) : (
+                <button className="space-ctx-item space-ctx-delete" onClick={() => handleArchiveArtifact(artifactCtx.artifact)}>
+                  Archive
+                </button>
+              )}
+            </>
+          )}
         </div>,
         document.body,
       )}

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -2,12 +2,13 @@ export type { Artifact, ArtifactKind, ArtifactStatus, IconStatus } from "../../.
 import type { Artifact } from "../../../shared/types";
 
 // Our mutation endpoints return `{error: "…"}` on failure. Surface that
-// message in thrown Error objects so UI alert()s show something actionable
-// instead of just "Update failed: 400". Best-effort: if the body isn't
-// JSON or doesn't carry `.error`, fall back to the status.
-async function throwFromResponse(res: Response, fallback: string): Promise<never> {
+// message in thrown Error objects so UI alert()s show something actionable.
+// Callers add their own action context (e.g. "Rename failed:") on the
+// alert side — this helper just carries the reason, so we don't get
+// double-prefixed messages like "Rename failed: Rename failed: 400".
+async function throwFromResponse(res: Response): Promise<never> {
   const body = await res.json().catch(() => null) as { error?: string } | null;
-  throw new Error(body?.error || `${fallback}: ${res.status}`);
+  throw new Error(body?.error || `HTTP ${res.status}`);
 }
 
 export async function fetchArtifacts(): Promise<Artifact[]> {
@@ -35,29 +36,29 @@ export async function updateArtifact(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(fields),
   });
-  if (!res.ok) await throwFromResponse(res, "Update failed");
+  if (!res.ok) await throwFromResponse(res);
   return res.json();
 }
 
 export async function archiveArtifact(id: string): Promise<void> {
   const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/archive`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res, "Archive failed");
+  if (!res.ok) await throwFromResponse(res);
 }
 
 export async function listArchivedArtifacts(): Promise<Artifact[]> {
   const res = await fetch("/api/artifacts/archived");
-  if (!res.ok) await throwFromResponse(res, "List archived failed");
+  if (!res.ok) await throwFromResponse(res);
   return res.json();
 }
 
 export async function restoreArtifact(id: string): Promise<void> {
   const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/restore`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res, "Restore failed");
+  if (!res.ok) await throwFromResponse(res);
 }
 
 export async function uninstallPlugin(id: string): Promise<void> {
   const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/uninstall`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res, "Uninstall failed");
+  if (!res.ok) await throwFromResponse(res);
 }
 
 export async function renameGroup(
@@ -70,7 +71,7 @@ export async function renameGroup(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ space_id: spaceId, old_name: oldName, new_name: newName }),
   });
-  if (!res.ok) await throwFromResponse(res, "Rename group failed");
+  if (!res.ok) await throwFromResponse(res);
   return res.json();
 }
 
@@ -80,6 +81,6 @@ export async function archiveGroup(spaceId: string, name: string): Promise<{ arc
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ space_id: spaceId, name }),
   });
-  if (!res.ok) await throwFromResponse(res, "Archive group failed");
+  if (!res.ok) await throwFromResponse(res);
   return res.json();
 }

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -16,3 +16,64 @@ export async function stopApp(name: string): Promise<{ status: string }> {
   const res = await fetch(`/api/apps/${name}/stop`);
   return res.json();
 }
+
+export async function updateArtifact(
+  id: string,
+  fields: { label?: string; group_name?: string | null },
+): Promise<Artifact> {
+  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(fields),
+  });
+  if (!res.ok) throw new Error(`Update failed: ${res.status}`);
+  return res.json();
+}
+
+export async function archiveArtifact(id: string): Promise<void> {
+  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/archive`, { method: "POST" });
+  if (!res.ok) throw new Error(`Archive failed: ${res.status}`);
+}
+
+export async function listArchivedArtifacts(): Promise<Artifact[]> {
+  const res = await fetch("/api/artifacts/archived");
+  if (!res.ok) throw new Error(`List archived failed: ${res.status}`);
+  return res.json();
+}
+
+export async function restoreArtifact(id: string): Promise<void> {
+  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/restore`, { method: "POST" });
+  if (!res.ok) throw new Error(`Restore failed: ${res.status}`);
+}
+
+export async function uninstallPlugin(id: string): Promise<void> {
+  const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/uninstall`, { method: "POST" });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(body.error || `Uninstall failed: ${res.status}`);
+  }
+}
+
+export async function renameGroup(
+  spaceId: string,
+  oldName: string,
+  newName: string,
+): Promise<{ updated: number }> {
+  const res = await fetch("/api/groups", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ space_id: spaceId, old_name: oldName, new_name: newName }),
+  });
+  if (!res.ok) throw new Error(`Rename group failed: ${res.status}`);
+  return res.json();
+}
+
+export async function archiveGroup(spaceId: string, name: string): Promise<{ archived: number }> {
+  const res = await fetch("/api/groups/archive", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ space_id: spaceId, name }),
+  });
+  if (!res.ok) throw new Error(`Archive group failed: ${res.status}`);
+  return res.json();
+}

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -1,6 +1,15 @@
 export type { Artifact, ArtifactKind, ArtifactStatus, IconStatus } from "../../../shared/types";
 import type { Artifact } from "../../../shared/types";
 
+// Our mutation endpoints return `{error: "…"}` on failure. Surface that
+// message in thrown Error objects so UI alert()s show something actionable
+// instead of just "Update failed: 400". Best-effort: if the body isn't
+// JSON or doesn't carry `.error`, fall back to the status.
+async function throwFromResponse(res: Response, fallback: string): Promise<never> {
+  const body = await res.json().catch(() => null) as { error?: string } | null;
+  throw new Error(body?.error || `${fallback}: ${res.status}`);
+}
+
 export async function fetchArtifacts(): Promise<Artifact[]> {
   const res = await fetch("/api/artifacts");
   if (!res.ok) throw new Error(`Server returned ${res.status}`);
@@ -26,32 +35,29 @@ export async function updateArtifact(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(fields),
   });
-  if (!res.ok) throw new Error(`Update failed: ${res.status}`);
+  if (!res.ok) await throwFromResponse(res, "Update failed");
   return res.json();
 }
 
 export async function archiveArtifact(id: string): Promise<void> {
   const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/archive`, { method: "POST" });
-  if (!res.ok) throw new Error(`Archive failed: ${res.status}`);
+  if (!res.ok) await throwFromResponse(res, "Archive failed");
 }
 
 export async function listArchivedArtifacts(): Promise<Artifact[]> {
   const res = await fetch("/api/artifacts/archived");
-  if (!res.ok) throw new Error(`List archived failed: ${res.status}`);
+  if (!res.ok) await throwFromResponse(res, "List archived failed");
   return res.json();
 }
 
 export async function restoreArtifact(id: string): Promise<void> {
   const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/restore`, { method: "POST" });
-  if (!res.ok) throw new Error(`Restore failed: ${res.status}`);
+  if (!res.ok) await throwFromResponse(res, "Restore failed");
 }
 
 export async function uninstallPlugin(id: string): Promise<void> {
   const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/uninstall`, { method: "POST" });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(body.error || `Uninstall failed: ${res.status}`);
-  }
+  if (!res.ok) await throwFromResponse(res, "Uninstall failed");
 }
 
 export async function renameGroup(
@@ -64,7 +70,7 @@ export async function renameGroup(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ space_id: spaceId, old_name: oldName, new_name: newName }),
   });
-  if (!res.ok) throw new Error(`Rename group failed: ${res.status}`);
+  if (!res.ok) await throwFromResponse(res, "Rename group failed");
   return res.json();
 }
 
@@ -74,6 +80,6 @@ export async function archiveGroup(spaceId: string, name: string): Promise<{ arc
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ space_id: spaceId, name }),
   });
-  if (!res.ok) throw new Error(`Archive group failed: ${res.status}`);
+  if (!res.ok) await throwFromResponse(res, "Archive group failed");
   return res.json();
 }


### PR DESCRIPTION
Adds a context-menu surface on the desktop for artifact and folder housekeeping — rename, archive, restore, uninstall — plus `#archived` to browse previously-archived items.

## UX

**Right-click an artifact tile:**
| Kind | Menu |
|---|---|
| User-created (notes, diagrams, AI output) | Rename · Archive (soft-delete) |
| Third-party plugin (`oyster install <id>`) | Rename · Uninstall (deletes the plugin folder, same as the CLI) |
| Built-in app (zombie-horde, quick-start, pomodoro pre-install) | "Read-only (built-in)" — no actions. Builtins re-seed from the package on boot so any destructive action would revert anyway. |

**Right-click a folder (group) tile:**
- Rename folder (bulk-updates `group_name` across matching artifacts in the space)
- Convert to Space (existing, unchanged)
- Archive folder (bulk soft-delete of every artifact in the group)

**`#archived` in the chat bar:**
- Switches to a special view listing every soft-deleted row.
- Right-click → Restore. "Delete permanently" is intentionally cut for v1 — it'd need careful gating around whether to also delete the backing file and how to handle onboarded (non-userland) paths.

**Rename is inline:** the tile's label becomes an input with autofocus + select-all, Enter commits, Esc cancels, blur commits. Native \`window.prompt()\` felt jarring; shell-like inline is the norm.

## Chat-bar side-effects that came along

- **Tab now completes, Enter executes** — typing \`#ar\` + Tab fills \`#archived\` instead of jumping to the view. Matches shell / IDE autocomplete.
- \`#archived\` auto-suggests alongside \`#all\` and \`#home\`.
- Tagline "Apps are dead. Welcome to your surface." → Barlow 600 (the only app-side Barlow touch in this PR; broader Barlow/body pairing deferred).

## New server endpoints

| Method | Path | Purpose |
|---|---|---|
| PATCH | \`/api/artifacts/:id\` | rename / regroup |
| POST | \`/api/artifacts/:id/archive\` | soft-delete |
| POST | \`/api/artifacts/:id/restore\` | undo soft-delete |
| GET | \`/api/artifacts/archived\` | list archived rows |
| PATCH | \`/api/groups\` | bulk rename a group across a space |
| POST | \`/api/groups/archive\` | bulk archive a group |
| POST | \`/api/plugins/:id/uninstall\` | delete plugin folder from userland |

## Artifact type extensions

\`Artifact\` gains two optional flags the web uses to branch the menu without guessing from id shape:
- \`builtin?: boolean\` — first-party, bundled with Oyster
- \`plugin?: boolean\` — third-party plugin installed via \`oyster install\`

## Bugs fixed along the way

1. **Ghost tile after archiving a scan-backed note.** In-memory scanner entry shadowed the archived DB row, so the tile kept rendering. \`getAllArtifacts\` now suppresses gen entries whose filePath matches an archived row (new store helper \`getArchivedFilePaths()\`).
2. **Duplicate rows on re-archive.** The scanner still saw the file on disk each boot and \`reconcileGeneratedArtifact\` would register a fresh active row alongside the archived one. Reconcile now skips paths that already have an archived row — user has to Restore to bring one back.

Both produced the "foo / testproject still showing after archive" symptom during development; the first fix handled the immediate ghost, the second stopped the duplication loop.

## Non-goals (deliberately cut)

- Delete permanently in \`#archived\` — dropped this round. The label was ambiguous (didn't actually remove the file) and the real implementation needs careful thought.
- Archived view for folders — if you archive a folder, its artifacts appear individually in \`#archived\`; no folder grouping there.
- Visual "archived" styling on the tiles in \`#archived\` — they render normally; if dimming would help it's a cheap follow-up.

## Test plan

- [ ] Right-click a note → Rename inline, Enter commits, Esc cancels, blur commits
- [ ] Right-click a note → Archive → tile disappears within ~5 s
- [ ] \`#archived\` shows the archived tile → right-click → Restore → tile reappears on the original space
- [ ] Right-click \`zombie-horde\` → "Read-only (built-in)" label, no actions
- [ ] Right-click pomodoro (after \`oyster install pomodoro\`) → Uninstall (with confirm), \`~/.oyster/userland/pomodoro/\` is removed
- [ ] Right-click a folder → Rename folder updates \`group_name\` across all items in the space; Archive folder clears them all
- [ ] Type \`#ar\` → dropdown highlights Archived; Tab completes to \`#archived\` without executing; Enter then executes
- [ ] Archive a scan-backed note (e.g. \`~/.oyster/userland/foo/bar.md\`) → no ghost tile, no duplicate rows on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)