### PR TITLE
perf(web): pause Grainient shader when window unfocused or tab hidden

### DIFF
--- a/web/src/components/reactbits/Grainient.tsx
+++ b/web/src/components/reactbits/Grainient.tsx
@@ -223,16 +223,42 @@ export default function Grainient({
     setSize();
 
     let raf = 0;
-    const t0 = performance.now();
+    let t0 = performance.now();
+    let pausedAt: number | null = null;
     const loop = (t: number) => {
       program.uniforms.iTime.value = (t - t0) * 0.001;
       renderer.render({ scene: mesh });
       raf = requestAnimationFrame(loop);
     };
-    raf = requestAnimationFrame(loop);
+    const start = () => {
+      if (raf) return;
+      if (pausedAt !== null) {
+        t0 += performance.now() - pausedAt;
+        pausedAt = null;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    const stop = () => {
+      if (!raf) return;
+      cancelAnimationFrame(raf);
+      raf = 0;
+      pausedAt = performance.now();
+    };
+    const onVisibility = () => {
+      if (document.hidden) stop();
+      else start();
+    };
+    if (document.hasFocus() && !document.hidden) start();
+    else pausedAt = performance.now();
+    window.addEventListener("blur", stop);
+    window.addEventListener("focus", start);
+    document.addEventListener("visibilitychange", onVisibility);
 
     return () => {
-      cancelAnimationFrame(raf);
+      stop();
+      window.removeEventListener("blur", stop);
+      window.removeEventListener("focus", start);
+      document.removeEventListener("visibilitychange", onVisibility);
       ro.disconnect();
       try {
         container.removeChild(canvas);


### PR DESCRIPTION
## Summary
- The Grainient WebGL2 shader (full-viewport noise + warp + rotation) ran `requestAnimationFrame` unconditionally, pinning the Chrome GPU process (~30%) and driving WindowServer compositing cost (~40%) whenever Oyster sat in the background.
- rAF auto-throttles for hidden tabs but **not** for unfocused windows — so the shader kept rendering every frame as long as the Chrome window existed.
- Now listens for `blur`/`focus` and `visibilitychange`; pauses rAF when inactive and shifts `t0` by paused duration so `iTime` stays continuous on resume (no visual jump).

## Test plan
- [ ] `npm run dev`, open Oyster, confirm Grainient renders normally
- [ ] Switch focus to another app — Chrome Task Manager GPU process CPU drops to near-zero
- [ ] Switch back — shader resumes without a visible time-jump
- [ ] Minimise Chrome / hide the tab — same pause behaviour via visibilitychange
- [ ] Unmount (navigate away) — no leaked listeners or rAF

🤖 Generated with [Claude Code](https://claude.com/claude-code)