### PR TITLE
fix(import): resolve spaces by display_name when slug lookup misses (#118)

### DIFF
--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -413,7 +413,12 @@ export function buildImportPlan(
 
   for (const memory of payload.memories ?? []) {
     if (!memory.content) continue;
-    const spaceId = targetSpaceId ?? (memory.space ? (deps.resolveSpaceByName(memory.space)?.id ?? slugify(memory.space)) : null);
+    const memorySpaceSlug = memory.space ? slugify(memory.space) : "";
+    const spaceId =
+      targetSpaceId ??
+      (memory.space && memorySpaceSlug
+        ? (deps.resolveSpaceByName(memory.space)?.id ?? memorySpaceSlug)
+        : null);
     const isDupe = deps.findMemory(memory.content, spaceId);
 
     actions.push({

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -276,7 +276,10 @@ export async function parseImportPayload(
 // ── Preview (Plan Building) ──
 
 export interface PreviewDeps {
-  getSpaceBySlug: (slug: string) => { id: string; displayName: string } | null;
+  // Resolve a space by the raw name an agent emitted. Implementation should
+  // try id match first, then fall back to case-insensitive display_name match
+  // so renamed spaces still resolve (issue #118).
+  resolveSpaceByName: (name: string) => { id: string; displayName: string } | null;
   getArtifactsBySpace: (spaceId: string) => Array<{ source_ref: string | null; label: string }>;
   findMemory: (content: string, spaceId: string | null) => boolean;
 }
@@ -299,7 +302,7 @@ export function buildImportPlan(
   const nextId = () => `act_${++actCounter}`;
 
   // When scoped to a target space, resolve the display name for remapping
-  const targetSpaceRow = targetSpaceId ? deps.getSpaceBySlug(targetSpaceId) : null;
+  const targetSpaceRow = targetSpaceId ? deps.resolveSpaceByName(targetSpaceId) : null;
   const targetSpaceName = targetSpaceRow?.displayName ?? targetSpaceId;
 
   const spaceActionIds = new Map<string, string>();
@@ -329,7 +332,7 @@ export function buildImportPlan(
 
     const slug = slugify(space.name);
     if (!slug) continue;
-    const existing = deps.getSpaceBySlug(slug);
+    const existing = deps.resolveSpaceByName(space.name);
     const actionId = nextId();
     spaceActionIds.set(space.name, actionId);
 
@@ -388,7 +391,7 @@ export function buildImportPlan(
     }
 
     const slug = slugify(summary.space);
-    const existing = deps.getSpaceBySlug(slug);
+    const existing = deps.resolveSpaceByName(summary.space);
     const parentActionId = spaceActionIds.get(summary.space);
     if (!existing && !parentActionId) continue;
     const spaceId = existing?.id ?? slug;
@@ -410,7 +413,7 @@ export function buildImportPlan(
 
   for (const memory of payload.memories ?? []) {
     if (!memory.content) continue;
-    const spaceId = targetSpaceId ?? (memory.space ? (deps.getSpaceBySlug(slugify(memory.space))?.id ?? slugify(memory.space)) : null);
+    const spaceId = targetSpaceId ?? (memory.space ? (deps.resolveSpaceByName(memory.space)?.id ?? slugify(memory.space)) : null);
     const isDupe = deps.findMemory(memory.content, spaceId);
 
     actions.push({
@@ -448,7 +451,8 @@ export interface ExecuteDeps {
   }) => Promise<{ id: string }>;
   remember: (input: { content: string; space_id?: string; tags?: string[] }) => Promise<{ id: string }>;
   findMemory: (content: string, spaceId: string | null) => boolean;
-  getSpaceBySlug: (slug: string) => { id: string } | null;
+  // See PreviewDeps.resolveSpaceByName
+  resolveSpaceByName: (name: string) => { id: string } | null;
 }
 
 function resolveSpaceId(
@@ -458,7 +462,7 @@ function resolveSpaceId(
 ): string {
   const fromCreated = createdSpaces.get(spaceName);
   if (fromCreated) return fromCreated;
-  const existing = deps.getSpaceBySlug(slugify(spaceName));
+  const existing = deps.resolveSpaceByName(spaceName);
   if (existing) return existing.id;
   return slugify(spaceName);
 }
@@ -508,7 +512,7 @@ export async function executeImportPlan(
       switch (action.type) {
         case "create_space": {
           if (action.status === "exists_will_merge") {
-            const existing = deps.getSpaceBySlug(slugify(action.name!));
+            const existing = deps.resolveSpaceByName(action.name!);
             if (existing) createdSpaces.set(action.name!, existing.id);
             results.push({ action_id: action.action_id, status: "skipped" });
           } else {

--- a/server/src/import.ts
+++ b/server/src/import.ts
@@ -331,8 +331,9 @@ export function buildImportPlan(
     }
 
     const slug = slugify(space.name);
-    if (!slug) continue;
     const existing = deps.resolveSpaceByName(space.name);
+    // Skip only when we can neither resolve an existing space nor mint a new slug.
+    if (!existing && !slug) continue;
     const actionId = nextId();
     spaceActionIds.set(space.name, actionId);
 
@@ -556,9 +557,12 @@ export async function executeImportPlan(
           break;
         }
         case "create_memory": {
-          const spaceSlug = action.space ? slugify(action.space) : undefined;
-          const spaceId = spaceSlug
-            ? resolveSpaceId(action.space!, createdSpaces, deps)
+          // Match the preview gate: require a non-empty slug before binding to
+          // a space. Keeps unscoped-memory behaviour consistent with
+          // buildImportPlan when space names slugify to empty.
+          const spaceSlug = action.space ? slugify(action.space) : "";
+          const spaceId = action.space && spaceSlug
+            ? resolveSpaceId(action.space, createdSpaces, deps)
             : undefined;
           // Check if already exists before creating
           if (deps.findMemory && deps.findMemory(action.content!, spaceId ?? null)) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -175,6 +175,18 @@ const db = initDb(USERLAND_DIR);
 const store = new SqliteArtifactStore(db);
 const artifactService = new ArtifactService(store, USERLAND_DIR);
 const spaceStore = new SqliteSpaceStore(db);
+
+// Shared resolver: try raw id, then slugified id, then case-insensitive display_name.
+// Used by import preview + execute so an agent-emitted space name (possibly
+// whitespace-padded or referring to a renamed space) resolves consistently.
+function resolveSpaceRow(name: string) {
+  const trimmed = name.trim();
+  return (
+    spaceStore.getById(trimmed) ??
+    spaceStore.getById(slugify(trimmed)) ??
+    spaceStore.getByDisplayName(trimmed)
+  );
+}
 const spaceService = new SpaceService(spaceStore, store);
 const memoryProvider = new SqliteFtsMemoryProvider(USERLAND_DIR);
 await memoryProvider.init();
@@ -573,11 +585,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
         const previewDeps: PreviewDeps = {
           resolveSpaceByName: (name) => {
-            const trimmed = name.trim();
-            const row =
-              spaceStore.getById(trimmed) ??
-              spaceStore.getById(slugify(trimmed)) ??
-              spaceStore.getByDisplayName(trimmed);
+            const row = resolveSpaceRow(name);
             return row ? { id: row.id, displayName: row.display_name } : null;
           },
           getArtifactsBySpace: (spaceId) => {
@@ -631,11 +639,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           remember: (input) => memoryProvider.remember(input),
           findMemory: (content, spaceId) => memoryProvider.findExact(content, spaceId ?? undefined),
           resolveSpaceByName: (name) => {
-            const trimmed = name.trim();
-            const row =
-              spaceStore.getById(trimmed) ??
-              spaceStore.getById(slugify(trimmed)) ??
-              spaceStore.getByDisplayName(trimmed);
+            const row = resolveSpaceRow(name);
             return row ? { id: row.id } : null;
           },
         };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,7 @@ import { SqliteArtifactStore } from "./artifact-store.js";
 import { ArtifactService } from "./artifact-service.js";
 import { SqliteSpaceStore } from "./space-store.js";
 import { SpaceService } from "./space-service.js";
+import { slugify } from "./utils.js";
 import { IconGenerator } from "./icon-generator.js";
 import { injectBridge } from "./error-bridge.js";
 import {
@@ -571,8 +572,8 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         const generatedAt = parseResult.payload.source?.generated_at || new Date().toISOString();
 
         const previewDeps: PreviewDeps = {
-          getSpaceBySlug: (slug) => {
-            const row = spaceStore.getAll().find((s) => s.id === slug);
+          resolveSpaceByName: (name) => {
+            const row = spaceStore.getById(slugify(name)) ?? spaceStore.getByDisplayName(name);
             return row ? { id: row.id, displayName: row.display_name } : null;
           },
           getArtifactsBySpace: (spaceId) => {
@@ -625,8 +626,8 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           createArtifact: (params) => artifactService.createArtifact(params, USERLAND_DIR),
           remember: (input) => memoryProvider.remember(input),
           findMemory: (content, spaceId) => memoryProvider.findExact(content, spaceId ?? undefined),
-          getSpaceBySlug: (slug) => {
-            const row = spaceStore.getAll().find((s) => s.id === slug);
+          resolveSpaceByName: (name) => {
+            const row = spaceStore.getById(slugify(name)) ?? spaceStore.getByDisplayName(name);
             return row ? { id: row.id } : null;
           },
         };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -573,7 +573,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
         const previewDeps: PreviewDeps = {
           resolveSpaceByName: (name) => {
-            const row = spaceStore.getById(slugify(name)) ?? spaceStore.getByDisplayName(name);
+            const trimmed = name.trim();
+            const row =
+              spaceStore.getById(trimmed) ??
+              spaceStore.getById(slugify(trimmed)) ??
+              spaceStore.getByDisplayName(trimmed);
             return row ? { id: row.id, displayName: row.display_name } : null;
           },
           getArtifactsBySpace: (spaceId) => {
@@ -627,7 +631,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
           remember: (input) => memoryProvider.remember(input),
           findMemory: (content, spaceId) => memoryProvider.findExact(content, spaceId ?? undefined),
           resolveSpaceByName: (name) => {
-            const row = spaceStore.getById(slugify(name)) ?? spaceStore.getByDisplayName(name);
+            const trimmed = name.trim();
+            const row =
+              spaceStore.getById(trimmed) ??
+              spaceStore.getById(slugify(trimmed)) ??
+              spaceStore.getByDisplayName(trimmed);
             return row ? { id: row.id } : null;
           },
         };

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -54,8 +54,8 @@ export class SqliteSpaceStore implements SpaceStore {
     this.stmts = {
       getAll: db.prepare("SELECT * FROM spaces ORDER BY display_name"),
       getById: db.prepare("SELECT * FROM spaces WHERE id = ?"),
-      // Case-insensitive match; most recently updated wins when displayNames collide
-      getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(display_name) = LOWER(?) ORDER BY updated_at DESC LIMIT 1"),
+      // Case-insensitive + trim-tolerant match; most recently updated wins when displayNames collide
+      getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(TRIM(display_name)) = LOWER(TRIM(?)) ORDER BY updated_at DESC LIMIT 1"),
       getByRepoPath: db.prepare("SELECT * FROM spaces WHERE repo_path = ?"),
       insert: db.prepare(`
         INSERT INTO spaces (

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -26,6 +26,7 @@ export interface SpacePath {
 export interface SpaceStore {
   getAll(): SpaceRow[];
   getById(id: string): SpaceRow | undefined;
+  getByDisplayName(name: string): SpaceRow | undefined;
   getByRepoPath(repoPath: string): SpaceRow | undefined;
   insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void;
   update(id: string, fields: Partial<Omit<SpaceRow, "id" | "created_at">>): void;
@@ -40,6 +41,7 @@ export class SqliteSpaceStore implements SpaceStore {
   private stmts: {
     getAll: Database.Statement;
     getById: Database.Statement;
+    getByDisplayName: Database.Statement;
     getByRepoPath: Database.Statement;
     insert: Database.Statement;
     getPaths: Database.Statement;
@@ -52,6 +54,8 @@ export class SqliteSpaceStore implements SpaceStore {
     this.stmts = {
       getAll: db.prepare("SELECT * FROM spaces ORDER BY display_name"),
       getById: db.prepare("SELECT * FROM spaces WHERE id = ?"),
+      // Case-insensitive match; most recently updated wins when displayNames collide
+      getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(display_name) = LOWER(?) ORDER BY updated_at DESC LIMIT 1"),
       getByRepoPath: db.prepare("SELECT * FROM spaces WHERE repo_path = ?"),
       insert: db.prepare(`
         INSERT INTO spaces (
@@ -73,6 +77,7 @@ export class SqliteSpaceStore implements SpaceStore {
 
   getAll(): SpaceRow[] { return this.stmts.getAll.all() as SpaceRow[]; }
   getById(id: string): SpaceRow | undefined { return this.stmts.getById.get(id) as SpaceRow | undefined; }
+  getByDisplayName(name: string): SpaceRow | undefined { return this.stmts.getByDisplayName.get(name) as SpaceRow | undefined; }
   getByRepoPath(repoPath: string): SpaceRow | undefined { return this.stmts.getByRepoPath.get(repoPath) as SpaceRow | undefined; }
   insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void { this.stmts.insert.run(row); }
   delete(id: string): void {


### PR DESCRIPTION
## Summary

After renaming a space, `display_name` changes but `id` (a slug frozen at creation) does not. The import pipeline was slugifying agent-emitted names and matching against `id` only — so imports for renamed spaces silently landed in newly-created duplicates.

This mirrors the resolution pattern `ChatBar.tsx` already uses for `/s` and `#` commands: try id match first, then case-insensitive `display_name` match. No data migration, no URL changes, no UI changes.

## Why this approach

Investigated the blast radius before choosing. Every other resolution site in the codebase is already correct: MCP tools take `space_id` directly, URLs use ids, filesystem paths use ids, rename leaves the id alone by design. Import was the only site that assumed `id === slugify(display_name)` — an assumption that breaks under rename.

The fix restores consistency with the existing convention rather than introducing a new one.

## Changes

- `space-store.ts`: add `getByDisplayName(name)` — case-insensitive, most recently updated wins on duplicate
- `import.ts`: rename dep `getSpaceBySlug` → `resolveSpaceByName`, pass raw names instead of pre-slugified strings
- `index.ts`: implement `resolveSpaceByName` as `getById(slugify(name)) ?? getByDisplayName(name)` at the two dep-injection sites

## Test plan

UAT scenarios (all verified via isolated node script against in-memory SQLite; script not committed):

- [x] **Rename then import** — create "Hello" → rename to "Poems" → import payload with `space: "Poems"` → plan shows `exists_will_merge` against the existing `hello`-id space
- [x] **No rename (regression)** — unchanged behaviour for spaces that were never renamed
- [x] **Not found (regression)** — payloads referencing unknown spaces still produce `create_space` actions
- [x] **Case-insensitive** — payload says `"poems"`, renamed space has `display_name: "Poems"` → resolves
- [x] **Collision** — slug match wins over displayName match (two spaces where one's id collides with another's renamed displayName)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)