### PR TITLE
docs: version-keyed CHANGELOG + oyster.to/changelog page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,6 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.notes }}
-          generate_release_notes: true
+          # Curated CHANGELOG section is the source of truth. Auto-generated PR
+          # list would be prepended/appended to our body and duplicate content.
+          generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
         id: changelog
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          NOTES=$(awk "/^## /{if(found)exit; if(/## $VERSION/||/## [0-9]{4}-/){found=1; next}} found" CHANGELOG.md 2>/dev/null || echo "Release $GITHUB_REF_NAME")
+          # Keep a Changelog format: match `## [X.Y.Z]` header, capture until the next `## ` header.
+          NOTES=$(awk -v v="$VERSION" 'BEGIN{re="^## \\[" v "\\]"} /^## /{if(found)exit; if($0~re){found=1; next}} found' CHANGELOG.md 2>/dev/null || true)
           if [ -z "$NOTES" ]; then
             NOTES="Release $GITHUB_REF_NAME"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,11 @@ jobs:
         id: changelog
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          # Keep a Changelog format: match `## [X.Y.Z]` header, capture until the next `## ` header.
-          NOTES=$(awk -v v="$VERSION" 'BEGIN{re="^## \\[" v "\\]"} /^## /{if(found)exit; if($0~re){found=1; next}} found' CHANGELOG.md 2>/dev/null || true)
+          # Keep a Changelog format: match literal `## [X.Y.Z]` header, capture
+          # until the next `## ` header. `index() == 1` avoids regex-metachar
+          # pitfalls (e.g. `.` in semver matching any character).
+          HEADER="## [$VERSION]"
+          NOTES=$(awk -v h="$HEADER" 'index($0, h)==1{found=1; next} /^## /{if(found)exit} found' CHANGELOG.md 2>/dev/null || true)
           if [ -z "$NOTES" ]; then
             NOTES="Release $GITHUB_REF_NAME"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,481 +1,252 @@
 # Changelog
 
-## 2026-04-15
+All notable changes to Oyster are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Cloud AI import
+## [Unreleased]
 
-- Import projects, context, and memories from ChatGPT, Claude, or Gemini
-- 3-step wizard: select provider, paste AI output, preview and import
-- Server converts any format to structured JSON via OpenCode
-- Merge-based: detects existing spaces, skips duplicates on re-import
-- First-run onboarding banner with "Import from AI" CTA
+### Performance
 
-### Builtin redesign
+- Grainient shader pauses `requestAnimationFrame` on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.
 
-- All builtins (Quick Start, Connect Your AI, Import from AI) redesigned with consistent design language
-- Glass cards, ambient glow, pill selectors, smooth animations
-- Iframe close support via postMessage
+### Added
 
-## 2026-04-14
+- `oyster --help` shows 🦪 in the header.
 
-### MCP onboarding
+### Changed
 
-- "Connect your AI" builtin artifact on home surface
-- Tabbed connection guide: Claude Code, Cursor, VS Code, Windsurf
-- Examples of what MCP enables + full tool reference
-- CLI startup prints MCP connect command and examples
-- New landing page at oyster.to/mcp with matching design
+- Docs site typography: Barlow headings paired with Space Grotesk body across landing and `/plugins`.
+- `/plugins` hero renamed to "Pearls".
 
-### Quick Start guide
+## [0.3.4] - 2026-04-19
 
-- "Quick Start" builtin artifact on home surface
-- 60-second overview: prompt bar, slash commands, spaces, artifacts
-- Links to MCP connection guide and drop-to-import
+### Fixed
 
-### Auto-backup
+- Stale tile icons cleared after `oyster uninstall <id>`.
 
-- Userland auto-backed up on every startup to `~/oyster-backups/auto/`
-- One backup per day — repeated restarts reuse the same slot
-- Rotates to last 5 days of history
-- Runs before bootstrap/migration — captures pre-upgrade state
-- Best-effort: never crashes server startup
+### Changed
 
-### Landing page updates
+- `/plugins` copy button uses `oyster install <id>` form.
 
-- MCP section: real client-specific connection snippets with tabs
-- Actual tool names (create_artifact, onboard_space, etc.)
-- Nav: replaced GitHub link with MCP page link
-- Mobile fix: terminal mockup no longer overflows on small screens
+### Chore
 
-## 2026-04-13
+- Adopted eslint 10 in web (fixed 16 surfaced errors).
+- Dependabot config for Actions and npm groups.
+- Release workflow actions bumped for Node 24.
+- Dep bumps: `marked` 17 → 18; `@types/node` 22 → 25; web/server/root minor+patch groups.
 
-### Drop-to-import
+## [0.3.3] - 2026-04-18
 
-- Drop a folder anywhere on the surface to import projects
-- Full-page drop zone — works on the chat bar, icons, anywhere
-- Background animates on drag (Grainient speeds up)
-- Icons and chat dim during drag to focus attention
-- Wizard skips straight to scanning when folder is dropped
-- Browser no longer navigates away on accidental file drops
+### Added
 
-### Dev / prod separation
+- **Plugins — Tier 2 installer.** `oyster install <id>`, `oyster uninstall <id>`, `oyster list` install community plugins by id.
+- `oyster install <id>` resolves the repo from the `mattslight/oyster-community-plugins` registry.
+- New `/plugins` catalog page on oyster.to with copy-install buttons, strict input validation, and a CDN fallback.
+- Plugin system design doc.
 
-- Dev server uses port 3333, prod uses 4444 — can run side by side
-- Dev uses `./userland`, prod uses `~/.oyster/userland`
-- `OYSTER_INSTALLED` flag from CLI controls which environment
-- Version badge on surface shows version + env (dev/prod)
-- Icon resolution fix: checks artifact root dir for `icon.png`
+### Changed
 
-### Persistent memory
+- README and `CLAUDE.md` updated to match shipped v1 — port 4444, 19 MCP tools, FTS5 memory.
+- `/plugins` page polish: hairline borders dropped, only purposeful ones kept.
 
-- AI agent remembers across sessions — preferences, decisions, context
-- `MemoryProvider` interface: async, storage-agnostic, swappable backends
-- First provider: SQLite FTS5 — separate `memory.db`, full-text search
-- 4 MCP tools: `remember`, `recall`, `forget`, `list_memories`
-- Export/import for provider migration
-- Explicit writes only — agent stores memory when asked, not automatically
+## [0.3.2] - 2026-04-18
 
-### First-run onboarding
+### Added
 
-- New users see "Drop a folder to get started" on the home surface
-- Subtitle: "We'll organise your projects into spaces"
-- Hint below space pills: "click + to add your projects"
-- Hides during chat, returns when clicking out
-- Disappears once first space is created
-- Surface accepts folder drops to trigger discovery
+- `--version` / `-v` flag on the `oyster` CLI.
 
-### Port resilience
+### Fixed
 
-- OpenCode config written dynamically with actual server port
-- OpenCode spawned after server listens (fixes MCP connection race)
-- Vite proxy reads `OYSTER_PORT` env var instead of hardcoding 4444
+- Chat user bubble no longer conflates visually with the assistant response.
 
-### Chat bar polish
+### Chore
 
-- Input placeholder now cycles on blur (was static per session)
-- Agent sessions use `oyster` agent (was defaulting to `build`)
+- Local discovery validation PoC script.
 
-## 2026-04-12
+## [0.3.1] - 2026-04-17
 
-### Multi-folder spaces and broader scanning
+First stable release of the 0.3 line. Bundles everything shipped across the 0.3.0 beta cycle (no stable 0.3.0 tag).
 
-**Multi-folder spaces**
-- A space can now have multiple folders (repos, project dirs, any folder)
-- New `space_paths` table — migrates existing `repo_path` values automatically
-- Add Space wizard: toggle between "New space" and "Existing space"
-- Drop multiple folders onto one space
-- API: `GET/POST/DELETE /api/spaces/:id/paths`
-
-**Broader scanner**
-- Finds artifacts in Go, Rust, Python, Ruby, Java projects (not just JS frameworks)
-- Root-level projects detected (single-repo projects, not just monorepo sub-dirs)
-- Any `.md` file discovered as notes (not just root README and `docs/`)
-- More JS frameworks: Angular, Nuxt, Astro, Remix, Solid
-- Non-JS projects stored correctly (no broken package.json references)
-- Apps grouped under "Apps", all notes/diagrams under "Docs"
-- Hidden dirs and tool dirs skipped to reduce noise
-- Folder resolution searches Dropbox, OneDrive, iCloud Drive, Downloads
-
-**Auth flow**
-- Removed API key prompt — runs `opencode providers login` inline on first run
-- Uses bundled OpenCode binary, no separate install step
-
-**Renamed builtin:** `snake-game` → `zombie-horde` (game was already Zombie Horde)
-
-### Phase B: CLI packaging — `npm install -g oyster-os`
-
-Oyster is now a published npm package. One command to install, one command to run.
-
-**CLI entry point (`bin/oyster.mjs`)**
-- Checks for OpenCode auth; runs `opencode providers login` inline on first run (OAuth in browser)
-- Spawns server process, opens browser to `http://localhost:4200`
-- Bootstraps `~/.oyster/userland/` with builtins (zombie-horde, the-worlds-your-oyster deck)
-- Handles SIGINT/SIGTERM cleanup
-
-**Compiled server + static web serving**
-- Server compiles to JS via tsc (no tsx at runtime)
-- Web build copied into `server/dist/public/` — one runtime root, one port
-- Package is ~2.2 MB unpacked, 6 runtime dependencies
-- `node-pty` moved to optionalDependencies with graceful fallback when unavailable
-
-**Cross-platform**
-- Windows support: finds `opencode.cmd`, uses `shell: true` for spawn on win32
-- Path traversal protection on static file serving
-- Userland defaults to `~/.oyster/userland/` (writable), not package dir
-
-### Documentation overhaul
-
-- CLAUDE.md rewritten to match shipped product — one server on 4200, OpenCode internal, `~/.oyster/userland/`, npm workflow
-- Design doc updated: architecture diagrams show OpenCode as internal subprocess, Graphiti deferred to v2
-- `opencode.json` model fixed to `anthropic/claude-sonnet-4-20250514`
-- README rewrite for npm — quick start is `npm install -g oyster-os`, not `git clone`; full loop from install to MCP to onboard
-
-### Landing page polish
-
-- Terminal window mockup with traffic light dots for `npm install` section
-- Mac/Windows OS toggle with pill-shaped sliding active state
-- `npx oyster-os` alternative with gold "no install?" note
-- Feature sections reordered: surface first, then navigate, then get started
-
-## 2026-04-11
-
-### Phase A: prompt-driven surface control + slash commands
-
-The chat bar now controls the OS. Dropped Graphiti dependency (memory deferred to v2), added SSE command channel for instant UI push events.
-
-**New MCP tools**
-- `open_artifact(id)` — opens viewer via SSE push, instant
-- `switch_space(id)` — navigates desktop via SSE push, instant
-- `list_artifacts` gains `search` and `limit` params for LLM-based resolution
-
-**Slash commands (client-side, no LLM call)**
-- `/s <prefix>` — instant space switch with subsequence matching
-- `/o <query>` — token-scored artifact open with autocomplete dropdown
-- Autocomplete on `/` with keyboard nav (↑↓ Enter Tab Escape)
-- Messages panel dims when autocomplete is open
-
-**# prefix shortcuts**
-- `#<name>` — space switch (Enter to confirm)
-- `#<digit>` — instant space switch (no Enter needed)
-- `#.` = home (like `cd .`), `#0` = all
-- "No match" feedback for unmatched `#` commands
-- Auto-focus chat input on any keypress
-
-**SSE command channel**
-- `GET /api/ui/events` — server pushes `open_artifact`, `switch_space`, `artifact.created` events
-- React subscribes on mount; viewer and desktop respond to push commands instantly
-
-**Bug fixes**
-- `source_origin` threaded through artifact creation
-- Artifact kind inference improvements
-- Stale closures fixed in ChatBar (missing `useCallback` deps)
-- Duplicated scoring logic extracted to shared `scoreArtifacts()` function
-- Silent failures on unmatched commands now show feedback
-
-### UX polish — connection banner, tagline, alignment toggle
-
-- Red glassmorphic connection banner with pulsing dot when server is unreachable
-- Tagline changed to "Apps are dead. Welcome to your surface."
-- Alignment toggle (left/center/right) available on all spaces, not just __all__
-- Agent instructions updated: navigation commands are instant, no deliberation
-- Dev port changed from 5555 to 7337
-
-### Landing page — full marketing site
-
-Built a GitHub Pages landing page with interactive mock UI:
-
-- Hero section with animated typing, space switching, and build progress
-- 3D tilt effect on mock panels (follows mouse cursor)
-- Real FAL-generated artifact icons
-- "Import your projects" section showing repo onboarding scan results
-- "Bring your own AI" section — MCP as a feature, tool names as pills (open, create, organise, search, navigate, import)
-- "UI that adapts to the job" section — dynamic UI carousel (kanban/chart/list cycling) with Coming Soon ribbon
-- "From zero to workspace in one command" — `npm install` section with animated space pills
-- Subtitle: "A modern workspace OS with AI at its core"
-- Space Grotesk + IBM Plex Mono typography
-- Bottom CTAs and footer
-
-## 2026-03-30
-
-### View toggle — always visible alongside kind filter
-
-- View toggle (grid/list) now floats next to the kind filter pill instead of being replaced by it
-- Filter pill simplified: "Showing" label removed — just `APPS ▾ ✕`
-- Toggle and pill share a `.filter-bar` flex wrapper, centered at the top of the surface
-- Kind switcher dropdown (▾) only shown when multiple kinds exist in the space
-- Fixed bug: clicking a kind option in the dropdown had no effect — `pointerdown` outside-click handler was unmounting the dropdown before the `click` could fire; fixed by stopping propagation on dropdown option `pointerdown`
-
-### Spaces hierarchy + list view polish
-
-- `parent_id` column added to spaces table for UI navigation hierarchy (nullable, top-level spaces are NULL)
-- List view space tags restyled: solid tinted background, soft white text, lighter font weight
-
-## 2026-03-29
-
-### Add Space — spaces as first-class entities with wizard, scanner, and MCP tool
-
-**Spaces table + provenance**
-- New `spaces` table in SQLite with display name, repo path, colour, scan status, and timestamps
-- Artifact table extended with `source_origin` (`manual` | `discovered`) and `source_ref` (e.g. `web/:app`, `README.md:notes`) for deterministic rescan identity
-- DB seeded from existing artifact `space_id` values on first startup; guard prevents resurrection of deleted spaces on restart
-
-**SpaceStore + SpaceService**
-- `SqliteSpaceStore`: CRUD for spaces with atomic updates
-- `SpaceService`: `createSpace`, `listSpaces`, `getSpace`, `deleteSpace` (cascades artifacts), `scanSpace`
-- Scanner walks repo up to 4 levels deep, detects apps (via `package.json` + framework keywords), notes (README, CHANGELOG, `docs/**/*.md`), and diagrams (`.mmd`, `.mermaid`)
-- Auto-groups by top-level directory: `Apps`, `Docs`, etc.; root files ungrouped
-
-**HTTP API**
-- `POST /api/spaces` — create space
-- `GET /api/spaces` — list spaces
-- `GET /api/spaces/:id` — get space
-- `DELETE /api/spaces/:id` — delete space (cascades artifacts)
-- `POST /api/spaces/:id/scan` — trigger scan, returns `ScanResult`
-- `GET /api/resolve-folder?name=` — resolves folder name to absolute path by searching common dev directories; deduplicates by inode to handle macOS case-insensitive filesystem
-
-**MCP `onboard_space` tool**
-- Creates space + triggers scan in one call
-- Returns `space_id` and `scan_summary` with discovered/skipped/resurfaced counts
-- `list_spaces` updated to read from `SpaceStore` (returns full `Space` objects with colour, scanStatus, etc.)
-
-**Add Space wizard (UI)**
-- 2-step modal: (1) name input + drag-and-drop folder picker → (2) scan results
-- Drag-and-drop uses `webkitGetAsEntry()` — no permission prompt, no file scanning; folder name sent to `/api/resolve-folder` for path resolution
-- 3-bar stepper (`— — —`) at top; step 3 dimmed (AI generation, not yet implemented)
-- Scan results show apps and docs in separate sections with dot indicators
-- Rollback: if scan fails, the space row is deleted so the user can retry with the same name
-- `+` pill in ChatBar opens the wizard
-
-**Bug fixes + polish**
-- `getDocFile()` fixed to return storage path for `local_process` artifacts (not just `static_file`) — unblocks icon regeneration for external repo apps
-- Icon regeneration for artifacts outside userland now stores icons in `userland/icons/<id>/`
-- Space pill `+` button: low opacity, brightens on hover
-
-### Desktop toggle — etched into surface
-
-- View toggle (grid/list) restyled from frosted glass card to a sunken/recessed appearance
-- Container: inset box-shadow, no backdrop blur — looks carved into the desktop surface
-- Inactive icons: 22% white opacity (present but unobtrusive)
-- Active state: slight lift with drop shadow, 65% white (clearly active, no purple glow)
-
-### Specs + planning
-
-- Design spec: `docs/superpowers/specs/2026-03-29-oyster-folder-design.md` — `.oyster/` repo-carried project config for team sharing (Option C: overrides only, keyed by `source_ref`, merge on rescan)
-- GitHub issues: #31 `.oyster/` folder, #32 Add Space via MCP parity, #33 wizard step 3 AI generation
-
-## 2026-03-28
-
-### Desktop polish — floating toggle, filter notice, list headers, icon centering
-
-**Floating view toggle + filter notice**
-- View toggle (grid/list) moved out of the auto-hide topbar to a persistent pill floating centered at the top of the desktop
-- When a kind filter is active, the toggle is replaced by a filter notice: "Showing APPS ▾ ✕"
-- Clicking the kind label opens a dropdown to switch to another kind directly
-- ✕ clears the filter and restores the view toggle
-
-**List column headers**
-- Name and Kind headers sit above their respective columns
-- Clicking a header sorts by that column; clicking again toggles asc/desc direction (↑/↓)
-- Sort direction persisted to localStorage
-- Section headers aligned above the Name column (not the dot)
-
-**Group-by none**
-- "none" added to the group-by control in all-space view — shows a flat unsectioned grid or list
-
-**Layout fixes**
-- Icon grid centered horizontally (`auto-fit` columns + `justify-content: center`; was `auto-fill` which kept icons left-aligned)
-- Scroll restored — `height: 100%` changed to `min-height: 100%` on the icon grid
-- Topbar controls centered (`justify-content: center`)
-- Hero fade starts earlier (18%→38%) to clear the centered chatbar; normal fade extended for taller chatbar clearance
-
-### Desktop redesign — topbar, sort/filter, drag-to-reorder, animated space pills, spotlight search
-
-**Desktop topbar (auto-hide)**
-- Topbar fades out after 2s of inactivity; hover top edge to reveal
-- View toggle: grid / list (persisted to localStorage globally)
-- Sort modes: A–Z, by kind, timeline (per-space localStorage)
-- Kind filter pills: show all or a specific artifact kind
-- Group-by (all-space only): by space or by kind
-- Clock component removed; topbar supersedes it
-
-**Drag-to-reorder**
-- Icons can be dragged to any position in grid view
-- Order persisted per-space in localStorage
-- Drag only active in A–Z sort mode (other modes have deterministic order)
-
-**Animated space pills**
-- Home icon pill, All pill, named space pills
-- Shared layout animation (framer-motion) for sliding active indicator
-- Per-space accent colors from a curated palette via `spaceColor` utility
-- Active pill text is white; `LayoutGroup` scopes animation to this pill group
-
-**Spotlight search (Cmd+K)**
-- Fuzzy label filter across all artifacts
-- Shows kind badge and space label per result
-- Keyboard nav (↑↓ Enter) and Escape to dismiss
-
-**Bug fixes**
-- Content top-padding increased from 24px to 60px across grid, all-grid, and list views — was hidden behind the 48px topbar
-- Space pill active text color set to white via `.space-pill.active` class
-
-## 2026-03-27
-
-### Oyster MCP — agent-facing tool surface
-
-Agents (Claude Code, OpenCode, Cursor, etc.) can now manage the Oyster desktop surface programmatically via MCP at `http://localhost:4200/mcp/`.
-
-**Discovery tools**
-- `get_context` — returns a full description of Oyster OS, artifact kinds, runtime model, and the actual userland path. Automatically called by fresh agent sessions.
-- `list_spaces` — lists all spaces with artifact counts
-- `list_artifacts` — lists all artifacts with id, label, kind, space, status, url, group, and source_path
-
-**Authoring tools**
-- `create_artifact` — writes a new file inside userland and registers it on the desktop in one step. Server computes the path from space + label; agent provides content. IDs are opaque UUIDs (not tied to filename or space), so the same label can exist in multiple spaces or subdirectories without collision. Exclusive write (`flag: wx`) + best-effort rollback prevents orphan files.
-- `read_artifact` — returns raw text content of static file artifacts (.md, .html, .mmd, .txt, .json, .csv)
-- `update_artifact` — updates display metadata only (label, space, group). Does not move or rename files. Space assignment is desktop metadata — the file stays where it is.
-- `register_artifact` — registers a pre-existing file on disk as a desktop artifact (legacy flow; prefer `create_artifact` for new content)
-
-**Design decisions recorded**
-- Stateless transport: fresh McpServer + fresh StreamableHTTPServerTransport per request
-- Localhost-only: non-local Origin headers rejected with 403
-- Approved roots: `register_artifact` only accepts paths under userland/
-- Spaces are emergent: no spaces table, derived from artifact space_id
-- Generated artifacts (`gen:` prefix) are in-memory only and cannot yet be updated via MCP — this is a known gap (Phase 3: `promote_artifact`)
-
-**Agent onboarding**
-- `opencode.json` updated with `oyster` MCP entry pointing to `localhost:4200/mcp/`
-- `.opencode/agents/oyster.md` updated with full tool table and usage guidance
-- Fresh-session test confirmed: agent called `get_context` proactively, surfaced userland path, understood spaces-are-emergent model
-
-## 2026-03-14 (night)
-
-### AI-generated artifact icons
-
-- Geometric icon generation pipeline: GPT-4o-mini reads app source code and crafts art-directed prompts, fal.ai Flux Schnell renders 512x512 geometric/low-poly icons
-- Icons use the desktop colour palette per artifact type (matching typeConfig gradients and accent colours)
-- Sequential job queue processes icons one at a time, skips if icon.png already exists on disk
-- Existing icons detected from disk on server restart (no re-generation)
-- Graceful degradation: no FAL_KEY disables icons entirely, no OPENAI_API_KEY falls back to basic prompts
-- Frontend renders AI icons with CSS border-radius clipping, falls back to SVG type icons
-- `@fal-ai/client` dependency added, env vars loaded via `node --env-file`
-
-### Fixes
-
-- Doc viewer "Not found" — `/docs/:name` route now strips query params (cache-bust `?t=` was breaking the regex)
-- Tagline: "Tools are dead. Welcome to the surface."
-- Ultra Hardcore popup: "This opens the shell." with white button text
-
-## 2026-03-14 (evening)
-
-### Global rebrand: mint green to electric blue/indigo
-
-- Accent colour changed from #21b981 (mint green) to #7c6bff (electric indigo) across all surfaces
-- Aurora background gradient updated to indigo tones
-- Terminal cursor, selection, and prompt colours updated
-- Chatbar bolt icon, send button, hover states all indigo
-
-### Showcase deck: "The World's Your Oyster" redesign
-
-- Replaced old-school scrolling webpage with modern scroll-driven reveal experience
-- Threads WebGL shader background (indigo flowing lines, mouse-reactive) replaces FaultyTerminal
-- GSAP ScrollTrigger word-by-word blur reveal on scroll (text sharpens as it reaches centre)
-- Hero: typing animation with leading cursor — "Tools are dead." then "Welcome to Oyster."
-- Scroll indicator: mouse oval with bouncing dot, fades on first scroll
-- "Your work is scattered" slide: Matter.js physics — tool names fall and tumble dramatically
-- Format list: alternating lavender/white — docs / slides / mind maps / apps / games / boards / sheets / charts / sites
-- Chat bar mockup with animated conic gradient glow border
-- Stats section: big bold numbers (1 surface, infinite artifacts, 0 tabs)
-- All copy tightened (Zinsser method) — removed jargon, shorter sentences throughout
-- Unified indigo palette — no more green/blue colour clash
-
-### Chat and UX fixes
-
-- Click outside chatbar collapses with animation; click bar to re-expand (works during streaming)
-- Placeholder hidden while AI is streaming
-- Disabled input uses pointer-events:none so clicks fall through to expand chat
-- Agent instructions: artifacts dir is the lookup path for existing user content
-- ViewerWindow iframe src memoised to prevent game restarts from polling re-renders
-- Server: query param stripping for static file serving (fixes cache-bust 404)
-- OpenCode spawned from project root (finds .opencode/agents/oyster.md)
-
-## 2026-03-14
-
-### Artifact contract and Tier 1 pipeline
-
-- Defined the artifact contract: every generated output gets a folder, manifest.json, and source files under `/artifacts/<id>/`
-- Manifest schema: id, name, type, runtime, entrypoint, ports, storage, capabilities, status, timestamps
-- Server detects artifacts by reading manifests first, falling back to filename inference for legacy files
-- Static file serving for `/artifacts/` path with markdown rendering
-- Recursive scan on startup finds existing artifacts in subdirectories
-- Agent instructions (oyster.md) rewritten with full artifact creation contract and examples
-- Added `table` artifact type (cyan, grid icon) for spreadsheets and structured data
-- Generated static apps open in ViewerWindow iframe instead of trying to start a dev server
-- Cache-busting on iframe src so updated artifacts always show fresh content
-- Query param stripping in static file server to support cache-busting
-
-### Architecture documentation
-
-- Superseded design doc with artifact contract, runtime tiers (static/vite/docker), and deployment models (single machine, control plane + runtime, central AI pool)
-- Deleted stale implementation doc, consolidated all content into single living design doc
-- Renamed to `oyster-os-design.md` (removed date prefix)
-
-### Chat improvements
-
-- Markdown rendering in assistant chat bubbles (installed marked, added .chat-markdown styles)
-- Filtered out empty tool-use message bubbles (no more `...` spam)
-- Session creation retries on 502 (handles OpenCode still starting up)
-- Click outside chatbar collapses messages panel with smooth animation
-- Click/focus on input expands messages panel
-- CSS transition for expand/collapse (opacity, transform, max-height)
-
-### Fixes
-
-- OpenCode serve now runs from project root (finds .opencode/agents/oyster.md)
-- PROJECT_ROOT hoisted to top of server for consistent use
-- Status dot on artifact icons only shows for registry apps with dev server ports
-- Self-healing artifact cleanup passes id for proper cache invalidation
-
-## 2026-03-13
-
-### Sprint 2: Wire the engine
-
-- OpenCode terminal embedded in surface (xterm.js + WebSocket PTY)
-- HTTP+WS hybrid server with app process management
-- Real workspace artifacts (Tokinvest apps + docs) replace mock data
-- Space-based navigation with pill row
-- Fresh session model (home = new session, session URLs bookmarkable)
-- Deck artifacts open fullscreen with draggable toolbar
-- Chat API layer with SSE streaming to OpenCode
-- Self-healing artifact cleanup and name override system
-- Showcase deck with WebGL shader background
-
-## 2026-03-12
-
-### Sprint 1: UI mockup
-
-- Surface with Aurora WebGL animated background
-- Typed artifact icons on grid with colour-coded badges
-- Chat bar embedded at bottom of surface
-- Simulated chat streaming with mock responses
-- Window system with viewer, z-order, drag
-- Glassmorphic viewer window with iframe
+### Added
+
+- **Cloud AI import.** Paste from ChatGPT / Claude / Gemini and Oyster scaffolds projects, context, and memories.
+  - 3-step wizard: select provider, paste AI output, preview and import.
+  - Server converts any format to structured JSON via OpenCode.
+  - Merge-based: detects existing spaces, skips duplicates on re-import.
+  - First-run onboarding banner with "Import from AI" CTA.
+- **Builtin redesign.** Quick Start, Connect Your AI, and Import from AI built as consistent glass-card builtins with ambient glow, pill selectors, and `postMessage` close support.
+- **Space management UI.** Rename, recolour, and remove spaces directly from the UI.
+
+### Fixed
+
+- **Cross-platform (Windows):**
+  - Hardcoded `/` path separators replaced with `path.basename` / `path.sep` throughout.
+  - Swapped `node-pty` for `@lydell/node-pty` — prebuilt binaries, no build tools required.
+  - Auth detection checks `~/.local/share/opencode/auth.json` directly.
+  - Windows 403 on artifact serving (path separator mismatch).
+- **Stability:**
+  - SSE fetch no longer crashes when OpenCode dies mid-stream.
+  - OpenCode port defaults to `0` (auto-select); was hardcoded `4096`.
+  - Kill OpenCode subprocess on shutdown; reset port on restart.
+
+### Changed
+
+- Terminal WebSocket uses dynamic host instead of hardcoded port 4200.
+- Connection banner says "oyster" (was "npm run dev").
+- Helpful error when import paste yields nothing.
+
+## [0.2.4] - 2026-04-15
+
+### Added
+
+- Release scripts: `release:minor`, `release:beta`, `release:promote` (later simplified to `release` and `release:beta`).
+
+### Fixed
+
+- Prod backups at `~/oyster-backups/auto/`, dev at `~/oyster-backups/dev/` (were conflating).
+- `import-state.json` stored in userland (was shared at `~/.oyster`).
+- Import wizard UI polish — prompt copy hint, paste area, consistent CTAs.
+- Native `select` replaced with a custom dark-themed dropdown.
+
+## [0.1.21] - 2026-04-14
+
+### Added
+
+- **Auto-backup.** Userland auto-backed up on every startup to `~/oyster-backups/auto/`.
+  - One backup per day — repeated restarts reuse the same slot.
+  - Rotates to last 5 days of history.
+  - Runs before bootstrap/migration — captures pre-upgrade state.
+  - Best-effort: never crashes server startup.
+- **MCP onboarding.** "Connect your AI" builtin on the home surface with a tabbed guide for Claude Code, Cursor, VS Code, and Windsurf. CLI startup prints the MCP connect command. Landing page at `oyster.to/mcp`.
+- **Quick Start guide.** 60-second overview builtin: prompt bar, slash commands, spaces, artifacts.
+
+### Changed
+
+- Landing page MCP section: real client-specific connection snippets with tabs, actual tool-name pills.
+- Nav replaced GitHub link with MCP page link.
+
+### Fixed
+
+- Mobile: terminal mockup no longer overflows on small screens.
+- "Bring Your Own AI" capitalisation and naming consistency.
+
+## [0.1.17] - 2026-04-13
+
+### Added
+
+- **Drop-to-import.** Drop a folder anywhere on the surface to import projects. Full-page drop zone, Grainient speeds up on drag, icons and chat dim to focus attention, wizard skips straight to scanning.
+- **Persistent memory.** AI agent remembers across sessions.
+  - `MemoryProvider` interface — async, storage-agnostic, swappable backends.
+  - First provider: SQLite FTS5 with full-text search in a separate `memory.db`.
+  - 4 MCP tools: `remember`, `recall`, `forget`, `list_memories`.
+  - Explicit writes only — agent stores memory when asked.
+- **First-run onboarding.** "Drop a folder to get started" hint, space-pill hint, surface-wide folder-drop trigger.
+- **Dev / prod separation.** Dev server on port 3333, prod on 4444 — run side by side. Dev uses `./userland`, prod uses `~/.oyster/userland`. Version badge on surface shows version + env.
+
+### Fixed
+
+- Icon resolution checks artifact root dir for `icon.png`.
+- `opencode.json` included in npm package.
+
+### Changed
+
+- Input placeholder cycles on blur (was static per session).
+- Agent sessions use the `oyster` agent (was defaulting to `build`).
+- Port resilience: OpenCode config written dynamically with actual server port; OpenCode spawned after server listens (fixes MCP connection race); Vite proxy reads `OYSTER_PORT` env var.
+
+## [0.1.10] - 2026-04-12
+
+### Added
+
+- **Multi-folder spaces + broader scanner.**
+  - A space can have multiple folders (repos, project dirs, any folder).
+  - `space_paths` table — migrates existing `repo_path` values automatically.
+  - Add Space wizard toggles between "New space" and "Existing space".
+  - Drop multiple folders onto one space. API: `GET/POST/DELETE /api/spaces/:id/paths`.
+  - Scanner finds artifacts in Go, Rust, Python, Ruby, Java (not just JS). Root-level projects detected. Any `.md` found as notes. More JS frameworks: Angular, Nuxt, Astro, Remix, Solid.
+  - Folder resolution searches Dropbox, OneDrive, iCloud Drive, Downloads.
+- **CLI packaging — `npm install -g oyster-os`.**
+  - Checks for OpenCode auth; runs `opencode providers login` inline on first run (OAuth in browser).
+  - Spawns server process, opens browser.
+  - Bootstraps `~/.oyster/userland/` with builtins (zombie-horde, the-worlds-your-oyster deck).
+  - Handles SIGINT/SIGTERM cleanup.
+  - Compiled server + static web serving — package is ~2.2 MB unpacked, 6 runtime dependencies.
+  - `node-pty` moved to optionalDependencies with graceful fallback.
+  - Windows support: finds `opencode.cmd`, uses `shell: true` for spawn.
+  - Path traversal protection on static file serving.
+
+### Changed
+
+- Auth flow: removed API key prompt — runs `opencode providers login` inline on first run.
+- Renamed builtin: `snake-game` → `zombie-horde`.
+- Documentation overhaul: CLAUDE.md rewritten to match shipped product; design doc updated; README rewrite for npm.
+- Landing page polish: terminal window mockup with traffic-light dots; Mac/Windows OS toggle.
+
+## [0.0.x] - Prototype (2026-03-12 through 2026-04-11)
+
+Milestones leading up to the first npm-packaged release, newest first.
+
+#### 2026-04-11 — Phase A: prompt-driven surface control
+
+The chat bar now controls the OS. Dropped Graphiti dependency (memory deferred to v2). Added SSE command channel for instant UI push events.
+
+- MCP tools: `open_artifact(id)`, `switch_space(id)`, `list_artifacts` with search/limit.
+- Slash commands: `/s <prefix>` (space switch), `/o <query>` (artifact open) — client-side, no LLM call.
+- `#` prefix shortcuts: `#<name>`, `#<digit>`, `#.`, `#0`.
+- SSE command channel at `GET /api/ui/events`.
+- Tagline: "Apps are dead. Welcome to your surface."
+- Landing page (GitHub Pages) with animated mock UI, 3D tilt panels, real FAL icons.
+
+#### 2026-03-30 — View toggle + kind filter polish
+
+- View toggle (grid/list) floats next to the kind filter pill.
+- List-view space tags restyled.
+
+#### 2026-03-29 — Spaces as first-class entities
+
+- `spaces` table, SpaceStore, SpaceService. Scanner walks repos up to 4 levels deep.
+- HTTP API: `POST/GET/DELETE /api/spaces`, `POST /api/spaces/:id/scan`.
+- MCP `onboard_space` — creates space + triggers scan in one call.
+- Add Space wizard: 2-step modal with drag-and-drop folder picker.
+
+#### 2026-03-28 — Desktop redesign
+
+- Auto-hide topbar with view toggle, sort modes, kind filter pills, group-by.
+- Drag-to-reorder icons in grid view.
+- Animated space pills (framer-motion), per-space accent colours.
+- Spotlight search (Cmd+K) with fuzzy filter across all artifacts.
+
+#### 2026-03-27 — Oyster MCP surface
+
+Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via MCP.
+
+- Discovery: `get_context`, `list_spaces`, `list_artifacts`.
+- Authoring: `create_artifact`, `read_artifact`, `update_artifact`, `register_artifact`.
+- Localhost-only (non-local Origin rejected with 403), approved roots, stateless transport.
+
+#### 2026-03-14 — Rebrand + artifact contract + AI icons
+
+- Global rebrand: mint green → electric indigo.
+- Artifact contract: every generated output gets a folder, `manifest.json`, and source files under `/artifacts/<id>/`.
+- AI-generated artifact icons — GPT-4o-mini + fal.ai Flux Schnell render geometric icons per artifact.
+- Showcase deck: "The World's Your Oyster" redesign with GSAP scroll-driven reveal.
+
+#### 2026-03-13 — Sprint 2: wire the engine
+
+- OpenCode terminal embedded (xterm.js + WebSocket PTY).
+- HTTP+WS hybrid server with app process management.
+- Space-based navigation, deck artifacts, chat API with SSE streaming.
+
+#### 2026-03-12 — Sprint 1: UI mockup
+
+- Surface with Aurora WebGL animated background.
+- Typed artifact icons, chat bar, window system with viewer.
+
+[Unreleased]: https://github.com/mattslight/oyster/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/mattslight/oyster/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/mattslight/oyster/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/mattslight/oyster/compare/v0.2.4...v0.3.1
+[0.2.4]: https://github.com/mattslight/oyster/compare/v0.1.21...v0.2.4
+[0.1.21]: https://github.com/mattslight/oyster/compare/v0.1.17...v0.1.21
+[0.1.17]: https://github.com/mattslight/oyster/compare/v0.1.10...v0.1.17
+[0.1.10]: https://github.com/mattslight/oyster/releases/tag/v0.1.10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ oyster                   # Starts server, opens browser to localhost:4444
 
 # Release (bump version, push tag — CI publishes to npm + creates GitHub release)
 npm run release          # runs: npm version patch && git push && git push --tags
+                         # npm `version` lifecycle regenerates docs/changelog.html from CHANGELOG.md
+
+# Regenerate the oyster.to changelog page after editing CHANGELOG.md between releases
+npm run build:changelog  # renders CHANGELOG.md → docs/changelog.html
 ```
 
 ## Conventions
@@ -79,6 +83,7 @@ npm run release          # runs: npm version patch && git push && git push --tag
 - SQLite migrations are additive `ALTER TABLE ... ADD COLUMN` with try/catch (idempotent)
 - Userland data lives at `~/.oyster/userland/` (not in the package directory)
 - Always use feature branches, never commit to main directly
+- Add a `CHANGELOG.md` entry in the same PR as any user-visible change; run `npm run build:changelog` to refresh `docs/changelog.html` (also auto-runs via the `version` lifecycle on `npm run release`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Early v1. Local-first. Single-user. Built for fast iteration.
 
 **Vision:** plugins, dynamic UI that reshapes to fit the task, build & share apps.
 
+See every shipped change in the [changelog](https://oyster.to/changelog).
+
 ## Contributing
 
 Oyster is early, but focused contributions are welcome.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -141,6 +141,14 @@
       color: #fff;
       letter-spacing: -0.5px;
     }
+    .release-version-link {
+      text-decoration: none;
+      border-bottom: 0 !important;
+      transition: opacity 0.15s;
+    }
+    .release-version-link:hover .release-version {
+      color: #a99eff;
+    }
     .release-date {
       font-family: 'IBM Plex Mono', monospace;
       font-size: 12px;
@@ -317,7 +325,7 @@
   </nav>
 
   <main class="entries">
-<h2 id="v-unreleased"><span class="release-version">Unreleased</span></h2>
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...HEAD"><span class="release-version">Unreleased</span></a></h2>
 <h3>Performance</h3>
 <ul>
 <li>Grainient shader pauses <code>requestAnimationFrame</code> on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.</li>
@@ -331,7 +339,7 @@
 <li>Docs site typography: Barlow headings paired with Space Grotesk body across landing and <code>/plugins</code>.</li>
 <li><code>/plugins</code> hero renamed to &quot;Pearls&quot;.</li>
 </ul>
-<h2 id="v-0-3-4"><span class="release-version">0.3.4</span><span class="release-date"> — 2026-04-19</span></h2>
+<h2 id="v-0-3-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4"><span class="release-version">0.3.4</span></a><span class="release-date"> — 2026-04-19</span></h2>
 <h3>Fixed</h3>
 <ul>
 <li>Stale tile icons cleared after <code>oyster uninstall &lt;id&gt;</code>.</li>
@@ -347,7 +355,7 @@
 <li>Release workflow actions bumped for Node 24.</li>
 <li>Dep bumps: <code>marked</code> 17 → 18; <code>@types/node</code> 22 → 25; web/server/root minor+patch groups.</li>
 </ul>
-<h2 id="v-0-3-3"><span class="release-version">0.3.3</span><span class="release-date"> — 2026-04-18</span></h2>
+<h2 id="v-0-3-3"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.2...v0.3.3"><span class="release-version">0.3.3</span></a><span class="release-date"> — 2026-04-18</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Plugins — Tier 2 installer.</strong> <code>oyster install &lt;id&gt;</code>, <code>oyster uninstall &lt;id&gt;</code>, <code>oyster list</code> install community plugins by id.</li>
@@ -360,7 +368,7 @@
 <li>README and <code>CLAUDE.md</code> updated to match shipped v1 — port 4444, 19 MCP tools, FTS5 memory.</li>
 <li><code>/plugins</code> page polish: hairline borders dropped, only purposeful ones kept.</li>
 </ul>
-<h2 id="v-0-3-2"><span class="release-version">0.3.2</span><span class="release-date"> — 2026-04-18</span></h2>
+<h2 id="v-0-3-2"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.1...v0.3.2"><span class="release-version">0.3.2</span></a><span class="release-date"> — 2026-04-18</span></h2>
 <h3>Added</h3>
 <ul>
 <li><code>--version</code> / <code>-v</code> flag on the <code>oyster</code> CLI.</li>
@@ -373,7 +381,7 @@
 <ul>
 <li>Local discovery validation PoC script.</li>
 </ul>
-<h2 id="v-0-3-1"><span class="release-version">0.3.1</span><span class="release-date"> — 2026-04-17</span></h2>
+<h2 id="v-0-3-1"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.2.4...v0.3.1"><span class="release-version">0.3.1</span></a><span class="release-date"> — 2026-04-17</span></h2>
 <p>First stable release of the 0.3 line. Bundles everything shipped across the 0.3.0 beta cycle (no stable 0.3.0 tag).</p>
 <h3>Added</h3>
 <ul>
@@ -409,7 +417,7 @@
 <li>Connection banner says &quot;oyster&quot; (was &quot;npm run dev&quot;).</li>
 <li>Helpful error when import paste yields nothing.</li>
 </ul>
-<h2 id="v-0-2-4"><span class="release-version">0.2.4</span><span class="release-date"> — 2026-04-15</span></h2>
+<h2 id="v-0-2-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.21...v0.2.4"><span class="release-version">0.2.4</span></a><span class="release-date"> — 2026-04-15</span></h2>
 <h3>Added</h3>
 <ul>
 <li>Release scripts: <code>release:minor</code>, <code>release:beta</code>, <code>release:promote</code> (later simplified to <code>release</code> and <code>release:beta</code>).</li>
@@ -421,7 +429,7 @@
 <li>Import wizard UI polish — prompt copy hint, paste area, consistent CTAs.</li>
 <li>Native <code>select</code> replaced with a custom dark-themed dropdown.</li>
 </ul>
-<h2 id="v-0-1-21"><span class="release-version">0.1.21</span><span class="release-date"> — 2026-04-14</span></h2>
+<h2 id="v-0-1-21"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.17...v0.1.21"><span class="release-version">0.1.21</span></a><span class="release-date"> — 2026-04-14</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Auto-backup.</strong> Userland auto-backed up on every startup to <code>~/oyster-backups/auto/</code>.<ul>
@@ -444,7 +452,7 @@
 <li>Mobile: terminal mockup no longer overflows on small screens.</li>
 <li>&quot;Bring Your Own AI&quot; capitalisation and naming consistency.</li>
 </ul>
-<h2 id="v-0-1-17"><span class="release-version">0.1.17</span><span class="release-date"> — 2026-04-13</span></h2>
+<h2 id="v-0-1-17"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.10...v0.1.17"><span class="release-version">0.1.17</span></a><span class="release-date"> — 2026-04-13</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Drop-to-import.</strong> Drop a folder anywhere on the surface to import projects. Full-page drop zone, Grainient speeds up on drag, icons and chat dim to focus attention, wizard skips straight to scanning.</li>
@@ -469,7 +477,7 @@
 <li>Agent sessions use the <code>oyster</code> agent (was defaulting to <code>build</code>).</li>
 <li>Port resilience: OpenCode config written dynamically with actual server port; OpenCode spawned after server listens (fixes MCP connection race); Vite proxy reads <code>OYSTER_PORT</code> env var.</li>
 </ul>
-<h2 id="v-0-1-10"><span class="release-version">0.1.10</span><span class="release-date"> — 2026-04-12</span></h2>
+<h2 id="v-0-1-10"><a class="release-version-link" href="https://github.com/mattslight/oyster/releases/tag/v0.1.10"><span class="release-version">0.1.10</span></a><span class="release-date"> — 2026-04-12</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Multi-folder spaces + broader scanner.</strong><ul>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -325,7 +325,7 @@
   </nav>
 
   <main class="entries">
-<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...HEAD"><span class="release-version">Unreleased</span></a></h2>
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Performance</h3>
 <ul>
 <li>Grainient shader pauses <code>requestAnimationFrame</code> on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.</li>
@@ -339,7 +339,7 @@
 <li>Docs site typography: Barlow headings paired with Space Grotesk body across landing and <code>/plugins</code>.</li>
 <li><code>/plugins</code> hero renamed to &quot;Pearls&quot;.</li>
 </ul>
-<h2 id="v-0-3-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4"><span class="release-version">0.3.4</span></a><span class="release-date"> — 2026-04-19</span></h2>
+<h2 id="v-0-3-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4" rel="noopener noreferrer"><span class="release-version">0.3.4</span></a><span class="release-date"> — 2026-04-19</span></h2>
 <h3>Fixed</h3>
 <ul>
 <li>Stale tile icons cleared after <code>oyster uninstall &lt;id&gt;</code>.</li>
@@ -355,7 +355,7 @@
 <li>Release workflow actions bumped for Node 24.</li>
 <li>Dep bumps: <code>marked</code> 17 → 18; <code>@types/node</code> 22 → 25; web/server/root minor+patch groups.</li>
 </ul>
-<h2 id="v-0-3-3"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.2...v0.3.3"><span class="release-version">0.3.3</span></a><span class="release-date"> — 2026-04-18</span></h2>
+<h2 id="v-0-3-3"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.2...v0.3.3" rel="noopener noreferrer"><span class="release-version">0.3.3</span></a><span class="release-date"> — 2026-04-18</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Plugins — Tier 2 installer.</strong> <code>oyster install &lt;id&gt;</code>, <code>oyster uninstall &lt;id&gt;</code>, <code>oyster list</code> install community plugins by id.</li>
@@ -368,7 +368,7 @@
 <li>README and <code>CLAUDE.md</code> updated to match shipped v1 — port 4444, 19 MCP tools, FTS5 memory.</li>
 <li><code>/plugins</code> page polish: hairline borders dropped, only purposeful ones kept.</li>
 </ul>
-<h2 id="v-0-3-2"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.1...v0.3.2"><span class="release-version">0.3.2</span></a><span class="release-date"> — 2026-04-18</span></h2>
+<h2 id="v-0-3-2"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.1...v0.3.2" rel="noopener noreferrer"><span class="release-version">0.3.2</span></a><span class="release-date"> — 2026-04-18</span></h2>
 <h3>Added</h3>
 <ul>
 <li><code>--version</code> / <code>-v</code> flag on the <code>oyster</code> CLI.</li>
@@ -381,7 +381,7 @@
 <ul>
 <li>Local discovery validation PoC script.</li>
 </ul>
-<h2 id="v-0-3-1"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.2.4...v0.3.1"><span class="release-version">0.3.1</span></a><span class="release-date"> — 2026-04-17</span></h2>
+<h2 id="v-0-3-1"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.2.4...v0.3.1" rel="noopener noreferrer"><span class="release-version">0.3.1</span></a><span class="release-date"> — 2026-04-17</span></h2>
 <p>First stable release of the 0.3 line. Bundles everything shipped across the 0.3.0 beta cycle (no stable 0.3.0 tag).</p>
 <h3>Added</h3>
 <ul>
@@ -417,7 +417,7 @@
 <li>Connection banner says &quot;oyster&quot; (was &quot;npm run dev&quot;).</li>
 <li>Helpful error when import paste yields nothing.</li>
 </ul>
-<h2 id="v-0-2-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.21...v0.2.4"><span class="release-version">0.2.4</span></a><span class="release-date"> — 2026-04-15</span></h2>
+<h2 id="v-0-2-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.21...v0.2.4" rel="noopener noreferrer"><span class="release-version">0.2.4</span></a><span class="release-date"> — 2026-04-15</span></h2>
 <h3>Added</h3>
 <ul>
 <li>Release scripts: <code>release:minor</code>, <code>release:beta</code>, <code>release:promote</code> (later simplified to <code>release</code> and <code>release:beta</code>).</li>
@@ -429,7 +429,7 @@
 <li>Import wizard UI polish — prompt copy hint, paste area, consistent CTAs.</li>
 <li>Native <code>select</code> replaced with a custom dark-themed dropdown.</li>
 </ul>
-<h2 id="v-0-1-21"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.17...v0.1.21"><span class="release-version">0.1.21</span></a><span class="release-date"> — 2026-04-14</span></h2>
+<h2 id="v-0-1-21"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.17...v0.1.21" rel="noopener noreferrer"><span class="release-version">0.1.21</span></a><span class="release-date"> — 2026-04-14</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Auto-backup.</strong> Userland auto-backed up on every startup to <code>~/oyster-backups/auto/</code>.<ul>
@@ -452,7 +452,7 @@
 <li>Mobile: terminal mockup no longer overflows on small screens.</li>
 <li>&quot;Bring Your Own AI&quot; capitalisation and naming consistency.</li>
 </ul>
-<h2 id="v-0-1-17"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.10...v0.1.17"><span class="release-version">0.1.17</span></a><span class="release-date"> — 2026-04-13</span></h2>
+<h2 id="v-0-1-17"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.1.10...v0.1.17" rel="noopener noreferrer"><span class="release-version">0.1.17</span></a><span class="release-date"> — 2026-04-13</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Drop-to-import.</strong> Drop a folder anywhere on the surface to import projects. Full-page drop zone, Grainient speeds up on drag, icons and chat dim to focus attention, wizard skips straight to scanning.</li>
@@ -477,7 +477,7 @@
 <li>Agent sessions use the <code>oyster</code> agent (was defaulting to <code>build</code>).</li>
 <li>Port resilience: OpenCode config written dynamically with actual server port; OpenCode spawned after server listens (fixes MCP connection race); Vite proxy reads <code>OYSTER_PORT</code> env var.</li>
 </ul>
-<h2 id="v-0-1-10"><a class="release-version-link" href="https://github.com/mattslight/oyster/releases/tag/v0.1.10"><span class="release-version">0.1.10</span></a><span class="release-date"> — 2026-04-12</span></h2>
+<h2 id="v-0-1-10"><a class="release-version-link" href="https://github.com/mattslight/oyster/releases/tag/v0.1.10" rel="noopener noreferrer"><span class="release-version">0.1.10</span></a><span class="release-date"> — 2026-04-12</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Multi-folder spaces + broader scanner.</strong><ul>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,584 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Changelog — Oyster</title>
+  <meta name="description" content="Every shipped change to Oyster, newest first.">
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; scroll-padding-top: 24px; }
+    body {
+      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0b14;
+      color: #e0e0e0;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+    .bg {
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
+                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
+                  #0a0b14;
+      z-index: 0;
+    }
+    .back-nav {
+      position: fixed;
+      top: 16px;
+      left: 0;
+      right: 0;
+      z-index: 10;
+      display: flex;
+      justify-content: center;
+    }
+    .back-bar {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 20px;
+      background: rgba(20, 22, 40, 0.9);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 9999px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+    }
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 500;
+      color: rgba(255,255,255,0.5);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .back-link:hover { color: #fff; }
+
+    .hero {
+      position: relative;
+      z-index: 1;
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 120px 24px 0;
+      text-align: center;
+    }
+    h1 {
+      font-family: 'Barlow', sans-serif;
+      font-size: clamp(32px, 5vw, 48px);
+      font-weight: 700;
+      line-height: 1.15;
+      color: #fff;
+      margin-bottom: 16px;
+    }
+    .subtitle {
+      font-size: 18px;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.5);
+      max-width: 560px;
+      margin: 0 auto;
+    }
+
+    .version-pills {
+      position: relative;
+      z-index: 1;
+      max-width: 820px;
+      margin: 48px auto 0;
+      padding: 0 24px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: center;
+    }
+    .version-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 6px 14px;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.55);
+      background: rgba(20, 22, 40, 0.7);
+      border: 1px solid rgba(124, 107, 255, 0.18);
+      border-radius: 9999px;
+      text-decoration: none;
+      transition: color 0.15s, border-color 0.15s, background 0.15s, transform 0.15s;
+    }
+    .version-pill:hover {
+      color: #fff;
+      border-color: rgba(124, 107, 255, 0.45);
+      background: rgba(124, 107, 255, 0.12);
+      transform: translateY(-1px);
+    }
+
+    .entries {
+      position: relative;
+      z-index: 1;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 48px 24px 120px;
+    }
+    .entries h2 {
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin: 64px 0 24px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid rgba(124, 107, 255, 0.18);
+      scroll-margin-top: 24px;
+    }
+    .entries h2:first-child { margin-top: 0; }
+    .release-version {
+      font-family: 'Barlow', sans-serif;
+      font-size: 28px;
+      font-weight: 700;
+      color: #fff;
+      letter-spacing: -0.5px;
+    }
+    .release-date {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 12px;
+      font-weight: 500;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: rgba(169, 158, 255, 0.7);
+    }
+    .entries h3 {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: rgba(169, 158, 255, 0.85);
+      margin: 28px 0 12px;
+    }
+    .entries h4 {
+      font-family: 'Barlow', sans-serif;
+      font-size: 18px;
+      font-weight: 700;
+      color: #fff;
+      margin: 20px 0 8px;
+    }
+    .entries p {
+      font-size: 15px;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.62);
+      margin-bottom: 10px;
+    }
+    .entries ul {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 16px;
+    }
+    .entries li {
+      position: relative;
+      padding-left: 20px;
+      margin-bottom: 8px;
+      font-size: 15px;
+      line-height: 1.65;
+      color: rgba(255, 255, 255, 0.62);
+    }
+    .entries li::before {
+      content: "";
+      position: absolute;
+      left: 4px;
+      top: 10px;
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: rgba(124, 107, 255, 0.6);
+    }
+    .entries li > ul {
+      margin: 8px 0 0;
+    }
+    .entries strong {
+      color: rgba(255, 255, 255, 0.82);
+      font-weight: 600;
+    }
+    .entries code {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 13px;
+      background: rgba(124, 107, 255, 0.1);
+      color: #a99eff;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .entries a {
+      color: #a99eff;
+      text-decoration: none;
+      border-bottom: 1px dotted rgba(169, 158, 255, 0.4);
+    }
+    .entries a:hover { color: #fff; border-bottom-color: #fff; }
+
+    .install-section {
+      position: relative;
+      z-index: 1;
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 0 24px 100px;
+      text-align: center;
+    }
+    .install-label {
+      font-family: 'Barlow', sans-serif;
+      font-size: 28px;
+      font-weight: 700;
+      color: #fff;
+      margin-bottom: 24px;
+    }
+    .terminal {
+      background: rgba(8, 9, 18, 0.95);
+      border: 2px solid rgba(124, 107, 255, 0.14);
+      border-radius: 12px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      overflow: hidden;
+      text-align: left;
+    }
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      padding: 12px 16px;
+      background: rgba(0, 0, 0, 0.25);
+      position: relative;
+    }
+    .terminal-dots { display: flex; gap: 6px; }
+    .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
+    .terminal-title {
+      position: absolute; left: 0; right: 0; text-align: center;
+      font-size: 11px; color: rgba(255,255,255,0.25);
+      font-family: 'IBM Plex Mono', monospace; pointer-events: none;
+    }
+    .terminal-body {
+      padding: 20px 24px 24px;
+      display: flex; flex-direction: column; gap: 10px;
+    }
+    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
+    .terminal-line code {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: clamp(16px, 2.5vw, 20px);
+      color: #a99eff;
+      background: none;
+      padding: 0;
+    }
+
+    .footer {
+      position: relative;
+      z-index: 1;
+      text-align: center;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.3);
+      padding: 0 24px 60px;
+    }
+    .footer .heart { color: #e25555; }
+    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
+    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
+
+    @media (max-width: 600px) {
+      .hero { padding-top: 100px; }
+      .entries { padding-top: 48px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="bg"></div>
+
+  <div class="back-nav">
+    <div class="back-bar">
+      <a class="back-link" href="/">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
+        </svg>
+        oyster.to
+      </a>
+    </div>
+  </div>
+
+  <div class="hero">
+    <h1>Changelog</h1>
+    <p class="subtitle">Every shipped change, newest first.</p>
+  </div>
+
+  <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
+      <a class="version-pill" href="#v-0-3-4">0.3.4</a>
+      <a class="version-pill" href="#v-0-3-3">0.3.3</a>
+      <a class="version-pill" href="#v-0-3-2">0.3.2</a>
+      <a class="version-pill" href="#v-0-3-1">0.3.1</a>
+      <a class="version-pill" href="#v-0-2-4">0.2.4</a>
+      <a class="version-pill" href="#v-0-1-21">0.1.21</a>
+      <a class="version-pill" href="#v-0-1-17">0.1.17</a>
+      <a class="version-pill" href="#v-0-1-10">0.1.10</a>
+      <a class="version-pill" href="#v-0-0-x">0.0.x</a>
+  </nav>
+
+  <main class="entries">
+<h2 id="v-unreleased"><span class="release-version">Unreleased</span></h2>
+<h3>Performance</h3>
+<ul>
+<li>Grainient shader pauses <code>requestAnimationFrame</code> on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.</li>
+</ul>
+<h3>Added</h3>
+<ul>
+<li><code>oyster --help</code> shows 🦪 in the header.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Docs site typography: Barlow headings paired with Space Grotesk body across landing and <code>/plugins</code>.</li>
+<li><code>/plugins</code> hero renamed to &quot;Pearls&quot;.</li>
+</ul>
+<h2 id="v-0-3-4"><span class="release-version">0.3.4</span><span class="release-date"> — 2026-04-19</span></h2>
+<h3>Fixed</h3>
+<ul>
+<li>Stale tile icons cleared after <code>oyster uninstall &lt;id&gt;</code>.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li><code>/plugins</code> copy button uses <code>oyster install &lt;id&gt;</code> form.</li>
+</ul>
+<h3>Chore</h3>
+<ul>
+<li>Adopted eslint 10 in web (fixed 16 surfaced errors).</li>
+<li>Dependabot config for Actions and npm groups.</li>
+<li>Release workflow actions bumped for Node 24.</li>
+<li>Dep bumps: <code>marked</code> 17 → 18; <code>@types/node</code> 22 → 25; web/server/root minor+patch groups.</li>
+</ul>
+<h2 id="v-0-3-3"><span class="release-version">0.3.3</span><span class="release-date"> — 2026-04-18</span></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Plugins — Tier 2 installer.</strong> <code>oyster install &lt;id&gt;</code>, <code>oyster uninstall &lt;id&gt;</code>, <code>oyster list</code> install community plugins by id.</li>
+<li><code>oyster install &lt;id&gt;</code> resolves the repo from the <code>mattslight/oyster-community-plugins</code> registry.</li>
+<li>New <code>/plugins</code> catalog page on oyster.to with copy-install buttons, strict input validation, and a CDN fallback.</li>
+<li>Plugin system design doc.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>README and <code>CLAUDE.md</code> updated to match shipped v1 — port 4444, 19 MCP tools, FTS5 memory.</li>
+<li><code>/plugins</code> page polish: hairline borders dropped, only purposeful ones kept.</li>
+</ul>
+<h2 id="v-0-3-2"><span class="release-version">0.3.2</span><span class="release-date"> — 2026-04-18</span></h2>
+<h3>Added</h3>
+<ul>
+<li><code>--version</code> / <code>-v</code> flag on the <code>oyster</code> CLI.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Chat user bubble no longer conflates visually with the assistant response.</li>
+</ul>
+<h3>Chore</h3>
+<ul>
+<li>Local discovery validation PoC script.</li>
+</ul>
+<h2 id="v-0-3-1"><span class="release-version">0.3.1</span><span class="release-date"> — 2026-04-17</span></h2>
+<p>First stable release of the 0.3 line. Bundles everything shipped across the 0.3.0 beta cycle (no stable 0.3.0 tag).</p>
+<h3>Added</h3>
+<ul>
+<li><strong>Cloud AI import.</strong> Paste from ChatGPT / Claude / Gemini and Oyster scaffolds projects, context, and memories.<ul>
+<li>3-step wizard: select provider, paste AI output, preview and import.</li>
+<li>Server converts any format to structured JSON via OpenCode.</li>
+<li>Merge-based: detects existing spaces, skips duplicates on re-import.</li>
+<li>First-run onboarding banner with &quot;Import from AI&quot; CTA.</li>
+</ul>
+</li>
+<li><strong>Builtin redesign.</strong> Quick Start, Connect Your AI, and Import from AI built as consistent glass-card builtins with ambient glow, pill selectors, and <code>postMessage</code> close support.</li>
+<li><strong>Space management UI.</strong> Rename, recolour, and remove spaces directly from the UI.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Cross-platform (Windows):</strong><ul>
+<li>Hardcoded <code>/</code> path separators replaced with <code>path.basename</code> / <code>path.sep</code> throughout.</li>
+<li>Swapped <code>node-pty</code> for <code>@lydell/node-pty</code> — prebuilt binaries, no build tools required.</li>
+<li>Auth detection checks <code>~/.local/share/opencode/auth.json</code> directly.</li>
+<li>Windows 403 on artifact serving (path separator mismatch).</li>
+</ul>
+</li>
+<li><strong>Stability:</strong><ul>
+<li>SSE fetch no longer crashes when OpenCode dies mid-stream.</li>
+<li>OpenCode port defaults to <code>0</code> (auto-select); was hardcoded <code>4096</code>.</li>
+<li>Kill OpenCode subprocess on shutdown; reset port on restart.</li>
+</ul>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Terminal WebSocket uses dynamic host instead of hardcoded port 4200.</li>
+<li>Connection banner says &quot;oyster&quot; (was &quot;npm run dev&quot;).</li>
+<li>Helpful error when import paste yields nothing.</li>
+</ul>
+<h2 id="v-0-2-4"><span class="release-version">0.2.4</span><span class="release-date"> — 2026-04-15</span></h2>
+<h3>Added</h3>
+<ul>
+<li>Release scripts: <code>release:minor</code>, <code>release:beta</code>, <code>release:promote</code> (later simplified to <code>release</code> and <code>release:beta</code>).</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Prod backups at <code>~/oyster-backups/auto/</code>, dev at <code>~/oyster-backups/dev/</code> (were conflating).</li>
+<li><code>import-state.json</code> stored in userland (was shared at <code>~/.oyster</code>).</li>
+<li>Import wizard UI polish — prompt copy hint, paste area, consistent CTAs.</li>
+<li>Native <code>select</code> replaced with a custom dark-themed dropdown.</li>
+</ul>
+<h2 id="v-0-1-21"><span class="release-version">0.1.21</span><span class="release-date"> — 2026-04-14</span></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Auto-backup.</strong> Userland auto-backed up on every startup to <code>~/oyster-backups/auto/</code>.<ul>
+<li>One backup per day — repeated restarts reuse the same slot.</li>
+<li>Rotates to last 5 days of history.</li>
+<li>Runs before bootstrap/migration — captures pre-upgrade state.</li>
+<li>Best-effort: never crashes server startup.</li>
+</ul>
+</li>
+<li><strong>MCP onboarding.</strong> &quot;Connect your AI&quot; builtin on the home surface with a tabbed guide for Claude Code, Cursor, VS Code, and Windsurf. CLI startup prints the MCP connect command. Landing page at <code>oyster.to/mcp</code>.</li>
+<li><strong>Quick Start guide.</strong> 60-second overview builtin: prompt bar, slash commands, spaces, artifacts.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Landing page MCP section: real client-specific connection snippets with tabs, actual tool-name pills.</li>
+<li>Nav replaced GitHub link with MCP page link.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Mobile: terminal mockup no longer overflows on small screens.</li>
+<li>&quot;Bring Your Own AI&quot; capitalisation and naming consistency.</li>
+</ul>
+<h2 id="v-0-1-17"><span class="release-version">0.1.17</span><span class="release-date"> — 2026-04-13</span></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Drop-to-import.</strong> Drop a folder anywhere on the surface to import projects. Full-page drop zone, Grainient speeds up on drag, icons and chat dim to focus attention, wizard skips straight to scanning.</li>
+<li><strong>Persistent memory.</strong> AI agent remembers across sessions.<ul>
+<li><code>MemoryProvider</code> interface — async, storage-agnostic, swappable backends.</li>
+<li>First provider: SQLite FTS5 with full-text search in a separate <code>memory.db</code>.</li>
+<li>4 MCP tools: <code>remember</code>, <code>recall</code>, <code>forget</code>, <code>list_memories</code>.</li>
+<li>Explicit writes only — agent stores memory when asked.</li>
+</ul>
+</li>
+<li><strong>First-run onboarding.</strong> &quot;Drop a folder to get started&quot; hint, space-pill hint, surface-wide folder-drop trigger.</li>
+<li><strong>Dev / prod separation.</strong> Dev server on port 3333, prod on 4444 — run side by side. Dev uses <code>./userland</code>, prod uses <code>~/.oyster/userland</code>. Version badge on surface shows version + env.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Icon resolution checks artifact root dir for <code>icon.png</code>.</li>
+<li><code>opencode.json</code> included in npm package.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Input placeholder cycles on blur (was static per session).</li>
+<li>Agent sessions use the <code>oyster</code> agent (was defaulting to <code>build</code>).</li>
+<li>Port resilience: OpenCode config written dynamically with actual server port; OpenCode spawned after server listens (fixes MCP connection race); Vite proxy reads <code>OYSTER_PORT</code> env var.</li>
+</ul>
+<h2 id="v-0-1-10"><span class="release-version">0.1.10</span><span class="release-date"> — 2026-04-12</span></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Multi-folder spaces + broader scanner.</strong><ul>
+<li>A space can have multiple folders (repos, project dirs, any folder).</li>
+<li><code>space_paths</code> table — migrates existing <code>repo_path</code> values automatically.</li>
+<li>Add Space wizard toggles between &quot;New space&quot; and &quot;Existing space&quot;.</li>
+<li>Drop multiple folders onto one space. API: <code>GET/POST/DELETE /api/spaces/:id/paths</code>.</li>
+<li>Scanner finds artifacts in Go, Rust, Python, Ruby, Java (not just JS). Root-level projects detected. Any <code>.md</code> found as notes. More JS frameworks: Angular, Nuxt, Astro, Remix, Solid.</li>
+<li>Folder resolution searches Dropbox, OneDrive, iCloud Drive, Downloads.</li>
+</ul>
+</li>
+<li><strong>CLI packaging — <code>npm install -g oyster-os</code>.</strong><ul>
+<li>Checks for OpenCode auth; runs <code>opencode providers login</code> inline on first run (OAuth in browser).</li>
+<li>Spawns server process, opens browser.</li>
+<li>Bootstraps <code>~/.oyster/userland/</code> with builtins (zombie-horde, the-worlds-your-oyster deck).</li>
+<li>Handles SIGINT/SIGTERM cleanup.</li>
+<li>Compiled server + static web serving — package is ~2.2 MB unpacked, 6 runtime dependencies.</li>
+<li><code>node-pty</code> moved to optionalDependencies with graceful fallback.</li>
+<li>Windows support: finds <code>opencode.cmd</code>, uses <code>shell: true</code> for spawn.</li>
+<li>Path traversal protection on static file serving.</li>
+</ul>
+</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li>Auth flow: removed API key prompt — runs <code>opencode providers login</code> inline on first run.</li>
+<li>Renamed builtin: <code>snake-game</code> → <code>zombie-horde</code>.</li>
+<li>Documentation overhaul: CLAUDE.md rewritten to match shipped product; design doc updated; README rewrite for npm.</li>
+<li>Landing page polish: terminal window mockup with traffic-light dots; Mac/Windows OS toggle.</li>
+</ul>
+<h2 id="v-0-0-x"><span class="release-version">0.0.x</span><span class="release-date"> — Prototype (2026-03-12 through 2026-04-11)</span></h2>
+<p>Milestones leading up to the first npm-packaged release, newest first.</p>
+<h4>2026-04-11 — Phase A: prompt-driven surface control</h4>
+<p>The chat bar now controls the OS. Dropped Graphiti dependency (memory deferred to v2). Added SSE command channel for instant UI push events.</p>
+<ul>
+<li>MCP tools: <code>open_artifact(id)</code>, <code>switch_space(id)</code>, <code>list_artifacts</code> with search/limit.</li>
+<li>Slash commands: <code>/s &lt;prefix&gt;</code> (space switch), <code>/o &lt;query&gt;</code> (artifact open) — client-side, no LLM call.</li>
+<li><code>#</code> prefix shortcuts: <code>#&lt;name&gt;</code>, <code>#&lt;digit&gt;</code>, <code>#.</code>, <code>#0</code>.</li>
+<li>SSE command channel at <code>GET /api/ui/events</code>.</li>
+<li>Tagline: &quot;Apps are dead. Welcome to your surface.&quot;</li>
+<li>Landing page (GitHub Pages) with animated mock UI, 3D tilt panels, real FAL icons.</li>
+</ul>
+<h4>2026-03-30 — View toggle + kind filter polish</h4>
+<ul>
+<li>View toggle (grid/list) floats next to the kind filter pill.</li>
+<li>List-view space tags restyled.</li>
+</ul>
+<h4>2026-03-29 — Spaces as first-class entities</h4>
+<ul>
+<li><code>spaces</code> table, SpaceStore, SpaceService. Scanner walks repos up to 4 levels deep.</li>
+<li>HTTP API: <code>POST/GET/DELETE /api/spaces</code>, <code>POST /api/spaces/:id/scan</code>.</li>
+<li>MCP <code>onboard_space</code> — creates space + triggers scan in one call.</li>
+<li>Add Space wizard: 2-step modal with drag-and-drop folder picker.</li>
+</ul>
+<h4>2026-03-28 — Desktop redesign</h4>
+<ul>
+<li>Auto-hide topbar with view toggle, sort modes, kind filter pills, group-by.</li>
+<li>Drag-to-reorder icons in grid view.</li>
+<li>Animated space pills (framer-motion), per-space accent colours.</li>
+<li>Spotlight search (Cmd+K) with fuzzy filter across all artifacts.</li>
+</ul>
+<h4>2026-03-27 — Oyster MCP surface</h4>
+<p>Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via MCP.</p>
+<ul>
+<li>Discovery: <code>get_context</code>, <code>list_spaces</code>, <code>list_artifacts</code>.</li>
+<li>Authoring: <code>create_artifact</code>, <code>read_artifact</code>, <code>update_artifact</code>, <code>register_artifact</code>.</li>
+<li>Localhost-only (non-local Origin rejected with 403), approved roots, stateless transport.</li>
+</ul>
+<h4>2026-03-14 — Rebrand + artifact contract + AI icons</h4>
+<ul>
+<li>Global rebrand: mint green → electric indigo.</li>
+<li>Artifact contract: every generated output gets a folder, <code>manifest.json</code>, and source files under <code>/artifacts/&lt;id&gt;/</code>.</li>
+<li>AI-generated artifact icons — GPT-4o-mini + fal.ai Flux Schnell render geometric icons per artifact.</li>
+<li>Showcase deck: &quot;The World&#39;s Your Oyster&quot; redesign with GSAP scroll-driven reveal.</li>
+</ul>
+<h4>2026-03-13 — Sprint 2: wire the engine</h4>
+<ul>
+<li>OpenCode terminal embedded (xterm.js + WebSocket PTY).</li>
+<li>HTTP+WS hybrid server with app process management.</li>
+<li>Space-based navigation, deck artifacts, chat API with SSE streaming.</li>
+</ul>
+<h4>2026-03-12 — Sprint 1: UI mockup</h4>
+<ul>
+<li>Surface with Aurora WebGL animated background.</li>
+<li>Typed artifact icons, chat bar, window system with viewer.</li>
+</ul>
+
+  </main>
+
+  <div class="install-section">
+    <div class="install-label">Don't have Oyster yet?</div>
+    <div class="terminal">
+      <div class="terminal-bar">
+        <div class="terminal-dots">
+          <span style="background: #ff5f57;"></span>
+          <span style="background: #febc2e;"></span>
+          <span style="background: #28c840;"></span>
+        </div>
+        <span class="terminal-title">terminal</span>
+      </div>
+      <div class="terminal-body">
+        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -427,10 +427,10 @@
   <!-- Nav -->
   <nav class="nav" id="nav">
     <img src="logo.png" alt="Oyster" class="nav-logo" />
-    <a href="#features">Features</a>
     <a href="#install">Install</a>
     <a href="/mcp">MCP</a>
     <a href="/plugins">Plugins</a>
+    <a href="/changelog">Changelog</a>
   </nav>
 
   <!-- Hero -->

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "build:web": "cd web && npx vite build",
     "build:server": "cd server && npm run build",
     "build": "npm run build:web && npm run build:server && node -e \"const fs=require('fs');fs.cpSync('web/dist','server/dist/public',{recursive:true})\"",
+    "build:changelog": "node scripts/build-changelog.mjs",
     "dev": "npx concurrently -n web,server -c blue,green \"cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev",
+    "version": "npm run build:changelog && git add docs/changelog.html",
     "release": "npm version patch && git push && git push --tags",
     "release:beta": "npm version prerelease --preid=beta && git push && git push --tags"
   },

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { marked } from "marked";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const mdPath = path.join(root, "CHANGELOG.md");
+const outPath = path.join(root, "docs", "changelog.html");
+
+const md = fs.readFileSync(mdPath, "utf8");
+// Strip the title + lead paragraph; the template owns the hero.
+const body = md.replace(/^#\s+Changelog[\s\S]*?\n## /m, "## ");
+const rawRendered = marked.parse(body, { gfm: true });
+
+const slug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+// Match: <h2>[Version]</h2>, <h2>[Version] - YYYY-MM-DD</h2>, <h2>[Version] - Prototype (...)</h2>
+// Marked may render `[X.Y.Z]` as a reference link if it parses as a shortcut reference.
+// We post-process both the raw-bracket form and the link-rendered form.
+const releases = [];
+
+// Single pass: marked renders `[Unreleased]` as a reference-link (because of the
+// compare-link footer defining it) and `[0.0.x]` as plain brackets (no matching
+// definition). Match both forms in one regex so releases stay in document order.
+const rendered = rawRendered.replace(
+  /<h2>(?:<a[^>]*>([^<]+)<\/a>|\[([^\]]+)\])(?:\s*-\s*([^<]+?))?<\/h2>/g,
+  (_, linkedVersion, bracketVersion, rest) => {
+    const version = linkedVersion || bracketVersion;
+    const id = `v-${slug(version)}`;
+    const suffix = rest ? `<span class="release-date"> — ${rest.trim()}</span>` : "";
+    releases.push({ version, id });
+    return `<h2 id="${id}"><span class="release-version">${version}</span>${suffix}</h2>`;
+  },
+);
+
+const pills = releases
+  .map((r) => `<a class="version-pill" href="#${r.id}">${r.version}</a>`)
+  .join("\n      ");
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Changelog — Oyster</title>
+  <meta name="description" content="Every shipped change to Oyster, newest first.">
+  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; scroll-padding-top: 24px; }
+    body {
+      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0b14;
+      color: #e0e0e0;
+      min-height: 100vh;
+      overflow-x: hidden;
+    }
+    .bg {
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
+                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
+                  #0a0b14;
+      z-index: 0;
+    }
+    .back-nav {
+      position: fixed;
+      top: 16px;
+      left: 0;
+      right: 0;
+      z-index: 10;
+      display: flex;
+      justify-content: center;
+    }
+    .back-bar {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 20px;
+      background: rgba(20, 22, 40, 0.9);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 9999px;
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+    }
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 500;
+      color: rgba(255,255,255,0.5);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .back-link:hover { color: #fff; }
+
+    .hero {
+      position: relative;
+      z-index: 1;
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 120px 24px 0;
+      text-align: center;
+    }
+    h1 {
+      font-family: 'Barlow', sans-serif;
+      font-size: clamp(32px, 5vw, 48px);
+      font-weight: 700;
+      line-height: 1.15;
+      color: #fff;
+      margin-bottom: 16px;
+    }
+    .subtitle {
+      font-size: 18px;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.5);
+      max-width: 560px;
+      margin: 0 auto;
+    }
+
+    .version-pills {
+      position: relative;
+      z-index: 1;
+      max-width: 820px;
+      margin: 48px auto 0;
+      padding: 0 24px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: center;
+    }
+    .version-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 6px 14px;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.55);
+      background: rgba(20, 22, 40, 0.7);
+      border: 1px solid rgba(124, 107, 255, 0.18);
+      border-radius: 9999px;
+      text-decoration: none;
+      transition: color 0.15s, border-color 0.15s, background 0.15s, transform 0.15s;
+    }
+    .version-pill:hover {
+      color: #fff;
+      border-color: rgba(124, 107, 255, 0.45);
+      background: rgba(124, 107, 255, 0.12);
+      transform: translateY(-1px);
+    }
+
+    .entries {
+      position: relative;
+      z-index: 1;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 48px 24px 120px;
+    }
+    .entries h2 {
+      display: flex;
+      align-items: baseline;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin: 64px 0 24px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid rgba(124, 107, 255, 0.18);
+      scroll-margin-top: 24px;
+    }
+    .entries h2:first-child { margin-top: 0; }
+    .release-version {
+      font-family: 'Barlow', sans-serif;
+      font-size: 28px;
+      font-weight: 700;
+      color: #fff;
+      letter-spacing: -0.5px;
+    }
+    .release-date {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 12px;
+      font-weight: 500;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: rgba(169, 158, 255, 0.7);
+    }
+    .entries h3 {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: rgba(169, 158, 255, 0.85);
+      margin: 28px 0 12px;
+    }
+    .entries h4 {
+      font-family: 'Barlow', sans-serif;
+      font-size: 18px;
+      font-weight: 700;
+      color: #fff;
+      margin: 20px 0 8px;
+    }
+    .entries p {
+      font-size: 15px;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.62);
+      margin-bottom: 10px;
+    }
+    .entries ul {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 16px;
+    }
+    .entries li {
+      position: relative;
+      padding-left: 20px;
+      margin-bottom: 8px;
+      font-size: 15px;
+      line-height: 1.65;
+      color: rgba(255, 255, 255, 0.62);
+    }
+    .entries li::before {
+      content: "";
+      position: absolute;
+      left: 4px;
+      top: 10px;
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: rgba(124, 107, 255, 0.6);
+    }
+    .entries li > ul {
+      margin: 8px 0 0;
+    }
+    .entries strong {
+      color: rgba(255, 255, 255, 0.82);
+      font-weight: 600;
+    }
+    .entries code {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 13px;
+      background: rgba(124, 107, 255, 0.1);
+      color: #a99eff;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .entries a {
+      color: #a99eff;
+      text-decoration: none;
+      border-bottom: 1px dotted rgba(169, 158, 255, 0.4);
+    }
+    .entries a:hover { color: #fff; border-bottom-color: #fff; }
+
+    .install-section {
+      position: relative;
+      z-index: 1;
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 0 24px 100px;
+      text-align: center;
+    }
+    .install-label {
+      font-family: 'Barlow', sans-serif;
+      font-size: 28px;
+      font-weight: 700;
+      color: #fff;
+      margin-bottom: 24px;
+    }
+    .terminal {
+      background: rgba(8, 9, 18, 0.95);
+      border: 2px solid rgba(124, 107, 255, 0.14);
+      border-radius: 12px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      overflow: hidden;
+      text-align: left;
+    }
+    .terminal-bar {
+      display: flex;
+      align-items: center;
+      padding: 12px 16px;
+      background: rgba(0, 0, 0, 0.25);
+      position: relative;
+    }
+    .terminal-dots { display: flex; gap: 6px; }
+    .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
+    .terminal-title {
+      position: absolute; left: 0; right: 0; text-align: center;
+      font-size: 11px; color: rgba(255,255,255,0.25);
+      font-family: 'IBM Plex Mono', monospace; pointer-events: none;
+    }
+    .terminal-body {
+      padding: 20px 24px 24px;
+      display: flex; flex-direction: column; gap: 10px;
+    }
+    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
+    .terminal-line code {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: clamp(16px, 2.5vw, 20px);
+      color: #a99eff;
+      background: none;
+      padding: 0;
+    }
+
+    .footer {
+      position: relative;
+      z-index: 1;
+      text-align: center;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.3);
+      padding: 0 24px 60px;
+    }
+    .footer .heart { color: #e25555; }
+    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
+    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
+
+    @media (max-width: 600px) {
+      .hero { padding-top: 100px; }
+      .entries { padding-top: 48px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="bg"></div>
+
+  <div class="back-nav">
+    <div class="back-bar">
+      <a class="back-link" href="/">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
+        </svg>
+        oyster.to
+      </a>
+    </div>
+  </div>
+
+  <div class="hero">
+    <h1>Changelog</h1>
+    <p class="subtitle">Every shipped change, newest first.</p>
+  </div>
+
+  <nav class="version-pills" aria-label="Jump to version">
+      ${pills}
+  </nav>
+
+  <main class="entries">
+${rendered}
+  </main>
+
+  <div class="install-section">
+    <div class="install-label">Don't have Oyster yet?</div>
+    <div class="terminal">
+      <div class="terminal-bar">
+        <div class="terminal-dots">
+          <span style="background: #ff5f57;"></span>
+          <span style="background: #febc2e;"></span>
+          <span style="background: #28c840;"></span>
+        </div>
+        <span class="terminal-title">terminal</span>
+      </div>
+      <div class="terminal-body">
+        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
+  </div>
+</body>
+</html>
+`;
+
+fs.writeFileSync(outPath, html);
+console.log(`wrote ${path.relative(root, outPath)}`);

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -8,20 +8,36 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const mdPath = path.join(root, "CHANGELOG.md");
 const outPath = path.join(root, "docs", "changelog.html");
 
-// Escape any raw HTML in CHANGELOG.md rather than pass it through. This page is
-// built from a file that gets edited in PRs and published to oyster.to, so a
-// `<script>` sneaking in would ship as stored XSS. We don't need HTML in the
-// changelog itself — markdown is enough — so the safest thing is to render
-// any html token as escaped text.
+// This page is built from CHANGELOG.md which is edited in PRs and published to
+// oyster.to, so anything exploitable there ships as stored XSS. Defense:
+//   1. Escape `&<>"'` everywhere we inject strings into the template.
+//   2. Render raw HTML tokens as escaped text (no pass-through).
+//   3. Allow only safe URL protocols on links and images.
 const escapeHtml = (s) =>
-  s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+  String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
+
+const SAFE_URL = /^(?:https?:|mailto:|#|\/|\.\/|\.\.\/)/i;
+const safeHref = (href) => (href && SAFE_URL.test(href) ? href : "#");
 
 marked.use({
   renderer: {
-    // Block-level html token (e.g. a `<div>...</div>` block). Marked v12+
-    // routes both block and inline html tokens through this renderer.
+    // Block + inline html tokens both route here in marked v12+.
     html({ text, raw }) {
       return escapeHtml(text ?? raw ?? "");
+    },
+    link({ href, title, tokens }) {
+      const url = escapeHtml(safeHref(href));
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+      const inner = this.parser.parseInline(tokens);
+      return `<a href="${url}"${titleAttr}>${inner}</a>`;
+    },
+    image({ href, title, text }) {
+      if (!href || !SAFE_URL.test(href)) return escapeHtml(`[image: ${text ?? ""}]`);
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+      return `<img src="${escapeHtml(href)}" alt="${escapeHtml(text ?? "")}"${titleAttr}>`;
     },
   },
 });
@@ -41,19 +57,30 @@ const releases = [];
 // Single pass: marked renders `[Unreleased]` as a reference-link (because of the
 // compare-link footer defining it) and `[0.0.x]` as plain brackets (no matching
 // definition). Match both forms in one regex so releases stay in document order.
+// The `<h2[^>]*>` tolerates any attributes marked may emit in future versions.
+// Captured values (version, rest, href) are escaped before interpolation.
 const rendered = rawRendered.replace(
-  /<h2>(?:<a[^>]*>([^<]+)<\/a>|\[([^\]]+)\])(?:\s*-\s*([^<]+?))?<\/h2>/g,
-  (_, linkedVersion, bracketVersion, rest) => {
+  /<h2[^>]*>(?:<a[^>]*href="([^"]*)"[^>]*>([^<]+)<\/a>|\[([^\]]+)\])(?:\s*-\s*([^<]+?))?<\/h2>/g,
+  (_, linkedHref, linkedVersion, bracketVersion, rest) => {
     const version = linkedVersion || bracketVersion;
     const id = `v-${slug(version)}`;
-    const suffix = rest ? `<span class="release-date"> — ${rest.trim()}</span>` : "";
+    const versionSpan = `<span class="release-version">${escapeHtml(version)}</span>`;
+    const versionHtml = linkedHref
+      ? `<a class="release-version-link" href="${escapeHtml(safeHref(linkedHref))}">${versionSpan}</a>`
+      : versionSpan;
+    const suffix = rest
+      ? `<span class="release-date"> — ${escapeHtml(rest.trim())}</span>`
+      : "";
     releases.push({ version, id });
-    return `<h2 id="${id}"><span class="release-version">${version}</span>${suffix}</h2>`;
+    return `<h2 id="${escapeHtml(id)}">${versionHtml}${suffix}</h2>`;
   },
 );
 
 const pills = releases
-  .map((r) => `<a class="version-pill" href="#${r.id}">${r.version}</a>`)
+  .map(
+    (r) =>
+      `<a class="version-pill" href="#${escapeHtml(r.id)}">${escapeHtml(r.version)}</a>`,
+  )
   .join("\n      ");
 
 const html = `<!DOCTYPE html>
@@ -198,6 +225,14 @@ const html = `<!DOCTYPE html>
       font-weight: 700;
       color: #fff;
       letter-spacing: -0.5px;
+    }
+    .release-version-link {
+      text-decoration: none;
+      border-bottom: 0 !important;
+      transition: opacity 0.15s;
+    }
+    .release-version-link:hover .release-version {
+      color: #a99eff;
     }
     .release-date {
       font-family: 'IBM Plex Mono', monospace;

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -8,6 +8,24 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const mdPath = path.join(root, "CHANGELOG.md");
 const outPath = path.join(root, "docs", "changelog.html");
 
+// Escape any raw HTML in CHANGELOG.md rather than pass it through. This page is
+// built from a file that gets edited in PRs and published to oyster.to, so a
+// `<script>` sneaking in would ship as stored XSS. We don't need HTML in the
+// changelog itself — markdown is enough — so the safest thing is to render
+// any html token as escaped text.
+const escapeHtml = (s) =>
+  s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]);
+
+marked.use({
+  renderer: {
+    // Block-level html token (e.g. a `<div>...</div>` block). Marked v12+
+    // routes both block and inline html tokens through this renderer.
+    html({ text, raw }) {
+      return escapeHtml(text ?? raw ?? "");
+    },
+  },
+});
+
 const md = fs.readFileSync(mdPath, "utf8");
 // Strip the title + lead paragraph; the template owns the hero.
 const body = md.replace(/^#\s+Changelog[\s\S]*?\n## /m, "## ");

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -19,8 +19,15 @@ const escapeHtml = (s) =>
     (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
   );
 
-const SAFE_URL = /^(?:https?:|mailto:|#|\/|\.\/|\.\.\/)/i;
-const safeHref = (href) => (href && SAFE_URL.test(href) ? href : "#");
+// `\/(?!\/)` allows `/path` (same-origin) but rejects `//evil.com` (protocol-relative).
+// `\.\.?\/` covers `./` and `../`. Trim leading whitespace before testing so
+// a href like `\tjavascript:...` can't sneak past the scheme check.
+const SAFE_URL = /^(?:https?:\/\/|mailto:|#|\.\.?\/|\/(?!\/))/i;
+const safeHref = (href) => {
+  if (!href) return "#";
+  const trimmed = String(href).trim();
+  return SAFE_URL.test(trimmed) ? trimmed : "#";
+};
 
 marked.use({
   renderer: {

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -29,10 +29,12 @@ marked.use({
       return escapeHtml(text ?? raw ?? "");
     },
     link({ href, title, tokens }) {
-      const url = escapeHtml(safeHref(href));
+      const resolved = safeHref(href);
+      const url = escapeHtml(resolved);
       const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+      const relAttr = /^https?:/i.test(resolved) ? ' rel="noopener noreferrer"' : "";
       const inner = this.parser.parseInline(tokens);
-      return `<a href="${url}"${titleAttr}>${inner}</a>`;
+      return `<a href="${url}"${titleAttr}${relAttr}>${inner}</a>`;
     },
     image({ href, title, text }) {
       if (!href || !SAFE_URL.test(href)) return escapeHtml(`[image: ${text ?? ""}]`);
@@ -65,8 +67,10 @@ const rendered = rawRendered.replace(
     const version = linkedVersion || bracketVersion;
     const id = `v-${slug(version)}`;
     const versionSpan = `<span class="release-version">${escapeHtml(version)}</span>`;
-    const versionHtml = linkedHref
-      ? `<a class="release-version-link" href="${escapeHtml(safeHref(linkedHref))}">${versionSpan}</a>`
+    const resolvedHref = linkedHref ? safeHref(linkedHref) : null;
+    const relAttr = resolvedHref && /^https?:/i.test(resolvedHref) ? ' rel="noopener noreferrer"' : "";
+    const versionHtml = resolvedHref
+      ? `<a class="release-version-link" href="${escapeHtml(resolvedHref)}"${relAttr}>${versionSpan}</a>`
       : versionSpan;
     const suffix = rest
       ? `<span class="release-date"> — ${escapeHtml(rest.trim())}</span>`


### PR DESCRIPTION
## Summary
- **CHANGELOG.md** restructured per [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — version-keyed (`[Unreleased]` / `[0.3.4]` / `[0.3.3]` / ... / `[0.0.x - Prototype]`) with `Added` / `Changed` / `Fixed` / `Chore` subsections and compare-links at the foot. Historical date entries mapped to the releases they shipped in.
- New **`oyster.to/changelog`** page — single source of truth rendered from `CHANGELOG.md`. Version pills at the top jump to each release. Styled to match the rest of the site (Barlow display, mono release-date, dotted-indigo bullets).
- **`scripts/build-changelog.mjs`** renders the page via existing `marked` dependency.
- **`.github/workflows/release.yml`** awk extractor fixed — it expected a format that never existed (every release fell through to the `generate_release_notes: true` PR-list fallback). Now matches `## [X.Y.Z]` so the curated section becomes the GitHub Release body.
- **npm `version` lifecycle hook** regenerates `docs/changelog.html` on `npm run release`; between releases, `npm run build:changelog`.
- **Nav tidy** on oyster.to: `Install · MCP · Plugins · Changelog` (dropped the `Features` anchor).
- README + CLAUDE.md reference the changelog and the workflow convention.

## Test plan
- [ ] Reload `http://oyster.to/changelog` after deploy — pills click-through to each version, release-date sits alongside version header.
- [ ] Run `npm run build:changelog` locally after editing `CHANGELOG.md`; `docs/changelog.html` regenerates.
- [ ] Verify `release.yml` awk: `awk -v v="0.3.4" 'BEGIN{re="^## \\[" v "\\]"} /^## /{if(found)exit; if(\$0~re){found=1; next}} found' CHANGELOG.md` outputs the 0.3.4 section only (tested — works).
- [ ] Next `npm run release` publishes a curated GitHub Release body (instead of auto PR-list).
- [ ] Nav on landing page lists `Install · MCP · Plugins · Changelog` and all links resolve.

## Out of scope (noted for follow-up)
- `/plugins` page could use a "how to build a plugin" section — separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)