### PR TITLE
docs(changelog): collapse pills to minor versions

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -313,15 +313,10 @@
 
   <nav class="version-pills" aria-label="Jump to version">
       <a class="version-pill" href="#v-unreleased">Unreleased</a>
-      <a class="version-pill" href="#v-0-3-4">0.3.4</a>
-      <a class="version-pill" href="#v-0-3-3">0.3.3</a>
-      <a class="version-pill" href="#v-0-3-2">0.3.2</a>
-      <a class="version-pill" href="#v-0-3-1">0.3.1</a>
-      <a class="version-pill" href="#v-0-2-4">0.2.4</a>
-      <a class="version-pill" href="#v-0-1-21">0.1.21</a>
-      <a class="version-pill" href="#v-0-1-17">0.1.17</a>
-      <a class="version-pill" href="#v-0-1-10">0.1.10</a>
-      <a class="version-pill" href="#v-0-0-x">0.0.x</a>
+      <a class="version-pill" href="#v-0-3-4">0.3</a>
+      <a class="version-pill" href="#v-0-2-4">0.2</a>
+      <a class="version-pill" href="#v-0-1-21">0.1</a>
+      <a class="version-pill" href="#v-0-0-x">0.0</a>
   </nav>
 
   <main class="entries">

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:server": "cd server && npm run build",
     "build": "npm run build:web && npm run build:server && node -e \"const fs=require('fs');fs.cpSync('web/dist','server/dist/public',{recursive:true})\"",
     "build:changelog": "node scripts/build-changelog.mjs",
+    "serve:docs": "npm run build:changelog && npx serve docs",
     "dev": "npx concurrently -n web,server -c blue,green \"cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:server": "cd server && npm run build",
     "build": "npm run build:web && npm run build:server && node -e \"const fs=require('fs');fs.cpSync('web/dist','server/dist/public',{recursive:true})\"",
     "build:changelog": "node scripts/build-changelog.mjs",
-    "serve:docs": "npm run build:changelog && npx serve docs",
+    "serve:docs": "npm run build:changelog && npx --yes serve@14 docs",
     "dev": "npx concurrently -n web,server -c blue,green \"cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev",

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -87,10 +87,25 @@ const rendered = rawRendered.replace(
   },
 );
 
-const pills = releases
+// Group pills by minor version (0.3.4 → 0.3) so the nav stays flat as patches
+// accumulate. Releases are already in reverse-chrono order, so the first entry
+// per minor is the newest patch — that's where the pill links to.
+const pillGroups = [];
+const seen = new Set();
+for (const r of releases) {
+  const minor =
+    r.version === "Unreleased"
+      ? "Unreleased"
+      : (r.version.match(/^(\d+\.\d+)/)?.[1] ?? r.version);
+  if (seen.has(minor)) continue;
+  seen.add(minor);
+  pillGroups.push({ label: minor, id: r.id });
+}
+
+const pills = pillGroups
   .map(
-    (r) =>
-      `<a class="version-pill" href="#${escapeHtml(r.id)}">${escapeHtml(r.version)}</a>`,
+    (g) =>
+      `<a class="version-pill" href="#${escapeHtml(g.id)}">${escapeHtml(g.label)}</a>`,
   )
   .join("\n      ");
 


### PR DESCRIPTION
## Summary
- Changelog nav pills now group by minor version (`0.3 · 0.2 · 0.1 · 0.0`) instead of one per patch release — so the nav stays flat as `0.3.5`, `0.3.6`… land.
- Each pill links to the newest patch's anchor in that minor (e.g. `0.3` → `#v-0-3-4`).
- Added `npm run serve:docs` to rebuild `docs/changelog.html` and serve `docs/` locally for eyeballing.

## Test plan
- [x] `npm run build:changelog` — pills render as `Unreleased · 0.3 · 0.2 · 0.1 · 0.0`
- [x] Each pill's `href` points to the latest patch in that minor
- [x] `npm run serve:docs` boots and serves `/changelog.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)