### PR TITLE
docs(changelog): publish 0.3.5 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - Right-click menu on desktop artifact tiles — Rename (inline), Archive (soft-delete), Uninstall for plugins, read-only label for builtins.
 - Right-click menu on folder tiles — Rename folder, Archive folder (bulk), alongside existing Convert to Space.
 - `#archived` view — browse soft-deleted artifacts and Restore them.
-- Changelog page at `oyster.to/changelog`, generated from this file.
+- Changelog page at `oyster.to/changelog`, generated from `CHANGELOG.md`.
 - `oyster --help` shows 🦪 in the header.
 
 ### Changed
@@ -258,7 +258,8 @@ Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via M
 - Surface with Aurora WebGL animated background.
 - Typed artifact icons, chat bar, window system with viewer.
 
-[Unreleased]: https://github.com/mattslight/oyster/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/mattslight/oyster/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/mattslight/oyster/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/mattslight/oyster/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/mattslight/oyster/compare/v0.3.1...v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,35 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
-### Performance
-
-- Grainient shader pauses `requestAnimationFrame` on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.
+## [0.3.5] - 2026-04-19
 
 ### Added
 
+- Right-click menu on desktop artifact tiles — Rename (inline), Archive (soft-delete), Uninstall for plugins, read-only label for builtins.
+- Right-click menu on folder tiles — Rename folder, Archive folder (bulk), alongside existing Convert to Space.
+- `#archived` view — browse soft-deleted artifacts and Restore them.
+- Changelog page at `oyster.to/changelog`, generated from this file.
 - `oyster --help` shows 🦪 in the header.
 
 ### Changed
 
 - Docs site typography: Barlow headings paired with Space Grotesk body across landing and `/plugins`.
 - `/plugins` hero renamed to "Pearls".
+- Chat-bar Tab now completes the highlighted suggestion instead of executing — press Enter to execute.
+
+### Fixed
+
+- Import resolves spaces by display_name when the slug lookup misses (prevents duplicate spaces when an agent emits a renamed space name).
+
+### Performance
+
+- Grainient shader pauses `requestAnimationFrame` on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.
+- Archived-paths lookup cached on `ArtifactService`, invalidated on mutations — `/api/artifacts` polling is now O(active) in steady state.
+
+### Security
+
+- Artifact endpoints (reads and mutations) locked to localhost origins — prevents cross-origin sites from enumerating or mutating the local surface.
+- JSON body size capped at 64 KB on mutation routes.
 
 ## [0.3.4] - 2026-04-19
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -313,27 +313,21 @@
 
   <nav class="version-pills" aria-label="Jump to version">
       <a class="version-pill" href="#v-unreleased">Unreleased</a>
-      <a class="version-pill" href="#v-0-3-5">0.3.5</a>
-      <a class="version-pill" href="#v-0-3-4">0.3.4</a>
-      <a class="version-pill" href="#v-0-3-3">0.3.3</a>
-      <a class="version-pill" href="#v-0-3-2">0.3.2</a>
-      <a class="version-pill" href="#v-0-3-1">0.3.1</a>
-      <a class="version-pill" href="#v-0-2-4">0.2.4</a>
-      <a class="version-pill" href="#v-0-1-21">0.1.21</a>
-      <a class="version-pill" href="#v-0-1-17">0.1.17</a>
-      <a class="version-pill" href="#v-0-1-10">0.1.10</a>
-      <a class="version-pill" href="#v-0-0-x">0.0.x</a>
+      <a class="version-pill" href="#v-0-3-5">0.3</a>
+      <a class="version-pill" href="#v-0-2-4">0.2</a>
+      <a class="version-pill" href="#v-0-1-21">0.1</a>
+      <a class="version-pill" href="#v-0-0-x">0.0</a>
   </nav>
 
   <main class="entries">
-<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
-<h2 id="v-0-3-5"><span class="release-version">0.3.5</span><span class="release-date"> — 2026-04-19</span></h2>
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h2 id="v-0-3-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...v0.3.5" rel="noopener noreferrer"><span class="release-version">0.3.5</span></a><span class="release-date"> — 2026-04-19</span></h2>
 <h3>Added</h3>
 <ul>
 <li>Right-click menu on desktop artifact tiles — Rename (inline), Archive (soft-delete), Uninstall for plugins, read-only label for builtins.</li>
 <li>Right-click menu on folder tiles — Rename folder, Archive folder (bulk), alongside existing Convert to Space.</li>
 <li><code>#archived</code> view — browse soft-deleted artifacts and Restore them.</li>
-<li>Changelog page at <code>oyster.to/changelog</code>, generated from this file.</li>
+<li>Changelog page at <code>oyster.to/changelog</code>, generated from <code>CHANGELOG.md</code>.</li>
 <li><code>oyster --help</code> shows 🦪 in the header.</li>
 </ul>
 <h3>Changed</h3>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -313,26 +313,48 @@
 
   <nav class="version-pills" aria-label="Jump to version">
       <a class="version-pill" href="#v-unreleased">Unreleased</a>
-      <a class="version-pill" href="#v-0-3-4">0.3</a>
-      <a class="version-pill" href="#v-0-2-4">0.2</a>
-      <a class="version-pill" href="#v-0-1-21">0.1</a>
-      <a class="version-pill" href="#v-0-0-x">0.0</a>
+      <a class="version-pill" href="#v-0-3-5">0.3.5</a>
+      <a class="version-pill" href="#v-0-3-4">0.3.4</a>
+      <a class="version-pill" href="#v-0-3-3">0.3.3</a>
+      <a class="version-pill" href="#v-0-3-2">0.3.2</a>
+      <a class="version-pill" href="#v-0-3-1">0.3.1</a>
+      <a class="version-pill" href="#v-0-2-4">0.2.4</a>
+      <a class="version-pill" href="#v-0-1-21">0.1.21</a>
+      <a class="version-pill" href="#v-0-1-17">0.1.17</a>
+      <a class="version-pill" href="#v-0-1-10">0.1.10</a>
+      <a class="version-pill" href="#v-0-0-x">0.0.x</a>
   </nav>
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
-<h3>Performance</h3>
-<ul>
-<li>Grainient shader pauses <code>requestAnimationFrame</code> on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.</li>
-</ul>
+<h2 id="v-0-3-5"><span class="release-version">0.3.5</span><span class="release-date"> — 2026-04-19</span></h2>
 <h3>Added</h3>
 <ul>
+<li>Right-click menu on desktop artifact tiles — Rename (inline), Archive (soft-delete), Uninstall for plugins, read-only label for builtins.</li>
+<li>Right-click menu on folder tiles — Rename folder, Archive folder (bulk), alongside existing Convert to Space.</li>
+<li><code>#archived</code> view — browse soft-deleted artifacts and Restore them.</li>
+<li>Changelog page at <code>oyster.to/changelog</code>, generated from this file.</li>
 <li><code>oyster --help</code> shows 🦪 in the header.</li>
 </ul>
 <h3>Changed</h3>
 <ul>
 <li>Docs site typography: Barlow headings paired with Space Grotesk body across landing and <code>/plugins</code>.</li>
 <li><code>/plugins</code> hero renamed to &quot;Pearls&quot;.</li>
+<li>Chat-bar Tab now completes the highlighted suggestion instead of executing — press Enter to execute.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>Import resolves spaces by display_name when the slug lookup misses (prevents duplicate spaces when an agent emits a renamed space name).</li>
+</ul>
+<h3>Performance</h3>
+<ul>
+<li>Grainient shader pauses <code>requestAnimationFrame</code> on window blur and tab hide (was pinning the Chrome GPU process while Oyster sat in the background). Time stays continuous on resume — no visual jump.</li>
+<li>Archived-paths lookup cached on <code>ArtifactService</code>, invalidated on mutations — <code>/api/artifacts</code> polling is now O(active) in steady state.</li>
+</ul>
+<h3>Security</h3>
+<ul>
+<li>Artifact endpoints (reads and mutations) locked to localhost origins — prevents cross-origin sites from enumerating or mutating the local surface.</li>
+<li>JSON body size capped at 64 KB on mutation routes.</li>
 </ul>
 <h2 id="v-0-3-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4" rel="noopener noreferrer"><span class="release-version">0.3.4</span></a><span class="release-date"> — 2026-04-19</span></h2>
 <h3>Fixed</h3>


### PR DESCRIPTION
Fixes the missing 0.3.5 heading on oyster.to/changelog — content was still under `[Unreleased]` in CHANGELOG.md at release time. Regenerated the page from the updated source.