### PR TITLE
fix(web): style chat scrollbar on Windows to match dark theme

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -987,6 +987,8 @@ body {
   padding: 20px;
   max-height: 50vh;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -997,6 +999,16 @@ body {
   -webkit-user-select: text;
   user-select: text;
   cursor: text;
+}
+
+.chatbar-messages::-webkit-scrollbar { width: 8px; }
+.chatbar-messages::-webkit-scrollbar-track { background: transparent; }
+.chatbar-messages::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+}
+.chatbar-messages::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.22);
 }
 
 .chatbar-messages.chat-expanded {


### PR DESCRIPTION
## Summary

Default Windows scrollbar is chunky light-gray and clashes with the dark chat panel. Added `::-webkit-scrollbar` styles (Chrome/Edge) plus Firefox equivalents (`scrollbar-width`, `scrollbar-color`) so the scrollbar is thin and blends in.

macOS already overlays its own thin scrollbar, so the change is mostly invisible there.

Closes #161.

## Test plan

- [x] Verified on the author's Mac — no regression
- [ ] Verify on Windows — scrollbar appears thin and dark
EOF