### PR TITLE
fix(server): Windows artifact shows as 'C:' and stays in generating state

### DIFF
--- a/server/src/artifact-detector.ts
+++ b/server/src/artifact-detector.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
-import { join, dirname, basename, sep } from "node:path";
+import { join, dirname, basename, sep, isAbsolute } from "node:path";
 import {
   registerGeneratedArtifact,
   updateGeneratedArtifact,
@@ -165,9 +165,11 @@ function registerArtifactFromManifest(
 }
 
 export function handleFileEdited(rawPath: string, artifactsDir: string, iconGenerator: IconGenerator) {
-  // Resolve relative paths against userland
+  // Resolve relative paths against userland. Must use isAbsolute to catch
+  // Windows drive-letter paths (C:\...) — startsWith("/") would miss them,
+  // causing userlandDir to be prepended and artifactId to become "C:".
   const userlandDir = artifactsDir; // ARTIFACTS_DIR === USERLAND_DIR + "/"
-  const filePath = rawPath.startsWith("/") ? rawPath : `${userlandDir}${rawPath}`;
+  const filePath = isAbsolute(rawPath) ? rawPath : `${userlandDir}${rawPath}`;
 
   // Check if this file is inside userland
   if (filePath.startsWith(artifactsDir)) {

--- a/server/src/artifact-detector.ts
+++ b/server/src/artifact-detector.ts
@@ -168,7 +168,7 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
   // Resolve relative paths against userland. Must use isAbsolute to catch
   // Windows drive-letter paths (C:\...) — startsWith("/") would miss them,
   // causing userlandDir to be prepended and artifactId to become "C:".
-  const userlandDir = artifactsDir; // ARTIFACTS_DIR === USERLAND_DIR + "/"
+  const userlandDir = artifactsDir; // ARTIFACTS_DIR is USERLAND_DIR with a trailing path.sep
   // Normalize so the separator matches artifactsDir on Windows (Node may hand
   // us a forward-slash path while artifactsDir uses backslashes, or vice versa).
   const filePath = normalize(isAbsolute(rawPath) ? rawPath : `${userlandDir}${rawPath}`);

--- a/server/src/artifact-detector.ts
+++ b/server/src/artifact-detector.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
-import { join, dirname, basename, sep, isAbsolute } from "node:path";
+import { join, dirname, basename, sep, isAbsolute, normalize } from "node:path";
 import {
   registerGeneratedArtifact,
   updateGeneratedArtifact,
@@ -169,7 +169,9 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
   // Windows drive-letter paths (C:\...) — startsWith("/") would miss them,
   // causing userlandDir to be prepended and artifactId to become "C:".
   const userlandDir = artifactsDir; // ARTIFACTS_DIR === USERLAND_DIR + "/"
-  const filePath = isAbsolute(rawPath) ? rawPath : `${userlandDir}${rawPath}`;
+  // Normalize so the separator matches artifactsDir on Windows (Node may hand
+  // us a forward-slash path while artifactsDir uses backslashes, or vice versa).
+  const filePath = normalize(isAbsolute(rawPath) ? rawPath : `${userlandDir}${rawPath}`);
 
   // Check if this file is inside userland
   if (filePath.startsWith(artifactsDir)) {
@@ -277,7 +279,8 @@ export function scanExistingArtifacts(artifactsDir: string, iconGenerator: IconG
             if (!seenArtifacts.has(id)) {
               const name = inferName(foundFile);
               const type = inferType(foundFile);
-              const serveRelative = `/artifacts/${foundFile.slice(artifactsDir.length)}`;
+              // URLs must use forward slashes; sep is "\" on Windows, so rewrite.
+              const serveRelative = `/artifacts/${foundFile.slice(artifactsDir.length).split(sep).join("/")}`;
               seenArtifacts.add(id);
               console.log(`[artifact-detect] scan: ${name} (${type}) → ${serveRelative}`);
               registerGeneratedArtifact({


### PR DESCRIPTION
## Summary

On Windows, the artifact filesystem watcher treats any agent-written path as a relative path, prepending `userlandDir` to an already-absolute path like `C:\Users\…\color-picker.html`. The resulting doubled path gets stripped back by `filePath.slice(artifactsDir.length)`, but the leftover `relativePath` starts with `C:\…` — so `relativePath.split(sep)[0]` returns `"C:"`, which then becomes the artifact id AND label.

The entrypoint path is also malformed, so the quiescence timer never sees an entrypoint file and the artifact stays in `status: generating` forever (pulsing icon).

## Fix

Use `path.isAbsolute()` instead of `rawPath.startsWith("/")` to detect already-absolute paths. `isAbsolute` handles both POSIX and Windows drive-letter conventions.

## Evidence

From a fresh 0.3.5 Windows install:

```
[artifact-detect] generating (inferred): C: (app)
[artifact-detect] abandoned: C: (no entrypoint after 300s)
```

## Test plan

- [x] `tsc --noEmit` on server
- [ ] Fresh Windows test: agent creates a small app, artifact appears with correct label and transitions to `ready`
- [x] Mac regression: POSIX paths still resolve (isAbsolute treats `/...` as absolute)

Closes #163.