### PR TITLE
feat(server): OYSTER_DEBUG artifact lifecycle logging

### DIFF
--- a/server/src/artifact-detector.ts
+++ b/server/src/artifact-detector.ts
@@ -5,6 +5,7 @@ import {
   updateGeneratedArtifact,
 } from "./process-manager.js";
 import { IconGenerator } from "./icon-generator.js";
+import { debug } from "./debug.js";
 
 // ── Artifact detection ──
 // Artifacts live in userland/<id>/ with a manifest.json and src/ directory.
@@ -172,13 +173,18 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
   // Normalize so the separator matches artifactsDir on Windows (Node may hand
   // us a forward-slash path while artifactsDir uses backslashes, or vice versa).
   const filePath = normalize(isAbsolute(rawPath) ? rawPath : `${userlandDir}${rawPath}`);
+  debug("watcher", "file.edited", { rawPath, filePath, isAbs: isAbsolute(rawPath) });
 
   // Check if this file is inside userland
   if (filePath.startsWith(artifactsDir)) {
     const relativePath = filePath.slice(artifactsDir.length);
     const topDir = relativePath.split(sep)[0];
-    if (!topDir || topDir.startsWith(".")) return; // Skip dotdirs (.opencode/, .git/, etc.)
+    if (!topDir || topDir.startsWith(".")) {
+      debug("watcher", "skip dotdir/empty", { topDir });
+      return; // Skip dotdirs (.opencode/, .git/, etc.)
+    }
     const artifactId = topDir;
+    debug("watcher", "artifactId derived", { artifactId, relativePath });
 
     const artifactDir = join(artifactsDir, artifactId);
     const id = `gen:${artifactId}`;
@@ -199,6 +205,7 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
     // Try manifest first
     const manifest = tryReadManifest(artifactDir);
     if (manifest) {
+      debug("watcher", "manifest found → register", { manifestName: manifest.name, manifestType: manifest.type, artifactDir });
       registerArtifactFromManifest(manifest, artifactDir, iconGenerator, true);
       return;
     }
@@ -207,6 +214,7 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
     // Use the directory name (artifact ID) for inference, not the individual file
     const name = inferName(join(artifactDir, "index.html"));
     const type = inferType(artifactDir);
+    debug("watcher", "no manifest → inferred", { name, type, artifactDir });
 
     seenArtifacts.add(id);
     console.log(`[artifact-detect] generating (inferred): ${name} (${type})`);

--- a/server/src/artifact-detector.ts
+++ b/server/src/artifact-detector.ts
@@ -5,7 +5,7 @@ import {
   updateGeneratedArtifact,
 } from "./process-manager.js";
 import { IconGenerator } from "./icon-generator.js";
-import { debug } from "./debug.js";
+import { debug, debugEnabled } from "./debug.js";
 
 // ── Artifact detection ──
 // Artifacts live in userland/<id>/ with a manifest.json and src/ directory.
@@ -172,19 +172,20 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
   const userlandDir = artifactsDir; // ARTIFACTS_DIR is USERLAND_DIR with a trailing path.sep
   // Normalize so the separator matches artifactsDir on Windows (Node may hand
   // us a forward-slash path while artifactsDir uses backslashes, or vice versa).
-  const filePath = normalize(isAbsolute(rawPath) ? rawPath : `${userlandDir}${rawPath}`);
-  debug("watcher", "file.edited", { rawPath, filePath, isAbs: isAbsolute(rawPath) });
+  const isAbs = isAbsolute(rawPath);
+  const filePath = normalize(isAbs ? rawPath : `${userlandDir}${rawPath}`);
+  if (debugEnabled) debug("watcher", "file.edited", { rawPath, filePath, isAbs });
 
   // Check if this file is inside userland
   if (filePath.startsWith(artifactsDir)) {
     const relativePath = filePath.slice(artifactsDir.length);
     const topDir = relativePath.split(sep)[0];
     if (!topDir || topDir.startsWith(".")) {
-      debug("watcher", "skip dotdir/empty", { topDir });
+      if (debugEnabled) debug("watcher", "skip dotdir/empty", { topDir });
       return; // Skip dotdirs (.opencode/, .git/, etc.)
     }
     const artifactId = topDir;
-    debug("watcher", "artifactId derived", { artifactId, relativePath });
+    if (debugEnabled) debug("watcher", "artifactId derived", { artifactId, relativePath });
 
     const artifactDir = join(artifactsDir, artifactId);
     const id = `gen:${artifactId}`;
@@ -205,7 +206,7 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
     // Try manifest first
     const manifest = tryReadManifest(artifactDir);
     if (manifest) {
-      debug("watcher", "manifest found → register", { manifestName: manifest.name, manifestType: manifest.type, artifactDir });
+      if (debugEnabled) debug("watcher", "manifest found → register", { manifestName: manifest.name, manifestType: manifest.type, artifactDir });
       registerArtifactFromManifest(manifest, artifactDir, iconGenerator, true);
       return;
     }
@@ -214,7 +215,7 @@ export function handleFileEdited(rawPath: string, artifactsDir: string, iconGene
     // Use the directory name (artifact ID) for inference, not the individual file
     const name = inferName(join(artifactDir, "index.html"));
     const type = inferType(artifactDir);
-    debug("watcher", "no manifest → inferred", { name, type, artifactDir });
+    if (debugEnabled) debug("watcher", "no manifest → inferred", { name, type, artifactDir });
 
     seenArtifacts.add(id);
     console.log(`[artifact-detect] generating (inferred): ${name} (${type})`);

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -5,7 +5,7 @@ import type { ArtifactStore, ArtifactRow } from "./artifact-store.js";
 import type { Artifact, ArtifactKind, ArtifactStatus } from "../../shared/types.js";
 import { isPortOpen, isStarting, clearStarting, getGeneratedArtifactEntries } from "./process-manager.js";
 import { slugify, inferKindFromPath, toArtifactKind } from "./utils.js";
-import { debug } from "./debug.js";
+import { debug, debugEnabled } from "./debug.js";
 
 // ── Config shapes (validated here, not in route handlers) ──
 
@@ -214,9 +214,12 @@ export class ArtifactService {
     debug("artifact-svc", "registerArtifact id resolved", { id, fromParams: !!params.id, absPath });
 
     // Log dedup-by-path observability so #167 diagnosis is easy; behaviour unchanged here.
-    const byPath = this.store.getByPath(absPath);
-    if (byPath) {
-      debug("artifact-svc", "registerArtifact path already has active row", { existingId: byPath.id, incomingId: id, path: absPath });
+    // Gated on debugEnabled so we don't pay for an extra SQLite query in hot paths when debug is off.
+    if (debugEnabled) {
+      const byPath = this.store.getByPath(absPath);
+      if (byPath) {
+        debug("artifact-svc", "registerArtifact path already has active row", { existingId: byPath.id, incomingId: id, path: absPath });
+      }
     }
 
     // If a removed record exists with this ID, resurface and update it

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -5,6 +5,7 @@ import type { ArtifactStore, ArtifactRow } from "./artifact-store.js";
 import type { Artifact, ArtifactKind, ArtifactStatus } from "../../shared/types.js";
 import { isPortOpen, isStarting, clearStarting, getGeneratedArtifactEntries } from "./process-manager.js";
 import { slugify, inferKindFromPath, toArtifactKind } from "./utils.js";
+import { debug } from "./debug.js";
 
 // ── Config shapes (validated here, not in route handlers) ──
 
@@ -189,6 +190,7 @@ export class ArtifactService {
     },
     approvedRoots: string[],
   ): Promise<Artifact> {
+    debug("artifact-svc", "registerArtifact called", { path: params.path, label: params.label, id: params.id ?? null, space_id: params.space_id });
     const absPath = resolve(params.path);
 
     // Validate file exists
@@ -209,6 +211,13 @@ export class ArtifactService {
 
     // Infer ID from filename stem if not provided
     const id = params.id || basename(absPath).replace(/\.[^.]+$/, "");
+    debug("artifact-svc", "registerArtifact id resolved", { id, fromParams: !!params.id, absPath });
+
+    // Log dedup-by-path observability so #167 diagnosis is easy; behaviour unchanged here.
+    const byPath = this.store.getByPath(absPath);
+    if (byPath) {
+      debug("artifact-svc", "registerArtifact path already has active row", { existingId: byPath.id, incomingId: id, path: absPath });
+    }
 
     // If a removed record exists with this ID, resurface and update it
     const existing = this.store.getById(id);
@@ -276,6 +285,7 @@ export class ArtifactService {
     },
     userlandDir: string,
   ): Promise<Artifact> {
+    debug("artifact-svc", "createArtifact called", { label: params.label, space_id: params.space_id, kind: params.artifact_kind, subdir: params.subdir ?? null });
     const label = params.label.trim();
     const space_id = params.space_id.trim();
     if (!label) throw new Error("label must not be empty");
@@ -295,6 +305,7 @@ export class ArtifactService {
 
     const ext = KIND_EXT[params.artifact_kind];
     const absPath = join(targetDir, `${slug}${ext}`);
+    debug("artifact-svc", "createArtifact writing file", { id, slug, absPath });
 
     // Filesystem collision check + exclusive write
     mkdirSync(targetDir, { recursive: true });
@@ -332,7 +343,11 @@ export class ArtifactService {
     userlandDir: string,
     archivedPaths?: Set<string>,
   ): void {
-    if (this.store.getByPath(filePath)) return; // already registered (active row)
+    debug("reconcile", "start", { genId: artifact.id, label: artifact.label, filePath });
+    if (this.store.getByPath(filePath)) {
+      debug("reconcile", "skipped: active row exists for path", { filePath });
+      return; // already registered (active row)
+    }
     // If the user archived this path previously, the scanner will keep
     // seeing the file on disk and a naive reconcile would create a fresh
     // active row next to the archived one — effectively ignoring the
@@ -344,8 +359,12 @@ export class ArtifactService {
     // loop) should pass a pre-loaded `archivedPaths` set to avoid re-
     // querying for every artifact.
     const archived = archivedPaths ?? this.store.getArchivedFilePaths();
-    if (archived.has(filePath)) return;
+    if (archived.has(filePath)) {
+      debug("reconcile", "skipped: archived path", { filePath });
+      return;
+    }
     console.log(`[reconcile] ${artifact.label} → DB`);
+    debug("reconcile", "inserting new row", { label: artifact.label, filePath, newId: "pending-uuid" });
     try {
       this.registerArtifact(
         { path: filePath, space_id: artifact.spaceId, label: artifact.label, artifact_kind: artifact.artifactKind, id: crypto.randomUUID() },

--- a/server/src/debug.ts
+++ b/server/src/debug.ts
@@ -6,7 +6,7 @@ const enabled = (() => {
   const v = process.env.OYSTER_DEBUG;
   if (!v) return false;
   if (v === "1" || v.toLowerCase() === "true") return true;
-  return v.split(",").map((s) => s.trim()).includes("artifact");
+  return v.split(",").map((s) => s.trim().toLowerCase()).includes("artifact");
 })();
 
 export function debug(scope: string, msg: string, data?: Record<string, unknown>): void {

--- a/server/src/debug.ts
+++ b/server/src/debug.ts
@@ -1,0 +1,22 @@
+// Opt-in structured debug logging for artifact lifecycle diagnostics.
+// Enable with OYSTER_DEBUG=1 (or =artifact to scope to this subsystem).
+// Kept intentionally tiny — no dependencies, no levels, no formatter.
+
+const enabled = (() => {
+  const v = process.env.OYSTER_DEBUG;
+  if (!v) return false;
+  if (v === "1" || v.toLowerCase() === "true") return true;
+  return v.split(",").map((s) => s.trim()).includes("artifact");
+})();
+
+export function debug(scope: string, msg: string, data?: Record<string, unknown>): void {
+  if (!enabled) return;
+  const ts = new Date().toISOString().slice(11, 23); // HH:mm:ss.sss
+  if (data) {
+    console.log(`[${ts}] [${scope}] ${msg}`, JSON.stringify(data));
+  } else {
+    console.log(`[${ts}] [${scope}] ${msg}`);
+  }
+}
+
+export const debugEnabled = enabled;

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -9,6 +9,7 @@ import type { SpaceService } from "./space-service.js";
 import type { MemoryProvider } from "./memory-store.js";
 import { registerMemoryTools } from "./memory-store.js";
 import type { ArtifactKind } from "../../shared/types.js";
+import { debug } from "./debug.js";
 
 // Kept local — value imports from shared/ don't transpile in tsx (include: ["src"] only).
 // `satisfies` ensures this stays in sync with the ArtifactKind union at compile time.
@@ -335,6 +336,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
       group_name: z.string().optional().describe("Group name for visual grouping on the surface"),
     },
     async ({ path, space_id, label, id, artifact_kind, group_name }) => {
+      debug("mcp", "register_artifact invoked", { path, label, id: id ?? null, space_id, kind: artifact_kind ?? null });
       try {
         const artifact = deps.service.registerArtifact(
           { path, space_id, label, id, artifact_kind, group_name },
@@ -398,6 +400,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
       source_origin: z.enum(["manual", "ai_generated"]).optional().describe("Provenance of the artifact. Defaults to 'manual'. Use 'ai_generated' when the content was produced by an AI agent."),
     },
     async ({ space_id, label, artifact_kind, content, subdir, group_name, source_origin }) => {
+      debug("mcp", "create_artifact invoked", { label, space_id, kind: artifact_kind, subdir: subdir ?? null });
       try {
         const artifact = deps.service.createArtifact(
           { space_id, label, artifact_kind, content, subdir, group_name, source_origin },


### PR DESCRIPTION
## Summary

Opt-in structured debug logs for every stage of the artifact lifecycle. Enable with `OYSTER_DEBUG=1 oyster` or `OYSTER_DEBUG=artifact oyster`.

Goal: make #167-class bugs (duplicate rows when the agent calls `create_artifact` AND `register_artifact` — or manually writes files AND calls `register_artifact` — for the same logical artifact) diagnosable in minutes.

## Logged points

- **MCP tool entry** — `create_artifact` and `register_artifact` invocations with params
- **OpenCode file events** — rawPath, normalised filePath, isAbsolute result (directly covers the #164 failure mode)
- **Watcher decisions** — dotdir skip, manifest-found, inferred fallback, derived artifactId
- **Service layer** — createArtifact resolved absPath/id, registerArtifact id resolution, path-already-has-active-row observability (log only — behaviour unchanged)
- **Reconciliation** — start, skip reasons (active row / archived), insert

## Behavioural change

None. The existing `getByPath` check in `registerArtifact` is now logged when it hits, but we don't change its flow. Dedup-by-path fix for #167 will be a separate PR once we have trace data confirming the exact duplicate-producing sequence.

## Test plan

- [x] `tsc --noEmit` passes
- [x] With `OYSTER_DEBUG` unset, no extra log output (default)
- [ ] With `OYSTER_DEBUG=1`, running through Windows calculator repro produces a trace showing both tool paths touching the same file

## Why now

0.3.6 is the target launch build and #167 is currently a hard blocker. Shipping this PR doesn't fix #167 on its own, but it gives us the diagnostic surface to land the actual fix in hours instead of days of reverse-engineering.