### PR TITLE
ci: auto-rebuild changelog page on CHANGELOG.md edits

### DIFF
--- a/.github/workflows/build-changelog.yml
+++ b/.github/workflows/build-changelog.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install marked
-        run: npm install --no-save marked@18
+      - name: Install dependencies
+        run: npm ci
 
       - name: Rebuild docs/changelog.html
         run: node scripts/build-changelog.mjs
@@ -45,5 +45,9 @@ jobs:
           git config user.name  'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add docs/changelog.html
-          git commit -m "docs(changelog): regenerate page [skip ci]"
+          git commit -m "docs(changelog): regenerate page"
+          # Pull-rebase covers the window between checkout and push where a
+          # human commit can land on main; the concurrency group handles
+          # workflow-vs-workflow races.
+          git pull --rebase origin main
           git push

--- a/.github/workflows/build-changelog.yml
+++ b/.github/workflows/build-changelog.yml
@@ -1,0 +1,49 @@
+name: Rebuild changelog page
+
+# Keeps docs/changelog.html in sync with CHANGELOG.md between releases. The
+# release workflow already regenerates on version bumps; this covers inter-
+# release edits so oyster.to/changelog never lags the source.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'CHANGELOG.md'
+      - 'scripts/build-changelog.mjs'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-changelog
+  cancel-in-progress: false
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    # Skip the commit this workflow pushes so it doesn't self-trigger.
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 24
+
+      - name: Install marked
+        run: npm install --no-save marked@18
+
+      - name: Rebuild docs/changelog.html
+        run: node scripts/build-changelog.mjs
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet docs/changelog.html; then
+            echo "changelog.html already in sync"
+            exit 0
+          fi
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add docs/changelog.html
+          git commit -m "docs(changelog): regenerate page [skip ci]"
+          git push


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-changelog.yml` — runs `scripts/build-changelog.mjs` on pushes to `main` that touch `CHANGELOG.md` or the build script, and commits the regenerated `docs/changelog.html` back.
- Closes the inter-release drift gap. Release cuts already regenerate via the `npm version` lifecycle; edits between releases (the case that bit us on #160) now auto-regenerate too.
- Install uses `npm ci` so `marked` tracks the lockfile — output matches what `npm run build:changelog` produces locally and in the release flow.
- Self-trigger protection: `if` checks `github.event.head_commit.author.name != 'github-actions[bot]'`. Concurrency group serializes workflow runs; `git pull --rebase` before push handles the rare case of a human commit landing during the run.

Related: #159 (adjacent release-flow automation).

## Test plan

- [ ] Merge this PR — no CHANGELOG changes in the diff, so the workflow won't fire.
- [ ] Next PR that edits `CHANGELOG.md` triggers the workflow; `docs/changelog.html` auto-commit shows up on `main` within ~1 min of merge.
- [ ] Auto-commit does not re-trigger the workflow (author-check skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)