### PR TITLE
fix(mcp): await async artifact service calls in tool handlers

### DIFF
--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -338,7 +338,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
     async ({ path, space_id, label, id, artifact_kind, group_name }) => {
       debug("mcp", "register_artifact invoked", { path, label, id: id ?? null, space_id, kind: artifact_kind ?? null });
       try {
-        const artifact = deps.service.registerArtifact(
+        const artifact = await deps.service.registerArtifact(
           { path, space_id, label, id, artifact_kind, group_name },
           [], // MCP callers are trusted — no path restriction
         );
@@ -402,7 +402,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
     async ({ space_id, label, artifact_kind, content, subdir, group_name, source_origin }) => {
       debug("mcp", "create_artifact invoked", { label, space_id, kind: artifact_kind, subdir: subdir ?? null });
       try {
-        const artifact = deps.service.createArtifact(
+        const artifact = await deps.service.createArtifact(
           { space_id, label, artifact_kind, content, subdir, group_name, source_origin },
           deps.userlandDir,
         );


### PR DESCRIPTION
## Summary

`create_artifact` and `register_artifact` service methods are `async`, but the MCP tool handlers called them without `await`. Two-character fix per call site.

## Why this matters

Without `await`:
- The local `artifact` was a Promise, not the resolved artifact
- `JSON.stringify(artifact, null, 2)` serialised to `"{}"`
- `{ ...artifact }` spread to `{}`
- The MCP client (the agent) received `{ content: [{ type: "text", text: "{}" }], structuredContent: {} }` — no id, no confirmation
- Rejected promises bypassed the `try/catch` and surfaced as unhandled rejections

Side effects (file write, DB insert) still happened because the async function ran to completion on its own — but the caller had no information about the result.

## Likely root cause of #167

If `create_artifact` returns `{}` to the agent, the agent has no artifact id to call `reveal_artifact` with. A reasonable recovery move is to write the file manually and call `register_artifact` to register it — producing the second DB row with `id: "index"` seen in the Windows Calculator repro.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] With `OYSTER_DEBUG=1` (#168), run the Windows calculator repro. Expect: one DB row, not two, and a populated `structuredContent` in the MCP response trace.

Closes #170
Related: #167