### PR TITLE
docs(changelog): backfill 0.3.6 and 0.3.7 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-04-20
+
+### Added
+
+- `OYSTER_DEBUG` artifact-lifecycle logging (`OYSTER_DEBUG=1 oyster` or `OYSTER_DEBUG=artifact oyster`) — opt-in structured traces across MCP tool entry, OpenCode file events, watcher decisions, service layer, and reconciliation. No output when unset.
+
+### Fixed
+
+- MCP `create_artifact` and `register_artifact` handlers now `await` the async service calls. Previously the tool response serialised as `{}` and the agent received no artifact id, triggering recovery paths that could duplicate rows.
+- `docs/changelog.html` auto-regenerates on pushes to `main` that touch `CHANGELOG.md` or the build script — `oyster.to/changelog` no longer lags between releases.
+
+## [0.3.6] - 2026-04-19
+
+### Fixed
+
+- Windows: artifact appeared as `C:` and hung in `generating` forever. Watcher now uses `path.isAbsolute()` instead of a POSIX-only `startsWith("/")` check.
+- Windows: dark-theme scrollbar styling on the chat panel (thin `::-webkit-scrollbar` + Firefox `scrollbar-color`) — macOS unchanged.
+
 ## [0.3.5] - 2026-04-19
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,13 +312,29 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
-      <a class="version-pill" href="#v-0-3-5">0.3</a>
+      <a class="version-pill" href="#v-0-3-7">0.3</a>
       <a class="version-pill" href="#v-0-2-4">0.2</a>
       <a class="version-pill" href="#v-0-1-21">0.1</a>
       <a class="version-pill" href="#v-0-0-x">0.0</a>
   </nav>
 
   <main class="entries">
+<h2 id="v-0-3-7"><span class="release-version">0.3.7</span><span class="release-date"> — 2026-04-20</span></h2>
+<h3>Added</h3>
+<ul>
+<li><code>OYSTER_DEBUG</code> artifact-lifecycle logging (<code>OYSTER_DEBUG=1 oyster</code> or <code>OYSTER_DEBUG=artifact oyster</code>) — opt-in structured traces across MCP tool entry, OpenCode file events, watcher decisions, service layer, and reconciliation. No output when unset.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>MCP <code>create_artifact</code> and <code>register_artifact</code> handlers now <code>await</code> the async service calls. Previously the tool response serialised as <code>{}</code> and the agent received no artifact id, triggering recovery paths that could duplicate rows.</li>
+<li><code>docs/changelog.html</code> auto-regenerates on pushes to <code>main</code> that touch <code>CHANGELOG.md</code> or the build script — <code>oyster.to/changelog</code> no longer lags between releases.</li>
+</ul>
+<h2 id="v-0-3-6"><span class="release-version">0.3.6</span><span class="release-date"> — 2026-04-19</span></h2>
+<h3>Fixed</h3>
+<ul>
+<li>Windows: artifact appeared as <code>C:</code> and hung in <code>generating</code> forever. Watcher now uses <code>path.isAbsolute()</code> instead of a POSIX-only <code>startsWith(&quot;/&quot;)</code> check.</li>
+<li>Windows: dark-theme scrollbar styling on the chat panel (thin <code>::-webkit-scrollbar</code> + Firefox <code>scrollbar-color</code>) — macOS unchanged.</li>
+</ul>
 <h2 id="v-0-3-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.4...v0.3.5" rel="noopener noreferrer"><span class="release-version">0.3.5</span></a><span class="release-date"> — 2026-04-19</span></h2>
 <h3>Added</h3>
 <ul>


### PR DESCRIPTION
## Summary

Both 0.3.6 and 0.3.7 shipped without CHANGELOG entries because \`[Unreleased]\` was empty at release time. This PR adds the missing sections, regenerates \`docs/changelog.html\`, and (by touching \`CHANGELOG.md\`) exercises the new #169 auto-rebuild workflow.

**0.3.6 (#162, #164)** — Windows fixes:
- Artifact-as-\`C:\` / stuck in generating (\`path.isAbsolute()\` fix)
- Dark-theme chat scrollbar styling

**0.3.7 (#168, #169, #171)**:
- \`OYSTER_DEBUG\` artifact-lifecycle logging (added)
- MCP handlers now await async service calls (fixed — #167-class duplicate rows)
- Auto-rebuild of changelog page on CHANGELOG.md push (fixed — stale oyster.to)

## Process note

Root cause of the gap: the two trailing releases were cut with an empty \`[Unreleased]\`. #159 would close the promotion half; PR-author discipline (CLAUDE.md rule) is the authoring half. Neither fix is in this PR — scope here is just to backfill what landed.

## Test plan

- [ ] Merge → #169's workflow triggers on the \`CHANGELOG.md\` diff; since this PR already includes a regenerated \`docs/changelog.html\`, the auto-rebuild step logs "already in sync" and doesn't produce a second commit.
- [ ] oyster.to/changelog shows 0.3.6 and 0.3.7 sections after Pages redeploys (~1 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)