### PR TITLE
fix: stop overriding OpenCode's own model selection (#174)

### DIFF
--- a/.opencode/config.toml
+++ b/.opencode/config.toml
@@ -1,12 +1,1 @@
-[provider.anthropic]
-
-[model.chat]
-provider = "anthropic"
-id = "claude-sonnet-4-20250514"
-
-[model.edit]
-provider = "anthropic"
-id = "claude-sonnet-4-20250514"
-
 # MCP config is written dynamically by the server with the actual port
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped overriding OpenCode's own model selection with a hardcoded `anthropic/claude-sonnet-4-20250514` string, which broke users authed with OpenAI / Google / other providers (`ProviderModelNotFoundError` → 502 in chat + AI import). OpenCode now picks its default model from whichever provider the user authed with via `opencode providers login` or env vars. ([#174](https://github.com/mattslight/oyster/issues/174))
+
 ## [0.3.7] - 2026-04-20
 
 ### Added

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "anthropic/claude-sonnet-4-20250514",
   "mcp": {
     "oyster": {
       "type": "remote",


### PR DESCRIPTION
Closes #174.

## Problem

\`opencode.json\` and \`.opencode/config.toml\` at the repo root hardcoded \`anthropic/claude-sonnet-4-20250514\`. The server copies these into \`~/.oyster/userland/\` at startup (\`server/src/index.ts:997-1007\`), so the hardcode was forcing Anthropic on every install. Users authed with OpenAI / Google / other providers via \`opencode providers login\` hit \`ProviderModelNotFoundError\` → 502 in chat and AI import (Bharat's Ubuntu session, 2026-04-20).

History: the hardcode has no documented reason. It was introduced incidentally in d08e931 (MCP server feature) and flipped from \`openai/gpt-5.4\` to anthropic in #83 (docs overhaul), bundled with unrelated changes.

## Fix

Remove the \`model\` field from \`opencode.json\` and the \`[model.chat]\` / \`[model.edit]\` blocks from \`.opencode/config.toml\`. OpenCode has its own model selection logic and picks a sensible default for whichever provider is authed — verified with \`opencode run\` against a config containing only the MCP block (picked \`build · claude-opus-4-6\` on its own).

Oyster still writes both files at startup to inject the dynamic MCP URL (\`http://localhost:\${port}/mcp/\`). Nothing else changes.

## Not in this PR

The ticket body mentions surfacing the "no AI connected" state cleanly in the UI (so an unauthed user sees a "connect an AI" banner instead of a 502 retry loop). That's orthogonal to this fix and bigger in scope — filing as a follow-up.

## Verification

- Simulated userland file generation with the edited source files — \`opencode.json\` contains only \`\$schema\` + \`mcp\`, \`config.toml\` contains only the \`[mcp.oyster]\` block.
- \`npm run build:server\` clean.
- Manual fresh-install test on Mac (Anthropic authed) recommended before merging.

## Test plan

- [ ] Fresh install on Mac with Anthropic key — chat + AI import still work
- [ ] Fresh install on Ubuntu with OpenAI-only key — chat + AI import now work (was the bug)
- [ ] CHANGELOG [Unreleased] entry present