### PR TITLE
docs: use --scope user for Claude Code MCP install (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-04-21
+
 ### Fixed
 
 - Stopped overriding OpenCode's own model selection with a hardcoded `anthropic/claude-sonnet-4-20250514` string, which broke users authed with OpenAI / Google / other providers (`ProviderModelNotFoundError` → 502 in chat + AI import). OpenCode now picks its default model from whichever provider the user authed with via `opencode providers login` or env vars. ([#174](https://github.com/mattslight/oyster/issues/174))
+- Claude Code MCP install command now uses `--scope user` so the Oyster MCP follows the user across every project instead of being pinned to the directory they happened to run `claude mcp add` from. Updated in README, landing page, `oyster.to/mcp`, the in-app "Connect your AI" builtin, and the CLI startup banner. ([#175](https://github.com/mattslight/oyster/issues/175))
 
 ## [0.3.7] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Oyster is an MCP server. Any MCP-compatible tool can connect and control your wo
 **Claude Code:**
 
 ```bash
-claude mcp add --transport http oyster http://localhost:4444/mcp/
+claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/
 ```
 
 **Cursor / VS Code / other MCP clients** — add to your MCP config:

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -414,7 +414,7 @@ async function main() {
         const url = match[1];
         console.log(`\n  👉 Open: ${url} 👈\n`);
         console.log(`  🔗 Bring your own AI:`);
-        console.log(`     claude mcp add --transport http oyster ${url}/mcp/\n`);
+        console.log(`     claude mcp add --scope user --transport http oyster ${url}/mcp/\n`);
         console.log(`  What you can do:`);
         console.log(`  • "Create a deck about our roadmap" → appears on your surface`);
         console.log(`  • "Scan ~/Dev/my-project" → new space with everything discovered`);

--- a/builtins/connect-your-ai/src/index.html
+++ b/builtins/connect-your-ai/src/index.html
@@ -299,7 +299,7 @@
     };
 
     document.getElementById('code-claude').textContent =
-      `claude mcp add --transport http oyster ${mcpUrl}`;
+      `claude mcp add --scope user --transport http oyster ${mcpUrl}`;
 
     document.getElementById('code-cursor').textContent =
 `{

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,18 +312,18 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
-      <a class="version-pill" href="#v-unreleased">Unreleased</a>
-      <a class="version-pill" href="#v-0-3-7">0.3</a>
+      <a class="version-pill" href="#v-0-3-8">0.3</a>
       <a class="version-pill" href="#v-0-2-4">0.2</a>
       <a class="version-pill" href="#v-0-1-21">0.1</a>
       <a class="version-pill" href="#v-0-0-x">0.0</a>
   </nav>
 
   <main class="entries">
-<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h2 id="v-0-3-8"><span class="release-version">0.3.8</span><span class="release-date"> — 2026-04-21</span></h2>
 <h3>Fixed</h3>
 <ul>
 <li>Stopped overriding OpenCode&#39;s own model selection with a hardcoded <code>anthropic/claude-sonnet-4-20250514</code> string, which broke users authed with OpenAI / Google / other providers (<code>ProviderModelNotFoundError</code> → 502 in chat + AI import). OpenCode now picks its default model from whichever provider the user authed with via <code>opencode providers login</code> or env vars. (<a href="https://github.com/mattslight/oyster/issues/174" rel="noopener noreferrer">#174</a>)</li>
+<li>Claude Code MCP install command now uses <code>--scope user</code> so the Oyster MCP follows the user across every project instead of being pinned to the directory they happened to run <code>claude mcp add</code> from. Updated in README, landing page, <code>oyster.to/mcp</code>, the in-app &quot;Connect your AI&quot; builtin, and the CLI startup banner. (<a href="https://github.com/mattslight/oyster/issues/175" rel="noopener noreferrer">#175</a>)</li>
 </ul>
 <h2 id="v-0-3-7"><span class="release-version">0.3.7</span><span class="release-date"> — 2026-04-20</span></h2>
 <h3>Added</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -603,7 +603,7 @@
         <div style="padding: 16px;">
           <div id="mcp-claude-code" class="mcp-panel" style="display: block;">
             <div style="font-size: 10px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace; margin-bottom: 6px;">terminal</div>
-            <pre style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #e0e0e8; white-space: pre-wrap; margin: 0;">claude mcp add --transport http oyster http://localhost:4444/mcp/</pre>
+            <pre style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #e0e0e8; white-space: pre-wrap; margin: 0;">claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/</pre>
           </div>
           <div id="mcp-cursor" class="mcp-panel" style="display: none;">
             <div style="font-size: 10px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace; margin-bottom: 6px;">.cursor/mcp.json</div>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -366,7 +366,7 @@
 
       <div id="panel-claude" class="panel active">
         <div class="panel-label">run in your terminal</div>
-        <pre>claude mcp add --transport http oyster http://localhost:4444/mcp/</pre>
+        <pre>claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/</pre>
       </div>
 
       <div id="panel-cursor" class="panel">


### PR DESCRIPTION
Closes #175.

## Problem

Our published install command was:

\`\`\`
claude mcp add --transport http oyster http://localhost:4444/mcp/
\`\`\`

Claude Code's default scope is \`local\`, which binds the MCP to the cwd the user ran the command from. Two separate users independently hit the symptom:

- **Bharat** (Ubuntu, 2026-04-20): MCP only worked from one folder
- **Merlin** (Windows, 2026-04-21): \"MCP setup worked but we did mcp add and it did it for one folder then when we changed to E:\Development the MCP wasn't there\"

Oyster is a user-wide utility. The right default is \`--scope user\` — MCP follows the user across every project.

(Verified against Claude Code 2.1.114: scopes are \`local\`, \`user\`, \`project\`. There is no \`global\` scope, despite what agents sometimes hallucinate.)

## Changes

Added \`--scope user\` to the install command in:

- \`README.md\`
- \`docs/mcp.html\` (oyster.to/mcp)
- \`docs/index.html\` (oyster.to landing)
- \`builtins/connect-your-ai/src/index.html\` (in-app onboarding)
- \`bin/oyster.mjs\` (CLI startup banner)

Also promotes CHANGELOG \`[Unreleased]\` → \`[0.3.8] - 2026-04-21\` bundling the #174 fix (already on main from PR #180) and the #175 fix (this PR), plus a fresh empty \`[Unreleased]\`. Regenerates \`docs/changelog.html\`.

## Test plan

- [x] \`npm run build:server\` clean
- [x] \`npm run build:changelog\` runs cleanly
- [ ] Fresh Mac test: \`claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/\` from one dir, verify MCP tools available from a different dir
- [ ] Once merged, cut 0.3.8 stable via \`npm run release\`

## After merge

This PR is the release-prep for 0.3.8. Merge → \`npm run release\` on main promotes 0.3.8-beta.0 → 0.3.8 and publishes with the \`latest\` dist-tag.