### PR TITLE
fix(chat): surface silent AI errors via banner (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Oyster are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Silent AI failures now surface.** When your AI provider rejects a message (expired key, rate limit, provider outage) Oyster shows a banner with the reason and, for auth failures, the exact command to reconnect — instead of the chat bar staying mute. ([#201](https://github.com/mattslight/oyster/issues/201))
+
 ## [0.4.0-beta.0] - 2026-04-23
 
 ### Added
@@ -303,7 +309,8 @@ Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via M
 - Surface with Aurora WebGL animated background.
 - Typed artifact icons, chat bar, window system with viewer.
 
-[Unreleased]: https://github.com/mattslight/oyster/compare/v0.3.5...HEAD
+[Unreleased]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.0...HEAD
+[0.4.0-beta.0]: https://github.com/mattslight/oyster/compare/v0.3.8...v0.4.0-beta.0
 [0.3.5]: https://github.com/mattslight/oyster/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/mattslight/oyster/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/mattslight/oyster/compare/v0.3.2...v0.3.3

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-4-0-beta-0">0.4</a>
       <a class="version-pill" href="#v-0-3-8">0.3</a>
       <a class="version-pill" href="#v-0-2-4">0.2</a>
@@ -320,7 +321,12 @@
   </nav>
 
   <main class="entries">
-<h2 id="v-0-4-0-beta-0"><span class="release-version">0.4.0-beta.0</span><span class="release-date"> — 2026-04-23</span></h2>
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Silent AI failures now surface.</strong> When your AI provider rejects a message (expired key, rate limit, provider outage) Oyster shows a banner with the reason and, for auth failures, the exact command to reconnect — instead of the chat bar staying mute. (<a href="https://github.com/mattslight/oyster/issues/201" rel="noopener noreferrer">#201</a>)</li>
+</ul>
+<h2 id="v-0-4-0-beta-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.8...v0.4.0-beta.0" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.0</span></a><span class="release-date"> — 2026-04-23</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Onboarding pill.</strong> A persistent setup companion in the top-right of a fresh Oyster walks you through three steps: connect your AI agent, ask it to set things up, and optionally import memories from another AI. Progress tracks automatically as you go. (<a href="https://github.com/mattslight/oyster/issues/184" rel="noopener noreferrer">#184</a>)</li>

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -79,6 +79,13 @@ body {
 
 .ai-error-banner {
   max-width: min(680px, calc(100vw - 32px));
+  flex-wrap: wrap;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.ai-error-banner > span {
+  min-width: 0;
 }
 
 .connection-hint code {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -77,6 +77,10 @@ body {
   color: rgba(255, 255, 255, 0.4);
 }
 
+.ai-error-banner {
+  max-width: min(680px, calc(100vw - 32px));
+}
+
 .connection-hint code {
   background: rgba(255, 255, 255, 0.08);
   padding: 2px 6px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,6 +96,7 @@ export default function App() {
   }, [artifacts, openGroup, activeSpace]);
   const [viewerHash, setViewerHash] = useState<string>(() => getUrlState().hash);
   const [connected, setConnected] = useState(true);
+  const [aiError, setAiError] = useState<string | null>(null);
 
   // Active-space-aware artifact loader. Mirrors current activeSpace via a ref
   // so callers don't have to thread it through every closure (polling,
@@ -336,6 +337,11 @@ export default function App() {
           <span className="connection-hint">Run <code>oyster</code> to start</span>
         </div>
       )}
+      {connected && aiError && (
+        <div className="connection-banner ai-error-banner">
+          <span>{aiError}</span>
+        </div>
+      )}
       <Desktop
         space={activeSpace}
         spaces={spaces.map(s => s.id)}
@@ -493,6 +499,7 @@ export default function App() {
         artifacts={artifacts}
         onArtifactOpen={handleArtifactClick}
         isFirstRun={isFirstRun}
+        onAiError={setAiError}
       />
 
       {spotlightOpen && (

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -243,6 +243,11 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   useEffect(() => { setSlashIndex(0); }, [slashItems.length]);
   const { resetTracking } = useChatEvents({ sessionId, setMessages, setStreaming, setStatusText, setAiError: onAiError });
 
+  // Clear any stale AI error when switching sessions — banner shouldn't leak across conversations.
+  useEffect(() => {
+    onAiError?.(null);
+  }, [sessionId, onAiError]);
+
   useEffect(() => {
     if (expanded) {
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -4,7 +4,7 @@ import { motion, LayoutGroup } from "framer-motion";
 import { spaceColor } from "../utils/spaceColor";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
-import { sendMessage, replyToQuestion } from "../data/chat-api";
+import { sendMessage, replyToQuestion, formatChatError, ChatSendError } from "../data/chat-api";
 import { useChatSession } from "../hooks/useChatSession";
 import { useChatEvents } from "../hooks/useChatEvents";
 import type { ToolPart } from "../hooks/useChatSession";
@@ -98,6 +98,7 @@ interface Props {
   artifacts?: Artifact[];
   onArtifactOpen?: (artifact: Artifact) => void;
   isFirstRun?: boolean;
+  onAiError?: (message: string | null) => void;
 }
 
 const SPACE_PALETTE = [
@@ -105,7 +106,7 @@ const SPACE_PALETTE = [
   "#8f5a9e", "#3a8a7a", "#9e7c2a", "#8f4a5a",
 ];
 
-export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activeSpace, onSpaceChange, onSpaceUpdate, onSpaceDelete, inputRef: externalInputRef, artifacts = [], onArtifactOpen, isFirstRun }: Props) {
+export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activeSpace, onSpaceChange, onSpaceUpdate, onSpaceDelete, inputRef: externalInputRef, artifacts = [], onArtifactOpen, isFirstRun, onAiError }: Props) {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [statusText, setStatusText] = useState("");
@@ -240,7 +241,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   // Reset index when items change
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setSlashIndex(0); }, [slashItems.length]);
-  const { resetTracking } = useChatEvents({ sessionId, setMessages, setStreaming, setStatusText });
+  const { resetTracking } = useChatEvents({ sessionId, setMessages, setStreaming, setStatusText, setAiError: onAiError });
 
   useEffect(() => {
     if (expanded) {
@@ -348,6 +349,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
     setStreaming(true);
     setExpanded(true);
     setStatusText("thinking...");
+    onAiError?.(null);
 
     // Push session URL on first message so refresh reloads this conversation
     pushSessionUrl();
@@ -361,8 +363,12 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
       console.error("Failed to send message:", err);
       setStreaming(false);
       setStatusText("");
+      const msg = err instanceof ChatSendError
+        ? formatChatError("http", err.status, err.body)
+        : "Can't reach Oyster — check that the server is running";
+      onAiError?.(msg);
     }
-  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts]);
+  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError]);
 
   function handleCopyChat() {
     const text = messages

--- a/web/src/data/chat-api.ts
+++ b/web/src/data/chat-api.ts
@@ -47,6 +47,47 @@ export async function getOrCreateSession(): Promise<string> {
   return session.id;
 }
 
+// Shape emitted on the OpenCode SSE stream when a provider call fails.
+export interface OpenCodeError {
+  data?: { message?: string; statusCode?: number };
+}
+
+// Build user-facing banner text for any chat failure. Three buckets:
+// auth → actionable reconnect hint; transient → retry hint; else → raw.
+export function formatChatError(
+  source: "http" | "stream",
+  status: number | undefined,
+  body: string | undefined,
+): string {
+  if (source === "http" && status === 502) {
+    try {
+      const parsed = JSON.parse(body || "{}");
+      if (parsed?.error === "opencode serve unavailable") {
+        return "Can't reach the AI engine — restart Oyster to recover";
+      }
+    } catch { /* fall through */ }
+    return "AI engine unavailable — check that Oyster is running";
+  }
+  if (status === 401) return "AI provider auth failed — run: opencode providers login";
+  if (status === 429 || (typeof status === "number" && status >= 500)) {
+    return "AI provider unavailable — try again in a moment";
+  }
+  if (source === "http") {
+    return `Couldn't send message${status ? ` (HTTP ${status})` : ""}`;
+  }
+  return body?.trim() || "AI request failed";
+}
+
+export class ChatSendError extends Error {
+  status: number;
+  body: string;
+  constructor(status: number, body: string) {
+    super(`sendMessage failed: ${status}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
 export async function sendMessage(
   sessionId: string,
   text: string
@@ -61,7 +102,11 @@ export async function sendMessage(
       agent: "oyster",
     }),
   });
-  if (!res.ok) throw new Error(`sendMessage failed: ${res.status}`);
+  if (!res.ok) {
+    let body = "";
+    try { body = await res.text(); } catch { /* ignore */ }
+    throw new ChatSendError(res.status, body);
+  }
 }
 
 export function subscribeToEvents(

--- a/web/src/hooks/useChatEvents.ts
+++ b/web/src/hooks/useChatEvents.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { subscribeToEvents, type ChatEvent } from "../data/chat-api";
+import { subscribeToEvents, formatChatError, type ChatEvent, type OpenCodeError } from "../data/chat-api";
 import type { Message, MessagePart, ToolPart, QuestionOption } from "./useChatSession";
 import { TOOL_LABELS, extractToolHint } from "./tool-labels";
 
@@ -8,6 +8,7 @@ interface UseChatEventsOptions {
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   setStreaming: (streaming: boolean) => void;
   setStatusText: (text: string) => void;
+  setAiError?: (message: string | null) => void;
 }
 
 export function useChatEvents({
@@ -15,6 +16,7 @@ export function useChatEvents({
   setMessages,
   setStreaming,
   setStatusText,
+  setAiError,
 }: UseChatEventsOptions) {
   // Track current assistant message being streamed
   const currentAssistantMsg = useRef<string | null>(null);
@@ -80,7 +82,17 @@ export function useChatEvents({
         }
 
         case "message.updated": {
-          const info = props.info as { id: string; role: string; sessionID: string };
+          const info = props.info as {
+            id: string;
+            role: string;
+            sessionID: string;
+            error?: OpenCodeError;
+          };
+          if (info.error) {
+            setAiError?.(formatChatError("stream", info.error.data?.statusCode, info.error.data?.message));
+            setStreaming(false);
+            setStatusText("");
+          }
           if (info.role === "assistant") {
             currentAssistantMsg.current = info.id;
             setMessages((prev) => {
@@ -111,6 +123,7 @@ export function useChatEvents({
           }
 
           if (field === "text") {
+            setAiError?.(null);
             if (!textPartsMap.current.has(messageId)) {
               textPartsMap.current.set(messageId, new Map());
             }
@@ -210,6 +223,20 @@ export function useChatEvents({
           break;
         }
 
+        case "session.error": {
+          const err = props.error as OpenCodeError | undefined;
+          setAiError?.(formatChatError("stream", err?.data?.statusCode, err?.data?.message));
+          setStreaming(false);
+          setStatusText("");
+          break;
+        }
+
+        case "session.idle": {
+          setStreaming(false);
+          setStatusText("");
+          break;
+        }
+
         case "question.asked": {
           const q = props as {
             id: string;
@@ -237,7 +264,7 @@ export function useChatEvents({
     });
 
     return unsubscribe;
-  }, [sessionId, setMessages, setStreaming, setStatusText]);
+  }, [sessionId, setMessages, setStreaming, setStatusText, setAiError]);
 
   function resetTracking() {
     currentAssistantMsg.current = null;


### PR DESCRIPTION
## Summary

- When OpenCode fails to produce a response (expired key, rate limit, provider outage), the chat bar no longer stays mute — a red banner appears at the top with the reason and, for auth failures, the exact command to reconnect.
- Banner is driven by three signal paths:
  - `session.error` SSE event → formatted with bucketed guidance (401 → actionable reconnect hint, 429/5xx → retry hint, else → raw message)
  - `message.updated` with `info.error` → same formatter (secondary signal)
  - `sendMessage` HTTP error → bucketed banner (502 engine-unreachable, 401 auth, 429/5xx transient, else raw)
- Banner clears optimistically on new send, and when the first text delta streams in.

## Scope left for follow-up

OpenCode errors that only surface on **stderr** (e.g. `ProviderModelNotFoundError` when provider auth is empty) still bypass the SSE stream entirely. That path needs stderr pattern-watching in `opencode-manager.ts` and a way to inject synthetic events. Filed separately.

## Test plan

- [x] Break auth: swap `~/.local/share/opencode/auth.json` anthropic key for `sk-ant-BOGUS`, restart `npm run dev`
- [x] Send a message → red banner: *"AI provider auth failed — run: opencode providers login"*
- [x] Restore auth, send again → banner clears as first text delta streams in
- [x] Confirmed `session.error` payload shape via `curl -N http://localhost:3333/api/chat/events`

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)