### PR TITLE
fix(opencode): reap orphan engines + isolate process group (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 ### Fixed
 
 - **Silent AI failures now surface.** When your AI provider rejects a message (expired key, rate limit, provider outage) Oyster shows a banner with the reason and, for auth failures, the exact command to reconnect — instead of the chat bar staying mute. ([#201](https://github.com/mattslight/oyster/issues/201))
+- **AI engine no longer piles up after crashes or force-quits.** Previous Oyster sessions that died without a clean shutdown used to leave their AI engine subprocess running forever, and across days of use these could stack up and fill your swap. Oyster now reaps any orphaned engines on startup, and uses OS-level process groups so a graceful shutdown kills the whole engine tree in one go. ([#191](https://github.com/mattslight/oyster/issues/191))
 
 ## [0.4.0-beta.0] - 2026-04-23
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -325,6 +325,7 @@
 <h3>Fixed</h3>
 <ul>
 <li><strong>Silent AI failures now surface.</strong> When your AI provider rejects a message (expired key, rate limit, provider outage) Oyster shows a banner with the reason and, for auth failures, the exact command to reconnect — instead of the chat bar staying mute. (<a href="https://github.com/mattslight/oyster/issues/201" rel="noopener noreferrer">#201</a>)</li>
+<li><strong>AI engine no longer piles up after crashes or force-quits.</strong> Previous Oyster sessions that died without a clean shutdown used to leave their AI engine subprocess running forever, and across days of use these could stack up and fill your swap. Oyster now reaps any orphaned engines on startup, and uses OS-level process groups so a graceful shutdown kills the whole engine tree in one go. (<a href="https://github.com/mattslight/oyster/issues/191" rel="noopener noreferrer">#191</a>)</li>
 </ul>
 <h2 id="v-0-4-0-beta-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.3.8...v0.4.0-beta.0" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.0</span></a><span class="release-date"> — 2026-04-23</span></h2>
 <h3>Added</h3>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -234,11 +234,16 @@ process.on("uncaughtException", (err) => {
   console.error(`[oyster] uncaught exception: ${err.message}`);
   markShuttingDown();
   try { killOpenCode(); } catch { /* best effort */ }
+  // Fail fast — the server is in an unknown state with opencode-ai dead and
+  // restart disabled. Exiting non-zero lets the user restart cleanly rather
+  // than leaving a zombie that silently drops every chat message.
+  process.exit(1);
 });
 process.on("unhandledRejection", (err) => {
   console.error(`[oyster] unhandled rejection: ${err instanceof Error ? err.message : err}`);
   markShuttingDown();
   try { killOpenCode(); } catch { /* best effort */ }
+  process.exit(1);
 });
 
 // ── UI push events (SSE) ──
@@ -1081,14 +1086,22 @@ httpServer.listen(port, () => {
   console.log(`  WebSocket: ws://localhost:${port}`);
   console.log(`  API:       http://localhost:${port}/api/artifacts`);
 
-  // Reap any orphaned opencode-ai processes from a prior Oyster run that
-  // didn't shut down cleanly (SIGKILL, crash, laptop sleep). See #191.
-  const sweep = sweepOrphanOpenCodeProcesses();
-  if (sweep.killed.length > 0) {
-    console.log(`[opencode-sweep] reaped ${sweep.killed.length} orphan opencode-ai process(es): ${sweep.killed.join(", ")}`);
-  }
-  for (const msg of sweep.errors) console.warn(`[opencode-sweep] ${msg}`);
-
   // Spawn OpenCode AFTER server is listening so MCP connection succeeds
   spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);
+
+  // Reap any orphaned opencode-ai processes from a prior Oyster run that
+  // didn't shut down cleanly (SIGKILL, crash, laptop sleep). See #191.
+  // Deferred to the next tick so a slow ps/PowerShell enumeration cannot
+  // block the listen callback and delay the first request.
+  setImmediate(() => {
+    try {
+      const sweep = sweepOrphanOpenCodeProcesses(OPENCODE_BIN);
+      if (sweep.killed.length > 0) {
+        console.log(`[opencode-sweep] reaped ${sweep.killed.length} orphan opencode-ai process(es): ${sweep.killed.join(", ")}`);
+      }
+      for (const msg of sweep.errors) console.warn(`[opencode-sweep] ${msg}`);
+    } catch (err) {
+      console.warn(`[opencode-sweep] failed: ${err instanceof Error ? err.message : err}`);
+    }
+  });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -49,6 +49,7 @@ import {
   proxyToOpenCode,
   proxySSE,
 } from "./opencode-manager.js";
+import { sweepOrphanOpenCodeProcesses } from "./opencode-orphan-sweep.js";
 import { spawnSession, attachWebSocket } from "./pty-manager.js";
 import { createMcpServer } from "./mcp-server.js";
 import {
@@ -231,9 +232,13 @@ process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); me
 process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); process.exit(0); });
 process.on("uncaughtException", (err) => {
   console.error(`[oyster] uncaught exception: ${err.message}`);
+  markShuttingDown();
+  try { killOpenCode(); } catch { /* best effort */ }
 });
 process.on("unhandledRejection", (err) => {
   console.error(`[oyster] unhandled rejection: ${err instanceof Error ? err.message : err}`);
+  markShuttingDown();
+  try { killOpenCode(); } catch { /* best effort */ }
 });
 
 // ── UI push events (SSE) ──
@@ -1075,6 +1080,14 @@ httpServer.listen(port, () => {
   console.log(`Oyster server listening on http://localhost:${port}`);
   console.log(`  WebSocket: ws://localhost:${port}`);
   console.log(`  API:       http://localhost:${port}/api/artifacts`);
+
+  // Reap any orphaned opencode-ai processes from a prior Oyster run that
+  // didn't shut down cleanly (SIGKILL, crash, laptop sleep). See #191.
+  const sweep = sweepOrphanOpenCodeProcesses();
+  if (sweep.killed.length > 0) {
+    console.log(`[opencode-sweep] reaped ${sweep.killed.length} orphan opencode-ai process(es): ${sweep.killed.join(", ")}`);
+  }
+  for (const msg of sweep.errors) console.warn(`[opencode-sweep] ${msg}`);
 
   // Spawn OpenCode AFTER server is listening so MCP connection succeeds
   spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -14,12 +14,19 @@ export function getOpenCodePort(): number {
 
 export function killOpenCode() {
   if (opencodeChild) {
-    if (process.platform === "win32" && opencodeChild.pid) {
-      try { execSync(`taskkill /PID ${opencodeChild.pid} /T /F`, { stdio: "ignore" }); } catch (err) {
+    const pid = opencodeChild.pid;
+    if (process.platform === "win32" && pid) {
+      try { execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" }); } catch (err) {
         console.warn(`[opencode-serve] taskkill failed: ${err instanceof Error ? err.message : err}`);
       }
-    } else {
-      opencodeChild.kill("SIGTERM");
+    } else if (pid) {
+      // Child is its own process-group leader (detached: true on spawn), so
+      // signalling -pid cascades to any workers opencode-ai itself spawned.
+      try {
+        process.kill(-pid, "SIGTERM");
+      } catch {
+        try { opencodeChild.kill("SIGTERM"); } catch { /* already gone */ }
+      }
     }
     opencodeChild = null;
   }
@@ -39,6 +46,10 @@ export function spawnOpenCodeServe(
     env: cleanEnv,
     stdio: ["ignore", "pipe", "pipe"],
     shell: process.platform === "win32",
+    // Give the child its own process group on Unix so killOpenCode can
+    // cascade SIGTERM to any workers it spawned. Windows uses taskkill /T
+    // which walks the tree directly and has no equivalent concept.
+    detached: process.platform !== "win32",
   });
   opencodeChild = child;
 

--- a/server/src/opencode-orphan-sweep.ts
+++ b/server/src/opencode-orphan-sweep.ts
@@ -2,26 +2,37 @@
 // Oyster run that died without reaping (SIGKILL, crash, OOM, laptop sleep).
 // See #191 — without this, orphans accumulate across sessions and fill swap.
 //
-// Filter is deliberately tight: only processes whose kernel-visible parent
-// is gone AND whose command line identifies them as opencode-ai. A live
-// Oyster always has its opencode child parented to the server PID, so the
-// parent-dead check alone is safe; the name match is belt-and-braces.
+// Filter layers: (1) kernel-visible parent is gone (ppid==1 on Unix, parent
+// PID not in live set on Windows); (2) command line matches an Oyster-owned
+// opencode-ai path (either a substring of OPENCODE_BIN, or the generic
+// "node_modules/opencode-ai" fingerprint of any npm-installed copy). This
+// avoids killing a user's own manually-run opencode-ai installed elsewhere.
 
 import { execSync } from "node:child_process";
 
-const PROCESS_NAME_PATTERN = /opencode-ai/;
+const ENUMERATION_TIMEOUT_MS = 5000;
+const NPM_OPENCODE_FINGERPRINT = "node_modules/opencode-ai";
+const NPM_OPENCODE_FINGERPRINT_WIN = "node_modules\\\\opencode-ai";
 
-export function sweepOrphanOpenCodeProcesses(): { killed: number[]; errors: string[] } {
-  if (process.platform === "win32") return sweepWindows();
-  return sweepUnix();
+export function sweepOrphanOpenCodeProcesses(opencodeBin?: string): { killed: number[]; errors: string[] } {
+  if (process.platform === "win32") return sweepWindows(opencodeBin);
+  return sweepUnix(opencodeBin);
 }
 
-function sweepUnix(): { killed: number[]; errors: string[] } {
+function matchesOysterOpencode(command: string, opencodeBin: string | undefined, fingerprint: string): boolean {
+  if (opencodeBin && command.includes(opencodeBin)) return true;
+  return command.includes(fingerprint);
+}
+
+function sweepUnix(opencodeBin: string | undefined): { killed: number[]; errors: string[] } {
   const killed: number[] = [];
   const errors: string[] = [];
   let output = "";
   try {
-    output = execSync("ps -Ao pid=,ppid=,command=", { encoding: "utf8" });
+    output = execSync("ps -Ao pid=,ppid=,command=", {
+      encoding: "utf8",
+      timeout: ENUMERATION_TIMEOUT_MS,
+    });
   } catch (err) {
     errors.push(`ps failed: ${err instanceof Error ? err.message : err}`);
     return { killed, errors };
@@ -36,7 +47,7 @@ function sweepUnix(): { killed: number[]; errors: string[] } {
     const ppid = parseInt(match[2], 10);
     const command = match[3];
     if (ppid !== 1) continue;
-    if (!PROCESS_NAME_PATTERN.test(command)) continue;
+    if (!matchesOysterOpencode(command, opencodeBin, NPM_OPENCODE_FINGERPRINT)) continue;
     try {
       process.kill(pid, "SIGTERM");
       killed.push(pid);
@@ -47,20 +58,23 @@ function sweepUnix(): { killed: number[]; errors: string[] } {
   return { killed, errors };
 }
 
-function sweepWindows(): { killed: number[]; errors: string[] } {
+function sweepWindows(opencodeBin: string | undefined): { killed: number[]; errors: string[] } {
   const killed: number[] = [];
   const errors: string[] = [];
-  // One PowerShell call: enumerate opencode-ai.exe processes, filter those
-  // whose ParentProcessId is not in the current live PID set, emit just the
-  // orphan PIDs on stdout.
+  // Match on CommandLine rather than Name: on Windows opencode-ai is usually
+  // launched as node.exe with the script path in CommandLine, not an
+  // opencode-ai.exe image. The PS query below returns ProcessId and
+  // CommandLine for every process whose CommandLine mentions opencode-ai;
+  // we filter down to orphans + Oyster-owned paths on the JS side.
   const script = `
-    $procs = Get-CimInstance Win32_Process -Filter "Name='opencode-ai.exe'"
+    $procs = Get-CimInstance Win32_Process |
+      Where-Object { $_.CommandLine -and $_.CommandLine -match 'opencode-ai' }
     if (-not $procs) { return }
     $alive = @{}
     Get-Process | ForEach-Object { $alive[$_.Id] = $true }
     foreach ($p in $procs) {
       if (-not $alive.ContainsKey([int]$p.ParentProcessId)) {
-        Write-Output $p.ProcessId
+        Write-Output ("{0}|{1}" -f $p.ProcessId, $p.CommandLine)
       }
     }
   `.trim();
@@ -68,6 +82,7 @@ function sweepWindows(): { killed: number[]; errors: string[] } {
   try {
     output = execSync(`powershell -NoProfile -Command "${script.replace(/"/g, '\\"')}"`, {
       encoding: "utf8",
+      timeout: ENUMERATION_TIMEOUT_MS,
     });
   } catch (err) {
     errors.push(`powershell enumeration failed: ${err instanceof Error ? err.message : err}`);
@@ -75,10 +90,16 @@ function sweepWindows(): { killed: number[]; errors: string[] } {
   }
 
   for (const line of output.split(/\r?\n/)) {
-    const pid = parseInt(line.trim(), 10);
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const sep = trimmed.indexOf("|");
+    if (sep < 0) continue;
+    const pid = parseInt(trimmed.slice(0, sep), 10);
+    const cmd = trimmed.slice(sep + 1);
     if (!Number.isFinite(pid) || pid <= 0) continue;
+    if (!matchesOysterOpencode(cmd, opencodeBin, NPM_OPENCODE_FINGERPRINT_WIN)) continue;
     try {
-      execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+      execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore", timeout: ENUMERATION_TIMEOUT_MS });
       killed.push(pid);
     } catch (err) {
       errors.push(`taskkill ${pid}: ${err instanceof Error ? err.message : err}`);

--- a/server/src/opencode-orphan-sweep.ts
+++ b/server/src/opencode-orphan-sweep.ts
@@ -1,0 +1,88 @@
+// Startup sweep for stale opencode-ai processes left behind by a previous
+// Oyster run that died without reaping (SIGKILL, crash, OOM, laptop sleep).
+// See #191 — without this, orphans accumulate across sessions and fill swap.
+//
+// Filter is deliberately tight: only processes whose kernel-visible parent
+// is gone AND whose command line identifies them as opencode-ai. A live
+// Oyster always has its opencode child parented to the server PID, so the
+// parent-dead check alone is safe; the name match is belt-and-braces.
+
+import { execSync } from "node:child_process";
+
+const PROCESS_NAME_PATTERN = /opencode-ai/;
+
+export function sweepOrphanOpenCodeProcesses(): { killed: number[]; errors: string[] } {
+  if (process.platform === "win32") return sweepWindows();
+  return sweepUnix();
+}
+
+function sweepUnix(): { killed: number[]; errors: string[] } {
+  const killed: number[] = [];
+  const errors: string[] = [];
+  let output = "";
+  try {
+    output = execSync("ps -Ao pid=,ppid=,command=", { encoding: "utf8" });
+  } catch (err) {
+    errors.push(`ps failed: ${err instanceof Error ? err.message : err}`);
+    return { killed, errors };
+  }
+
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.*)$/);
+    if (!match) continue;
+    const pid = parseInt(match[1], 10);
+    const ppid = parseInt(match[2], 10);
+    const command = match[3];
+    if (ppid !== 1) continue;
+    if (!PROCESS_NAME_PATTERN.test(command)) continue;
+    try {
+      process.kill(pid, "SIGTERM");
+      killed.push(pid);
+    } catch (err) {
+      errors.push(`kill ${pid}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+  return { killed, errors };
+}
+
+function sweepWindows(): { killed: number[]; errors: string[] } {
+  const killed: number[] = [];
+  const errors: string[] = [];
+  // One PowerShell call: enumerate opencode-ai.exe processes, filter those
+  // whose ParentProcessId is not in the current live PID set, emit just the
+  // orphan PIDs on stdout.
+  const script = `
+    $procs = Get-CimInstance Win32_Process -Filter "Name='opencode-ai.exe'"
+    if (-not $procs) { return }
+    $alive = @{}
+    Get-Process | ForEach-Object { $alive[$_.Id] = $true }
+    foreach ($p in $procs) {
+      if (-not $alive.ContainsKey([int]$p.ParentProcessId)) {
+        Write-Output $p.ProcessId
+      }
+    }
+  `.trim();
+  let output = "";
+  try {
+    output = execSync(`powershell -NoProfile -Command "${script.replace(/"/g, '\\"')}"`, {
+      encoding: "utf8",
+    });
+  } catch (err) {
+    errors.push(`powershell enumeration failed: ${err instanceof Error ? err.message : err}`);
+    return { killed, errors };
+  }
+
+  for (const line of output.split(/\r?\n/)) {
+    const pid = parseInt(line.trim(), 10);
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    try {
+      execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+      killed.push(pid);
+    } catch (err) {
+      errors.push(`taskkill ${pid}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+  return { killed, errors };
+}


### PR DESCRIPTION
## Summary

- **Startup orphan sweep (all platforms)** — on boot, kill any `opencode-ai` processes whose kernel-visible parent is gone. Unix: `ppid == 1` + command-line match. Windows: PowerShell `Get-CimInstance Win32_Process` + dead-parent check. This is the backstop that catches every non-graceful death (SIGKILL, OOM, crash, laptop sleep).
- **Process-group isolation on Unix** — spawn `opencode-ai` with `detached: true` so it becomes its own group leader, then `process.kill(-pid, SIGTERM)` on graceful shutdown cascades to any workers it spawned. Windows keeps `taskkill /T` (already walks the tree).
- **Crash-path cleanup** — `uncaughtException` and `unhandledRejection` handlers now call `killOpenCode()` before returning, so a server crash doesn't leak.

Closes the #191 accumulation-over-days scenario described by the laptop nuke (100+ orphans, 20 GB swap). Alpha testers on Windows (Merlin, son) are covered by the PowerShell-based sweep.

Not included: Linux `PR_SET_PDEATHSIG` / macOS ppid-polling shim wrapper / Windows Job Objects. These would give zero-lag parent-death detection but require a wrapper process or native bindings. Startup sweep covers the actual pain point — orphans reaped on next boot — and can be revisited if real alpha-user telemetry shows it isn't enough.

## Test plan

- [x] Typecheck + build clean
- [x] Unit test: sweep against synthetic orphan (perl with rewritten argv, kernel-reparented to PID 1) — reaped correctly, killed list returned
- [x] Unit test: sweep against clean system (live opencode-ai children with real parents) — no false positives
- [ ] Manual smoke: run `npm run dev`, send a chat message, `kill -TERM` the server — verify no stragglers via `pgrep -f opencode-ai`
- [ ] Manual smoke: run `npm run dev`, `kill -KILL` the server (SIGKILL, no handler runs), restart — verify sweep logs the reaped orphan
- [ ] Manual smoke: trigger an uncaught exception in the server, verify opencode-ai dies
- [ ] Windows manual smoke (Merlin / son): same three scenarios against `taskkill` paths

Part of #200 launch readiness (section 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)