### PR TITLE
fix(windows): orphan-sweep encoded-command + scrollbar style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows: orphan-opencode sweep no longer errors on startup.** The PowerShell enumeration was being mangled by cmd.exe quoting (the embedded `|` in the output format string got parsed as a shell pipe), producing "empty pipe element" on every boot. Now passed via `-EncodedCommand` so cmd.exe never sees the script body.
+- **Windows: onboarding code snippet uses the thin dark scrollbar** instead of the chunky native Windows one.
+
 ## [0.4.0-beta.2] - 2026-04-24
 
 ### Fixed

--- a/server/src/opencode-orphan-sweep.ts
+++ b/server/src/opencode-orphan-sweep.ts
@@ -66,6 +66,11 @@ function sweepWindows(opencodeBin: string | undefined): { killed: number[]; erro
   // opencode-ai.exe image. The PS query below returns ProcessId and
   // CommandLine for every process whose CommandLine mentions opencode-ai;
   // we filter down to orphans + Oyster-owned paths on the JS side.
+  // Pass the script via -EncodedCommand (base64 UTF-16LE) so cmd.exe never
+  // sees the pipes, braces, or quotes embedded in the PowerShell body —
+  // previously `execSync` with `-Command "..."` was mangled by cmd.exe's
+  // quoting rules (the `|` inside `"{0}|{1}"` got parsed as a shell pipe,
+  // yielding "empty pipe element" errors).
   const script = `
     $procs = Get-CimInstance Win32_Process |
       Where-Object { $_.CommandLine -and $_.CommandLine -match 'opencode-ai' }
@@ -78,9 +83,10 @@ function sweepWindows(opencodeBin: string | undefined): { killed: number[]; erro
       }
     }
   `.trim();
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
   let output = "";
   try {
-    output = execSync(`powershell -NoProfile -Command "${script.replace(/"/g, '\\"')}"`, {
+    output = execSync(`powershell -NoProfile -EncodedCommand ${encoded}`, {
       encoding: "utf8",
       timeout: ENUMERATION_TIMEOUT_MS,
     });

--- a/web/src/components/OnboardingDock.css
+++ b/web/src/components/OnboardingDock.css
@@ -244,15 +244,22 @@
   max-height: 180px;
   overflow-y: auto;
   scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
 }
 
 .onboarding-code-box pre::-webkit-scrollbar {
   height: 4px;
   width: 4px;
 }
+.onboarding-code-box pre::-webkit-scrollbar-track {
+  background: transparent;
+}
 .onboarding-code-box pre::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.12);
   border-radius: 2px;
+}
+.onboarding-code-box pre::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.22);
 }
 
 .onboarding-code-box code {


### PR DESCRIPTION
## Summary

Two Windows fixes surfaced by the clean-machine smoke test on 0.4.0-beta.2:

- **Orphan-opencode sweep broken.** Every boot logged:
  > ``[opencode-sweep] powershell enumeration failed: An empty pipe element is not allowed.``
  The PS script was passed through cmd.exe with ``\"…\"`` quoting. cmd.exe doesn't recognise ``\"`` as an escape, so the ``|`` inside the script's own output-format string (``"{0}|{1}"``) got parsed as a shell pipe, and PowerShell received a broken fragment. Switched to ``-EncodedCommand`` (base64 UTF-16LE) so cmd.exe never sees the script body.
- **Onboarding code snippet had the chunky native Windows scrollbar.** Added ``scrollbar-color`` + track/hover rules to ``.onboarding-code-box pre`` so it matches the thin dark treatment used for ``.chatbar-messages``.

## Test plan

- [ ] Windows: ``npx oyster`` — no ``[opencode-sweep]`` errors in console
- [ ] Windows: open "Set up Oyster" dock, check the "run in your terminal" code box — scrollbar is thin/dark, not the native Win32 bar
- [ ] macOS: no regression (scrollbars look identical, sweep still runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)