### PR TITLE
fix(opencode): inline oyster agent into generated opencode.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Windows: embedded opencode terminal now includes Oyster in the agent tab-cycle.** The `.opencode/agents/oyster.md` definition wasn't being picked up by opencode's TUI on Windows (worked on Mac), so only `build` / `plan` appeared. The agent is now inlined into the generated `opencode.json` as well, which the TUI reads directly.
 - **Windows: orphan-opencode sweep no longer errors on startup.** The PowerShell enumeration was being mangled by cmd.exe quoting (the embedded `|` in the output format string got parsed as a shell pipe), producing "empty pipe element" on every boot. Now passed via `-EncodedCommand` so cmd.exe never sees the script body.
 - **Windows: onboarding code snippet uses the thin dark scrollbar** instead of the chunky native Windows one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Windows: embedded opencode terminal now includes Oyster in the agent tab-cycle.** The `.opencode/agents/oyster.md` definition wasn't being picked up by opencode's TUI on Windows (worked on Mac), so only `build` / `plan` appeared. The agent is now inlined into the generated `opencode.json` as well, which the TUI reads directly.
 - **Windows: orphan-opencode sweep no longer errors on startup.** The PowerShell enumeration was being mangled by cmd.exe quoting (the embedded `|` in the output format string got parsed as a shell pipe), producing "empty pipe element" on every boot. Now passed via `-EncodedCommand` so cmd.exe never sees the script body.
+- **Windows: artifact iframes use the thin dark scrollbar** instead of the chunky native Windows one. Applied globally via the bridge script so every builtin and AI-generated artifact gets it for free.
 - **Windows: onboarding code snippet uses the thin dark scrollbar** instead of the chunky native Windows one.
 
 ## [0.4.0-beta.2] - 2026-04-24

--- a/server/src/error-bridge.ts
+++ b/server/src/error-bridge.ts
@@ -1,7 +1,18 @@
 // server/src/error-bridge.ts
 // Exports the error bridge script and an injection function.
 
-const BRIDGE_SCRIPT = `<script data-oyster-bridge>
+// Thin dark scrollbars so Windows artifact iframes don't show the chunky
+// native Win32 bar. Chromium (all platforms) honours scrollbar-color; the
+// ::-webkit-scrollbar rules keep older WebViews consistent.
+const SCROLLBAR_STYLE = `<style data-oyster-scrollbar>
+* { scrollbar-width: thin; scrollbar-color: rgba(255,255,255,0.15) transparent; }
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
+*::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.25); }
+</style>`;
+
+const BRIDGE_SCRIPT = SCROLLBAR_STYLE + `<script data-oyster-bridge>
 (function() {
   if (window.__oysterBridge) return;
   window.__oysterBridge = true;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1349,6 +1349,32 @@ writeFileSync(join(USERLAND_DIR, ".opencode", "config.toml"), opencodeConfig);
 // Also write opencode.json (OpenCode reads this from cwd)
 const sourceOpencode = JSON.parse(readFileSync(join(PROJECT_ROOT, "opencode.json"), "utf8"));
 sourceOpencode.mcp = { oyster: { type: "remote", url: INTERNAL_MCP_URL } };
+
+// Inline the Oyster agent definition. We also copy the .md file into
+// `.opencode/agents/` (bootstrapUserland), but opencode's filesystem-based
+// agent discovery doesn't fire on Windows — the file is on disk but the
+// agent never shows up in `tab` cycle, and our HTTP proxy's `agent: "oyster"`
+// gets silently downgraded to the default build agent. Baking the agent
+// into opencode.json side-steps discovery entirely and keeps Mac/Linux
+// working too.
+try {
+  const agentSrc = readFileSync(join(PROJECT_ROOT, ".opencode", "agents", "oyster.md"), "utf8");
+  const fm = agentSrc.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (fm) {
+    const [, frontmatter, body] = fm;
+    const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+    sourceOpencode.agent = {
+      ...(sourceOpencode.agent || {}),
+      oyster: {
+        description: descMatch ? descMatch[1].trim() : "Oyster OS agent",
+        prompt: body.trim(),
+      },
+    };
+  }
+} catch (err) {
+  console.warn(`[bootstrap] could not inline oyster agent: ${err instanceof Error ? err.message : err}`);
+}
+
 writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(sourceOpencode, null, 2) + "\n");
 
 const httpServer = createServer(handleHttpRequest);


### PR DESCRIPTION
## Summary

Windows bug surfaced in #214: the embedded opencode TUI doesn't include ``oyster`` in its agent tab-cycle, even though ``.opencode/agents/oyster.md`` ships with the package and is copied into ``%USERPROFILE%\\Oyster\\.opencode\\agents\\``. On Mac the same file works.

Rather than chase opencode's Windows-specific discovery behaviour, inline the agent definition into the generated ``opencode.json``. The TUI reads that file directly, so the agent is guaranteed available.

## Scope

- **Only affects the embedded TUI.** The main Oyster chatbar sends ``agent: "oyster"`` in every HTTP request (``server/src/index.ts:1057``) and was already working on Windows — the user's son's-PC chat correctly self-identifies as Oyster.
- The ``.md`` file is still shipped/copied — no removal of the existing path.
- Bootstrap parses the YAML frontmatter (``description``) and body, then writes ``agent.oyster`` into the generated config alongside the MCP block.

## Test plan

- [ ] Windows: ``npx oyster`` → open embedded terminal → ``tab`` through agents → ``oyster`` now appears alongside ``build`` / ``plan``
- [ ] macOS: no regression (agent list still shows oyster; chat still responds as oyster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)