### PR TITLE
feat(cli): colored box around the startup banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Startup banner is now a coloured box** so the "Open Oyster" URL and starter prompts don't get lost in the server logs or deprecation warnings.
+
 ## [0.4.0-beta.3] - 2026-04-24
 
 ### Changed

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -22,6 +22,47 @@ const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-commun
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = join(__dirname, "..");
+
+// ── Hero banner ──
+// The block printed once the server is listening is the primary thing a
+// user needs to act on. Boxed + coloured so it doesn't get lost in the
+// scrolling server logs above and deprecation warnings below.
+function printHeroBox(url) {
+  // ANSI colour codes — no extra dep. `\x1b[95m` bright magenta (indigo-ish,
+  // Oyster's accent). `\x1b[1;96m` bold bright cyan (link-obvious).
+  const M = "\x1b[95m";
+  const C = "\x1b[1;96m";
+  const R = "\x1b[0m";
+  const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
+  // `.length` on strings with surrogate-pair emojis (👉, 🔗) returns 2, and
+  // those emojis render as 2 terminal cells — so length ≈ display width in
+  // the modern terminals we target.
+  const lines = [
+    ``,
+    ` 👉  Open: ${C}${url}${R}`,
+    ``,
+    ` 🔗  Bring your own AI:`,
+    `    ${C}claude mcp add --scope user --transport http oyster ${url}/mcp/${R}`,
+    ``,
+    ` What you can do:`,
+    ` • "Create a deck about our roadmap" → appears on your surface`,
+    ` • "Scan ~/Dev/my-project" → new space with everything discovered`,
+    ` • "Open the competitor analysis" → opens in viewer`,
+    ``,
+  ];
+  const maxVis = Math.max(...lines.map((l) => stripAnsi(l).length));
+  const innerWidth = maxVis + 4; // 2 cells breathing room on each side
+  const hr = "─".repeat(innerWidth);
+  const out = [];
+  out.push(`\n  ${M}╭${hr}╮${R}`);
+  for (const line of lines) {
+    const plain = stripAnsi(line);
+    const rightPad = innerWidth - 2 - plain.length;
+    out.push(`  ${M}│${R}  ${line}${" ".repeat(rightPad)}${M}│${R}`);
+  }
+  out.push(`  ${M}╰${hr}╯${R}\n`);
+  console.log(out.join("\n"));
+}
 // Detect installed vs dev-from-source by checking if we're under node_modules.
 // Matches the server's own `isInstalledPackage` signal so paths stay in sync.
 const isInstalledPackage = PACKAGE_ROOT.includes(`${sep}node_modules${sep}`);
@@ -417,13 +458,7 @@ async function main() {
       if (match) {
         opened = true;
         const url = match[1];
-        console.log(`\n  👉 Open: ${url} 👈\n`);
-        console.log(`  🔗 Bring your own AI:`);
-        console.log(`     claude mcp add --scope user --transport http oyster ${url}/mcp/\n`);
-        console.log(`  What you can do:`);
-        console.log(`  • "Create a deck about our roadmap" → appears on your surface`);
-        console.log(`  • "Scan ~/Dev/my-project" → new space with everything discovered`);
-        console.log(`  • "Open the competitor analysis" → opens in viewer\n`);
+        printHeroBox(url);
         try {
           const platform = process.platform;
           if (platform === "darwin") execSync(`open ${url}`);


### PR DESCRIPTION
## Summary

The \`oyster\` CLI prints an "Open Oyster" block once the server is listening, but it was just plain ``console.log`` lines that got lost between the server logs scrolling above and the ``DeprecationWarning`` from ``@lydell/node-pty`` appearing below. Wrap the block in a rounded-corner box with bright-magenta borders and bold-cyan URL / install command so it stands out visually.

## Preview

\`\`\`
  ╭──────────────────────────────────────────────────────────────────────────────────────╮
  │                                                                                      │
  │   👉  Open: http://localhost:4444                                                    │
  │                                                                                      │
  │   🔗  Bring your own AI:                                                             │
  │      claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/  │
  │                                                                                      │
  │   What you can do:                                                                   │
  │   • "Create a deck about our roadmap" → appears on your surface                      │
  │   • "Scan ~/Dev/my-project" → new space with everything discovered                   │
  │   • "Open the competitor analysis" → opens in viewer                                 │
  │                                                                                      │
  ╰──────────────────────────────────────────────────────────────────────────────────────╯
\`\`\`

## Scope

- Inline ANSI escapes (``\\x1b[95m``, ``\\x1b[1;96m``, ``\\x1b[0m``) — no new dependency.
- Box width sized to the longest line. Fits in any ≥90-column terminal; will wrap on older 80-column setups.
- Emoji width assumption: modern terminals render 👉 / 🔗 as 2 cells, matching JS ``.length``. Older Windows cmd.exe consoles may show slight misalignment — acceptable trade-off.

## Test plan

- [ ] ``npx oyster`` (or local dev run) — box appears after "Oyster server listening" with correct borders
- [ ] Windows Terminal / PowerShell — box renders (ANSI supported by default in modern Windows 10+)
- [ ] Legacy cmd.exe on Windows — degrades gracefully (colours may not render but box still appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)