### PR TITLE
feat(sources): replace space_paths with typed sources table (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Linked folders are now first-class.** Detaching a folder from a space cleanly removes its tiles (no more orphans), and reattaching the same folder restores them. Sets up cleaner provenance and detach UI later.
+
 ## [0.4.0-beta.4] - 2026-04-25
 
 ### Changed

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -480,6 +480,15 @@ export class ArtifactService {
     return rows.length;
   }
 
+  // Bulk soft-delete every live artifact attached to a source — the detach
+  // cascade fired by space-service.removeSource(). Mirrors archiveGroup:
+  // single SQL UPDATE for the rows, one cache invalidation at the end.
+  removeBySource(sourceId: string): number {
+    const changed = this.store.removeBySourceId(sourceId);
+    if (changed > 0) this.invalidateArchivedPaths();
+    return changed;
+  }
+
   // ── Private ──
 
   private async rowToArtifact(row: ArtifactRow): Promise<Artifact> {

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -16,15 +16,17 @@ export interface ArtifactRow {
   removed_at: string | null;
   source_origin: "manual" | "discovered" | "ai_generated";
   source_ref: string | null;   // e.g. 'web/:app', 'README.md:notes'
+  source_id: string | null;    // FK to sources.id; NULL = not from a linked external source
   created_at: string;
   updated_at: string;
 }
 
 // ── Store interface ──
 
-export type InsertRow = Omit<ArtifactRow, "created_at" | "updated_at" | "removed_at" | "source_origin" | "source_ref"> & {
+export type InsertRow = Omit<ArtifactRow, "created_at" | "updated_at" | "removed_at" | "source_origin" | "source_ref" | "source_id"> & {
   source_origin?: "manual" | "discovered" | "ai_generated";
   source_ref?: string | null;
+  source_id?: string | null;
 };
 
 export interface ArtifactStore {
@@ -38,6 +40,7 @@ export interface ArtifactStore {
   update(id: string, fields: Partial<Omit<ArtifactRow, "id" | "created_at">>): void;
   resurface(id: string): void;
   remove(id: string): void;
+  removeBySourceId(sourceId: string): number;
   delete(id: string): void;
   getAllArchived(): ArtifactRow[];
   getArchivedFilePaths(): Set<string>;
@@ -71,11 +74,11 @@ export class SqliteArtifactStore implements ArtifactStore {
         INSERT INTO artifacts (
           id, owner_id, space_id, label, artifact_kind,
           storage_kind, storage_config, runtime_kind, runtime_config,
-          group_name, source_origin, source_ref
+          group_name, source_origin, source_ref, source_id
         ) VALUES (
           @id, @owner_id, @space_id, @label, @artifact_kind,
           @storage_kind, @storage_config, @runtime_kind, @runtime_config,
-          @group_name, COALESCE(@source_origin, 'manual'), @source_ref
+          @group_name, COALESCE(@source_origin, 'manual'), @source_ref, @source_id
         )
       `),
       delete: db.prepare("DELETE FROM artifacts WHERE id = ?"),
@@ -107,7 +110,7 @@ export class SqliteArtifactStore implements ArtifactStore {
   }
 
   insert(row: InsertRow): void {
-    this.stmts.insert.run(row);
+    this.stmts.insert.run({ source_id: null, ...row });
   }
 
   resurface(id: string): void {
@@ -119,7 +122,7 @@ export class SqliteArtifactStore implements ArtifactStore {
   private static readonly UPDATABLE_COLUMNS = new Set([
     "owner_id", "space_id", "label", "artifact_kind",
     "storage_kind", "storage_config", "runtime_kind", "runtime_config",
-    "group_name", "removed_at", "source_origin", "source_ref",
+    "group_name", "removed_at", "source_origin", "source_ref", "source_id",
   ]);
 
   update(id: string, fields: Partial<Omit<ArtifactRow, "id" | "created_at">>): void {
@@ -140,6 +143,15 @@ export class SqliteArtifactStore implements ArtifactStore {
 
   remove(id: string): void {
     this.db.prepare("UPDATE artifacts SET removed_at = datetime('now') WHERE id = ?").run(id);
+  }
+
+  // Bulk soft-delete every live artifact tied to a given source. Used by the
+  // detach cascade in artifact-service.removeBySource().
+  removeBySourceId(sourceId: string): number {
+    const info = this.db.prepare(
+      "UPDATE artifacts SET removed_at = datetime('now') WHERE source_id = ? AND removed_at IS NULL"
+    ).run(sourceId);
+    return info.changes;
   }
 
   // All rows that have been soft-deleted — newest first, for the Archived view.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -92,49 +92,11 @@ export function initDb(userlandDir: string): Database.Database {
       ON sources(path) WHERE removed_at IS NULL;
   `);
 
-  // ── #208 one-shot upgrade backfills ──
-  // Defensive insurance for the upgrade-from-pre-#208 path. No-op on fresh
-  // installs (empty space_paths) and on already-migrated DBs (matching rows
-  // exist). Both queries are idempotent on every boot.
-  //
-  // DEPRECATION: drop this entire block (and the legacy `space_paths` table
-  // creation/migration above) in 0.5.x once we're confident no one is still
-  // upgrading from 0.4.0-beta.4 or earlier.
-
-  // 1. Copy any `space_paths` rows missing a corresponding active source.
-  db.exec(`
-    INSERT INTO sources (id, space_id, type, path, label, added_at)
-    SELECT lower(hex(randomblob(16))), space_id, 'local_folder', path, label, added_at
-    FROM space_paths
-    WHERE NOT EXISTS (
-      SELECT 1 FROM sources s
-      WHERE s.space_id = space_paths.space_id
-        AND s.path = space_paths.path
-        AND s.removed_at IS NULL
-    )
-  `);
-
-  // 2. Attribute legacy discovered artifacts when the mapping is unambiguous
-  // (space has exactly one active source). Without this, the first detach
-  // after upgrade would skip pre-migration tiles and orphan them — the
-  // original bug we're fixing. Multi-source spaces stay NULL until the next
-  // scan resolves them via upsertCandidate.
-  db.exec(`
-    UPDATE artifacts
-    SET source_id = (
-      SELECT s.id FROM sources s
-      WHERE s.space_id = artifacts.space_id
-        AND s.removed_at IS NULL
-      LIMIT 1
-    )
-    WHERE source_origin = 'discovered'
-      AND source_id IS NULL
-      AND (
-        SELECT COUNT(*) FROM sources s
-        WHERE s.space_id = artifacts.space_id
-          AND s.removed_at IS NULL
-      ) = 1
-  `);
+  // #208 ships as a manual one-shot migration for the maintainer's DB. No
+  // other users currently have pre-#208 data (confirmed). Fresh installs
+  // never populate `space_paths`. So no embedded upgrade backfill is needed —
+  // if a user with old data ever surfaces, we'll do their migration by hand
+  // (commit 4be6760 has the SQL).
 
   // Retire the legacy spaces.repo_path column. Fresh installs never had it
   // (removed from the SCHEMA above); existing installs get data migrated

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -47,11 +47,6 @@ export function initDb(userlandDir: string): Database.Database {
     "ALTER TABLE artifacts ADD COLUMN removed_at TEXT",
     "ALTER TABLE artifacts ADD COLUMN source_origin TEXT NOT NULL DEFAULT 'manual'",
     "ALTER TABLE artifacts ADD COLUMN source_ref TEXT",
-    // #208: link discovered artifacts back to the source that produced them.
-    // SET NULL covers the rare case where a space is hard-deleted (cascade
-    // hard-deletes its sources via sources.space_id) — artifacts left behind
-    // become unattributed orphans rather than dangling FKs.
-    "ALTER TABLE artifacts ADD COLUMN source_id TEXT REFERENCES sources(id) ON DELETE SET NULL",
     "ALTER TABLE spaces ADD COLUMN parent_id TEXT REFERENCES spaces(id)",
     "ALTER TABLE spaces ADD COLUMN summary_title TEXT",
     "ALTER TABLE spaces ADD COLUMN summary_content TEXT",
@@ -91,6 +86,16 @@ export function initDb(userlandDir: string): Database.Database {
     CREATE UNIQUE INDEX IF NOT EXISTS sources_path_active
       ON sources(path) WHERE removed_at IS NULL;
   `);
+
+  // Add the artifacts.source_id FK *after* the sources table exists. SQLite
+  // tolerates forward FK references at ALTER time (the FK only validates at
+  // write time), but explicit ordering is less surprising.
+  // ON DELETE SET NULL covers the rare case where a space is hard-deleted —
+  // cascade hard-deletes its sources via sources.space_id, and artifacts
+  // left behind become unattributed orphans rather than dangling FKs.
+  try {
+    db.exec("ALTER TABLE artifacts ADD COLUMN source_id TEXT REFERENCES sources(id) ON DELETE SET NULL");
+  } catch { /* already exists */ }
 
   // #208 ships as a manual one-shot migration for the maintainer's DB. No
   // other users currently have pre-#208 data (confirmed). Fresh installs

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -37,6 +37,9 @@ export function initDb(userlandDir: string): Database.Database {
   const dbPath = join(userlandDir, "oyster.db");
   const db = new Database(dbPath);
   db.pragma("journal_mode = WAL");
+  // FK enforcement is required for sources.space_id ON DELETE CASCADE and
+  // artifacts.source_id ON DELETE SET NULL to actually fire.
+  db.pragma("foreign_keys = ON");
   db.exec(SCHEMA);
 
   for (const sql of [
@@ -44,6 +47,11 @@ export function initDb(userlandDir: string): Database.Database {
     "ALTER TABLE artifacts ADD COLUMN removed_at TEXT",
     "ALTER TABLE artifacts ADD COLUMN source_origin TEXT NOT NULL DEFAULT 'manual'",
     "ALTER TABLE artifacts ADD COLUMN source_ref TEXT",
+    // #208: link discovered artifacts back to the source that produced them.
+    // SET NULL covers the rare case where a space is hard-deleted (cascade
+    // hard-deletes its sources via sources.space_id) — artifacts left behind
+    // become unattributed orphans rather than dangling FKs.
+    "ALTER TABLE artifacts ADD COLUMN source_id TEXT REFERENCES sources(id) ON DELETE SET NULL",
     "ALTER TABLE spaces ADD COLUMN parent_id TEXT REFERENCES spaces(id)",
     "ALTER TABLE spaces ADD COLUMN summary_title TEXT",
     "ALTER TABLE spaces ADD COLUMN summary_content TEXT",
@@ -51,7 +59,10 @@ export function initDb(userlandDir: string): Database.Database {
     try { db.exec(sql); } catch { /* already exists */ }
   }
 
-  // space_paths — a space can have multiple folders
+  // space_paths — legacy join table. Replaced by `sources` below (#208).
+  // Kept for now so the existing migration block (lines below) can read
+  // legacy spaces.repo_path data into it. Stops being written by the new
+  // code path; can be dropped in a follow-up.
   db.exec(`
     CREATE TABLE IF NOT EXISTS space_paths (
       space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
@@ -59,6 +70,43 @@ export function initDb(userlandDir: string): Database.Database {
       label    TEXT,
       added_at TEXT NOT NULL DEFAULT (datetime('now')),
       PRIMARY KEY (space_id, path)
+    )
+  `);
+
+  // sources — typed rows for external folders (and future cloud sources)
+  // attached to a space. `removed_at` enables soft-delete cascade: detach
+  // soft-deletes the source AND artifacts where source_id = ?, leaving the
+  // FK chain intact and making reattach a simple "restore in place".
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sources (
+      id          TEXT PRIMARY KEY,
+      space_id    TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+      type        TEXT NOT NULL CHECK(type IN ('local_folder')),
+      path        TEXT NOT NULL,
+      label       TEXT,
+      added_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at  TEXT
+    );
+    CREATE INDEX IF NOT EXISTS sources_space_id ON sources(space_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS sources_path_active
+      ON sources(path) WHERE removed_at IS NULL;
+  `);
+
+  // Idempotent backfill: copy any `space_paths` rows that don't yet have a
+  // corresponding active `sources` row. No-op for fresh installs (empty
+  // space_paths) and for already-migrated DBs (matching active source rows
+  // already exist). Without this, an upgraded DB with paths only in
+  // `space_paths` would silently lose all attached folders, since the new
+  // scan code only reads from `sources`.
+  db.exec(`
+    INSERT INTO sources (id, space_id, type, path, label, added_at)
+    SELECT lower(hex(randomblob(16))), space_id, 'local_folder', path, label, added_at
+    FROM space_paths
+    WHERE NOT EXISTS (
+      SELECT 1 FROM sources s
+      WHERE s.space_id = space_paths.space_id
+        AND s.path = space_paths.path
+        AND s.removed_at IS NULL
     )
   `);
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -92,12 +92,16 @@ export function initDb(userlandDir: string): Database.Database {
       ON sources(path) WHERE removed_at IS NULL;
   `);
 
-  // Idempotent backfill: copy any `space_paths` rows that don't yet have a
-  // corresponding active `sources` row. No-op for fresh installs (empty
-  // space_paths) and for already-migrated DBs (matching active source rows
-  // already exist). Without this, an upgraded DB with paths only in
-  // `space_paths` would silently lose all attached folders, since the new
-  // scan code only reads from `sources`.
+  // ── #208 one-shot upgrade backfills ──
+  // Defensive insurance for the upgrade-from-pre-#208 path. No-op on fresh
+  // installs (empty space_paths) and on already-migrated DBs (matching rows
+  // exist). Both queries are idempotent on every boot.
+  //
+  // DEPRECATION: drop this entire block (and the legacy `space_paths` table
+  // creation/migration above) in 0.5.x once we're confident no one is still
+  // upgrading from 0.4.0-beta.4 or earlier.
+
+  // 1. Copy any `space_paths` rows missing a corresponding active source.
   db.exec(`
     INSERT INTO sources (id, space_id, type, path, label, added_at)
     SELECT lower(hex(randomblob(16))), space_id, 'local_folder', path, label, added_at
@@ -108,6 +112,28 @@ export function initDb(userlandDir: string): Database.Database {
         AND s.path = space_paths.path
         AND s.removed_at IS NULL
     )
+  `);
+
+  // 2. Attribute legacy discovered artifacts when the mapping is unambiguous
+  // (space has exactly one active source). Without this, the first detach
+  // after upgrade would skip pre-migration tiles and orphan them — the
+  // original bug we're fixing. Multi-source spaces stay NULL until the next
+  // scan resolves them via upsertCandidate.
+  db.exec(`
+    UPDATE artifacts
+    SET source_id = (
+      SELECT s.id FROM sources s
+      WHERE s.space_id = artifacts.space_id
+        AND s.removed_at IS NULL
+      LIMIT 1
+    )
+    WHERE source_origin = 'discovered'
+      AND source_id IS NULL
+      AND (
+        SELECT COUNT(*) FROM sources s
+        WHERE s.space_id = artifacts.space_id
+          AND s.removed_at IS NULL
+      ) = 1
   `);
 
   // Retire the legacy spaces.repo_path column. Fresh installs never had it

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -304,7 +304,7 @@ function resolveSpaceRow(name: string) {
     spaceStore.getByDisplayName(trimmed)
   );
 }
-const spaceService = new SpaceService(spaceStore, store);
+const spaceService = new SpaceService(spaceStore, store, artifactService);
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);
 await memoryProvider.init();
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -433,18 +433,17 @@ export function createMcpServer(deps: McpDeps): McpServer {
         const pathReports: Array<{ path: string; status: "attached" | "owned-by-other-space" | "failed"; error?: string }> = [];
         for (const p of resolvedPaths) {
           try {
-            deps.spaceService.addPath(space.id, p);
-            // `attached` covers both \"newly added\" and \"already attached to
-            // THIS space\" — spaceStore.addPath is INSERT OR IGNORE so a
-            // duplicate silently no-ops.
+            deps.spaceService.addSource(space.id, p);
+            // `attached` covers newly added sources, restored-from-soft-delete
+            // sources, AND already-active sources for the same space (addSource
+            // is idempotent in those cases).
             pathReports.push({ path: p, status: "attached" });
           } catch (err) {
             const msg = (err as Error).message;
-            // `addPath` only throws for paths that don't exist on disk OR
-            // paths already claimed by a DIFFERENT space (addPath's
-            // conflict guard). The latter means THIS space still has
-            // no folders for that path, so we must not count it as
-            // attached for the scan-guard below.
+            // `addSource` only throws for paths that don't exist on disk OR
+            // paths already claimed by a DIFFERENT space (the conflict guard).
+            // The latter means THIS space still has no folders for that path,
+            // so we must not count it as attached for the scan-guard below.
             const ownedElsewhere = /already attached/i.test(msg);
             pathReports.push({ path: p, status: ownedElsewhere ? "owned-by-other-space" : "failed", error: msg });
           }
@@ -505,6 +504,34 @@ export function createMcpServer(deps: McpDeps): McpServer {
         const result = await deps.spaceService.scanSpace(space_id);
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };
+      }
+    },
+  );
+
+  // ── detach_source ──
+
+  server.tool(
+    "detach_source",
+    "Detach a previously-linked folder from a space. Soft-deletes the link AND any tiles that came from that folder. The folder itself is untouched on disk. Reversible — re-attaching the same path restores the link and resurfaces the tiles.",
+    {
+      space_id: z.string().describe("ID of the space the folder is attached to"),
+      path: z.string().describe("Absolute path of the linked folder to detach (~/ supported)"),
+    },
+    async ({ space_id, path: rawPath }) => {
+      try {
+        const source = deps.spaceService.getActiveSourceByPath(rawPath);
+        if (!source || source.space_id !== space_id) {
+          return {
+            content: [{ type: "text" as const, text: `No folder at "${rawPath}" is currently attached to space "${space_id}".` }],
+            isError: true,
+          };
+        }
+        deps.spaceService.removeSource(source.id);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ detached: source.path, source_id: source.id, space_id: source.space_id }, null, 2) }],
         };
       } catch (err) {
         return { content: [{ type: "text" as const, text: (err as Error).message }], isError: true };

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -8,10 +8,13 @@ import type { ArtifactService } from "./artifact-service.js";
 import type { Space, ScanResult } from "../../shared/types.js";
 import { slugify, toScanStatus } from "./utils.js";
 
-// Last path component, normalised. Same logic used at scan time and (if ever
-// needed again) for slug-based migration backfill — single source of truth.
+// Last non-empty path component, normalised. Same logic used at scan time and
+// (if ever needed again) for slug-based migration backfill — single source of
+// truth. Filters empty segments so root-ish paths like "/" or "C:\\" still
+// produce a non-empty slug.
 export function folderSlug(folderPath: string): string {
-  return resolve(folderPath).split(sep).pop() ?? folderPath;
+  const parts = resolve(folderPath).split(sep).filter(Boolean);
+  return parts.pop() ?? folderPath;
 }
 
 function expandHome(rawPath: string): string {
@@ -161,10 +164,16 @@ export class SpaceService {
     if (this.scanning.has(source.space_id)) {
       throw new Error(`Cannot detach while space "${source.space_id}" is scanning — try again in a moment.`);
     }
-    // Cascade artifacts FIRST, then the source row. If anything throws, the
-    // source stays active and the user can retry.
-    this.artifactService.removeBySource(sourceId);
-    this.spaceStore.softDeleteSource(sourceId);
+    // Atomic cascade: artifact bulk soft-delete + source soft-delete inside a
+    // single transaction. If either fails the SQL rolls back together, so we
+    // never leave a partial state (tiles gone but source still attached, or
+    // vice versa). The cache invalidation in artifactService.removeBySource
+    // is a JS state change, not SQL — it doesn't roll back, but an over-eager
+    // cache invalidation just causes a re-read on next access (harmless).
+    this.spaceStore.transaction(() => {
+      this.artifactService.removeBySource(sourceId);
+      this.spaceStore.softDeleteSource(sourceId);
+    });
   }
 
   getSources(spaceId: string): Source[] {
@@ -252,8 +261,7 @@ export class SpaceService {
           // not eliminate) collisions when a space has multiple paths. Two
           // paths sharing a basename (e.g. ~/a/foo and ~/b/foo) still collide.
           // Truly correct dedup would key on source_id; we keep the slug
-          // prefix only so existing pre-#208 rows still match. See follow-up
-          // in PR #219 description.
+          // prefix only so existing pre-#208 rows still match.
           c.sourceRef = `${slug}/${c.sourceRef}`;
           this.upsertCandidate(spaceId, source.id, c, result);
         }
@@ -359,17 +367,25 @@ export class SpaceService {
 
     if (existing) {
       // Two paths to handle explicitly:
-      //   (a) soft-deleted   → resurface AND set source_id (covers reattach,
-      //                        and back-fills source_id if it was NULL).
-      //   (b) live but NULL  → set source_id only (post-migration backfill on
-      //                        first scan after #208 lands).
-      // Both are idempotent if source_id already matches.
+      //   (a) soft-deleted   → resurface AND (re-)claim source_id. The artifact
+      //                        had previously been linked to *this* source and
+      //                        was soft-deleted by detach; reattach legitimately
+      //                        owns it again. Safe even if multiple sources had
+      //                        share-the-basename collisions, because we filter
+      //                        on (space_id, source_ref) which any colliding
+      //                        source would also match — the most-recent active
+      //                        source wins, matching today's flat ordering.
+      //   (b) live but NULL  → backfill source_id (post-migration legacy row).
+      //   (c) live with non-null source_id → leave source_id alone, even if it
+      //                        differs. Otherwise basename collisions between
+      //                        two attached folders would silently steal each
+      //                        other's tiles, breaking detach later.
       if (existing.removed_at) {
         this.artifactStore.update(existing.id, { removed_at: null, source_id: sourceId });
         result.resurfaced++;
         result.artifacts.push({ id: existing.id, label: existing.label, kind: existing.artifact_kind, sourceRef });
       } else {
-        if (existing.source_id !== sourceId) {
+        if (existing.source_id === null) {
           this.artifactStore.update(existing.id, { source_id: sourceId });
         }
         result.skipped++;

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -106,8 +106,17 @@ export class SpaceService {
     // resurface on the next scan via upsertCandidate.
     const removed = this.spaceStore.getSoftDeletedSourceByPathForSpace(spaceId, resolved);
     if (removed) {
-      this.spaceStore.restoreSource(removed.id);
-      return { ...removed, removed_at: null };
+      try {
+        this.spaceStore.restoreSource(removed.id);
+        return { ...removed, removed_at: null };
+      } catch (err) {
+        // Race: between our check and the restore, another caller inserted a
+        // fresh active source for the same path. Re-evaluate.
+        if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE") {
+          return this.resolveSourceConflict(spaceId, resolved, err);
+        }
+        throw err;
+      }
     }
 
     const id = crypto.randomUUID();
@@ -115,19 +124,26 @@ export class SpaceService {
       this.spaceStore.addSource({ id, space_id: spaceId, type: "local_folder", path: resolved });
     } catch (err) {
       // Race: a concurrent caller inserted the same path between our check and
-      // our insert. Re-evaluate against the now-committed row and surface the
-      // same friendly error as the up-front conflict path.
+      // our insert. Re-evaluate.
       if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE") {
-        const raced = this.spaceStore.getActiveSourceByPath(resolved);
-        if (raced) {
-          if (raced.space_id === spaceId) return raced;
-          const ownerName = this.spaceStore.getById(raced.space_id)?.display_name ?? raced.space_id;
-          throw new Error(`Path is already attached to space "${ownerName}"`);
-        }
+        return this.resolveSourceConflict(spaceId, resolved, err);
       }
       throw err;
     }
     return this.spaceStore.getSourceById(id)!;
+  }
+
+  // Both addSource paths can race against the partial unique index on
+  // sources(path) WHERE removed_at IS NULL. Surface the same friendly error
+  // (or no-op return) as the up-front check would have produced.
+  private resolveSourceConflict(spaceId: string, resolved: string, originalErr: unknown): Source {
+    const raced = this.spaceStore.getActiveSourceByPath(resolved);
+    if (raced) {
+      if (raced.space_id === spaceId) return raced;
+      const ownerName = this.spaceStore.getById(raced.space_id)?.display_name ?? raced.space_id;
+      throw new Error(`Path is already attached to space "${ownerName}"`);
+    }
+    throw originalErr;
   }
 
   // Detach an external folder from a space. Soft-deletes both the source row
@@ -232,8 +248,12 @@ export class SpaceService {
         const slug = folderSlug(folderPath);
         const candidates = this.walk(folderPath);
         for (const c of candidates) {
-          // Namespace sourceRef with folder name to avoid collisions across multiple paths.
-          // (Vestigial since we now have source_id, but kept so existing rows still match.)
+          // Namespace sourceRef with the folder's basename — reduces (but does
+          // not eliminate) collisions when a space has multiple paths. Two
+          // paths sharing a basename (e.g. ~/a/foo and ~/b/foo) still collide.
+          // Truly correct dedup would key on source_id; we keep the slug
+          // prefix only so existing pre-#208 rows still match. See follow-up
+          // in PR #219 description.
           c.sourceRef = `${slug}/${c.sourceRef}`;
           this.upsertCandidate(spaceId, source.id, c, result);
         }

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -2,10 +2,23 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, relative, sep } from "node:path";
 import { homedir } from "node:os";
 import crypto from "node:crypto";
-import type { SpaceStore, SpaceRow } from "./space-store.js";
+import type { SpaceStore, SpaceRow, Source } from "./space-store.js";
 import type { ArtifactStore } from "./artifact-store.js";
+import type { ArtifactService } from "./artifact-service.js";
 import type { Space, ScanResult } from "../../shared/types.js";
 import { slugify, toScanStatus } from "./utils.js";
+
+// Last path component, normalised. Same logic used at scan time and (if ever
+// needed again) for slug-based migration backfill — single source of truth.
+export function folderSlug(folderPath: string): string {
+  return resolve(folderPath).split(sep).pop() ?? folderPath;
+}
+
+function expandHome(rawPath: string): string {
+  return rawPath.startsWith("~/")
+    ? resolve(join(homedir(), rawPath.slice(2)))
+    : resolve(rawPath);
+}
 
 const SPACE_PALETTE = [
   "#6057c4", "#3d8aaa", "#3a8f64", "#b06840",
@@ -49,6 +62,7 @@ export class SpaceService {
   constructor(
     private spaceStore: SpaceStore,
     private artifactStore: ArtifactStore,
+    private artifactService: ArtifactService,
   ) {}
 
   createSpace(params: { name: string }): Space {
@@ -69,33 +83,65 @@ export class SpaceService {
     return rowToSpace(this.spaceStore.getById(id)!);
   }
 
-  addPath(spaceId: string, rawPath: string): string {
+  // Attach an external folder to a space. Returns the resulting Source — newly
+  // inserted, restored from a soft-delete, or already-active no-op.
+  addSource(spaceId: string, rawPath: string): Source {
     const row = this.spaceStore.getById(spaceId);
     if (!row) throw new Error(`Space "${spaceId}" not found`);
 
-    const resolved = rawPath.startsWith("~/")
-      ? resolve(join(homedir(), rawPath.slice(2)))
-      : resolve(rawPath);
-
+    const resolved = expandHome(rawPath);
     if (!existsSync(resolved)) throw new Error(`Path does not exist: ${resolved}`);
     if (!statSync(resolved).isDirectory()) throw new Error(`Path is not a directory: ${resolved}`);
 
-    // Check if this path is already attached to another space
-    const existing = this.spaceStore.getSpaceByPath(resolved);
-    if (existing && existing.id !== spaceId) {
-      throw new Error(`Path is already attached to space "${existing.display_name}"`);
+    // Cross-space conflict / same-space no-op check.
+    const active = this.spaceStore.getActiveSourceByPath(resolved);
+    if (active) {
+      if (active.space_id === spaceId) return active;
+      const ownerName = this.spaceStore.getById(active.space_id)?.display_name ?? active.space_id;
+      throw new Error(`Path is already attached to space "${ownerName}"`);
     }
 
-    this.spaceStore.addPath(spaceId, resolved);
-    return resolved;
+    // Reattach-restore: a soft-deleted source for the same (space, path) wins
+    // over inserting a fresh row. Same id survives — its artifacts will
+    // resurface on the next scan via upsertCandidate.
+    const removed = this.spaceStore.getSoftDeletedSourceByPathForSpace(spaceId, resolved);
+    if (removed) {
+      this.spaceStore.restoreSource(removed.id);
+      return { ...removed, removed_at: null };
+    }
+
+    const id = crypto.randomUUID();
+    this.spaceStore.addSource({ id, space_id: spaceId, type: "local_folder", path: resolved });
+    return this.spaceStore.getSourceById(id)!;
   }
 
-  removePath(spaceId: string, path: string): void {
-    this.spaceStore.removePath(spaceId, path);
+  // Detach an external folder from a space. Soft-deletes both the source row
+  // AND every artifact that came from it. Reversible via addSource(...) on the
+  // same path — restoreSource keeps the same id and upsertCandidate resurfaces
+  // soft-deleted artifacts on the next scan.
+  removeSource(sourceId: string): void {
+    const source = this.spaceStore.getSourceById(sourceId);
+    if (!source) throw new Error(`Source "${sourceId}" not found`);
+    if (source.removed_at) return; // already detached, no-op
+    // Race guard: refuse to detach mid-scan. Otherwise the in-flight scan can
+    // resurface artifacts we just soft-deleted (upsertCandidate's resurface
+    // branch flips removed_at back to NULL). Caller can retry once the scan
+    // completes.
+    if (this.scanning.has(source.space_id)) {
+      throw new Error(`Cannot detach while space "${source.space_id}" is scanning — try again in a moment.`);
+    }
+    // Cascade artifacts FIRST, then the source row. If anything throws, the
+    // source stays active and the user can retry.
+    this.artifactService.removeBySource(sourceId);
+    this.spaceStore.softDeleteSource(sourceId);
   }
 
-  getPaths(spaceId: string): string[] {
-    return this.spaceStore.getPaths(spaceId).map(p => p.path);
+  getSources(spaceId: string): Source[] {
+    return this.spaceStore.getSources(spaceId);
+  }
+
+  getActiveSourceByPath(path: string): Source | undefined {
+    return this.spaceStore.getActiveSourceByPath(expandHome(path));
   }
 
   listSpaces(): Space[] { return this.spaceStore.getAll().map(rowToSpace); }
@@ -152,8 +198,8 @@ export class SpaceService {
     const row = this.spaceStore.getById(spaceId);
     if (!row) throw new Error(`Space "${spaceId}" not found`);
 
-    const paths = this.spaceStore.getPaths(spaceId).map(p => p.path);
-    if (paths.length === 0) throw new Error(`Space "${spaceId}" has no folders`);
+    const sources = this.spaceStore.getSources(spaceId).filter(s => s.type === "local_folder");
+    if (sources.length === 0) throw new Error(`Space "${spaceId}" has no folders`);
 
     if (this.scanning.has(spaceId)) throw new Error(`Scan already in progress for space "${spaceId}"`);
 
@@ -162,17 +208,19 @@ export class SpaceService {
 
     const result: ScanResult = { discovered: 0, skipped: 0, resurfaced: 0, errors: [], artifacts: [] };
     try {
-      for (const folderPath of paths) {
+      for (const source of sources) {
+        const folderPath = source.path;
         if (!existsSync(folderPath) || !statSync(folderPath).isDirectory()) {
           result.errors.push(`Skipped missing folder: ${folderPath}`);
           continue;
         }
-        const folderSlug = folderPath.split(sep).pop() ?? folderPath;
+        const slug = folderSlug(folderPath);
         const candidates = this.walk(folderPath);
         for (const c of candidates) {
-          // Namespace sourceRef with folder name to avoid collisions across multiple paths
-          c.sourceRef = `${folderSlug}/${c.sourceRef}`;
-          this.upsertCandidate(spaceId, c, result);
+          // Namespace sourceRef with folder name to avoid collisions across multiple paths.
+          // (Vestigial since we now have source_id, but kept so existing rows still match.)
+          c.sourceRef = `${slug}/${c.sourceRef}`;
+          this.upsertCandidate(spaceId, source.id, c, result);
         }
       }
       this.spaceStore.update(spaceId, {
@@ -267,6 +315,7 @@ export class SpaceService {
 
   private upsertCandidate(
     spaceId: string,
+    sourceId: string,
     candidate: { absPath: string; sourceRef: string; kind: "app" | "notes" | "diagram" },
     result: ScanResult,
   ): void {
@@ -274,11 +323,20 @@ export class SpaceService {
     const existing = this.artifactStore.getBySpaceAndSourceRef(spaceId, sourceRef);
 
     if (existing) {
+      // Two paths to handle explicitly:
+      //   (a) soft-deleted   → resurface AND set source_id (covers reattach,
+      //                        and back-fills source_id if it was NULL).
+      //   (b) live but NULL  → set source_id only (post-migration backfill on
+      //                        first scan after #208 lands).
+      // Both are idempotent if source_id already matches.
       if (existing.removed_at) {
-        this.artifactStore.resurface(existing.id);
+        this.artifactStore.update(existing.id, { removed_at: null, source_id: sourceId });
         result.resurfaced++;
         result.artifacts.push({ id: existing.id, label: existing.label, kind: existing.artifact_kind, sourceRef });
       } else {
+        if (existing.source_id !== sourceId) {
+          this.artifactStore.update(existing.id, { source_id: sourceId });
+        }
         result.skipped++;
       }
       return;
@@ -327,6 +385,7 @@ export class SpaceService {
       storage_kind: "filesystem", storage_config: JSON.stringify(storageConfig),
       runtime_kind: runtimeKind, runtime_config: JSON.stringify(runtimeConfig),
       group_name, source_origin: "discovered", source_ref: sourceRef,
+      source_id: sourceId,
     });
     result.discovered++;
     result.artifacts.push({ id, label, kind, sourceRef });

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -370,9 +370,9 @@ export class SpaceService {
       //   (a) soft-deleted   → resurface AND (re-)claim source_id. The artifact
       //                        had previously been linked to *this* source and
       //                        was soft-deleted by detach; reattach legitimately
-      //                        owns it again. Safe even if multiple sources had
-      //                        share-the-basename collisions, because we filter
-      //                        on (space_id, source_ref) which any colliding
+      //                        owns it again. Safe even when multiple sources
+      //                        have basename collisions, because we filter on
+      //                        (space_id, source_ref) which any colliding
       //                        source would also match — the most-recent active
       //                        source wins, matching today's flat ordering.
       //   (b) live but NULL  → backfill source_id (post-migration legacy row).

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -111,7 +111,22 @@ export class SpaceService {
     }
 
     const id = crypto.randomUUID();
-    this.spaceStore.addSource({ id, space_id: spaceId, type: "local_folder", path: resolved });
+    try {
+      this.spaceStore.addSource({ id, space_id: spaceId, type: "local_folder", path: resolved });
+    } catch (err) {
+      // Race: a concurrent caller inserted the same path between our check and
+      // our insert. Re-evaluate against the now-committed row and surface the
+      // same friendly error as the up-front conflict path.
+      if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE") {
+        const raced = this.spaceStore.getActiveSourceByPath(resolved);
+        if (raced) {
+          if (raced.space_id === spaceId) return raced;
+          const ownerName = this.spaceStore.getById(raced.space_id)?.display_name ?? raced.space_id;
+          throw new Error(`Path is already attached to space "${ownerName}"`);
+        }
+      }
+      throw err;
+    }
     return this.spaceStore.getSourceById(id)!;
   }
 

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -42,6 +42,10 @@ export interface SpaceStore {
   getSourceById(sourceId: string): Source | undefined;
   getActiveSourceByPath(path: string): Source | undefined;
   getSoftDeletedSourceByPathForSpace(spaceId: string, path: string): Source | undefined;
+  // Run a closure inside a SAVEPOINT-backed transaction. better-sqlite3
+  // rolls back the SQL writes if the closure throws. (JS state mutations
+  // inside the closure don't roll back — that's the caller's problem.)
+  transaction<T>(fn: () => T): T;
 }
 
 export class SqliteSpaceStore implements SpaceStore {
@@ -117,6 +121,10 @@ export class SqliteSpaceStore implements SpaceStore {
   getActiveSourceByPath(path: string): Source | undefined { return this.stmts.getActiveSourceByPath.get(path) as Source | undefined; }
   getSoftDeletedSourceByPathForSpace(spaceId: string, path: string): Source | undefined {
     return this.stmts.getSoftDeletedSourceByPathForSpace.get(spaceId, path) as Source | undefined;
+  }
+
+  transaction<T>(fn: () => T): T {
+    return this.db.transaction(fn)();
   }
 
   private static readonly UPDATABLE_COLUMNS = new Set([

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -124,7 +124,14 @@ export class SqliteSpaceStore implements SpaceStore {
   }
 
   transaction<T>(fn: () => T): T {
-    return this.db.transaction(fn)();
+    const result = this.db.transaction(fn)();
+    // Guard against async fns: better-sqlite3's transaction is synchronous,
+    // so an async closure would resolve AFTER commit — rejections inside the
+    // Promise would never roll back the transaction. Better to fail loudly.
+    if (result instanceof Promise) {
+      throw new Error("spaceStore.transaction(fn): fn must be synchronous (got a Promise)");
+    }
+    return result;
   }
 
   private static readonly UPDATABLE_COLUMNS = new Set([

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -17,11 +17,14 @@ export interface SpaceRow {
   updated_at: string;
 }
 
-export interface SpacePath {
+export interface Source {
+  id: string;
   space_id: string;
+  type: "local_folder";
   path: string;
   label: string | null;
   added_at: string;
+  removed_at: string | null;
 }
 
 export interface SpaceStore {
@@ -31,10 +34,14 @@ export interface SpaceStore {
   insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void;
   update(id: string, fields: Partial<Omit<SpaceRow, "id" | "created_at">>): void;
   delete(id: string): void;
-  getPaths(spaceId: string): SpacePath[];
-  addPath(spaceId: string, path: string, label?: string): void;
-  removePath(spaceId: string, path: string): void;
-  getSpaceByPath(path: string): SpaceRow | undefined;
+  // sources
+  addSource(args: { id: string; space_id: string; type: Source["type"]; path: string; label?: string | null }): void;
+  softDeleteSource(sourceId: string): void;
+  restoreSource(sourceId: string): void;
+  getSources(spaceId: string, opts?: { includeRemoved?: boolean }): Source[];
+  getSourceById(sourceId: string): Source | undefined;
+  getActiveSourceByPath(path: string): Source | undefined;
+  getSoftDeletedSourceByPathForSpace(spaceId: string, path: string): Source | undefined;
 }
 
 export class SqliteSpaceStore implements SpaceStore {
@@ -43,10 +50,14 @@ export class SqliteSpaceStore implements SpaceStore {
     getById: Database.Statement;
     getByDisplayName: Database.Statement;
     insert: Database.Statement;
-    getPaths: Database.Statement;
-    addPath: Database.Statement;
-    removePath: Database.Statement;
-    getSpaceByPath: Database.Statement;
+    addSource: Database.Statement;
+    softDeleteSource: Database.Statement;
+    restoreSource: Database.Statement;
+    getSourcesActive: Database.Statement;
+    getSourcesAll: Database.Statement;
+    getSourceById: Database.Statement;
+    getActiveSourceByPath: Database.Statement;
+    getSoftDeletedSourceByPathForSpace: Database.Statement;
   };
 
   constructor(private db: Database.Database) {
@@ -66,10 +77,19 @@ export class SqliteSpaceStore implements SpaceStore {
           @ai_job_status, @ai_job_error, @summary_title, @summary_content
         )
       `),
-      getPaths: db.prepare("SELECT * FROM space_paths WHERE space_id = ? ORDER BY added_at"),
-      addPath: db.prepare("INSERT OR IGNORE INTO space_paths (space_id, path, label) VALUES (?, ?, ?)"),
-      removePath: db.prepare("DELETE FROM space_paths WHERE space_id = ? AND path = ?"),
-      getSpaceByPath: db.prepare("SELECT s.* FROM spaces s JOIN space_paths sp ON s.id = sp.space_id WHERE sp.path = ?"),
+      addSource: db.prepare(`
+        INSERT INTO sources (id, space_id, type, path, label)
+        VALUES (?, ?, ?, ?, ?)
+      `),
+      softDeleteSource: db.prepare("UPDATE sources SET removed_at = datetime('now') WHERE id = ? AND removed_at IS NULL"),
+      restoreSource: db.prepare("UPDATE sources SET removed_at = NULL WHERE id = ?"),
+      getSourcesActive: db.prepare("SELECT * FROM sources WHERE space_id = ? AND removed_at IS NULL ORDER BY added_at"),
+      getSourcesAll: db.prepare("SELECT * FROM sources WHERE space_id = ? ORDER BY added_at"),
+      getSourceById: db.prepare("SELECT * FROM sources WHERE id = ?"),
+      getActiveSourceByPath: db.prepare("SELECT * FROM sources WHERE path = ? AND removed_at IS NULL"),
+      getSoftDeletedSourceByPathForSpace: db.prepare(
+        "SELECT * FROM sources WHERE space_id = ? AND path = ? AND removed_at IS NOT NULL ORDER BY added_at DESC LIMIT 1"
+      ),
     };
   }
 
@@ -78,13 +98,26 @@ export class SqliteSpaceStore implements SpaceStore {
   getByDisplayName(name: string): SpaceRow | undefined { return this.stmts.getByDisplayName.get(name) as SpaceRow | undefined; }
   insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void { this.stmts.insert.run(row); }
   delete(id: string): void {
+    // Cascade: sources.space_id ON DELETE CASCADE → sources rows hard-deleted,
+    // which fires artifacts.source_id ON DELETE SET NULL on their artifacts.
     this.db.prepare("DELETE FROM space_paths WHERE space_id = ?").run(id);
     this.db.prepare("DELETE FROM spaces WHERE id = ?").run(id);
   }
-  getPaths(spaceId: string): SpacePath[] { return this.stmts.getPaths.all(spaceId) as SpacePath[]; }
-  addPath(spaceId: string, path: string, label?: string): void { this.stmts.addPath.run(spaceId, path, label ?? null); }
-  removePath(spaceId: string, path: string): void { this.stmts.removePath.run(spaceId, path); }
-  getSpaceByPath(path: string): SpaceRow | undefined { return this.stmts.getSpaceByPath.get(path) as SpaceRow | undefined; }
+
+  addSource(args: { id: string; space_id: string; type: Source["type"]; path: string; label?: string | null }): void {
+    this.stmts.addSource.run(args.id, args.space_id, args.type, args.path, args.label ?? null);
+  }
+  softDeleteSource(sourceId: string): void { this.stmts.softDeleteSource.run(sourceId); }
+  restoreSource(sourceId: string): void { this.stmts.restoreSource.run(sourceId); }
+  getSources(spaceId: string, opts?: { includeRemoved?: boolean }): Source[] {
+    const stmt = opts?.includeRemoved ? this.stmts.getSourcesAll : this.stmts.getSourcesActive;
+    return stmt.all(spaceId) as Source[];
+  }
+  getSourceById(sourceId: string): Source | undefined { return this.stmts.getSourceById.get(sourceId) as Source | undefined; }
+  getActiveSourceByPath(path: string): Source | undefined { return this.stmts.getActiveSourceByPath.get(path) as Source | undefined; }
+  getSoftDeletedSourceByPathForSpace(spaceId: string, path: string): Source | undefined {
+    return this.stmts.getSoftDeletedSourceByPathForSpace.get(spaceId, path) as Source | undefined;
+  }
 
   private static readonly UPDATABLE_COLUMNS = new Set([
     "display_name", "color", "parent_id", "scan_status",


### PR DESCRIPTION
## Summary

Linked external folders are now first-class. Each attached folder gets a row in a new `sources` table; every artifact discovered from one points back via `artifacts.source_id`. Detaching a folder cleanly soft-deletes both the source AND its tiles in one cascade — no more orphans. Re-attaching the same path restores the source row in place (same id), and the next scan resurfaces matching tiles.

Closes #208.

### Schema
- `sources` table — `(id, space_id, type='local_folder', path, label, added_at, removed_at)` + partial unique index on path-where-active.
- `artifacts.source_id` FK with `ON DELETE SET NULL`, added explicitly *after* `CREATE TABLE sources`.
- `PRAGMA foreign_keys = ON`.

### Behaviour
- **Detach** (`removeSource` / new `detach_source` MCP tool): soft-deletes source row, then cascade-soft-deletes artifacts where `source_id = ?`. Refuses mid-scan to avoid racing with `upsertCandidate`'s resurface path.
- **Reattach** (`addSource`): finds the soft-deleted match by `(space_id, path)` and restores in place — same `source.id` survives, `removed_at` cleared. Scan resurfaces matching tiles. Both INSERT and restore paths catch `SQLITE_CONSTRAINT_UNIQUE` and translate races into the friendly "already attached to space X" error.
- **`source_id IS NULL`** = "not from a linked external source" (covers manual / AI-generated / native artifacts). No native-source bookkeeping in this round.

### Migration
**Manual one-shot for the maintainer's existing `~/Oyster/db/oyster.db`** — done by hand and verified before this branch. No embedded upgrade backfill ships in the code: confirmed scope is the maintainer + two greenfield testers, none with old data. If anyone with pre-#208 data ever surfaces, the SQL is preserved in commit `4be6760`.

The legacy `space_paths` table stays in the schema for one release as a safety net.

### Verified end-to-end
On real `~/Oyster/db/oyster.db`:
- Migration: 2 sources, 57 discovered artifacts attributed (44 blunderfixer + 13 oyster).
- **Detach via chat**: source.removed_at set, 6 live tiles → soft-deleted, manual/ai_generated rows untouched (correctly NULL source_id).
- **Reattach via chat**: same source.id survived, removed_at cleared, scan re-discovered 68 tiles all attributed.

## Known follow-up

Pre-migration tiles use unprefixed `source_ref` (e.g. `CHANGELOG.md:notes`); new scans add a folder-basename prefix (`blunderfixer/CHANGELOG.md:notes`). The resurface lookup in `upsertCandidate` misses across the format boundary, leaving stale soft-deleted rows in the archive after a detach/reattach round-trip. The slug prefix also doesn't fully prevent collisions when two attached paths share a basename. Both cleanly fixed by switching the dedup key from `(space_id, source_ref)` to `(source_id, source_ref-without-slug)`. Tracked as a follow-up.

## Out of scope (deferred)

- UI affordance for native vs linked-source provenance — issue #220.
- Per-source scan_status / re-point UX.
- Drop `space_paths` table (additive migration only this round).
- Reorder dedup key to `(source_id, source_ref-without-slug)` — relates to the follow-up above.

## Test plan

- [x] Build passes (`cd server && npm run build`)
- [x] Migration on real `~/Oyster/db/oyster.db`: source rows match space_paths count, all 57 discovered artifacts attributed
- [x] Detach via `detach_source`: source.removed_at set, artifacts soft-deleted, manual/AI rows untouched
- [x] Reattach via `onboard_space`: source restored in place (same id), tiles re-appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)