### PR TITLE
docs(files-tile): redesign in Quick Start's visual language

### DIFF
--- a/builtins/where-are-my-files/src/index.html
+++ b/builtins/where-are-my-files/src/index.html
@@ -237,28 +237,30 @@
   <div class="page">
     <div class="page-header">
       <h1>Where do my files live?</h1>
-      <p>Two homes for your files. Oyster manages one. You manage the other.</p>
+      <p>Two homes for your files.</p>
     </div>
 
     <div id="error-slot"></div>
 
-    <div class="section-label">Your Oyster workspace</div>
+    <div class="section-label">Your Oyster home</div>
     <div class="card">
-      <div class="card-title">Oyster's territory</div>
-      <p>Everything inside this folder is managed by Oyster — kept in sync with the surface, backed up, and editable through chat. Tiles created in the chat bar, AI-generated apps, notes, invoices: all live here. Delete a tile from the surface and the file is gone too.</p>
       <div class="primary" id="oyster-home"><span class="loading">loading…</span></div>
+      <p>Everything you make in Oyster lives here. Delete a tile from the surface, the file's gone too.</p>
+    </div>
+
+    <div class="section-label">What's inside</div>
+    <div class="card">
+      <div class="shortcuts">
+        <div class="shortcut"><span class="shortcut-key">spaces/</span><span class="shortcut-desc">your work, one folder per space</span></div>
+        <div class="shortcut"><span class="shortcut-key">apps/</span><span class="shortcut-desc">apps you've installed</span></div>
+        <div class="shortcut"><span class="shortcut-key">db/</span><span class="shortcut-desc">Oyster's database</span></div>
+        <div class="shortcut"><span class="shortcut-key">backups/</span><span class="shortcut-desc">automatic daily snapshots</span></div>
+      </div>
     </div>
 
     <div class="section-label">Linked folders</div>
     <div class="card">
-      <div class="card-title">
-        <span class="chip" aria-hidden="true">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
-        </span>
-        <span>Your territory</span>
-      </div>
-      <p>Folders elsewhere on disk — e.g. <code>~/Dev/my-project/</code> — that you've attached to a space. Oyster shows tiles as a window into your folder. Files stay where they are, edits write back in place, and detaching a tile leaves the file untouched on disk. Backups, version control, sync — your responsibility.</p>
-      <p>Tiles from linked folders carry a small chain-link marker:</p>
+      <p>Tiles from folders you've attached from elsewhere on disk show a small chain-link chip. The file stays where you keep it — Oyster's just a window in.</p>
       <div class="marker-preview">
         <div class="marker-tile">
           <div class="marker-thumb">
@@ -270,18 +272,8 @@
           <div class="marker-label">README</div>
         </div>
         <div class="marker-caption">
-          The bottom-left chip on the icon means this tile lives in a folder you own — not in the Oyster workspace. Hover the marker for the source folder name.
+          Detaching one of these from the surface leaves the file untouched on disk. Backups and version control are yours to handle.
         </div>
-      </div>
-    </div>
-
-    <div class="section-label">What's inside ~/Oyster</div>
-    <div class="card">
-      <div class="shortcuts">
-        <div class="shortcut"><span class="shortcut-key">spaces/</span><span class="shortcut-desc" id="spaces-path"><span class="loading">loading…</span></span></div>
-        <div class="shortcut"><span class="shortcut-key">apps/</span><span class="shortcut-desc" id="apps-path"></span></div>
-        <div class="shortcut"><span class="shortcut-key">db/</span><span class="shortcut-desc" id="db-path"></span></div>
-        <div class="shortcut"><span class="shortcut-key">backups/</span><span class="shortcut-desc" id="backups-path"></span></div>
       </div>
     </div>
 
@@ -292,19 +284,8 @@
       </div>
     </div>
 
-    <div class="section-label">Finding a specific file</div>
-    <div class="card">
-      <div class="shortcuts">
-        <div class="shortcut"><span class="shortcut-key">A tokinvest invoice</span><span class="shortcut-desc"><code id="ex-invoice"></code></span></div>
-        <div class="shortcut"><span class="shortcut-key">A note in home</span><span class="shortcut-desc"><code id="ex-note"></code></span></div>
-        <div class="shortcut"><span class="shortcut-key">An AI-generated app</span><span class="shortcut-desc"><code id="ex-app"></code></span></div>
-        <div class="shortcut"><span class="shortcut-key">An installed app</span><span class="shortcut-desc"><code id="ex-installed"></code></span></div>
-      </div>
-    </div>
-
-    <div class="section-label">Moving things</div>
-    <div class="card">
-      <p>Use Oyster — the agent or the UI — for moves and renames so the filesystem and the database stay in sync. Finder-only moves aren't reconciled yet.</p>
+    <div class="card" style="margin-top: 24px; background: rgba(0,0,0,0.18); border-color: rgba(255,255,255,0.04);">
+      <p>Move or rename through Oyster — Finder-only changes aren't reconciled with the database yet.</p>
     </div>
   </div>
 
@@ -317,14 +298,6 @@
         const el = document.getElementById(id);
         if (el) el.textContent = text;
       };
-      const setCode = (cellId, p) => {
-        const cell = document.getElementById(cellId);
-        if (!cell) return;
-        cell.replaceChildren();
-        const code = document.createElement("code");
-        code.textContent = p;
-        cell.appendChild(code);
-      };
 
       try {
         const res = await fetch("/api/workspace");
@@ -333,10 +306,6 @@
         const sep = info.platform === "win32" ? "\\" : "/";
 
         setText("oyster-home", info.oysterHome);
-        setCode("spaces-path", info.paths.spaces);
-        setCode("apps-path", info.paths.apps);
-        setCode("db-path", info.paths.db);
-        setCode("backups-path", info.paths.backups);
 
         const sl = document.getElementById("spaces-list");
         sl.replaceChildren();
@@ -361,27 +330,17 @@
           row.className = "shortcut";
           const desc = document.createElement("span");
           desc.className = "shortcut-desc";
-          desc.textContent = "No spaces yet. Ask your AI to set up Oyster, or create one via the chat bar.";
+          desc.textContent = "No spaces yet. Ask your AI to set one up.";
           row.appendChild(desc);
           sl.appendChild(row);
         }
-
-        // Examples — use real space names where available so they're concrete
-        const tokinvest = info.spaces.find(s => s === "tokinvest") || "<space>";
-        const home = info.spaces.find(s => s === "home") || info.spaces[0] || "home";
-        setText("ex-invoice", info.paths.spaces + sep + tokinvest + sep + "invoices" + sep + "<name>.md");
-        setText("ex-note", info.paths.spaces + sep + home + sep + "<name>.md");
-        setText("ex-app", info.paths.spaces + sep + "<space>" + sep + "<app-name>" + sep);
-        setText("ex-installed", info.paths.apps + sep + "<app-name>" + sep);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         const banner = document.createElement("div");
         banner.className = "error-banner";
         banner.textContent = "Couldn't reach /api/workspace: " + message;
         document.getElementById("error-slot").appendChild(banner);
-        // Clear placeholders so the page isn't stuck on "loading…"
         setText("oyster-home", "—");
-        for (const id of ["spaces-path", "apps-path", "db-path", "backups-path"]) setText(id, "—");
         const sl = document.getElementById("spaces-list");
         sl.replaceChildren();
         const row = document.createElement("div");
@@ -391,7 +350,6 @@
         desc.textContent = "Couldn't load paths — see error above.";
         row.appendChild(desc);
         sl.appendChild(row);
-        for (const id of ["ex-invoice", "ex-note", "ex-app", "ex-installed"]) setText(id, "—");
       }
     })();
   </script>

--- a/builtins/where-are-my-files/src/index.html
+++ b/builtins/where-are-my-files/src/index.html
@@ -8,177 +8,390 @@
   <style>
     :root {
       --accent: #7c6bff;
+      --accent-bright: #a597ff;
       --text: #f0f0f5;
-      --text-dim: rgba(232,233,240,0.55);
-      --text-muted: rgba(232,233,240,0.3);
-      --surface: rgba(22,23,40,0.6);
-      --border: rgba(124,107,255,0.18);
+      --text-dim: rgba(232,233,240,0.45);
+      --text-muted: rgba(232,233,240,0.2);
+      --surface: rgba(12,13,28,0.85);
+      --border: rgba(124,107,255,0.15);
       --font-body: 'Space Grotesk', -apple-system, sans-serif;
       --font-mono: 'IBM Plex Mono', monospace;
     }
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { height: 100%; }
     body {
       font-family: var(--font-body);
       color: var(--text);
       background: rgba(30, 31, 54, 1);
       min-height: 100vh;
-      padding: 48px 24px 80px;
+      display: flex;
+      justify-content: center;
+      padding: 60px 24px 80px;
       overflow-x: hidden;
-      line-height: 1.5;
     }
+
     .glow {
-      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
       background:
         radial-gradient(ellipse 80% 50% at 50% -10%, rgba(124,107,255,0.10) 0%, transparent 60%),
-        radial-gradient(ellipse 60% 40% at 100% 110%, rgba(124,107,255,0.08) 0%, transparent 60%);
+        radial-gradient(ellipse 50% 35% at 80% 90%, rgba(165,151,255,0.04) 0%, transparent 50%);
     }
-    .wrap { position: relative; z-index: 1; max-width: 760px; margin: 0 auto; }
-    h1 { font-size: 2rem; font-weight: 700; margin-bottom: 8px; letter-spacing: -0.02em; }
-    .lead { color: var(--text-dim); font-size: 1rem; margin-bottom: 32px; }
-    code, .path {
+
+    .page {
+      max-width: 640px;
+      width: 100%;
+      position: relative;
+      z-index: 1;
+      animation: fadeUp 0.5s cubic-bezier(0.16,1,0.3,1);
+    }
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(16px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .page-header { text-align: center; margin-bottom: 48px; }
+    .page-header h1 {
+      font-size: clamp(1.6rem, 4vw, 2.2rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 8px;
+    }
+    .page-header p { font-size: 15px; color: var(--text-dim); }
+
+    .section-label {
       font-family: var(--font-mono);
-      font-size: 0.9em;
-      background: rgba(124,107,255,0.08);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--accent);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 16px;
+      margin-top: 40px;
+    }
+    .section-label:first-of-type { margin-top: 0; }
+
+    .card {
+      background: var(--surface);
       border: 1px solid var(--border);
-      padding: 2px 7px;
-      border-radius: 4px;
+      border-radius: 16px;
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      padding: 20px 24px;
+      margin-bottom: 12px;
+    }
+    .card-title {
+      font-size: 15px;
+      font-weight: 600;
       color: var(--text);
+      margin-bottom: 6px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .card p {
+      font-size: 13px;
+      color: var(--text-dim);
+      line-height: 1.6;
+    }
+    .card p + p { margin-top: 8px; }
+
+    code {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      background: rgba(124,107,255,0.1);
+      padding: 2px 7px;
+      border-radius: 5px;
+      color: var(--accent-bright);
       word-break: break-all;
     }
+
+    /* Primary path block — the resolved Oyster home */
     .primary {
       display: block;
-      padding: 18px 22px;
+      margin-top: 14px;
+      padding: 14px 16px;
       font-family: var(--font-mono);
-      font-size: 1.05rem;
+      font-size: 13px;
       background: rgba(124,107,255,0.12);
       border: 1px solid rgba(124,107,255,0.3);
       border-radius: 10px;
-      margin: 20px 0 36px;
+      color: var(--text);
       user-select: all;
+      word-break: break-all;
     }
-    h2 { font-size: 1.1rem; font-weight: 600; margin: 28px 0 12px; letter-spacing: -0.01em; }
-    ul { list-style: none; padding: 0; margin: 12px 0; }
-    li { margin: 10px 0; }
-    li .lbl { color: var(--text); font-weight: 500; margin-right: 8px; }
-    li .desc { color: var(--text-dim); font-size: 0.92em; margin-left: 8px; }
-    table { border-collapse: collapse; width: 100%; margin: 12px 0; }
-    td { padding: 10px 8px; border-bottom: 1px solid var(--border); vertical-align: top; }
-    td.k { color: var(--text-dim); white-space: nowrap; padding-right: 16px; }
-    .note { color: var(--text-muted); font-size: 0.88em; margin-top: 20px; line-height: 1.55; }
-    .note code { background: transparent; border: none; padding: 0; color: var(--text-dim); }
-    .loading { color: var(--text-muted); font-family: var(--font-mono); }
+
+    /* Shortcut rows (key/value pairs) — same pattern as quick-start */
+    .shortcuts { display: flex; flex-direction: column; }
+    .shortcut {
+      display: flex;
+      align-items: baseline;
+      gap: 16px;
+      padding: 12px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.03);
+    }
+    .shortcut:last-child { border-bottom: none; }
+    .shortcut-key {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--accent-bright);
+      min-width: 160px;
+      flex-shrink: 0;
+    }
+    .shortcut-desc {
+      font-size: 13px;
+      color: var(--text-dim);
+      line-height: 1.5;
+      word-break: break-all;
+    }
+    .shortcut-desc code { font-size: 12px; }
+
+    @media (max-width: 540px) {
+      .shortcut { flex-direction: column; gap: 3px; }
+      .shortcut-key { min-width: 0; }
+    }
+
+    /* Marker mock — preview of the chain-link affordance */
+    .marker-preview {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-top: 14px;
+      padding: 14px 16px;
+      background: rgba(0,0,0,0.18);
+      border-radius: 10px;
+    }
+    .marker-tile {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      width: 88px;
+      flex-shrink: 0;
+    }
+    .marker-thumb {
+      width: 56px;
+      height: 56px;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #1e3a2f, #243f34);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+    .marker-thumb > svg.kind { width: 24px; height: 24px; opacity: 0.9; }
+    .marker-glyph {
+      position: absolute;
+      bottom: 3px;
+      left: 3px;
+      width: 16px;
+      height: 16px;
+      border-radius: 5px;
+      background: rgba(0, 0, 0, 0.55);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .marker-glyph svg { width: 10px; height: 10px; }
+    .marker-label {
+      font-size: 11px;
+      color: var(--text);
+      text-align: center;
+    }
+    .marker-caption {
+      font-size: 12px;
+      color: var(--text-dim);
+      line-height: 1.5;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 6px;
+      background: rgba(124,107,255,0.18);
+      color: var(--accent-bright);
+    }
+    .chip svg { width: 12px; height: 12px; }
+
+    .loading { color: var(--text-muted); font-family: var(--font-mono); font-size: 12px; }
+    .error-banner {
+      background: rgba(239, 100, 100, 0.08);
+      border: 1px solid rgba(239, 100, 100, 0.3);
+      color: #ff9090;
+      padding: 12px 14px;
+      border-radius: 10px;
+      font-size: 13px;
+      margin-bottom: 24px;
+    }
   </style>
 </head>
 <body>
   <div class="glow"></div>
-  <div class="wrap">
-    <h1>Where do my files live?</h1>
-    <p class="lead">Two homes for your files. <strong>Your Oyster workspace</strong> — Oyster manages, syncs, backs up, and any tile you delete from the surface deletes the file. <strong>Linked folders</strong> elsewhere on disk (e.g. <code>~/Dev/my-project/</code>) — Oyster shows tiles as a window into your folder; the files stay yours, edits write back in place, and detaching a tile leaves the file on disk untouched. Tiles from linked folders carry a small chain-link marker.</p>
+  <div class="page">
+    <div class="page-header">
+      <h1>Where do my files live?</h1>
+      <p>Two homes for your files. Oyster manages one. You manage the other.</p>
+    </div>
 
-    <div class="primary" id="oyster-home"><span class="loading">loading…</span></div>
+    <div id="error-slot"></div>
 
-    <h2>What's inside</h2>
-    <table>
-      <tr><td class="k">spaces/</td><td id="spaces-path" class="path-cell"></td></tr>
-      <tr><td class="k">apps/</td><td id="apps-path" class="path-cell"></td></tr>
-      <tr><td class="k">db/</td><td id="db-path" class="path-cell"></td></tr>
-      <tr><td class="k">backups/</td><td id="backups-path" class="path-cell"></td></tr>
-    </table>
+    <div class="section-label">Your Oyster workspace</div>
+    <div class="card">
+      <div class="card-title">Oyster's territory</div>
+      <p>Everything inside this folder is managed by Oyster — kept in sync with the surface, backed up, and editable through chat. Tiles created in the chat bar, AI-generated apps, notes, invoices: all live here. Delete a tile from the surface and the file is gone too.</p>
+      <div class="primary" id="oyster-home"><span class="loading">loading…</span></div>
+    </div>
 
-    <h2>Your spaces</h2>
-    <ul id="spaces-list"><li class="loading">loading…</li></ul>
+    <div class="section-label">Linked folders</div>
+    <div class="card">
+      <div class="card-title">
+        <span class="chip" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+        </span>
+        <span>Your territory</span>
+      </div>
+      <p>Folders elsewhere on disk — e.g. <code>~/Dev/my-project/</code> — that you've attached to a space. Oyster shows tiles as a window into your folder. Files stay where they are, edits write back in place, and detaching a tile leaves the file untouched on disk. Backups, version control, sync — your responsibility.</p>
+      <p>Tiles from linked folders carry a small chain-link marker:</p>
+      <div class="marker-preview">
+        <div class="marker-tile">
+          <div class="marker-thumb">
+            <svg class="kind" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8zM14 2v6h6M16 13H8M16 17H8"/></svg>
+            <span class="marker-glyph" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+            </span>
+          </div>
+          <div class="marker-label">README</div>
+        </div>
+        <div class="marker-caption">
+          The bottom-left chip on the icon means this tile lives in a folder you own — not in the Oyster workspace. Hover the marker for the source folder name.
+        </div>
+      </div>
+    </div>
 
-    <h2>Finding a specific file</h2>
-    <table>
-      <tr><td class="k">A tokinvest invoice</td><td><code id="ex-invoice"></code></td></tr>
-      <tr><td class="k">A note in home</td><td><code id="ex-note"></code></td></tr>
-      <tr><td class="k">An AI-generated app</td><td><code id="ex-app"></code></td></tr>
-      <tr><td class="k">An installed app</td><td><code id="ex-installed"></code></td></tr>
-    </table>
+    <div class="section-label">What's inside ~/Oyster</div>
+    <div class="card">
+      <div class="shortcuts">
+        <div class="shortcut"><span class="shortcut-key">spaces/</span><span class="shortcut-desc" id="spaces-path"><span class="loading">loading…</span></span></div>
+        <div class="shortcut"><span class="shortcut-key">apps/</span><span class="shortcut-desc" id="apps-path"></span></div>
+        <div class="shortcut"><span class="shortcut-key">db/</span><span class="shortcut-desc" id="db-path"></span></div>
+        <div class="shortcut"><span class="shortcut-key">backups/</span><span class="shortcut-desc" id="backups-path"></span></div>
+      </div>
+    </div>
 
-    <p class="note">
-      <strong>Moving things:</strong> use Oyster (the agent or the UI) for moves and renames so the filesystem and the database stay in sync. Finder-only moves aren't reconciled yet.
-    </p>
+    <div class="section-label">Your spaces</div>
+    <div class="card">
+      <div class="shortcuts" id="spaces-list">
+        <div class="shortcut"><span class="loading">loading…</span></div>
+      </div>
+    </div>
+
+    <div class="section-label">Finding a specific file</div>
+    <div class="card">
+      <div class="shortcuts">
+        <div class="shortcut"><span class="shortcut-key">A tokinvest invoice</span><span class="shortcut-desc"><code id="ex-invoice"></code></span></div>
+        <div class="shortcut"><span class="shortcut-key">A note in home</span><span class="shortcut-desc"><code id="ex-note"></code></span></div>
+        <div class="shortcut"><span class="shortcut-key">An AI-generated app</span><span class="shortcut-desc"><code id="ex-app"></code></span></div>
+        <div class="shortcut"><span class="shortcut-key">An installed app</span><span class="shortcut-desc"><code id="ex-installed"></code></span></div>
+      </div>
+    </div>
+
+    <div class="section-label">Moving things</div>
+    <div class="card">
+      <p>Use Oyster — the agent or the UI — for moves and renames so the filesystem and the database stay in sync. Finder-only moves aren't reconciled yet.</p>
+    </div>
   </div>
 
   <script>
     (async () => {
-      // Use textContent + DOM-node creation (not innerHTML with string
-      // concatenation) — space names are user-controlled and paths could
-      // contain any characters; innerHTML would open a DOM-XSS surface.
+      // textContent + DOM-node creation only (no innerHTML with concatenation).
+      // Space names are user-controlled and paths can contain anything; innerHTML
+      // would open a DOM-XSS surface.
+      const setText = (id, text) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = text;
+      };
+      const setCode = (cellId, p) => {
+        const cell = document.getElementById(cellId);
+        if (!cell) return;
+        cell.replaceChildren();
+        const code = document.createElement("code");
+        code.textContent = p;
+        cell.appendChild(code);
+      };
+
       try {
         const res = await fetch("/api/workspace");
         if (!res.ok) throw new Error("workspace api " + res.status);
         const info = await res.json();
         const sep = info.platform === "win32" ? "\\" : "/";
 
-        document.getElementById("oyster-home").textContent = info.oysterHome;
+        setText("oyster-home", info.oysterHome);
+        setCode("spaces-path", info.paths.spaces);
+        setCode("apps-path", info.paths.apps);
+        setCode("db-path", info.paths.db);
+        setCode("backups-path", info.paths.backups);
 
-        const setPathCell = (id, p) => {
-          const cell = document.getElementById(id);
-          cell.replaceChildren();
-          const code = document.createElement("code");
-          code.textContent = p;
-          cell.appendChild(code);
-        };
-        setPathCell("spaces-path", info.paths.spaces);
-        setPathCell("apps-path", info.paths.apps);
-        setPathCell("db-path", info.paths.db);
-        setPathCell("backups-path", info.paths.backups);
-
-        // Spaces list
         const sl = document.getElementById("spaces-list");
         sl.replaceChildren();
         if (info.spaces && info.spaces.length) {
           for (const name of info.spaces) {
-            const li = document.createElement("li");
-            const lbl = document.createElement("span");
-            lbl.className = "lbl";
-            lbl.textContent = name;
+            const row = document.createElement("div");
+            row.className = "shortcut";
+            const key = document.createElement("span");
+            key.className = "shortcut-key";
+            key.textContent = name;
+            const desc = document.createElement("span");
+            desc.className = "shortcut-desc";
             const code = document.createElement("code");
             code.textContent = info.paths.spaces + sep + name;
-            li.appendChild(lbl);
-            li.appendChild(code);
-            sl.appendChild(li);
+            desc.appendChild(code);
+            row.appendChild(key);
+            row.appendChild(desc);
+            sl.appendChild(row);
           }
         } else {
-          const li = document.createElement("li");
-          li.className = "desc";
-          li.textContent = "No spaces yet. Ask your AI to set up Oyster, or create one via the chat bar.";
-          sl.appendChild(li);
+          const row = document.createElement("div");
+          row.className = "shortcut";
+          const desc = document.createElement("span");
+          desc.className = "shortcut-desc";
+          desc.textContent = "No spaces yet. Ask your AI to set up Oyster, or create one via the chat bar.";
+          row.appendChild(desc);
+          sl.appendChild(row);
         }
 
-        // Examples — use a real space name where available
+        // Examples — use real space names where available so they're concrete
         const tokinvest = info.spaces.find(s => s === "tokinvest") || "<space>";
         const home = info.spaces.find(s => s === "home") || info.spaces[0] || "home";
-        document.getElementById("ex-invoice").textContent = info.paths.spaces + sep + tokinvest + sep + "invoices" + sep + "<name>.md";
-        document.getElementById("ex-note").textContent = info.paths.spaces + sep + home + sep + "<name>.md";
-        document.getElementById("ex-app").textContent = info.paths.spaces + sep + "<space>" + sep + "<app-name>" + sep;
-        document.getElementById("ex-installed").textContent = info.paths.apps + sep + "<app-name>" + sep;
+        setText("ex-invoice", info.paths.spaces + sep + tokinvest + sep + "invoices" + sep + "<name>.md");
+        setText("ex-note", info.paths.spaces + sep + home + sep + "<name>.md");
+        setText("ex-app", info.paths.spaces + sep + "<space>" + sep + "<app-name>" + sep);
+        setText("ex-installed", info.paths.apps + sep + "<app-name>" + sep);
       } catch (err) {
-        // `err` might not be an Error instance (a plain string, a DOMException, etc.).
-        // Treating it as Error would render "undefined" or throw. Coerce safely.
         const message = err instanceof Error ? err.message : String(err);
-        const oh = document.getElementById("oyster-home");
-        oh.replaceChildren();
-        const span = document.createElement("span");
-        span.className = "loading";
-        span.textContent = "couldn't reach /api/workspace: " + message;
-        oh.appendChild(span);
-        // Clear the remaining "loading…" placeholders so the page doesn't look half-rendered.
+        const banner = document.createElement("div");
+        banner.className = "error-banner";
+        banner.textContent = "Couldn't reach /api/workspace: " + message;
+        document.getElementById("error-slot").appendChild(banner);
+        // Clear placeholders so the page isn't stuck on "loading…"
+        setText("oyster-home", "—");
+        for (const id of ["spaces-path", "apps-path", "db-path", "backups-path"]) setText(id, "—");
         const sl = document.getElementById("spaces-list");
         sl.replaceChildren();
-        const fallback = document.createElement("li");
-        fallback.className = "desc";
-        fallback.textContent = "Couldn't load paths — see error above.";
-        sl.appendChild(fallback);
-        for (const id of ["spaces-path", "apps-path", "db-path", "backups-path"]) {
-          document.getElementById(id).textContent = "—";
-        }
-        for (const id of ["ex-invoice", "ex-note", "ex-app", "ex-installed"]) {
-          document.getElementById(id).textContent = "—";
-        }
+        const row = document.createElement("div");
+        row.className = "shortcut";
+        const desc = document.createElement("span");
+        desc.className = "shortcut-desc";
+        desc.textContent = "Couldn't load paths — see error above.";
+        row.appendChild(desc);
+        sl.appendChild(row);
+        for (const id of ["ex-invoice", "ex-note", "ex-app", "ex-installed"]) setText(id, "—");
       }
     })();
   </script>

--- a/builtins/where-are-my-files/src/index.html
+++ b/builtins/where-are-my-files/src/index.html
@@ -50,6 +50,9 @@
       from { opacity: 0; transform: translateY(16px); }
       to { opacity: 1; transform: translateY(0); }
     }
+    @media (prefers-reduced-motion: reduce) {
+      .page { animation: none; }
+    }
 
     .page-header { text-align: center; margin-bottom: 48px; }
     .page-header h1 {
@@ -82,6 +85,13 @@
       -webkit-backdrop-filter: blur(20px);
       padding: 20px 24px;
       margin-bottom: 12px;
+    }
+    /* Muted variant — for the footer "Moving things" caveat. Quieter than a
+       regular card so it doesn't compete with the primary content. */
+    .card.muted {
+      background: rgba(0,0,0,0.18);
+      border-color: rgba(255,255,255,0.04);
+      margin-top: 24px;
     }
     .card p {
       font-size: 13px;
@@ -265,7 +275,7 @@
       </div>
     </div>
 
-    <div class="card" style="margin-top: 24px; background: rgba(0,0,0,0.18); border-color: rgba(255,255,255,0.04);">
+    <div class="card muted">
       <p>Move or rename through Oyster — Finder-only changes aren't reconciled with the database yet.</p>
     </div>
   </div>

--- a/builtins/where-are-my-files/src/index.html
+++ b/builtins/where-are-my-files/src/index.html
@@ -68,9 +68,11 @@
       letter-spacing: 0.08em;
       text-transform: uppercase;
       margin-bottom: 16px;
-      margin-top: 40px;
     }
-    .section-label:first-of-type { margin-top: 0; }
+    /* Add the gap only between sections — first label sits flush against the
+       header. :first-of-type would lie because .page-header / #error-slot are
+       earlier divs, so the first .section-label isn't the first div sibling. */
+    .card + .section-label { margin-top: 40px; }
 
     .card {
       background: var(--surface);
@@ -248,7 +250,7 @@
       <p>Everything you make in Oyster lives here. Delete a tile from the surface, the file's gone too.</p>
     </div>
 
-    <div class="section-label">What's inside</div>
+    <div class="section-label">What's inside your Oyster home</div>
     <div class="card">
       <div class="shortcuts">
         <div class="shortcut"><span class="shortcut-key">spaces/</span><span class="shortcut-desc">your work, one folder per space</span></div>
@@ -264,7 +266,7 @@
       <div class="marker-preview">
         <div class="marker-tile">
           <div class="marker-thumb">
-            <svg class="kind" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8zM14 2v6h6M16 13H8M16 17H8"/></svg>
+            <svg class="kind" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8zM14 2v6h6M16 13H8M16 17H8"/></svg>
             <span class="marker-glyph" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
             </span>

--- a/builtins/where-are-my-files/src/index.html
+++ b/builtins/where-are-my-files/src/index.html
@@ -83,15 +83,6 @@
       padding: 20px 24px;
       margin-bottom: 12px;
     }
-    .card-title {
-      font-size: 15px;
-      font-weight: 600;
-      color: var(--text);
-      margin-bottom: 6px;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
     .card p {
       font-size: 13px;
       color: var(--text-dim);
@@ -209,18 +200,6 @@
       color: var(--text-dim);
       line-height: 1.5;
     }
-
-    .chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 22px;
-      height: 22px;
-      border-radius: 6px;
-      background: rgba(124,107,255,0.18);
-      color: var(--accent-bright);
-    }
-    .chip svg { width: 12px; height: 12px; }
 
     .loading { color: var(--text-muted); font-family: var(--font-mono); font-size: 12px; }
     .error-banner {


### PR DESCRIPTION
## Summary

- Rewrites the *Where do my files live?* tile to match the Quick Start design language (page-header + section-label + card + shortcut-row pattern).
- Adds a small **mock tile preview** of the chain-link marker so users can see the affordance, not just read about it.
- Tightens the copy: less prose, more answer. The big resolved Oyster home path goes top, then a one-line description per directory, then the linked-folder explanation, then the spaces list. "Finding a specific file" is gone — the template-strings (`<space>/<name>.md`) read as spec text rather than user content, and the spaces list already gives users what they need.
- Error path becomes a discrete banner at the top of the page instead of overwriting the home-path block.

## Why

After #221 the tile carries a chain-link marker on linked artifacts, but the explainer in this builtin only mentioned it in the lead paragraph and looked nothing like its sibling Quick Start tile. The two now share visual DNA, and the chain-link affordance has somewhere to live that's both visible and visually demonstrated.

## Test plan

- [ ] Open the *Where do my files live?* tile from the surface — fonts, spacing, card treatment match Quick Start
- [ ] The big home-path block populates with the resolved `oysterHome`
- [ ] Linked folders section shows a mini tile with the chain-link chip in the bottom-left
- [ ] *Your spaces* card populates with the list of spaces and their absolute paths
- [ ] Stop the server / break /api/workspace — error banner appears at the top, home-path falls back to "—", spaces list shows a fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)