### PR TITLE
docs(changelog): backfill [Unreleased] entry for #222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,7 +369,12 @@ Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via M
 - Surface with Aurora WebGL animated background.
 - Typed artifact icons, chat bar, window system with viewer.
 
-[Unreleased]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.1...HEAD
+[Unreleased]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.6...HEAD
+[0.4.0-beta.6]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.5...v0.4.0-beta.6
+[0.4.0-beta.5]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.4...v0.4.0-beta.5
+[0.4.0-beta.4]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.3...v0.4.0-beta.4
+[0.4.0-beta.3]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.2...v0.4.0-beta.3
+[0.4.0-beta.2]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.1...v0.4.0-beta.2
 [0.4.0-beta.1]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.0...v0.4.0-beta.1
 [0.4.0-beta.0]: https://github.com/mattslight/oyster/compare/v0.3.8...v0.4.0-beta.0
 [0.3.5]: https://github.com/mattslight/oyster/compare/v0.3.4...v0.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **"Where do my files live?" tile is more useful at a glance.** Adopts the Quick Start visual language, leads with the resolved path of your Oyster home, and shows a small preview of the chain-link marker so you can see what a linked tile looks like — not just be told. ([#222](https://github.com/mattslight/oyster/pull/222))
+
 ## [0.4.0-beta.6] - 2026-04-25
 
 ### Changed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -321,22 +321,22 @@
   </nav>
 
   <main class="entries">
-<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.1...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.6...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Changed</h3>
 <ul>
 <li><strong>&quot;Where do my files live?&quot; tile is more useful at a glance.</strong> Adopts the Quick Start visual language, leads with the resolved path of your Oyster home, and shows a small preview of the chain-link marker so you can see what a linked tile looks like — not just be told. (<a href="https://github.com/mattslight/oyster/pull/222" rel="noopener noreferrer">#222</a>)</li>
 </ul>
-<h2 id="v-0-4-0-beta-6"><span class="release-version">0.4.0-beta.6</span><span class="release-date"> — 2026-04-25</span></h2>
+<h2 id="v-0-4-0-beta-6"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.5...v0.4.0-beta.6" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.6</span></a><span class="release-date"> — 2026-04-25</span></h2>
 <h3>Changed</h3>
 <ul>
 <li><strong>Linked tiles now carry a small chain-link marker</strong> (bottom-left of the icon) so you can tell at a glance which tiles are windows into folders elsewhere on disk vs. native to your Oyster workspace. Hover the marker for the source folder name. The &quot;Where are my files?&quot; tile is now <strong>&quot;Where do my files live?&quot;</strong> and explains the two homes — Oyster-managed workspace, and linked folders you own. (<a href="https://github.com/mattslight/oyster/issues/220" rel="noopener noreferrer">#220</a>)</li>
 </ul>
-<h2 id="v-0-4-0-beta-5"><span class="release-version">0.4.0-beta.5</span><span class="release-date"> — 2026-04-25</span></h2>
+<h2 id="v-0-4-0-beta-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.4...v0.4.0-beta.5" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.5</span></a><span class="release-date"> — 2026-04-25</span></h2>
 <h3>Changed</h3>
 <ul>
 <li><strong>Linked folders are now first-class.</strong> Detaching a folder from a space cleanly removes its tiles (no more orphans), and reattaching the same folder restores them. Sets up cleaner provenance and detach UI later.</li>
 </ul>
-<h2 id="v-0-4-0-beta-4"><span class="release-version">0.4.0-beta.4</span><span class="release-date"> — 2026-04-25</span></h2>
+<h2 id="v-0-4-0-beta-4"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.3...v0.4.0-beta.4" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.4</span></a><span class="release-date"> — 2026-04-25</span></h2>
 <h3>Changed</h3>
 <ul>
 <li><strong>Startup banner is now a coloured box</strong> so the &quot;Open Oyster&quot; URL and starter prompts don&#39;t get lost in the logs.</li>
@@ -345,7 +345,7 @@
 <ul>
 <li><strong>Setup dock no longer skips &quot;Connect your AI&quot;</strong> after the chat bar creates your first space.</li>
 </ul>
-<h2 id="v-0-4-0-beta-3"><span class="release-version">0.4.0-beta.3</span><span class="release-date"> — 2026-04-24</span></h2>
+<h2 id="v-0-4-0-beta-3"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.2...v0.4.0-beta.3" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.3</span></a><span class="release-date"> — 2026-04-24</span></h2>
 <h3>Changed</h3>
 <ul>
 <li><strong>Clearer first-run hero.</strong> <em>&quot;Welcome to your surface. Ask: <code>Set up Oyster</code>&quot;</em> — tap the prompt pill to send it, or type your own.</li>
@@ -354,7 +354,7 @@
 <ul>
 <li><strong>Windows polish.</strong> Cleaner startup (no more alarming error messages in the terminal), thin dark scrollbars on artifacts and setup dialogs to match Mac, and the built-in terminal now recognises Oyster as an AI agent option.</li>
 </ul>
-<h2 id="v-0-4-0-beta-2"><span class="release-version">0.4.0-beta.2</span><span class="release-date"> — 2026-04-24</span></h2>
+<h2 id="v-0-4-0-beta-2"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.1...v0.4.0-beta.2" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.2</span></a><span class="release-date"> — 2026-04-24</span></h2>
 <h3>Fixed</h3>
 <ul>
 <li><strong><code>oyster install &lt;id&gt;</code> now works.</strong> The CLI was writing to the pre-0.4 hidden workspace path while the server scans the new <code>~/Oyster/apps/</code> — so installs silently landed where nothing looked. Community plugins now install and appear on the surface after a restart. (<a href="https://github.com/mattslight/oyster/pull/212" rel="noopener noreferrer">#212</a>)</li>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-4-0-beta-6">0.4</a>
       <a class="version-pill" href="#v-0-3-8">0.3</a>
       <a class="version-pill" href="#v-0-2-4">0.2</a>
@@ -320,6 +321,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.1...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>&quot;Where do my files live?&quot; tile is more useful at a glance.</strong> Adopts the Quick Start visual language, leads with the resolved path of your Oyster home, and shows a small preview of the chain-link marker so you can see what a linked tile looks like — not just be told. (<a href="https://github.com/mattslight/oyster/pull/222" rel="noopener noreferrer">#222</a>)</li>
+</ul>
 <h2 id="v-0-4-0-beta-6"><span class="release-version">0.4.0-beta.6</span><span class="release-date"> — 2026-04-25</span></h2>
 <h3>Changed</h3>
 <ul>


### PR DESCRIPTION
## Summary

#222 was user-visible (tile redesign + chain-link marker preview) but didn't carry a CHANGELOG entry, so [Unreleased] is currently empty after that merge. This adds the entry so the next beta cut picks it up. Also regenerates \`docs/changelog.html\` per the project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)