### PR TITLE
feat(filter): "show me X" changes the desktop, not just the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **"Show me my X" now changes what you see, not just what's said.** Asking the assistant to show or filter to a subset of artifacts (e.g. *"show me tokinvest invoices"*) narrows the desktop in place — same surface, fewer tiles — instead of replying with text. A small ✦ pill at the top of the desktop names the active filter; ✕ clears it. Built on a new `filter_desktop` MCP tool any connected agent can drive.
+- **Search now matches space and source folder, not just label.** A query for *"tokinvest"* finds tiles in the tokinvest space (or under a tokinvest source folder), not only tiles whose name contains the word.
+
 ## [0.4.0-beta.7] - 2026-04-25
 
 ### Changed

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -856,12 +856,20 @@ export function createMcpServer(deps: McpDeps): McpServer {
 
   server.tool(
     "filter_desktop",
-    'Change what the user sees on the desktop surface. Use this when the user says "show me X" / "only X" / "filter to X" — the request is a visual action, not a question. For "how many X do I have?" or "what artifacts exist?" use list_artifacts instead. Optionally switches space and applies a search/kind filter; pass clear=true to remove any active filter.',
+    `Change what the user sees on the desktop surface. Use this when the user says "show me X" / "only X" / "filter to X" — the request is a visual action, not a question. For "how many X do I have?" or "what artifacts exist?" use list_artifacts instead.
+
+CHOOSING ARGUMENTS:
+- kind is ONLY for the seven enum values (${ARTIFACT_KINDS.join(", ")}). The user must literally have said one of those words. Don't infer kind from a category that's close to one (e.g. "games" → search, not kind=app; "documents" → search, not kind=notes).
+- search is the default for any noun that doesn't exactly match a kind ("invoices", "games", "tokinvest", "Q3"). It matches the artifact label, space name, or source folder name.
+- space is the user's named workspace (e.g. "tokinvest"). With a search term but no explicit space, the surface broadens to all spaces ("__all__") automatically.
+- clear=true removes any active filter.`,
     {
-      space: z.string().optional().describe("Space ID to switch to before filtering"),
-      kind: z.enum(ARTIFACT_KINDS).optional().describe("Restrict the surface to one artifact kind"),
-      search: z.string().optional().describe("Free-text term — matches artifact label, space name, or source folder name (case-insensitive)"),
-      clear: z.boolean().optional().describe("Set true to clear the active filter — overrides other args"),
+      // .nullish() so agents that send `null` for unprovided optional fields
+      // (instead of omitting them) don't trip Zod validation.
+      space: z.string().nullish().describe('Space ID to switch to before filtering. Use "__all__" to search across every space; omit to default to __all__ when a search is provided.'),
+      kind: z.enum(ARTIFACT_KINDS).nullish().describe(`Restrict the surface to one artifact kind. ONLY use this when the user's word is literally one of: ${ARTIFACT_KINDS.join(", ")}. For anything else ("games", "invoices", project names, etc.) use search.`),
+      search: z.string().nullish().describe("Free-text term — matches artifact label, space name, or source folder name (case-insensitive). Use this for any term that isn't one of the kind enum values."),
+      clear: z.boolean().nullish().describe("Set true to clear the active filter — overrides other args"),
     },
     async ({ space, kind, search, clear }) => {
       if (clear) {
@@ -874,17 +882,26 @@ export function createMcpServer(deps: McpDeps): McpServer {
       }
 
       let resolvedSpaceId: string | null = null;
-      if (space) {
+      if (space && space !== "__all__" && space !== "__archived__") {
         const spaces = deps.spaceService.listSpaces();
         const match = spaces.find(s => s.id === space);
         if (!match) {
           return { content: [{ type: "text" as const, text: `Space "${space}" not found. Available: ${spaces.map(s => s.id).join(", ")}` }], isError: true };
         }
         resolvedSpaceId = match.id;
+      } else if (space === "__all__" || space === "__archived__") {
+        resolvedSpaceId = space;
       }
 
       if (!resolvedSpaceId && !kind && !search) {
         return { content: [{ type: "text" as const, text: "filter_desktop needs at least one of space, kind, search, or clear=true." }], isError: true };
+      }
+
+      // A search with no explicit space implies "find this anywhere" — broaden
+      // to __all__ so the user actually sees results, instead of silently
+      // applying the filter to whichever space they happen to be in.
+      if (!resolvedSpaceId && search) {
+        resolvedSpaceId = "__all__";
       }
 
       deps.broadcastUiEvent({

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -571,7 +571,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         .enum(ARTIFACT_KINDS)
         .optional()
         .describe("Filter by artifact kind"),
-      search: z.string().optional().describe("Search term — filters artifacts whose label contains this text (case-insensitive)"),
+      search: z.string().optional().describe("Search term — case-insensitive match against artifact label, the artifact's space id/name, or its source file basename"),
       limit: z.number().int().min(1).max(100).optional().describe("Max results to return (default 20)"),
     },
     async ({ space_id, artifact_kind, search, limit }) => {
@@ -580,7 +580,18 @@ export function createMcpServer(deps: McpDeps): McpServer {
       if (artifact_kind) artifacts = artifacts.filter((a) => a.artifactKind === artifact_kind);
       if (search) {
         const q = search.toLowerCase();
-        artifacts = artifacts.filter((a) => a.label.toLowerCase().includes(q));
+        // Match label OR space id/name OR source file basename — a search for
+        // "tokinvest" should find artifacts in a tokinvest space (or under a
+        // tokinvest source folder), not just ones with "tokinvest" in the label.
+        const spaceById = new Map(deps.spaceService.listSpaces().map(s => [s.id, s]));
+        artifacts = artifacts.filter((a) => {
+          if (a.label.toLowerCase().includes(q)) return true;
+          const space = spaceById.get(a.spaceId);
+          if (space && (space.id.toLowerCase().includes(q) || space.displayName.toLowerCase().includes(q))) return true;
+          const src = deps.service.getDocFile(a.id);
+          if (src && basename(src).toLowerCase().includes(q)) return true;
+          return false;
+        });
       }
       artifacts = artifacts.slice(0, limit ?? 20);
 
@@ -838,6 +849,60 @@ export function createMcpServer(deps: McpDeps): McpServer {
         payload: { spaceId: space.id },
       });
       return { content: [{ type: "text" as const, text: `Switched to "${space.displayName}"` }] };
+    },
+  );
+
+  // ── filter_desktop ──
+
+  server.tool(
+    "filter_desktop",
+    'Change what the user sees on the desktop surface. Use this when the user says "show me X" / "only X" / "filter to X" — the request is a visual action, not a question. For "how many X do I have?" or "what artifacts exist?" use list_artifacts instead. Optionally switches space and applies a search/kind filter; pass clear=true to remove any active filter.',
+    {
+      space: z.string().optional().describe("Space ID to switch to before filtering"),
+      kind: z.enum(ARTIFACT_KINDS).optional().describe("Restrict the surface to one artifact kind"),
+      search: z.string().optional().describe("Free-text term — matches artifact label, space name, or source folder name (case-insensitive)"),
+      clear: z.boolean().optional().describe("Set true to clear the active filter — overrides other args"),
+    },
+    async ({ space, kind, search, clear }) => {
+      if (clear) {
+        deps.broadcastUiEvent({
+          version: 1,
+          command: "desktop_filter_changed",
+          payload: { spaceId: null, kind: null, search: null, cleared: true },
+        });
+        return { content: [{ type: "text" as const, text: "Filter cleared." }] };
+      }
+
+      let resolvedSpaceId: string | null = null;
+      if (space) {
+        const spaces = deps.spaceService.listSpaces();
+        const match = spaces.find(s => s.id === space);
+        if (!match) {
+          return { content: [{ type: "text" as const, text: `Space "${space}" not found. Available: ${spaces.map(s => s.id).join(", ")}` }], isError: true };
+        }
+        resolvedSpaceId = match.id;
+      }
+
+      if (!resolvedSpaceId && !kind && !search) {
+        return { content: [{ type: "text" as const, text: "filter_desktop needs at least one of space, kind, search, or clear=true." }], isError: true };
+      }
+
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "desktop_filter_changed",
+        payload: {
+          spaceId: resolvedSpaceId,
+          kind: kind ?? null,
+          search: search ?? null,
+          cleared: false,
+        },
+      });
+
+      const parts: string[] = [];
+      if (resolvedSpaceId) parts.push(`space=${resolvedSpaceId}`);
+      if (kind) parts.push(`kind=${kind}`);
+      if (search) parts.push(`search="${search}"`);
+      return { content: [{ type: "text" as const, text: `Desktop filter applied (${parts.join(", ")}).` }] };
     },
   );
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -579,10 +579,11 @@ export function createMcpServer(deps: McpDeps): McpServer {
       if (space_id) artifacts = artifacts.filter((a) => a.spaceId === space_id);
       if (artifact_kind) artifacts = artifacts.filter((a) => a.artifactKind === artifact_kind);
       if (search) {
+        // TEMPORARY: naive substring matcher. Do not extend — see #231
+        // (artifactSearchService: FTS5 + deterministic path tags + ID-resolved
+        // SSE). Plural/singular handling, group-name matching, content body
+        // search, and semantic tags all belong in that service, not here.
         const q = search.toLowerCase();
-        // Match label OR space id/name OR source file basename — a search for
-        // "tokinvest" should find artifacts in a tokinvest space (or under a
-        // tokinvest source folder), not just ones with "tokinvest" in the label.
         const spaceById = new Map(deps.spaceService.listSpaces().map(s => [s.id, s]));
         artifacts = artifacts.filter((a) => {
           if (a.label.toLowerCase().includes(q)) return true;
@@ -854,6 +855,12 @@ export function createMcpServer(deps: McpDeps): McpServer {
 
   // ── filter_desktop ──
 
+  // TEMPORARY: filter_desktop currently broadcasts the *search query* and the
+  // web client reapplies a parallel substring matcher (web/src/App.tsx
+  // applyAgentFilter). Once #231 lands, this tool calls artifactSearchService,
+  // resolves to a list of matching artifact IDs, and broadcasts those IDs in
+  // the SSE payload — the web becomes dumb (filter by id-set, no matcher).
+  // Do not extend the current matching surface here; that work belongs in #231.
   server.tool(
     "filter_desktop",
     `Change what the user sees on the desktop surface. Use this when the user says "show me X" / "only X" / "filter to X" — the request is a visual action, not a question. For "how many X do I have?" or "what artifacts exist?" use list_artifacts instead.

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -571,7 +571,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
         .enum(ARTIFACT_KINDS)
         .optional()
         .describe("Filter by artifact kind"),
-      search: z.string().optional().describe("Search term — case-insensitive match against artifact label, the artifact's space id/name, or its source file basename"),
+      search: z.string().optional().describe("Search term — case-insensitive substring match against the artifact label, the artifact's space id or display name, or the source file's basename"),
       limit: z.number().int().min(1).max(100).optional().describe("Max results to return (default 20)"),
     },
     async ({ space_id, artifact_kind, search, limit }) => {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -380,6 +380,19 @@ body {
   white-space: nowrap;
 }
 
+/* Agent-driven filter — distinct from the user-clicked kind filter so it's
+   obvious the AI did this and one ✕ click clears it. */
+.filter-notice--agent {
+  background: rgba(124, 107, 255, 0.32);
+  box-shadow: 0 0 0 1px rgba(124, 107, 255, 0.45) inset;
+}
+.filter-notice--agent::before {
+  content: "✦";
+  color: var(--accent);
+  font-size: 0.7rem;
+  margin-right: 2px;
+}
+
 .filter-notice-kind-wrap {
   position: relative;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -116,9 +116,14 @@ export default function App() {
   const [connected, setConnected] = useState(true);
   const [aiError, setAiError] = useState<string | null>(null);
 
-  // Apply the agent-driven desktop filter on top of the space-scoped list.
-  // Intersection semantics — kind + search both narrow further. Search matches
-  // label, space id/name, or sourceLabel (basename of linked source folder).
+  // TEMPORARY: this matcher mirrors the server-side substring filter in
+  // mcp-server.ts:list_artifacts so the desktop can react to the SSE event
+  // payload's search term. It is deliberately minimal and will be DELETED
+  // once #231 (artifactSearchService) lands — at that point the
+  // desktop_filter_changed event carries pre-resolved artifact IDs and the
+  // web simply applies `artifacts.filter(a => matchedIds.has(a.id))`.
+  // Do not extend this with plural-stripping, content matching, tag matching,
+  // or anything else — that all belongs server-side in #231.
   function applyAgentFilter(list: Artifact[]): Artifact[] {
     if (!agentFilter) return list;
     const { kind, search } = agentFilter;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,9 @@ export default function App() {
 
   const [activeSpace, setActiveSpace] = useState<string>(() => getUrlState().space);
   const [spotlightOpen, setSpotlightOpen] = useState(false);
+  // Agent-driven desktop filter, set by the `filter_desktop` MCP tool. Layered
+  // on top of the user's space-pill / kind-pill state — see line 365.
+  const [agentFilter, setAgentFilter] = useState<{ kind: ArtifactKind | null; search: string | null } | null>(null);
 
   // Global keyboard shortcuts
   const chatInputRef = useRef<HTMLInputElement>(null);
@@ -112,6 +115,28 @@ export default function App() {
   const [viewerHash, setViewerHash] = useState<string>(() => getUrlState().hash);
   const [connected, setConnected] = useState(true);
   const [aiError, setAiError] = useState<string | null>(null);
+
+  // Apply the agent-driven desktop filter on top of the space-scoped list.
+  // Intersection semantics — kind + search both narrow further. Search matches
+  // label, space id/name, or sourceLabel (basename of linked source folder).
+  function applyAgentFilter(list: Artifact[]): Artifact[] {
+    if (!agentFilter) return list;
+    const { kind, search } = agentFilter;
+    let next = list;
+    if (kind) next = next.filter((a) => a.artifactKind === kind);
+    if (search) {
+      const q = search.toLowerCase();
+      const space = spaces.find((s) => s.id === activeSpace);
+      next = next.filter((a) => {
+        if (a.label.toLowerCase().includes(q)) return true;
+        if (a.spaceId.toLowerCase().includes(q)) return true;
+        if (space && space.displayName.toLowerCase().includes(q)) return true;
+        if (a.sourceLabel && a.sourceLabel.toLowerCase().includes(q)) return true;
+        return false;
+      });
+    }
+    return next;
+  }
 
   // Active-space-aware artifact loader. Mirrors current activeSpace via a ref
   // so callers don't have to thread it through every closure (polling,
@@ -196,6 +221,15 @@ export default function App() {
       setActiveSpace(spaceId);
       window.history.pushState(null, "", `/s/${spaceId}`);
       dispatch({ type: "CLOSE_ALL_VIEWERS" });
+    }
+    if (event.command === "desktop_filter_changed") {
+      const { spaceId, kind, search, cleared } = event.payload as { spaceId: string | null; kind: ArtifactKind | null; search: string | null; cleared: boolean };
+      if (cleared) { setAgentFilter(null); return; }
+      if (spaceId) {
+        setActiveSpace(spaceId);
+        window.history.pushState(null, "", `/s/${spaceId}`);
+      }
+      setAgentFilter(kind || search ? { kind, search } : null);
     }
   }), []);
 
@@ -362,7 +396,9 @@ export default function App() {
         space={activeSpace}
         spaces={spaces.map(s => s.id)}
         isHero={isHero}
-        artifacts={(activeSpace === "__all__" || activeSpace === "__archived__") ? artifacts : artifacts.filter((a) => a.spaceId === activeSpace)}
+        artifacts={applyAgentFilter((activeSpace === "__all__" || activeSpace === "__archived__") ? artifacts : artifacts.filter((a) => a.spaceId === activeSpace))}
+        agentFilter={agentFilter}
+        onClearAgentFilter={() => setAgentFilter(null)}
         isArchivedView={isArchivedView}
         onArtifactClick={handleArtifactClick}
         onArtifactStop={handleArtifactStop}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -131,10 +131,14 @@ export default function App() {
     if (kind) next = next.filter((a) => a.artifactKind === kind);
     if (search) {
       const q = search.toLowerCase();
-      const space = spaces.find((s) => s.id === activeSpace);
+      // Look up each artifact's *own* space — looking up the active view's
+      // space would mean __all__ never matches space displayNames and named
+      // views match every artifact when the query happens to match the view.
+      const spaceById = new Map(spaces.map((s) => [s.id, s]));
       next = next.filter((a) => {
         if (a.label.toLowerCase().includes(q)) return true;
         if (a.spaceId.toLowerCase().includes(q)) return true;
+        const space = spaceById.get(a.spaceId);
         if (space && space.displayName.toLowerCase().includes(q)) return true;
         if (a.sourceLabel && a.sourceLabel.toLowerCase().includes(q)) return true;
         return false;

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -350,7 +350,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                   agentFilter.search ? `"${agentFilter.search}"` : null,
                 ].filter(Boolean).join(" · ")}
               </span>
-              <button className="filter-notice-clear" onClick={() => onClearAgentFilter?.()}>✕</button>
+              <button type="button" aria-label="Clear AI filter" className="filter-notice-clear" onClick={() => onClearAgentFilter?.()}>✕</button>
             </div>
           )}
           {activeKind && (
@@ -384,7 +384,7 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
                   <span className="filter-notice-kind">{kindLabel(activeKind)}</span>
                 )}
               </div>
-              <button className="filter-notice-clear" onClick={() => { selectKind(null); setKindDropdownOpen(false); }}>✕</button>
+              <button type="button" aria-label="Clear kind filter" className="filter-notice-clear" onClick={() => { selectKind(null); setKindDropdownOpen(false); }}>✕</button>
             </div>
           )}
           <div className="view-toggle-float">

--- a/web/src/components/Desktop.tsx
+++ b/web/src/components/Desktop.tsx
@@ -32,9 +32,12 @@ interface Props {
   revealId?: string | null;
   /** When true, render the archived-items view: context menu shows Restore. */
   isArchivedView?: boolean;
+  /** Agent-driven filter set via filter_desktop MCP tool. App.tsx applies the filter to `artifacts` before passing them in; this only renders the dismissable notice. */
+  agentFilter?: { kind: string | null; search: string | null } | null;
+  onClearAgentFilter?: () => void;
 }
 
-export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onSpaceChange, onConvertToSpace, onImportFromAI, onRefresh, onArtifactUpdate, onArtifactRemove, revealId, isArchivedView }: Props) {
+export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onArtifactStop, onGroupClick, onSpaceChange, onConvertToSpace, onImportFromAI, onRefresh, onArtifactUpdate, onArtifactRemove, revealId, isArchivedView, agentFilter, onClearAgentFilter }: Props) {
   const isAllSpace = space === "__all__";
 
   // ── Folder context menu ──
@@ -339,6 +342,17 @@ export function Desktop({ space, spaces, artifacts, isHero, onArtifactClick, onA
 
       <div className={`desktop-scroll${isHero ? " desktop-scroll--hero" : ""}`}>
         <div className="filter-bar">
+          {agentFilter && (
+            <div className="filter-notice filter-notice--agent" title="Filter set by AI assistant. Click ✕ to clear.">
+              <span className="filter-notice-kind">
+                {[
+                  agentFilter.kind ? kindLabel(agentFilter.kind) : null,
+                  agentFilter.search ? `"${agentFilter.search}"` : null,
+                ].filter(Boolean).join(" · ")}
+              </span>
+              <button className="filter-notice-clear" onClick={() => onClearAgentFilter?.()}>✕</button>
+            </div>
+          )}
           {activeKind && (
             <div className="filter-notice">
               <div className="filter-notice-kind-wrap">


### PR DESCRIPTION
## Summary

Closes the *show me tokinvest invoices → No invoices found* dead-end: when the user's intent is visual (*show me*, *only*, *filter to*), Oyster narrows the desktop in place instead of replying with text.

This PR is the **plumbing**. The matcher is deliberately minimal — proper search lands in #231–#234 (see *Follow-ups* below).

- **New `filter_desktop` MCP tool** — takes `space?`, `kind?`, `search?` (or `clear: true`). Switches space if asked, broadcasts a `desktop_filter_changed` SSE event. Mirrors the existing `switch_space` pattern.
- **Auto-broaden** — search with no explicit space defaults to `__all__` so *"show me invoices"* searches every space, not just the one the user happens to be in.
- **`.nullish()` on optional args** — agents that pass `null` for unfilled fields don't trip Zod validation.
- **Sharper kind/search guardrails in tool description** — `kind` is restricted to the seven enum values; everything else is `search`. Prevents *"show me all games"* getting mapped to `kind=app`.
- **Substring matcher (temporary)** — searches label OR space id/name OR source file basename; explicitly flagged with `// TEMPORARY: see #231` at both call sites. Will be deleted when #231 lands.
- **Web side** — `App.tsx` subscribes, holds an `agentFilter` state, applies it on top of the user's space-pill / kind-pill filters. `Desktop.tsx` renders a `.filter-notice--agent` pill with a ✦ glyph and ✕ to clear.

## Follow-ups (do not extend the matcher in this PR)

The naive matcher only reaches so far — *"invoices"* misses singular `Invoice-Jan.pdf`, *"games"* misses Zombie Horde because no metadata says "game". The right fix is **server-side search**, not more special cases on the matcher:

- **#231 — artifactSearchService.** Single chokepoint. SQLite FTS5 over label/group/space/path. Deterministic path tags from day one. **`desktop_filter_changed` event carries resolved artifact IDs**, not search terms — web becomes dumb and `applyAgentFilter` is deleted.
- **#232 — content extraction.** First ~16KB of HTML/MD/code bodies into the FTS index. Solves the invoice case (most invoice docs say "Invoice" / "Bill To:" in their body).
- **#233 — OpenCode-backed LLM tag generator.** Background queue mirroring icon-generator. Calls OpenCode `/session` (provider-agnostic) not raw OpenAI. Deterministic path-tag fallback when no LLM is wired. Solves the games case.
- **#234 — icon-generator off direct OpenAI.** Same OpenCode-gateway refactor; drops the second-key requirement.

## Test plan

- [x] Server: `tsc` clean
- [x] Web: `tsc -b && vite build` clean
- [x] MCP: `tools/list` includes `filter_desktop`
- [x] MCP: tool call broadcasts `desktop_filter_changed` SSE event with right payload (kind / search / clear / errored cases all verified)
- [x] MCP: `list_artifacts(search: "Quick")` still finds *Quick Start* (label match)
- [x] Manual (real userland): *"show me all invoices"* — auto-broadens to All view; pill renders. (Empty result for now — solved by #232.)
- [x] Manual (real userland): *"show me all games"* — agent picks `search="games"`, pill renders. (Empty for now — solved by #233.)
- [x] Manual: ✕ on the pill clears the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)