### PR TITLE
fix(hero): hide first-run tagline once chat has messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **First-run hero tagline no longer overlays the chat output.** Clicking the *Set up Oyster* prompt-pill (instead of typing into the input) used to send the message without focusing the chat, so the *"Welcome to your surface."* tagline stayed on screen and floated over the streaming reply. The tagline now hides as soon as any chat message exists.
+
 ## [0.4.0-beta.7] - 2026-04-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
-- **First-run hero tagline no longer overlays the chat output.** Clicking the *Set up Oyster* prompt-pill (instead of typing into the input) used to send the message without focusing the chat, so the *"Welcome to your surface."* tagline stayed on screen and floated over the streaming reply. The tagline now hides as soon as any chat message exists.
+- **First-run hero tagline no longer overlays the chat output.** Clicking the *Set up Oyster* prompt pill (instead of typing into the input) used to send the message without focusing the chat, so the *"Welcome to your surface."* tagline stayed on screen and floated over the streaming reply. The tagline now hides as soon as any chat message exists.
 
 ## [0.4.0-beta.7] - 2026-04-25
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-4-0-beta-7">0.4</a>
       <a class="version-pill" href="#v-0-3-8">0.3</a>
       <a class="version-pill" href="#v-0-2-4">0.2</a>
@@ -320,6 +321,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.7...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>First-run hero tagline no longer overlays the chat output.</strong> Clicking the <em>Set up Oyster</em> prompt pill (instead of typing into the input) used to send the message without focusing the chat, so the <em>&quot;Welcome to your surface.&quot;</em> tagline stayed on screen and floated over the streaming reply. The tagline now hides as soon as any chat message exists.</li>
+</ul>
 <h2 id="v-0-4-0-beta-7"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.6...v0.4.0-beta.7" rel="noopener noreferrer"><span class="release-version">0.4.0-beta.7</span></a><span class="release-date"> — 2026-04-25</span></h2>
 <h3>Changed</h3>
 <ul>

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -393,8 +393,13 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
       {/* Hidden when the input is focused OR once any chat message exists,
           so it doesn't reappear behind streamed output if the user clicks
           out of the input. */}
-      {isHero && (
-        <div className={`chatbar-hero-tagline${focused || messages.length > 0 ? " tagline-hidden" : ""}`}>
+      {isHero && (() => {
+        const taglineHidden = focused || messages.length > 0;
+        return (
+        <div
+          className={`chatbar-hero-tagline${taglineHidden ? " tagline-hidden" : ""}`}
+          aria-hidden={taglineHidden || undefined}
+        >
           {isFirstRun ? (
             <>
               <span className="tagline-bright">Welcome to your surface.</span>
@@ -405,6 +410,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
                   className="chatbar-hero-prompt"
                   onClick={() => handleSend("Set up Oyster")}
                   disabled={!sessionId || streaming}
+                  tabIndex={taglineHidden ? -1 : 0}
                   title="Click to send, or type it yourself"
                 >
                   Set up Oyster
@@ -423,7 +429,8 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
             </>
           )}
         </div>
-      )}
+        );
+      })()}
 
       {/* Messages panel — expands upward */}
       {messages.length > 0 && (

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -390,8 +390,11 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
   return (
     <div ref={wrapperRef} className={`chatbar-wrapper ${isHero ? "chatbar-hero" : ""}`}>
       {/* Hero tagline — one block, three states */}
+      {/* Hidden when the input is focused OR once any chat message exists,
+          so it doesn't reappear behind streamed output if the user clicks
+          out of the input. */}
       {isHero && (
-        <div className={`chatbar-hero-tagline${focused ? " tagline-hidden" : ""}`}>
+        <div className={`chatbar-hero-tagline${focused || messages.length > 0 ? " tagline-hidden" : ""}`}>
           {isFirstRun ? (
             <>
               <span className="tagline-bright">Welcome to your surface.</span>


### PR DESCRIPTION
## Summary

On a fresh install, clicking the *Set up Oyster* prompt-pill sends the message via \`handleSend\` without ever focusing the input. The tagline's fade-out trigger was just \`focused\`, so the *"Welcome to your surface."* / *"Set up Oyster"* block stayed visible and floated over the streaming reply (caught on a Windows smoke test on 0.4.0-beta.7 — see screenshot in the related conversation).

Fix: hide the tagline whenever \`focused || messages.length > 0\`. Once any chat message exists, the tagline is gone for the session, regardless of where focus is. The existing click-into-input behaviour is unchanged.

## Test plan

- [x] \`tsc -b && vite build\` clean
- [ ] Manual: fresh install (incognito or cleared localStorage). Click *Set up Oyster* pill — agent reply streams in, tagline fades out and stays out.
- [ ] Manual: fresh install. Click into the input (don't type) — tagline still fades out (existing behaviour unchanged).
- [ ] Manual: blur the input mid-streaming — tagline does not reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)