### PR TITLE
feat(sessions): DB schema for sessions arc (#250)

### DIFF
--- a/docs/plans/sessions-arc.md
+++ b/docs/plans/sessions-arc.md
@@ -43,14 +43,19 @@ raw          TEXT NULL            -- original JSONL line (or excerpt) for fideli
 
 **`session_artifacts`**
 ```
+id           INTEGER PRIMARY KEY
 session_id   TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE
 artifact_id  TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE
 role         TEXT NOT NULL        -- 'create' | 'modify' | 'read'
 when_at      TEXT NOT NULL DEFAULT (datetime('now'))
-PRIMARY KEY (session_id, artifact_id, role, when_at)
 ```
 
-The composite key allows the same session to read then later modify the same artefact, recorded as two rows.
+Surrogate `id` rather than a composite PK on `(session_id, artifact_id, role, when_at)` — `datetime('now')` is only second-precise, so two same-role touches in the same second would collide on a composite. Lookups go through two indexes:
+
+- `(session_id, when_at)` — "what did this session touch, in order"
+- `(artifact_id)` — "which sessions touched this artefact"
+
+The same session reading then later modifying the same artefact is just two rows with different `role` values.
 
 ## State machine
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -125,6 +125,56 @@ export function initDb(userlandDir: string): Database.Database {
     `);
   } catch { /* already exists */ }
 
+  // Sessions arc (0.5.0). Three tables that capture agent activity (claude-code,
+  // opencode, codex) read from external session logs. See
+  // docs/plans/sessions-arc.md for the design.
+  //
+  // - sessions.space_id is nullable + ON DELETE SET NULL: sessions whose CWD
+  //   doesn't match a registered space's source path land as orphans (no space
+  //   badge on Home), and deleting a space leaves its sessions intact rather
+  //   than cascading. Mirrors the artifacts.source_id pattern above.
+  // - session_events / session_artifacts cascade on session deletion so we
+  //   don't leak transcript rows when a session is reaped.
+  // - session_artifacts uses a composite PK including when_at so a session can
+  //   read then later modify the same artefact without colliding.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      id            TEXT PRIMARY KEY,
+      space_id      TEXT REFERENCES spaces(id) ON DELETE SET NULL,
+      agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
+      title         TEXT,
+      state         TEXT NOT NULL CHECK (state IN ('running','awaiting','disconnected','done')),
+      started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at      TEXT,
+      model         TEXT,
+      last_event_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);
+    CREATE INDEX IF NOT EXISTS sessions_state_last_event
+      ON sessions(state, last_event_at);
+
+    CREATE TABLE IF NOT EXISTS session_events (
+      id         INTEGER PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      role       TEXT NOT NULL CHECK (role IN ('user','assistant','tool','tool_result','system')),
+      text       TEXT NOT NULL,
+      ts         TEXT NOT NULL DEFAULT (datetime('now')),
+      raw        TEXT
+    );
+    CREATE INDEX IF NOT EXISTS session_events_session_ts
+      ON session_events(session_id, ts);
+
+    CREATE TABLE IF NOT EXISTS session_artifacts (
+      session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+      artifact_id TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+      role        TEXT NOT NULL CHECK (role IN ('create','modify','read')),
+      when_at     TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (session_id, artifact_id, role, when_at)
+    );
+    CREATE INDEX IF NOT EXISTS session_artifacts_artifact
+      ON session_artifacts(artifact_id);
+  `);
+
   // One-time seed: populate spaces from artifact space_ids only if the table is empty.
   // Using INSERT OR IGNORE on an existing table would resurrect deleted spaces on restart.
   const spaceCount = (db.prepare("SELECT COUNT(*) as n FROM spaces").get() as { n: number }).n;

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -135,8 +135,10 @@ export function initDb(userlandDir: string): Database.Database {
   //   than cascading. Mirrors the artifacts.source_id pattern above.
   // - session_events / session_artifacts cascade on session deletion so we
   //   don't leak transcript rows when a session is reaped.
-  // - session_artifacts uses a composite PK including when_at so a session can
-  //   read then later modify the same artefact without colliding.
+  // - session_artifacts uses a surrogate INTEGER id (not a composite key on
+  //   when_at) because datetime('now') is only second-precise — two same-role
+  //   touches in the same second would have collided. Lookups go through the
+  //   two indexes below.
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (
       id            TEXT PRIMARY KEY,
@@ -165,12 +167,14 @@ export function initDb(userlandDir: string): Database.Database {
       ON session_events(session_id, ts);
 
     CREATE TABLE IF NOT EXISTS session_artifacts (
+      id          INTEGER PRIMARY KEY,
       session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
       artifact_id TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
       role        TEXT NOT NULL CHECK (role IN ('create','modify','read')),
-      when_at     TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (session_id, artifact_id, role, when_at)
+      when_at     TEXT NOT NULL DEFAULT (datetime('now'))
     );
+    CREATE INDEX IF NOT EXISTS session_artifacts_session
+      ON session_artifacts(session_id, when_at);
     CREATE INDEX IF NOT EXISTS session_artifacts_artifact
       ON session_artifacts(artifact_id);
   `);


### PR DESCRIPTION
Closes #250 — Sprint 1 of 8 in the [0.5.0 sessions arc](https://github.com/mattslight/oyster/blob/main/docs/plans/sessions-arc.md).

## Summary

Three new SQLite tables for the agent-session model: `sessions`, `session_events`, `session_artifacts`. Schema only — no callers, no behaviour change. Sets up the storage shape for the watcher (#251) and the new Home feed (#252+).

## Shape

Follows the existing `server/src/db.ts` migration pattern: embedded `db.exec()` of `CREATE TABLE IF NOT EXISTS`, idempotent on rerun.

```sql
sessions (id, space_id, agent, title, state, started_at, ended_at,
          model, last_event_at)
session_events (id, session_id, role, text, ts, raw)
session_artifacts (session_id, artifact_id, role, when_at) -- composite PK
```

Key choices (per design doc):

- **`sessions.space_id` is nullable + `ON DELETE SET NULL`.** Sessions whose CWD doesn't match a registered space's source path land as orphans on Home with no space badge. Mirrors the `artifacts.source_id` pattern.
- **Cascade on session deletion.** `session_events` and `session_artifacts` both `ON DELETE CASCADE` so a reaped session doesn't leave transcript rows or M:N stubs behind.
- **Composite PK on `session_artifacts` includes `when_at`.** A session that reads then later modifies the same artefact records two rows, not a collision.
- **All timestamps `TEXT NOT NULL DEFAULT (datetime('now'))`.** Same convention as the rest of the schema (consistency over numeric-comparison speed).
- **CHECK constraints on enums** (`agent`, `state`, `role`) — fail-loud when the watcher writes an unexpected value.

## Indexes

Targeted at the access patterns from the design doc:

| Index | Use |
|---|---|
| `sessions(space_id)` | "show me sessions for tokinvest" |
| `sessions(state, last_event_at)` | heartbeat sweep — find running sessions older than 30s |
| `session_events(session_id, ts)` | transcript replay |
| `session_artifacts(artifact_id)` | reverse lookup — "which sessions touched this artefact" |

## Verification

Ran `initDb` twice on a fresh DB and confirmed:

- All three tables created
- Idempotent — second run errors nothing
- TypeScript clean (`tsc --noEmit`)
- FK enforcement live — inserting a session with a bad `space_id` rejects
- Orphan sessions (`space_id = NULL`) accepted
- All CHECK constraints fire on bad enum values

## Test plan

- [x] `tsc --noEmit` clean
- [x] Schema applies idempotently on rerun
- [x] FK + nullable behaviour verified manually
- [ ] Existing prod DB unaffected (additive migration only — no ALTER on existing tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)