### PR TITLE
feat(sessions): claude-code JSONL watcher (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Oyster sees your claude-code sessions.** When you run `claude` in any folder mapped to a space, Oyster now picks the session up automatically — no setup, no MCP wiring. The session shows as *running* / *disconnected* on the home feed (UI lands in the next sprint), with title pulled from your first prompt and tracked file reads/edits attributed back to their tiles. Sessions started in unregistered folders land as orphans rather than being dropped. ([#251](https://github.com/mattslight/oyster/issues/251))
+
 ## [0.4.0] - 2026-04-28
 
 The 0.4.0 line is now stable. Code is identical to `0.4.0-beta.8`. Headline changes from the beta cycle:

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-4-0">0.4</a>
       <a class="version-pill" href="#v-0-3-8">0.3</a>
       <a class="version-pill" href="#v-0-2-4">0.2</a>
@@ -320,6 +321,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Oyster sees your claude-code sessions.</strong> When you run <code>claude</code> in any folder mapped to a space, Oyster now picks the session up automatically — no setup, no MCP wiring. The session shows as <em>running</em> / <em>disconnected</em> on the home feed (UI lands in the next sprint), with title pulled from your first prompt and tracked file reads/edits attributed back to their tiles. Sessions started in unregistered folders land as orphans rather than being dropped. (<a href="https://github.com/mattslight/oyster/issues/251" rel="noopener noreferrer">#251</a>)</li>
+</ul>
 <h2 id="v-0-4-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0-beta.8...v0.4.0" rel="noopener noreferrer"><span class="release-version">0.4.0</span></a><span class="release-date"> — 2026-04-28</span></h2>
 <p>The 0.4.0 line is now stable. Code is identical to <code>0.4.0-beta.8</code>. Headline changes from the beta cycle:</p>
 <ul>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "@lydell/node-pty": "^1.2.0-beta.12",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
+        "chokidar": "^5.0.0",
         "marked": "^18.0.2",
         "opencode-ai": "^1.14.25",
         "ws": "^8.20.0"
@@ -856,6 +857,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chownr": {
@@ -2026,6 +2042,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-from-string": {

--- a/server/package.json
+++ b/server/package.json
@@ -10,10 +10,11 @@
   },
   "dependencies": {
     "@fal-ai/client": "^1.10.0",
+    "@lydell/node-pty": "^1.2.0-beta.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
+    "chokidar": "^5.0.0",
     "marked": "^18.0.2",
-    "@lydell/node-pty": "^1.2.0-beta.12",
     "opencode-ai": "^1.14.25",
     "ws": "^8.20.0"
   },

--- a/server/scripts/smoke-claude-code-watcher.ts
+++ b/server/scripts/smoke-claude-code-watcher.ts
@@ -194,6 +194,48 @@ async function run() {
   assert.equal(orphan.space_id, null, "orphan session should have null space_id");
   console.log("[smoke] phase 4 ok — orphan session has null space_id");
 
+  // ── Phase 5: caveat-prefixed user message is skipped for title ──
+  const caveatProjectDir = join(projectsRoot, "-Users-Test-caveat");
+  mkdirSync(caveatProjectDir, { recursive: true });
+  const caveatId = "00000000-aaaa-bbbb-cccc-333333333333";
+  const caveatPath = join(caveatProjectDir, `${caveatId}.jsonl`);
+  writeFileSync(caveatPath, [
+    JSON.stringify({
+      type: "user",
+      sessionId: caveatId,
+      cwd: fakeCwd,
+      timestamp: "2026-04-28T12:02:00.000Z",
+      message: { role: "user", content: "<local-command-caveat>Caveat text</local-command-caveat>" },
+    }),
+    JSON.stringify({
+      type: "user",
+      sessionId: caveatId,
+      cwd: fakeCwd,
+      timestamp: "2026-04-28T12:02:01.000Z",
+      message: { role: "user", content: "the real prompt" },
+    }),
+  ].join("\n") + "\n");
+  await sleep(800);
+
+  const caveatSession = sessionStore.getById(caveatId);
+  assert(caveatSession, "caveat session should be inserted");
+  assert.equal(caveatSession.title, "the real prompt", "caveat title should be skipped");
+  console.log("[smoke] phase 5 ok — local-command-caveat user message skipped for title");
+
+  // ── Phase 6: ISO-8601 timestamps everywhere — no naive YYYY-MM-DD HH:MM:SS ──
+  const allSessions = sessionStore.getAll();
+  for (const s of allSessions) {
+    assert(
+      /T.*Z$/.test(s.started_at),
+      `started_at must be ISO-8601 with Z, got: ${s.started_at} (id=${s.id})`,
+    );
+    assert(
+      /T.*Z$/.test(s.last_event_at),
+      `last_event_at must be ISO-8601 with Z, got: ${s.last_event_at} (id=${s.id})`,
+    );
+  }
+  console.log("[smoke] phase 6 ok — all timestamps are ISO-8601");
+
   // ── Cleanup ──
   await watcher.stop();
   db.close();

--- a/server/scripts/smoke-claude-code-watcher.ts
+++ b/server/scripts/smoke-claude-code-watcher.ts
@@ -1,0 +1,208 @@
+// Smoke test for Sprint 2 (#251) — claude-code JSONL watcher.
+// Runs the real watcher against a synthetic ~/.claude/projects layout,
+// asserts session rows / events / artifact touches land correctly.
+// Run: npx tsx scripts/smoke-claude-code-watcher.ts
+//
+// This is an ad-hoc smoke script (no test framework in the server package).
+// It will be replaced by proper unit tests in a follow-up.
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { SqliteSpaceStore } from "../src/space-store.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { ClaudeCodeWatcher } from "../src/watchers/claude-code.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function run() {
+  // Isolated workspace
+  const root = mkdtempSync(join(tmpdir(), "oyster-watcher-smoke-"));
+  console.log("[smoke] root:", root);
+
+  // The watcher uses better-sqlite3 directly. initDb expects a userland dir
+  // and writes oyster.db inside it.
+  const dbDir = join(root, "db");
+  mkdirSync(dbDir, { recursive: true });
+  const db = initDb(dbDir);
+
+  const spaceStore = new SqliteSpaceStore(db);
+  const artifactStore = new SqliteArtifactStore(db);
+  const sessionStore = new SqliteSessionStore(db);
+
+  // Seed a space + source so cwd → space resolution has something to match.
+  const fakeCwd = join(root, "fake-project");
+  mkdirSync(fakeCwd, { recursive: true });
+  spaceStore.insert({
+    id: "test-space",
+    display_name: "Test Space",
+    color: null,
+    parent_id: null,
+    scan_status: "none",
+    scan_error: null,
+    last_scanned_at: null,
+    last_scan_summary: null,
+    ai_job_status: null,
+    ai_job_error: null,
+    summary_title: null,
+    summary_content: null,
+  });
+  spaceStore.addSource({
+    id: "src-1",
+    space_id: "test-space",
+    type: "local_folder",
+    path: fakeCwd,
+    label: null,
+  });
+
+  // Seed an artifact so artifact-touch logic finds a match.
+  const trackedFile = join(fakeCwd, "README.md");
+  writeFileSync(trackedFile, "# hi\n");
+  artifactStore.insert({
+    id: "art-1",
+    owner_id: null,
+    space_id: "test-space",
+    label: "README",
+    artifact_kind: "notes",
+    storage_kind: "filesystem",
+    storage_config: JSON.stringify({ path: trackedFile }),
+    runtime_kind: "static",
+    runtime_config: "{}",
+    group_name: null,
+    source_origin: "discovered",
+    source_ref: null,
+    source_id: null,
+  });
+
+  // ── Start the watcher pointed at our synthetic projects root ──
+  const projectsRoot = join(root, "projects");
+  mkdirSync(projectsRoot, { recursive: true });
+
+  const sessionEvents: string[] = [];
+  const watcher = new ClaudeCodeWatcher({
+    sessionStore,
+    spaceStore,
+    artifactStore,
+    projectsRoot,
+    emitSessionChanged: (id) => sessionEvents.push(id),
+  });
+  await watcher.start();
+  console.log("[smoke] watcher started");
+
+  // ── Phase 1: brand-new session file appears, with one user event ──
+  const projectDir = join(projectsRoot, "-Users-Test-fake-project");
+  mkdirSync(projectDir, { recursive: true });
+  const sessionId = "00000000-aaaa-bbbb-cccc-111111111111";
+  const jsonlPath = join(projectDir, `${sessionId}.jsonl`);
+
+  const userEvent = {
+    type: "user",
+    sessionId,
+    cwd: fakeCwd,
+    timestamp: "2026-04-28T12:00:00.000Z",
+    message: { role: "user", content: "fix the README typo" },
+  };
+  writeFileSync(jsonlPath, JSON.stringify(userEvent) + "\n");
+
+  // chokidar's `add` typically fires within 100–300ms of the syscall.
+  await sleep(800);
+
+  let session = sessionStore.getById(sessionId);
+  assert(session, "session row should exist after first event");
+  assert.equal(session.id, sessionId);
+  assert.equal(session.space_id, "test-space", "cwd should resolve to test-space");
+  assert.equal(session.agent, "claude-code");
+  assert.equal(session.title, "fix the README typo");
+  assert.equal(session.state, "running");
+  console.log("[smoke] phase 1 ok — session row created with title + space");
+
+  // ── Phase 2: assistant turn with text + tool_use(Read) on tracked file ──
+  const assistantEvent = {
+    type: "assistant",
+    sessionId,
+    cwd: fakeCwd,
+    timestamp: "2026-04-28T12:00:05.000Z",
+    message: {
+      role: "assistant",
+      model: "claude-opus-4-7",
+      content: [
+        { type: "text", text: "Let me read the README." },
+        { type: "tool_use", id: "tu1", name: "Read", input: { file_path: trackedFile } },
+      ],
+    },
+  };
+  appendFileSync(jsonlPath, JSON.stringify(assistantEvent) + "\n");
+  await sleep(500);
+
+  const events = sessionStore.getEventsBySession(sessionId);
+  assert(events.length >= 2, `expected ≥2 events, got ${events.length}`);
+  const userRow = events.find((e) => e.role === "user");
+  const assistantRow = events.find((e) => e.role === "assistant");
+  assert(userRow && /fix the README/.test(userRow.text));
+  assert(assistantRow && /Let me read/.test(assistantRow.text));
+
+  const touches = sessionStore.getArtifactsBySession(sessionId);
+  assert.equal(touches.length, 1, "expected one artifact touch");
+  assert.equal(touches[0].artifact_id, "art-1");
+  assert.equal(touches[0].role, "read");
+
+  session = sessionStore.getById(sessionId);
+  assert.equal(session?.model, "claude-opus-4-7", "model should be backfilled from assistant event");
+  console.log("[smoke] phase 2 ok — assistant text + Read tool tracked artifact touch");
+
+  // ── Phase 3: tool_result wrapped in user-typed event maps to tool_result ──
+  const toolResultEvent = {
+    type: "user",
+    sessionId,
+    cwd: fakeCwd,
+    timestamp: "2026-04-28T12:00:06.000Z",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tu1", content: "# hi" }],
+    },
+  };
+  appendFileSync(jsonlPath, JSON.stringify(toolResultEvent) + "\n");
+  await sleep(500);
+
+  const allEvents = sessionStore.getEventsBySession(sessionId);
+  const toolResult = allEvents.find((e) => e.role === "tool_result");
+  assert(toolResult, "tool_result event should be inserted");
+  assert(/# hi/.test(toolResult.text));
+  console.log("[smoke] phase 3 ok — tool_result event tagged with tool_result role");
+
+  // ── Phase 4: orphan session (no matching source) lands with space_id=null ──
+  const orphanCwd = "/tmp/some-unregistered-place";
+  const orphanProjectDir = join(projectsRoot, "-tmp-some-unregistered-place");
+  mkdirSync(orphanProjectDir, { recursive: true });
+  const orphanId = "00000000-aaaa-bbbb-cccc-222222222222";
+  const orphanPath = join(orphanProjectDir, `${orphanId}.jsonl`);
+  writeFileSync(orphanPath, JSON.stringify({
+    type: "user",
+    sessionId: orphanId,
+    cwd: orphanCwd,
+    timestamp: "2026-04-28T12:01:00.000Z",
+    message: { role: "user", content: "hello from nowhere" },
+  }) + "\n");
+  await sleep(800);
+
+  const orphan = sessionStore.getById(orphanId);
+  assert(orphan, "orphan session should still be inserted");
+  assert.equal(orphan.space_id, null, "orphan session should have null space_id");
+  console.log("[smoke] phase 4 ok — orphan session has null space_id");
+
+  // ── Cleanup ──
+  await watcher.stop();
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+
+  console.log("\n[smoke] ALL PHASES PASSED ✓");
+}
+
+run().catch((err) => {
+  console.error("[smoke] FAILED:", err);
+  process.exit(1);
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,8 @@ import {
 } from "./process-manager.js";
 import { initDb } from "./db.js";
 import { SqliteArtifactStore } from "./artifact-store.js";
+import { SqliteSessionStore } from "./session-store.js";
+import { ClaudeCodeWatcher } from "./watchers/claude-code.js";
 import { ArtifactService } from "./artifact-service.js";
 import { SqliteSpaceStore } from "./space-store.js";
 import { SpaceService } from "./space-service.js";
@@ -295,6 +297,7 @@ delete cleanEnv["OPENAI_API_KEY"];
 const db = initDb(DB_DIR);
 const store = new SqliteArtifactStore(db);
 const spaceStore = new SqliteSpaceStore(db);
+const sessionStore = new SqliteSessionStore(db);
 // artifactService reads the dedicated icons dir at `<root>/icons/<id>/icon.png`
 // — that lives at OYSTER_HOME root (URL-addressable via /artifacts/icons/...),
 // not inside DB_DIR. spaceStore is passed in so rowToArtifact can resolve the
@@ -524,6 +527,15 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         }); } catch { return []; }
       })(),
     }));
+    return;
+  }
+
+  // GET /api/sessions — agent sessions captured by the watchers (#251).
+  // Read-only for 0.5.0; the home feed renders these. Local-origin only —
+  // session titles are derived from user prompts, which are private.
+  if (url === "/api/sessions" && req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return;
+    sendJson(sessionStore.getAll());
     return;
   }
 
@@ -1395,6 +1407,20 @@ httpServer.listen(port, () => {
 
   // Spawn OpenCode AFTER server is listening so MCP connection succeeds
   spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);
+
+  // Sessions arc — start the claude-code log watcher (#251). Failures
+  // (missing ~/.claude/projects, permission denied) shouldn't block the
+  // server; the watcher logs and stays dormant.
+  const claudeCodeWatcher = new ClaudeCodeWatcher({
+    sessionStore,
+    spaceStore,
+    artifactStore: store,
+    emitSessionChanged: (id) =>
+      broadcastUiEvent({ version: 1, command: "session_changed", payload: { id } }),
+  });
+  claudeCodeWatcher.start().catch((err) => {
+    console.warn(`[claude-code-watcher] start failed: ${err instanceof Error ? err.message : err}`);
+  });
 
   // Reap any orphaned opencode-ai processes from a prior Oyster run that
   // didn't shut down cleanly (SIGKILL, crash, laptop sleep). See #191.

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -1,0 +1,263 @@
+import type Database from "better-sqlite3";
+
+// Sessions arc (0.5.0). See docs/plans/sessions-arc.md.
+//
+// Three tables, three row types. The store is pure DB — the watcher / SSE
+// layers wrap calls in their own logic. Writes go through prepared statements
+// so the high-volume session_events insert path stays cheap.
+
+// ── Row types (mirror SQLite schema in db.ts) ──
+
+export type SessionState = "running" | "awaiting" | "disconnected" | "done";
+export type SessionAgent = "claude-code" | "opencode" | "codex";
+export type SessionEventRole =
+  | "user"
+  | "assistant"
+  | "tool"
+  | "tool_result"
+  | "system";
+export type SessionArtifactRole = "create" | "modify" | "read";
+
+export interface SessionRow {
+  id: string;
+  space_id: string | null;
+  agent: SessionAgent;
+  title: string | null;
+  state: SessionState;
+  started_at: string;
+  ended_at: string | null;
+  model: string | null;
+  last_event_at: string;
+}
+
+export interface SessionEventRow {
+  id: number;
+  session_id: string;
+  role: SessionEventRole;
+  text: string;
+  ts: string;
+  raw: string | null;
+}
+
+export interface SessionArtifactRow {
+  id: number;
+  session_id: string;
+  artifact_id: string;
+  role: SessionArtifactRole;
+  when_at: string;
+}
+
+// ── Insert shapes (let SQLite supply timestamps + auto-id) ──
+
+export interface InsertSession {
+  id: string;
+  space_id: string | null;
+  agent: SessionAgent;
+  title?: string | null;
+  state: SessionState;
+  started_at?: string;
+  model?: string | null;
+  last_event_at?: string;
+}
+
+export interface InsertSessionEvent {
+  session_id: string;
+  role: SessionEventRole;
+  text: string;
+  ts?: string;
+  raw?: string | null;
+}
+
+export interface InsertSessionArtifact {
+  session_id: string;
+  artifact_id: string;
+  role: SessionArtifactRole;
+}
+
+// ── Store interface ──
+
+export interface SessionStore {
+  // sessions
+  getAll(): SessionRow[];
+  getById(id: string): SessionRow | undefined;
+  insertSession(row: InsertSession): void;
+  upsertSession(row: InsertSession): void;
+  updateSessionState(id: string, state: SessionState, lastEventAt: string): void;
+  updateSession(id: string, fields: Partial<Omit<SessionRow, "id" | "started_at">>): void;
+  // session_events — bulk-friendly
+  insertEvent(row: InsertSessionEvent): number;
+  insertEvents(rows: InsertSessionEvent[]): void;
+  getEventsBySession(sessionId: string, opts?: { limit?: number }): SessionEventRow[];
+  // session_artifacts
+  insertArtifactTouch(row: InsertSessionArtifact): void;
+  getArtifactsBySession(sessionId: string): SessionArtifactRow[];
+  getSessionsByArtifact(artifactId: string): SessionArtifactRow[];
+}
+
+// ── SQLite implementation ──
+
+export class SqliteSessionStore implements SessionStore {
+  private stmts: {
+    getAll: Database.Statement;
+    getById: Database.Statement;
+    insertSession: Database.Statement;
+    upsertSession: Database.Statement;
+    updateSessionState: Database.Statement;
+    insertEvent: Database.Statement;
+    getEventsBySession: Database.Statement;
+    getEventsBySessionLimit: Database.Statement;
+    insertArtifactTouch: Database.Statement;
+    getArtifactsBySession: Database.Statement;
+    getSessionsByArtifact: Database.Statement;
+  };
+
+  private insertEventsTxn: (rows: InsertSessionEvent[]) => void;
+
+  constructor(private db: Database.Database) {
+    this.stmts = {
+      getAll: db.prepare("SELECT * FROM sessions ORDER BY last_event_at DESC"),
+      getById: db.prepare("SELECT * FROM sessions WHERE id = ?"),
+      insertSession: db.prepare(`
+        INSERT INTO sessions (id, space_id, agent, title, state, started_at, model, last_event_at)
+        VALUES (
+          @id, @space_id, @agent, @title, @state,
+          COALESCE(@started_at, datetime('now')),
+          @model,
+          COALESCE(@last_event_at, datetime('now'))
+        )
+      `),
+      // Idempotent boot scan needs upsert: re-seeing a session file should
+      // refresh metadata (state / last_event_at / title once derived) without
+      // duplicating the row. ON CONFLICT preserves started_at (the original
+      // birth) and only ratchets last_event_at forward.
+      upsertSession: db.prepare(`
+        INSERT INTO sessions (id, space_id, agent, title, state, started_at, model, last_event_at)
+        VALUES (
+          @id, @space_id, @agent, @title, @state,
+          COALESCE(@started_at, datetime('now')),
+          @model,
+          COALESCE(@last_event_at, datetime('now'))
+        )
+        ON CONFLICT(id) DO UPDATE SET
+          space_id      = COALESCE(excluded.space_id, sessions.space_id),
+          title         = COALESCE(excluded.title, sessions.title),
+          state         = excluded.state,
+          model         = COALESCE(excluded.model, sessions.model),
+          last_event_at = MAX(excluded.last_event_at, sessions.last_event_at)
+      `),
+      updateSessionState: db.prepare(
+        "UPDATE sessions SET state = ?, last_event_at = ? WHERE id = ?"
+      ),
+      insertEvent: db.prepare(`
+        INSERT INTO session_events (session_id, role, text, ts, raw)
+        VALUES (@session_id, @role, @text, COALESCE(@ts, datetime('now')), @raw)
+      `),
+      getEventsBySession: db.prepare(
+        "SELECT * FROM session_events WHERE session_id = ? ORDER BY id"
+      ),
+      getEventsBySessionLimit: db.prepare(
+        "SELECT * FROM session_events WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+      ),
+      insertArtifactTouch: db.prepare(`
+        INSERT INTO session_artifacts (session_id, artifact_id, role)
+        VALUES (@session_id, @artifact_id, @role)
+      `),
+      getArtifactsBySession: db.prepare(
+        "SELECT * FROM session_artifacts WHERE session_id = ? ORDER BY when_at"
+      ),
+      getSessionsByArtifact: db.prepare(
+        "SELECT * FROM session_artifacts WHERE artifact_id = ? ORDER BY when_at DESC"
+      ),
+    };
+
+    // Bulk insert helper. Wrap N inserts in a single transaction so a JSONL
+    // backfill (hundreds of lines) commits in O(1) fsyncs instead of O(N).
+    const insertOne = this.stmts.insertEvent;
+    this.insertEventsTxn = db.transaction((rows: InsertSessionEvent[]) => {
+      for (const r of rows) {
+        insertOne.run({ ts: null, raw: null, ...r });
+      }
+    });
+  }
+
+  getAll(): SessionRow[] {
+    return this.stmts.getAll.all() as SessionRow[];
+  }
+
+  getById(id: string): SessionRow | undefined {
+    return this.stmts.getById.get(id) as SessionRow | undefined;
+  }
+
+  insertSession(row: InsertSession): void {
+    this.stmts.insertSession.run({
+      title: null,
+      started_at: null,
+      model: null,
+      last_event_at: null,
+      ...row,
+    });
+  }
+
+  upsertSession(row: InsertSession): void {
+    this.stmts.upsertSession.run({
+      title: null,
+      started_at: null,
+      model: null,
+      last_event_at: null,
+      ...row,
+    });
+  }
+
+  updateSessionState(id: string, state: SessionState, lastEventAt: string): void {
+    this.stmts.updateSessionState.run(state, lastEventAt, id);
+  }
+
+  private static readonly UPDATABLE_SESSION_COLUMNS = new Set([
+    "space_id", "title", "state", "ended_at", "model", "last_event_at",
+  ]);
+
+  updateSession(
+    id: string,
+    fields: Partial<Omit<SessionRow, "id" | "started_at">>,
+  ): void {
+    const sets: string[] = [];
+    const values: Record<string, unknown> = { id };
+    for (const [key, value] of Object.entries(fields)) {
+      if (!SqliteSessionStore.UPDATABLE_SESSION_COLUMNS.has(key)) continue;
+      sets.push(`${key} = @${key}`);
+      values[key] = value;
+    }
+    if (sets.length === 0) return;
+    this.db.prepare(`UPDATE sessions SET ${sets.join(", ")} WHERE id = @id`).run(values);
+  }
+
+  insertEvent(row: InsertSessionEvent): number {
+    const info = this.stmts.insertEvent.run({ ts: null, raw: null, ...row });
+    return Number(info.lastInsertRowid);
+  }
+
+  insertEvents(rows: InsertSessionEvent[]): void {
+    if (rows.length === 0) return;
+    this.insertEventsTxn(rows);
+  }
+
+  getEventsBySession(sessionId: string, opts?: { limit?: number }): SessionEventRow[] {
+    if (opts?.limit !== undefined) {
+      const rows = this.stmts.getEventsBySessionLimit.all(sessionId, opts.limit) as SessionEventRow[];
+      return rows.reverse();
+    }
+    return this.stmts.getEventsBySession.all(sessionId) as SessionEventRow[];
+  }
+
+  insertArtifactTouch(row: InsertSessionArtifact): void {
+    this.stmts.insertArtifactTouch.run(row);
+  }
+
+  getArtifactsBySession(sessionId: string): SessionArtifactRow[] {
+    return this.stmts.getArtifactsBySession.all(sessionId) as SessionArtifactRow[];
+  }
+
+  getSessionsByArtifact(artifactId: string): SessionArtifactRow[] {
+    return this.stmts.getSessionsByArtifact.all(artifactId) as SessionArtifactRow[];
+  }
+}

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -127,9 +127,11 @@ export class SqliteSessionStore implements SessionStore {
         )
       `),
       // Idempotent boot scan needs upsert: re-seeing a session file should
-      // refresh metadata (state / last_event_at / title once derived) without
-      // duplicating the row. ON CONFLICT preserves started_at (the original
-      // birth) and only ratchets last_event_at forward.
+      // refresh metadata without duplicating the row. The watcher is the
+      // authoritative source for title/model/space_id — when it re-derives
+      // them (with, e.g., better filters than a previous version), the new
+      // value should overwrite. started_at is the one column we preserve,
+      // since the session only starts once. last_event_at ratchets forward.
       upsertSession: db.prepare(`
         INSERT INTO sessions (id, space_id, agent, title, state, started_at, model, last_event_at)
         VALUES (
@@ -139,10 +141,11 @@ export class SqliteSessionStore implements SessionStore {
           COALESCE(@last_event_at, datetime('now'))
         )
         ON CONFLICT(id) DO UPDATE SET
-          space_id      = COALESCE(excluded.space_id, sessions.space_id),
-          title         = COALESCE(excluded.title, sessions.title),
+          space_id      = excluded.space_id,
+          title         = excluded.title,
           state         = excluded.state,
-          model         = COALESCE(excluded.model, sessions.model),
+          model         = excluded.model,
+          started_at    = excluded.started_at,
           last_event_at = MAX(excluded.last_event_at, sessions.last_event_at)
       `),
       updateSessionState: db.prepare(

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -492,12 +492,11 @@ export function userMessageTitleCandidate(ev: Record<string, any>): string | nul
   if (typeof content !== "string") return null;
   const trimmed = content.trim();
   if (!trimmed) return null;
-  if (
-    trimmed.startsWith("<local-command-caveat>") ||
-    trimmed.startsWith("<command-name>") ||
-    trimmed.startsWith("<command-message>") ||
-    trimmed.startsWith("<command-stdout>")
-  ) {
+  // Slash-command machinery shows up under several tag prefixes — current
+  // ones are <local-command-caveat>, <local-command-stdout>, and the older
+  // <command-name>/<command-message>. Catch the family with a single check
+  // so future variants don't slip through.
+  if (trimmed.startsWith("<local-command-") || trimmed.startsWith("<command-")) {
     return null;
   }
   return trimmed;

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -89,7 +89,7 @@ export class ClaudeCodeWatcher {
 
     await this.bootScan();
 
-    this.watcher = chokidar.watch(this.root, {
+    const watcher = chokidar.watch(this.root, {
       persistent: true,
       ignoreInitial: true, // bootScan handled existing files
       depth: 2, // projects/<encoded-cwd>/<file>.jsonl
@@ -103,10 +103,18 @@ export class ClaudeCodeWatcher {
         return base.includes(".") && !base.endsWith(".jsonl");
       },
     });
+    this.watcher = watcher;
 
-    this.watcher.on("add", (path) => this.onFileAppeared(path).catch(this.logError));
-    this.watcher.on("change", (path) => this.onFileChanged(path).catch(this.logError));
-    this.watcher.on("error", (err) => this.logError(err));
+    watcher.on("add", (path) => this.onFileAppeared(path).catch(this.logError));
+    watcher.on("change", (path) => this.onFileChanged(path).catch(this.logError));
+    watcher.on("error", (err) => this.logError(err));
+
+    // Don't return until chokidar has finished its initial scan. Otherwise
+    // a caller that creates a session file immediately after start() can
+    // race the watcher's setup and miss the resulting `add` event.
+    await new Promise<void>((resolve) => {
+      watcher.once("ready", () => resolve());
+    });
 
     this.heartbeat = setInterval(() => this.heartbeatSweep(), HEARTBEAT_INTERVAL_MS);
   }
@@ -178,13 +186,20 @@ export class ClaudeCodeWatcher {
     const ageMs = this.now().getTime() - stat.mtime.getTime();
     const state: SessionState = ageMs > DISCONNECT_THRESHOLD_MS ? "disconnected" : "running";
 
+    // Always pass ISO-8601 timestamps. If the JSONL didn't have a usable
+    // event timestamp in the first 32KB, fall back to the file's birth time
+    // (or mtime as a last resort) — both are better proxies for "session
+    // started" than the boot-scan moment, and they keep the column shape
+    // consistent (`YYYY-MM-DDTHH:MM:SS.mmmZ`).
+    const startedAt = meta.startedAt ?? (stat.birthtime ?? stat.mtime).toISOString();
+
     this.deps.sessionStore.upsertSession({
       id: meta.sessionId,
       space_id: this.resolveSpaceId(meta.cwd),
       agent: "claude-code",
       title: meta.title,
       state,
-      started_at: meta.startedAt ?? undefined,
+      started_at: startedAt,
       model: meta.model,
       last_event_at: stat.mtime.toISOString(),
     });
@@ -247,8 +262,9 @@ export class ClaudeCodeWatcher {
       if (model === null && ev.type === "assistant" && ev.message?.model) {
         model = String(ev.message.model);
       }
-      if (title === null && ev.type === "user" && typeof ev.message?.content === "string") {
-        title = ev.message.content.trim().slice(0, TITLE_MAX) || null;
+      if (title === null) {
+        const candidate = userMessageTitleCandidate(ev);
+        if (candidate) title = candidate.slice(0, TITLE_MAX);
       }
       if (cwd && startedAt && model && title) break;
     }
@@ -324,25 +340,36 @@ export class ClaudeCodeWatcher {
     const events: InsertSessionEvent[] = [];
     let latestTimestamp: string | null = null;
     let sessionEnsured = false;
+    let titleChanged = false;
 
     for (const line of lines) {
       if (!line) continue;
       const ev = safeParse(line);
       if (!ev) continue;
 
-      // First event from a brand-new file: derive session metadata and
-      // upsert the row before any events are inserted (FK constraint).
-      if (!sessionEnsured && tracker.sessionId) {
+      if (tracker.sessionId) {
+        // Metadata refresh — every event can contribute. cwd/startedAt/model
+        // are usually set on the first event, but title often isn't (the
+        // first user-typed event may be a slash-command caveat we skip).
         if (!tracker.cwd && typeof ev.cwd === "string") tracker.cwd = ev.cwd;
         if (!tracker.startedAt && typeof ev.timestamp === "string") {
           tracker.startedAt = ev.timestamp;
         }
-        if (!tracker.title && ev.type === "user" && typeof ev.message?.content === "string") {
-          tracker.title = ev.message.content.trim().slice(0, TITLE_MAX) || null;
+        if (!tracker.title) {
+          const candidate = userMessageTitleCandidate(ev);
+          if (candidate) {
+            tracker.title = candidate.slice(0, TITLE_MAX);
+            if (sessionEnsured) titleChanged = true;
+          }
         }
         if (!tracker.model && ev.type === "assistant" && ev.message?.model) {
           tracker.model = String(ev.message.model);
         }
+      }
+
+      // First event from a brand-new file: upsert the row before any events
+      // are inserted (FK constraint).
+      if (!sessionEnsured && tracker.sessionId) {
         this.deps.sessionStore.upsertSession({
           id: tracker.sessionId,
           space_id: this.resolveSpaceId(tracker.cwd),
@@ -397,9 +424,19 @@ export class ClaudeCodeWatcher {
     if (tracker.sessionId) {
       // Bump the session's last_event_at + state to running. If the session
       // was previously 'disconnected' (heartbeat fired during a quiet turn),
-      // this brings it back to 'running'.
+      // this brings it back to 'running'. If a title we couldn't derive on
+      // the first pass (e.g. opening event was a caveat) is now available,
+      // patch it through here in the same write.
       const ts = latestTimestamp ?? this.now().toISOString();
-      this.deps.sessionStore.updateSessionState(tracker.sessionId, "running", ts);
+      if (titleChanged) {
+        this.deps.sessionStore.updateSession(tracker.sessionId, {
+          state: "running",
+          last_event_at: ts,
+          title: tracker.title,
+        });
+      } else {
+        this.deps.sessionStore.updateSessionState(tracker.sessionId, "running", ts);
+      }
       this.deps.emitSessionChanged?.(tracker.sessionId);
     }
   }
@@ -443,6 +480,28 @@ export class ClaudeCodeWatcher {
 }
 
 // ── Pure helpers (exported for tests) ─────────────────────────────────────
+
+// Pull a usable title out of a `type:"user"` event's content, or return null.
+// claude-code wraps slash-command machinery (/compact, /clear, etc.) in
+// pseudo-user messages prefixed with <local-command-caveat>, <command-name>,
+// or <command-message>. Those are noise — keep scanning until we find a
+// real prompt the user actually typed.
+export function userMessageTitleCandidate(ev: Record<string, any>): string | null {
+  if (ev?.type !== "user") return null;
+  const content = ev.message?.content;
+  if (typeof content !== "string") return null;
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  if (
+    trimmed.startsWith("<local-command-caveat>") ||
+    trimmed.startsWith("<command-name>") ||
+    trimmed.startsWith("<command-message>") ||
+    trimmed.startsWith("<command-stdout>")
+  ) {
+    return null;
+  }
+  return trimmed;
+}
 
 export function filenameToSessionId(filePath: string): string {
   // Filename is `<uuid>.jsonl`. The UUID is the session id.

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -1,0 +1,551 @@
+import { promises as fs, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import chokidar, { type FSWatcher } from "chokidar";
+import type { ArtifactStore } from "../artifact-store.js";
+import type { SpaceStore } from "../space-store.js";
+import type {
+  InsertSessionEvent,
+  SessionArtifactRole,
+  SessionEventRole,
+  SessionState,
+  SessionStore,
+} from "../session-store.js";
+
+// claude-code session log watcher (Sprint 2 of the 0.5.0 sessions arc).
+// See docs/plans/sessions-arc.md.
+//
+// claude-code writes one JSONL file per session under
+//   ~/.claude/projects/<url-encoded-cwd>/<session-uuid>.jsonl
+// Each line is a transcript event. We tail every file under that root and
+// turn the events into rows in `sessions` / `session_events` /
+// `session_artifacts`. The format is not a public API — the parser ignores
+// fields it doesn't recognise rather than failing.
+
+const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
+
+// Heartbeat: how long without a new event before we call a running session
+// "disconnected". Heuristic — claude-code emits no explicit done marker, so
+// we fall back to file mtime / event freshness. Generous enough to ride out
+// long Anthropic-side stalls (multi-minute extended thinking turns).
+const DISCONNECT_THRESHOLD_MS = 90_000;
+
+// How often the heartbeat sweep runs. Cheap query; this can be aggressive.
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+// Truncation budgets for transcript text. We store the raw JSONL in `raw`
+// for fidelity; `text` is the rendered preview. Keep it short — the home
+// feed renders a single line per event.
+const TEXT_PREVIEW_MAX = 280;
+const TITLE_MAX = 80;
+
+export interface ClaudeCodeWatcherDeps {
+  sessionStore: SessionStore;
+  spaceStore: SpaceStore;
+  artifactStore: ArtifactStore;
+  /** Called whenever a session row is inserted/updated, for SSE broadcast. */
+  emitSessionChanged?: (sessionId: string) => void;
+  /** Override the watch root (tests). */
+  projectsRoot?: string;
+  /** Override `now()` (tests). */
+  now?: () => Date;
+}
+
+interface FileTracker {
+  // Byte offset into the .jsonl already consumed.
+  offset: number;
+  // Cached session metadata extracted from the file's first event(s). The
+  // session row may not yet exist in the DB if the very first event is still
+  // partial (rare — we read line-by-line, so partial lines are buffered).
+  sessionId: string | null;
+  cwd: string | null;
+  startedAt: string | null;
+  model: string | null;
+  title: string | null;
+  // Carry-over for partial trailing lines between change events.
+  partial: string;
+}
+
+export class ClaudeCodeWatcher {
+  private watcher: FSWatcher | null = null;
+  private heartbeat: NodeJS.Timeout | null = null;
+  private trackers = new Map<string, FileTracker>();
+  private readonly root: string;
+  private readonly now: () => Date;
+
+  constructor(private deps: ClaudeCodeWatcherDeps) {
+    this.root = deps.projectsRoot ?? DEFAULT_PROJECTS_ROOT;
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  async start(): Promise<void> {
+    // Stat the root first — if the user has never run claude-code, the dir
+    // doesn't exist and chokidar would warn. Silently no-op until then.
+    try {
+      await fs.access(this.root);
+    } catch {
+      return;
+    }
+
+    await this.bootScan();
+
+    this.watcher = chokidar.watch(this.root, {
+      persistent: true,
+      ignoreInitial: true, // bootScan handled existing files
+      depth: 2, // projects/<encoded-cwd>/<file>.jsonl
+      awaitWriteFinish: false,
+      ignored: (path) => {
+        // Only care about .jsonl. Cheaper than letting chokidar hand us
+        // every file then filtering downstream.
+        const base = basename(path);
+        if (base.startsWith(".")) return true;
+        // Allow dirs through (they have no extension); reject other files.
+        return base.includes(".") && !base.endsWith(".jsonl");
+      },
+    });
+
+    this.watcher.on("add", (path) => this.onFileAppeared(path).catch(this.logError));
+    this.watcher.on("change", (path) => this.onFileChanged(path).catch(this.logError));
+    this.watcher.on("error", (err) => this.logError(err));
+
+    this.heartbeat = setInterval(() => this.heartbeatSweep(), HEARTBEAT_INTERVAL_MS);
+  }
+
+  async stop(): Promise<void> {
+    if (this.heartbeat) {
+      clearInterval(this.heartbeat);
+      this.heartbeat = null;
+    }
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+    this.trackers.clear();
+  }
+
+  // ── Boot reconciliation ─────────────────────────────────────────────────
+  // Walk every .jsonl already on disk, upsert a session row for it, and seed
+  // the offset tracker with the current file size so we don't replay history
+  // into session_events on every restart. State is set conservatively:
+  // - file modified within DISCONNECT_THRESHOLD_MS → 'running' (will get
+  //   bumped to 'disconnected' by the heartbeat if no events arrive)
+  // - older → 'disconnected'
+  // We never set 'done' on boot because claude-code emits no end marker.
+  private async bootScan(): Promise<void> {
+    let projectDirs: string[];
+    try {
+      projectDirs = await fs.readdir(this.root);
+    } catch {
+      return;
+    }
+
+    for (const projectDir of projectDirs) {
+      const dirPath = join(this.root, projectDir);
+      let stat;
+      try {
+        stat = await fs.stat(dirPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isDirectory()) continue;
+
+      let entries: string[];
+      try {
+        entries = await fs.readdir(dirPath);
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (!entry.endsWith(".jsonl")) continue;
+        const filePath = join(dirPath, entry);
+        await this.reconcileExistingFile(filePath).catch(this.logError);
+      }
+    }
+  }
+
+  private async reconcileExistingFile(filePath: string): Promise<void> {
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return;
+    }
+
+    const meta = await this.readSessionMetadata(filePath);
+    if (!meta) return;
+
+    const ageMs = this.now().getTime() - stat.mtime.getTime();
+    const state: SessionState = ageMs > DISCONNECT_THRESHOLD_MS ? "disconnected" : "running";
+
+    this.deps.sessionStore.upsertSession({
+      id: meta.sessionId,
+      space_id: this.resolveSpaceId(meta.cwd),
+      agent: "claude-code",
+      title: meta.title,
+      state,
+      started_at: meta.startedAt ?? undefined,
+      model: meta.model,
+      last_event_at: stat.mtime.toISOString(),
+    });
+    this.deps.emitSessionChanged?.(meta.sessionId);
+
+    // Seed offset at end-of-file so future appends are read incrementally.
+    this.trackers.set(filePath, {
+      offset: stat.size,
+      sessionId: meta.sessionId,
+      cwd: meta.cwd,
+      startedAt: meta.startedAt,
+      model: meta.model,
+      title: meta.title,
+      partial: "",
+    });
+  }
+
+  // Read just enough of a file to populate the session row. We scan up to
+  // ~32KB looking for the first user message (title) and first assistant
+  // message (model). Anything past that is irrelevant to the session row.
+  private async readSessionMetadata(
+    filePath: string,
+  ): Promise<{
+    sessionId: string;
+    cwd: string | null;
+    startedAt: string | null;
+    model: string | null;
+    title: string | null;
+  } | null> {
+    let buf: Buffer;
+    try {
+      const fh = await fs.open(filePath, "r");
+      try {
+        const stat = await fh.stat();
+        const len = Math.min(stat.size, 32_768);
+        buf = Buffer.alloc(len);
+        await fh.read(buf, 0, len, 0);
+      } finally {
+        await fh.close();
+      }
+    } catch {
+      return null;
+    }
+
+    const sessionIdFromName = filenameToSessionId(filePath);
+    if (!sessionIdFromName) return null;
+
+    let cwd: string | null = null;
+    let startedAt: string | null = null;
+    let model: string | null = null;
+    let title: string | null = null;
+
+    for (const line of buf.toString("utf8").split("\n")) {
+      if (!line) continue;
+      const ev = safeParse(line);
+      if (!ev) continue;
+
+      if (cwd === null && typeof ev.cwd === "string") cwd = ev.cwd;
+      if (startedAt === null && typeof ev.timestamp === "string") startedAt = ev.timestamp;
+      if (model === null && ev.type === "assistant" && ev.message?.model) {
+        model = String(ev.message.model);
+      }
+      if (title === null && ev.type === "user" && typeof ev.message?.content === "string") {
+        title = ev.message.content.trim().slice(0, TITLE_MAX) || null;
+      }
+      if (cwd && startedAt && model && title) break;
+    }
+
+    return { sessionId: sessionIdFromName, cwd, startedAt, model, title };
+  }
+
+  // ── Live updates ────────────────────────────────────────────────────────
+
+  private async onFileAppeared(filePath: string): Promise<void> {
+    if (!filePath.endsWith(".jsonl")) return;
+    if (this.trackers.has(filePath)) return; // boot scan already seeded it
+
+    // Brand-new file: start at offset 0 so we ingest the whole transcript
+    // (which for a freshly-spawned session is just the first event or two).
+    this.trackers.set(filePath, {
+      offset: 0,
+      sessionId: filenameToSessionId(filePath),
+      cwd: null,
+      startedAt: null,
+      model: null,
+      title: null,
+      partial: "",
+    });
+    await this.consumeAppended(filePath);
+  }
+
+  private async onFileChanged(filePath: string): Promise<void> {
+    if (!filePath.endsWith(".jsonl")) return;
+    if (!this.trackers.has(filePath)) {
+      // Race: change fired before add (rare). Treat as new.
+      await this.onFileAppeared(filePath);
+      return;
+    }
+    await this.consumeAppended(filePath);
+  }
+
+  private async consumeAppended(filePath: string): Promise<void> {
+    const tracker = this.trackers.get(filePath);
+    if (!tracker) return;
+
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return; // file removed mid-flight
+    }
+
+    if (stat.size <= tracker.offset) {
+      // Truncation or no growth — not expected for append-only logs.
+      // Reset offset to current size and bail.
+      tracker.offset = stat.size;
+      return;
+    }
+
+    const fh = await fs.open(filePath, "r");
+    let chunk: Buffer;
+    try {
+      const len = stat.size - tracker.offset;
+      chunk = Buffer.alloc(len);
+      await fh.read(chunk, 0, len, tracker.offset);
+    } finally {
+      await fh.close();
+    }
+    tracker.offset = stat.size;
+
+    const text = tracker.partial + chunk.toString("utf8");
+    const lines = text.split("\n");
+    // Last element is whatever's after the final newline — empty on a clean
+    // boundary, partial line otherwise. Buffer it for the next change event.
+    tracker.partial = lines.pop() ?? "";
+
+    const events: InsertSessionEvent[] = [];
+    let latestTimestamp: string | null = null;
+    let sessionEnsured = false;
+
+    for (const line of lines) {
+      if (!line) continue;
+      const ev = safeParse(line);
+      if (!ev) continue;
+
+      // First event from a brand-new file: derive session metadata and
+      // upsert the row before any events are inserted (FK constraint).
+      if (!sessionEnsured && tracker.sessionId) {
+        if (!tracker.cwd && typeof ev.cwd === "string") tracker.cwd = ev.cwd;
+        if (!tracker.startedAt && typeof ev.timestamp === "string") {
+          tracker.startedAt = ev.timestamp;
+        }
+        if (!tracker.title && ev.type === "user" && typeof ev.message?.content === "string") {
+          tracker.title = ev.message.content.trim().slice(0, TITLE_MAX) || null;
+        }
+        if (!tracker.model && ev.type === "assistant" && ev.message?.model) {
+          tracker.model = String(ev.message.model);
+        }
+        this.deps.sessionStore.upsertSession({
+          id: tracker.sessionId,
+          space_id: this.resolveSpaceId(tracker.cwd),
+          agent: "claude-code",
+          title: tracker.title,
+          state: "running",
+          started_at: tracker.startedAt ?? undefined,
+          model: tracker.model,
+          last_event_at: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
+        });
+        this.deps.emitSessionChanged?.(tracker.sessionId);
+        sessionEnsured = true;
+      }
+
+      const rendered = renderEvent(ev);
+      if (rendered && tracker.sessionId) {
+        events.push({
+          session_id: tracker.sessionId,
+          role: rendered.role,
+          text: rendered.text.slice(0, TEXT_PREVIEW_MAX),
+          ts: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
+          raw: line,
+        });
+        if (typeof ev.timestamp === "string") latestTimestamp = ev.timestamp;
+      }
+
+      // Artifact touches from tool_use blocks.
+      if (ev.type === "assistant" && Array.isArray(ev.message?.content) && tracker.sessionId) {
+        const spaceId = this.resolveSpaceId(tracker.cwd);
+        for (const block of ev.message.content) {
+          const touch = artifactTouchFromToolUse(block);
+          if (!touch) continue;
+          const artifact = this.deps.artifactStore.getByPath(touch.path);
+          if (!artifact) continue;
+          // Only attribute touches to artifacts in the same space the session
+          // is registered to — guards against accidentally tagging artifacts
+          // from a different space if a tool happens to read across.
+          if (spaceId && artifact.space_id !== spaceId) continue;
+          this.deps.sessionStore.insertArtifactTouch({
+            session_id: tracker.sessionId,
+            artifact_id: artifact.id,
+            role: touch.role,
+          });
+        }
+      }
+    }
+
+    if (events.length > 0) {
+      this.deps.sessionStore.insertEvents(events);
+    }
+
+    if (tracker.sessionId) {
+      // Bump the session's last_event_at + state to running. If the session
+      // was previously 'disconnected' (heartbeat fired during a quiet turn),
+      // this brings it back to 'running'.
+      const ts = latestTimestamp ?? this.now().toISOString();
+      this.deps.sessionStore.updateSessionState(tracker.sessionId, "running", ts);
+      this.deps.emitSessionChanged?.(tracker.sessionId);
+    }
+  }
+
+  // ── Heartbeat ───────────────────────────────────────────────────────────
+  // Sessions that are 'running' but haven't seen an event in
+  // DISCONNECT_THRESHOLD_MS get demoted to 'disconnected'. Any new file event
+  // promotes them back to 'running' inside consumeAppended above.
+  private heartbeatSweep(): void {
+    const now = this.now().getTime();
+    for (const session of this.deps.sessionStore.getAll()) {
+      if (session.state !== "running") continue;
+      if (session.agent !== "claude-code") continue;
+      const last = Date.parse(session.last_event_at);
+      if (!Number.isFinite(last)) continue;
+      if (now - last > DISCONNECT_THRESHOLD_MS) {
+        this.deps.sessionStore.updateSessionState(
+          session.id,
+          "disconnected",
+          session.last_event_at,
+        );
+        this.deps.emitSessionChanged?.(session.id);
+      }
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  private resolveSpaceId(cwd: string | null): string | null {
+    if (!cwd) return null;
+    const source = this.deps.spaceStore.getActiveSourceByPath(cwd);
+    return source?.space_id ?? null;
+  }
+
+  private logError = (err: unknown) => {
+    // Watcher errors are non-fatal; log and continue. Silence in tests by
+    // overriding via deps.now isn't enough — we just don't throw.
+    // eslint-disable-next-line no-console
+    console.warn("[claude-code-watcher]", err instanceof Error ? err.message : err);
+  };
+}
+
+// ── Pure helpers (exported for tests) ─────────────────────────────────────
+
+export function filenameToSessionId(filePath: string): string {
+  // Filename is `<uuid>.jsonl`. The UUID is the session id.
+  const base = basename(filePath);
+  return base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
+}
+
+function safeParse(line: string): Record<string, any> | null {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+interface RenderedEvent {
+  role: SessionEventRole;
+  text: string;
+}
+
+// Map a raw JSONL event to a (role, text) pair the home feed can render.
+// Returns null for events we deliberately skip (file-history-snapshot,
+// last-prompt, attachment metadata, etc — useful in `raw` only).
+export function renderEvent(ev: Record<string, any>): RenderedEvent | null {
+  switch (ev.type) {
+    case "user": {
+      const content = ev.message?.content;
+      if (typeof content === "string") {
+        return { role: "user", text: content };
+      }
+      if (Array.isArray(content)) {
+        // user-typed array events are tool_result wrappers
+        const first = content.find((b) => b?.type === "tool_result");
+        if (first) {
+          const inner = typeof first.content === "string"
+            ? first.content
+            : Array.isArray(first.content)
+              ? first.content
+                  .map((c: any) => (typeof c?.text === "string" ? c.text : ""))
+                  .join("")
+              : "";
+          return { role: "tool_result", text: inner || "(tool result)" };
+        }
+      }
+      return null;
+    }
+    case "assistant": {
+      const blocks = ev.message?.content;
+      if (!Array.isArray(blocks)) return null;
+      const text = blocks
+        .map((b: any) => {
+          if (b?.type === "text" && typeof b.text === "string") return b.text;
+          if (b?.type === "tool_use" && typeof b.name === "string") {
+            return `[${b.name}]`;
+          }
+          return "";
+        })
+        .filter(Boolean)
+        .join(" ");
+      // Pure-thinking turns produce empty text — store the marker so timeline
+      // doesn't silently lose them.
+      return { role: "assistant", text: text || "(thinking)" };
+    }
+    case "system": {
+      const subtype = typeof ev.subtype === "string" ? ev.subtype : "system";
+      const content = typeof ev.content === "string" ? ev.content : "";
+      return { role: "system", text: content ? `${subtype}: ${content}` : subtype };
+    }
+    default:
+      return null;
+  }
+}
+
+// Recognise tool_use blocks that touch a tracked file path. Read=>read,
+// Write=>create, Edit=>modify. We don't try to detect existence of the file
+// pre-call — Write on an existing file is "create" in our taxonomy (it
+// replaces). Bash output isn't parsed; future ticket if needed.
+export function artifactTouchFromToolUse(
+  block: any,
+): { path: string; role: SessionArtifactRole } | null {
+  if (!block || block.type !== "tool_use") return null;
+  const name = typeof block.name === "string" ? block.name : null;
+  const filePath = typeof block.input?.file_path === "string" ? block.input.file_path : null;
+  if (!name || !filePath) return null;
+  switch (name) {
+    case "Read":
+      return { path: filePath, role: "read" };
+    case "Write":
+      return { path: filePath, role: "create" };
+    case "Edit":
+      return { path: filePath, role: "modify" };
+    default:
+      return null;
+  }
+}
+
+// Convenience for code that doesn't want to import statSync from node:fs.
+// Kept for symmetry with chokidar's add/change which give us paths only.
+export function isJsonlFile(path: string): boolean {
+  if (!path.endsWith(".jsonl")) return false;
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 2 of the [0.5.0 sessions arc](https://github.com/mattslight/oyster/blob/main/docs/plans/sessions-arc.md). The load-bearing piece — every other sprint depends on data this watcher produces.

When you run `claude` in any folder mapped to a space, Oyster now picks the session up automatically. No setup, no MCP wiring. The session shows as *running* / *disconnected* on the home feed (UI lands in #252), with title pulled from your first prompt and tracked file reads/edits attributed back to their tiles.

## What's in

- **`server/src/watchers/claude-code.ts`** — chokidar watcher on `~/.claude/projects/`. Boot scan upserts existing session files; live mode reads only appended bytes via a per-file offset tracker. 15s heartbeat sweep demotes idle `running` sessions to `disconnected`.
- **`server/src/session-store.ts`** — typed CRUD over `sessions` / `session_events` / `session_artifacts`. Bulk `insertEvents` wraps inserts in a transaction so multi-line appends commit in one fsync.
- **Server wiring** — `GET /api/sessions` (read-only, local-origin), `session_changed` SSE broadcast on every state transition, watcher started after `httpServer.listen` so missing `~/.claude/projects` is a silent no-op.
- **Smoke test** at `server/scripts/smoke-claude-code-watcher.ts` covers all four phases against a synthetic projects root.

## Defensive design choices

- **JSONL format isn't a public API.** Parser ignores unknown event types (`permission-mode`, `attachment`, `file-history-snapshot`, `last-prompt`, etc.) rather than failing. Raw line is preserved in `session_events.raw` for fidelity.
- **No explicit session-end marker exists.** `done` is never set automatically; sessions stay in `disconnected` after going idle. Adding a TTL → `done` transition is a follow-up.
- **`awaiting` deferred** per the design doc — tool-approval detection in default-mode is fragile and not load-bearing for the home feed v1.
- **Restart safety** — boot scan reseeds offsets at current file size, so we don't replay history into `session_events` on every startup.

## Risks

JSONL schema changes between claude-code releases will silently degrade what we render. Mitigation: only parse what we need (`type`, `cwd`, `timestamp`, `message.role`, `message.content`, `message.model`, tool_use blocks); everything else is stored verbatim in `raw`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Smoke script: 4 phases pass (new session, tool_use → artifact touch, tool_result role, orphan cwd → null space_id)
- [ ] Manual: run dev server, start a fresh `claude` in a registered space, verify a row lands in `sessions` with the right title and space
- [ ] Manual: verify boot scan picks up existing `~/.claude/projects/*/` files and tags stale ones as `disconnected`

## Part of

[0.5.0 Sessions arc](https://github.com/mattslight/oyster/milestone/2) — Sprint 2 of 8 (load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)