### PR TITLE
feat(home, sessions): process-aware states + Elsewhere + spaces nav surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Session states are now process-aware.** Oyster looks at the running `claude` processes on your machine to tell whether a session is still alive — not just whether the JSONL file has been quiet. New states: **active** (green, "updated recently"), **waiting** (amber, "process still open"), **disconnected** (red, "no running process found"), and **done** (grey, "inactive for 24h"). Long thinking turns no longer flicker into red, and a finished session correctly drops to disconnected within seconds of you closing the terminal.
+
 ## [0.5.0-beta.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
-- **Session states are now process-aware.** Oyster looks at the running `claude` processes on your machine to tell whether a session is still alive — not just whether the JSONL file has been quiet. New states: **active** (green, "updated recently"), **waiting** (amber, "process still open"), **disconnected** (red, "no running process found"), and **done** (grey, "inactive for 24h"). Long thinking turns no longer flicker into red, and a finished session correctly drops to disconnected within seconds of you closing the terminal.
+- **Session states are now process-aware.** Oyster looks at the running `claude` processes on your machine to tell whether a session is still alive — not just whether the JSONL file has been quiet. New states: **active** (green, "updated recently"), **waiting** (amber, "process still open"), **disconnected** (red, "no running process found"), and **done** (grey, "inactive for 24h"). Long thinking turns no longer flicker into red, and a finished session converges to disconnected within a minute or so of you closing the terminal (active window plus the next heartbeat tick).
 
 ## [0.5.0-beta.0] - 2026-04-28
 
@@ -404,7 +404,8 @@ Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via M
 - Surface with Aurora WebGL animated background.
 - Typed artifact icons, chat bar, window system with viewer.
 
-[Unreleased]: https://github.com/mattslight/oyster/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/mattslight/oyster/compare/v0.5.0-beta.0...HEAD
+[0.5.0-beta.0]: https://github.com/mattslight/oyster/compare/v0.4.0...v0.5.0-beta.0
 [0.4.0]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.8...v0.4.0
 [0.4.0-beta.8]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.7...v0.4.0-beta.8
 [0.4.0-beta.7]: https://github.com/mattslight/oyster/compare/v0.4.0-beta.6...v0.4.0-beta.7

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -322,12 +322,12 @@
   </nav>
 
   <main class="entries">
-<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0-beta.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Changed</h3>
 <ul>
-<li><strong>Session states are now process-aware.</strong> Oyster looks at the running <code>claude</code> processes on your machine to tell whether a session is still alive — not just whether the JSONL file has been quiet. New states: <strong>active</strong> (green, &quot;updated recently&quot;), <strong>waiting</strong> (amber, &quot;process still open&quot;), <strong>disconnected</strong> (red, &quot;no running process found&quot;), and <strong>done</strong> (grey, &quot;inactive for 24h&quot;). Long thinking turns no longer flicker into red, and a finished session correctly drops to disconnected within seconds of you closing the terminal.</li>
+<li><strong>Session states are now process-aware.</strong> Oyster looks at the running <code>claude</code> processes on your machine to tell whether a session is still alive — not just whether the JSONL file has been quiet. New states: <strong>active</strong> (green, &quot;updated recently&quot;), <strong>waiting</strong> (amber, &quot;process still open&quot;), <strong>disconnected</strong> (red, &quot;no running process found&quot;), and <strong>done</strong> (grey, &quot;inactive for 24h&quot;). Long thinking turns no longer flicker into red, and a finished session converges to disconnected within a minute or so of you closing the terminal (active window plus the next heartbeat tick).</li>
 </ul>
-<h2 id="v-0-5-0-beta-0"><span class="release-version">0.5.0-beta.0</span><span class="release-date"> — 2026-04-28</span></h2>
+<h2 id="v-0-5-0-beta-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0...v0.5.0-beta.0" rel="noopener noreferrer"><span class="release-version">0.5.0-beta.0</span></a><span class="release-date"> — 2026-04-28</span></h2>
 <h3>Added</h3>
 <ul>
 <li><strong>Oyster sees your claude-code sessions.</strong> When you run <code>claude</code> in any folder mapped to a space, Oyster now picks the session up automatically — no setup, no MCP wiring. The session shows as <em>running</em> / <em>disconnected</em> on the home feed, with title pulled from your first prompt and tracked file reads/edits attributed back to their tiles. Sessions started in unregistered folders land as orphans rather than being dropped. (<a href="https://github.com/mattslight/oyster/issues/251" rel="noopener noreferrer">#251</a>)</li>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-5-0-beta-0">0.5</a>
       <a class="version-pill" href="#v-0-4-0">0.4</a>
       <a class="version-pill" href="#v-0-3-8">0.3</a>
@@ -321,6 +322,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.4.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>Session states are now process-aware.</strong> Oyster looks at the running <code>claude</code> processes on your machine to tell whether a session is still alive — not just whether the JSONL file has been quiet. New states: <strong>active</strong> (green, &quot;updated recently&quot;), <strong>waiting</strong> (amber, &quot;process still open&quot;), <strong>disconnected</strong> (red, &quot;no running process found&quot;), and <strong>done</strong> (grey, &quot;inactive for 24h&quot;). Long thinking turns no longer flicker into red, and a finished session correctly drops to disconnected within seconds of you closing the terminal.</li>
+</ul>
 <h2 id="v-0-5-0-beta-0"><span class="release-version">0.5.0-beta.0</span><span class="release-date"> — 2026-04-28</span></h2>
 <h3>Added</h3>
 <ul>

--- a/server/scripts/smoke-claude-code-watcher.ts
+++ b/server/scripts/smoke-claude-code-watcher.ts
@@ -117,7 +117,7 @@ async function run() {
   assert.equal(session.space_id, "test-space", "cwd should resolve to test-space");
   assert.equal(session.agent, "claude-code");
   assert.equal(session.title, "fix the README typo");
-  assert.equal(session.state, "running");
+  assert.equal(session.state, "active");
   console.log("[smoke] phase 1 ok — session row created with title + space");
 
   // ── Phase 2: assistant turn with text + tool_use(Read) on tracked file ──

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -180,19 +180,37 @@ export function initDb(userlandDir: string): Database.Database {
   `);
 
   // ── Sessions state-rename migration (running/awaiting → active/waiting) ──
-  // SQLite can't ALTER a CHECK constraint. Detect the old constraint by
-  // looking at the table's defining SQL; if it still names 'running', do the
-  // 12-step rename-rebuild. Idempotent — subsequent boots find the new SQL
-  // and skip.
-  const sessionsSql = (db.prepare(
-    "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'",
-  ).get() as { sql: string } | undefined)?.sql ?? "";
-  if (sessionsSql.includes("'running'")) {
+  // SQLite can't ALTER a CHECK constraint, so we rebuild via temp table.
+  //
+  // Two trigger conditions:
+  //   (a) sessions table SQL still contains the old CHECK constraint
+  //       ('running'/'awaiting') — pre-migration.
+  //   (b) session_events / session_artifacts FK references point at
+  //       "sessions_old" — half-migrated state from an earlier broken
+  //       version of this migration that used `RENAME TO sessions_old`
+  //       and let SQLite auto-rewrite the dependent FKs to that phantom
+  //       name. Detect either; both paths run the same rebuild.
+  //
+  // The rebuild is idempotent — once dependent FKs reference 'sessions'
+  // and the CHECK lists the new state names, neither condition fires.
+  const tableSql = (name: string): string =>
+    (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name=?").get(name) as { sql: string } | undefined)?.sql ?? "";
+
+  const sessionsSql = tableSql("sessions");
+  const eventsSql = tableSql("session_events");
+  const artifactsSql = tableSql("session_artifacts");
+  const needsMigrate =
+    sessionsSql.includes("'running'") ||
+    eventsSql.includes("sessions_old") ||
+    artifactsSql.includes("sessions_old");
+
+  if (needsMigrate) {
     db.exec(`
       PRAGMA foreign_keys = OFF;
       BEGIN TRANSACTION;
-      ALTER TABLE sessions RENAME TO sessions_old;
-      CREATE TABLE sessions (
+
+      -- 1. Rebuild sessions with the new CHECK constraint and remap states.
+      CREATE TABLE _sessions_new (
         id            TEXT PRIMARY KEY,
         space_id      TEXT REFERENCES spaces(id) ON DELETE SET NULL,
         agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
@@ -203,14 +221,46 @@ export function initDb(userlandDir: string): Database.Database {
         model         TEXT,
         last_event_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
-      INSERT INTO sessions (id, space_id, agent, title, state, started_at, ended_at, model, last_event_at)
+      INSERT INTO _sessions_new (id, space_id, agent, title, state, started_at, ended_at, model, last_event_at)
         SELECT id, space_id, agent, title,
           CASE state WHEN 'running' THEN 'active' WHEN 'awaiting' THEN 'waiting' ELSE state END,
           started_at, ended_at, model, last_event_at
-        FROM sessions_old;
-      DROP TABLE sessions_old;
+        FROM sessions;
+      DROP TABLE sessions;
+      ALTER TABLE _sessions_new RENAME TO sessions;
       CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);
       CREATE INDEX IF NOT EXISTS sessions_state_last_event ON sessions(state, last_event_at);
+
+      -- 2. Rebuild session_events so its FK points at the new sessions table.
+      CREATE TABLE _session_events_new (
+        id         INTEGER PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        role       TEXT NOT NULL CHECK (role IN ('user','assistant','tool','tool_result','system')),
+        text       TEXT NOT NULL,
+        ts         TEXT NOT NULL DEFAULT (datetime('now')),
+        raw        TEXT
+      );
+      INSERT INTO _session_events_new (session_id, role, text, ts, raw)
+        SELECT session_id, role, text, ts, raw FROM session_events;
+      DROP TABLE session_events;
+      ALTER TABLE _session_events_new RENAME TO session_events;
+      CREATE INDEX IF NOT EXISTS session_events_session_ts ON session_events(session_id, ts);
+
+      -- 3. Same for session_artifacts.
+      CREATE TABLE _session_artifacts_new (
+        id          INTEGER PRIMARY KEY,
+        session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        artifact_id TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+        role        TEXT NOT NULL CHECK (role IN ('create','modify','read')),
+        when_at     TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO _session_artifacts_new (session_id, artifact_id, role, when_at)
+        SELECT session_id, artifact_id, role, when_at FROM session_artifacts;
+      DROP TABLE session_artifacts;
+      ALTER TABLE _session_artifacts_new RENAME TO session_artifacts;
+      CREATE INDEX IF NOT EXISTS session_artifacts_session ON session_artifacts(session_id, when_at);
+      CREATE INDEX IF NOT EXISTS session_artifacts_artifact ON session_artifacts(artifact_id);
+
       COMMIT;
       PRAGMA foreign_keys = ON;
     `);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -145,7 +145,7 @@ export function initDb(userlandDir: string): Database.Database {
       space_id      TEXT REFERENCES spaces(id) ON DELETE SET NULL,
       agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
       title         TEXT,
-      state         TEXT NOT NULL CHECK (state IN ('running','awaiting','disconnected','done')),
+      state         TEXT NOT NULL CHECK (state IN ('active','waiting','disconnected','done')),
       started_at    TEXT NOT NULL DEFAULT (datetime('now')),
       ended_at      TEXT,
       model         TEXT,
@@ -178,6 +178,43 @@ export function initDb(userlandDir: string): Database.Database {
     CREATE INDEX IF NOT EXISTS session_artifacts_artifact
       ON session_artifacts(artifact_id);
   `);
+
+  // ── Sessions state-rename migration (running/awaiting → active/waiting) ──
+  // SQLite can't ALTER a CHECK constraint. Detect the old constraint by
+  // looking at the table's defining SQL; if it still names 'running', do the
+  // 12-step rename-rebuild. Idempotent — subsequent boots find the new SQL
+  // and skip.
+  const sessionsSql = (db.prepare(
+    "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'",
+  ).get() as { sql: string } | undefined)?.sql ?? "";
+  if (sessionsSql.includes("'running'")) {
+    db.exec(`
+      PRAGMA foreign_keys = OFF;
+      BEGIN TRANSACTION;
+      ALTER TABLE sessions RENAME TO sessions_old;
+      CREATE TABLE sessions (
+        id            TEXT PRIMARY KEY,
+        space_id      TEXT REFERENCES spaces(id) ON DELETE SET NULL,
+        agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
+        title         TEXT,
+        state         TEXT NOT NULL CHECK (state IN ('active','waiting','disconnected','done')),
+        started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        ended_at      TEXT,
+        model         TEXT,
+        last_event_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO sessions (id, space_id, agent, title, state, started_at, ended_at, model, last_event_at)
+        SELECT id, space_id, agent, title,
+          CASE state WHEN 'running' THEN 'active' WHEN 'awaiting' THEN 'waiting' ELSE state END,
+          started_at, ended_at, model, last_event_at
+        FROM sessions_old;
+      DROP TABLE sessions_old;
+      CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);
+      CREATE INDEX IF NOT EXISTS sessions_state_last_event ON sessions(state, last_event_at);
+      COMMIT;
+      PRAGMA foreign_keys = ON;
+    `);
+  }
 
   // One-time seed: populate spaces from artifact space_ids only if the table is empty.
   // Using INSERT OR IGNORE on an existing table would resurrect deleted spaces on restart.

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -8,7 +8,7 @@ import type Database from "better-sqlite3";
 
 // ── Row types (mirror SQLite schema in db.ts) ──
 
-export type SessionState = "running" | "awaiting" | "disconnected" | "done";
+export type SessionState = "active" | "waiting" | "disconnected" | "done";
 export type SessionAgent = "claude-code" | "opencode" | "codex";
 export type SessionEventRole =
   | "user"

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -11,7 +11,7 @@ import type {
   SessionState,
   SessionStore,
 } from "../session-store.js";
-import { activeClaudeCwds } from "./claude-process-probe.js";
+import { activeClaudeCwdCounts } from "./claude-process-probe.js";
 
 // claude-code session log watcher (Sprint 2 of the 0.5.0 sessions arc).
 // See docs/plans/sessions-arc.md.
@@ -25,21 +25,27 @@ import { activeClaudeCwds } from "./claude-process-probe.js";
 
 const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 
-// State derivation, two observable signals:
-//   1. Process probe: is there a `claude` process whose cwd matches this
-//      session's recorded cwd? (See claude-process-probe.ts.)
-//   2. JSONL recency: how recently was the file appended to?
+// State derivation: JSONL recency is the source of truth, process probe
+// only gates whether a recent-but-not-fresh session reads as `waiting`
+// vs `disconnected`. We can't externally identify *which* claude process
+// is driving *which* session — there's no PID in the JSONL and the file
+// isn't held open between turns. Anything more ambitious than "is there
+// some claude at this cwd?" devolves into heuristics with edge cases.
 //
-//   process alive + JSONL fresh   → active        ("Updated recently")
-//   process alive + JSONL idle    → waiting       ("Process still open")
-//   process gone  + JSONL recent  → disconnected  ("No running process found")
-//   process gone  + JSONL >24h    → done          ("Inactive for 24h")
+//   ageMs < ACTIVE_WINDOW_MS                                → active
+//   ageMs < WAITING_WINDOW_MS    + claude at this cwd       → waiting
+//   ageMs < DONE_THRESHOLD_MS                               → disconnected
+//   otherwise                                               → done
 //
-// "active" is bounded by JSONL recency so a session that's been streaming
-// in the last few seconds shows as bright-green; once the model finishes
-// generating and claude is just sitting at the prompt, it drops to waiting.
-// Both states still mean "live process you can return to".
+// The 30-min waiting window is the honest cap: if a JSONL hasn't been
+// touched in 30 minutes we treat the session as disconnected regardless
+// of whether a claude process is at the cwd. That means an old transcript
+// at a cwd where the user is currently working doesn't get falsely
+// elevated to waiting. False negative case: a claude tab idle for >30min
+// reads as disconnected even though the process is live — that flips
+// back to active the moment the user types and JSONL streams.
 const ACTIVE_WINDOW_MS = 30_000;
+const WAITING_WINDOW_MS = 30 * 60 * 1000;
 const DONE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
 // How often the heartbeat sweep runs. Each tick probes processes (~40ms on
@@ -180,7 +186,7 @@ export class ClaudeCodeWatcher {
   // (see deriveState), so a session whose claude process is still running
   // comes back as 'active'/'waiting' even after a server restart.
   private async bootScan(): Promise<void> {
-    const activeCwds = await activeClaudeCwds();
+    const cwdCounts = await activeClaudeCwdCounts();
     let projectDirs: string[];
     try {
       projectDirs = await fs.readdir(this.root);
@@ -208,12 +214,12 @@ export class ClaudeCodeWatcher {
       for (const entry of entries) {
         if (!entry.endsWith(".jsonl")) continue;
         const filePath = join(dirPath, entry);
-        await this.reconcileExistingFile(filePath, activeCwds).catch(this.logError);
+        await this.reconcileExistingFile(filePath, cwdCounts).catch(this.logError);
       }
     }
   }
 
-  private async reconcileExistingFile(filePath: string, activeCwds: Set<string>): Promise<void> {
+  private async reconcileExistingFile(filePath: string, cwdCounts: Map<string, number>): Promise<void> {
     let stat;
     try {
       stat = await fs.stat(filePath);
@@ -225,7 +231,10 @@ export class ClaudeCodeWatcher {
     if (!meta) return;
 
     const ageMs = this.now().getTime() - stat.mtime.getTime();
-    const processAlive = meta.cwd ? activeCwds.has(meta.cwd) : false;
+    // Coarse seed: if there's any claude at this cwd, assume this session
+    // *might* be live. The immediate heartbeatSweep at the end of start()
+    // refines this to the top-K freshest per cwd.
+    const processAlive = meta.cwd ? (cwdCounts.get(meta.cwd) ?? 0) > 0 : false;
     const state = deriveState(ageMs, processAlive);
 
     // Always pass ISO-8601 timestamps. If the JSONL didn't have a usable
@@ -597,15 +606,14 @@ export class ClaudeCodeWatcher {
   }
 
   // ── Heartbeat ───────────────────────────────────────────────────────────
-  // Probe every running `claude` process for its cwd. Cross-reference each
-  // session's recorded cwd against that set, then narrow further: among
-  // multiple sessions that share a cwd (e.g. you've run claude in the same
-  // repo a hundred times), only the freshest JSONL — the one currently
-  // being appended to — is "the live session". The others are old
-  // transcripts that finished. Without this, a single live claude process
-  // marks every past session at that cwd as `waiting`.
+  // Probe every running `claude` process for its cwd. The probe answers
+  // "does any claude process have this cwd open?" — coarser than per-session
+  // identity, but it's the strongest signal we can observe externally
+  // (claude doesn't log its PID in the JSONL, and the file isn't held open
+  // between turns). The recency cap in deriveState handles the one-live-
+  // claude-many-old-transcripts case cleanly.
   private async heartbeatSweep(): Promise<void> {
-    const activeCwds = await activeClaudeCwds();
+    const cwdCounts = await activeClaudeCwdCounts();
     const now = this.now().getTime();
 
     // sessionId → cwd, from in-memory trackers seeded by bootScan + watch.
@@ -614,31 +622,15 @@ export class ClaudeCodeWatcher {
       if (t.sessionId && t.cwd) sessionCwds.set(t.sessionId, t.cwd);
     }
 
-    const allSessions = this.deps.sessionStore.getAll().filter(
-      (s) => s.agent === "claude-code",
-    );
-
-    // cwd → sessionId of the freshest claude-code session in that cwd.
-    // Sort desc by last_event_at and pick the first occurrence per cwd.
-    const freshestPerCwd = new Map<string, string>();
-    const sortedDesc = [...allSessions].sort(
-      (a, b) => Date.parse(b.last_event_at) - Date.parse(a.last_event_at),
-    );
-    for (const s of sortedDesc) {
-      const cwd = sessionCwds.get(s.id);
-      if (cwd && !freshestPerCwd.has(cwd)) freshestPerCwd.set(cwd, s.id);
-    }
-
-    for (const session of allSessions) {
+    for (const session of this.deps.sessionStore.getAll()) {
+      if (session.agent !== "claude-code") continue;
       const last = Date.parse(session.last_event_at);
       if (!Number.isFinite(last)) continue;
       const ageMs = now - last;
 
       const cwd = sessionCwds.get(session.id);
-      const cwdHasLiveProcess = cwd ? activeCwds.has(cwd) : false;
-      const isFreshestInCwd = cwd ? freshestPerCwd.get(cwd) === session.id : false;
-      const processAlive = cwdHasLiveProcess && isFreshestInCwd;
-      const next = deriveState(ageMs, processAlive);
+      const cwdHasLiveProcess = cwd ? (cwdCounts.get(cwd) ?? 0) > 0 : false;
+      const next = deriveState(ageMs, cwdHasLiveProcess);
 
       if (next !== session.state) {
         this.deps.sessionStore.updateSessionState(session.id, next, session.last_event_at);
@@ -665,9 +657,11 @@ export class ClaudeCodeWatcher {
 
 // ── Pure helpers (exported for tests) ─────────────────────────────────────
 
-export function deriveState(ageMs: number, processAlive: boolean): SessionState {
-  if (processAlive) return ageMs < ACTIVE_WINDOW_MS ? "active" : "waiting";
-  return ageMs > DONE_THRESHOLD_MS ? "done" : "disconnected";
+export function deriveState(ageMs: number, processAtCwd: boolean): SessionState {
+  if (ageMs < ACTIVE_WINDOW_MS) return "active";
+  if (ageMs < WAITING_WINDOW_MS && processAtCwd) return "waiting";
+  if (ageMs > DONE_THRESHOLD_MS) return "done";
+  return "disconnected";
 }
 
 // Pull a usable title out of a `type:"user"` event's content, or return null.

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -11,6 +11,7 @@ import type {
   SessionState,
   SessionStore,
 } from "../session-store.js";
+import { activeClaudeCwds } from "./claude-process-probe.js";
 
 // claude-code session log watcher (Sprint 2 of the 0.5.0 sessions arc).
 // See docs/plans/sessions-arc.md.
@@ -24,22 +25,27 @@ import type {
 
 const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 
-// State transition thresholds. claude-code emits no explicit end marker, so
-// "done" is heuristic — anything that's been quiet for a full day is treated
-// as concluded. Hooks or MCP-push registration would give a real signal;
-// follow-up tickets.
+// State derivation, two observable signals:
+//   1. Process probe: is there a `claude` process whose cwd matches this
+//      session's recorded cwd? (See claude-process-probe.ts.)
+//   2. JSONL recency: how recently was the file appended to?
 //
-// running       --(quiet > 5 min)-->       disconnected
-// disconnected  --(quiet > 24h)-->         done
-// done          --(any new event)-->       running   (consumeAppended path)
+//   process alive + JSONL fresh   → active        ("Updated recently")
+//   process alive + JSONL idle    → waiting       ("Process still open")
+//   process gone  + JSONL recent  → disconnected  ("No running process found")
+//   process gone  + JSONL >24h    → done          ("Inactive for 24h")
 //
-// 5 minutes is generous enough to ride out long Anthropic-side stalls during
-// extended-thinking turns (which routinely run 3-4 min on Opus). Tighter
-// thresholds caused false-positive disconnections in real use.
-const DISCONNECT_THRESHOLD_MS = 5 * 60 * 1000;
+// "active" is bounded by JSONL recency so a session that's been streaming
+// in the last few seconds shows as bright-green; once the model finishes
+// generating and claude is just sitting at the prompt, it drops to waiting.
+// Both states still mean "live process you can return to".
+const ACTIVE_WINDOW_MS = 30_000;
 const DONE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
-// How often the heartbeat sweep runs. Cheap query; this can be aggressive.
+// How often the heartbeat sweep runs. Each tick probes processes (~40ms on
+// macOS for a few claude PIDs) and recomputes state for every claude-code
+// session. 15s is the longest a freshly-closed claude can linger as
+// "active"/"waiting" before flipping to "disconnected". Tighten if needed.
 const HEARTBEAT_INTERVAL_MS = 15_000;
 
 // Truncation budgets for transcript text. We store the raw JSONL in `raw`
@@ -144,7 +150,9 @@ export class ClaudeCodeWatcher {
       watcher.once("ready", () => resolve());
     });
 
-    this.heartbeat = setInterval(() => this.heartbeatSweep(), HEARTBEAT_INTERVAL_MS);
+    this.heartbeat = setInterval(() => {
+      this.heartbeatSweep().catch(this.logError);
+    }, HEARTBEAT_INTERVAL_MS);
   }
 
   async stop(): Promise<void> {
@@ -163,12 +171,11 @@ export class ClaudeCodeWatcher {
   // ── Boot reconciliation ─────────────────────────────────────────────────
   // Walk every .jsonl already on disk, upsert a session row for it, and seed
   // the offset tracker with the current file size so we don't replay history
-  // into session_events on every restart. State is set conservatively:
-  // - file modified within DISCONNECT_THRESHOLD_MS → 'running' (will get
-  //   bumped to 'disconnected' by the heartbeat if no events arrive)
-  // - older → 'disconnected'
-  // We never set 'done' on boot because claude-code emits no end marker.
+  // into session_events on every restart. State derives from probe+recency
+  // (see deriveState), so a session whose claude process is still running
+  // comes back as 'active'/'waiting' even after a server restart.
   private async bootScan(): Promise<void> {
+    const activeCwds = await activeClaudeCwds();
     let projectDirs: string[];
     try {
       projectDirs = await fs.readdir(this.root);
@@ -196,12 +203,12 @@ export class ClaudeCodeWatcher {
       for (const entry of entries) {
         if (!entry.endsWith(".jsonl")) continue;
         const filePath = join(dirPath, entry);
-        await this.reconcileExistingFile(filePath).catch(this.logError);
+        await this.reconcileExistingFile(filePath, activeCwds).catch(this.logError);
       }
     }
   }
 
-  private async reconcileExistingFile(filePath: string): Promise<void> {
+  private async reconcileExistingFile(filePath: string, activeCwds: Set<string>): Promise<void> {
     let stat;
     try {
       stat = await fs.stat(filePath);
@@ -213,9 +220,8 @@ export class ClaudeCodeWatcher {
     if (!meta) return;
 
     const ageMs = this.now().getTime() - stat.mtime.getTime();
-    const state: SessionState = ageMs > DONE_THRESHOLD_MS ? "done"
-      : ageMs > DISCONNECT_THRESHOLD_MS ? "disconnected"
-      : "running";
+    const processAlive = meta.cwd ? activeCwds.has(meta.cwd) : false;
+    const state = deriveState(ageMs, processAlive);
 
     // Always pass ISO-8601 timestamps. If the JSONL didn't have a usable
     // event timestamp in the first 32KB, fall back to the file's birth time
@@ -512,7 +518,7 @@ export class ClaudeCodeWatcher {
           space_id: this.resolveSpaceId(tracker.cwd),
           agent: "claude-code",
           title: effectiveTitle(tracker),
-          state: "running",
+          state: "active",
           // Always pass ISO. Falling through to SQL's datetime('now')
           // produces the naive `YYYY-MM-DD HH:MM:SS` form which Date.parse()
           // is allowed to reject in some browsers — kept the wire contract
@@ -566,46 +572,50 @@ export class ClaudeCodeWatcher {
     }
 
     if (tracker.sessionId) {
-      // Bump the session's last_event_at + state to running. If the session
-      // was previously 'disconnected' (heartbeat fired during a quiet turn),
-      // this brings it back to 'running'. If a title we couldn't derive on
-      // the first pass (e.g. opening event was a caveat) is now available,
-      // patch it through here in the same write.
+      // Bytes just landed → JSONL is fresh by definition, so this session is
+      // 'active'. Even if the heartbeat had previously demoted it to
+      // 'waiting'/'disconnected', a new event resurrects it. If a title we
+      // couldn't derive on the first pass (e.g. opening event was a caveat)
+      // is now available, patch it through here in the same write.
       const ts = latestTimestamp ?? this.now().toISOString();
       if (titleChanged) {
         this.deps.sessionStore.updateSession(tracker.sessionId, {
-          state: "running",
+          state: "active",
           last_event_at: ts,
           title: effectiveTitle(tracker),
         });
       } else {
-        this.deps.sessionStore.updateSessionState(tracker.sessionId, "running", ts);
+        this.deps.sessionStore.updateSessionState(tracker.sessionId, "active", ts);
       }
       this.deps.emitSessionChanged?.(tracker.sessionId);
     }
   }
 
   // ── Heartbeat ───────────────────────────────────────────────────────────
-  // running → disconnected after DISCONNECT_THRESHOLD_MS of quiet.
-  // disconnected → done after DONE_THRESHOLD_MS — i.e. a session that's been
-  // idle for a full day is treated as concluded. Any new file event in
-  // consumeAppended below resurrects it back to 'running'.
-  private heartbeatSweep(): void {
+  // Probe every running `claude` process for its cwd. Cross-reference each
+  // claude-code session's recorded cwd against that set. Recompute state
+  // and update any rows whose state has shifted.
+  private async heartbeatSweep(): Promise<void> {
+    const activeCwds = await activeClaudeCwds();
     const now = this.now().getTime();
+
+    // sessionId → cwd, from in-memory trackers seeded by bootScan + watch.
+    const sessionCwds = new Map<string, string>();
+    for (const t of this.trackers.values()) {
+      if (t.sessionId && t.cwd) sessionCwds.set(t.sessionId, t.cwd);
+    }
+
     for (const session of this.deps.sessionStore.getAll()) {
       if (session.agent !== "claude-code") continue;
-      if (session.state === "done") continue;
       const last = Date.parse(session.last_event_at);
       if (!Number.isFinite(last)) continue;
       const ageMs = now - last;
 
-      let next: SessionState | null = null;
-      if (ageMs > DONE_THRESHOLD_MS) next = "done";
-      else if (session.state === "running" && ageMs > DISCONNECT_THRESHOLD_MS) {
-        next = "disconnected";
-      }
+      const cwd = sessionCwds.get(session.id);
+      const processAlive = cwd ? activeCwds.has(cwd) : false;
+      const next = deriveState(ageMs, processAlive);
 
-      if (next && next !== session.state) {
+      if (next !== session.state) {
         this.deps.sessionStore.updateSessionState(session.id, next, session.last_event_at);
         this.deps.emitSessionChanged?.(session.id);
       }
@@ -629,6 +639,11 @@ export class ClaudeCodeWatcher {
 }
 
 // ── Pure helpers (exported for tests) ─────────────────────────────────────
+
+export function deriveState(ageMs: number, processAlive: boolean): SessionState {
+  if (processAlive) return ageMs < ACTIVE_WINDOW_MS ? "active" : "waiting";
+  return ageMs > DONE_THRESHOLD_MS ? "done" : "disconnected";
+}
 
 // Pull a usable title out of a `type:"user"` event's content, or return null.
 // claude-code wraps slash-command machinery (/compact, /clear, etc.) in

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -44,7 +44,7 @@ const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 // elevated to waiting. False negative case: a claude tab idle for >30min
 // reads as disconnected even though the process is live — that flips
 // back to active the moment the user types and JSONL streams.
-const ACTIVE_WINDOW_MS = 30_000;
+const ACTIVE_WINDOW_MS = 60_000;
 const WAITING_WINDOW_MS = 30 * 60 * 1000;
 const DONE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -150,6 +150,11 @@ export class ClaudeCodeWatcher {
       watcher.once("ready", () => resolve());
     });
 
+    // Run an immediate sweep so state reflects current process reality
+    // straight away rather than waiting up to HEARTBEAT_INTERVAL_MS for
+    // the first scheduled tick.
+    await this.heartbeatSweep().catch(this.logError);
+
     this.heartbeat = setInterval(() => {
       this.heartbeatSweep().catch(this.logError);
     }, HEARTBEAT_INTERVAL_MS);
@@ -593,8 +598,12 @@ export class ClaudeCodeWatcher {
 
   // ── Heartbeat ───────────────────────────────────────────────────────────
   // Probe every running `claude` process for its cwd. Cross-reference each
-  // claude-code session's recorded cwd against that set. Recompute state
-  // and update any rows whose state has shifted.
+  // session's recorded cwd against that set, then narrow further: among
+  // multiple sessions that share a cwd (e.g. you've run claude in the same
+  // repo a hundred times), only the freshest JSONL — the one currently
+  // being appended to — is "the live session". The others are old
+  // transcripts that finished. Without this, a single live claude process
+  // marks every past session at that cwd as `waiting`.
   private async heartbeatSweep(): Promise<void> {
     const activeCwds = await activeClaudeCwds();
     const now = this.now().getTime();
@@ -605,14 +614,30 @@ export class ClaudeCodeWatcher {
       if (t.sessionId && t.cwd) sessionCwds.set(t.sessionId, t.cwd);
     }
 
-    for (const session of this.deps.sessionStore.getAll()) {
-      if (session.agent !== "claude-code") continue;
+    const allSessions = this.deps.sessionStore.getAll().filter(
+      (s) => s.agent === "claude-code",
+    );
+
+    // cwd → sessionId of the freshest claude-code session in that cwd.
+    // Sort desc by last_event_at and pick the first occurrence per cwd.
+    const freshestPerCwd = new Map<string, string>();
+    const sortedDesc = [...allSessions].sort(
+      (a, b) => Date.parse(b.last_event_at) - Date.parse(a.last_event_at),
+    );
+    for (const s of sortedDesc) {
+      const cwd = sessionCwds.get(s.id);
+      if (cwd && !freshestPerCwd.has(cwd)) freshestPerCwd.set(cwd, s.id);
+    }
+
+    for (const session of allSessions) {
       const last = Date.parse(session.last_event_at);
       if (!Number.isFinite(last)) continue;
       const ageMs = now - last;
 
       const cwd = sessionCwds.get(session.id);
-      const processAlive = cwd ? activeCwds.has(cwd) : false;
+      const cwdHasLiveProcess = cwd ? activeCwds.has(cwd) : false;
+      const isFreshestInCwd = cwd ? freshestPerCwd.get(cwd) === session.id : false;
+      const processAlive = cwdHasLiveProcess && isFreshestInCwd;
       const next = deriveState(ageMs, processAlive);
 
       if (next !== session.state) {

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -33,17 +33,25 @@ const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 // some claude at this cwd?" devolves into heuristics with edge cases.
 //
 //   ageMs < ACTIVE_WINDOW_MS                                → active
-//   ageMs < WAITING_WINDOW_MS    + claude at this cwd       → waiting
+//   ageMs < WAITING_WINDOW_MS    + signal != "absent"       → waiting
 //   ageMs < DONE_THRESHOLD_MS                               → disconnected
 //   otherwise                                               → done
 //
-// The 30-min waiting window is the honest cap: if a JSONL hasn't been
-// touched in 30 minutes we treat the session as disconnected regardless
-// of whether a claude process is at the cwd. That means an old transcript
-// at a cwd where the user is currently working doesn't get falsely
-// elevated to waiting. False negative case: a claude tab idle for >30min
-// reads as disconnected even though the process is live — that flips
-// back to active the moment the user types and JSONL streams.
+// `signal` is tri-state to handle Windows / probe-unavailable gracefully:
+//   "alive"   — probe ran, found a claude process at this cwd
+//   "absent"  — probe ran, found no claude at this cwd (terminal closed)
+//   "unknown" — probe couldn't run at all (no pgrep). Treat as benefit-
+//               of-doubt: a recent session reads as waiting, not
+//               disconnected. Otherwise Windows would force every idle
+//               session to disconnected, worse than the pre-probe state.
+//
+// The 30-min waiting window is the honest cap: a JSONL untouched for
+// 30 min reads as disconnected regardless of probe. That means an old
+// transcript at a cwd where the user is currently working doesn't get
+// falsely elevated to waiting. False negative: a claude tab idle for
+// >30min on POSIX reads as disconnected even if the process is live —
+// flips back to active the moment the user types.
+export type ProbeSignal = "alive" | "absent" | "unknown";
 const ACTIVE_WINDOW_MS = 60_000;
 const WAITING_WINDOW_MS = 30 * 60 * 1000;
 const DONE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
@@ -191,7 +199,7 @@ export class ClaudeCodeWatcher {
   // (see deriveState), so a session whose claude process is still running
   // comes back as 'active'/'waiting' even after a server restart.
   private async bootScan(): Promise<void> {
-    const cwdCounts = await activeClaudeCwdCounts();
+    const probe = await activeClaudeCwdCounts();
     let projectDirs: string[];
     try {
       projectDirs = await fs.readdir(this.root);
@@ -219,12 +227,12 @@ export class ClaudeCodeWatcher {
       for (const entry of entries) {
         if (!entry.endsWith(".jsonl")) continue;
         const filePath = join(dirPath, entry);
-        await this.reconcileExistingFile(filePath, cwdCounts).catch(this.logError);
+        await this.reconcileExistingFile(filePath, probe).catch(this.logError);
       }
     }
   }
 
-  private async reconcileExistingFile(filePath: string, cwdCounts: Map<string, number>): Promise<void> {
+  private async reconcileExistingFile(filePath: string, probe: { counts: Map<string, number>; available: boolean }): Promise<void> {
     let stat;
     try {
       stat = await fs.stat(filePath);
@@ -236,11 +244,10 @@ export class ClaudeCodeWatcher {
     if (!meta) return;
 
     const ageMs = this.now().getTime() - stat.mtime.getTime();
-    // Coarse seed: if there's any claude at this cwd, assume this session
-    // *might* be live. The immediate heartbeatSweep at the end of start()
-    // refines this to the top-K freshest per cwd.
-    const processAlive = meta.cwd ? (cwdCounts.get(meta.cwd) ?? 0) > 0 : false;
-    const state = deriveState(ageMs, processAlive);
+    const signal: ProbeSignal = !probe.available
+      ? "unknown"
+      : meta.cwd && (probe.counts.get(meta.cwd) ?? 0) > 0 ? "alive" : "absent";
+    const state = deriveState(ageMs, signal);
 
     // Always pass ISO-8601 timestamps. If the JSONL didn't have a usable
     // event timestamp in the first 32KB, fall back to the file's birth time
@@ -628,7 +635,7 @@ export class ClaudeCodeWatcher {
   }
 
   private async runHeartbeatSweep(): Promise<void> {
-    const cwdCounts = await activeClaudeCwdCounts();
+    const probe = await activeClaudeCwdCounts();
     const now = this.now().getTime();
 
     // sessionId → cwd, from in-memory trackers seeded by bootScan + watch.
@@ -644,8 +651,10 @@ export class ClaudeCodeWatcher {
       const ageMs = now - last;
 
       const cwd = sessionCwds.get(session.id);
-      const cwdHasLiveProcess = cwd ? (cwdCounts.get(cwd) ?? 0) > 0 : false;
-      const next = deriveState(ageMs, cwdHasLiveProcess);
+      const signal: ProbeSignal = !probe.available
+        ? "unknown"
+        : cwd && (probe.counts.get(cwd) ?? 0) > 0 ? "alive" : "absent";
+      const next = deriveState(ageMs, signal);
 
       if (next !== session.state) {
         this.deps.sessionStore.updateSessionState(session.id, next, session.last_event_at);
@@ -672,10 +681,12 @@ export class ClaudeCodeWatcher {
 
 // ── Pure helpers (exported for tests) ─────────────────────────────────────
 
-export function deriveState(ageMs: number, processAtCwd: boolean): SessionState {
+export function deriveState(ageMs: number, signal: ProbeSignal): SessionState {
   if (ageMs < ACTIVE_WINDOW_MS) return "active";
-  if (ageMs < WAITING_WINDOW_MS && processAtCwd) return "waiting";
   if (ageMs > DONE_THRESHOLD_MS) return "done";
+  if (ageMs < WAITING_WINDOW_MS) {
+    return signal === "absent" ? "disconnected" : "waiting";
+  }
   return "disconnected";
 }
 

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -102,6 +102,11 @@ function effectiveTitle(t: Pick<FileTracker, "customTitle" | "agentName" | "user
 export class ClaudeCodeWatcher {
   private watcher: FSWatcher | null = null;
   private heartbeat: NodeJS.Timeout | null = null;
+  // Guard against overlapping heartbeat sweeps. Each sweep does a subprocess
+  // probe (pgrep + lsof) plus per-session DB updates. If a slow lsof call
+  // pushes a sweep past HEARTBEAT_INTERVAL_MS, the next tick would otherwise
+  // start in parallel and duplicate work.
+  private heartbeatInFlight = false;
   private trackers = new Map<string, FileTracker>();
   // Per-file serialisation: chokidar can fire two `change` events for the
   // same path before the first read finishes. Without a lock, both reads
@@ -613,6 +618,16 @@ export class ClaudeCodeWatcher {
   // between turns). The recency cap in deriveState handles the one-live-
   // claude-many-old-transcripts case cleanly.
   private async heartbeatSweep(): Promise<void> {
+    if (this.heartbeatInFlight) return;
+    this.heartbeatInFlight = true;
+    try {
+      await this.runHeartbeatSweep();
+    } finally {
+      this.heartbeatInFlight = false;
+    }
+  }
+
+  private async runHeartbeatSweep(): Promise<void> {
     const cwdCounts = await activeClaudeCwdCounts();
     const now = this.now().getTime();
 

--- a/server/src/watchers/claude-process-probe.ts
+++ b/server/src/watchers/claude-process-probe.ts
@@ -15,25 +15,34 @@ const execP = promisify(exec);
 // on the watcher heartbeat (every 15s), so a few hundred ms/min of subprocess
 // time at the high end. Fine.
 //
-// Cross-platform note: pgrep + lsof are POSIX-only. On Windows this returns
-// an empty map, and the watcher falls back to JSONL-recency-only state
-// derivation. Tracked separately — see issue #268.
+// Cross-platform note: pgrep + lsof are POSIX-only. On Windows (or any
+// system without pgrep), `available: false` is returned and the watcher
+// falls back to JSONL-recency-only state derivation. Tracked separately —
+// see issue #268.
 //
-// Returns a count per cwd (not a set) because two claude processes can be
-// running at the same cwd — worktrees, pair-programming workflows, parallel
-// investigations. Counts let the heartbeat pick the top-K most-recently-
-// streamed sessions per cwd as live, instead of either marking only one
-// (false negative) or marking every past transcript at that cwd (false
-// positive).
-export async function activeClaudeCwdCounts(): Promise<Map<string, number>> {
+// `counts` is per-cwd because two claude processes can share a cwd
+// (worktrees, pair-programming, parallel investigations). The heartbeat
+// uses count > 0 today; the per-cwd structure leaves room for a finer
+// matching strategy later if we revisit per-PID identity.
+export interface ClaudeProbeResult {
+  counts: Map<string, number>;
+  available: boolean;
+}
+
+export async function activeClaudeCwdCounts(): Promise<ClaudeProbeResult> {
   let pidsOut: string;
   try {
     const result = await execP("pgrep -x claude", { timeout: 2000 });
     pidsOut = result.stdout;
-  } catch {
-    // pgrep returns exit 1 when no matches; also covers Windows / missing
-    // pgrep. Empty map is the right answer in all those cases.
-    return new Map();
+  } catch (err) {
+    // pgrep exits 1 when no matches — probe DID run, just no claude
+    // around. Anything else (ENOENT, shell "command not found" 127,
+    // Windows) means we couldn't probe at all; report unavailable so the
+    // watcher can fall back to JSONL recency rather than treating every
+    // session as "no process".
+    const code = (err as { code?: number | string } | null)?.code;
+    if (code === 1) return { counts: new Map(), available: true };
+    return { counts: new Map(), available: false };
   }
 
   const pids = pidsOut
@@ -41,7 +50,7 @@ export async function activeClaudeCwdCounts(): Promise<Map<string, number>> {
     .map((s) => s.trim())
     .filter((s) => s.length > 0 && /^\d+$/.test(s));
 
-  if (pids.length === 0) return new Map();
+  if (pids.length === 0) return { counts: new Map(), available: true };
 
   const counts = new Map<string, number>();
   await Promise.all(
@@ -63,5 +72,5 @@ export async function activeClaudeCwdCounts(): Promise<Map<string, number>> {
       }
     }),
   );
-  return counts;
+  return { counts, available: true };
 }

--- a/server/src/watchers/claude-process-probe.ts
+++ b/server/src/watchers/claude-process-probe.ts
@@ -16,17 +16,24 @@ const execP = promisify(exec);
 // time at the high end. Fine.
 //
 // Cross-platform note: pgrep + lsof are POSIX-only. On Windows this returns
-// an empty set, and the watcher falls back to JSONL-recency-only state
+// an empty map, and the watcher falls back to JSONL-recency-only state
 // derivation. Tracked separately — see issue #268.
-export async function activeClaudeCwds(): Promise<Set<string>> {
+//
+// Returns a count per cwd (not a set) because two claude processes can be
+// running at the same cwd — worktrees, pair-programming workflows, parallel
+// investigations. Counts let the heartbeat pick the top-K most-recently-
+// streamed sessions per cwd as live, instead of either marking only one
+// (false negative) or marking every past transcript at that cwd (false
+// positive).
+export async function activeClaudeCwdCounts(): Promise<Map<string, number>> {
   let pidsOut: string;
   try {
     const result = await execP("pgrep -x claude", { timeout: 2000 });
     pidsOut = result.stdout;
   } catch {
     // pgrep returns exit 1 when no matches; also covers Windows / missing
-    // pgrep. Empty set is the right answer in all those cases.
-    return new Set();
+    // pgrep. Empty map is the right answer in all those cases.
+    return new Map();
   }
 
   const pids = pidsOut
@@ -34,9 +41,9 @@ export async function activeClaudeCwds(): Promise<Set<string>> {
     .map((s) => s.trim())
     .filter((s) => s.length > 0 && /^\d+$/.test(s));
 
-  if (pids.length === 0) return new Set();
+  if (pids.length === 0) return new Map();
 
-  const cwds = new Set<string>();
+  const counts = new Map<string, number>();
   await Promise.all(
     pids.map(async (pid) => {
       try {
@@ -46,12 +53,15 @@ export async function activeClaudeCwds(): Promise<Set<string>> {
         );
         // lsof -F n format: lines starting with 'n' have the path.
         for (const line of stdout.split("\n")) {
-          if (line.startsWith("n/")) cwds.add(line.slice(1));
+          if (line.startsWith("n/")) {
+            const cwd = line.slice(1);
+            counts.set(cwd, (counts.get(cwd) ?? 0) + 1);
+          }
         }
       } catch {
         // Process exited between pgrep and lsof; ignore.
       }
     }),
   );
-  return cwds;
+  return counts;
 }

--- a/server/src/watchers/claude-process-probe.ts
+++ b/server/src/watchers/claude-process-probe.ts
@@ -1,0 +1,57 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execP = promisify(exec);
+
+// Discover the working directories of every running `claude` process.
+//
+// The trick: every running process has a current working directory, and
+// claude-code runs in the same cwd that gets recorded in its JSONL session
+// file. So if `pgrep` finds a `claude` PID and `lsof -p <pid> -a -d cwd`
+// reports a cwd that matches a session's recorded cwd, that session has a
+// live process behind it. No IPC, no file-handle racing, no per-agent SDK.
+//
+// Cost: ~40ms wall clock for 1-5 claude processes on macOS. The probe runs
+// on the watcher heartbeat (every 15s), so a few hundred ms/min of subprocess
+// time at the high end. Fine.
+//
+// Cross-platform note: pgrep + lsof are POSIX-only. On Windows this returns
+// an empty set, and the watcher falls back to JSONL-recency-only state
+// derivation. Tracked separately — see issue #268.
+export async function activeClaudeCwds(): Promise<Set<string>> {
+  let pidsOut: string;
+  try {
+    const result = await execP("pgrep -x claude", { timeout: 2000 });
+    pidsOut = result.stdout;
+  } catch {
+    // pgrep returns exit 1 when no matches; also covers Windows / missing
+    // pgrep. Empty set is the right answer in all those cases.
+    return new Set();
+  }
+
+  const pids = pidsOut
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && /^\d+$/.test(s));
+
+  if (pids.length === 0) return new Set();
+
+  const cwds = new Set<string>();
+  await Promise.all(
+    pids.map(async (pid) => {
+      try {
+        const { stdout } = await execP(
+          `lsof -p ${pid} -a -d cwd -F n`,
+          { timeout: 2000 },
+        );
+        // lsof -F n format: lines starting with 'n' have the path.
+        for (const line of stdout.split("\n")) {
+          if (line.startsWith("n/")) cwds.add(line.slice(1));
+        }
+      } catch {
+        // Process exited between pgrep and lsof; ignore.
+      }
+    }),
+  );
+  return cwds;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -51,7 +51,7 @@ export interface ScanResult {
   artifacts: Array<{ id: string; label: string; kind: string; sourceRef: string | null }>;
 }
 
-export type SessionState = "running" | "awaiting" | "disconnected" | "done";
+export type SessionState = "active" | "waiting" | "disconnected" | "done";
 export type SessionAgent = "claude-code" | "opencode" | "codex";
 
 /** Agent session captured by the watchers (#251). Read-only on the wire — UI mutations come later. */

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -324,9 +324,9 @@
 .home-space-card--elsewhere .home-space-card-name {
   font-style: italic;
 }
-.home-space-card--elsewhere.selected {
-  border-style: solid;
-}
+/* Elsewhere keeps its dashed border even when selected — the dashed
+   line is a "you're not in a real space" cue, distinct from the solid
+   space cards. */
 
 /* ── Sessions surface (icon view) ── */
 .home-surface {

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -270,6 +270,10 @@
   gap: 10px;
 }
 .home-space-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
   text-align: left;
   padding: 10px 14px;
   background: var(--home-surface);

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -408,12 +408,12 @@
   height: 10px;
   border-radius: 50%;
 }
-.home-status.running::before {
+.home-status.active::before {
   background: var(--home-green);
   box-shadow: 0 0 10px var(--home-green);
   animation: home-breathe 2.4s ease-in-out infinite;
 }
-.home-status.awaiting::before {
+.home-status.waiting::before {
   background: var(--home-amber);
   box-shadow: 0 0 10px var(--home-amber);
 }
@@ -499,8 +499,8 @@
   height: 8px;
   border-radius: 50%;
 }
-.home-row-status.running { background: var(--home-green); box-shadow: 0 0 6px var(--home-green); animation: home-breathe 2.4s ease-in-out infinite; }
-.home-row-status.awaiting { background: var(--home-amber); box-shadow: 0 0 6px var(--home-amber); }
+.home-row-status.active { background: var(--home-green); box-shadow: 0 0 6px var(--home-green); animation: home-breathe 2.4s ease-in-out infinite; }
+.home-row-status.waiting { background: var(--home-amber); box-shadow: 0 0 6px var(--home-amber); }
 .home-row-status.disconnected { background: var(--home-red); box-shadow: 0 0 6px var(--home-red); }
 .home-row-status.done { background: rgba(255, 255, 255, 0.18); }
 

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -184,6 +184,13 @@
   align-items: center;
 }
 
+.stat-divider {
+  flex: 0 0 1px;
+  height: 16px;
+  background: var(--home-border);
+  margin: 0 4px;
+}
+
 .stat-btn {
   display: inline-flex;
   align-items: center;

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -515,7 +515,7 @@
 
 .home-row {
   display: grid;
-  grid-template-columns: 18px 130px 1fr 130px 100px;
+  grid-template-columns: 18px 130px 1fr 130px 130px;
   gap: 14px;
   align-items: center;
   padding: 12px 18px;
@@ -576,6 +576,7 @@
   font-size: 11px;
   color: var(--text-dim);
   text-align: right;
+  white-space: nowrap;
 }
 
 /* ── Artefacts table row (renders inside .home-table when toggled) ── */

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -122,7 +122,7 @@
   font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--text-dim);
+  color: var(--home-accent-bright);
   margin-bottom: 8px;
 }
 

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -285,6 +285,11 @@
   border-color: var(--home-border-accent);
   background: rgba(124, 107, 255, 0.05);
 }
+.home-space-card.selected {
+  background: rgba(124, 107, 255, 0.14);
+  border-color: var(--home-border-accent);
+  box-shadow: 0 0 0 1px var(--home-border-accent) inset;
+}
 .home-space-card-name {
   font-family: var(--font-mono);
   font-size: 13px;
@@ -320,8 +325,6 @@
   font-style: italic;
 }
 .home-space-card--elsewhere.selected {
-  background: rgba(124, 107, 255, 0.12);
-  border-color: var(--home-border-accent);
   border-style: solid;
 }
 

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -310,6 +310,20 @@
   width: 5px;
   height: 5px;
 }
+/* Elsewhere card: same shape, dashed border to read as a meta-bucket
+   rather than a real space. Selected state mirrors the chip-bar
+   stat-btn highlight. */
+.home-space-card--elsewhere {
+  border-style: dashed;
+}
+.home-space-card--elsewhere .home-space-card-name {
+  font-style: italic;
+}
+.home-space-card--elsewhere.selected {
+  background: rgba(124, 107, 255, 0.12);
+  border-color: var(--home-border-accent);
+  border-style: solid;
+}
 
 /* ── Sessions surface (icon view) ── */
 .home-surface {

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -266,15 +266,15 @@
   margin: 0 auto;
   padding: 0 32px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
 }
 .home-space-card {
   text-align: left;
-  padding: 16px 18px;
+  padding: 10px 14px;
   background: var(--home-surface);
   border: 1px solid var(--home-border);
-  border-radius: 14px;
+  border-radius: 12px;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   cursor: pointer;
@@ -292,15 +292,15 @@
 }
 .home-space-card-name {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: 12px;
   color: var(--home-accent-bright);
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 }
 .home-space-card-counts {
   display: flex;
-  gap: 14px;
+  gap: 10px;
   flex-wrap: wrap;
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-dim);
 }
 .home-space-card-counts .signal {

--- a/web/src/components/Home.css
+++ b/web/src/components/Home.css
@@ -326,7 +326,11 @@
 }
 /* Elsewhere keeps its dashed border even when selected — the dashed
    line is a "you're not in a real space" cue, distinct from the solid
-   space cards. */
+   space cards. Drop the inset ring used for solid cards; it clashes
+   with the dashes. */
+.home-space-card--elsewhere.selected {
+  box-shadow: none;
+}
 
 /* ── Sessions surface (icon view) ── */
 .home-surface {

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -15,13 +15,20 @@ interface Props {
 }
 
 type ViewMode = "icons" | "table";
-type StateFilter = SessionState | "all";
+type StateFilter = SessionState | "live" | "all";
 
-const FILTER_ORDER: StateFilter[] = ["active", "waiting", "disconnected", "done", "all"];
+// "live" is a preset bundling active+waiting+disconnected (everything that
+// isn't archived). It's the default because that's the common case — done
+// is review/history, not active inventory. The dot after "live" indicates
+// the live cluster ends; the per-state chips after it are for fine-grained
+// filtering.
+const FILTER_ORDER: StateFilter[] = ["live", "active", "waiting", "disconnected", "done", "all"];
+const LIVE_STATES: SessionState[] = ["active", "waiting", "disconnected"];
 
 const EMPTY_COUNTS = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
 
 const FILTER_LABELS: Record<StateFilter, string> = {
+  live: "live",
   active: "active",
   waiting: "waiting",
   disconnected: "disconnected",
@@ -49,7 +56,7 @@ const AGENT_PIP_CLASS: Record<SessionAgent, string> = {
 
 export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange }: Props) {
   const { sessions, error, loading } = useSessions();
-  const [stateFilter, setStateFilter] = useState<StateFilter>("all");
+  const [stateFilter, setStateFilter] = useState<StateFilter>("live");
   const [sessionsView, setSessionsView] = useState<ViewMode>("icons");
   const [artefactsView, setArtefactsView] = useState<ViewMode>("icons");
 
@@ -65,15 +72,17 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
   );
 
   const stateCounts = useMemo(() => {
-    const counts: Record<StateFilter, number> = { active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
+    const counts: Record<StateFilter, number> = { live: 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
     for (const s of scopedSessions) counts[s.state]++;
+    counts.live = counts.active + counts.waiting + counts.disconnected;
     return counts;
   }, [scopedSessions]);
 
-  const visibleSessions = useMemo(
-    () => (stateFilter === "all" ? scopedSessions : scopedSessions.filter((s) => s.state === stateFilter)),
-    [scopedSessions, stateFilter],
-  );
+  const visibleSessions = useMemo(() => {
+    if (stateFilter === "all") return scopedSessions;
+    if (stateFilter === "live") return scopedSessions.filter((s) => LIVE_STATES.includes(s.state));
+    return scopedSessions.filter((s) => s.state === stateFilter);
+  }, [scopedSessions, stateFilter]);
 
   // Drop meta-spaces from the Spaces summary cards: the chat bar already
   // renders Home as its own pill, so a `home` row in the spaces table would
@@ -149,16 +158,19 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
             <span className="home-section-stats">
               {FILTER_ORDER.map((f) => {
                 const count = stateCounts[f];
-                if (count === 0 && f !== "all") return null;
+                if (count === 0 && f !== "all" && f !== "live") return null;
+                const showPip = f !== "all" && f !== "live";
                 return (
-                  <button
-                    key={f}
-                    className={`stat-btn${stateFilter === f ? " active" : ""}`}
-                    onClick={() => setStateFilter(f)}
-                  >
-                    {f !== "all" && <span className={`pip pip-${stateColor(f)}`} />}
-                    {count} {FILTER_LABELS[f]}
-                  </button>
+                  <span key={f} style={{ display: "contents" }}>
+                    <button
+                      className={`stat-btn${stateFilter === f ? " active" : ""}`}
+                      onClick={() => setStateFilter(f)}
+                    >
+                      {showPip && <span className={`pip pip-${stateColor(f as SessionState)}`} />}
+                      {count} {FILTER_LABELS[f]}
+                    </button>
+                    {f === "live" && <span className="stat-divider" aria-hidden="true" />}
+                  </span>
                 );
               })}
             </span>

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -115,22 +115,6 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
     return scopedSessions.filter((s) => s.state === stateFilter);
   }, [scopedSessions, stateFilter]);
 
-  // Drop meta-spaces from the Spaces summary cards: the chat bar already
-  // renders Home as its own pill, so a `home` row in the spaces table would
-  // surface a redundant card. __all__ and __archived__ are similar.
-  // Sort by most recent session activity desc; spaces with no sessions
-  // fall to the bottom in their original (alphabetical) order. Home and
-  // Elsewhere cards are rendered around this list — always first / always
-  // last regardless of activity.
-  const realSpaces = useMemo(() => {
-    const filtered = spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__");
-    return [...filtered].sort((a, b) => {
-      const aT = lastActivityBySpace[a.id] ?? 0;
-      const bT = lastActivityBySpace[b.id] ?? 0;
-      return bT - aT;
-    });
-  }, [spaces, lastActivityBySpace]);
-
   // Per-space session counts + a separate orphan tally (sessions with
   // spaceId === null) + a grand total for the Home card, plus the most
   // recent lastEventAt per space so we can sort the cards by activity.
@@ -158,6 +142,22 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
     }
     return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total, lastActivityBySpace: lastActivity };
   }, [sessions]);
+
+  // Drop meta-spaces from the Spaces summary cards: the chat bar already
+  // renders Home as its own pill, so a `home` row in the spaces table would
+  // surface a redundant card. __all__ and __archived__ are similar.
+  // Sort by most recent session activity desc; spaces with no sessions
+  // fall to the bottom in their original (alphabetical) order. Home and
+  // Elsewhere cards are rendered around this list — always first / always
+  // last regardless of activity.
+  const realSpaces = useMemo(() => {
+    const filtered = spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__");
+    return [...filtered].sort((a, b) => {
+      const aT = lastActivityBySpace[a.id] ?? 0;
+      const bT = lastActivityBySpace[b.id] ?? 0;
+      return bT - aT;
+    });
+  }, [spaces, lastActivityBySpace]);
 
   // When scoped to Elsewhere, artefacts should mirror the sessions filter:
   // anything not attributed to a known real space (null spaceId or a stale

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -17,13 +17,13 @@ interface Props {
 type ViewMode = "icons" | "table";
 type StateFilter = SessionState | "all";
 
-const FILTER_ORDER: StateFilter[] = ["running", "awaiting", "disconnected", "done", "all"];
+const FILTER_ORDER: StateFilter[] = ["active", "waiting", "disconnected", "done", "all"];
 
-const EMPTY_COUNTS = { total: 0, running: 0, awaiting: 0, disconnected: 0, done: 0 };
+const EMPTY_COUNTS = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
 
 const FILTER_LABELS: Record<StateFilter, string> = {
-  running: "running",
-  awaiting: "awaiting you",
+  active: "active",
+  waiting: "waiting",
   disconnected: "disconnected",
   done: "done",
   all: "all",
@@ -65,7 +65,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
   );
 
   const stateCounts = useMemo(() => {
-    const counts: Record<StateFilter, number> = { running: 0, awaiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
+    const counts: Record<StateFilter, number> = { active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
     for (const s of scopedSessions) counts[s.state]++;
     return counts;
   }, [scopedSessions]);
@@ -87,10 +87,10 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
   // re-render. The Home component re-renders on every session_changed SSE,
   // so the inner loop matters once you have many spaces and sessions.
   const sessionCountsBySpace = useMemo(() => {
-    const acc: Record<string, { total: number; running: number; awaiting: number; disconnected: number; done: number }> = {};
+    const acc: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
     for (const s of sessions) {
       if (!s.spaceId) continue;
-      const c = acc[s.spaceId] ?? { total: 0, running: 0, awaiting: 0, disconnected: 0, done: 0 };
+      const c = acc[s.spaceId] ?? { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
       c.total++;
       c[s.state]++;
       acc[s.spaceId] = c;
@@ -130,8 +130,8 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
                   >
                     <div className="home-space-card-name">{space.displayName}</div>
                     <div className="home-space-card-counts">
-                      {counts.running > 0 && <span className="signal"><span className="pip pip-green" />{counts.running} running</span>}
-                      {counts.awaiting > 0 && <span className="signal"><span className="pip pip-amber" />{counts.awaiting} awaiting</span>}
+                      {counts.active > 0 && <span className="signal"><span className="pip pip-green" />{counts.active} active</span>}
+                      {counts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{counts.waiting} waiting</span>}
                       {counts.disconnected > 0 && <span className="signal"><span className="pip pip-red" />{counts.disconnected} disconnected</span>}
                       {counts.done > 0 && <span className="signal"><span className="pip pip-dim" />{counts.done} done</span>}
                       {counts.total === 0 && <span className="signal signal-muted">no sessions yet</span>}
@@ -274,8 +274,8 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
 
 function stateColor(state: SessionState): "green" | "amber" | "red" | "dim" {
   switch (state) {
-    case "running": return "green";
-    case "awaiting": return "amber";
+    case "active": return "green";
+    case "waiting": return "amber";
     case "disconnected": return "red";
     case "done": return "dim";
   }
@@ -287,7 +287,7 @@ function spaceLabelFor(spaceId: string | null, spaces: Space[]): string | null {
 }
 
 function metaForSession(session: Session): string {
-  if (session.state === "awaiting") return `${session.agent} · awaiting`;
+  if (session.state === "waiting") return `${session.agent} · waiting`;
   if (session.state === "disconnected") return `${session.agent} · disconnected`;
   return `${session.agent} · ${formatRelative(session.lastEventAt) ?? "—"}`;
 }
@@ -323,7 +323,7 @@ interface SessionRowProps {
 
 function SessionRow({ session, spaces }: SessionRowProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
-  const time = session.state === "awaiting" ? "awaiting"
+  const time = session.state === "waiting" ? "waiting"
     : session.state === "disconnected" ? "disconnected"
     : formatRelative(session.lastEventAt) ?? "—";
   const title = session.title ?? "(no title yet)";

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -145,6 +145,19 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
         {!isAllView && !isArchivedView && (realSpaces.length > 0 || orphanCounts.total > 0) && (
           <div className="home-spaces-section">
             <div className="home-spaces-grid">
+              <button
+                className={`home-space-card home-space-card--home${isHomeView && !showElsewhere ? " selected" : ""}`}
+                onClick={() => {
+                  setShowElsewhere(false);
+                  onSpaceChange("home");
+                }}
+                title="Everything across all spaces"
+              >
+                <div className="home-space-card-name">Home</div>
+                <div className="home-space-card-counts">
+                  <span className="signal signal-muted">all spaces</span>
+                </div>
+              </button>
               {realSpaces.map((space) => {
                 const counts = sessionCountsBySpace[space.id] ?? EMPTY_COUNTS;
                 const isActive = scopedSpace === space.id;

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -154,7 +154,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
     if (showElsewhere && isHomeView) {
       return {
         ...desktopProps,
-        artifacts: effectiveDesktopProps.artifacts.filter((a) => !a.spaceId || !realSpaceIds.has(a.spaceId)),
+        artifacts: desktopProps.artifacts.filter((a) => !a.spaceId || !realSpaceIds.has(a.spaceId)),
       };
     }
     return desktopProps;

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -175,7 +175,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
       <div className={`home-scroll${isHero ? " home-scroll--hero" : ""}`}>
         <header className="home-header">
           <div className="home-eyebrow">{eyebrow}</div>
-          <h1 className="home-title">{isHomeView ? "Today." : eyebrow}</h1>
+          <h1 className="home-title">{isHomeView ? (showElsewhere ? "Elsewhere." : "Everything.") : eyebrow}</h1>
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -145,6 +145,21 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
     return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total };
   }, [sessions]);
 
+  // When scoped to Elsewhere, artefacts should mirror the sessions filter:
+  // anything not attributed to a known real space (null spaceId or a stale
+  // pointer to a deleted space). App.tsx hands us all artefacts on home —
+  // we narrow them locally so artefacts and sessions tell the same story.
+  const realSpaceIds = useMemo(() => new Set(realSpaces.map((s) => s.id)), [realSpaces]);
+  const effectiveDesktopProps = useMemo(() => {
+    if (showElsewhere && isHomeView) {
+      return {
+        ...desktopProps,
+        artifacts: effectiveDesktopProps.artifacts.filter((a) => !a.spaceId || !realSpaceIds.has(a.spaceId)),
+      };
+    }
+    return desktopProps;
+  }, [showElsewhere, isHomeView, desktopProps, realSpaceIds]);
+
   const activeSpaceRow = scopedSpace ? spaces.find((s) => s.id === scopedSpace) : null;
   const eyebrow = isHomeView ? (showElsewhere ? "Elsewhere" : "Home")
     : isAllView ? "All"
@@ -315,7 +330,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
         <section className="home-section">
           <div className="home-section-head">
             <span className="home-section-label">Artefacts</span>
-            <span className="home-artefacts-count">{desktopProps.artifacts.length}</span>
+            <span className="home-artefacts-count">{effectiveDesktopProps.artifacts.length}</span>
             <span className="home-section-rule" />
             <div className="home-view-toggle">
               <button
@@ -347,13 +362,13 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
           </div>
           {artefactsView === "icons" ? (
             <div className="home-artefacts">
-              <Desktop {...desktopProps} isHero={false} showMeta />
+              <Desktop {...effectiveDesktopProps} isHero={false} showMeta />
             </div>
           ) : (
             <ArtefactTable
-              artifacts={desktopProps.artifacts}
+              artifacts={effectiveDesktopProps.artifacts}
               spaces={spaces}
-              onArtifactClick={desktopProps.onArtifactClick}
+              onArtifactClick={effectiveDesktopProps.onArtifactClick}
             />
           )}
         </section>

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -17,6 +17,25 @@ interface Props {
 type ViewMode = "icons" | "table";
 type StateFilter = SessionState | "live" | "all";
 
+// Persists a view toggle (icons / table) to localStorage so it survives
+// reloads. Returns a useState-shaped pair so callsites stay one-liner.
+function useStickyView(key: string, defaultValue: ViewMode): [ViewMode, (v: ViewMode) => void] {
+  const [value, setValue] = useState<ViewMode>(() => {
+    if (typeof window === "undefined") return defaultValue;
+    const stored = window.localStorage.getItem(key);
+    return stored === "icons" || stored === "table" ? stored : defaultValue;
+  });
+  const set = (v: ViewMode) => {
+    setValue(v);
+    try {
+      window.localStorage.setItem(key, v);
+    } catch {
+      // private browsing / disabled storage — fine, just lose persistence
+    }
+  };
+  return [value, set];
+}
+
 // "live" is a preset bundling active+waiting+disconnected (everything that
 // isn't archived). It's the default because that's the common case — done
 // is review/history, not active inventory. The dot after "live" indicates
@@ -57,8 +76,8 @@ const AGENT_PIP_CLASS: Record<SessionAgent, string> = {
 export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange }: Props) {
   const { sessions, error, loading } = useSessions();
   const [stateFilter, setStateFilter] = useState<StateFilter>("live");
-  const [sessionsView, setSessionsView] = useState<ViewMode>("icons");
-  const [artefactsView, setArtefactsView] = useState<ViewMode>("icons");
+  const [sessionsView, setSessionsView] = useStickyView("oyster.home.sessionsView", "icons");
+  const [artefactsView, setArtefactsView] = useStickyView("oyster.home.artefactsView", "icons");
 
   // Local "Elsewhere" scope: filters Sessions to those whose spaceId is null
   // (claude/codex sessions started in folders that aren't attached to any

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -287,9 +287,10 @@ function spaceLabelFor(spaceId: string | null, spaces: Space[]): string | null {
 }
 
 function metaForSession(session: Session): string {
-  if (session.state === "waiting") return `${session.agent} · waiting`;
-  if (session.state === "disconnected") return `${session.agent} · disconnected`;
-  return `${session.agent} · ${formatRelative(session.lastEventAt) ?? "—"}`;
+  const rel = formatRelative(session.lastEventAt) ?? "—";
+  if (session.state === "waiting") return `${session.agent} · waiting ${rel}`;
+  if (session.state === "disconnected") return `${session.agent} · disconnected ${rel}`;
+  return `${session.agent} · ${rel}`;
 }
 
 interface SessionTileProps {
@@ -323,9 +324,10 @@ interface SessionRowProps {
 
 function SessionRow({ session, spaces }: SessionRowProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
-  const time = session.state === "waiting" ? "waiting"
-    : session.state === "disconnected" ? "disconnected"
-    : formatRelative(session.lastEventAt) ?? "—";
+  const rel = formatRelative(session.lastEventAt) ?? "—";
+  const time = session.state === "waiting" ? `waiting ${rel}`
+    : session.state === "disconnected" ? `disconnected ${rel}`
+    : rel;
   const title = session.title ?? "(no title yet)";
   return (
     <div className="home-row">

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -118,17 +118,27 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
   // Drop meta-spaces from the Spaces summary cards: the chat bar already
   // renders Home as its own pill, so a `home` row in the spaces table would
   // surface a redundant card. __all__ and __archived__ are similar.
-  const realSpaces = useMemo(
-    () => spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__"),
-    [spaces],
-  );
+  // Sort by most recent session activity desc; spaces with no sessions
+  // fall to the bottom in their original (alphabetical) order. Home and
+  // Elsewhere cards are rendered around this list — always first / always
+  // last regardless of activity.
+  const realSpaces = useMemo(() => {
+    const filtered = spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__");
+    return [...filtered].sort((a, b) => {
+      const aT = lastActivityBySpace[a.id] ?? 0;
+      const bT = lastActivityBySpace[b.id] ?? 0;
+      return bT - aT;
+    });
+  }, [spaces, lastActivityBySpace]);
 
   // Per-space session counts + a separate orphan tally (sessions with
-  // spaceId === null) + a grand total for the Home card, all in one pass.
-  const { sessionCountsBySpace, orphanCounts, totalCounts } = useMemo(() => {
+  // spaceId === null) + a grand total for the Home card, plus the most
+  // recent lastEventAt per space so we can sort the cards by activity.
+  const { sessionCountsBySpace, orphanCounts, totalCounts, lastActivityBySpace } = useMemo(() => {
     const bySpace: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
     const orphans = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     const total = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+    const lastActivity: Record<string, number> = {};
     for (const s of sessions) {
       total.total++;
       total[s.state]++;
@@ -137,12 +147,16 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
         c.total++;
         c[s.state]++;
         bySpace[s.spaceId] = c;
+        const t = parseTimestamp(s.lastEventAt);
+        if (Number.isFinite(t) && t > (lastActivity[s.spaceId] ?? 0)) {
+          lastActivity[s.spaceId] = t;
+        }
       } else {
         orphans.total++;
         orphans[s.state]++;
       }
     }
-    return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total };
+    return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total, lastActivityBySpace: lastActivity };
   }, [sessions]);
 
   // When scoped to Elsewhere, artefacts should mirror the sessions filter:

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -142,15 +142,16 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 
-        {isHomeView && (realSpaces.length > 0 || orphanCounts.total > 0) && (
+        {!isAllView && !isArchivedView && (realSpaces.length > 0 || orphanCounts.total > 0) && (
           <div className="home-spaces-section">
             <div className="home-spaces-grid">
               {realSpaces.map((space) => {
                 const counts = sessionCountsBySpace[space.id] ?? EMPTY_COUNTS;
+                const isActive = scopedSpace === space.id;
                 return (
                   <button
                     key={space.id}
-                    className="home-space-card"
+                    className={`home-space-card${isActive ? " selected" : ""}`}
                     onClick={() => onSpaceChange(space.id)}
                   >
                     <div className="home-space-card-name">{space.displayName}</div>
@@ -166,8 +167,15 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
               })}
               {orphanCounts.total > 0 && (
                 <button
-                  className={`home-space-card home-space-card--elsewhere${showElsewhere ? " selected" : ""}`}
-                  onClick={() => setShowElsewhere((v) => !v)}
+                  className={`home-space-card home-space-card--elsewhere${isHomeView && showElsewhere ? " selected" : ""}`}
+                  onClick={() => {
+                    if (isHomeView) {
+                      setShowElsewhere((v) => !v);
+                    } else {
+                      setShowElsewhere(true);
+                      onSpaceChange("home");
+                    }
+                  }}
                   title="Sessions outside any registered space"
                 >
                   <div className="home-space-card-name">Elsewhere</div>

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -189,7 +189,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
       <div className={`home-scroll${isHero ? " home-scroll--hero" : ""}`}>
         <header className="home-header">
           <div className="home-eyebrow">{eyebrow}</div>
-          <h1 className="home-title">{isHomeView ? (showElsewhere ? "Elsewhere." : "Everything.") : eyebrow}</h1>
+          <h1 className="home-title">{isHomeView ? (showElsewhere ? "Everything else." : "Everything.") : eyebrow}</h1>
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -105,11 +105,14 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
   );
 
   // Per-space session counts + a separate orphan tally (sessions with
-  // spaceId === null), all in one pass.
-  const { sessionCountsBySpace, orphanCounts } = useMemo(() => {
+  // spaceId === null) + a grand total for the Home card, all in one pass.
+  const { sessionCountsBySpace, orphanCounts, totalCounts } = useMemo(() => {
     const bySpace: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
     const orphans = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+    const total = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     for (const s of sessions) {
+      total.total++;
+      total[s.state]++;
       if (s.spaceId) {
         const c = bySpace[s.spaceId] ?? { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
         c.total++;
@@ -120,7 +123,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
         orphans[s.state]++;
       }
     }
-    return { sessionCountsBySpace: bySpace, orphanCounts: orphans };
+    return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total };
   }, [sessions]);
 
   const activeSpaceRow = scopedSpace ? spaces.find((s) => s.id === scopedSpace) : null;
@@ -155,7 +158,11 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
               >
                 <div className="home-space-card-name">Home</div>
                 <div className="home-space-card-counts">
-                  <span className="signal signal-muted">all spaces</span>
+                  {totalCounts.active > 0 && <span className="signal"><span className="pip pip-green" />{totalCounts.active} active</span>}
+                  {totalCounts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{totalCounts.waiting} waiting</span>}
+                  {totalCounts.disconnected > 0 && <span className="signal"><span className="pip pip-red" />{totalCounts.disconnected} disconnected</span>}
+                  {totalCounts.done > 0 && <span className="signal"><span className="pip pip-dim" />{totalCounts.done} done</span>}
+                  {totalCounts.total === 0 && <span className="signal signal-muted">no sessions yet</span>}
                 </div>
               </button>
               {realSpaces.map((space) => {

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Session, SessionState, SessionAgent } from "../data/sessions-api";
 import type { Space } from "../../../shared/types";
 import { useSessions } from "../hooks/useSessions";
@@ -60,16 +60,28 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
   const [sessionsView, setSessionsView] = useState<ViewMode>("icons");
   const [artefactsView, setArtefactsView] = useState<ViewMode>("icons");
 
+  // Local "Elsewhere" scope: filters Sessions to those whose spaceId is null
+  // (claude/codex sessions started in folders that aren't attached to any
+  // registered space). Only applies in Home view; navigating to a real space
+  // resets it.
+  const [showElsewhere, setShowElsewhere] = useState(false);
+
   const isHomeView = activeSpace === "home";
   const isAllView = activeSpace === "__all__";
   const isArchivedView = activeSpace === "__archived__";
   const isMetaView = isHomeView || isAllView || isArchivedView;
   const scopedSpace = !isMetaView ? activeSpace : null;
 
-  const scopedSessions = useMemo(
-    () => (scopedSpace ? sessions.filter((s) => s.spaceId === scopedSpace) : sessions),
-    [sessions, scopedSpace],
-  );
+  // Reset Elsewhere scope when we navigate away from Home (e.g. user clicks
+  // a real space card or chat-bar pill).
+  useEffect(() => {
+    if (!isHomeView) setShowElsewhere(false);
+  }, [isHomeView]);
+
+  const scopedSessions = useMemo(() => {
+    if (showElsewhere && isHomeView) return sessions.filter((s) => s.spaceId === null);
+    return scopedSpace ? sessions.filter((s) => s.spaceId === scopedSpace) : sessions;
+  }, [sessions, scopedSpace, showElsewhere, isHomeView]);
 
   const stateCounts = useMemo(() => {
     const counts: Record<StateFilter, number> = { live: 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
@@ -92,23 +104,27 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
     [spaces],
   );
 
-  // Per-space session counts in a single pass instead of N×4 filter calls per
-  // re-render. The Home component re-renders on every session_changed SSE,
-  // so the inner loop matters once you have many spaces and sessions.
-  const sessionCountsBySpace = useMemo(() => {
-    const acc: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
+  // Per-space session counts + a separate orphan tally (sessions with
+  // spaceId === null), all in one pass.
+  const { sessionCountsBySpace, orphanCounts } = useMemo(() => {
+    const bySpace: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
+    const orphans = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     for (const s of sessions) {
-      if (!s.spaceId) continue;
-      const c = acc[s.spaceId] ?? { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
-      c.total++;
-      c[s.state]++;
-      acc[s.spaceId] = c;
+      if (s.spaceId) {
+        const c = bySpace[s.spaceId] ?? { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+        c.total++;
+        c[s.state]++;
+        bySpace[s.spaceId] = c;
+      } else {
+        orphans.total++;
+        orphans[s.state]++;
+      }
     }
-    return acc;
+    return { sessionCountsBySpace: bySpace, orphanCounts: orphans };
   }, [sessions]);
 
   const activeSpaceRow = scopedSpace ? spaces.find((s) => s.id === scopedSpace) : null;
-  const eyebrow = isHomeView ? "Home"
+  const eyebrow = isHomeView ? (showElsewhere ? "Elsewhere" : "Home")
     : isAllView ? "All"
     : isArchivedView ? "Archived"
     : activeSpaceRow?.displayName ?? scopedSpace ?? "";
@@ -126,7 +142,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 
-        {isHomeView && realSpaces.length > 0 && (
+        {isHomeView && (realSpaces.length > 0 || orphanCounts.total > 0) && (
           <div className="home-spaces-section">
             <div className="home-spaces-grid">
               {realSpaces.map((space) => {
@@ -148,6 +164,21 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange 
                   </button>
                 );
               })}
+              {orphanCounts.total > 0 && (
+                <button
+                  className={`home-space-card home-space-card--elsewhere${showElsewhere ? " selected" : ""}`}
+                  onClick={() => setShowElsewhere((v) => !v)}
+                  title="Sessions outside any registered space"
+                >
+                  <div className="home-space-card-name">Elsewhere</div>
+                  <div className="home-space-card-counts">
+                    {orphanCounts.active > 0 && <span className="signal"><span className="pip pip-green" />{orphanCounts.active} active</span>}
+                    {orphanCounts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{orphanCounts.waiting} waiting</span>}
+                    {orphanCounts.disconnected > 0 && <span className="signal"><span className="pip pip-red" />{orphanCounts.disconnected} disconnected</span>}
+                    {orphanCounts.done > 0 && <span className="signal"><span className="pip pip-dim" />{orphanCounts.done} done</span>}
+                  </div>
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -22,8 +22,13 @@ type StateFilter = SessionState | "live" | "all";
 function useStickyView(key: string, defaultValue: ViewMode): [ViewMode, (v: ViewMode) => void] {
   const [value, setValue] = useState<ViewMode>(() => {
     if (typeof window === "undefined") return defaultValue;
-    const stored = window.localStorage.getItem(key);
-    return stored === "icons" || stored === "table" ? stored : defaultValue;
+    try {
+      const stored = window.localStorage.getItem(key);
+      return stored === "icons" || stored === "table" ? stored : defaultValue;
+    } catch {
+      // Safari private browsing / storage disabled — fall through to default
+      return defaultValue;
+    }
   });
   const set = (v: ViewMode) => {
     setValue(v);


### PR DESCRIPTION
17 commits on this branch — what started as the process-aware state machine (#268) grew to cover several Home polish items that surfaced while testing it. All on the same branch because each iteration revealed the next problem.

Closes #268. Partially addresses #267.

## Sessions: state derivation

Replaces the 5-minute mtime threshold with a probe of running \`claude\` processes. Each session's state derives from two observable signals:

| Process at cwd | JSONL fresh (<1m) | State | Helper text | Colour |
|---|---|---|---|---|
| ✓ | ✓ | **active** | Updated recently | Green |
| ✓ | ✗ (within 30m) | **waiting** | Process still open | Amber |
| any | older than 30m, ≤24h | **disconnected** | No running process found | Red |
| any | >24h | **done** | Inactive for 24h | Grey |

The probe uses \`pgrep -x claude\` + \`lsof -p <pid> -a -d cwd\` (POSIX). Cute and reliable: every process has a cwd by definition, so the check never flickers.

**JSONL recency is the source of truth.** The probe only gates whether a recent-but-not-fresh session reads as \`waiting\` vs \`disconnected\`. An earlier iteration tried per-cwd identity matching (top-K freshest sessions) but Anthropic confirmed there's no public API to enumerate live sessions externally ([anthropics/claude-code#38494](https://github.com/anthropics/claude-code/issues/38494)) — every external mapping is heuristic with edge cases. The 30-min cap on \`waiting\` honestly limits how confident we can be without per-session identity.

Documented limitation: a claude tab idle >30m reads as disconnected even if alive. Flips back to active the moment user types and JSONL streams.

**Cross-platform**: Windows pgrep/lsof unavailable → empty probe set → graceful degrade to JSONL-recency-only.

## Migration

\`sessions.state\` had a CHECK constraint pinning the old names (\`running\`/\`awaiting\`). SQLite can't ALTER a CHECK, so \`initDb()\` does a rename-copy-drop migration when it spots either the old constraint OR FK references to the leftover \`sessions_old\` (recovery from an earlier mid-PR broken state).

Migration also rebuilds \`session_events\` + \`session_artifacts\` to fix FKs — \`ALTER TABLE sessions RENAME TO sessions_old\` auto-rewrote dependent FKs to the phantom name. Without rebuild, every \`db.prepare()\` failed with \"no such table: sessions_old\".

State remap: \`running\` → \`active\`, \`awaiting\` → \`waiting\`, others unchanged. Idempotent.

## Home: filter UX

Picked option 4 from a side-by-side prototype of five patterns (\`docs/mockups/filter-options.html\`):

- **Live preset chip** that bundles active+waiting+disconnected. Default filter on Home — \"what's still relevant?\" is the question this surface answers most often.
- Per-state chips (active/waiting/disconnected/done/all) still work; small vertical divider separates \"live\" from them so it reads as a preset rather than a sixth state.

## Home: spaces grid as nav surface

The grid of space cards was previously only visible on Home itself. Now renders on per-space views too, with the active card highlighted. Click any card to switch — same affordance as the chat-bar pills, kept both.

- **Home card** at the start: shows total counts across all spaces. Selected when on home (and not in Elsewhere scope).
- **Elsewhere card** at the end: dashed border (visual cue for \"not a real space\"). Surfaces orphan sessions/artefacts (those whose \`spaceId\` doesn't match any registered space). Click filters Sessions + Artefacts to orphans only. Renders only when there are orphans.
- Selected state: stronger purple tint + inset ring on solid cards; dashed cards keep their border style as the meta-bucket cue.

## Other tweaks

- View toggles (icons / table) for Sessions and Artefacts now persist to localStorage.
- Tile/row meta shows duration alongside state: \`claude-code · waiting 2m\` instead of just \`claude-code · waiting\`.
- Title \"Today.\" → \"Everything.\"; switches to \"Elsewhere.\" when scoped.
- Heartbeat sweep guarded against overlapping ticks (skips if a previous sweep is still in-flight).

## Test plan

- [x] \`server/scripts/smoke-claude-code-watcher.ts\` — all 7 phases green
- [x] Migration verified against prod-shape DB (43 rows, 1 \`running\` → \`active\`)
- [x] Migration also recovers the half-migrated state with FKs pointing at sessions_old (verified against the dev DB that hit the broken intermediate)
- [x] Browser-tested: Home card / space cards / Elsewhere card click navigation; Live filter; sticky view toggles
- [x] Reviewer sanity-check: bounce server, watch a claude session go active → waiting (idle 1m) → disconnected (close terminal) within ~15s of the heartbeat

## Out of scope (follow-ups)

- New orphan sessions don't push via SSE on creation — chokidar misses brand-new subdirs under \`~/.claude/projects/\` until a refresh. Likely needs a periodic readdir alongside chokidar's watch. Tracked as a comment on #267.
- Windows process probe — needs \`Get-Process\` + netstat equivalent. Tracked under #268-cohort.