### PR TITLE
fix(sessions): backfill transcript on boot scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Older sessions now show their transcripts.** Sessions whose `claude` process finished before Oyster started watching used to land with empty transcripts in the inspector — Oyster only ingested events appended after it was running. The watcher now backfills events from each JSONL on boot scan, so existing sessions show their full transcript on the next server restart. Idempotent across restarts. ([#275](https://github.com/mattslight/oyster/issues/275))
+
 ### Added
 
 - **Session inspector.** Click a session tile (or row) and a slide-panel opens with the live transcript, the artefacts the agent touched, and a *Copy resume command* button — paste it in your terminal to pick the conversation back up. Disconnected sessions show a banner with the last heartbeat. Click any artefact to see which sessions touched it, then jump back into one. The transcript updates live as the agent works. ([#253](https://github.com/mattslight/oyster/issues/253))

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -323,6 +323,10 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0-beta.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Older sessions now show their transcripts.</strong> Sessions whose <code>claude</code> process finished before Oyster started watching used to land with empty transcripts in the inspector — Oyster only ingested events appended after it was running. The watcher now backfills events from each JSONL on boot scan, so existing sessions show their full transcript on the next server restart. Idempotent across restarts. (<a href="https://github.com/mattslight/oyster/issues/275" rel="noopener noreferrer">#275</a>)</li>
+</ul>
 <h3>Added</h3>
 <ul>
 <li><strong>Session inspector.</strong> Click a session tile (or row) and a slide-panel opens with the live transcript, the artefacts the agent touched, and a <em>Copy resume command</em> button — paste it in your terminal to pick the conversation back up. Disconnected sessions show a banner with the last heartbeat. Click any artefact to see which sessions touched it, then jump back into one. The transcript updates live as the agent works. (<a href="https://github.com/mattslight/oyster/issues/253" rel="noopener noreferrer">#253</a>)</li>

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -149,7 +149,13 @@ export function initDb(userlandDir: string): Database.Database {
       started_at    TEXT NOT NULL DEFAULT (datetime('now')),
       ended_at      TEXT,
       model         TEXT,
-      last_event_at TEXT NOT NULL DEFAULT (datetime('now'))
+      last_event_at TEXT NOT NULL DEFAULT (datetime('now')),
+      -- Persisted JSONL byte offset. Boot scan reads from last_offset to
+      -- EOF and inserts events; live appends update it on every consume.
+      -- Without this, sessions that finished before the watcher started
+      -- (or before a restart) seeded the tracker at EOF and silently lost
+      -- their transcript.
+      last_offset   INTEGER NOT NULL DEFAULT 0
     );
     CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);
     CREATE INDEX IF NOT EXISTS sessions_state_last_event
@@ -178,6 +184,12 @@ export function initDb(userlandDir: string): Database.Database {
     CREATE INDEX IF NOT EXISTS session_artifacts_artifact
       ON session_artifacts(artifact_id);
   `);
+
+  // last_offset added in 0.5.0 to backfill transcripts on boot scan (#275).
+  // Existing installs created sessions without this column; ALTER adds it.
+  try {
+    db.exec("ALTER TABLE sessions ADD COLUMN last_offset INTEGER NOT NULL DEFAULT 0");
+  } catch { /* already exists */ }
 
   // ── Sessions state-rename migration (running/awaiting → active/waiting) ──
   // SQLite can't ALTER a CHECK constraint, so we rebuild via temp table.
@@ -210,6 +222,10 @@ export function initDb(userlandDir: string): Database.Database {
       BEGIN TRANSACTION;
 
       -- 1. Rebuild sessions with the new CHECK constraint and remap states.
+      -- last_offset is set to 0 here; it only matters for installs that
+      -- pre-date the running/awaiting rename, and those rebuilds always
+      -- ran before #275 anyway (so the source rows have no last_offset).
+      -- The boot scan re-derives offsets from disk on first run.
       CREATE TABLE _sessions_new (
         id            TEXT PRIMARY KEY,
         space_id      TEXT REFERENCES spaces(id) ON DELETE SET NULL,
@@ -219,7 +235,8 @@ export function initDb(userlandDir: string): Database.Database {
         started_at    TEXT NOT NULL DEFAULT (datetime('now')),
         ended_at      TEXT,
         model         TEXT,
-        last_event_at TEXT NOT NULL DEFAULT (datetime('now'))
+        last_event_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_offset   INTEGER NOT NULL DEFAULT 0
       );
       INSERT INTO _sessions_new (id, space_id, agent, title, state, started_at, ended_at, model, last_event_at)
         SELECT id, space_id, agent, title,

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -93,6 +93,9 @@ export interface SessionStore {
   insertArtifactTouch(row: InsertSessionArtifact): void;
   getArtifactsBySession(sessionId: string): SessionArtifactRow[];
   getSessionsByArtifact(artifactId: string): SessionArtifactRow[];
+  // last_offset — JSONL bytes already ingested for this session.
+  getLastOffset(sessionId: string): number;
+  setLastOffset(sessionId: string, offset: number): void;
 }
 
 // ── SQLite implementation ──
@@ -111,6 +114,8 @@ export class SqliteSessionStore implements SessionStore {
     insertArtifactTouch: Database.Statement;
     getArtifactsBySession: Database.Statement;
     getSessionsByArtifact: Database.Statement;
+    getLastOffset: Database.Statement;
+    setLastOffset: Database.Statement;
   };
 
   private insertEventsTxn: (rows: InsertSessionEvent[]) => void;
@@ -179,6 +184,12 @@ export class SqliteSessionStore implements SessionStore {
       ),
       getSessionsByArtifact: db.prepare(
         "SELECT * FROM session_artifacts WHERE artifact_id = ? ORDER BY when_at DESC"
+      ),
+      getLastOffset: db.prepare(
+        "SELECT last_offset FROM sessions WHERE id = ?"
+      ),
+      setLastOffset: db.prepare(
+        "UPDATE sessions SET last_offset = ? WHERE id = ?"
       ),
     };
 
@@ -275,5 +286,14 @@ export class SqliteSessionStore implements SessionStore {
 
   getSessionsByArtifact(artifactId: string): SessionArtifactRow[] {
     return this.stmts.getSessionsByArtifact.all(artifactId) as SessionArtifactRow[];
+  }
+
+  getLastOffset(sessionId: string): number {
+    const row = this.stmts.getLastOffset.get(sessionId) as { last_offset: number } | undefined;
+    return row?.last_offset ?? 0;
+  }
+
+  setLastOffset(sessionId: string, offset: number): void {
+    this.stmts.setLastOffset.run(offset, sessionId);
   }
 }

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -268,7 +268,19 @@ export class ClaudeCodeWatcher {
     });
     this.deps.emitSessionChanged?.(meta.sessionId);
 
-    // Seed offset at end-of-file so future appends are read incrementally.
+    // Backfill any unread bytes. Persisted offset is 0 on first sight (so we
+    // ingest the whole transcript) and `stat.size` on subsequent boots (no
+    // work). If the file was truncated since last boot — unusual for an
+    // append-only log — fall back to 0 and re-read.
+    let lastOffset = this.deps.sessionStore.getLastOffset(meta.sessionId);
+    if (lastOffset > stat.size) lastOffset = 0;
+    if (stat.size > lastOffset) {
+      await this.backfillRange(filePath, meta.sessionId, meta.cwd, lastOffset, stat.size);
+    }
+    this.deps.sessionStore.setLastOffset(meta.sessionId, stat.size);
+
+    // Seed in-memory tracker at EOF — backfill covered everything up to
+    // here, and live appends pick up from here.
     this.trackers.set(filePath, {
       offset: stat.size,
       sessionId: meta.sessionId,
@@ -281,6 +293,80 @@ export class ClaudeCodeWatcher {
       slug: meta.slug,
       partial: "",
     });
+  }
+
+  // One-shot backfill of [fromOffset, toOffset). Used by boot scan to ingest
+  // the existing JSONL contents into session_events / session_artifacts.
+  // The session row is assumed already upserted by the caller.
+  private async backfillRange(
+    filePath: string,
+    sessionId: string,
+    cwd: string | null,
+    fromOffset: number,
+    toOffset: number,
+  ): Promise<void> {
+    const len = toOffset - fromOffset;
+    if (len <= 0) return;
+    const fh = await fs.open(filePath, "r");
+    let chunk: Buffer;
+    try {
+      chunk = Buffer.alloc(len);
+      await fh.read(chunk, 0, len, fromOffset);
+    } finally {
+      await fh.close();
+    }
+
+    // Boot scan reads complete files, but a non-zero `fromOffset` means we
+    // may start mid-line (partial line landed before the previous stop).
+    // Drop the leading fragment in that case; if it ever had a complete
+    // event we'd have ingested it last time.
+    const text = chunk.toString("utf8");
+    const lines = text.split("\n");
+    if (fromOffset > 0) lines.shift();
+    // Trailing empty (clean newline boundary) or partial line. The watcher
+    // will pick up any partial via consumeOnce on the next append.
+    if (lines.length > 0) lines.pop();
+
+    const spaceId = this.resolveSpaceId(cwd);
+    const events: InsertSessionEvent[] = [];
+
+    for (const line of lines) {
+      if (!line) continue;
+      const ev = safeParse(line);
+      if (!ev) continue;
+
+      const rendered = renderEvent(ev);
+      if (rendered) {
+        events.push({
+          session_id: sessionId,
+          role: rendered.role,
+          text: rendered.text.slice(0, TEXT_PREVIEW_MAX),
+          ts: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
+          raw: line,
+        });
+      }
+
+      // Same orphan-skip rule as consumeOnce: don't attribute touches when
+      // we can't anchor them to a space.
+      if (ev.type === "assistant" && Array.isArray(ev.message?.content) && spaceId) {
+        for (const block of ev.message.content) {
+          const touch = artifactTouchFromToolUse(block);
+          if (!touch) continue;
+          const artifact = this.deps.artifactStore.getByPath(touch.path);
+          if (!artifact) continue;
+          if (artifact.space_id !== spaceId) continue;
+          this.deps.sessionStore.insertArtifactTouch({
+            session_id: sessionId,
+            artifact_id: artifact.id,
+            role: touch.role,
+          });
+        }
+      }
+    }
+
+    if (events.length > 0) {
+      this.deps.sessionStore.insertEvents(events);
+    }
   }
 
   // Read enough of a file to populate the session row. JSONLs grow to
@@ -598,6 +684,11 @@ export class ClaudeCodeWatcher {
     }
 
     if (tracker.sessionId) {
+      // Persist the new offset so a restart picks up exactly where we
+      // stopped. Without this, every restart would re-seed at EOF and drop
+      // anything appended between offset persistence and shutdown.
+      this.deps.sessionStore.setLastOffset(tracker.sessionId, stat.size);
+
       // Bytes just landed → JSONL is fresh by definition, so this session is
       // 'active'. Even if the heartbeat had previously demoted it to
       // 'waiting'/'disconnected', a new event resurrects it. If a title we

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -316,15 +316,14 @@ export class ClaudeCodeWatcher {
       await fh.close();
     }
 
-    // Boot scan reads complete files, but a non-zero `fromOffset` means we
-    // may start mid-line (partial line landed before the previous stop).
-    // Drop the leading fragment in that case; if it ever had a complete
-    // event we'd have ingested it last time.
+    // The persisted offset always lands on a \n boundary (consumeOnce
+    // strips trailing partial bytes before persisting), so the chunk
+    // begins at a complete line.
     const text = chunk.toString("utf8");
     const lines = text.split("\n");
-    if (fromOffset > 0) lines.shift();
-    // Trailing empty (clean newline boundary) or partial line. The watcher
-    // will pick up any partial via consumeOnce on the next append.
+    // Trailing empty on a clean newline boundary, or partial line if the
+    // file is mid-write. consumeOnce will pick up the rest on the next
+    // append.
     if (lines.length > 0) lines.pop();
 
     const spaceId = this.resolveSpaceId(cwd);
@@ -684,10 +683,12 @@ export class ClaudeCodeWatcher {
     }
 
     if (tracker.sessionId) {
-      // Persist the new offset so a restart picks up exactly where we
-      // stopped. Without this, every restart would re-seed at EOF and drop
-      // anything appended between offset persistence and shutdown.
-      this.deps.sessionStore.setLastOffset(tracker.sessionId, stat.size);
+      // Persist the *fully-ingested* offset — bytes through the last
+      // complete \n. The trailing partial line is buffered in memory only;
+      // on restart it'd be lost, so we mustn't include it in the persisted
+      // offset or backfill would skip the rest of that line on next boot.
+      const persistedOffset = stat.size - Buffer.byteLength(tracker.partial, "utf8");
+      this.deps.sessionStore.setLastOffset(tracker.sessionId, persistedOffset);
 
       // Bytes just landed → JSONL is fresh by definition, so this session is
       // 'active'. Even if the heartbeat had previously demoted it to


### PR DESCRIPTION
## Summary
- Sessions that finished before the watcher started used to land with empty transcripts in the inspector — `reconcileExistingFile` seeded the tracker at EOF, so anything already on disk was "already seen".
- Adds persisted `last_offset` per session. Boot scan reads `[last_offset, stat.size)` and ingests events + artefact touches. Live appends update the offset on every consume so restarts are idempotent.

Closes #275.

## Test plan
- [x] Restart server → existing sessions backfill: 44/45 sessions seeded with non-zero offset, 838 MB tracked
- [x] Second restart adds 0 new events (live ticks excepted) — no duplicates
- [x] Hard test: deleted a session's events + reset offset to 0; restart restored all 6174 events
- [x] New sessions still ingest live (live ticks visible across restart)
- [x] CHANGELOG entry added under [Unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)