### PR TITLE
feat(inspector): scroll-up loads older transcript turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Scroll up to load older transcript turns.** The session inspector loads the latest 1000 turns by default and shows a `1000+` badge when there's more behind them. Scroll near the top of the transcript and the next 1000 older turns prepend in place — your scroll position stays pinned to the same turn so you don't lose your place. Live updates still append to the bottom as the agent works. ([#274](https://github.com/mattslight/oyster/issues/274))
+
 ### Fixed
 
+- **`?limit=N` on the events endpoint was silently ignored.** The route regex `$`-anchored before the query string so the parameter never reached the handler — the inspector always got the default 1000. Fixed as part of #274.
 - **Older sessions now show their transcripts.** Sessions whose `claude` process finished before Oyster started watching used to land with empty transcripts in the inspector — Oyster only ingested events appended after it was running. The watcher now backfills events from each JSONL on boot scan, so existing sessions show their full transcript on the next server restart. Idempotent across restarts. ([#275](https://github.com/mattslight/oyster/issues/275))
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -323,8 +323,13 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0-beta.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Scroll up to load older transcript turns.</strong> The session inspector loads the latest 1000 turns by default and shows a <code>1000+</code> badge when there&#39;s more behind them. Scroll near the top of the transcript and the next 1000 older turns prepend in place — your scroll position stays pinned to the same turn so you don&#39;t lose your place. Live updates still append to the bottom as the agent works. (<a href="https://github.com/mattslight/oyster/issues/274" rel="noopener noreferrer">#274</a>)</li>
+</ul>
 <h3>Fixed</h3>
 <ul>
+<li><strong><code>?limit=N</code> on the events endpoint was silently ignored.</strong> The route regex <code>$</code>-anchored before the query string so the parameter never reached the handler — the inspector always got the default 1000. Fixed as part of #274.</li>
 <li><strong>Older sessions now show their transcripts.</strong> Sessions whose <code>claude</code> process finished before Oyster started watching used to land with empty transcripts in the inspector — Oyster only ingested events appended after it was running. The watcher now backfills events from each JSONL on boot scan, so existing sessions show their full transcript on the next server restart. Idempotent across restarts. (<a href="https://github.com/mattslight/oyster/issues/275" rel="noopener noreferrer">#275</a>)</li>
 </ul>
 <h3>Added</h3>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -575,13 +575,22 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     }
   }
 
-  // GET /api/sessions/:id/events — latest N transcript events (oldest first
-  // within the slice). The `raw` JSONL line is dropped from the list response
-  // because long sessions can ship 50+MB of raw blobs (tool outputs, file
-  // reads). Clients fetch the raw on-demand via /events/:eventId when the
-  // user expands a tool turn. ?limit=N overrides the default of 1000.
+  // GET /api/sessions/:id/events — transcript events (oldest first within
+  // the returned slice). The `raw` JSONL line is dropped because long
+  // sessions can ship 50+MB of raw blobs; clients lazy-fetch raw via
+  // /events/:eventId when they expand a tool turn.
+  //
+  // Cursors:
+  //   ?before=<id> — events with id < before, latest N (load older on scroll up)
+  //   ?after=<id>  — events with id > after, oldest N (live append)
+  //   neither     — latest N (bootstrap)
+  // ?limit=N defaults to 1000.
   {
-    const m = url.match(/^\/api\/sessions\/([^/]+)\/events$/);
+    // Strip the query string before path matching — the `$` anchor in the
+    // regex would otherwise reject any URL with `?...`. Pre-existing bug:
+    // `?limit=N` was always silently ignored before this fix.
+    const eventsPath = url.split("?")[0];
+    const m = eventsPath.match(/^\/api\/sessions\/([^/]+)\/events$/);
     if (m && req.method === "GET") {
       if (rejectIfNonLocalOrigin()) return;
       const parsed = new URL(req.url ?? "/", "http://localhost");
@@ -589,7 +598,20 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       const limit = limitParam && Number.isFinite(Number(limitParam))
         ? Math.max(1, Math.min(10_000, Number(limitParam)))
         : 1000;
-      const events = sessionStore.getEventsBySession(m[1], { limit });
+      const beforeParam = parsed.searchParams.get("before");
+      const afterParam = parsed.searchParams.get("after");
+      const before = beforeParam && Number.isFinite(Number(beforeParam))
+        ? Number(beforeParam) : null;
+      const after = afterParam && Number.isFinite(Number(afterParam))
+        ? Number(afterParam) : null;
+      let events;
+      if (before !== null) {
+        events = sessionStore.getEventsBeforeBySession(m[1], before, limit);
+      } else if (after !== null) {
+        events = sessionStore.getEventsAfterBySession(m[1], after, limit);
+      } else {
+        events = sessionStore.getEventsBySession(m[1], { limit });
+      }
       sendJson(events.map((e) => ({
         id: e.id,
         sessionId: e.session_id,

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -88,6 +88,9 @@ export interface SessionStore {
   insertEvent(row: InsertSessionEvent): number;
   insertEvents(rows: InsertSessionEvent[]): void;
   getEventsBySession(sessionId: string, opts?: { limit?: number }): SessionEventRow[];
+  // Cursor pagination: scroll-up to load older, live SSE to append newer.
+  getEventsBeforeBySession(sessionId: string, beforeId: number, limit: number): SessionEventRow[];
+  getEventsAfterBySession(sessionId: string, afterId: number, limit: number): SessionEventRow[];
   getEventById(sessionId: string, eventId: number): SessionEventRow | undefined;
   // session_artifacts
   insertArtifactTouch(row: InsertSessionArtifact): void;
@@ -110,6 +113,8 @@ export class SqliteSessionStore implements SessionStore {
     insertEvent: Database.Statement;
     getEventsBySession: Database.Statement;
     getEventsBySessionLimit: Database.Statement;
+    getEventsBefore: Database.Statement;
+    getEventsAfter: Database.Statement;
     getEventById: Database.Statement;
     insertArtifactTouch: Database.Statement;
     getArtifactsBySession: Database.Statement;
@@ -171,6 +176,12 @@ export class SqliteSessionStore implements SessionStore {
       ),
       getEventsBySessionLimit: db.prepare(
         "SELECT * FROM session_events WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+      ),
+      getEventsBefore: db.prepare(
+        "SELECT * FROM session_events WHERE session_id = ? AND id < ? ORDER BY id DESC LIMIT ?"
+      ),
+      getEventsAfter: db.prepare(
+        "SELECT * FROM session_events WHERE session_id = ? AND id > ? ORDER BY id ASC LIMIT ?"
       ),
       getEventById: db.prepare(
         "SELECT * FROM session_events WHERE session_id = ? AND id = ? LIMIT 1"
@@ -274,6 +285,19 @@ export class SqliteSessionStore implements SessionStore {
 
   getEventById(sessionId: string, eventId: number): SessionEventRow | undefined {
     return this.stmts.getEventById.get(sessionId, eventId) as SessionEventRow | undefined;
+  }
+
+  // Returns up to `limit` events with id < beforeId, oldest first within the
+  // slice. Used for scroll-up infinite load.
+  getEventsBeforeBySession(sessionId: string, beforeId: number, limit: number): SessionEventRow[] {
+    const rows = this.stmts.getEventsBefore.all(sessionId, beforeId, limit) as SessionEventRow[];
+    return rows.reverse();
+  }
+
+  // Returns up to `limit` events with id > afterId, oldest first. Used for
+  // live append: SSE fires, fetch only the new events past the latest cursor.
+  getEventsAfterBySession(sessionId: string, afterId: number, limit: number): SessionEventRow[] {
+    return this.stmts.getEventsAfter.all(sessionId, afterId, limit) as SessionEventRow[];
   }
 
   insertArtifactTouch(row: InsertSessionArtifact): void {

--- a/web/src/components/SessionInspector.tsx
+++ b/web/src/components/SessionInspector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   fetchSession,
   fetchSessionEvents,
@@ -39,6 +39,9 @@ const STATE_LABEL: Record<SessionState, string> = {
 };
 
 const RAW_CAP_BYTES = 4096;
+// Matches the server default. If a fetch returns exactly this many events,
+// assume there are more upstream and surface the "1000+" affordance.
+const PAGE_SIZE = 1000;
 
 type Tab = "transcript" | "artefacts";
 
@@ -90,6 +93,11 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
   const [artefacts, setArtefacts] = useState<SessionArtifactJoined[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("transcript");
+  // True if the bootstrap fetch returned a full page — i.e. there are older
+  // events still on the server. Drives the "1000+" badge and the scroll-up
+  // load. Flips to false once an older fetch returns less than a full page.
+  const [hasMoreOlder, setHasMoreOlder] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
   const latestReqId = useRef(0);
   // Capture onNotFound by ref so the effects don't re-run when the caller
   // passes a fresh inline lambda each render. Without this, a parent
@@ -113,11 +121,13 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
     setEvents(null);
     setArtefacts(null);
     setTab("transcript");
+    setHasMoreOlder(false);
+    setLoadingOlder(false);
     setBootstrapDone(false);
     const ac = new AbortController();
     Promise.all([
       fetchSession(sessionId, ac.signal),
-      fetchSessionEvents(sessionId, ac.signal),
+      fetchSessionEvents(sessionId, { signal: ac.signal }),
       fetchSessionArtifacts(sessionId, ac.signal),
     ])
       .then(([s, ev, art]) => {
@@ -125,6 +135,7 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
         setSession(s);
         setEvents(ev);
         setArtefacts(art);
+        setHasMoreOlder(ev.length >= PAGE_SIZE);
         setBootstrapDone(true);
       })
       .catch((err) => {
@@ -150,14 +161,29 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
         const reqId = ++latestReqId.current;
         if (inflight) inflight.abort();
         inflight = new AbortController();
+        // Fetch session metadata fresh, but only NEW events past the last
+        // cursor. Replacing the whole events array would clobber any older
+        // events the user has scrolled up to load.
+        const lastEventId = (() => {
+          // Read the freshest events without putting events in deps —
+          // adding events as a dep would re-subscribe to SSE on every
+          // append, which is wasteful and risks dropping ticks.
+          const arr = eventsRef.current;
+          return arr && arr.length > 0 ? arr[arr.length - 1].id : undefined;
+        })();
         Promise.all([
           fetchSession(sessionId, inflight.signal),
-          fetchSessionEvents(sessionId, inflight.signal),
+          fetchSessionEvents(sessionId, {
+            after: lastEventId,
+            signal: inflight.signal,
+          }),
         ])
-          .then(([s, ev]) => {
+          .then(([s, newEvents]) => {
             if (reqId !== latestReqId.current) return;
             setSession(s);
-            setEvents(ev);
+            if (newEvents.length > 0) {
+              setEvents((prev) => (prev ? [...prev, ...newEvents] : newEvents));
+            }
           })
           .catch((err) => {
             if (inflight?.signal.aborted) return;
@@ -185,6 +211,37 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
       unsubscribe();
     };
   }, [sessionId, bootstrapDone]);
+
+  // Mirror events into a ref so live SSE fetches can read the freshest
+  // last-id without re-running their effect on every append.
+  const eventsRef = useRef<SessionEvent[] | null>(null);
+  useEffect(() => { eventsRef.current = events; }, [events]);
+
+  // Load-older handler: triggered by the transcript scroll listener.
+  // Returns a flag indicating whether the caller should preserve scroll
+  // position (true if a fetch was actually issued and resolved with rows).
+  const loadOlderRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  loadOlderRef.current = async () => {
+    if (loadingOlder || !hasMoreOlder) return;
+    const arr = eventsRef.current;
+    if (!arr || arr.length === 0) return;
+    const cursor = arr[0].id;
+    setLoadingOlder(true);
+    try {
+      const older = await fetchSessionEvents(sessionId, { before: cursor });
+      // Drop overlap defensively (id < cursor server-side guarantees this,
+      // but if a future change introduces ≤ semantics we'd dupe rows).
+      const fresh = older.filter((e) => e.id < cursor);
+      if (fresh.length > 0) {
+        setEvents((prev) => (prev ? [...fresh, ...prev] : fresh));
+      }
+      setHasMoreOlder(older.length >= PAGE_SIZE);
+    } catch (err) {
+      console.warn("[SessionInspector] load older failed:", err);
+    } finally {
+      setLoadingOlder(false);
+    }
+  };
 
   if (error) {
     return (
@@ -224,6 +281,7 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
         tab={tab}
         setTab={setTab}
         eventsCount={events?.length ?? 0}
+        hasMoreOlder={hasMoreOlder}
         artefactsCount={artefacts ? new Set(artefacts.map((a) => a.artifact.id)).size : 0}
       />
       <TranscriptBody
@@ -233,6 +291,9 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
         onSwitchTo={onSwitchTo}
         sessionId={sessionId}
         agent={session.agent}
+        hasMoreOlder={hasMoreOlder}
+        loadingOlder={loadingOlder}
+        onLoadOlder={() => loadOlderRef.current()}
       />
     </>
   );
@@ -248,6 +309,7 @@ export function SessionInspector({ sessionId, onSwitchTo, onClose, onNotFound }:
  */
 function TranscriptBody({
   tab, events, artefacts, onSwitchTo, sessionId, agent,
+  hasMoreOlder, loadingOlder, onLoadOlder,
 }: {
   tab: Tab;
   events: SessionEvent[] | null;
@@ -255,10 +317,25 @@ function TranscriptBody({
   onSwitchTo: (next: ActivePanel) => void;
   sessionId: string;
   agent: SessionAgent;
+  hasMoreOlder: boolean;
+  loadingOlder: boolean;
+  onLoadOlder: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const wasNearBottomRef = useRef(true);
   const [visible, setVisible] = useState<Set<RoleCategory>>(loadVisibleCategories);
+  // When set to a number (saved scrollHeight), the layout effect below
+  // restores the user's scroll position after a load-older prepend. Cleared
+  // after restore so live appends continue to behave normally.
+  const restoreFromBottomRef = useRef<number | null>(null);
+  const onLoadOlderRef = useRef(onLoadOlder);
+  useEffect(() => { onLoadOlderRef.current = onLoadOlder; }, [onLoadOlder]);
+  // Latest values for the scroll handler — keeping them in refs avoids
+  // re-attaching the listener on every state tick.
+  const hasMoreOlderRef = useRef(hasMoreOlder);
+  useEffect(() => { hasMoreOlderRef.current = hasMoreOlder; }, [hasMoreOlder]);
+  const loadingOlderRef = useRef(loadingOlder);
+  useEffect(() => { loadingOlderRef.current = loadingOlder; }, [loadingOlder]);
 
   function toggleCategory(cat: RoleCategory) {
     setVisible((prev) => {
@@ -278,14 +355,39 @@ function TranscriptBody({
     const onScroll = () => {
       const fromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
       wasNearBottomRef.current = fromBottom < 80;
+      // Trigger load-older when within 200px of the top. Take the
+      // loading lock synchronously so a flurry of scroll events doesn't
+      // queue duplicate fetches before React commits the state change.
+      // The prop-mirroring useEffect catches up afterwards.
+      if (
+        el.scrollTop < 200
+        && hasMoreOlderRef.current
+        && !loadingOlderRef.current
+      ) {
+        loadingOlderRef.current = true;
+        // Capture distance-from-bottom *before* the prepend so we can
+        // restore it after React re-renders. scrollTop alone is fragile —
+        // it grows by N pixels on prepend and the user appears to "jump
+        // back" to where they were; pinning to bottom-distance keeps the
+        // visible turn at the same screen position.
+        restoreFromBottomRef.current = el.scrollHeight - el.scrollTop;
+        onLoadOlderRef.current();
+      }
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
   }, []);
 
-  useEffect(() => {
+  // Run BEFORE paint so the scroll restore is invisible to the user. A
+  // post-paint useEffect would briefly show the jumped position.
+  useLayoutEffect(() => {
     const el = ref.current;
     if (!el || tab !== "transcript") return;
+    if (restoreFromBottomRef.current != null) {
+      el.scrollTop = el.scrollHeight - restoreFromBottomRef.current;
+      restoreFromBottomRef.current = null;
+      return;
+    }
     if (wasNearBottomRef.current) {
       el.scrollTop = el.scrollHeight;
     }
@@ -298,7 +400,14 @@ function TranscriptBody({
       )}
       <div className="inspector-body" ref={ref}>
         {tab === "transcript" && (
-          <Transcript events={filteredEvents} sessionId={sessionId} agent={agent} />
+          <>
+            {loadingOlder && (
+              <div className="inspector-empty" style={{ textAlign: "center", padding: "8px 0" }}>
+                Loading older…
+              </div>
+            )}
+            <Transcript events={filteredEvents} sessionId={sessionId} agent={agent} />
+          </>
         )}
         {tab === "artefacts" && <Artefacts items={artefacts} onSwitchTo={onSwitchTo} />}
       </div>
@@ -427,13 +536,18 @@ function Banner({ session }: { session: Session }) {
 }
 
 function Tabs({
-  tab, setTab, eventsCount, artefactsCount,
+  tab, setTab, eventsCount, hasMoreOlder, artefactsCount,
 }: {
   tab: Tab;
   setTab: (t: Tab) => void;
   eventsCount: number;
+  hasMoreOlder: boolean;
   artefactsCount: number;
 }) {
+  // While older events haven't all been loaded, clamp the badge to "1000+"
+  // — the loaded count grows as the user scrolls, but the user wants the
+  // single "more than a thousand" signal, not an interim 2000+/3000+/…
+  const transcriptLabel = hasMoreOlder ? "1000+" : String(eventsCount);
   return (
     <div className="inspector-tabs">
       <button
@@ -441,7 +555,7 @@ function Tabs({
         className={`inspector-tab${tab === "transcript" ? " active" : ""}`}
         onClick={() => setTab("transcript")}
       >
-        Transcript <span className="badge">{eventsCount}</span>
+        Transcript <span className="badge">{transcriptLabel}</span>
       </button>
       <button
         type="button"

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -28,8 +28,27 @@ export async function fetchSession(id: string, signal?: AbortSignal): Promise<Se
   return res.json();
 }
 
-export async function fetchSessionEvents(id: string, signal?: AbortSignal): Promise<SessionEvent[]> {
-  const res = await fetch(`/api/sessions/${encodeURIComponent(id)}/events`, { signal });
+export interface FetchSessionEventsOpts {
+  // Cursor pagination. Pass `before` to load older events; `after` to fetch
+  // only events newer than the cursor (live append). Mutually exclusive.
+  before?: number;
+  after?: number;
+  // Server caps at 1000 default; pass to override (max 10_000).
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+export async function fetchSessionEvents(
+  id: string,
+  opts: FetchSessionEventsOpts = {},
+): Promise<SessionEvent[]> {
+  const params = new URLSearchParams();
+  if (opts.before !== undefined) params.set("before", String(opts.before));
+  if (opts.after !== undefined) params.set("after", String(opts.after));
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  const qs = params.toString();
+  const url = `/api/sessions/${encodeURIComponent(id)}/events${qs ? `?${qs}` : ""}`;
+  const res = await fetch(url, { signal: opts.signal });
   if (!res.ok) throw new Error(`Server returned ${res.status}`);
   return res.json();
 }


### PR DESCRIPTION
## Summary

- Inspector loads the latest 1000 events by default. When more exist, the Transcript tab badge shows **"1000+"**.
- Scrolling within 200px of the top of the transcript prepends the next 1000 older events. Scroll position pinned to distance-from-bottom so the visible turn doesn't jump.
- Live SSE refresh now uses \`?after=<latestId>\` and **appends** new events. The previous behaviour replaced the entire array, which would clobber older events the user had scrolled up to load.
- Drive-by fix: the events route regex was \`\$\`-anchored before the query string, so \`?limit=N\` was silently ignored — the inspector always got the default 1000 regardless of the param.

Closes #274.

## History
Replaces #277, which was auto-closed when its base branch (\`feat/session-backfill-on-boot\`) was deleted on merge of #276. Same code, rebased onto main.

## Test plan
- [x] Server cursors verified end-to-end (before/after both return correct slices)
- [x] Type-check clean (server + web)
- [x] UAT: scroll up on a >1000 event session — older turns prepend without scroll jump, badge stays at "1000+", live updates still arrive at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)