### PR TITLE
fix(server): bind to 127.0.0.1 and harden Origin guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Memories on Home.** Your agents' `remember` notes now show up as a section on Home alongside Sessions and Artefacts. The space pills scope all three together — pick *tokinvest* and you see what each agent learned about that project, not the global pile. Orphan memories (no space attached) live under *Elsewhere*. ([#254](https://github.com/mattslight/oyster/issues/254))
 - **Scroll up to load older transcript turns.** The session inspector loads the latest 1000 turns by default and shows a `1000+` badge when there's more behind them. Scroll near the top of the transcript and the next 1000 older turns prepend in place — your scroll position stays pinned to the same turn so you don't lose your place. Live updates still append to the bottom as the agent works. ([#274](https://github.com/mattslight/oyster/issues/274))
 
+### Security
+
+- **Local-only endpoints now refuse non-loopback callers.** The Oyster server used to listen on every network interface and rely on the HTTP `Origin` header alone to gate access — fine against a browser tab on `evil.com`, but a non-browser client on the same WiFi could omit `Origin` and pull `/api/vault/inventory`, `/api/memories`, etc. The server now binds to `127.0.0.1` *and* the Origin guard rejects requests with no Origin from non-loopback addresses (belt and braces). ([#289](https://github.com/mattslight/oyster/issues/289))
+
 ### Fixed
 
 - **`?limit=N` on the events endpoint was silently ignored.** The route regex `$`-anchored before the query string so the parameter never reached the handler — the inspector always got the default 1000. Fixed as part of #274.

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -454,7 +454,7 @@ async function main() {
     const text = data.toString();
     process.stdout.write(text);
     if (!opened) {
-      const match = text.match(/listening on (http:\/\/localhost:\d+)/);
+      const match = text.match(/listening on (http:\/\/(?:localhost|127\.0\.0\.1):\d+)/);
       if (match) {
         opened = true;
         const url = match[1];

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -335,6 +335,10 @@
 <li><strong>Memories on Home.</strong> Your agents&#39; <code>remember</code> notes now show up as a section on Home alongside Sessions and Artefacts. The space pills scope all three together — pick <em>tokinvest</em> and you see what each agent learned about that project, not the global pile. Orphan memories (no space attached) live under <em>Elsewhere</em>. (<a href="https://github.com/mattslight/oyster/issues/254" rel="noopener noreferrer">#254</a>)</li>
 <li><strong>Scroll up to load older transcript turns.</strong> The session inspector loads the latest 1000 turns by default and shows a <code>1000+</code> badge when there&#39;s more behind them. Scroll near the top of the transcript and the next 1000 older turns prepend in place — your scroll position stays pinned to the same turn so you don&#39;t lose your place. Live updates still append to the bottom as the agent works. (<a href="https://github.com/mattslight/oyster/issues/274" rel="noopener noreferrer">#274</a>)</li>
 </ul>
+<h3>Security</h3>
+<ul>
+<li><strong>Local-only endpoints now refuse non-loopback callers.</strong> The Oyster server used to listen on every network interface and rely on the HTTP <code>Origin</code> header alone to gate access — fine against a browser tab on <code>evil.com</code>, but a non-browser client on the same WiFi could omit <code>Origin</code> and pull <code>/api/vault/inventory</code>, <code>/api/memories</code>, etc. The server now binds to <code>127.0.0.1</code> <em>and</em> the Origin guard rejects requests with no Origin from non-loopback addresses (belt and braces). (<a href="https://github.com/mattslight/oyster/issues/289" rel="noopener noreferrer">#289</a>)</li>
+</ul>
 <h3>Fixed</h3>
 <ul>
 <li><strong><code>?limit=N</code> on the events endpoint was silently ignored.</strong> The route regex <code>$</code>-anchored before the query string so the parameter never reached the handler — the inspector always got the default 1000. Fixed as part of #274.</li>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -691,6 +691,17 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       sendJson({ error: "Forbidden origin" }, 403);
       return true;
     }
+    if (!origin) {
+      const remote = req.socket.remoteAddress || "";
+      const isLoopback =
+        remote === "127.0.0.1" ||
+        remote === "::1" ||
+        remote === "::ffff:127.0.0.1";
+      if (!isLoopback) {
+        sendJson({ error: "Forbidden — non-local origin" }, 403);
+        return true;
+      }
+    }
     if (origin) res.setHeader("Access-Control-Allow-Origin", origin);
     return false;
   };
@@ -1999,7 +2010,7 @@ writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(sourceOpencode
 const httpServer = createServer(handleHttpRequest);
 attachWebSocket(httpServer);
 
-httpServer.listen(port, () => {
+httpServer.listen(port, "127.0.0.1", () => {
   console.log(`Oyster server listening on http://localhost:${port}`);
   console.log(`  WebSocket: ws://localhost:${port}`);
   console.log(`  API:       http://localhost:${port}/api/artifacts`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1956,7 +1956,7 @@ function findPort(preferred: number, maxAttempts = 10): Promise<number> {
           reject(new Error(`No available port found (tried ${preferred}-${port})`));
         }
       });
-      testServer.listen(port, () => {
+      testServer.listen(port, "127.0.0.1", () => {
         testServer.close(() => resolve(port));
       });
     }
@@ -2011,9 +2011,9 @@ const httpServer = createServer(handleHttpRequest);
 attachWebSocket(httpServer);
 
 httpServer.listen(port, "127.0.0.1", () => {
-  console.log(`Oyster server listening on http://localhost:${port}`);
-  console.log(`  WebSocket: ws://localhost:${port}`);
-  console.log(`  API:       http://localhost:${port}/api/artifacts`);
+  console.log(`Oyster server listening on http://127.0.0.1:${port}`);
+  console.log(`  WebSocket: ws://127.0.0.1:${port}`);
+  console.log(`  API:       http://127.0.0.1:${port}/api/artifacts`);
 
   // Spawn OpenCode AFTER server is listening so MCP connection succeeds
   spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);


### PR DESCRIPTION
## Summary

Closes #289 — the LAN exposure flagged on PR #288.

The Oyster server used to listen on every interface (`0.0.0.0`) and rely on the HTTP `Origin` header alone to gate `rejectIfNonLocalOrigin()`. Browsers always send `Origin`, so `evil.com` got 403'd — but a non-browser client (curl, a script) on the same WiFi could omit `Origin` entirely and pull `/api/vault/inventory`, `/api/memories`, etc.

This applies both fixes from the issue (belt and braces):

1. **Bind to localhost.** `httpServer.listen(port, "127.0.0.1", …)` — server stops accepting LAN connections entirely.
2. **Tighten the guard.** When the request has no `Origin` header, `rejectIfNonLocalOrigin()` now also requires `req.socket.remoteAddress` to be a loopback address (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`). Anything else returns 403.

## Test plan

Smoke-tested locally with a fresh server on `OYSTER_PORT=4455`:

- [x] Loopback, no Origin: `curl http://127.0.0.1:4455/api/vault/inventory` → **200**
- [x] Loopback, localhost Origin: `curl -H "Origin: http://localhost:4455" …` → **200**
- [x] Evil Origin: `curl -H "Origin: http://evil.com" …` → **403** (unchanged behaviour)
- [x] LAN IP from same machine: `curl http://192.168.1.25:4455/…` → connection refused (server not bound to that interface)
- [x] Server typecheck clean (`tsc --noEmit`)

## Notes

WebSocket (`attachWebSocket(httpServer)`) inherits the bind, so it's covered too.

CHANGELOG entry added under `### Security` for `[Unreleased]`; `docs/changelog.html` regenerated via `npm run build:changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)