### PR TITLE
docs(pricing): public release moves to 0.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 ---
 
-**🦪 The OS that understands your projects, remembers your work, and acts from one prompt. Powered by MCP — bring any AI.**
+**🦪 Every agent, one shared brain.** Oyster watches your AI sessions, captures the files they touched and the memories they wrote, and brings them all into one workspace — visible, searchable, persistent across every machine. Built on MCP.
 
 ```bash
 # 1. Install
 npm install -g oyster-os
 
-# 2. Configure & Start
+# 2. Start
 oyster
 
 # 3. Open your browser to http://localhost:4444
@@ -22,14 +22,12 @@ oyster
 
 ## Why Oyster
 
-Your work is scattered across folders, repos, docs, tabs, and chat threads. Oyster puts it all on one visual surface and lets you control it from a chat bar.
+Your AI sessions, files, and memories live in tool-shaped silos. Oyster puts every agent's work on one shared surface, organised by space.
 
-- **Open things fast** — type `/o competitor analysis` and it opens, no folder hunting
-- **Switch context instantly** — `#blunderfixer` or `#1` to jump between projects
-- **See everything at once** — docs, diagrams, apps, decks, and spreadsheets on one desktop
-- **Any AI can control it** — Oyster speaks MCP, the open standard for AI tools. Connect Claude Code, Cursor, or any MCP client and your AI can manage the surface directly
-
-![Oyster desktop](docs/screenshots/desktop.png)
+- **See every agent at work** — Oyster watches Claude Code automatically. Live transcripts, status (active / awaiting / disconnected / done), and the files each session touched, all on Home.
+- **Memory that survives sessions** — `remember` notes are first-class. Every agent's `recall` reads from the same store, so context follows you across tools and machines.
+- **Drop in any project** — point Oyster at a folder and it scans for documents, apps, and diagrams, then attributes future sessions back to the right project.
+- **Bring any agent** — Oyster is an MCP server. Claude Code, Cursor, VS Code, Windsurf, or your own — one standard, every agent.
 
 ## Quick Start
 
@@ -107,11 +105,10 @@ Browser → http://localhost:4444
 
 Early v1. Local-first. Single-user. Built for fast iteration.
 
-**Now:** MCP powered workspace, bring your own AI, prompt-driven navigation, space switching, artefact desktop, repo onboarding, persistent memory (remember/recall), 19 MCP tools, slash commands, instant UI updates via SSE.
-
-**Next:** smoother onboarding, faster artefact navigation, better repo import.
-
-**Vision:** plugins, dynamic UI that reshapes to fit the task, build & share apps.
+- **Now (`0.5.x`)** — Sessions feed (Claude Code), Memories on Home, Project tiles per space, repo onboarding, 19 MCP tools, slash commands.
+- **Next (`0.6.x`)** — Bundles. Multi-file static artefacts; agents push artefacts via MCP.
+- **Then (`0.7.x`)** — Oyster Pro. Auth, cross-device sync, end-to-end encrypted storage, shareable links. ([pricing](https://oyster.to/pricing))
+- **Then (`0.8.x`)** — Multi-agent ingestion. Cursor, Codex, OpenCode session feeds — every agent feeds the same workspace.
 
 See every shipped change in the [changelog](https://oyster.to/changelog).
 

--- a/docs/assets/hero-mock.css
+++ b/docs/assets/hero-mock.css
@@ -1,0 +1,472 @@
+/* Hero mock — inline visual of the Home surface */
+.hero-mock {
+  width: 100%;
+  max-width: 820px;
+  margin: 56px auto 0;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(30, 31, 54, 1) 0%, rgba(18, 19, 36, 1) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(124, 107, 255, 0.06);
+  overflow: hidden;
+  text-align: left;
+  position: relative;
+}
+/* Items dim when their space isn't the one being hovered */
+.hero-mock [data-space] { transition: opacity 0.18s ease; }
+.hero-mock:has(.hm-pill[data-space="acme-app"]:hover) [data-space]:not([data-space="acme-app"]):not(.hm-pill) { opacity: 0.25; }
+.hero-mock:has(.hm-pill[data-space="pitch-deck"]:hover) [data-space]:not([data-space="pitch-deck"]):not(.hm-pill) { opacity: 0.25; }
+.hero-mock:has(.hm-pill[data-space="field-notes"]:hover) [data-space]:not([data-space="field-notes"]):not(.hm-pill) { opacity: 0.25; }
+.hm-tile { transition: background 0.15s ease, transform 0.15s ease; }
+.hm-tile:hover { background: rgba(255, 255, 255, 0.06); }
+.hero-mock-chrome {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.18);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.hero-mock-chrome span.dot {
+  width: 10px; height: 10px; border-radius: 50%;
+}
+.hero-mock-chrome .dot-r { background: #ff5f57; }
+.hero-mock-chrome .dot-y { background: #febc2e; }
+.hero-mock-chrome .dot-g { background: #28c840; }
+.hero-mock-chrome-title {
+  margin-left: 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.35);
+}
+.hero-mock-body {
+  padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 22px;
+}
+.hero-mock-breadcrumb {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  align-items: center;
+}
+.hm-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  color: rgba(232, 233, 240, 0.55);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.hm-pill:hover {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(232, 233, 240, 0.85);
+}
+.hm-pill-active {
+  background: rgba(124, 107, 255, 0.16);
+  border-color: rgba(124, 107, 255, 0.4);
+  color: #a597ff;
+}
+.hm-pill-active:hover {
+  background: rgba(124, 107, 255, 0.22);
+  border-color: rgba(124, 107, 255, 0.55);
+  color: #c4b5fd;
+}
+.hm-pill-icon {
+  padding: 0;
+  width: 32px; height: 32px;
+  justify-content: center;
+}
+.hm-pill-icon svg { width: 14px; height: 14px; opacity: 1; }
+.hm-pill .pip {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+}
+.hm-pill .pip-g { background: #4ade80; box-shadow: 0 0 5px #4ade80; }
+.hm-pill .pip-a { background: #fbbf24; box-shadow: 0 0 5px #fbbf24; }
+.hm-pill .pip-r { background: #f87171; box-shadow: 0 0 5px #f87171; }
+
+/* Filter chips (lifted from filter-options.html) */
+.hm-chips { display: inline-flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.hm-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: rgba(232, 233, 240, 0.55);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 3px 10px;
+  border-radius: 9999px;
+}
+.hm-chip-selected {
+  background: rgba(124, 107, 255, 0.18);
+  border-color: rgba(124, 107, 255, 0.3);
+  color: #a597ff;
+}
+.hm-chip .pip { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.hm-chip .pip-g { background: #4ade80; box-shadow: 0 0 6px #4ade80; animation: hmBreathe 2.4s ease-in-out infinite; }
+.hm-chip .pip-a { background: #fbbf24; box-shadow: 0 0 6px #fbbf24; }
+.hm-chip .pip-r { background: #f87171; box-shadow: 0 0 6px #f87171; }
+.hm-chip .pip-d { background: rgba(255, 255, 255, 0.18); }
+@keyframes hmBreathe { 50% { opacity: 0.45; } }
+@media (prefers-reduced-motion: reduce) {
+  .hm-chip .pip-g { animation: none; }
+}
+
+/* Section heads + sessions */
+.hm-section-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 10px;
+}
+.hm-section-name {
+  font-family: 'Barlow', sans-serif;
+  font-size: 11px; font-weight: 600;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase; letter-spacing: 1.5px;
+}
+.hm-section-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+}
+.hm-tiles { display: flex; flex-direction: column; gap: 6px; }
+.hm-tile {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+}
+.hm-status { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.hm-status-g { background: #4ade80; box-shadow: 0 0 8px rgba(74, 222, 128, 0.6); }
+.hm-status-a { background: #fbbf24; box-shadow: 0 0 8px rgba(251, 191, 36, 0.6); }
+.hm-status-r { background: #f87171; box-shadow: 0 0 8px rgba(248, 113, 113, 0.5); }
+.hm-status-d { background: rgba(255, 255, 255, 0.22); }
+.hm-tile-body { flex: 1; min-width: 0; }
+.hm-tile-title {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.88);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.hm-tile-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: 1px;
+}
+.hm-tile-time {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+}
+
+/* Artefact tiles */
+.hm-art-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 72px));
+  gap: 14px 14px;
+  justify-content: start;
+}
+.hm-art-cell {
+  display: flex; flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  width: 100%;
+}
+.hm-art {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.22),
+    0 3px 10px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  position: relative;
+}
+.hm-art-icon {
+  width: 26px; height: 26px;
+  color: rgba(255, 255, 255, 0.95);
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.45));
+  stroke-width: 2;
+}
+.hm-art-label {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 10px; font-weight: 500;
+  color: rgba(255, 255, 255, 0.78);
+  text-align: center;
+  width: 100%;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.hm-art-more {
+  background: rgba(255, 255, 255, 0.03) !important;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08) !important;
+}
+.hm-art-more-text {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0.04em;
+}
+
+/* Memories */
+.hm-mems { display: flex; flex-direction: column; gap: 6px; }
+.hm-mem {
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+}
+.hm-mem-text {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.86);
+  line-height: 1.4;
+}
+.hm-mem-meta {
+  display: flex; gap: 8px; align-items: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: 4px;
+}
+.hm-mem-space { color: #a99eff; }
+.hm-mem-sep { opacity: 0.4; }
+
+/* Floating preview window — shows on artefact hover */
+.hm-preview {
+  position: absolute;
+  left: 24px; right: 24px;
+  bottom: 110px;
+  height: 158px;
+  background: rgba(14, 15, 30, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+  z-index: 6;
+  overflow: hidden;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+.hero-mock:has(.hm-art-cell[data-artefact]:hover) .hm-preview {
+  opacity: 1;
+  transform: translateY(0);
+}
+.hm-preview-chrome {
+  display: flex; align-items: center; gap: 7px;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.25);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.hm-preview-chrome span.dot { width: 9px; height: 9px; border-radius: 50%; }
+.hm-preview-title {
+  margin-left: 6px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.5);
+}
+.hm-preview-body {
+  padding: 14px 18px;
+  height: calc(100% - 32px);
+  overflow: hidden;
+}
+
+/* Per-artefact preview shapes */
+.pv-app-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; height: 100%; }
+.pv-card {
+  background: rgba(124, 107, 255, 0.08);
+  border: 1px solid rgba(124, 107, 255, 0.18);
+  border-radius: 8px;
+  padding: 10px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  font-family: 'Space Grotesk', sans-serif;
+}
+.pv-card-label { font-size: 9px; color: rgba(255, 255, 255, 0.4); font-family: 'IBM Plex Mono', monospace; letter-spacing: 0.06em; text-transform: uppercase; }
+.pv-card-title { font-size: 11px; font-weight: 600; color: rgba(255, 255, 255, 0.85); }
+.pv-slide { font-family: 'Space Grotesk', sans-serif; }
+.pv-slide-num { font-family: 'IBM Plex Mono', monospace; font-size: 9px; color: rgba(255, 255, 255, 0.35); letter-spacing: 0.08em; margin-bottom: 8px; }
+.pv-slide h4 { font-size: 16px; font-weight: 700; color: #fff; margin-bottom: 8px; letter-spacing: -0.01em; }
+.pv-slide ul { list-style: none; display: flex; flex-direction: column; gap: 5px; }
+.pv-slide li { font-size: 11px; color: rgba(255, 255, 255, 0.7); padding-left: 14px; position: relative; }
+.pv-slide li::before { content: ''; position: absolute; left: 0; top: 6px; width: 5px; height: 5px; background: #7c6bff; border-radius: 50%; }
+.pv-diag { display: flex; align-items: center; justify-content: center; gap: 14px; height: 100%; }
+.pv-node {
+  padding: 12px 16px;
+  background: rgba(124, 107, 255, 0.12);
+  border: 1px solid rgba(124, 107, 255, 0.3);
+  border-radius: 8px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: #a597ff;
+}
+.pv-arrow {
+  width: 32px; height: 1px; background: rgba(255, 255, 255, 0.25);
+  position: relative;
+}
+.pv-arrow::after {
+  content: ''; position: absolute; right: 0; top: -3px;
+  border-left: 6px solid rgba(255, 255, 255, 0.4);
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+}
+.pv-wire { display: flex; gap: 10px; height: 100%; }
+.pv-wire-side {
+  width: 24%;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 10px;
+}
+.pv-wire-side-row { height: 6px; background: rgba(255, 255, 255, 0.1); border-radius: 3px; }
+.pv-wire-side-row.active { background: rgba(124, 107, 255, 0.6); width: 70%; }
+.pv-wire-main {
+  flex: 1; background: rgba(255, 255, 255, 0.02); border-radius: 6px; padding: 12px;
+  display: flex; flex-direction: column; gap: 7px;
+}
+.pv-wire-bar { height: 8px; border-radius: 3px; background: rgba(255, 255, 255, 0.08); }
+.pv-wire-bar.long { width: 100%; }
+.pv-wire-bar.med { width: 70%; }
+.pv-wire-bar.short { width: 40%; }
+.pv-list { font-family: 'Space Grotesk', sans-serif; }
+.pv-list h4 { font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 8px; }
+.pv-list ul { list-style: none; display: grid; grid-template-columns: 1fr 1fr; gap: 6px 16px; }
+.pv-list li { display: flex; align-items: center; gap: 8px; font-size: 11px; color: rgba(255, 255, 255, 0.78); }
+.pv-chk {
+  width: 13px; height: 13px; border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 9px;
+  flex-shrink: 0;
+}
+.pv-chk.done { background: #4ade80; border-color: #4ade80; color: #0a0b14; font-weight: 700; }
+.pv-list li.done { color: rgba(255, 255, 255, 0.4); text-decoration: line-through; }
+
+/* Slide-in side panel — preview when hovering a session */
+.hm-side {
+  position: absolute;
+  top: 36px; right: 0; bottom: 0;
+  width: 56%;
+  padding: 22px 24px;
+  background: rgba(20, 21, 40, 0.97);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  transform: translateX(102%);
+  transition: transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 5;
+  pointer-events: none;
+  box-shadow: -16px 0 40px rgba(0, 0, 0, 0.4);
+  overflow-y: auto;
+}
+.hero-mock:has(.hm-tile:hover) .hm-side,
+.hero-mock:has(.hm-mem:hover) .hm-side { transform: translateX(0); }
+.hm-mem { transition: background 0.15s ease; }
+.hm-mem:hover { background: rgba(255, 255, 255, 0.06); cursor: default; }
+.hm-status-mem {
+  width: 10px; height: 10px; border-radius: 3px;
+  background: #a597ff;
+  box-shadow: 0 0 8px rgba(165, 151, 255, 0.55);
+}
+.hm-side-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 6px;
+  margin-right: 6px;
+}
+.hm-side-pill .pip-g { width: 6px; height: 6px; border-radius: 50%; background: #4ade80; box-shadow: 0 0 5px #4ade80; }
+.hm-side-pill .pip-d { width: 6px; height: 6px; border-radius: 50%; background: rgba(255, 255, 255, 0.22); }
+.hm-side-bigtext {
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.92);
+  padding: 14px 16px;
+  background: rgba(124, 107, 255, 0.06);
+  border: 1px solid rgba(124, 107, 255, 0.18);
+  border-radius: 8px;
+  margin-bottom: 18px;
+}
+.hm-side-head {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 4px;
+}
+.hm-side-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 14px; font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+}
+.hm-side-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.4);
+  margin-bottom: 18px;
+}
+.hm-side-block { margin-bottom: 16px; }
+.hm-side-block-name {
+  font-family: 'Barlow', sans-serif;
+  font-size: 10px; font-weight: 600;
+  color: rgba(255, 255, 255, 0.45);
+  text-transform: uppercase; letter-spacing: 1.5px;
+  margin-bottom: 8px;
+}
+.hm-side-line {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.65);
+  padding: 3px 0;
+}
+.hm-side-line.user { color: rgba(255, 255, 255, 0.92); }
+.hm-side-line.tool { color: #a597ff; }
+.hm-side-file {
+  display: flex; gap: 10px; align-items: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 4px 0;
+}
+.hm-side-file .add { color: #4ade80; }
+.hm-side-file .rm { color: #f87171; }
+.hm-side-file-name { flex: 1; }
+.hm-side-mem {
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 6px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.45;
+  margin-bottom: 6px;
+}
+.hm-side-arts { display: flex; gap: 6px; flex-wrap: wrap; }
+.hm-side-art-chip {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  background: rgba(124, 107, 255, 0.12);
+  border: 1px solid rgba(124, 107, 255, 0.22);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: #a597ff;
+}
+.hm-side-empty {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+  font-style: italic;
+}
+
+@media (max-width: 700px) {
+  .hero-mock-body { padding: 16px 16px; }
+  .hm-art-grid { grid-template-columns: repeat(5, 1fr); }
+  .hm-pill { font-size: 11px; padding: 5px 10px; }
+  .hm-side { display: none; }
+}

--- a/docs/assets/hero-mock.js
+++ b/docs/assets/hero-mock.js
@@ -1,0 +1,239 @@
+// Hero mock — per-session side panel + per-artefact preview
+(function () {
+  const sessions = {
+    s1: {
+      title: 'Refactor checkout flow',
+      status: 'hm-status-g',
+      meta: 'claude-code · acme-app · 2m ago',
+      transcript: [
+        ['user', '↳ Refactor billing module to handle multi-currency.'],
+        ['', 'Reading src/checkout/cart.ts and the payment flow…'],
+        ['tool', 'edit_file: src/checkout/cart.ts'],
+        ['tool', 'edit_file: src/checkout/payment.ts'],
+        ['tool', 'run: npm test'],
+      ],
+      memories: ['Customer prefers email summaries on Fridays — keep under 200 words.'],
+      artefacts: ['Onboarding', 'Settings UI'],
+      files: [['cart.ts', 24, 3], ['payment.ts', 18, 7], ['checkout.test.ts', 9, 0]],
+    },
+    s2: {
+      title: 'Stakeholder pitch v3',
+      status: 'hm-status-a',
+      meta: 'cursor · pitch-deck · awaiting',
+      transcript: [
+        ['user', '↳ Refresh the Q4 deck with the new pricing slide.'],
+        ['', 'Pulled 1 memory about the pricing decision.'],
+        ['tool', 'edit_file: pitch-deck/04-pricing.md'],
+        ['', 'Awaiting your review on slide 4.'],
+      ],
+      memories: ['Pitch deck needs the revised pricing slide before Wednesday’s review.'],
+      artefacts: ['Q4 Pitch'],
+      files: [['04-pricing.md', 32, 8], ['outline.md', 4, 0]],
+    },
+    s3: {
+      title: 'Investigate API latency',
+      status: 'hm-status-r',
+      meta: 'claude-code · acme-app · 1h ago',
+      transcript: [
+        ['user', '↳ p99 spiking on /api/checkout — can you take a look?'],
+        ['tool', 'read_file: server/logs/2026-05-01.log'],
+        ['', 'Database query taking 2.3s — missing index on orders.created_at.'],
+        ['tool', 'edit_file: migrations/0042_orders_index.sql'],
+        ['', 'Connection lost. Resume with: claude -c <id>'],
+      ],
+      memories: [],
+      artefacts: ['Onboarding'],
+      files: [['0042_orders_index.sql', 8, 0]],
+    },
+    s4: {
+      title: 'Weekly retro write-up',
+      status: 'hm-status-d',
+      meta: 'claude-code · field-notes · yesterday',
+      transcript: [
+        ['user', '↳ Summarise this week — wins, blockers, decisions.'],
+        ['tool', 'list_artifacts: field-notes'],
+        ['', 'Collated 7 sessions into a retro doc. Ready for review.'],
+        ['tool', 'edit_file: field-notes/2026-04-29.md'],
+      ],
+      memories: [],
+      artefacts: ['Launch list'],
+      files: [['2026-04-29.md', 142, 0]],
+    },
+  };
+
+  const memories = {
+    m1: {
+      text: 'Customer prefers email summaries on Fridays — keep under 200 words and lead with decisions, not analysis.',
+      meta: 'acme-app · claude-code · 4h ago',
+      writtenBy: { agent: 'claude-code', session: 'Refactor checkout flow', state: 'g' },
+      pulledBy: [
+        { title: 'Refactor checkout flow', state: 'g' },
+        { title: 'Investigate API latency', state: 'd' },
+      ],
+      artefacts: ['Onboarding'],
+    },
+    m2: {
+      text: 'Pitch deck needs the revised pricing slide before Wednesday’s stakeholder review.',
+      meta: 'pitch-deck · cursor · yesterday',
+      writtenBy: { agent: 'cursor', session: 'Stakeholder pitch v3', state: 'a' },
+      pulledBy: [
+        { title: 'Stakeholder pitch v3', state: 'a' },
+      ],
+      artefacts: ['Q4 Pitch'],
+    },
+  };
+
+  const status = document.getElementById('hm-side-status');
+  const title = document.getElementById('hm-side-title');
+  const meta = document.getElementById('hm-side-meta');
+  const body = document.getElementById('hm-side-body');
+  if (!status || !body) return;
+
+  function esc(s) { return String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c])); }
+
+  function block(name, html) {
+    return '<div class="hm-side-block"><div class="hm-side-block-name">' + name + '</div>' + html + '</div>';
+  }
+
+  function renderSession(id) {
+    const s = sessions[id];
+    if (!s) return;
+    status.className = 'hm-status ' + s.status;
+    title.textContent = s.title;
+    meta.textContent = s.meta;
+
+    const transcript = s.transcript.map(([k, t]) =>
+      '<div class="hm-side-line' + (k ? ' ' + k : '') + '">' + esc(t) + '</div>'
+    ).join('');
+
+    const mems = s.memories.length
+      ? s.memories.map(m => '<div class="hm-side-mem">' + esc(m) + '</div>').join('')
+      : '<div class="hm-side-empty">No memories pulled.</div>';
+
+    const arts = '<div class="hm-side-arts">' + (s.artefacts.length
+      ? s.artefacts.map(a => '<span class="hm-side-art-chip">' + esc(a) + '</span>').join('')
+      : '<div class="hm-side-empty">No artefacts touched.</div>') + '</div>';
+
+    const files = s.files.length
+      ? s.files.map(([n, a, r]) =>
+        '<div class="hm-side-file"><span class="hm-side-file-name">' + esc(n) + '</span>' +
+        (a ? '<span class="add">+' + a + '</span>' : '') +
+        (r ? '<span class="rm">−' + r + '</span>' : '') + '</div>'
+      ).join('')
+      : '<div class="hm-side-empty">No files touched.</div>';
+
+    body.innerHTML = block('Transcript', transcript) + block('Memories', mems) + block('Artefacts', arts) + block('Files touched', files);
+  }
+
+  function renderMemory(id) {
+    const m = memories[id];
+    if (!m) return;
+    status.className = 'hm-status hm-status-mem';
+    title.textContent = 'Memory';
+    meta.textContent = m.meta;
+
+    const text = '<div class="hm-side-bigtext">' + esc(m.text) + '</div>';
+
+    const written = '<div class="hm-side-pill"><span class="pip-' + m.writtenBy.state + '"></span>' +
+      esc(m.writtenBy.session) + ' · ' + esc(m.writtenBy.agent) + '</div>';
+
+    const pulled = m.pulledBy.length
+      ? m.pulledBy.map(p => '<div class="hm-side-pill"><span class="pip-' + p.state + '"></span>' + esc(p.title) + '</div>').join('')
+      : '<div class="hm-side-empty">Not yet recalled.</div>';
+
+    const arts = '<div class="hm-side-arts">' + (m.artefacts.length
+      ? m.artefacts.map(a => '<span class="hm-side-art-chip">' + esc(a) + '</span>').join('')
+      : '<div class="hm-side-empty">No artefacts linked.</div>') + '</div>';
+
+    body.innerHTML = text + block('Written by', written) + block('Pulled by', pulled) + block('Linked artefacts', arts);
+  }
+
+  document.querySelectorAll('.hm-tile').forEach(tile => {
+    tile.addEventListener('mouseenter', () => renderSession(tile.dataset.session));
+  });
+  document.querySelectorAll('.hm-mem[data-memory]').forEach(mem => {
+    mem.addEventListener('mouseenter', () => renderMemory(mem.dataset.memory));
+  });
+
+  renderSession('s1');
+
+  // Artefact preview content
+  const artefacts = {
+    onboarding: {
+      title: 'Onboarding · acme-app',
+      body: `<div class="pv-app-grid">
+        <div class="pv-card"><div class="pv-card-label">step 1</div><div class="pv-card-title">Profile</div></div>
+        <div class="pv-card"><div class="pv-card-label">step 2</div><div class="pv-card-title">Connect repo</div></div>
+        <div class="pv-card"><div class="pv-card-label">step 3</div><div class="pv-card-title">Invite team</div></div>
+        <div class="pv-card"><div class="pv-card-label">step 4</div><div class="pv-card-title">First task</div></div>
+      </div>`,
+    },
+    pitch: {
+      title: 'Q4 Pitch · 04 of 12',
+      body: `<div class="pv-slide">
+        <div class="pv-slide-num">04 / 12 · pricing</div>
+        <h4>What changes in Q4</h4>
+        <ul>
+          <li>$20/month for Pro, individual</li>
+          <li>$192/year — save 20%</li>
+          <li>Free tier stays unlimited</li>
+        </ul>
+      </div>`,
+    },
+    auth: {
+      title: 'Auth flow · diagram',
+      body: `<div class="pv-diag">
+        <div class="pv-node">User</div>
+        <div class="pv-arrow"></div>
+        <div class="pv-node">Magic link</div>
+        <div class="pv-arrow"></div>
+        <div class="pv-node">Session</div>
+        <div class="pv-arrow"></div>
+        <div class="pv-node">Workspace</div>
+      </div>`,
+    },
+    settings: {
+      title: 'Settings UI · wireframe',
+      body: `<div class="pv-wire">
+        <div class="pv-wire-side">
+          <div class="pv-wire-side-row active"></div>
+          <div class="pv-wire-side-row"></div>
+          <div class="pv-wire-side-row"></div>
+          <div class="pv-wire-side-row"></div>
+        </div>
+        <div class="pv-wire-main">
+          <div class="pv-wire-bar long"></div>
+          <div class="pv-wire-bar med"></div>
+          <div class="pv-wire-bar long"></div>
+          <div class="pv-wire-bar short"></div>
+        </div>
+      </div>`,
+    },
+    launch: {
+      title: 'Launch list · field-notes',
+      body: `<div class="pv-list">
+        <h4>Launch checklist</h4>
+        <ul>
+          <li class="done"><span class="pv-chk done">✓</span>Pricing page live</li>
+          <li class="done"><span class="pv-chk done">✓</span>Hero mock approved</li>
+          <li class="done"><span class="pv-chk done">✓</span>0.5.0-beta.1 published</li>
+          <li><span class="pv-chk"></span>Beta to Henry</li>
+          <li><span class="pv-chk"></span>Reddit announcement</li>
+          <li><span class="pv-chk"></span>HN post</li>
+        </ul>
+      </div>`,
+    },
+  };
+
+  const previewTitle = document.getElementById('hm-preview-title');
+  const previewBody = document.getElementById('hm-preview-body');
+
+  document.querySelectorAll('.hm-art-cell[data-artefact]').forEach(cell => {
+    cell.addEventListener('mouseenter', () => {
+      const a = artefacts[cell.dataset.artefact];
+      if (!a) return;
+      previewTitle.textContent = a.title;
+      previewBody.innerHTML = a.body;
+    });
+  });
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
   <title>Oyster — Every AI you use, one shared brain.</title>
   <meta name="description" content="Claude Code, Cursor, Codex — every agent you use connects to one shared workspace. Their sessions, files, and memories land in one place. Built on MCP.">
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/hero-mock.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { scroll-padding-top: 60px; }
@@ -106,6 +107,8 @@
       margin: 0 auto 0;
       display: block;
     }
+
+    /* Hero mock styles live in assets/hero-mock.css */
 
     /* Feature sections */
     .feature-section {
@@ -428,7 +431,6 @@
   <nav class="nav" id="nav">
     <img src="logo.png" alt="Oyster" class="nav-logo" />
     <a href="#install">Install</a>
-    <a href="/mcp">MCP</a>
     <a href="/plugins">Plugins</a>
     <a href="/pricing">Pricing</a>
     <a href="/changelog">Changelog</a>
@@ -438,13 +440,177 @@
   <div class="hero">
     <h1>Every agent, one shared brain.</h1>
     <p class="subtitle">
-      Claude Code, Cursor, Codex, your own. Every agent's sessions, files, and memories land in one workspace — visible, searchable, persistent across every machine. Built on MCP.
+      Every agent's sessions, files, and memories land in one workspace — visible, searchable, persistent across every machine. Built on MCP.
     </p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>
       <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
     </div>
-    <img src="screenshots/desktop.png" alt="Oyster desktop" class="hero-img">
+    <div class="hero-mock" aria-hidden="true">
+      <div class="hero-mock-chrome">
+        <span class="dot dot-r"></span>
+        <span class="dot dot-y"></span>
+        <span class="dot dot-g"></span>
+        <span class="hero-mock-chrome-title">Oyster</span>
+      </div>
+
+      <div class="hm-preview" aria-hidden="true">
+        <div class="hm-preview-chrome">
+          <span class="dot dot-r"></span>
+          <span class="dot dot-y"></span>
+          <span class="dot dot-g"></span>
+          <span class="hm-preview-title" id="hm-preview-title">Preview</span>
+        </div>
+        <div class="hm-preview-body" id="hm-preview-body"></div>
+      </div>
+
+      <div class="hm-side" aria-hidden="true">
+        <div class="hm-side-head">
+          <span class="hm-status" id="hm-side-status"></span>
+          <span class="hm-side-title" id="hm-side-title"></span>
+        </div>
+        <div class="hm-side-meta" id="hm-side-meta"></div>
+        <div id="hm-side-body"></div>
+      </div>
+      <div class="hero-mock-body">
+        <div class="hero-mock-breadcrumb">
+          <span class="hm-pill hm-pill-icon hm-pill-active" aria-label="Home">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          </span>
+          <span class="hm-pill" data-space="acme-app">
+            <span class="pip pip-g"></span>
+            acme-app
+          </span>
+          <span class="hm-pill" data-space="pitch-deck">
+            <span class="pip pip-a"></span>
+            pitch-deck
+          </span>
+          <span class="hm-pill" data-space="field-notes">
+            <span class="pip pip-r"></span>
+            field-notes
+          </span>
+        </div>
+
+        <div>
+          <div class="hm-section-head">
+            <span class="hm-section-name">Sessions</span>
+            <span class="hm-chips">
+              <span class="hm-chip hm-chip-selected"><span class="pip pip-g"></span>2 active</span>
+              <span class="hm-chip"><span class="pip pip-a"></span>1 awaiting</span>
+              <span class="hm-chip"><span class="pip pip-r"></span>1 disconnected</span>
+            </span>
+          </div>
+          <div class="hm-tiles">
+            <div class="hm-tile" data-space="acme-app" data-session="s1">
+              <span class="hm-status hm-status-g"></span>
+              <div class="hm-tile-body">
+                <div class="hm-tile-title">Refactor checkout flow</div>
+                <div class="hm-tile-meta">claude-code · acme-app</div>
+              </div>
+              <span class="hm-tile-time">2m ago</span>
+            </div>
+            <div class="hm-tile" data-space="pitch-deck" data-session="s2">
+              <span class="hm-status hm-status-a"></span>
+              <div class="hm-tile-body">
+                <div class="hm-tile-title">Stakeholder pitch v3</div>
+                <div class="hm-tile-meta">cursor · pitch-deck</div>
+              </div>
+              <span class="hm-tile-time">awaiting</span>
+            </div>
+            <div class="hm-tile" data-space="acme-app" data-session="s3">
+              <span class="hm-status hm-status-r"></span>
+              <div class="hm-tile-body">
+                <div class="hm-tile-title">Investigate API latency</div>
+                <div class="hm-tile-meta">claude-code · acme-app</div>
+              </div>
+              <span class="hm-tile-time">1h ago</span>
+            </div>
+            <div class="hm-tile" data-space="field-notes" data-session="s4">
+              <span class="hm-status hm-status-d"></span>
+              <div class="hm-tile-body">
+                <div class="hm-tile-title">Weekly retro write-up</div>
+                <div class="hm-tile-meta">claude-code · field-notes</div>
+              </div>
+              <span class="hm-tile-time">yesterday</span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="hm-section-head">
+            <span class="hm-section-name">Memories</span>
+            <span class="hm-section-meta">23 · 4 pinned</span>
+          </div>
+          <div class="hm-mems">
+            <div class="hm-mem" data-space="acme-app" data-memory="m1">
+              <div class="hm-mem-text">Customer prefers email summaries on Fridays — keep under 200 words and lead with decisions, not analysis.</div>
+              <div class="hm-mem-meta">
+                <span class="hm-mem-space">acme-app</span>
+                <span class="hm-mem-sep">·</span>
+                <span>claude-code</span>
+                <span class="hm-mem-sep">·</span>
+                <span>4h ago</span>
+              </div>
+            </div>
+            <div class="hm-mem" data-space="pitch-deck" data-memory="m2">
+              <div class="hm-mem-text">Pitch deck needs the revised pricing slide before Wednesday's stakeholder review.</div>
+              <div class="hm-mem-meta">
+                <span class="hm-mem-space">pitch-deck</span>
+                <span class="hm-mem-sep">·</span>
+                <span>cursor</span>
+                <span class="hm-mem-sep">·</span>
+                <span>yesterday</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="hm-section-head">
+            <span class="hm-section-name">Artefacts</span>
+            <span class="hm-section-meta">12 · across 3 spaces</span>
+          </div>
+          <div class="hm-art-grid">
+            <div class="hm-art-cell" data-space="acme-app" data-artefact="onboarding">
+              <div class="hm-art" style="background: linear-gradient(135deg, #ff9a5a, #f06d3f);">
+                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7.5" height="7.5" rx="1.6"/><rect x="13.5" y="3" width="7.5" height="7.5" rx="1.6"/><rect x="3" y="13.5" width="7.5" height="7.5" rx="1.6"/><rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.6"/></svg>
+              </div>
+              <span class="hm-art-label">Onboarding</span>
+            </div>
+            <div class="hm-art-cell" data-space="pitch-deck" data-artefact="pitch">
+              <div class="hm-art" style="background: linear-gradient(135deg, #34d4c0, #1d4ed8);">
+                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"/><path d="M9 21h6M12 17v4"/><path d="M7 12V9M11 12V8M15 12V10"/></svg>
+              </div>
+              <span class="hm-art-label">Q4 Pitch</span>
+            </div>
+            <div class="hm-art-cell" data-space="acme-app" data-artefact="auth">
+              <div class="hm-art" style="background: linear-gradient(135deg, #f472b6, #be123c);">
+                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.6"/><circle cx="18" cy="6" r="2.6"/><circle cx="12" cy="18" r="2.6"/><path d="M7.6 8l3.4 7.5M16.4 8l-3.4 7.5"/></svg>
+              </div>
+              <span class="hm-art-label">Auth flow</span>
+            </div>
+            <div class="hm-art-cell" data-space="acme-app" data-artefact="settings">
+              <div class="hm-art" style="background: linear-gradient(135deg, #93c5fd, #0891b2);">
+                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2.5"/><path d="M3 9h18M9 21V9"/></svg>
+              </div>
+              <span class="hm-art-label">Settings UI</span>
+            </div>
+            <div class="hm-art-cell" data-space="field-notes" data-artefact="launch">
+              <div class="hm-art" style="background: linear-gradient(135deg, #fcd34d, #ea580c);">
+                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/><path d="M9 13h6M9 17h4"/></svg>
+              </div>
+              <span class="hm-art-label">Launch list</span>
+            </div>
+            <div class="hm-art-cell">
+              <div class="hm-art hm-art-more">
+                <span class="hm-art-more-text">+ 7</span>
+              </div>
+              <span class="hm-art-label" style="opacity: 0;">&nbsp;</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Feature 1: See every agent at work (Sessions — shipped 0.5.0) — leads the page -->
@@ -593,6 +759,7 @@
     <div class="feature-text">
       <h3>Built on MCP. Bring Your Own Agents.</h3>
       <p>Oyster is an MCP server. That means any agent that speaks the protocol — Claude Code, Cursor, VS Code, Windsurf, or your own — can control your workspace. Create documents, organise spaces, open artefacts. One standard, every agent.</p>
+      <a href="/mcp" class="cta cta-secondary" style="margin-top: 18px; display: inline-flex;">Detailed setup →</a>
     </div>
     <div class="feature-mock">
       <div class="mock-panel" style="padding: 0; overflow: hidden;">
@@ -958,6 +1125,8 @@
     // Set initial active tab style
     document.querySelector('.mcp-tab-active').style.color = '#fff';
     document.querySelector('.mcp-tab-active').style.background = 'rgba(124,107,255,0.15)';
+
   </script>
+  <script src="assets/hero-mock.js" defer></script>
 </body>
 </html>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pricing — Oyster</title>
-  <meta name="description" content="Oyster is free without limits. Optional add-ons let your work follow you everywhere — Sync, Memory, Publish.">
+  <meta name="description" content="Oyster is free without limits. Optional add-ons make your work smarter and follow you everywhere — Sync, Memory, Publish.">
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -228,18 +228,19 @@
     }
     .tier-name {
       font-family: 'Barlow', sans-serif;
-      font-size: 22px; font-weight: 700;
+      font-size: 34px; font-weight: 700;
       color: #fff;
-      letter-spacing: -0.01em;
+      letter-spacing: -0.02em;
+      line-height: 1.1;
     }
     .tier-tagline {
-      font-size: 13px; color: rgba(255, 255, 255, 0.5);
-      margin-top: 4px;
-      margin-bottom: 22px;
+      font-size: 19px; color: rgba(255, 255, 255, 0.7);
+      margin-top: 8px;
+      margin-bottom: 32px;
     }
     .tier-price {
       display: flex; align-items: baseline; gap: 8px;
-      margin-bottom: 4px;
+      margin-bottom: 16px;
     }
     .tier-price-amount {
       font-family: 'Barlow', sans-serif;
@@ -257,6 +258,18 @@
       color: rgba(255, 255, 255, 0.4);
       margin-bottom: 22px;
       letter-spacing: 0.04em;
+    }
+    .tier-pledge {
+      display: flex; flex-wrap: wrap;
+      gap: 0 14px;
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 13px; font-weight: 600;
+      color: #a99eff;
+      margin-bottom: 22px;
+      letter-spacing: 0.01em;
+    }
+    .tier-pledge .sep {
+      color: rgba(169, 158, 255, 0.45);
     }
     .tier-coming {
       display: inline-flex; align-items: center;
@@ -279,6 +292,13 @@
     .tier-features svg { flex: none; margin-top: 3px; color: #7c6bff; }
     .tier-features li.tier-features-plus { font-weight: 500; color: #fff; }
     .tier-features li.tier-features-add svg { color: #fbbf24; }
+    .tier-feature-primitive-name {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: #fbbf24;
+    }
     .tier-cta {
       display: inline-flex; align-items: center; gap: 8px;
       padding: 11px 22px; border-radius: 9999px;
@@ -327,7 +347,7 @@
       No strings attached.
     </p>
     <p class="subtitle">
-      Optional Oyster Pro adds <strong>Sync</strong>, <strong>Memory</strong>, and <strong>Publish</strong> — your work follows you everywhere.
+      Optional Oyster Pro adds <strong>Sync</strong>, <strong>Memory</strong>, and <strong>Publish</strong> — your work is smarter and follows you everywhere.
     </p>
   </section>
 
@@ -360,15 +380,15 @@
       </span>
       <div>
         <div class="primitive-name">Memory</div>
-        <h2>Your AI's brain, every agent.</h2>
+        <h2>One brain, every agent.</h2>
         <p class="primitive-desc">
           Claude, Cursor, Codex, the next one — every agent you use shares the same memory of your work.
           Pick up a session anywhere, switch tools mid-thought, and your AI keeps the context.
           The thing nobody else does.
         </p>
         <ul class="primitive-bullets">
-          <li>One memory, every agent</li>
-          <li>One memory, every machine</li>
+          <li>One brain, every agent</li>
+          <li>One brain, every machine</li>
           <li>Pick up where you left off</li>
           <li>Context that grows with your work</li>
         </ul>
@@ -412,7 +432,13 @@
           <span class="tier-price-amount">$0</span>
           <span class="tier-price-unit">/ month</span>
         </div>
-        <div class="tier-price-note">No sign-up. No strings. Yours to keep.</div>
+        <div class="tier-pledge">
+          <span>No sign-up</span>
+          <span class="sep">·</span>
+          <span>No strings</span>
+          <span class="sep">·</span>
+          <span>Yours to keep</span>
+        </div>
         <ul class="tier-features">
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Unlimited spaces &amp; artifacts</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Universal memory (local)</li>
@@ -421,7 +447,7 @@
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Local-only mode</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>All your data, exportable</li>
         </ul>
-        <a href="/" class="tier-cta tier-cta--ghost">Download Oyster</a>
+        <a href="/#install" class="tier-cta tier-cta--ghost">Install</a>
       </div>
 
       <div class="tier tier--featured">
@@ -435,9 +461,9 @@
         <div class="tier-price-note">or $192/year — save 20%</div>
         <ul class="tier-features">
           <li class="tier-features-plus"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Everything in Free</li>
-          <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>Sync — every device</li>
-          <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>Memory — every agent</li>
-          <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>Publish — shareable links</li>
+          <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg><span><span class="tier-feature-primitive-name">Sync</span> — take your work anywhere</span></li>
+          <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg><span><span class="tier-feature-primitive-name">Memory</span> — centralised intelligence</span></li>
+          <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg><span><span class="tier-feature-primitive-name">Publish</span> — share work as a link</span></li>
           <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>Continuous backup with version history</li>
           <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>End-to-end encrypted</li>
         </ul>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -442,7 +442,7 @@
           <li class="tier-features-add"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>End-to-end encrypted</li>
         </ul>
         <button type="button" class="tier-cta tier-cta--primary" disabled>Join the waitlist</button>
-        <span class="tier-fineprint">Private beta now · public release with 0.6.x</span>
+        <span class="tier-fineprint">Private beta now · public release with 0.7.x</span>
       </div>
 
     </div>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -414,7 +414,7 @@
         </div>
         <div class="tier-price-note">No sign-up. No strings. Yours to keep.</div>
         <ul class="tier-features">
-          <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Spaces &amp; artifacts</li>
+          <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Unlimited spaces &amp; artifacts</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Universal memory (local)</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Plugins &amp; MCP integration</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Bring any AI</li>


### PR DESCRIPTION
## Summary

Two pricing-page polish edits:

1. **Public release moves to 0.7.x.** Sync, Memory cloud, and Publish need real backing infra (auth, sync engine, optional headless mode), so the Pro public release now targets `0.7.x`. `0.6.x` is the bundles arc. Tracked in #294.
2. **Free tier: "Unlimited spaces & artifacts".** No caps anywhere in the product — name it explicitly so users don't wonder if there are hidden limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)