### PR TITLE
fix(home): default sessions to 'all' + table view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **Sessions default to "all" + table view.** Previously a fresh install showed sessions in icon-grid view filtered to "live", which made fresh installs look empty whenever no Claude session was actively running. Now a new install lands on every session in a list view with state, title, and cwd visible at a glance. Existing users who'd switched to icon view keep their preference.
 - **Pricing page hero.** Restructured into two stanzas — Free promise (*"No sign-up. No strings. Yours to keep."*) and a gold-rule Oyster Pro section that names what Pro is and what it adds. Pro is correctly framed as the optional thing (rather than its features).
 
 ## [0.5.0-beta.1] - 2026-05-01

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -329,6 +329,7 @@
 </ul>
 <h3>Changed</h3>
 <ul>
+<li><strong>Sessions default to &quot;all&quot; + table view.</strong> Previously a fresh install showed sessions in icon-grid view filtered to &quot;live&quot;, which made fresh installs look empty whenever no Claude session was actively running. Now a new install lands on every session in a list view with state, title, and cwd visible at a glance. Existing users who&#39;d switched to icon view keep their preference.</li>
 <li><strong>Pricing page hero.</strong> Restructured into two stanzas — Free promise (<em>&quot;No sign-up. No strings. Yours to keep.&quot;</em>) and a gold-rule Oyster Pro section that names what Pro is and what it adds. Pro is correctly framed as the optional thing (rather than its features).</li>
 </ul>
 <h2 id="v-0-5-0-beta-1"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0-beta.0...v0.5.0-beta.1" rel="noopener noreferrer"><span class="release-version">0.5.0-beta.1</span></a><span class="release-date"> — 2026-05-01</span></h2>

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -172,8 +172,8 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // Reset the attach form whenever scope changes so it doesn't carry
   // across spaces.
   useEffect(() => { setShowAttachForm(false); }, [sourcesSpaceId]);
-  const [stateFilter, setStateFilter] = useState<StateFilter>("live");
-  const [sessionsView, setSessionsView] = useStickyView("oyster.home.sessionsView", "icons");
+  const [stateFilter, setStateFilter] = useState<StateFilter>("all");
+  const [sessionsView, setSessionsView] = useStickyView("oyster.home.sessionsView", "table");
   const [artefactsView, setArtefactsView] = useStickyView("oyster.home.artefactsView", "icons");
   const [activePanel, setActivePanel] = useState<ActivePanel | null>(null);
 


### PR DESCRIPTION
## Summary

Surfaced by smoke-testing 0.5.0-beta.1 on a Windows machine with 5 done Claude sessions on disk — none visible in Oyster after install.

**Cause:** the default state filter was \`live\` (excludes done) and the default view was \`icons\` (no labels at a glance). Any fresh install on a machine without an actively running Claude session looked empty.

**Fix:** flip the two defaults.
- \`web/src/components/Home.tsx:175\` — \`stateFilter\` default \`"live"\` → \`"all"\`
- \`web/src/components/Home.tsx:176\` — \`sessionsView\` default \`"icons"\` → \`"table"\`

\`useStickyView\` persists view preference to localStorage, so users who'd already picked icons keep them. Only fresh installs (and the next-machine scenario) get the new default.

## Test plan

- [ ] Fresh install on a machine with done-only Claude sessions → sessions visible without changing any filter
- [ ] Existing user with localStorage \`oyster.home.sessionsView=icons\` → still in icon view after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)