### PR TITLE
docs(requirements): pin Oyster Cloud user requirements (free + Pro, R1–R7)

### DIFF
--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -22,7 +22,7 @@ The substrate is the same: the same identity layer, the same cloud surface, the 
 
 A user who signs into Oyster on a fresh machine sees their full context with no manual setup — every space pill renders with live counts, sessions list populates, memories are recallable, the inventory tile reflects what's in the cloud. The act of signing in is sufficient; nothing else is required of the user.
 
-**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents and locally-ingested transcript bodies. No manual import, file copy, or configuration step is required between sign-in and the populated Home page rendering.
+**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents (which require their git remote to be cloned to a local path). Transcript bodies of historical sessions are durable per R3 and are pulled on demand when their inspector is opened — they don't need to be on the new machine for the Home page to render. No manual import, file copy, or configuration step is required between sign-in and the populated Home page rendering.
 
 **Variant — self-hosted continuity via a git remote.** Users may opt to use their own git remote as the durable copy instead of Oyster's managed cloud. Same R1 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
 
@@ -32,24 +32,26 @@ A user who signs into Oyster on a fresh machine sees their full context with no 
 
 ## R2. Conversational recall across machines
 
-A user can ask their agent in natural language about any prior conversation, and get back the relevant summary, memories, and artefact references — regardless of which machine the original conversation happened on.
+A user can ask their agent in natural language about any prior conversation, and get back the relevant summary, memories, artefact references, and — when needed — the verbatim transcript content, regardless of which machine the original conversation happened on.
 
-Examples that must work:
-- *"Remember that pricing conversation yesterday?"*
-- *"What did Bharat suggest about memory sync?"*
-- *"Pick up that auth thread we had on the laptop last week."*
+Recall has two levels and both must work:
+
+- **Summary-level** (the everyday case): *"Remember that pricing conversation yesterday?"* / *"What did Bharat suggest about memory sync?"* — answered from the LLM-generated summary plus relevant memories.
+- **Verbatim** (the needle-in-the-haystack case): *"What were the exact specs we agreed for the render server?"* / *"What FTS5 schema did we settle on?"* — answered from the actual transcript content, retrieved across the full transcript corpus.
 
 The natural-language phrasing is the canonical UX. Explicit handles (e.g. `@BLUNDERFIXER:chat-with-bharat`) are at best a power-user fallback, not the primary interface — the engine is meaning, not strings.
 
-**Verify:** have a conversation on Machine A; on Machine B, query the agent in natural language about the topic; the agent responds with content traceable to A. "Pick up here" is a special case where the agent is then primed to continue the thread.
+**Verify:** have a conversation on Machine A; on Machine B, query the agent in natural language about the topic; the agent responds with content traceable to A. The verbatim case must surface the specific phrasing or detail from the original transcript, not just a summary that gestures at the topic. "Pick up here" is a special case where the agent is then primed to continue the thread.
 
 ---
 
 ## R3. Durability against machine loss
 
-If a user's primary machine is destroyed, restoring Oyster on a new machine restores their memories, spaces, artefact manifests, session metadata, and configs from the cloud (or self-hosted remote per R1's variant).
+If a user's primary machine is destroyed, restoring Oyster on a new machine restores their memories, spaces, artefact manifests, session metadata, session transcript bodies, and configs from the cloud (or self-hosted remote per R1's variant).
 
-**Verify:** fresh install + sign-in restores the Home UI to within "transcripts and locally-mounted file contents" of the lost machine.
+Transcript bodies live in cold storage rather than the live-sync hot path — they are not replicated to every device on every change, but they are **durably stored** and **retrievable on demand** by any signed-in device. The transcript inspector renders the full conversation on a non-origin device by lazy-pulling the bytes from cold storage on first open.
+
+**Verify:** fresh install + sign-in restores the Home UI to within "locally-mounted folder contents" of the lost machine. Opening any session's inspector on the new machine renders the full transcript (after a one-time pull on first open per device).
 
 R3 and R1 share most of the same plumbing — if the cloud (or remote) is the durable copy, fresh-machine sign-in is just a restore of the same dataset.
 

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -1,4 +1,4 @@
-# Oyster Pro — user requirements
+# Oyster Cloud — user requirements
 
 > **Status (2026-05):** Canonical. Requirements get pinned; architecture is a decision tree. This doc states what we are solving for in language that survives any implementation change.
 
@@ -9,6 +9,12 @@ Requirements describe **observable user outcomes**. They have one right shape �
 Architecture and engineering decisions are different. They're trade-offs weighed against complexity, cost, performance, reliability, and viability. There is rarely "one right answer" — there are good answers in context. Those live in `docs/plans/*.md` and evolve as we learn.
 
 If a design decision and a requirement conflict, the requirement wins (or we re-examine the requirement explicitly, not implicitly).
+
+## Two tiers, one substrate
+
+Oyster has a **free account tier** (identity, local workspace, publish/share with caps) and a **Pro tier** (cross-device sync, durability, cloud-backed semantic recall, agent-crossing memory). The requirements below describe outcomes in tier-neutral language; the tier mapping at the end maps each to where it's delivered.
+
+The substrate is the same: the same identity layer, the same cloud surface, the same artefact and memory model. Pro is an entitlement on top of the free account, not a separate product.
 
 ---
 
@@ -65,7 +71,37 @@ Any artefact — markdown plan, HTML mockup, mermaid diagram, app, deck — can 
 
 **Verify:** click *Publish* on an artefact, get a URL; opening it in a fresh browser renders correctly under each access mode. Auth-gated mode rejects viewers who aren't signed in and accepts those who are.
 
-R5 implies an **identity layer Oyster doesn't currently have**: a notion of a free Oyster account (no Pro entitlement, just identity) distinct from the local-only model today. Pro then becomes "this account + entitlement," and the auth substrate serves Pro sync, share-link viewing, and any future multi-user feature uniformly.
+R5 is the reason the **free account tier exists at all**: identity is needed both to publish and to view sign-in-gated content. Caps on free (number of published artefacts, bandwidth, etc.) are pricing detail, not a requirement.
+
+---
+
+## R6. Traceable recall
+
+Whenever Oyster surfaces a memory, session summary, decision, or artefact reference in response to a recall query, the user can see its provenance: the originating conversation, the timestamp, the space it belongs to, and any linked artefacts.
+
+Without this, recall feels magical but is untrustworthy — *"remember what we decided"* gives a confident answer the user has no way to verify. R6 is the difference between a parlour trick and a reliable memory layer.
+
+**Verify:** every recall result exposes a source link / metadata that resolves to the originating session, memory entry, or artefact. The user can click through and read the original context.
+
+R6 is cross-cutting: it applies to free-tier local recall and Pro cross-device recall alike.
+
+---
+
+## Tier mapping
+
+How each requirement is delivered across tiers. Statements above stay tier-neutral; this is the entitlement axis.
+
+| Requirement | Free account | Pro |
+|---|---|---|
+| R1 Empty-machine continuity | — | ✓ |
+| R2 Conversational recall — local-only semantic | ✓ | ✓ |
+| R2 Conversational recall — cross-device | — | ✓ |
+| R3 Durability against machine loss | — | ✓ |
+| R4 Memory that crosses agents | — | ✓ |
+| R5 Publish & share (free has caps) | ✓ | ✓ (higher caps) |
+| R6 Traceable recall | ✓ | ✓ |
+
+The free tier is the identity-and-publishing substrate. Pro is the sync, durability, and cross-device guarantees on top of it.
 
 ---
 
@@ -73,4 +109,5 @@ R5 implies an **identity layer Oyster doesn't currently have**: a notion of a fr
 
 - Before starting an architecture/plan doc, check that every decision serves at least one requirement here.
 - When proposing a design that doesn't satisfy one of these requirements, that's a flag — either the design needs changing or the requirement needs an explicit re-examination.
+- When designing a paywall / entitlement check, look at the tier mapping rather than re-deriving it from the requirement text.
 - New requirements get added here only after the same kind of grounded conversation that produced this list. Anything written without a verification clause isn't a requirement yet.

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -89,15 +89,17 @@ R6 is cross-cutting: it applies to free-tier local recall and Pro cross-device r
 
 ---
 
-## R7. Artefact continuity across devices
+## R7. Artefact continuity across devices and across time
 
 Artefacts produced or stored in the user's Oyster vault — mockups, prototypes, presentations, HTML reports, markdown plans, diagrams, decks, apps, any other typed output — are available for the user to open, edit, and continue working with on any signed-in device. Edits propagate so the user is never silently working on a stale copy.
 
-**Verify:** produce an artefact on Machine A. Sign into Machine B. Open the artefact — the contents match what was last saved on A. Edit it on B; the change is reflected on A on its next sign-in or refresh.
+Edits are also **version-controlled**: the user can see the history of an artefact, compare any two versions, and revert to a prior state. The expectation is the same one any developer or AI hacker brings — *"I edited this, I can roll it back."* The mechanism doesn't have to be git; any turnkey approach that delivers history, diff, and revert satisfies the requirement.
+
+**Verify (cross-device):** produce an artefact on Machine A. Sign into Machine B. Open the artefact — the contents match what was last saved on A. Edit it on B; the change is reflected on A on its next sign-in or refresh.
+
+**Verify (across time):** edit an artefact at least twice with distinct content. Open its history; both prior states are visible. Compare any two versions; the differences are shown. Revert to an earlier version; the artefact's current content returns to that state.
 
 **Compound scenario** (anchors R1, R2, R4, R5, R7 together): on Machine A, ask the agent to produce a *competitor analysis matrix* presentation in your vault. Switch to Machine B. Sign in. Ask any connected agent: *"please add a new competitor (Acme Co) to the analysis matrix presentation, then publish it as a password-protected share URL so I can present to my CEO."* The request resolves end-to-end — the agent recognises the artefact (R2/R4), opens its current contents (R7), edits it, publishes to a share URL with password mode (R5), and returns the URL. No manual file copy, no "I'll do that on my other laptop."
-
-Version history of artefact edits is **nice-to-have but not required**. Whether it's preserved depends on the storage choice (e.g. git-backed storage gives it for free); it isn't part of the verification.
 
 ---
 
@@ -114,7 +116,7 @@ How each requirement is delivered across tiers. Statements above stay tier-neutr
 | R4 Memory that crosses agents | — | ✓ |
 | R5 Publish & share (free has caps) | ✓ | ✓ (higher caps) |
 | R6 Traceable recall | ✓ | ✓ |
-| R7 Artefact continuity across devices | — | ✓ |
+| R7 Artefact continuity (across devices and across time) | — | ✓ |
 
 The free tier is the identity-and-publishing substrate. Pro is the sync, durability, and cross-device guarantees on top of it.
 

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -89,6 +89,18 @@ R6 is cross-cutting: it applies to free-tier local recall and Pro cross-device r
 
 ---
 
+## R7. Artefact continuity across devices
+
+Artefacts produced or stored in the user's Oyster vault — mockups, prototypes, presentations, HTML reports, markdown plans, diagrams, decks, apps, any other typed output — are available for the user to open, edit, and continue working with on any signed-in device. Edits propagate so the user is never silently working on a stale copy.
+
+**Verify:** produce an artefact on Machine A. Sign into Machine B. Open the artefact — the contents match what was last saved on A. Edit it on B; the change is reflected on A on its next sign-in or refresh.
+
+**Compound scenario** (anchors R1, R2, R4, R5, R7 together): on Machine A, ask the agent to produce a *competitor analysis matrix* presentation in your vault. Switch to Machine B. Sign in. Ask any connected agent: *"please add a new competitor (Acme Co) to the analysis matrix presentation, then publish it as a password-protected share URL so I can present to my CEO."* The request resolves end-to-end — the agent recognises the artefact (R2/R4), opens its current contents (R7), edits it, publishes to a share URL with password mode (R5), and returns the URL. No manual file copy, no "I'll do that on my other laptop."
+
+Version history of artefact edits is **nice-to-have but not required**. Whether it's preserved depends on the storage choice (e.g. git-backed storage gives it for free); it isn't part of the verification.
+
+---
+
 ## Tier mapping
 
 How each requirement is delivered across tiers. Statements above stay tier-neutral; this is the entitlement axis.
@@ -102,6 +114,7 @@ How each requirement is delivered across tiers. Statements above stay tier-neutr
 | R4 Memory that crosses agents | — | ✓ |
 | R5 Publish & share (free has caps) | ✓ | ✓ (higher caps) |
 | R6 Traceable recall | ✓ | ✓ |
+| R7 Artefact continuity across devices | — | ✓ |
 
 The free tier is the identity-and-publishing substrate. Pro is the sync, durability, and cross-device guarantees on top of it.
 

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -20,11 +20,13 @@ The substrate is the same: the same identity layer, the same cloud surface, the 
 
 ## R1. Empty-machine continuity
 
-A user who signs into Oyster on a fresh machine sees their full context within seconds — every space pill renders with live counts, sessions list populates, memories are recallable, the inventory tile reflects what's in the cloud. No setup beyond sign-in.
+A user who signs into Oyster on a fresh machine sees their full context with no manual setup — every space pill renders with live counts, sessions list populates, memories are recallable, the inventory tile reflects what's in the cloud. The act of signing in is sufficient; nothing else is required of the user.
 
-**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents and locally-ingested transcript bodies.
+**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents and locally-ingested transcript bodies. No manual import, file copy, or configuration step is required between sign-in and the populated Home page rendering.
 
-**Variant:** users may opt for **self-hosted continuity via their own git remote** instead of Oyster's managed cloud — same R1/R3 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
+**Variant — self-hosted continuity via a git remote.** Users may opt to use their own git remote as the durable copy instead of Oyster's managed cloud. Same R1 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
+
+**Verify (variant):** with a self-hosted git remote configured on the primary machine, performing the equivalent setup on a fresh machine (install Oyster, point it at the same remote, pull) produces the same Home page as the managed-cloud path — same modulus, same no-manual-import constraint.
 
 ---
 

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -12,9 +12,9 @@ If a design decision and a requirement conflict, the requirement wins (or we re-
 
 ## Two tiers, one substrate
 
-Oyster has a **free account tier** (identity, local workspace, publish/share with caps) and a **Pro tier** (cross-device sync, durability, cloud-backed semantic recall, agent-crossing memory). The requirements below describe outcomes in tier-neutral language; the tier mapping at the end maps each to where it's delivered.
+Oyster has a **free account tier** (identity, local workspace, publish/share with caps) and a **Pro tier** (cross-device continuity, durability, recall by meaning across all your conversations, agent-crossing memory). The requirements below describe outcomes in tier-neutral language; the tier mapping at the end maps each to where it's delivered.
 
-The substrate is the same: the same identity layer, the same cloud surface, the same artefact and memory model. Pro is an entitlement on top of the free account, not a separate product.
+The substrate is the same identity layer, the same artefact and memory model, the same recall surface. Pro is an entitlement on top of the free account, not a separate product.
 
 ---
 
@@ -22,7 +22,7 @@ The substrate is the same: the same identity layer, the same cloud surface, the 
 
 A user who signs into Oyster on a fresh machine sees their full context with no manual setup — every space pill renders with live counts, sessions list populates, memories are recallable, the inventory tile reflects what's in the cloud. The act of signing in is sufficient; nothing else is required of the user.
 
-**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents (which require their git remote to be cloned to a local path). Transcript bodies of historical sessions are durable per R3 and are pulled on demand when their inspector is opened — they don't need to be on the new machine for the Home page to render. No manual import, file copy, or configuration step is required between sign-in and the populated Home page rendering.
+**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents — the user must still acquire the underlying files separately (e.g. clone a git remote into a local path). No manual import, file copy, or configuration step is required between sign-in and the populated Home page rendering.
 
 **Variant — self-hosted continuity via a git remote.** Users may opt to use their own git remote as the durable copy instead of Oyster's managed cloud. Same R1 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
 
@@ -32,36 +32,34 @@ A user who signs into Oyster on a fresh machine sees their full context with no 
 
 ## R2. Conversational recall across machines
 
-A user can ask their agent in natural language about any prior conversation, and get back the relevant summary, memories, artefact references, and — when needed — the verbatim transcript content, regardless of which machine the original conversation happened on.
+A user can ask their agent in natural language about any prior conversation and get back the relevant content, regardless of which machine the original conversation happened on.
 
 Recall has two levels and both must work:
 
-- **Summary-level** (the everyday case): *"Remember that pricing conversation yesterday?"* / *"What did Bharat suggest about memory sync?"* — answered from the LLM-generated summary plus relevant memories.
-- **Verbatim** (the needle-in-the-haystack case): *"What were the exact specs we agreed for the render server?"* / *"What FTS5 schema did we settle on?"* — answered from the actual transcript content, retrieved across the full transcript corpus.
+- **Summary-level** (the everyday case): *"Remember that pricing conversation yesterday?"* / *"What did Bharat suggest about memory sync?"* — the answer captures the gist of what was discussed.
+- **Verbatim** (the needle-in-the-haystack case): *"What were the exact specs we agreed for the render server?"* / *"What FTS5 schema did we settle on?"* — the answer surfaces the specific phrasing or detail from the original conversation, not just a gesture at the topic.
 
-The natural-language phrasing is the canonical UX. Explicit handles (e.g. `@BLUNDERFIXER:chat-with-bharat`) are at best a power-user fallback, not the primary interface — the engine is meaning, not strings.
+The natural-language phrasing is the canonical UX. Explicit handles (e.g. `@BLUNDERFIXER:chat-with-bharat`) are at best a power-user fallback, not the primary interface — recall keys on meaning, not literal strings.
 
-**Verify:** have a conversation on Machine A; on Machine B, query the agent in natural language about the topic; the agent responds with content traceable to A. The verbatim case must surface the specific phrasing or detail from the original transcript, not just a summary that gestures at the topic. "Pick up here" is a special case where the agent is then primed to continue the thread.
+**Verify:** have a conversation on Machine A; on Machine B, query the agent in natural language about the topic; the agent responds with content traceable to A, at both levels. The verbatim case must reproduce specifics that a summary alone could not. "Pick up here" is a special case where the agent is then primed to continue the thread.
 
 ---
 
 ## R3. Durability against machine loss
 
-If a user's primary machine is destroyed, restoring Oyster on a new machine restores their memories, spaces, artefact manifests, session metadata, session transcript bodies, and configs from the cloud (or self-hosted remote per R1's variant).
+If a user's primary machine is destroyed, restoring Oyster on a new machine restores their memories, spaces, artefact manifests, session metadata, session transcripts, and configs.
 
-Transcript bodies live in cold storage rather than the live-sync hot path — they are not replicated to every device on every change, but they are **durably stored** and **retrievable on demand** by any signed-in device. The transcript inspector renders the full conversation on a non-origin device by lazy-pulling the bytes from cold storage on first open.
+**Verify:** fresh install + sign-in restores the Home UI to within "locally-mounted folder contents" of the lost machine. Opening any session's inspector on the new machine renders the full transcript of that conversation.
 
-**Verify:** fresh install + sign-in restores the Home UI to within "locally-mounted folder contents" of the lost machine. Opening any session's inspector on the new machine renders the full transcript (after a one-time pull on first open per device).
-
-R3 and R1 share most of the same plumbing — if the cloud (or remote) is the durable copy, fresh-machine sign-in is just a restore of the same dataset.
+R3 and R1 are closely related — if there is a durable copy of the user's data somewhere reachable, fresh-machine sign-in is just a restore of it.
 
 ---
 
 ## R4. Memory that crosses agents
 
-A memory written by one AI assistant (Claude, Cursor, Codex, anything MCP-connected) is recallable by any other. The moat is the layer above the agent: Claude won't sync your Cursor sessions; Cursor won't sync your Claude sessions; Oyster does.
+A memory written by one AI assistant (Claude, Cursor, Codex, anything connected to Oyster) is recallable by any other. The value is the layer above the agent: Claude won't sync your Cursor sessions; Cursor won't sync your Claude sessions; Oyster does.
 
-**Verify:** Claude writes a memory through Oyster's MCP; switch to Cursor with the Oyster MCP connected; recall surfaces it.
+**Verify:** one connected agent writes a memory through Oyster; a different connected agent (same user) issues a recall query that surfaces it.
 
 ---
 

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -26,13 +26,13 @@ A user who signs into Oyster on a fresh machine sees their full context with no 
 
 **Variant — self-hosted continuity via a git remote.** Users may opt to use their own git remote as the durable copy instead of Oyster's managed cloud. Same R1 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
 
-**Verify (variant):** with a self-hosted git remote configured on the primary machine, performing the equivalent setup on a fresh machine (install Oyster, point it at the same remote, pull) produces the same Home page as the managed-cloud path — same modulus, same no-manual-import constraint.
+**Verify (variant):** with a self-hosted git remote configured on the primary machine, performing the equivalent setup on a fresh machine (install Oyster, point it at the same remote, pull) produces the same Home page as the managed-cloud path, with the same caveats around locally-mounted folder contents and the same no-manual-import constraint.
 
 ---
 
-## R2. Conversational recall across machines
+## R2. Conversational recall
 
-A user can ask their agent in natural language about any prior conversation and get back the relevant content, regardless of which machine the original conversation happened on.
+A user can ask their agent in natural language about any prior conversation and get back the relevant content. The cross-device extension of this — *regardless of which device the original conversation happened on* — is the Pro upgrade and is captured in the tier mapping; the recall outcome itself applies to both tiers.
 
 Recall has two levels and both must work:
 
@@ -41,7 +41,9 @@ Recall has two levels and both must work:
 
 The natural-language phrasing is the canonical UX. Explicit handles (e.g. `@BLUNDERFIXER:chat-with-bharat`) are at best a power-user fallback, not the primary interface — recall keys on meaning, not literal strings.
 
-**Verify:** have a conversation on Machine A; on Machine B, query the agent in natural language about the topic; the agent responds with content traceable to A, at both levels. The verbatim case must reproduce specifics that a summary alone could not. "Pick up here" is a special case where the agent is then primed to continue the thread.
+**Verify (same-device, applies to free + Pro):** have a conversation; later — same machine, different session — ask the agent in natural language about the topic; the agent responds at both levels, with content traceable to the original. The verbatim case must reproduce specifics a summary alone could not.
+
+**Verify (cross-device, Pro):** the same query works when the original conversation happened on a different signed-in device. *Pick up here* is a special case where the agent is then primed to continue the thread.
 
 ---
 

--- a/docs/requirements/oyster-pro.md
+++ b/docs/requirements/oyster-pro.md
@@ -1,0 +1,76 @@
+# Oyster Pro — user requirements
+
+> **Status (2026-05):** Canonical. Requirements get pinned; architecture is a decision tree. This doc states what we are solving for in language that survives any implementation change.
+
+## Why this doc is separate from design / plan docs
+
+Requirements describe **observable user outcomes**. They have one right shape — a verifiable statement about what the product does for the person using it. They change rarely, and only when our understanding of the user changes.
+
+Architecture and engineering decisions are different. They're trade-offs weighed against complexity, cost, performance, reliability, and viability. There is rarely "one right answer" — there are good answers in context. Those live in `docs/plans/*.md` and evolve as we learn.
+
+If a design decision and a requirement conflict, the requirement wins (or we re-examine the requirement explicitly, not implicitly).
+
+---
+
+## R1. Empty-machine continuity
+
+A user who signs into Oyster on a fresh machine sees their full context within seconds — every space pill renders with live counts, sessions list populates, memories are recallable, the inventory tile reflects what's in the cloud. No setup beyond sign-in.
+
+**Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents and locally-ingested transcript bodies.
+
+**Variant:** users may opt for **self-hosted continuity via their own git remote** instead of Oyster's managed cloud — same R1/R3 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
+
+---
+
+## R2. Conversational recall across machines
+
+A user can ask their agent in natural language about any prior conversation, and get back the relevant summary, memories, and artefact references — regardless of which machine the original conversation happened on.
+
+Examples that must work:
+- *"Remember that pricing conversation yesterday?"*
+- *"What did Bharat suggest about memory sync?"*
+- *"Pick up that auth thread we had on the laptop last week."*
+
+The natural-language phrasing is the canonical UX. Explicit handles (e.g. `@BLUNDERFIXER:chat-with-bharat`) are at best a power-user fallback, not the primary interface — the engine is meaning, not strings.
+
+**Verify:** have a conversation on Machine A; on Machine B, query the agent in natural language about the topic; the agent responds with content traceable to A. "Pick up here" is a special case where the agent is then primed to continue the thread.
+
+---
+
+## R3. Durability against machine loss
+
+If a user's primary machine is destroyed, restoring Oyster on a new machine restores their memories, spaces, artefact manifests, session metadata, and configs from the cloud (or self-hosted remote per R1's variant).
+
+**Verify:** fresh install + sign-in restores the Home UI to within "transcripts and locally-mounted file contents" of the lost machine.
+
+R3 and R1 share most of the same plumbing — if the cloud (or remote) is the durable copy, fresh-machine sign-in is just a restore of the same dataset.
+
+---
+
+## R4. Memory that crosses agents
+
+A memory written by one AI assistant (Claude, Cursor, Codex, anything MCP-connected) is recallable by any other. The moat is the layer above the agent: Claude won't sync your Cursor sessions; Cursor won't sync your Claude sessions; Oyster does.
+
+**Verify:** Claude writes a memory through Oyster's MCP; switch to Cursor with the Oyster MCP connected; recall surfaces it.
+
+---
+
+## R5. Publish & share artefacts
+
+Any artefact — markdown plan, HTML mockup, mermaid diagram, app, deck — can be turned into a resolvable URL with three access modes:
+
+- **Open** — anyone with the link can view.
+- **Password-protected** — link plus shared password.
+- **Sign-in required** — viewer must sign into a free Oyster account. Doubles as the funnel for free signups.
+
+**Verify:** click *Publish* on an artefact, get a URL; opening it in a fresh browser renders correctly under each access mode. Auth-gated mode rejects viewers who aren't signed in and accepts those who are.
+
+R5 implies an **identity layer Oyster doesn't currently have**: a notion of a free Oyster account (no Pro entitlement, just identity) distinct from the local-only model today. Pro then becomes "this account + entitlement," and the auth substrate serves Pro sync, share-link viewing, and any future multi-user feature uniformly.
+
+---
+
+## How to use this doc
+
+- Before starting an architecture/plan doc, check that every decision serves at least one requirement here.
+- When proposing a design that doesn't satisfy one of these requirements, that's a flag — either the design needs changing or the requirement needs an explicit re-examination.
+- New requirements get added here only after the same kind of grounded conversation that produced this list. Anything written without a verification clause isn't a requirement yet.


### PR DESCRIPTION
## Summary

- Pin the user requirements (R1–R7) for Oyster's account/cloud surface in a new `docs/requirements/` directory, separate from `docs/plans/`.
- Framed as "Oyster Cloud" (not "Oyster Pro") to reflect that R5 (publish & share) and R6 (traceable recall) are free-tier territory while R1–R4 and R7 are Pro entitlements — they share the same identity substrate.
- Each requirement has at least one verification clause; the substantive ones (R1, R2, R7) carry tier-specific verify clauses where the entitlement split changes what's testable.
- Tier mapping table at the end so requirement statements stay tier-neutral and entitlement is a separate axis.
- Frames why this lives apart from architecture/plan docs: requirements describe verifiable user outcomes and change rarely; architecture is a decision tree evaluated against complexity, cost, performance, reliability, viability.

## Requirements

| | | Free | Pro |
|---|---|---|---|
| R1 | Empty-machine continuity | — | ✓ |
| R2 | Conversational recall — same-device | ✓ | ✓ |
| R2 | Conversational recall — cross-device | — | ✓ |
| R3 | Durability against machine loss | — | ✓ |
| R4 | Memory that crosses agents | — | ✓ |
| R5 | Publish & share artefacts | ✓ | ✓ (higher caps) |
| R6 | Traceable recall | ✓ | ✓ |
| R7 | Artefact continuity (across devices and across time) | — | ✓ |

R7 covers both axes of artefact continuity: cross-device sync (open/edit/keep working on any signed-in device) and across-time versioning (history, diff, revert) — the workflow any developer or AI hacker brings.

## Test plan

- [x] Renders cleanly in GitHub markdown
- [x] Each requirement has a verification clause (R1, R2, R7 carry tier-specific verifies)
- [x] Tier mapping covers every requirement
- [x] Compound scenario in R7 anchors R1, R2, R4, R5, R7 against an end-to-end user request

🤖 Generated with [Claude Code](https://claude.com/claude-code)