### PR TITLE
docs(plans): capture 0.5.0 gap matrix vs Oyster Cloud requirements

### DIFF
--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -16,7 +16,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R1. Empty-machine continuity
 
-**Current state:** No identity layer, no cloud restore. `bootstrapUserland()` (`server/src/index.ts:446`) creates an empty `~/Oyster/` tree with a fresh `oyster.db`. Auto-backup (`server/src/backup.ts`) writes daily snapshots to `~/oyster-backups/auto/` — local-only, rotates at 5 days. The `/api/vault/inventory` endpoint surfaces what's in `~/Oyster/` but no pull path from any remote. Self-hosted-via-git variant: zero code.
+**Current state:** No identity layer, no cloud restore. `bootstrapUserland()` (`server/src/index.ts:446`) creates the empty `~/Oyster/` tree; the SQLite DB is then created/opened by `initDb(DB_DIR)` (`index.ts:516`) at `~/Oyster/db/oyster.db`. Auto-backup (`server/src/backup.ts`) writes daily snapshots to `~/oyster-backups/auto/` — local-only, rotates at 5 days. The `/api/vault/inventory` endpoint surfaces what's in `~/Oyster/` but no pull path from any remote. Self-hosted-via-git variant: zero code.
 
 **Survives:** The `~/Oyster/` layout (`db/`, `spaces/`, `apps/`, `config/`) is per-space-addressable and could serve as the restore target. `MemoryProvider.importMemories()` (`server/src/memory-store.ts:244`) already implements idempotent bulk-insert. `initDb()` migrations are additive and idempotent.
 
@@ -28,7 +28,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R2. Conversational recall
 
-**Current state:** Two surfaces. `SqliteFtsMemoryProvider` (`server/src/memory-store.ts`) does FTS5 keyword recall over `memories`. The `recall` MCP tool (`server/src/mcp-server.ts:285`) tokenises the query as OR-joined FTS5 terms — same-device only, keyword-not-semantic. Session inspector (`web/src/components/SessionInspector.tsx`) browses transcript events from `session_events` but has no query interface — display only.
+**Current state:** Two surfaces. `SqliteFtsMemoryProvider` (`server/src/memory-store.ts`) does FTS5 keyword recall over `memories`; its `recall()` implementation (`memory-store.ts:183`) tokenises the query into OR-joined FTS5 terms. The `recall` MCP tool (`server/src/mcp-server.ts:285`) forwards to that provider path — same-device only, keyword-not-semantic. Session inspector (`web/src/components/SessionInspector.tsx`) browses transcript events from `session_events` but has no query interface — display only.
 
 **Survives:** The `MemoryProvider` interface (`memory-store.ts:31`) is already abstract — swap implementation without touching MCP registration. The four MCP tools (`remember` / `recall` / `forget` / `list_memories`) are the right agent-facing contract.
 
@@ -64,7 +64,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R5. Publish & share artefacts
 
-**Current state:** No publish or share mechanism. Artefacts served at `/docs/:id` and `/artifacts/...` with no access control — entire API locked to localhost via `rejectIfNonLocalOrigin()` (`server/src/index.ts:688`). No public URL, no share token, no remote viewer. `artifacts` schema has no `published_at` / `share_token` / `share_mode`. `owner_id` column exists (`artifact-store.ts:7`) but always `NULL`.
+**Current state:** No publish or share mechanism. Artefacts served at `/docs/:id` and `/artifacts/...` with no access control — entire API locked to localhost via `rejectIfNonLocalOrigin()` (`server/src/index.ts:688`). No public URL, no share token, no remote viewer. `artifacts` schema has no `published_at` / `share_token` / `share_mode`. `owner_id` exists on the schema (`server/src/db.ts:7`); current insert paths still write `owner_id: null` (`server/src/artifact-service.ts:266`, `server/src/space-service.ts:487`).
 
 **Survives:** `artifact_kind` taxonomy and the filesystem-backed serving at `/docs/:id` could double as the canonical "view" route — the published URL becomes a cloud proxy to the same content. `source_origin` provenance would surface in a published view.
 
@@ -118,7 +118,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 **Code already pointing in the right direction:**
 
-- `artifacts.owner_id` (`db.ts:8`, `artifact-store.ts:7`) — always NULL today, but the column slot exists.
+- `artifacts.owner_id` (schema at `db.ts:7`; insert sites pass `null` at `artifact-service.ts:266` and `space-service.ts:487`) — always NULL today, but the column slot exists.
 - `artifacts.source_origin` — provenance tracked at write time throughout MCP. R6's foundation is already there.
 - `session_artifacts` M:N with `role` + `when_at`, populated by the watcher, plus the bidirectional API routes — the artefact provenance graph already works.
 - `MemoryProvider` interface with `exportMemories()` / `importMemories()` — explicit escape hatches for backup/restore. A cloud-backed provider can implement the same interface.

--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -1,0 +1,165 @@
+# 0.5.0 → Pro: gap matrix
+
+> **Status:** 2026-05-01 snapshot. True as of `0.5.0`; goes stale as work lands.
+>
+> **Reads alongside** [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md). The requirements doc is canonical and pins observable user outcomes (R1–R7). This doc is a snapshot of where the current implementation stands against those outcomes — what survives, what changes, what's missing entirely. Architecture decisions are made *against* the requirements, evaluated against this matrix.
+
+## Framing
+
+`0.5.0` is directionally right but still local-first. The codebase already has useful foundations: MCP as the agent-facing layer, an abstract `MemoryProvider` with import/export hooks, a per-space filesystem layout, artefact provenance via `source_origin` + `session_artifacts`, and a session-to-artefact graph that the watcher already populates. None of that gets thrown out.
+
+What the requirements demand on top is identity, cloud storage, sync, restore, publish/share, traceable recall, and artefact versioning. Most of those are net-new infrastructure. The biggest forcing function is R3 — which now (post-merge of #306) requires machine-loss restore to include **session transcripts**, not just memories and metadata. Pro therefore is not merely "semantic memory sync"; it is closer to *cloud durability for the user's Oyster working history*. That's a stronger product, and a heavier one.
+
+---
+
+## Per-requirement gap
+
+### R1. Empty-machine continuity
+
+**Current state:** No identity layer, no cloud restore. `bootstrapUserland()` (`server/src/index.ts:446`) creates an empty `~/Oyster/` tree with a fresh `oyster.db`. Auto-backup (`server/src/backup.ts`) writes daily snapshots to `~/oyster-backups/auto/` — local-only, rotates at 5 days. The `/api/vault/inventory` endpoint surfaces what's in `~/Oyster/` but no pull path from any remote. Self-hosted-via-git variant: zero code.
+
+**Survives:** The `~/Oyster/` layout (`db/`, `spaces/`, `apps/`, `config/`) is per-space-addressable and could serve as the restore target. `MemoryProvider.importMemories()` (`server/src/memory-store.ts:244`) already implements idempotent bulk-insert. `initDb()` migrations are additive and idempotent.
+
+**Changes:** `backup.ts` is local filesystem `cpSync` only — needs an upload hook or push/pull transport. The DB is one SQLite file (easy to snapshot) but needs a defined serialisation contract before it's portable.
+
+**Missing entirely:** Identity/auth (no user concept anywhere). Cloud storage. Restore flow (sign-in → pull → populate). Git-remote variant has zero implementation.
+
+---
+
+### R2. Conversational recall
+
+**Current state:** Two surfaces. `SqliteFtsMemoryProvider` (`server/src/memory-store.ts`) does FTS5 keyword recall over `memories`. The `recall` MCP tool (`server/src/mcp-server.ts:285`) tokenises the query as OR-joined FTS5 terms — same-device only, keyword-not-semantic. Session inspector (`web/src/components/SessionInspector.tsx`) browses transcript events from `session_events` but has no query interface — display only.
+
+**Survives:** The `MemoryProvider` interface (`memory-store.ts:31`) is already abstract — swap implementation without touching MCP registration. The four MCP tools (`remember` / `recall` / `forget` / `list_memories`) are the right agent-facing contract.
+
+**Changes:** `recall()` (`memory-store.ts:183`) does `"how OR old OR am OR I"` — brittle for natural language, no semantic match. Needs BM25 tuning at minimum, embedding-backed search ideally. For verbatim recall: `session_events.raw` already stores full event JSON (`server/src/db.ts:170`), but no query interface over it — the inspector displays known sessions but can't search across them.
+
+**Missing entirely:** Embedding/semantic layer. FTS over `session_events.text` (current FTS index is on `memories`, not events). Cross-device recall. "Pick up here" agent priming.
+
+---
+
+### R3. Durability against machine loss
+
+**Current state:** Local auto-backup of entire `~/Oyster/` to `~/oyster-backups/auto/` (`backup.ts:37–92`), 5-day rotation. Transcripts are stored as `session_events` rows in `oyster.db`, so they ride along inside the DB. Machine destroyed on day 6 with no off-machine copy = unrecoverable.
+
+**Survives:** Transcripts being in SQLite means R3's "inspector renders full transcript on the new machine" is structurally satisfied if the DB is restored. `session_events.raw` preserves the original JSONL line. Per-space folders are self-contained.
+
+**Changes:** `backup.ts` needs an off-machine leg. JSONL source files at `~/.claude/projects/` are watched but not copied — sessions reconstructed from `session_events`, but if the DB is lost before today's backup, the last day is gone.
+
+**Missing entirely:** Off-machine backup destination. Restore CLI / in-app flow. Real-time push of session data off-machine.
+
+---
+
+### R4. Memory that crosses agents
+
+**Current state:** Memory is MCP-accessible and agent-agnostic *by design* — any client connecting to `/mcp/` (`server/src/index.ts:1842`) gets the same four tools. Mechanically already works on a single machine: Claude Code, Cursor, Codex all share the same `memory.db`. `clientContext` on `McpDeps` (`mcp-server.ts:138`) distinguishes internal from external for telemetry only — same provider instance.
+
+**Survives:** The architecture (one MCP, one memory store, multiple agents) carries forward. `memories.space_id` already handles global vs space-scoped recall. MCP tool surface is stable.
+
+**Changes:** Cross-agent memory today is single-device. Pro entitlement requires cloud-backed memory store. `SqliteFtsMemoryProvider` has no publish/subscribe hook — writes don't fan out. Add an `onChange` hook to the interface, or replace the implementation with a cloud-backed one.
+
+**Missing entirely:** Cross-device propagation. Identity tying a corpus to an account.
+
+---
+
+### R5. Publish & share artefacts
+
+**Current state:** No publish or share mechanism. Artefacts served at `/docs/:id` and `/artifacts/...` with no access control — entire API locked to localhost via `rejectIfNonLocalOrigin()` (`server/src/index.ts:688`). No public URL, no share token, no remote viewer. `artifacts` schema has no `published_at` / `share_token` / `share_mode`. `owner_id` column exists (`artifact-store.ts:7`) but always `NULL`.
+
+**Survives:** `artifact_kind` taxonomy and the filesystem-backed serving at `/docs/:id` could double as the canonical "view" route — the published URL becomes a cloud proxy to the same content. `source_origin` provenance would surface in a published view.
+
+**Changes:** Nothing. R5 is greenfield. The `owner_id` stub is the only forward-pointing artefact.
+
+**Missing entirely:** Publish action (UI + MCP tool + API). Share URL routing. Three access modes. Remote viewer. Identity. `share_token` / `share_mode` / `published_at` columns.
+
+---
+
+### R6. Traceable recall
+
+**Current state:** **The data model for provenance is substantially in place.** `session_artifacts` (`db.ts:175`) is an M:N join with `role` (create / modify / read) + `when_at`. `artifacts.source_origin` (`manual` / `discovered` / `ai_generated`) tracks origin. Memory rows carry `space_id` / `created_at` / `tags` (`memory-store.ts:10–17`). `/api/artifacts/:id/sessions` and `/api/sessions/:id/artifacts` (`index.ts:1100`, `1076`) form a bidirectional graph. The session inspector renders the "Artefacts" tab.
+
+**Survives:** `session_artifacts` with `role` + `when_at` is the right primitive. Bidirectional API routes carry forward. `memories.space_id` is the right scope shape. Inspector as UI entry point.
+
+**Changes:** `recall()` returns `{id, content, space_id, tags, created_at}` — no `source_session_id` or `linked_artifact_ids`. Today there's no way to trace "this memory came from that conversation." The watcher (`server/src/watchers/claude-code.ts`) doesn't write memories — `remember` is agent-called, so the originating session isn't recorded at write time.
+
+**Missing entirely:** `source_session_id` field on memory rows. Click-through provenance from recall result → originating conversation. UI affordance for "memories written during this session."
+
+---
+
+### R7. Artefact continuity across devices and across time
+
+**Current state:** Artefacts are files on the local filesystem at `~/Oyster/spaces/<space-id>/` plus a metadata row. No sync, no version history, no diff, no revert. `updateArtifact` (`artifact-service.ts:419`) only touches metadata fields. Content writes go via `createArtifact` (one-shot) or direct filesystem writes by the agent — no write hook for snapshotting. `artifacts` table has `created_at` / `updated_at` but no version table.
+
+**Survives:** The per-space filesystem layout is well-defined; all artefact paths in `storage_config`. Clean anchor for a content-addressed or git-backed version store.
+
+**Changes:** `createArtifact` does single `writeFileSync` with no version hook. Versioning needs intercept at the *content* layer, not metadata. `read_artifact` / `create_artifact` MCP tools are the right primitives but have no version side-effects.
+
+**Missing entirely:** Version history table or git-backed content store. Snapshot-on-write. Diff view + revert API. Cross-device sync of artefact bytes (depends on the same cloud storage as R1/R3). The compound scenario also depends on R1/R2/R4/R5.
+
+---
+
+## Cross-cutting observations
+
+**Net-new infrastructure implied** (and how many requirements each unblocks):
+
+- **Identity + auth layer** — zero today. Unblocks R1, R5, and is the precondition for any data being attributed to a user. Every Pro requirement depends on it.
+- **Cloud data store (DB + blob)** — unblocks R1, R3, R4, R7. One hosted DB + blob store, OR user-controlled git remote (R1's variant).
+- **Sync / push-pull layer** — unblocks R1, R3, R4, R7. Distinct from the storage choice.
+- **Artefact version store** — unblocks R7. Could be an `artifact_versions` SQLite table or `git` per space directory.
+- **Share/publish CDN or proxy** — unblocks R5 entirely. The only piece with no local-only stepping stone.
+
+**Hard-coded localhost / single-device assumptions:**
+
+- `httpServer.listen(port, "127.0.0.1")` (`index.ts:2013`) plus per-route `rejectIfNonLocalOrigin()`. Multi-device callers can't reach the local API; a separate channel is needed.
+- `SqliteFtsMemoryProvider` initialised with `DB_DIR = ~/Oyster/db/` (`index.ts:538`) — no env var or config point for remote backing.
+- `ClaudeCodeWatcher` watches `~/.claude/projects/` (`watchers/claude-code.ts:26`) — inherently per-device. Cross-device session recall requires `session_events` rows to be synced, not just that the watcher runs everywhere.
+- `backup.ts` copies to `~/oyster-backups/` — entirely local, no upload hook.
+- Artefact bytes served via `readFileSync` from `~/Oyster/spaces/` (`index.ts:1502–1514`).
+
+**Code already pointing in the right direction:**
+
+- `artifacts.owner_id` (`db.ts:8`, `artifact-store.ts:7`) — always NULL today, but the column slot exists.
+- `artifacts.source_origin` — provenance tracked at write time throughout MCP. R6's foundation is already there.
+- `session_artifacts` M:N with `role` + `when_at`, populated by the watcher, plus the bidirectional API routes — the artefact provenance graph already works.
+- `MemoryProvider` interface with `exportMemories()` / `importMemories()` — explicit escape hatches for backup/restore. A cloud-backed provider can implement the same interface.
+- MCP being agent-agnostic — R4 is a structural property, not a feature to build (single-device case already works).
+- `sources.type` CHECK constraint reads `'local_folder'` with a comment noting "and future cloud sources" (`db.ts:76`) — the CHECK is the only thing that needs relaxing.
+
+---
+
+## Recommended sequencing
+
+A naïve read of the gap matrix would suggest **auth → store → sync** as the build order. That's correct from a dependency standpoint but wrong from a *product progress* standpoint, because it spends the first three milestones building infrastructure with no visible user value, and risks the cloud durability/sync work becoming an infrastructure swamp before anyone has a Pro feature in their hands.
+
+The product-aware sequence is:
+
+1. **Identity / free account** — magic-link sign-in, account-scoped tenant. Unblocks everything else and is the smallest credible vertical slice. Pattern already prototyped in `~/Dev/oyster-crm`. Surfaces a free-tier funnel.
+2. **Publish & share artefact (R5)** — almost greenfield, but contained once identity exists. Independent of R1/R3/R4/R7 sync. Proves account value quickly with a visible cloud feature; produces a real funnel for free signups.
+3. **Traceable recall improvements (R6)** — small, targeted. `source_session_id` on memory rows, surface provenance in recall results and the inspector. Makes recall trustworthy *before* the sync work scales it.
+4. **Cloud durability / sync (R1, R3, R4)** — the big infrastructure piece. Cloud store + push/pull, restore flow, cross-device memory propagation. Land R1 + R3 first (read-only restore), then R4 (cross-device memory writes). R2's cross-device extension falls out of R4 + R3 once the data exists in the cloud.
+5. **Cross-device artefact editing & versioning (R7)** — last. The hardest piece. See below.
+
+Each step delivers visible Pro value. None of the early ones is blocked by the bigger pieces.
+
+---
+
+## R7 caveat: don't let it block cloud progress
+
+R7 is the monster. The *across-time* axis (history / diff / revert) is contained — a snapshot-on-write hook plus an `artifact_versions` table or a `git` invocation per space. That's tractable.
+
+The *across-devices* axis is materially harder than R1/R3 read-only restore, because it's bidirectional artefact-byte sync. That brings real questions:
+
+- Conflicts when both machines edit. Last-write-wins is too coarse for content the user spent an hour on.
+- Partial writes during a save in progress. CRDT? Lock-on-edit? Periodic snapshot only?
+- Binary artefact bytes (images, decks) versus text — different merge semantics.
+- File-on-disk semantics (the user can `vim` an artefact in the vault outside Oyster) versus DB-mediated edits.
+
+**These are real engineering problems with no obvious cheap answer.** The risk is that R7 cross-device editing becomes the thing that blocks all cloud progress — sequence 1–4 above stalls because step 5 turns out to be three months instead of three weeks.
+
+Mitigation: ship R7's *across-time* axis (versioning) on local-only artefacts as part of step 5a — that's a useful product feature on its own ("oops, revert"), and proves the version-store choice. R7's *across-device* axis (5b) can ship later, once R1/R3 sync infra is steady-state. The compound scenario in R7 (the CEO presentation example) requires both axes, but R7's value is real even with the dual-axis split.
+
+---
+
+## How to update this doc
+
+This file is a snapshot. As work lands, update the relevant per-requirement section to reflect the new state — or, when a requirement is fully delivered, mark it `**Delivered in <version>**` rather than removing it. When the matrix is mostly green, fork a new snapshot rather than rewriting in place; the history of how each gap closed is useful.


### PR DESCRIPTION
## Summary

- Snapshot of where `0.5.0` stands against the seven requirements pinned in [`docs/requirements/oyster-cloud.md`](https://github.com/mattslight/oyster/blob/main/docs/requirements/oyster-cloud.md) (#306).
- Per-requirement gap analysis (`Survives` / `Changes` / `Missing entirely`) with file paths and line numbers from the current source.
- Cross-cutting observations: new infrastructure implied by the gaps (auth, cloud store, sync, version store, share CDN); hard-coded localhost assumptions that need addressing; code already pointing in the right direction.
- Recommended sequencing: **identity → publish/share → traceable recall → cloud durability/sync → artefact continuity**. Product-aware ordering that delivers visible Pro value at each step, rather than three milestones of pure infrastructure.
- R7 caveat upfront: across-time axis (versioning) is tractable; across-device axis (bidirectional artefact-byte sync) is the monster. Split R7 so versioning ships locally first and doesn't block cloud progress.

## Why this lives in `plans/`, not `requirements/`

This is a snapshot — true *as of* `0.5.0`, goes stale as work lands. The requirements doc is canonical and pins observable user outcomes (R1–R7). This doc is the bridge from those requirements to architecture decisions, evaluated against the current code surface. When the matrix is mostly green, fork a new snapshot rather than rewriting in place.

## Test plan

- [x] Renders cleanly in GitHub markdown
- [x] Each requirement section follows the same shape: current state / survives / changes / missing
- [x] All file paths and line numbers reference real locations in the current `0.5.0` source
- [x] Sequencing recommendation matches the ChatGPT/team discussion captured at PR #306 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)