### PR TITLE
feat(schema): R5 publish & share columns on artifacts

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -125,6 +125,23 @@ export function initDb(userlandDir: string): Database.Database {
     `);
   } catch { /* already exists */ }
 
+  // R5 publish & share (#314). Turn an artifact into a shareable URL.
+  // share_token gets a UNIQUE index in a separate statement — SQLite
+  // ADD COLUMN doesn't allow UNIQUE inline. NULL tokens are treated as
+  // distinct under SQL UNIQUE, so unpublished rows coexist freely.
+  // published_at / unpublished_at are INTEGER unix-ms per the ticket
+  // (viewer Workers want Date.now() directly, no iso8601 round-trip).
+  for (const sql of [
+    "ALTER TABLE artifacts ADD COLUMN share_token TEXT",
+    "ALTER TABLE artifacts ADD COLUMN share_mode TEXT CHECK (share_mode IS NULL OR share_mode IN ('open','password','signin'))",
+    "ALTER TABLE artifacts ADD COLUMN share_password_hash TEXT",
+    "ALTER TABLE artifacts ADD COLUMN published_at INTEGER",
+    "ALTER TABLE artifacts ADD COLUMN unpublished_at INTEGER",
+  ]) {
+    try { db.exec(sql); } catch { /* already exists */ }
+  }
+  db.exec("CREATE UNIQUE INDEX IF NOT EXISTS artifacts_share_token_uq ON artifacts(share_token)");
+
   // Sessions arc (0.5.0). Three tables that capture agent activity (claude-code,
   // opencode, codex) read from external session logs. See
   // docs/plans/sessions-arc.md for the design.


### PR DESCRIPTION
Closes #314.

## Summary
- Five additive `ALTER TABLE artifacts` columns: `share_token`, `share_mode`, `share_password_hash`, `published_at`, `unpublished_at`. All nullable; existing rows unaffected.
- `UNIQUE INDEX artifacts_share_token_uq` on `share_token` (separate statement — SQLite `ADD COLUMN` doesn't allow `UNIQUE` inline; NULL tokens are treated as distinct, so unpublished rows coexist).
- `CHECK` on `share_mode` enforces `open` / `password` / `signin` (or NULL).
- Idempotent per the existing `try { ALTER } catch {}` convention in `db.ts`.

## Why these shapes
- **`published_at` / `unpublished_at` as `INTEGER` unix-ms** per the ticket. The viewer Worker wants `Date.now()` round-tripping without iso8601 conversion; the rest of `artifacts` uses TEXT iso8601, so the comment in the migration calls this out.
- **Plain `UNIQUE` (not partial) on `share_token`**. SQL treats multiple NULLs as distinct, so a partial index on `WHERE unpublished_at IS NULL` would be redundant. Revoke can either keep the row with `unpublished_at NOT NULL` or hard-delete; either works.
- **No CHANGELOG bullet.** Per the convention added to `CLAUDE.md` this session: bullets are user-visible outcomes. Schema columns alone give users nothing to click. The Publish bullet lands with #315 / #317 when users can actually publish an artefact.

## Verify
Verified locally with a one-shot tsx script (not committed) that runs `initDb` against a fresh temp dir and the same dir again, and asserts:
- All five columns present after pass 1 and pass 2 (idempotent).
- `artifacts_share_token_uq` exists and is unique.
- Multiple rows with NULL `share_token` are allowed.
- Two rows with the same non-null `share_token` raise.
- `share_mode = 'garbage'` is rejected; `share_mode = NULL` is allowed.

`tsc --noEmit` clean.

## Test plan
- [ ] Pull this branch, delete `userland/db/oyster.db`, start the server — server boots cleanly on a fresh DB.
- [ ] Restart the server against the now-existing DB — second boot is a no-op (idempotent).
- [ ] `sqlite3 userland/db/oyster.db ".schema artifacts"` shows the five new columns and the unique index.

## Anchor docs
- `docs/requirements/oyster-cloud.md` — R5
- `docs/plans/roadmap.md` — 0.7.0
- `docs/plans/0.5.0-gap-matrix.md` — R5 (greenfield)

Part of the R5 Publish epic in 0.7.0. Sibling tickets: #295 (auth), #315 (MCP/API/upload), #316 (viewer), #317 (UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)