### PR TITLE
feat(auth-worker): magic-link send + verify + cookie + whoami

### DIFF
--- a/infra/auth-worker/README.md
+++ b/infra/auth-worker/README.md
@@ -2,12 +2,15 @@
 
 Cloudflare Worker that handles magic-link sign-in for the free Oyster account, plus the device-flow bridge that lets the local server at `localhost:4444` see the signed-in state. Design: [`docs/plans/auth.md`](../../docs/plans/auth.md).
 
-PR 1 scaffold — only `GET /auth/whoami` is wired (returns 401). Magic-link send/verify and the device-flow endpoints land in PR 2 + PR 3.
+```
+GET  /auth/sign-in        HTML form (browser entry point)
+POST /auth/magic-link     {email, user_code?} → email a sign-in link
+GET  /auth/verify?t=...   consume token, set session cookie, redirect to /auth/welcome
+GET  /auth/welcome        landing page after verify (shows the signed-in email)
+GET  /auth/whoami         {id, email} for a valid session, 401 otherwise
+```
 
-```
-GET /auth/whoami
-→ 401 { "error": "unauthenticated" }
-```
+PR 3 will add `/auth/device-init`, `/auth/device/<code>`, `/auth/sign-out`, and the local-server bridge that writes `~/Oyster/config/auth.json`.
 
 ## One-time setup
 
@@ -37,24 +40,50 @@ npm run db:migrate
 
 Applies `migrations/0001_init.sql` — creates `users`, `sessions`, `device_codes`, `magic_link_tokens`. Re-running is safe (every `CREATE TABLE` and `CREATE INDEX` has `IF NOT EXISTS`).
 
-### 4. Deploy
+### 4. Resend domain verification
+
+The waitlist worker already uses Resend with `oyster.to` verified. The auth worker reuses the verified domain but sends from `noreply@oyster.to` rather than `matt@oyster.to`. If your Resend account already has `oyster.to` verified you can skip straight to the API key step.
+
+1. Sign in at https://resend.com.
+2. Domains → confirm `oyster.to` is verified (green tick on MX/SPF/DKIM rows).
+3. API Keys → Create → name it `oyster-auth-worker`. Copy the key.
+
+### 5. Set the Resend secret
+
+```bash
+npx wrangler secret put RESEND_API_KEY
+```
+
+Paste the key when prompted.
+
+### 6. Deploy
 
 ```bash
 npm run deploy
 ```
 
-Worker is now live at `https://oyster.to/auth/*`.
+Worker is now live at `https://oyster.to/auth/*`. The per-IP rate-limit binding is provisioned automatically on deploy from the `[[unsafe.bindings]]` block in `wrangler.toml` — no separate command needed.
 
-### 5. Smoke test
+### 7. Smoke test the full flow
+
+In a browser, open `https://oyster.to/auth/sign-in`. Enter your email. The form should report "Check your inbox". Click the link in the email. You should land on `/auth/welcome` with `Signed in as <your email>`.
+
+Then verify the cookie set:
+
+```bash
+# Pull the cookie out of your browser dev tools (oyster_session=...) and:
+curl -i https://oyster.to/auth/whoami -H "cookie: oyster_session=<paste>"
+# → HTTP/2 200
+# → {"id":"...","email":"..."}
+```
+
+Without a cookie:
 
 ```bash
 curl -i https://oyster.to/auth/whoami
 # → HTTP/2 401
-# → content-type: application/json
 # → {"error":"unauthenticated"}
 ```
-
-That's all PR 1 verifies. PR 2 will add `/auth/magic-link` + `/auth/verify` and the Resend secret + per-IP rate-limit binding; PR 3 will add the device-flow endpoints + sign-out + the local-server bridge.
 
 ## Day-to-day
 
@@ -64,12 +93,14 @@ npm run dev         # local Worker on localhost:8787 with a local D1
 npm run tail        # stream Worker logs from production
 ```
 
+`wrangler dev` won't actually send email unless `RESEND_API_KEY` is in `.dev.vars`; absent that the Worker logs the failure but still returns `{ ok: true }` so the rest of the flow is testable. To exercise sending locally, drop the key into `infra/auth-worker/.dev.vars` (gitignored).
+
 ## Local development
 
 ```bash
 npm run db:migrate:local   # one-time, creates a local D1
 npm run dev                # runs the Worker on localhost:8787
-curl -i http://localhost:8787/auth/whoami  # expect 401
+# Open http://localhost:8787/auth/sign-in
 ```
 
 ## Cost (as of 2026)
@@ -78,3 +109,5 @@ curl -i http://localhost:8787/auth/whoami  # expect 401
 |---|---|---|
 | Workers | 100k req/day | $5/mo if exceeded |
 | D1 | 5 GB · 5M reads/day · 100k writes/day | Far past realistic free-tier sign-in |
+| Workers Rate Limiting | 1k req/s default | Free at this scale |
+| Resend | 3,000 emails/mo · 100/day | $20/mo for 50k |

--- a/infra/auth-worker/README.md
+++ b/infra/auth-worker/README.md
@@ -93,8 +93,6 @@ npm run dev         # local Worker on localhost:8787 with a local D1
 npm run tail        # stream Worker logs from production
 ```
 
-`wrangler dev` won't actually send email unless `RESEND_API_KEY` is in `.dev.vars`; absent that the Worker logs the failure but still returns `{ ok: true }` so the rest of the flow is testable. To exercise sending locally, drop the key into `infra/auth-worker/.dev.vars` (gitignored).
-
 ## Local development
 
 ```bash
@@ -102,6 +100,16 @@ npm run db:migrate:local   # one-time, creates a local D1
 npm run dev                # runs the Worker on localhost:8787
 # Open http://localhost:8787/auth/sign-in
 ```
+
+The Worker detects the `localhost` host and drops `Domain=` and `Secure` from the session cookie, so the cookie flow works end-to-end on `http://localhost:8787` — no HTTPS or hosts-file aliasing required.
+
+Without `RESEND_API_KEY` set, `/auth/magic-link` still returns `{ ok: true }` and writes the token row, but logs the verify URL to the Worker console instead of sending an email:
+
+```
+[magic-link] no RESEND_API_KEY; verify URL for you@example.com: http://localhost:8787/auth/verify?t=...
+```
+
+Watch `npm run dev`'s output, paste the URL into the same browser, and the cookie + welcome page flow works without Resend setup. To exercise real sending locally, drop the key into `infra/auth-worker/.dev.vars` (gitignored).
 
 ## Cost (as of 2026)
 

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -113,18 +113,31 @@ async function getSession(db: D1Database, sessionId: string, now: number): Promi
   };
 }
 
-function sessionCookie(sessionId: string): string {
-  // Domain=.oyster.to so the cookie is visible on the apex and any
-  // subdomain the publish/viewer flows might end up on. HttpOnly blocks
-  // JS reads; SameSite=Lax allows the magic-link redirect to carry the
-  // cookie back; Secure means HTTPS-only.
+function isLocalHost(host: string): boolean {
+  return host === "localhost" || host === "127.0.0.1" || host.startsWith("localhost:") || host.startsWith("127.0.0.1:");
+}
+
+// Cookie shape adapts to the request host so wrangler dev (http://localhost:8787)
+// can exercise the cookie flow. Production: Domain=.oyster.to + Secure so the
+// cookie is visible on the apex and any subdomain the publish/viewer flows
+// might end up on. Localhost: omit Domain (browsers reject Domain= on
+// localhost) and omit Secure (no HTTPS). HttpOnly + SameSite=Lax stay on both.
+function sessionCookie(sessionId: string, host: string): string {
   const maxAge = Math.floor(SESSION_TTL_MS / 1000);
+  if (isLocalHost(host)) {
+    return `${COOKIE_NAME}=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}`;
+  }
   return `${COOKIE_NAME}=${sessionId}; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
 }
 
-function clearedCookie(): string {
+function clearedCookie(host: string): string {
+  if (isLocalHost(host)) {
+    return `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
+  }
   return `${COOKIE_NAME}=; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
 }
+
+const NO_STORE: Record<string, string> = { "cache-control": "no-store" };
 
 const SIGN_IN_HTML = (userCode: string | null) => `<!doctype html>
 <html lang="en"><head>
@@ -222,6 +235,13 @@ const SIGN_IN_ERROR_HTML = (message: string) => `<!doctype html>
 </body></html>`;
 
 async function sendMagicLink(env: Env, email: string, link: string): Promise<void> {
+  // Dev fallback: no Resend key configured → log the verify URL so a
+  // local maintainer can complete the flow without Resend setup.
+  // Never trips in production because deploy fails without the secret.
+  if (!env.RESEND_API_KEY) {
+    console.log(`[magic-link] no RESEND_API_KEY; verify URL for ${email}: ${link}`);
+    return;
+  }
   const from = env.FROM_ADDRESS ?? "noreply@oyster.to";
   const replyTo = env.REPLY_TO ?? "matthew@slight.me";
   const subject = "Sign in to Oyster";
@@ -257,7 +277,7 @@ async function sendMagicLink(env: Env, email: string, link: string): Promise<voi
   }
 }
 
-async function handleMagicLink(req: Request, env: Env, url: URL): Promise<Response> {
+async function handleMagicLink(req: Request, env: Env, ctx: ExecutionContext, url: URL): Promise<Response> {
   // Per-IP gate first — cheapest reject path. The Workers Rate Limit
   // binding does the bookkeeping at the edge; no D1 row needed.
   const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
@@ -313,120 +333,151 @@ async function handleMagicLink(req: Request, env: Env, url: URL): Promise<Respon
     .run();
 
   const verifyUrl = `${url.origin}/auth/verify?t=${encodeURIComponent(rawToken)}`;
-  try {
-    await sendMagicLink(env, rawEmail, verifyUrl);
-  } catch {
-    // We've already written the token row; failing the response would
-    // make the client retry and burn the per-email cap. Log and ack ok.
-    return json({ ok: true });
-  }
-
+  // Fire the email asynchronously so the response doesn't block on Resend.
+  // On failure, delete the token row — otherwise a failed send burns a
+  // slot in the per-email cap until the 15-min TTL clears.
+  ctx.waitUntil(
+    sendMagicLink(env, rawEmail, verifyUrl).catch(async (err) => {
+      console.error("send_failed", err);
+      await env.DB
+        .prepare("DELETE FROM magic_link_tokens WHERE token_hash = ?")
+        .bind(tokenHash)
+        .run()
+        .catch((cleanupErr) => console.error("cleanup_failed", cleanupErr));
+    })
+  );
   return json({ ok: true });
 }
 
 async function handleVerify(env: Env, url: URL): Promise<Response> {
   const raw = url.searchParams.get("t");
-  if (!raw) return htmlResponse(SIGN_IN_ERROR_HTML("Missing or invalid sign-in link."), 400);
+  if (!raw) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("Missing or invalid sign-in link."), 400, NO_STORE);
+  }
 
   const tokenHash = await sha256Hex(raw);
   const now = Date.now();
-  const tokenRow = await env.DB
-    .prepare(
-      `SELECT t.token_hash, t.user_id, t.device_code, t.expires_at, t.consumed_at, u.email
-       FROM magic_link_tokens t JOIN users u ON u.id = t.user_id
-       WHERE t.token_hash = ?`
-    )
-    .bind(tokenHash)
-    .first<{ token_hash: string; user_id: string; device_code: string | null; expires_at: number; consumed_at: number | null; email: string }>();
 
-  if (!tokenRow) {
-    return htmlResponse(SIGN_IN_ERROR_HTML("This sign-in link is not valid."), 400);
+  // Atomic consume. The WHERE clause is the gate: only an unconsumed,
+  // unexpired token marks itself as used here. RETURNING gives us the
+  // user_id / device_code in one round-trip — the email comes from a
+  // separate SELECT below since RETURNING in SQLite can't join.
+  // Two concurrent verify requests can't both pass: only one will see
+  // meta.changes === 1 (or the RETURNING row); the other races and
+  // sees nothing back.
+  const consumed = await env.DB
+    .prepare(
+      `UPDATE magic_link_tokens
+         SET consumed_at = ?
+       WHERE token_hash = ? AND consumed_at IS NULL AND expires_at > ?
+       RETURNING user_id, device_code`
+    )
+    .bind(now, tokenHash, now)
+    .first<{ user_id: string; device_code: string | null }>();
+
+  if (!consumed) {
+    return htmlResponse(
+      SIGN_IN_ERROR_HTML("This sign-in link is invalid, expired, or has already been used. Sign-in links are single-use and valid for 15 minutes."),
+      400,
+      NO_STORE,
+    );
   }
-  if (tokenRow.consumed_at !== null) {
-    return htmlResponse(SIGN_IN_ERROR_HTML("This sign-in link has already been used. Magic links are single-use."), 400);
-  }
-  if (tokenRow.expires_at <= now) {
-    return htmlResponse(SIGN_IN_ERROR_HTML("This sign-in link has expired. Sign-in links are valid for 15 minutes."), 400);
+
+  const userRow = await env.DB
+    .prepare("SELECT email FROM users WHERE id = ?")
+    .bind(consumed.user_id)
+    .first<{ email: string }>();
+  if (!userRow) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("Account not found."), 400, NO_STORE);
   }
 
   const sessionId = crypto.randomUUID();
   const sessionExpires = now + SESSION_TTL_MS;
   await env.DB.batch([
-    env.DB.prepare("UPDATE magic_link_tokens SET consumed_at = ? WHERE token_hash = ?").bind(now, tokenHash),
     env.DB.prepare("INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)")
-      .bind(sessionId, tokenRow.user_id, now, sessionExpires),
-    env.DB.prepare("UPDATE users SET last_seen_at = ? WHERE id = ?").bind(now, tokenRow.user_id),
+      .bind(sessionId, consumed.user_id, now, sessionExpires),
+    env.DB.prepare("UPDATE users SET last_seen_at = ? WHERE id = ?").bind(now, consumed.user_id),
   ]);
 
   // If this token was issued via the device flow, attach the session
   // to the device_codes row so the local server's poller (PR 3) can
-  // pick it up.
-  if (tokenRow.device_code) {
+  // pick it up. The expires_at predicate prevents claiming a stale
+  // device-code row that was abandoned past its 10-min window.
+  if (consumed.device_code) {
     await env.DB
-      .prepare("UPDATE device_codes SET session_id = ? WHERE device_code = ? AND session_id IS NULL")
-      .bind(sessionId, tokenRow.device_code)
+      .prepare(
+        "UPDATE device_codes SET session_id = ? WHERE device_code = ? AND session_id IS NULL AND expires_at > ?"
+      )
+      .bind(sessionId, consumed.device_code, now)
       .run();
   }
+
+  const cookie = sessionCookie(sessionId, url.host);
 
   // Browser-only logins: redirect to /auth/welcome with the cookie set.
   // Device-flow logins: render the welcome page directly so the user
   // sees the "you can close this window" copy without an extra hop.
-  if (tokenRow.device_code) {
-    return htmlResponse(WELCOME_HTML(tokenRow.email, true), 200, { "set-cookie": sessionCookie(sessionId) });
+  if (consumed.device_code) {
+    return htmlResponse(WELCOME_HTML(userRow.email, true), 200, {
+      "set-cookie": cookie,
+      ...NO_STORE,
+    });
   }
   return new Response(null, {
     status: 302,
     headers: {
       location: "/auth/welcome",
-      "set-cookie": sessionCookie(sessionId),
+      "set-cookie": cookie,
+      ...NO_STORE,
     },
   });
 }
 
-async function handleWelcome(req: Request, env: Env): Promise<Response> {
+async function handleWelcome(req: Request, env: Env, host: string): Promise<Response> {
   const cookies = parseCookies(req);
   const sid = cookies[COOKIE_NAME];
   if (!sid) {
-    return htmlResponse(SIGN_IN_ERROR_HTML("No active session — sign in to continue."), 401);
+    return htmlResponse(SIGN_IN_ERROR_HTML("No active session — sign in to continue."), 401, NO_STORE);
   }
   const lookup = await getSession(env.DB, sid, Date.now());
   if (!lookup) {
     return htmlResponse(SIGN_IN_ERROR_HTML("Your session has expired. Sign in again."), 401, {
-      "set-cookie": clearedCookie(),
+      "set-cookie": clearedCookie(host),
+      ...NO_STORE,
     });
   }
-  return htmlResponse(WELCOME_HTML(lookup.user.email, false));
+  return htmlResponse(WELCOME_HTML(lookup.user.email, false), 200, NO_STORE);
 }
 
-async function handleWhoami(req: Request, env: Env): Promise<Response> {
+async function handleWhoami(req: Request, env: Env, host: string): Promise<Response> {
   const cookies = parseCookies(req);
   const sid = cookies[COOKIE_NAME];
-  if (!sid) return json({ error: "unauthenticated" }, 401);
+  if (!sid) return json({ error: "unauthenticated" }, 401, NO_STORE);
   const lookup = await getSession(env.DB, sid, Date.now());
   if (!lookup) {
-    return json({ error: "unauthenticated" }, 401, { "set-cookie": clearedCookie() });
+    return json({ error: "unauthenticated" }, 401, { "set-cookie": clearedCookie(host), ...NO_STORE });
   }
-  return json({ id: lookup.user.id, email: lookup.user.email });
+  return json({ id: lookup.user.id, email: lookup.user.email }, 200, NO_STORE);
 }
 
 export default {
-  async fetch(req: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
 
     if (url.pathname === "/auth/sign-in" && req.method === "GET") {
       return htmlResponse(SIGN_IN_HTML(url.searchParams.get("d")));
     }
     if (url.pathname === "/auth/magic-link" && req.method === "POST") {
-      return handleMagicLink(req, env, url);
+      return handleMagicLink(req, env, ctx, url);
     }
     if (url.pathname === "/auth/verify" && req.method === "GET") {
       return handleVerify(env, url);
     }
     if (url.pathname === "/auth/welcome" && req.method === "GET") {
-      return handleWelcome(req, env);
+      return handleWelcome(req, env, url.host);
     }
     if (url.pathname === "/auth/whoami" && req.method === "GET") {
-      return handleWhoami(req, env);
+      return handleWhoami(req, env, url.host);
     }
 
     return new Response("Not found", { status: 404 });

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -18,10 +18,18 @@ interface RateLimit {
 export interface Env {
   DB: D1Database;
   MAGIC_LINK_LIMIT: RateLimit;
-  RESEND_API_KEY: string;
+  // Optional so wrangler dev works without a Resend secret — sendMagicLink()
+  // logs the verify URL to the Worker console when this is unset.
+  RESEND_API_KEY?: string;
   FROM_ADDRESS?: string;
   REPLY_TO?: string;
 }
+
+// Magic-link tokens are always 43 chars (32 bytes base64url, no padding).
+// Cap the input well above that to keep `?t=<huge>` from wasting CPU on
+// the sha256, but loose enough to tolerate URL-encoding wraps and future
+// token-length changes.
+const MAX_TOKEN_LEN = 100;
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAGIC_LINK_TTL_MS = 15 * 60 * 1000;
@@ -351,7 +359,7 @@ async function handleMagicLink(req: Request, env: Env, ctx: ExecutionContext, ur
 
 async function handleVerify(env: Env, url: URL): Promise<Response> {
   const raw = url.searchParams.get("t");
-  if (!raw) {
+  if (!raw || raw.length > MAX_TOKEN_LEN) {
     return htmlResponse(SIGN_IN_ERROR_HTML("Missing or invalid sign-in link."), 400, NO_STORE);
   }
 
@@ -463,23 +471,33 @@ async function handleWhoami(req: Request, env: Env, host: string): Promise<Respo
 export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
-
-    if (url.pathname === "/auth/sign-in" && req.method === "GET") {
-      return htmlResponse(SIGN_IN_HTML(url.searchParams.get("d")));
+    try {
+      if (url.pathname === "/auth/sign-in" && req.method === "GET") {
+        // /auth/sign-in carries an optional ?d=<user_code> for the device
+        // flow; no-store stops browsers and intermediaries from caching a
+        // URL that contains a login-related code.
+        return htmlResponse(SIGN_IN_HTML(url.searchParams.get("d")), 200, NO_STORE);
+      }
+      if (url.pathname === "/auth/magic-link" && req.method === "POST") {
+        return await handleMagicLink(req, env, ctx, url);
+      }
+      if (url.pathname === "/auth/verify" && req.method === "GET") {
+        return await handleVerify(env, url);
+      }
+      if (url.pathname === "/auth/welcome" && req.method === "GET") {
+        return await handleWelcome(req, env, url.host);
+      }
+      if (url.pathname === "/auth/whoami" && req.method === "GET") {
+        return await handleWhoami(req, env, url.host);
+      }
+      return new Response("Not found", { status: 404 });
+    } catch (err) {
+      // Single-point catch so a transient D1 error or thrown exception
+      // returns a structured 503 instead of an unstructured 500. The
+      // most common failure mode at this layer is D1 being unreachable;
+      // service_unavailable is the honest shape.
+      console.error("worker_unhandled", url.pathname, err);
+      return json({ error: "service_unavailable" }, 503);
     }
-    if (url.pathname === "/auth/magic-link" && req.method === "POST") {
-      return handleMagicLink(req, env, ctx, url);
-    }
-    if (url.pathname === "/auth/verify" && req.method === "GET") {
-      return handleVerify(env, url);
-    }
-    if (url.pathname === "/auth/welcome" && req.method === "GET") {
-      return handleWelcome(req, env, url.host);
-    }
-    if (url.pathname === "/auth/whoami" && req.method === "GET") {
-      return handleWhoami(req, env, url.host);
-    }
-
-    return new Response("Not found", { status: 404 });
   },
 };

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -1,39 +1,432 @@
-// Oyster auth worker — Cloudflare-native magic-link auth and device-flow
-// bridge to the local server at localhost:4444. See docs/plans/auth.md
-// for the full design.
+// Oyster auth worker — Cloudflare-native magic-link auth and (in PR 3)
+// device-flow bridge to the local server at localhost:4444. See
+// docs/plans/auth.md for the full design.
 //
-// PR 1 scaffold: only `GET /auth/whoami` is wired, and it always 401s.
-// Magic-link send/verify and the device-flow endpoints land in PR 2 + PR 3.
+// PR 2 endpoints:
+//   GET  /auth/sign-in       HTML form (also accepts ?d=<user_code> for the device flow)
+//   POST /auth/magic-link    {email, user_code?} — send the email
+//   GET  /auth/verify?t=...  consume the token, set the session cookie, redirect
+//   GET  /auth/welcome       landing page after verify (shows the signed-in email)
+//   GET  /auth/whoami        {id, email} for a valid session, 401 otherwise
+//
+// PR 3 will add /auth/device-init, /auth/device/<code>, /auth/sign-out.
+
+interface RateLimit {
+  limit(opts: { key: string }): Promise<{ success: boolean }>;
+}
 
 export interface Env {
   DB: D1Database;
+  MAGIC_LINK_LIMIT: RateLimit;
+  RESEND_API_KEY: string;
+  FROM_ADDRESS?: string;
+  REPLY_TO?: string;
 }
 
-function json(body: unknown, status = 200): Response {
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAGIC_LINK_TTL_MS = 15 * 60 * 1000;
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+// Per-email cap: count of valid (non-expired) magic-link tokens for the user.
+// Window = TTL so a single SQL count answers both questions ("issued in the
+// last N minutes" ≡ "still valid"). Locks for the full TTL once 3 are out;
+// any expiry frees a slot.
+const PER_EMAIL_CAP = 3;
+const COOKIE_NAME = "oyster_session";
+
+function json(body: unknown, status = 200, extra: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...extra },
   });
+}
+
+function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", ...extra },
+  });
+}
+
+function htmlEscape(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" } as Record<string, string>
+  )[c]!);
+}
+
+async function sha256Hex(s: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function randomToken(byteLen = 32): string {
+  const bytes = new Uint8Array(byteLen);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function parseCookies(req: Request): Record<string, string> {
+  const out: Record<string, string> = {};
+  const header = req.headers.get("cookie") ?? "";
+  for (const part of header.split(/;\s*/)) {
+    const eq = part.indexOf("=");
+    if (eq > 0) out[part.slice(0, eq)] = part.slice(eq + 1);
+  }
+  return out;
+}
+
+interface UserRow { id: string; email: string }
+interface SessionRow { id: string; user_id: string; expires_at: number; revoked_at: number | null }
+
+async function findOrCreateUser(db: D1Database, email: string, now: number): Promise<UserRow> {
+  // INSERT OR IGNORE then SELECT — D1 supports RETURNING, but the two-step
+  // form is more portable across SQLite-likes and the SELECT is required
+  // anyway when the row already exists.
+  const id = crypto.randomUUID();
+  await db
+    .prepare("INSERT OR IGNORE INTO users (id, email, created_at, last_seen_at) VALUES (?, ?, ?, ?)")
+    .bind(id, email, now, now)
+    .run();
+  const row = await db
+    .prepare("SELECT id, email FROM users WHERE email = ?")
+    .bind(email)
+    .first<UserRow>();
+  if (!row) throw new Error("user upsert failed");
+  return row;
+}
+
+async function getSession(db: D1Database, sessionId: string, now: number): Promise<{ session: SessionRow; user: UserRow } | null> {
+  const row = await db
+    .prepare(
+      `SELECT s.id, s.user_id, s.expires_at, s.revoked_at, u.email
+       FROM sessions s JOIN users u ON u.id = s.user_id
+       WHERE s.id = ? AND s.revoked_at IS NULL AND s.expires_at > ?`
+    )
+    .bind(sessionId, now)
+    .first<SessionRow & { email: string }>();
+  if (!row) return null;
+  return {
+    session: { id: row.id, user_id: row.user_id, expires_at: row.expires_at, revoked_at: row.revoked_at },
+    user: { id: row.user_id, email: row.email },
+  };
+}
+
+function sessionCookie(sessionId: string): string {
+  // Domain=.oyster.to so the cookie is visible on the apex and any
+  // subdomain the publish/viewer flows might end up on. HttpOnly blocks
+  // JS reads; SameSite=Lax allows the magic-link redirect to carry the
+  // cookie back; Secure means HTTPS-only.
+  const maxAge = Math.floor(SESSION_TTL_MS / 1000);
+  return `${COOKIE_NAME}=${sessionId}; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
+}
+
+function clearedCookie(): string {
+  return `${COOKIE_NAME}=; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
+}
+
+const SIGN_IN_HTML = (userCode: string | null) => `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in to Oyster</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 28rem; margin: 6rem auto; padding: 0 1.5rem; line-height: 1.5; }
+  h1 { font-size: 1.5rem; margin: 0 0 1.5rem; }
+  form { display: flex; flex-direction: column; gap: 0.75rem; }
+  label { font-size: 0.85rem; opacity: 0.7; }
+  input[type=email] { padding: 0.6rem 0.75rem; font-size: 1rem; border: 1px solid #888; border-radius: 0.4rem; background: transparent; color: inherit; }
+  button { padding: 0.6rem 0.75rem; font-size: 1rem; font-weight: 600; border: 0; border-radius: 0.4rem; background: #6750a4; color: #fff; cursor: pointer; }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  #status { margin-top: 1rem; font-size: 0.9rem; }
+  .ok { color: #2e7d32; }
+  .err { color: #c62828; }
+</style>
+</head><body>
+<h1>Sign in to Oyster</h1>
+<form id="f">
+  <label for="email">Email</label>
+  <input id="email" name="email" type="email" required autofocus autocomplete="email">
+  <button type="submit">Send magic link</button>
+</form>
+<p id="status" hidden></p>
+<script>
+const f = document.getElementById('f');
+const s = document.getElementById('status');
+const userCode = ${userCode ? JSON.stringify(userCode) : "null"};
+f.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = f.email.value.trim();
+  const btn = f.querySelector('button');
+  btn.disabled = true;
+  btn.textContent = 'Sending…';
+  try {
+    const res = await fetch('/auth/magic-link', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, user_code: userCode }),
+    });
+    if (res.ok) {
+      f.style.display = 'none';
+      s.hidden = false;
+      s.className = 'ok';
+      s.textContent = 'Check your inbox for a sign-in link. The link expires in 15 minutes.';
+    } else {
+      s.hidden = false;
+      s.className = 'err';
+      s.textContent = 'Could not send the link. Check the email and try again.';
+      btn.disabled = false;
+      btn.textContent = 'Send magic link';
+    }
+  } catch {
+    s.hidden = false;
+    s.className = 'err';
+    s.textContent = 'Network error. Try again.';
+    btn.disabled = false;
+    btn.textContent = 'Send magic link';
+  }
+});
+</script>
+</body></html>`;
+
+const WELCOME_HTML = (email: string, deviceLogin: boolean) => `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Signed in to Oyster</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 28rem; margin: 6rem auto; padding: 0 1.5rem; line-height: 1.5; text-align: center; }
+  h1 { font-size: 1.5rem; }
+  code { background: rgba(127,127,127,0.15); padding: 0.1em 0.3em; border-radius: 0.25rem; }
+</style>
+</head><body>
+<h1>You're signed in</h1>
+<p>Signed in as <code>${htmlEscape(email)}</code>.</p>
+${deviceLogin
+  ? "<p>You can close this window — your local Oyster app will pick up the session automatically.</p>"
+  : "<p><a href=\"https://oyster.to/\">← Back to Oyster</a></p>"}
+</body></html>`;
+
+const SIGN_IN_ERROR_HTML = (message: string) => `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>Sign in failed</title>
+<style>body { font-family: system-ui, sans-serif; max-width: 28rem; margin: 6rem auto; padding: 0 1.5rem; }</style>
+</head><body>
+<h1>Sign in failed</h1>
+<p>${htmlEscape(message)}</p>
+<p><a href="/auth/sign-in">Try again</a></p>
+</body></html>`;
+
+async function sendMagicLink(env: Env, email: string, link: string): Promise<void> {
+  const from = env.FROM_ADDRESS ?? "noreply@oyster.to";
+  const replyTo = env.REPLY_TO ?? "matthew@slight.me";
+  const subject = "Sign in to Oyster";
+  const text =
+    "Click the link below to sign in to Oyster. The link is single-use and expires in 15 minutes.\n\n" +
+    `${link}\n\n` +
+    "If you didn't request this, ignore this email — no account changes were made.";
+  const html =
+    `<p>Click the link below to sign in to Oyster. The link is single-use and expires in 15 minutes.</p>` +
+    `<p><a href="${htmlEscape(link)}" style="display:inline-block;padding:0.6rem 1rem;background:#6750a4;color:#fff;text-decoration:none;border-radius:0.4rem;font-weight:600;">Sign in to Oyster</a></p>` +
+    `<p style="font-size:0.85rem;color:#666;">Or paste this URL into your browser:<br><code>${htmlEscape(link)}</code></p>` +
+    `<p style="font-size:0.85rem;color:#666;">If you didn't request this, ignore this email — no account changes were made.</p>`;
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      from: `Oyster <${from}>`,
+      to: email,
+      reply_to: replyTo,
+      subject,
+      text,
+      html,
+    }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    console.error("resend_failed", res.status, detail);
+    throw new Error(`resend ${res.status}`);
+  }
+}
+
+async function handleMagicLink(req: Request, env: Env, url: URL): Promise<Response> {
+  // Per-IP gate first — cheapest reject path. The Workers Rate Limit
+  // binding does the bookkeeping at the edge; no D1 row needed.
+  const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
+  const ipGate = await env.MAGIC_LINK_LIMIT.limit({ key: ip });
+  if (!ipGate.success) return json({ error: "rate_limited" }, 429);
+
+  let payload: { email?: unknown; user_code?: unknown };
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: "invalid_json" }, 400);
+  }
+  const rawEmail = typeof payload.email === "string" ? payload.email.trim().toLowerCase() : "";
+  if (!EMAIL_RE.test(rawEmail) || rawEmail.length > 254) {
+    return json({ error: "invalid_email" }, 400);
+  }
+  const userCode =
+    typeof payload.user_code === "string" && payload.user_code.length > 0
+      ? payload.user_code
+      : null;
+
+  const now = Date.now();
+  const user = await findOrCreateUser(env.DB, rawEmail, now);
+
+  // Per-email cap: count of still-valid tokens for this user.
+  const live = await env.DB
+    .prepare("SELECT count(*) AS n FROM magic_link_tokens WHERE user_id = ? AND consumed_at IS NULL AND expires_at > ?")
+    .bind(user.id, now)
+    .first<{ n: number }>();
+  if ((live?.n ?? 0) >= PER_EMAIL_CAP) {
+    // Silent no-op — return ok so the response is identical regardless
+    // of whether the email is mid-flood. No leak about cap state.
+    return json({ ok: true });
+  }
+
+  // Resolve user_code → device_code if present. Unknown user_codes are
+  // ignored silently (degrades gracefully to a non-device login).
+  let deviceCode: string | null = null;
+  if (userCode) {
+    const dc = await env.DB
+      .prepare("SELECT device_code FROM device_codes WHERE user_code = ? AND expires_at > ? AND session_id IS NULL")
+      .bind(userCode, now)
+      .first<{ device_code: string }>();
+    deviceCode = dc?.device_code ?? null;
+  }
+
+  const rawToken = randomToken(32);
+  const tokenHash = await sha256Hex(rawToken);
+  const expiresAt = now + MAGIC_LINK_TTL_MS;
+  await env.DB
+    .prepare("INSERT INTO magic_link_tokens (token_hash, user_id, device_code, expires_at) VALUES (?, ?, ?, ?)")
+    .bind(tokenHash, user.id, deviceCode, expiresAt)
+    .run();
+
+  const verifyUrl = `${url.origin}/auth/verify?t=${encodeURIComponent(rawToken)}`;
+  try {
+    await sendMagicLink(env, rawEmail, verifyUrl);
+  } catch {
+    // We've already written the token row; failing the response would
+    // make the client retry and burn the per-email cap. Log and ack ok.
+    return json({ ok: true });
+  }
+
+  return json({ ok: true });
+}
+
+async function handleVerify(env: Env, url: URL): Promise<Response> {
+  const raw = url.searchParams.get("t");
+  if (!raw) return htmlResponse(SIGN_IN_ERROR_HTML("Missing or invalid sign-in link."), 400);
+
+  const tokenHash = await sha256Hex(raw);
+  const now = Date.now();
+  const tokenRow = await env.DB
+    .prepare(
+      `SELECT t.token_hash, t.user_id, t.device_code, t.expires_at, t.consumed_at, u.email
+       FROM magic_link_tokens t JOIN users u ON u.id = t.user_id
+       WHERE t.token_hash = ?`
+    )
+    .bind(tokenHash)
+    .first<{ token_hash: string; user_id: string; device_code: string | null; expires_at: number; consumed_at: number | null; email: string }>();
+
+  if (!tokenRow) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("This sign-in link is not valid."), 400);
+  }
+  if (tokenRow.consumed_at !== null) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("This sign-in link has already been used. Magic links are single-use."), 400);
+  }
+  if (tokenRow.expires_at <= now) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("This sign-in link has expired. Sign-in links are valid for 15 minutes."), 400);
+  }
+
+  const sessionId = crypto.randomUUID();
+  const sessionExpires = now + SESSION_TTL_MS;
+  await env.DB.batch([
+    env.DB.prepare("UPDATE magic_link_tokens SET consumed_at = ? WHERE token_hash = ?").bind(now, tokenHash),
+    env.DB.prepare("INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)")
+      .bind(sessionId, tokenRow.user_id, now, sessionExpires),
+    env.DB.prepare("UPDATE users SET last_seen_at = ? WHERE id = ?").bind(now, tokenRow.user_id),
+  ]);
+
+  // If this token was issued via the device flow, attach the session
+  // to the device_codes row so the local server's poller (PR 3) can
+  // pick it up.
+  if (tokenRow.device_code) {
+    await env.DB
+      .prepare("UPDATE device_codes SET session_id = ? WHERE device_code = ? AND session_id IS NULL")
+      .bind(sessionId, tokenRow.device_code)
+      .run();
+  }
+
+  // Browser-only logins: redirect to /auth/welcome with the cookie set.
+  // Device-flow logins: render the welcome page directly so the user
+  // sees the "you can close this window" copy without an extra hop.
+  if (tokenRow.device_code) {
+    return htmlResponse(WELCOME_HTML(tokenRow.email, true), 200, { "set-cookie": sessionCookie(sessionId) });
+  }
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: "/auth/welcome",
+      "set-cookie": sessionCookie(sessionId),
+    },
+  });
+}
+
+async function handleWelcome(req: Request, env: Env): Promise<Response> {
+  const cookies = parseCookies(req);
+  const sid = cookies[COOKIE_NAME];
+  if (!sid) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("No active session — sign in to continue."), 401);
+  }
+  const lookup = await getSession(env.DB, sid, Date.now());
+  if (!lookup) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("Your session has expired. Sign in again."), 401, {
+      "set-cookie": clearedCookie(),
+    });
+  }
+  return htmlResponse(WELCOME_HTML(lookup.user.email, false));
+}
+
+async function handleWhoami(req: Request, env: Env): Promise<Response> {
+  const cookies = parseCookies(req);
+  const sid = cookies[COOKIE_NAME];
+  if (!sid) return json({ error: "unauthenticated" }, 401);
+  const lookup = await getSession(env.DB, sid, Date.now());
+  if (!lookup) {
+    return json({ error: "unauthenticated" }, 401, { "set-cookie": clearedCookie() });
+  }
+  return json({ id: lookup.user.id, email: lookup.user.email });
 }
 
 export default {
   async fetch(req: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
 
+    if (url.pathname === "/auth/sign-in" && req.method === "GET") {
+      return htmlResponse(SIGN_IN_HTML(url.searchParams.get("d")));
+    }
+    if (url.pathname === "/auth/magic-link" && req.method === "POST") {
+      return handleMagicLink(req, env, url);
+    }
+    if (url.pathname === "/auth/verify" && req.method === "GET") {
+      return handleVerify(env, url);
+    }
+    if (url.pathname === "/auth/welcome" && req.method === "GET") {
+      return handleWelcome(req, env);
+    }
     if (url.pathname === "/auth/whoami" && req.method === "GET") {
-      // Wired in PR 2 once the session cookie is being set. Until then,
-      // the endpoint exists so the deploy is verifiable end-to-end.
-      // The throwaway COUNT(*) on users isn't part of the eventual
-      // implementation — it's here so the smoke test exercises the D1
-      // binding and the applied migration, not just route wiring.
-      // PR 2 replaces this body with the real session lookup.
-      try {
-        await env.DB.prepare("SELECT count(*) FROM users").first();
-      } catch (err) {
-        console.error("d1_unavailable", err);
-        return json({ error: "database_unavailable" }, 503);
-      }
-      return json({ error: "unauthenticated" }, 401);
+      return handleWhoami(req, env);
     }
 
     return new Response("Not found", { status: 404 });

--- a/infra/auth-worker/wrangler.toml
+++ b/infra/auth-worker/wrangler.toml
@@ -19,3 +19,17 @@ zone_name = "oyster.to"
 [[routes]]
 pattern = "www.oyster.to/auth/*"
 zone_name = "oyster.to"
+
+# Per-IP rate limit on /auth/magic-link, keyed on cf.connecting_ip.
+# namespace_id is local to this Worker — any unused integer works.
+# 20 requests per hour matches docs/plans/auth.md.
+[[unsafe.bindings]]
+name = "MAGIC_LINK_LIMIT"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 20, period = 3600 }
+
+# Non-secret config. Secrets (RESEND_API_KEY) go via `wrangler secret put`.
+[vars]
+FROM_ADDRESS = "noreply@oyster.to"
+REPLY_TO = "matthew@slight.me"


### PR DESCRIPTION
Second of three PRs delivering #295. PR 1 (#337) shipped the schema + scaffold; this PR implements the browser half of the magic-link flow per [`docs/plans/auth.md`](https://github.com/mattslight/oyster/blob/main/docs/plans/auth.md). PR 3 (device flow + sign-out + local bridge) follows.

## Summary
- `POST /auth/magic-link` — generates a 32-byte random token, stores `sha256(token)` in `magic_link_tokens`, sends a Resend email containing a verify URL.
- `GET /auth/verify?t=<raw>` — hashes, looks up, validates expiry/single-use, creates a session, sets the `oyster_session` cookie, redirects to `/auth/welcome`.
- `GET /auth/whoami` — reads the cookie, looks up the session, returns `{ id, email }` for valid sessions or `401 { error: "unauthenticated" }` otherwise. Replaces the PR 1 placeholder.
- `GET /auth/sign-in` — minimal HTML form for testing end-to-end without a marketing-side sign-in page.
- `GET /auth/welcome` — landing page after verify, shows `Signed in as <email>`. Branches copy for device-flow logins ("you can close this window") vs browser logins ("← Back to Oyster").
- Device-flow handoff is wired on the verify side: when a token carries a `device_code`, verify writes `sessions.id` into the matching `device_codes` row so PR 3's polling endpoint can claim it.

## Rate limits (both arms of the design doc's rate-limit section)
- **Per-IP** — `MAGIC_LINK_LIMIT` binding (Workers Rate Limiting) keyed on `cf.connecting_ip`, 20 req/hour. The binding sits in `wrangler.toml`'s `[[unsafe.bindings]]` block; no separate provisioning step.
- **Per-email** — D1 row-count over `magic_link_tokens` for the user. Cap of 3 unconsumed, unexpired tokens at a time. Hitting the cap returns `{ ok: true }` silently — same shape as a successful send, no information leak about cap state.

## Cookie shape
`oyster_session=<sessionId>; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=2592000`.

## What's NOT in this PR
- `POST /auth/device-init`, `GET /auth/device/<device_code>` — PR 3.
- `POST /auth/sign-out` — PR 3.
- Local Oyster server bridge (`~/Oyster/config/auth.json` writer + sign-in button in the local UI) — PR 3.
- Marketing-side sign-in page link from `oyster.to/`. The Worker's `/auth/sign-in` form is enough to verify the flow end-to-end; integrating the marketing site is a separate concern.

## Verify (deploy steps)
The Worker is already deployed on PR 1, but PR 2 needs **two new prerequisites** before `npm run deploy`:

1. `npx wrangler secret put RESEND_API_KEY` — paste a Resend API key with sending permission for the (already-verified) `oyster.to` domain.
2. Nothing else — the per-IP rate-limit binding provisions automatically from `[[unsafe.bindings]]` on deploy.

Then:
- `npm run typecheck` — clean.
- `npm run deploy`.
- Open `https://oyster.to/auth/sign-in`, submit your email, click the link, land on `/auth/welcome` showing `Signed in as <you>`.
- `curl -i https://oyster.to/auth/whoami -H "cookie: oyster_session=<from devtools>"` returns `200 { id, email }`.
- `curl -i https://oyster.to/auth/whoami` (no cookie) returns 401.

## No CHANGELOG entry
Per the convention in CLAUDE.md, bullets are user-visible outcomes. The Worker is reachable but the local Oyster app at `localhost:4444` doesn't surface it yet — that's PR 3. The free-account bullet lands when sign-in works inside the app.

## Test plan
- [ ] `npx wrangler secret put RESEND_API_KEY` (paste key).
- [ ] `npm run deploy` — Worker deploys without errors; deploy log shows the `MAGIC_LINK_LIMIT` rate-limit binding.
- [ ] Browser flow: open `https://oyster.to/auth/sign-in`, enter your email, click link, see `/auth/welcome`.
- [ ] `curl` whoami with cookie → 200; without cookie → 401.
- [ ] Re-clicking the same magic-link returns the "already used" error page.
- [ ] Submitting the same email three times in a row + a fourth: fourth submit returns `{ ok: true }` but no fourth email arrives (per-email cap).
- [ ] Submit malformed JSON → 400 `invalid_json`. Submit non-email string → 400 `invalid_email`.

## Anchor docs
- `docs/requirements/oyster-cloud.md` — R5
- `docs/plans/auth.md` — design (PR 1/2/3 sequencing in "Sequencing inside #295")
- `docs/plans/roadmap.md` — 0.7.0

Part of #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)