### PR TITLE
feat(auth): device-flow bridge + sign-in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Sign in to Oyster.** A free account in three clicks — enter email, click the link, you're signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. ([#295](https://github.com/mattslight/oyster/issues/295))
+
 ## [0.6.0] - 2026-05-02
 
 Trustworthy recall — every memory traceable, every conversation searchable.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
       <a class="version-pill" href="#v-0-5-0">0.5</a>
       <a class="version-pill" href="#v-0-4-0">0.4</a>
@@ -322,6 +323,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.6.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Sign in to Oyster.</strong> A free account in three clicks — enter email, click the link, you&#39;re signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish &amp; share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. (<a href="https://github.com/mattslight/oyster/issues/295" rel="noopener noreferrer">#295</a>)</li>
+</ul>
 <h2 id="v-0-6-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0...v0.6.0" rel="noopener noreferrer"><span class="release-version">0.6.0</span></a><span class="release-date"> — 2026-05-02</span></h2>
 <p>Trustworthy recall — every memory traceable, every conversation searchable.</p>
 <h3>Added</h3>

--- a/infra/auth-worker/README.md
+++ b/infra/auth-worker/README.md
@@ -3,14 +3,15 @@
 Cloudflare Worker that handles magic-link sign-in for the free Oyster account, plus the device-flow bridge that lets the local server at `localhost:4444` see the signed-in state. Design: [`docs/plans/auth.md`](../../docs/plans/auth.md).
 
 ```
-GET  /auth/sign-in        HTML form (browser entry point)
-POST /auth/magic-link     {email, user_code?} → email a sign-in link
-GET  /auth/verify?t=...   consume token, set session cookie, redirect to /auth/welcome
-GET  /auth/welcome        landing page after verify (shows the signed-in email)
-GET  /auth/whoami         {id, email} for a valid session, 401 otherwise
+GET  /auth/sign-in              HTML form (browser entry point; ?d=<user_code> for device flow)
+POST /auth/magic-link           {email, user_code?} → email a sign-in link
+GET  /auth/verify?t=...         consume token, set session cookie, redirect to /auth/welcome
+GET  /auth/welcome              landing page after verify (shows the signed-in email)
+GET  /auth/whoami               {id, email} for a valid session, 401 otherwise (cookie OR Bearer)
+POST /auth/device-init          → {device_code, user_code, expires_in} for the local-server bridge
+GET  /auth/device/<device_code> 202 pending / 200 with session_token / 410 gone — polled by local server
+POST /auth/sign-out             revokes the session, clears the cookie (cookie OR Bearer)
 ```
-
-PR 3 will add `/auth/device-init`, `/auth/device/<code>`, `/auth/sign-out`, and the local-server bridge that writes `~/Oyster/config/auth.json`.
 
 ## One-time setup
 

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -478,9 +478,26 @@ function randomUserCode(): string {
   return out;
 }
 
-async function handleDeviceInit(env: Env): Promise<Response> {
+async function handleDeviceInit(req: Request, env: Env): Promise<Response> {
+  // Per-IP gate. Reuses the same rate-limit binding as /auth/magic-link —
+  // both endpoints are auth-attempt surface and an abuser hitting either
+  // is the same problem. Cap is 20/hour per IP across both.
+  const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
+  const ipGate = await env.MAGIC_LINK_LIMIT.limit({ key: ip });
+  if (!ipGate.success) return json({ error: "rate_limited" }, 429, NO_STORE);
+
   const now = Date.now();
   const expiresAt = now + DEVICE_CODE_TTL_MS;
+
+  // Opportunistic GC: delete a small batch of expired rows on every
+  // init. Bounded LIMIT so a single request never spends too long; over
+  // many requests the table stays trimmed without a separate cron Worker.
+  await env.DB
+    .prepare("DELETE FROM device_codes WHERE expires_at < ? LIMIT 100")
+    .bind(now)
+    .run()
+    .catch((err) => console.error("device_codes_gc_failed", err));
+
   // user_code has UNIQUE — retry on the rare collision rather than
   // letting a duplicate slip through.
   for (let attempt = 0; attempt < 4; attempt++) {
@@ -509,50 +526,50 @@ async function handleDevicePoll(env: Env, deviceCode: string): Promise<Response>
     return json({ error: "invalid_device_code" }, 400, NO_STORE);
   }
   const now = Date.now();
-  // Atomic claim: a successful UPDATE returns the session bits exactly
-  // once. Subsequent polls see no rows and return 410. Pre-claim polls
-  // (session_id IS NULL but expires_at > now) return 202 to keep the
-  // local poller in its loop.
-  const claimed = await env.DB
-    .prepare(
-      `UPDATE device_codes
-         SET claimed_at = ?
-       WHERE device_code = ? AND session_id IS NOT NULL AND claimed_at IS NULL AND expires_at > ?
-       RETURNING session_id`
-    )
-    .bind(now, deviceCode, now)
-    .first<{ session_id: string }>();
 
-  if (claimed) {
-    const userRow = await env.DB
-      .prepare(
-        `SELECT u.id, u.email FROM sessions s
-         JOIN users u ON u.id = s.user_id
-         WHERE s.id = ? AND s.revoked_at IS NULL AND s.expires_at > ?`
-      )
-      .bind(claimed.session_id, now)
-      .first<{ id: string; email: string }>();
-    if (!userRow) {
-      // Session was revoked between verify and poll. Surface a clean 410
-      // so the local poller stops; user can retry from the start.
-      return json({ error: "session_unavailable" }, 410, NO_STORE);
-    }
-    return json(
-      { session_token: claimed.session_id, user: { id: userRow.id, email: userRow.email } },
-      200,
-      NO_STORE,
-    );
+  // Load the user FIRST. The previous version marked claimed_at before
+  // fetching the user row; if the user fetch (or any subsequent step)
+  // failed, the row was burnt — every retry returned 410 already_claimed
+  // and the login was lost. Now: read everything we need to respond,
+  // *then* race to claim. A failed read returns the same status the
+  // poller already handles (404 → "unknown" → 410); only the atomic
+  // UPDATE+meta.changes is the gate.
+  const candidate = await env.DB
+    .prepare(
+      `SELECT d.session_id, d.claimed_at, d.expires_at, u.id AS user_id, u.email
+       FROM device_codes d
+       LEFT JOIN sessions s ON s.id = d.session_id AND s.revoked_at IS NULL AND s.expires_at > ?
+       LEFT JOIN users u ON u.id = s.user_id
+       WHERE d.device_code = ?`
+    )
+    .bind(now, deviceCode)
+    .first<{ session_id: string | null; claimed_at: number | null; expires_at: number; user_id: string | null; email: string | null }>();
+
+  if (!candidate) return json({ error: "unknown_device_code" }, 410, NO_STORE);
+  if (candidate.claimed_at !== null) return json({ error: "already_claimed" }, 410, NO_STORE);
+  if (candidate.expires_at <= now) return json({ error: "expired" }, 410, NO_STORE);
+  if (candidate.session_id === null) return json({ status: "pending" }, 202, NO_STORE);
+  if (!candidate.user_id || !candidate.email) {
+    // Session was revoked between verify and poll. Don't burn the row.
+    return json({ error: "session_unavailable" }, 410, NO_STORE);
   }
 
-  // No claim — distinguish "still waiting" (202) from "gone" (410).
-  const row = await env.DB
-    .prepare("SELECT session_id, claimed_at, expires_at FROM device_codes WHERE device_code = ?")
-    .bind(deviceCode)
-    .first<{ session_id: string | null; claimed_at: number | null; expires_at: number }>();
-  if (!row) return json({ error: "unknown_device_code" }, 410, NO_STORE);
-  if (row.claimed_at !== null) return json({ error: "already_claimed" }, 410, NO_STORE);
-  if (row.expires_at <= now) return json({ error: "expired" }, 410, NO_STORE);
-  return json({ status: "pending" }, 202, NO_STORE);
+  // Atomic claim. Only one concurrent poll wins.
+  const res = await env.DB
+    .prepare(
+      "UPDATE device_codes SET claimed_at = ? WHERE device_code = ? AND claimed_at IS NULL AND session_id = ?"
+    )
+    .bind(now, deviceCode, candidate.session_id)
+    .run();
+  if ((res.meta?.changes ?? 0) !== 1) {
+    return json({ error: "already_claimed" }, 410, NO_STORE);
+  }
+
+  return json(
+    { session_token: candidate.session_id, user: { id: candidate.user_id, email: candidate.email } },
+    200,
+    NO_STORE,
+  );
 }
 
 async function handleSignOut(req: Request, env: Env, host: string): Promise<Response> {
@@ -612,7 +629,7 @@ export default {
         return await handleWhoami(req, env, url.host);
       }
       if (url.pathname === "/auth/device-init" && req.method === "POST") {
-        return await handleDeviceInit(env);
+        return await handleDeviceInit(req, env);
       }
       const deviceMatch = url.pathname.match(/^\/auth\/device\/([^/]+)$/);
       if (deviceMatch && req.method === "GET") {

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -457,9 +457,130 @@ async function handleWelcome(req: Request, env: Env, host: string): Promise<Resp
   return htmlResponse(WELCOME_HTML(lookup.user.email, false), 200, NO_STORE);
 }
 
-async function handleWhoami(req: Request, env: Env, host: string): Promise<Response> {
+// Device-flow handoff window: how long a device_code is valid for. Matches
+// docs/plans/auth.md (10 min — long enough for a slow inbox, short enough
+// that abandoned codes don't litter the table).
+const DEVICE_CODE_TTL_MS = 10 * 60 * 1000;
+
+// 8 chars, base32-Crockford-ish (no confusable I/L/O/0/1). Rendered to
+// the user as `XXXX-XXXX` in the sign-in URL — readable and short
+// enough to be paste-friendly even if the auto-open browser fails.
+const USER_CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+function randomUserCode(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += USER_CODE_ALPHABET[bytes[i] % USER_CODE_ALPHABET.length];
+    if (i === 3) out += "-";
+  }
+  return out;
+}
+
+async function handleDeviceInit(env: Env): Promise<Response> {
+  const now = Date.now();
+  const expiresAt = now + DEVICE_CODE_TTL_MS;
+  // user_code has UNIQUE — retry on the rare collision rather than
+  // letting a duplicate slip through.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const deviceCode = randomToken(32);
+    const userCode = randomUserCode();
+    try {
+      await env.DB
+        .prepare("INSERT INTO device_codes (device_code, user_code, expires_at) VALUES (?, ?, ?)")
+        .bind(deviceCode, userCode, expiresAt)
+        .run();
+      return json({
+        device_code: deviceCode,
+        user_code: userCode,
+        expires_in: Math.floor(DEVICE_CODE_TTL_MS / 1000),
+      }, 200, NO_STORE);
+    } catch (err) {
+      if (attempt === 3) throw err;
+      // UNIQUE collision on user_code or device_code; retry.
+    }
+  }
+  return json({ error: "device_init_failed" }, 500, NO_STORE);
+}
+
+async function handleDevicePoll(env: Env, deviceCode: string): Promise<Response> {
+  if (!deviceCode || deviceCode.length > MAX_TOKEN_LEN) {
+    return json({ error: "invalid_device_code" }, 400, NO_STORE);
+  }
+  const now = Date.now();
+  // Atomic claim: a successful UPDATE returns the session bits exactly
+  // once. Subsequent polls see no rows and return 410. Pre-claim polls
+  // (session_id IS NULL but expires_at > now) return 202 to keep the
+  // local poller in its loop.
+  const claimed = await env.DB
+    .prepare(
+      `UPDATE device_codes
+         SET claimed_at = ?
+       WHERE device_code = ? AND session_id IS NOT NULL AND claimed_at IS NULL AND expires_at > ?
+       RETURNING session_id`
+    )
+    .bind(now, deviceCode, now)
+    .first<{ session_id: string }>();
+
+  if (claimed) {
+    const userRow = await env.DB
+      .prepare(
+        `SELECT u.id, u.email FROM sessions s
+         JOIN users u ON u.id = s.user_id
+         WHERE s.id = ? AND s.revoked_at IS NULL AND s.expires_at > ?`
+      )
+      .bind(claimed.session_id, now)
+      .first<{ id: string; email: string }>();
+    if (!userRow) {
+      // Session was revoked between verify and poll. Surface a clean 410
+      // so the local poller stops; user can retry from the start.
+      return json({ error: "session_unavailable" }, 410, NO_STORE);
+    }
+    return json(
+      { session_token: claimed.session_id, user: { id: userRow.id, email: userRow.email } },
+      200,
+      NO_STORE,
+    );
+  }
+
+  // No claim — distinguish "still waiting" (202) from "gone" (410).
+  const row = await env.DB
+    .prepare("SELECT session_id, claimed_at, expires_at FROM device_codes WHERE device_code = ?")
+    .bind(deviceCode)
+    .first<{ session_id: string | null; claimed_at: number | null; expires_at: number }>();
+  if (!row) return json({ error: "unknown_device_code" }, 410, NO_STORE);
+  if (row.claimed_at !== null) return json({ error: "already_claimed" }, 410, NO_STORE);
+  if (row.expires_at <= now) return json({ error: "expired" }, 410, NO_STORE);
+  return json({ status: "pending" }, 202, NO_STORE);
+}
+
+async function handleSignOut(req: Request, env: Env, host: string): Promise<Response> {
+  // Accept the session token from either the cookie (browser) or a
+  // Bearer header (local server / CLI). Either revokes the same row.
   const cookies = parseCookies(req);
-  const sid = cookies[COOKIE_NAME];
+  const fromCookie = cookies[COOKIE_NAME];
+  const auth = req.headers.get("authorization") ?? "";
+  const fromBearer = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  const sid = fromCookie || fromBearer;
+  if (!sid) {
+    return json({ ok: true }, 200, { "set-cookie": clearedCookie(host), ...NO_STORE });
+  }
+  await env.DB
+    .prepare("UPDATE sessions SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL")
+    .bind(Date.now(), sid)
+    .run();
+  return json({ ok: true }, 200, { "set-cookie": clearedCookie(host), ...NO_STORE });
+}
+
+async function handleWhoami(req: Request, env: Env, host: string): Promise<Response> {
+  // Accept either the browser cookie or a Bearer header from the local
+  // server. Same session row backs both.
+  const cookies = parseCookies(req);
+  const fromCookie = cookies[COOKIE_NAME];
+  const auth = req.headers.get("authorization") ?? "";
+  const fromBearer = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  const sid = fromCookie || fromBearer;
   if (!sid) return json({ error: "unauthenticated" }, 401, NO_STORE);
   const lookup = await getSession(env.DB, sid, Date.now());
   if (!lookup) {
@@ -489,6 +610,16 @@ export default {
       }
       if (url.pathname === "/auth/whoami" && req.method === "GET") {
         return await handleWhoami(req, env, url.host);
+      }
+      if (url.pathname === "/auth/device-init" && req.method === "POST") {
+        return await handleDeviceInit(env);
+      }
+      const deviceMatch = url.pathname.match(/^\/auth\/device\/([^/]+)$/);
+      if (deviceMatch && req.method === "GET") {
+        return await handleDevicePoll(env, decodeURIComponent(deviceMatch[1]));
+      }
+      if (url.pathname === "/auth/sign-out" && req.method === "POST") {
+        return await handleSignOut(req, env, url.host);
       }
       return new Response("Not found", { status: 404 });
     } catch (err) {

--- a/server/src/auth-service.ts
+++ b/server/src/auth-service.ts
@@ -46,7 +46,6 @@ interface DevicePollSuccess {
 
 const AUTH_WORKER_BASE = process.env.OYSTER_AUTH_BASE ?? "https://oyster.to/auth";
 const POLL_INTERVAL_MS = 2_000;
-const POLL_MAX_AGE_MS = 10 * 60 * 1000; // matches device_code TTL on the Worker
 
 export type AuthChangedListener = (state: AuthState) => void;
 
@@ -70,12 +69,13 @@ export class AuthService {
     return () => this.listeners.delete(listener);
   }
 
-  // Kick off a sign-in flow. Returns the user_code so the UI can show
-  // a fallback ("Open https://oyster.to/auth/sign-in?d=ABCD-1234 if your
-  // browser didn't open") and the URL it tried to open. Idempotent: if
-  // there's already an active poll, abort the old one first so a stale
-  // device_code doesn't keep claiming the slot when the user retries.
-  async startSignIn(): Promise<{ user_code: string; sign_in_url: string }> {
+  // Kick off a sign-in flow. Returns the user_code, the URL the browser
+  // was directed to, and the expires_in window so the UI can run a
+  // matching client-side timeout (badge flips back to signed-out if the
+  // poll ages out without producing a session). Idempotent: an existing
+  // active poll is aborted first so a stale device_code doesn't keep
+  // claiming the slot when the user retries.
+  async startSignIn(): Promise<{ user_code: string; sign_in_url: string; expires_in: number }> {
     if (this.activePoll) {
       this.activePoll.abort.abort();
       this.activePoll = null;
@@ -83,8 +83,36 @@ export class AuthService {
     const init = await this.fetchJson<DeviceInitResponse>("/device-init", { method: "POST" });
     const signInUrl = `${AUTH_WORKER_BASE}/sign-in?d=${encodeURIComponent(init.user_code)}`;
     this.openBrowser(signInUrl);
-    this.beginPolling(init.device_code);
-    return { user_code: init.user_code, sign_in_url: signInUrl };
+    this.beginPolling(init.device_code, init.expires_in * 1000);
+    return { user_code: init.user_code, sign_in_url: signInUrl, expires_in: init.expires_in };
+  }
+
+  // Validate the persisted session against the cloud Worker. If the
+  // server was offline when the session was revoked elsewhere (sign-out
+  // on another device, manual D1 revoke), the local cache shows
+  // signed-in until next refresh — this catches that on startup.
+  // Network failure leaves the state alone (don't punish offline users
+  // by signing them out on every flaky boot).
+  async validatePersistedSession(): Promise<void> {
+    const token = this.state.sessionToken;
+    if (!token) return;
+    try {
+      const res = await fetch(`${AUTH_WORKER_BASE}/whoami`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      if (res.status === 401) {
+        console.warn("[auth] persisted session is no longer valid; clearing");
+        this.setState({ user: null, sessionToken: null, signedInAt: null });
+        try { if (existsSync(this.authJsonPath)) unlinkSync(this.authJsonPath); }
+        catch (err) { console.error("[auth] failed to delete auth.json:", err); }
+        return;
+      }
+      // 200 or any other status: leave state untouched. 5xx / network
+      // errors are handled the same as success here — we trust the disk
+      // cache until the Worker tells us otherwise (401).
+    } catch (err) {
+      console.error("[auth] startup whoami probe failed (offline?); keeping cached session:", err);
+    }
   }
 
   // Local sign-out: revoke on the cloud side (best-effort), then clear
@@ -97,14 +125,22 @@ export class AuthService {
     }
     if (token) {
       try {
-        await fetch(`${AUTH_WORKER_BASE}/sign-out`, {
+        const res = await fetch(`${AUTH_WORKER_BASE}/sign-out`, {
           method: "POST",
           headers: { authorization: `Bearer ${token}` },
         });
+        if (!res.ok) {
+          // Cloud reachable but rejected the call (5xx / 503 / DB
+          // transient). The local sign-out still completes, but the
+          // cloud row remains valid until validatePersistedSession()
+          // hits a 401 on next start. Log so it's visible in dev.
+          const detail = await res.text().catch(() => "");
+          console.error(`[auth] cloud sign-out non-ok ${res.status}: ${detail}`);
+        }
       } catch (err) {
-        // Cloud unreachable: revoke happens on the Worker side eventually
-        // when we next call /whoami. Local sign-out still completes.
-        console.error("[auth] cloud sign-out failed:", err);
+        // Cloud unreachable. Same caveat as the !res.ok branch — local
+        // sign-out completes, cloud cleanup deferred to next whoami probe.
+        console.error("[auth] cloud sign-out threw:", err);
       }
     }
     this.setState({ user: null, sessionToken: null, signedInAt: null });
@@ -156,14 +192,14 @@ export class AuthService {
     }
   }
 
-  private beginPolling(deviceCode: string): void {
+  private beginPolling(deviceCode: string, maxAgeMs: number): void {
     const abort = new AbortController();
     this.activePoll = { deviceCode, abort };
     const startedAt = Date.now();
 
     const tick = async (): Promise<void> => {
       if (abort.signal.aborted) return;
-      if (Date.now() - startedAt > POLL_MAX_AGE_MS) {
+      if (Date.now() - startedAt > maxAgeMs) {
         if (this.activePoll?.deviceCode === deviceCode) this.activePoll = null;
         return;
       }
@@ -212,12 +248,14 @@ export class AuthService {
 
   private openBrowser(url: string): void {
     // Best-effort. If the spawn fails (e.g. headless env), the UI still
-    // shows the user_code + URL for manual paste. Same pattern bin/oyster.mjs
-    // uses for opening localhost:4444 on first launch.
+    // shows the user_code + URL for manual paste. Windows note: `start`
+    // treats the first quoted argument as the window title — passing
+    // an empty title placeholder before the URL is the documented fix
+    // (otherwise the URL itself becomes the title and nothing opens).
     try {
       if (process.platform === "darwin") execSync(`open ${JSON.stringify(url)}`);
       else if (process.platform === "linux") execSync(`xdg-open ${JSON.stringify(url)}`);
-      else if (process.platform === "win32") execSync(`start ${JSON.stringify(url)}`);
+      else if (process.platform === "win32") execSync(`start "" ${JSON.stringify(url)}`);
     } catch {
       // ignored — user can paste the URL from the UI
     }

--- a/server/src/auth-service.ts
+++ b/server/src/auth-service.ts
@@ -1,0 +1,225 @@
+// Auth bridge between the local Oyster server and the cloud auth Worker.
+//
+// Flow (per docs/plans/auth.md):
+//   1. UI calls POST /api/auth/login.
+//   2. Service calls POST <AUTH_WORKER_BASE>/device-init → { device_code, user_code }.
+//   3. Service opens browser to <AUTH_WORKER_BASE>/sign-in?d=<user_code>.
+//   4. Service polls <AUTH_WORKER_BASE>/device/<device_code> every 2s.
+//   5. On 200 with { session_token, user }, persist to <CONFIG_DIR>/auth.json,
+//      emit auth_changed SSE so the UI re-fetches whoami.
+//   6. On 410 / timeout, give up silently — UI stays in signed-out state.
+//
+// State is cached in memory; auth.json is the durable source of truth on disk.
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+}
+
+export interface AuthState {
+  user: AuthUser | null;
+  sessionToken: string | null;
+  signedInAt: number | null;
+}
+
+interface PersistedAuth {
+  session_token: string;
+  user_id: string;
+  email: string;
+  signed_in_at: number;
+}
+
+interface DeviceInitResponse {
+  device_code: string;
+  user_code: string;
+  expires_in: number;
+}
+
+interface DevicePollSuccess {
+  session_token: string;
+  user: AuthUser;
+}
+
+const AUTH_WORKER_BASE = process.env.OYSTER_AUTH_BASE ?? "https://oyster.to/auth";
+const POLL_INTERVAL_MS = 2_000;
+const POLL_MAX_AGE_MS = 10 * 60 * 1000; // matches device_code TTL on the Worker
+
+export type AuthChangedListener = (state: AuthState) => void;
+
+export class AuthService {
+  private state: AuthState = { user: null, sessionToken: null, signedInAt: null };
+  private listeners = new Set<AuthChangedListener>();
+  private activePoll: { deviceCode: string; abort: AbortController } | null = null;
+  private readonly authJsonPath: string;
+
+  constructor(configDir: string) {
+    this.authJsonPath = join(configDir, "auth.json");
+    this.loadFromDisk();
+  }
+
+  getState(): AuthState {
+    return this.state;
+  }
+
+  onAuthChanged(listener: AuthChangedListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  // Kick off a sign-in flow. Returns the user_code so the UI can show
+  // a fallback ("Open https://oyster.to/auth/sign-in?d=ABCD-1234 if your
+  // browser didn't open") and the URL it tried to open. Idempotent: if
+  // there's already an active poll, abort the old one first so a stale
+  // device_code doesn't keep claiming the slot when the user retries.
+  async startSignIn(): Promise<{ user_code: string; sign_in_url: string }> {
+    if (this.activePoll) {
+      this.activePoll.abort.abort();
+      this.activePoll = null;
+    }
+    const init = await this.fetchJson<DeviceInitResponse>("/device-init", { method: "POST" });
+    const signInUrl = `${AUTH_WORKER_BASE}/sign-in?d=${encodeURIComponent(init.user_code)}`;
+    this.openBrowser(signInUrl);
+    this.beginPolling(init.device_code);
+    return { user_code: init.user_code, sign_in_url: signInUrl };
+  }
+
+  // Local sign-out: revoke on the cloud side (best-effort), then clear
+  // the local cache + auth.json. UI sees the SSE event and re-renders.
+  async signOut(): Promise<void> {
+    const token = this.state.sessionToken;
+    if (this.activePoll) {
+      this.activePoll.abort.abort();
+      this.activePoll = null;
+    }
+    if (token) {
+      try {
+        await fetch(`${AUTH_WORKER_BASE}/sign-out`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${token}` },
+        });
+      } catch (err) {
+        // Cloud unreachable: revoke happens on the Worker side eventually
+        // when we next call /whoami. Local sign-out still completes.
+        console.error("[auth] cloud sign-out failed:", err);
+      }
+    }
+    this.setState({ user: null, sessionToken: null, signedInAt: null });
+    try { if (existsSync(this.authJsonPath)) unlinkSync(this.authJsonPath); }
+    catch (err) { console.error("[auth] failed to delete auth.json:", err); }
+  }
+
+  // ── internals ──
+
+  private loadFromDisk(): void {
+    if (!existsSync(this.authJsonPath)) return;
+    try {
+      const raw = readFileSync(this.authJsonPath, "utf-8");
+      const parsed = JSON.parse(raw) as PersistedAuth;
+      if (typeof parsed.session_token !== "string" || typeof parsed.user_id !== "string" || typeof parsed.email !== "string") {
+        console.error("[auth] auth.json has unexpected shape; ignoring");
+        return;
+      }
+      this.state = {
+        user: { id: parsed.user_id, email: parsed.email },
+        sessionToken: parsed.session_token,
+        signedInAt: parsed.signed_in_at ?? null,
+      };
+    } catch (err) {
+      console.error("[auth] failed to read auth.json:", err);
+    }
+  }
+
+  private persistToDisk(): void {
+    if (!this.state.user || !this.state.sessionToken) return;
+    const payload: PersistedAuth = {
+      session_token: this.state.sessionToken,
+      user_id: this.state.user.id,
+      email: this.state.user.email,
+      signed_in_at: this.state.signedInAt ?? Date.now(),
+    };
+    try {
+      mkdirSync(dirname(this.authJsonPath), { recursive: true });
+      writeFileSync(this.authJsonPath, JSON.stringify(payload, null, 2), { mode: 0o600 });
+    } catch (err) {
+      console.error("[auth] failed to write auth.json:", err);
+    }
+  }
+
+  private setState(next: AuthState): void {
+    this.state = next;
+    for (const listener of this.listeners) {
+      try { listener(next); } catch (err) { console.error("[auth] listener threw:", err); }
+    }
+  }
+
+  private beginPolling(deviceCode: string): void {
+    const abort = new AbortController();
+    this.activePoll = { deviceCode, abort };
+    const startedAt = Date.now();
+
+    const tick = async (): Promise<void> => {
+      if (abort.signal.aborted) return;
+      if (Date.now() - startedAt > POLL_MAX_AGE_MS) {
+        if (this.activePoll?.deviceCode === deviceCode) this.activePoll = null;
+        return;
+      }
+      try {
+        const res = await fetch(`${AUTH_WORKER_BASE}/device/${encodeURIComponent(deviceCode)}`, {
+          signal: abort.signal,
+        });
+        if (res.status === 200) {
+          const body = await res.json() as DevicePollSuccess;
+          this.handleSignInSuccess(body);
+          if (this.activePoll?.deviceCode === deviceCode) this.activePoll = null;
+          return;
+        }
+        if (res.status === 410) {
+          // Code expired or already claimed — give up. UI stays signed-out.
+          if (this.activePoll?.deviceCode === deviceCode) this.activePoll = null;
+          return;
+        }
+        // 202 or transient error — keep polling.
+      } catch (err) {
+        if ((err as { name?: string }).name === "AbortError") return;
+        console.error("[auth] poll error:", err);
+      }
+      setTimeout(tick, POLL_INTERVAL_MS).unref?.();
+    };
+    setTimeout(tick, POLL_INTERVAL_MS).unref?.();
+  }
+
+  private handleSignInSuccess(body: DevicePollSuccess): void {
+    this.setState({
+      user: body.user,
+      sessionToken: body.session_token,
+      signedInAt: Date.now(),
+    });
+    this.persistToDisk();
+  }
+
+  private async fetchJson<T>(path: string, init: RequestInit): Promise<T> {
+    const res = await fetch(`${AUTH_WORKER_BASE}${path}`, init);
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`auth worker ${path} ${res.status}: ${detail}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  private openBrowser(url: string): void {
+    // Best-effort. If the spawn fails (e.g. headless env), the UI still
+    // shows the user_code + URL for manual paste. Same pattern bin/oyster.mjs
+    // uses for opening localhost:4444 on first launch.
+    try {
+      if (process.platform === "darwin") execSync(`open ${JSON.stringify(url)}`);
+      else if (process.platform === "linux") execSync(`xdg-open ${JSON.stringify(url)}`);
+      else if (process.platform === "win32") execSync(`start ${JSON.stringify(url)}`);
+    } catch {
+      // ignored — user can paste the URL from the UI
+    }
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -63,6 +63,7 @@ import {
   lastConnectedAt,
 } from "./mcp-client-tracker.js";
 import { SqliteFtsMemoryProvider } from "./memory-store.js";
+import { AuthService } from "./auth-service.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
 // ── Config ──
@@ -537,6 +538,17 @@ function resolveSpaceRow(name: string) {
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore);
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);
 await memoryProvider.init();
+
+// Auth bridge to oyster.to/auth/*. Reads ~/Oyster/config/auth.json on
+// startup so a previously-signed-in user is recognised across restarts.
+const authService = new AuthService(CONFIG_DIR);
+authService.onAuthChanged((state) => {
+  broadcastUiEvent({
+    version: 1,
+    command: "auth_changed",
+    payload: { user: state.user },
+  });
+});
 
 // ── Initialize subsystems ──
 
@@ -1521,6 +1533,35 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // `mcp_tool_called` events (connected-agent telemetry), which a
   // cross-origin page in the same browser must not be able to observe
   // by opening an EventSource against a running local Oyster.
+  if (url === "/api/auth/whoami" && req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return;
+    const state = authService.getState();
+    sendJson({ user: state.user });
+    return;
+  }
+  if (url === "/api/auth/login" && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return;
+    try {
+      const result = await authService.startSignIn();
+      sendJson(result);
+    } catch (err) {
+      console.error("[auth] /api/auth/login failed:", err);
+      sendJson({ error: "auth_unavailable" }, 503);
+    }
+    return;
+  }
+  if (url === "/api/auth/logout" && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return;
+    try {
+      await authService.signOut();
+      sendJson({ ok: true });
+    } catch (err) {
+      console.error("[auth] /api/auth/logout failed:", err);
+      sendJson({ error: "logout_failed" }, 500);
+    }
+    return;
+  }
+
   if (url === "/api/ui/events") {
     if (rejectIfNonLocalOrigin()) return;
     res.writeHead(200, {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -541,6 +541,9 @@ await memoryProvider.init();
 
 // Auth bridge to oyster.to/auth/*. Reads ~/Oyster/config/auth.json on
 // startup so a previously-signed-in user is recognised across restarts.
+// validatePersistedSession() then re-checks the cloud session in the
+// background — clears local state if the cloud reports 401 (revoked
+// elsewhere), keeps it if the cloud is unreachable.
 const authService = new AuthService(CONFIG_DIR);
 authService.onAuthChanged((state) => {
   broadcastUiEvent({
@@ -549,6 +552,7 @@ authService.onAuthChanged((state) => {
     payload: { user: state.user },
   });
 });
+void authService.validatePersistedSession();
 
 // ── Initialize subsystems ──
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { ViewerWindow } from "./components/ViewerWindow";
 import { TerminalWindow } from "./components/TerminalWindow";
 import { SpotlightSearch } from "./components/SpotlightSearch";
 import { OnboardingDock } from "./components/OnboardingDock";
+import { AuthBadge } from "./components/AuthBadge";
 import { windowsReducer } from "./stores/windows";
 import {
   type Artifact,
@@ -364,6 +365,7 @@ export default function App() {
 
   return (
     <div className="oyster-shell">
+      <AuthBadge />
       {!connected && (
         <div className="connection-banner">
           <span>Oyster server not connected</span>

--- a/web/src/components/AuthBadge.css
+++ b/web/src/components/AuthBadge.css
@@ -77,3 +77,27 @@
 .auth-badge__menu-item:hover {
   background: var(--icon-hover);
 }
+
+.auth-badge__cancel {
+  margin-top: 4px;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--glass-border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.auth-badge__cancel:hover {
+  color: var(--text);
+  background: var(--icon-hover);
+}
+
+.auth-badge__error {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #f87171;
+}

--- a/web/src/components/AuthBadge.css
+++ b/web/src/components/AuthBadge.css
@@ -1,0 +1,79 @@
+.auth-badge {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 5;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.auth-badge--pending {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 12px;
+  background: var(--window-chrome);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  max-width: 280px;
+}
+
+.auth-badge__hint {
+  color: var(--text);
+}
+
+.auth-badge__link {
+  color: var(--accent-bright);
+  text-decoration: none;
+  font-size: 11px;
+}
+
+.auth-badge__link:hover {
+  text-decoration: underline;
+}
+
+.auth-badge__chip {
+  font-family: inherit;
+  font-size: inherit;
+  padding: 6px 10px;
+  background: var(--window-chrome);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.auth-badge__chip:hover {
+  background: var(--icon-hover);
+}
+
+.auth-badge__menu {
+  margin-top: 4px;
+  background: var(--window-body);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  overflow: hidden;
+  min-width: 120px;
+}
+
+.auth-badge__menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.auth-badge__menu-item:hover {
+  background: var(--icon-hover);
+}

--- a/web/src/components/AuthBadge.css
+++ b/web/src/components/AuthBadge.css
@@ -1,7 +1,7 @@
 .auth-badge {
   position: absolute;
   top: 12px;
-  right: 16px;
+  left: 16px;
   z-index: 5;
   font-family: var(--font-mono);
   font-size: 12px;

--- a/web/src/components/AuthBadge.tsx
+++ b/web/src/components/AuthBadge.tsx
@@ -1,10 +1,10 @@
-// Top-right badge showing the signed-in account, with a single click
+// Top-left badge showing the signed-in account, with a single click
 // to start sign-in or sign out. Mounted at App-shell level so it sits
 // above any space's surface. Auth state syncs over SSE — the local
 // server emits `auth_changed` whenever the device-flow poll lands or
 // the user signs out.
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { subscribeUiEvents } from "../data/ui-events";
 import "./AuthBadge.css";
 
@@ -18,6 +18,7 @@ type Phase = "loading" | "signed-out" | "signing-in" | "signed-in";
 interface SignInPending {
   user_code: string;
   sign_in_url: string;
+  expires_in: number;
 }
 
 export function AuthBadge() {
@@ -25,6 +26,20 @@ export function AuthBadge() {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [pending, setPending] = useState<SignInPending | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+
+  // Client-side timeout that mirrors the device_code TTL on the Worker.
+  // Without it, the badge can stay stuck in `signing-in` indefinitely:
+  // the local server's poller goes silent on timeout/410 and never
+  // emits an auth_changed event (state didn't change — user is still
+  // null). The expires_in from /api/auth/login tells us how long to wait.
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearAbortTimeout = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
 
   // Initial whoami + SSE subscription. The server emits `auth_changed`
   // when the device-flow poll resolves or sign-out completes; we
@@ -39,6 +54,7 @@ export function AuthBadge() {
         if (cancelled) return;
         setUser(body.user);
         setPending(null);
+        clearAbortTimeout();
         setPhase(body.user ? "signed-in" : "signed-out");
       } catch {
         if (cancelled) return;
@@ -52,33 +68,63 @@ export function AuthBadge() {
     return () => {
       cancelled = true;
       unsub();
+      clearAbortTimeout();
     };
   }, []);
 
   const handleSignIn = async () => {
+    // If a previous flow is still pending, restart cleanly. The local
+    // server's startSignIn() also aborts the old poll on its end.
+    clearAbortTimeout();
     setPhase("signing-in");
     setPending(null);
+    setSignOutError(null);
     try {
       const res = await fetch("/api/auth/login", { method: "POST" });
       if (!res.ok) throw new Error(String(res.status));
       const body = (await res.json()) as SignInPending;
       setPending(body);
+      // Mirror the server-side device_code TTL on the client. If the
+      // poll ages out or the cloud 410s, no auth_changed event will
+      // fire; this timer is what flips the UI back to signed-out.
+      timeoutRef.current = setTimeout(() => {
+        setPhase("signed-out");
+        setPending(null);
+      }, body.expires_in * 1000);
     } catch (err) {
       console.error("[auth] login failed:", err);
       setPhase("signed-out");
     }
   };
 
+  const handleCancelSignIn = () => {
+    clearAbortTimeout();
+    setPending(null);
+    setPhase("signed-out");
+  };
+
   const handleSignOut = async () => {
     setMenuOpen(false);
+    setSignOutError(null);
     try {
-      await fetch("/api/auth/logout", { method: "POST" });
+      const res = await fetch("/api/auth/logout", { method: "POST" });
+      if (!res.ok) {
+        // Local server failed to sign out (cloud unreachable / D1
+        // transient). Don't flip the UI — the user is still signed in
+        // as far as the system is concerned. Show an error so they can
+        // retry rather than silently leaving them in an inconsistent
+        // state until reload.
+        setSignOutError("Sign-out failed. Try again.");
+        console.error("[auth] logout returned", res.status);
+        return;
+      }
     } catch (err) {
+      setSignOutError("Sign-out failed. Try again.");
       console.error("[auth] logout failed:", err);
+      return;
     }
-    // Auth-changed SSE will pull state back, but pre-emptively flip the
-    // UI so the menu doesn't sit on the screen with stale info while
-    // we wait for the round-trip.
+    // The server emits auth_changed on success; pre-emptively flip the
+    // UI so the menu doesn't sit on stale info while the SSE round-trips.
     setUser(null);
     setPhase("signed-out");
   };
@@ -90,16 +136,26 @@ export function AuthBadge() {
   if (phase === "signing-in" && pending) {
     return (
       <div className="auth-badge auth-badge--pending">
-        <span className="auth-badge__hint">Check your email — sign-in link sent.</span>
+        <span className="auth-badge__hint">Sign-in opened in a new tab — enter your email there.</span>
         <a className="auth-badge__link" href={pending.sign_in_url} target="_blank" rel="noreferrer">
           Or open the sign-in page manually
         </a>
+        <button type="button" className="auth-badge__cancel" onClick={handleCancelSignIn}>
+          Cancel
+        </button>
       </div>
     );
   }
 
   if (phase === "signing-in") {
-    return <div className="auth-badge auth-badge--pending"><span>Starting sign-in…</span></div>;
+    return (
+      <div className="auth-badge auth-badge--pending">
+        <span>Starting sign-in…</span>
+        <button type="button" className="auth-badge__cancel" onClick={handleCancelSignIn}>
+          Cancel
+        </button>
+      </div>
+    );
   }
 
   if (phase === "signed-in" && user) {
@@ -121,6 +177,7 @@ export function AuthBadge() {
             </button>
           </div>
         )}
+        {signOutError && <div className="auth-badge__error">{signOutError}</div>}
       </div>
     );
   }

--- a/web/src/components/AuthBadge.tsx
+++ b/web/src/components/AuthBadge.tsx
@@ -1,0 +1,135 @@
+// Top-right badge showing the signed-in account, with a single click
+// to start sign-in or sign out. Mounted at App-shell level so it sits
+// above any space's surface. Auth state syncs over SSE — the local
+// server emits `auth_changed` whenever the device-flow poll lands or
+// the user signs out.
+
+import { useEffect, useState } from "react";
+import { subscribeUiEvents } from "../data/ui-events";
+import "./AuthBadge.css";
+
+interface AuthUser {
+  id: string;
+  email: string;
+}
+
+type Phase = "loading" | "signed-out" | "signing-in" | "signed-in";
+
+interface SignInPending {
+  user_code: string;
+  sign_in_url: string;
+}
+
+export function AuthBadge() {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [pending, setPending] = useState<SignInPending | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Initial whoami + SSE subscription. The server emits `auth_changed`
+  // when the device-flow poll resolves or sign-out completes; we
+  // refetch the canonical state rather than trusting the payload.
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const res = await fetch("/api/auth/whoami");
+        if (!res.ok) throw new Error(String(res.status));
+        const body = (await res.json()) as { user: AuthUser | null };
+        if (cancelled) return;
+        setUser(body.user);
+        setPending(null);
+        setPhase(body.user ? "signed-in" : "signed-out");
+      } catch {
+        if (cancelled) return;
+        setPhase("signed-out");
+      }
+    };
+    refresh();
+    const unsub = subscribeUiEvents((event) => {
+      if (event.command === "auth_changed") refresh();
+    });
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, []);
+
+  const handleSignIn = async () => {
+    setPhase("signing-in");
+    setPending(null);
+    try {
+      const res = await fetch("/api/auth/login", { method: "POST" });
+      if (!res.ok) throw new Error(String(res.status));
+      const body = (await res.json()) as SignInPending;
+      setPending(body);
+    } catch (err) {
+      console.error("[auth] login failed:", err);
+      setPhase("signed-out");
+    }
+  };
+
+  const handleSignOut = async () => {
+    setMenuOpen(false);
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } catch (err) {
+      console.error("[auth] logout failed:", err);
+    }
+    // Auth-changed SSE will pull state back, but pre-emptively flip the
+    // UI so the menu doesn't sit on the screen with stale info while
+    // we wait for the round-trip.
+    setUser(null);
+    setPhase("signed-out");
+  };
+
+  if (phase === "loading") {
+    return null; // avoid a flash of "Sign in" before whoami resolves
+  }
+
+  if (phase === "signing-in" && pending) {
+    return (
+      <div className="auth-badge auth-badge--pending">
+        <span className="auth-badge__hint">Check your email — sign-in link sent.</span>
+        <a className="auth-badge__link" href={pending.sign_in_url} target="_blank" rel="noreferrer">
+          Or open the sign-in page manually
+        </a>
+      </div>
+    );
+  }
+
+  if (phase === "signing-in") {
+    return <div className="auth-badge auth-badge--pending"><span>Starting sign-in…</span></div>;
+  }
+
+  if (phase === "signed-in" && user) {
+    return (
+      <div className="auth-badge">
+        <button
+          type="button"
+          className="auth-badge__chip"
+          onClick={() => setMenuOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+        >
+          {user.email}
+        </button>
+        {menuOpen && (
+          <div className="auth-badge__menu" role="menu">
+            <button type="button" className="auth-badge__menu-item" onClick={handleSignOut}>
+              Sign out
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="auth-badge">
+      <button type="button" className="auth-badge__chip" onClick={handleSignIn}>
+        Sign in
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Final of three PRs delivering #295. This closes the issue.

PR 1 (#337) shipped the schema + Worker scaffold. PR 2 (#338) shipped magic-link send/verify + cookie + browser whoami. This PR ties it to the local Oyster app via the OAuth 2.0 device authorization grant pattern (RFC 8628 — same shape as `gh auth login` / `stripe login`).

## Summary

**Worker side** (`infra/auth-worker/src/worker.ts`)
- `POST /auth/device-init` — issues a 32-char opaque `device_code` and an 8-char `XXXX-XXXX` user-readable `user_code`. 10-min TTL. Used the confusable-free base32 alphabet (no I/L/O/0/1) so the user code is robust against mis-reads.
- `GET /auth/device/<device_code>` — atomic claim via single conditional UPDATE+RETURNING. 202 pending, 200 with `{session_token, user}` on claim, 410 thereafter or on expiry. Race-free: a code can be claimed exactly once.
- `POST /auth/sign-out` — revokes the session, clears the cookie. Accepts cookie OR `Authorization: Bearer` so the local server can call it with its stored token. `GET /auth/whoami` also accepts Bearer for symmetry.

**Local server** (`server/src/auth-service.ts`, `index.ts`)
- `AuthService` class. Reads `~/Oyster/config/auth.json` on startup, so a previously-signed-in user is recognised across restarts. Persists on poll success with `0o600` mode.
- Three new local routes: `GET /api/auth/whoami`, `POST /api/auth/login` (kicks off device flow + opens browser), `POST /api/auth/logout`.
- Emits `auth_changed` on the existing UI SSE channel whenever state changes. The web UI refetches the canonical state rather than trusting the payload.

**Web UI** (`web/src/components/AuthBadge.{tsx,css}`)
- Top-right corner badge mounted at App-shell level so it sits above any space's surface.
- Three visible states: **signed-out** (Sign in button), **signing-in** (check-your-email hint + fallback link to the sign-in URL in case the auto-open browser failed), **signed-in** (email chip with a Sign out menu).
- Subscribes to the existing shared `EventSource` so it doesn't open a second SSE connection.

## End-to-end flow

```
click Sign in
  → POST /api/auth/login
  → server hits oyster.to/auth/device-init, gets {device_code, user_code}
  → server opens browser to oyster.to/auth/sign-in?d=<user_code>
  → server starts polling oyster.to/auth/device/<device_code> every 2s
user enters email, clicks magic link
  → /auth/verify creates session, attaches it to device_codes
local poller claims session_token
  → server writes ~/Oyster/config/auth.json (mode 0o600)
  → broadcasts auth_changed via SSE
  → AuthBadge refetches, flips to email + Sign out menu
```

## Verify

**Worker re-deploy required** — three new endpoints land on `oyster.to/auth/*`:

```bash
cd ~/Dev/oyster-os.worktrees/0.7.0-auth-bridge/infra/auth-worker
npm run deploy
```

**Local server restart** — `auth-service.ts` only initialises on startup:

```bash
cd ~/Dev/oyster-os.worktrees/0.7.0-auth-bridge
npm run dev
# Open http://localhost:7337
# Click "Sign in" in the top-right
# Browser opens oyster.to/auth/sign-in?d=BHRT-9KQ2 (or similar)
# Enter your email → check inbox → click link → land on /auth/welcome
# Within ~2s the local badge flips to your email
```

`~/Oyster/config/auth.json` should now contain the persisted session. Restart `npm run dev`; the badge should still show signed-in (no new email round-trip).

Sign out from the badge dropdown — `auth.json` is deleted, the cloud session is revoked (`sessions.revoked_at` set), the badge flips back to "Sign in".

## CHANGELOG

First user-visible Cloud bullet in 0.7.0:

> **Sign in to Oyster.** A free account in three clicks — enter email, click the link, you're signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0.

## Test plan

- [ ] Worker deploys cleanly. `curl -X POST https://oyster.to/auth/device-init` returns `{device_code, user_code, expires_in}`.
- [ ] First-time sign-in: badge → email enter → magic link → badge flips to email within ~2s.
- [ ] Auth survives a server restart (auth.json persists).
- [ ] Sign-out: cloud session is revoked (`/auth/whoami` returns 401 from a browser with the old cookie); auth.json is removed; badge resets.
- [ ] If the browser doesn't auto-open, the "Or open the sign-in page manually" fallback link works.
- [ ] Re-clicking Sign in mid-flow aborts the prior poll cleanly (no orphan device_codes claim).
- [ ] Wrong email / network drop during polling doesn't crash; badge stays in signing-in until the 10-min poll TTL.

## Anchor docs

- `docs/requirements/oyster-cloud.md` — R5
- `docs/plans/auth.md` — design (PR 1/2/3 sequencing in "Sequencing inside #295")
- `docs/plans/roadmap.md` — 0.7.0

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)