### PR TITLE
fix(inspector): artefact click opens viewer on top, panel stays behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Sign in to Oyster.** A free account in three clicks — enter email, click the link, you're signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. ([#295](https://github.com/mattslight/oyster/issues/295))
 
+### Fixed
+
+- **Clicking an artefact in the session inspector** now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.
+
 ## [0.6.0] - 2026-05-02
 
 Trustworthy recall — every memory traceable, every conversation searchable.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -328,6 +328,10 @@
 <ul>
 <li><strong>Sign in to Oyster.</strong> A free account in three clicks — enter email, click the link, you&#39;re signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish &amp; share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. (<a href="https://github.com/mattslight/oyster/issues/295" rel="noopener noreferrer">#295</a>)</li>
 </ul>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Clicking an artefact in the session inspector</strong> now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.</li>
+</ul>
 <h2 id="v-0-6-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0...v0.6.0" rel="noopener noreferrer"><span class="release-version">0.6.0</span></a><span class="release-date"> — 2026-05-02</span></h2>
 <p>Trustworthy recall — every memory traceable, every conversation searchable.</p>
 <h3>Added</h3>

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1415,8 +1415,9 @@ body {
 .confirm-modal-overlay {
   position: fixed;
   inset: 0;
-  /* Sits above everything — chat bar (900), spotlight (200), viewer windows
-     (1000), tooltips (9999). Modal dialogs must beat all of them. */
+  /* Sits above everything — chat bar (90), inspector (4999/5000), viewer
+     windows (5100), spotlight (5500), tooltips (9999). Modal dialogs must
+     beat all of them. */
   z-index: 10000;
   background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(8px);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1110,7 +1110,12 @@ body {
   inset: 0;
   bottom: 0;
   pointer-events: none;
-  z-index: 100;
+  /* Above inspector panel (5000) so opening a file from the session
+     inspector lifts the viewer onto the foreground without forcing the
+     panel to close. Stays below Spotlight (5500) and ConfirmModal
+     (10000). pointer-events:none on the layer means clicks fall through
+     to the inspector backdrop where no viewer covers it. */
+  z-index: 5100;
 }
 
 .windows-layer > div {

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -1082,6 +1082,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             focusEventId={activePanel.focusEventId}
             initialSearchQuery={activePanel.initialSearchQuery}
             onSwitchTo={setActivePanel}
+            onOpenArtefact={(a) => desktopProps.onArtifactClick(a)}
             onClose={() => setActivePanel(null)}
             onNotFound={() => {
               setActivePanel(null);

--- a/web/src/components/InspectorPanel.css
+++ b/web/src/components/InspectorPanel.css
@@ -5,7 +5,9 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
-  /* Above ChatBar (90), viewer windows (1000); below ConfirmModal (10000). */
+  /* Above ChatBar (90); below viewer windows (5100), Spotlight (5500),
+     ConfirmModal (10000). Viewer sits above so an artefact opened from
+     the inspector layers on top of the panel. */
   z-index: 4999;
 }
 .inspector-backdrop.open {

--- a/web/src/components/SessionInspector.tsx
+++ b/web/src/components/SessionInspector.tsx
@@ -19,6 +19,7 @@ import type {
 } from "../data/sessions-api";
 import { KindThumb } from "./KindThumb";
 import type { ActivePanel } from "./InspectorPanel";
+import type { Artifact } from "../data/artifacts-api";
 
 interface Props {
   sessionId: string;
@@ -33,6 +34,11 @@ interface Props {
    *  (#332). */
   initialSearchQuery?: string;
   onSwitchTo: (next: ActivePanel) => void;
+  /** Open an artefact directly in the file viewer (closes this panel).
+   *  Clicking an artefact in the Artefacts tab routes here rather than
+   *  through the ArtefactInspector — users want the file, not a metadata
+   *  sidebar on top of a metadata sidebar. */
+  onOpenArtefact: (artefact: Artifact) => void;
   onClose: () => void;
   onNotFound: () => void;
 }
@@ -100,7 +106,7 @@ function saveVisibleCategories(set: Set<RoleCategory>) {
   } catch { /* ignore */ }
 }
 
-export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, onSwitchTo, onClose, onNotFound }: Props) {
+export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, onSwitchTo, onOpenArtefact, onClose, onNotFound }: Props) {
   const [session, setSession] = useState<Session | null>(null);
   const [events, setEvents] = useState<SessionEvent[] | null>(null);
   const [artefacts, setArtefacts] = useState<SessionArtifactJoined[] | null>(null);
@@ -334,6 +340,7 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
         focusEventId={focusEventId}
         initialSearchQuery={initialSearchQuery}
         onSwitchTo={onSwitchTo}
+        onOpenArtefact={onOpenArtefact}
         sessionId={sessionId}
         agent={session.agent}
         hasMoreOlder={hasMoreOlder}
@@ -354,7 +361,7 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
  */
 function TranscriptBody({
   tab, events, artefacts, memory, memoryError, focusEventId, initialSearchQuery,
-  onSwitchTo, sessionId, agent, hasMoreOlder, loadingOlder, onLoadOlder,
+  onSwitchTo, onOpenArtefact, sessionId, agent, hasMoreOlder, loadingOlder, onLoadOlder,
 }: {
   tab: Tab;
   events: SessionEvent[] | null;
@@ -364,6 +371,7 @@ function TranscriptBody({
   focusEventId: number | undefined;
   initialSearchQuery: string | undefined;
   onSwitchTo: (next: ActivePanel) => void;
+  onOpenArtefact: (artefact: Artifact) => void;
   sessionId: string;
   agent: SessionAgent;
   hasMoreOlder: boolean;
@@ -650,7 +658,7 @@ function TranscriptBody({
             />
           </>
         )}
-        {tab === "artefacts" && <Artefacts items={artefacts} onSwitchTo={onSwitchTo} />}
+        {tab === "artefacts" && <Artefacts items={artefacts} onOpenArtefact={onOpenArtefact} />}
         {tab === "memory" && <MemoryTab memory={memory} memoryError={memoryError} onSwitchTo={onSwitchTo} sessionId={sessionId} />}
       </div>
       {tab === "transcript" && showScrollBottom && (
@@ -1209,10 +1217,10 @@ function dedupeTouches(items: SessionArtifactJoined[]): SessionArtifactJoined[] 
 }
 
 function Artefacts({
-  items, onSwitchTo,
+  items, onOpenArtefact,
 }: {
   items: SessionArtifactJoined[] | null;
-  onSwitchTo: (next: ActivePanel) => void;
+  onOpenArtefact: (artefact: Artifact) => void;
 }) {
   if (items === null) return <div className="inspector-empty">Loading artefacts…</div>;
   const deduped = dedupeTouches(items);
@@ -1226,7 +1234,7 @@ function Artefacts({
           type="button"
           key={item.artifact.id}
           className="link-row"
-          onClick={() => onSwitchTo({ kind: "artefact", id: item.artifact.id })}
+          onClick={() => onOpenArtefact(item.artifact)}
         >
           <KindThumb kind={item.artifact.artifactKind} />
           <div className="link-body">

--- a/web/src/components/SessionInspector.tsx
+++ b/web/src/components/SessionInspector.tsx
@@ -34,7 +34,9 @@ interface Props {
    *  (#332). */
   initialSearchQuery?: string;
   onSwitchTo: (next: ActivePanel) => void;
-  /** Open an artefact directly in the file viewer (closes this panel).
+  /** Open an artefact directly in the file viewer. The session inspector
+   *  stays mounted behind the viewer (windows-layer renders above
+   *  inspector-panel) so the user returns to it when the viewer closes.
    *  Clicking an artefact in the Artefacts tab routes here rather than
    *  through the ArtefactInspector — users want the file, not a metadata
    *  sidebar on top of a metadata sidebar. */


### PR DESCRIPTION
## Summary

- Clicking an artefact in the session inspector's Artefacts tab now opens the file viewer directly. Previously it swapped the panel to the ArtefactInspector (a metadata-only sidebar) — a forced waypoint that closed out the session you were reading mid-thought.
- The viewer layers on top of the inspector + backdrop (`windows-layer` z-index 100 → 5100, still below Spotlight 5500 and ConfirmModal 10000) so the panel stays open behind it instead of being collapsed.
- `SessionArtifactJoined` already carries the full `Artifact` row, so the click goes straight to `desktopProps.onArtifactClick(a)` (same handler as Home tile clicks) — no resolution roundtrip and no cross-space lookup edge case.

The Home grid → ArtefactInspector path is unchanged: that one is still reachable when a user wants metadata + linked sessions deliberately.

## Test plan

- [x] Build clean (`npm run build`)
- [x] Manual: session inspector → Artefacts tab → click an artefact → file viewer opens on top, inspector visible behind
- [x] Manual: closing the viewer leaves you in the session inspector, exactly where you were
- [x] Regression: clicking an artefact tile from Home still opens the ArtefactInspector (unchanged path)
- [x] Regression: Spotlight (Cmd+K) still renders above the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)