### PR TITLE
docs(plans): OAuth design — GitHub primary, Google deferred

### DIFF
--- a/docs/plans/auth-oauth.md
+++ b/docs/plans/auth-oauth.md
@@ -1,0 +1,315 @@
+# Auth: OAuth (GitHub primary, Google deferred)
+
+> **Status:** canonical for 0.7.0 OAuth work (#340). Supplements [`auth.md`](./auth.md), which covers the magic-link substrate (#336/#337/#338/#339). When this doc and `auth.md` disagree on the OAuth path, this doc wins; `auth.md` remains canonical for magic-link. If a requirement in [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md) and this doc conflict, the requirement wins.
+
+## Decision
+
+OAuth via the existing `oyster-auth` Cloudflare Worker on `oyster.to`. **GitHub** is the only provider for 0.7.0; Google is deferred to a follow-up issue. **Magic-link stays as a secondary fallback** for users without a GitHub account or who prefer email.
+
+Identity is resolved through a new `user_identities` table keyed on `(provider, provider_user_id)` — provider IDs are stable across email changes, email is not. The local Oyster app's existing sign-in handoff (`device-init` → `?d=<user_code>` → poll, shipped in #339) is reused unchanged; OAuth is the *inner* loop, not a replacement.
+
+## User-facing description
+
+> Sign in with GitHub. Oyster opens your browser, you authorise, and Oyster signs in.
+
+Three clicks: Sign in (in Oyster) → Continue with GitHub (in browser) → Authorise (on GitHub). No inbox, no codes.
+
+```
+Local Oyster (UNCHANGED — shipped in #339):
+  POST oyster.to/auth/device-init       → { device_code, user_code }
+  open browser to oyster.to/auth/sign-in?d=<user_code>
+  poll oyster.to/auth/device/<device_code> until session attaches
+
+oyster.to/auth/sign-in?d=<user_code>:
+  Primary CTA: "Continue with GitHub" (NEW)
+  Fallback below a divider: existing email form (UNCHANGED)
+
+NEW: Continue with GitHub →
+  GET /auth/github/start?d=<user_code>
+    Validate ?d=<user_code> if present — fail closed if invalid
+    Generate state + PKCE verifier, store in oauth_states
+    302 to https://github.com/login/oauth/authorize?...
+
+GitHub consent → Authorise → 302 back:
+  GET /auth/github/callback?code=...&state=...
+    Validate + atomic-consume state row
+    Exchange code at GitHub token endpoint (PKCE verifier round-trips)
+    Fetch GitHub /user + /user/emails (user:email scope)
+    Pick the email row where primary && verified — fail closed otherwise
+    Resolve identity (rules below)
+    Create session, attach to device_codes row if user_code was set
+    Render WELCOME_HTML
+
+Local server poll picks up the attached session; writes ~/Oyster/config/auth.json.
+```
+
+## Why cloud-first (and not local-only OAuth)
+
+A simpler-on-paper alternative — OAuth callback registered to `localhost:4444/auth/github/callback`, session in local SQLite — was considered and rejected. The same `oyster_session` cookie this flow sets later powers (a) the publish/share UI on oyster.to, (b) the public viewer (#316) in sign-in mode, (c) cloud memory store reads in 0.8.0, (d) any future synced-docs surface. Local-only OAuth would force a second sign-in (and a second auth implementation) the moment any cloud-side gate ships. The dual-surface property is the reason auth lives on `oyster.to` at all.
+
+## D1 schema delta
+
+Two new tables, both in `0002_oauth.sql`. Existing tables (`users`, `sessions`, `device_codes`, `magic_link_tokens`) unchanged.
+
+```sql
+CREATE TABLE IF NOT EXISTS user_identities (
+  provider           TEXT NOT NULL,                  -- 'github' (later: 'google')
+  provider_user_id   TEXT NOT NULL,                  -- GitHub's stable numeric id, as text
+  user_id            TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider_email     TEXT,                           -- informational; current verified primary email
+  linked_at          INTEGER NOT NULL,               -- unix ms
+  last_seen_at       INTEGER NOT NULL,               -- unix ms; bumped per sign-in
+  PRIMARY KEY (provider, provider_user_id)
+);
+CREATE INDEX IF NOT EXISTS user_identities_user ON user_identities(user_id);
+
+CREATE TABLE IF NOT EXISTS oauth_states (
+  state              TEXT PRIMARY KEY,               -- 32-byte base64url, single-use CSRF token
+  provider           TEXT NOT NULL,
+  pkce_verifier      TEXT NOT NULL,                  -- 43-char base64url, S256-only
+  user_code          TEXT,                           -- nullable; ties this flow to a local-sign-in handoff
+  created_at         INTEGER NOT NULL,
+  expires_at         INTEGER NOT NULL,               -- 5 min from created_at
+  consumed_at        INTEGER                         -- set on /callback; replay defence
+);
+```
+
+`(provider, provider_user_id)` is the natural key. GitHub's user `id` (numeric) is stable across email and username changes; email is not, which is why STEP 1 of identity resolution reads provider_user_id and never email.
+
+`ON DELETE CASCADE` is enforceable on D1 — Cloudflare's docs confirm foreign-key enforcement is on by default (equivalent to SQLite's `PRAGMA foreign_keys = on`). The escape hatch for migrations that need to bypass FKs is `PRAGMA defer_foreign_keys = on`; not relevant here, this migration is purely additive.
+
+`oauth_states.consumed_at` provides server-side replay defence that a stateless signed cookie couldn't.
+
+## Worker endpoints
+
+### `GET /auth/github/start?d=<user_code>`
+
+1. Per-IP gate via the existing `MAGIC_LINK_LIMIT` binding (shared 20/hour bucket with `/magic-link` and `/device-init` — auth-attempt surface is one budget).
+2. **If `?d=` is present, validate before going further.** Look up `device_codes` by `user_code`. Fail closed (the "Sign-in request expired" page) if the row doesn't exist, has expired, has `session_id IS NOT NULL`, or has `claimed_at IS NOT NULL`. Saves a wasted GitHub round-trip when the handoff is already dead. If `?d=` is absent, this validation is skipped — cloud-only sign-in is allowed.
+3. Generate `state` (32-byte base64url) and `pkce_verifier` (43-char base64url, S256).
+4. Insert `oauth_states` row.
+5. 302 to:
+   ```
+   https://github.com/login/oauth/authorize
+     ?client_id=<GITHUB_OAUTH_CLIENT_ID>
+     &redirect_uri=https://oyster.to/auth/github/callback
+     &scope=user:email
+     &state=<state>
+     &code_challenge=<base64url(sha256(verifier))>
+     &code_challenge_method=S256
+     &allow_signup=true
+   ```
+6. `Cache-Control: no-store`.
+
+### `GET /auth/github/callback?code=...&state=...`
+
+1. **Validate + atomic-consume state.** Single statement, mirroring the existing `handleVerify` pattern:
+   ```sql
+   UPDATE oauth_states
+      SET consumed_at = ?
+    WHERE state = ? AND consumed_at IS NULL AND expires_at > ?
+    RETURNING provider, pkce_verifier, user_code
+   ```
+   No row returned (missing / already consumed / expired) → 400 with the "Sign-in request expired" page. Two concurrent callbacks for the same `state` cannot both pass: only one sees the `RETURNING` row.
+2. **Exchange code at GitHub token endpoint.** `POST https://github.com/login/oauth/access_token` with `client_id`, `client_secret`, `code`, `redirect_uri`, `code_verifier`. Header `Accept: application/json` so the response is JSON. Non-200 or missing `access_token` → 502 generic error page.
+3. **Fetch identity.**
+   - `GET https://api.github.com/user` (`Authorization: Bearer <access_token>`, `User-Agent: oyster-auth`) → `{ id, login, ... }`. The numeric `id` is `provider_user_id`.
+   - `GET https://api.github.com/user/emails` → array of `{ email, primary, verified, visibility }`. Pick the entry where `primary && verified`. **No match → fail closed** with the verified-email error page (specific copy below). Discard the access token after this — we don't need it again.
+4. **Resolve identity** (rules below). Output: a `user_id`.
+5. **Create session, attach, render.** Mirrors `handleVerify`:
+   - Insert into `sessions`, bump `users.last_seen_at` (batched).
+   - If `oauth_states.user_code` was set: atomic `UPDATE device_codes SET session_id = ? WHERE device_code = ? AND session_id IS NULL AND expires_at > now`. If `meta.changes !== 1`, the row TTL'd during the OAuth round-trip — render "Sign-in request expired". (The session row in `sessions` stays valid; the user is signed in for the browser cookie. The error page tells them to retry from the local app.)
+   - Set `oyster_session` cookie via the existing `sessionCookie()` helper.
+   - Render `WELCOME_HTML(email, deviceLogin)` — same component, no fork. `deviceLogin = oauth_states.user_code !== null`.
+
+All callback responses set `Cache-Control: no-store`. Cookie shape (Domain, Secure, HttpOnly, SameSite=Lax, Max-Age) is identical to magic-link verify — same helper, same cookie name.
+
+### Where this lives
+
+All four handlers + helpers go in `infra/auth-worker/src/worker.ts`. Two new pathname matches in the existing router. Roughly +200 LOC. No new files in the Worker.
+
+### No new bindings, no local-server changes
+
+Two new env entries: `GITHUB_OAUTH_CLIENT_ID` (in `[vars]`) and `GITHUB_OAUTH_CLIENT_SECRET` (via `wrangler secret put`). No new D1 bindings, no new rate-limit bindings. Local Oyster (`server/`, `web/`) is untouched — `AuthService` already speaks only to `/auth/device-init`, `/auth/sign-in?d=...`, and `/auth/device/<code>`, none of which know or care which provider produced the session.
+
+## Identity resolution
+
+Run on every successful `/callback` after token exchange and verified-primary-email pick. Inputs: `provider = 'github'`, `provider_user_id` (GitHub's numeric id, stringified), `provider_email` (the picked verified primary, lowercased).
+
+```
+STEP 1 — identity match (provider_user_id is the truth)
+  SELECT user_id FROM user_identities
+   WHERE provider = 'github' AND provider_user_id = ?
+
+  HIT → user_id is the answer.
+        UPDATE user_identities
+           SET provider_email = ?, last_seen_at = now
+         WHERE provider = 'github' AND provider_user_id = ?;
+        try UPDATE users SET email = ?, last_seen_at = now WHERE id = ?
+          → UNIQUE violation on email (another users row owns it):
+              keep users.email unchanged
+              log structured event { kind: 'oauth_email_conflict',
+                                     user_id, conflicting_user_id,
+                                     attempted_email, kept_email }
+              proceed with the sign-in (no automatic merge)
+          → success: users.email is now the current verified primary GitHub email,
+                    closing the magic-link footgun for this user from now on.
+        Skip to STEP 4.
+
+STEP 2 — first-time link, email match (only path that reads provider_email)
+  SELECT id FROM users WHERE email = ?     -- COLLATE NOCASE on the column
+
+  HIT → user_id is that row.
+        INSERT INTO user_identities
+          (provider, provider_user_id, user_id, provider_email, linked_at, last_seen_at)
+          VALUES ('github', ?, ?, ?, now, now);
+        Skip to STEP 4.
+
+STEP 3 — first-time link, no existing user
+  INSERT INTO users (id, email, created_at, last_seen_at) VALUES (newUlid(), ?, now, now);
+  INSERT INTO user_identities (...);
+  Continue to STEP 4.
+
+STEP 4 — done; return user_id to /callback (which creates the session).
+```
+
+### Properties
+
+- **Email change is safe.** A returning user changes their GitHub email; STEP 1 hits on `provider_user_id`, returns the same `user_id`, *and* updates `users.email` to the new one (with the conflict guard). Their existing artefacts/memory stay attached.
+- **Existing magic-link users get linked, not duplicated.** A user who signed up by email and later clicks "Continue with GitHub" hits STEP 2: same `users.id` row, new `user_identities` row attached. No data migration, no duplicate account.
+- **Unverified email never creates a user.** STEP 3 is only reachable after STEP 2 missed; STEP 2 reads only the email returned under the `primary && verified` rule. If GitHub returned no such email, the callback already failed before resolution started.
+- **Multiple GitHub accounts on one Oyster user is allowed when they share the same verified primary email at link time.** STEP 2 attaches the second identity to the existing `users` row; both `(provider, provider_user_id)` rows resolve to the same `user_id`. Same human, two GitHub accounts.
+
+### Concurrency
+
+Two simultaneous first-link sign-ins for the same email are vanishingly unlikely. Schema handles it: `users.email` has `UNIQUE COLLATE NOCASE`, so the second `INSERT INTO users` errors; we catch and re-run STEP 2 (now a hit). `user_identities` similarly has `PRIMARY KEY (provider, provider_user_id)`. INSERT-or-fall-through retry around STEP 3 — three attempts max, same shape as the existing `randomUserCode` collision retry in `handleDeviceInit`. After three retries: 503 with "Sign-in failed. Please try again."
+
+### Known limitation: stale-email window
+
+Between the moment a user changes their GitHub primary email and their next OAuth sign-in, `users.email` is stale. Someone who acquires the old address could sign in via magic-link during that window. Closing this fully would require GitHub email-change webhooks or revalidating on every magic-link send (which would cripple the magic-link path). For 0.7.0 we accept the window. Documented; not blocking.
+
+## Sign-in page
+
+The existing `SIGN_IN_HTML(userCode)` in `worker.ts` grows a button row above the email form.
+
+```
+┌──────────────────────────────┐
+│  Sign in to Oyster           │
+│                              │
+│  ┌────────────────────────┐  │   ← primary CTA
+│  │  ▶ Continue with GitHub│  │     full-width <a href>, GitHub mark glyph
+│  └────────────────────────┘  │
+│                              │
+│  ── or use email ──          │   ← divider, lower visual weight
+│                              │
+│  Email                       │
+│  ┌────────────────────────┐  │   ← existing email input (UNCHANGED)
+│  │                        │  │
+│  └────────────────────────┘  │
+│  ┌────────────────────────┐  │
+│  │  Send magic link       │  │   ← secondary CTA
+│  └────────────────────────┘  │
+└──────────────────────────────┘
+```
+
+- The GitHub button is an `<a href>`, not a JS submit. `href` is `/auth/github/start?d=${encodeURIComponent(userCode)}` when `userCode` is present, `/auth/github/start` otherwise. Server-rendered, works without JS.
+- Magic-link form below is structurally unchanged (same `<form>`, same JS handler, same `POST /auth/magic-link` body). Visible by default — fallback is not a hidden affordance.
+- Inline GitHub mark SVG (one `<svg>` literal in the HTML string). No external assets, matches the existing self-contained-template style.
+
+`WELCOME_HTML(email, deviceLogin)` and `SIGN_IN_ERROR_HTML(message)` don't need structural changes.
+
+### New error pages (both reuse `SIGN_IN_ERROR_HTML`'s shape — same template, different copy)
+
+**Sign-in request expired** — for an invalid/expired/already-attached/already-claimed local handoff at `/start`, or an attach UPDATE that affected 0 rows at `/callback`:
+
+> Return to the Oyster app and start sign-in again.
+>
+> *(button)* Close this window
+
+If the failing flow had no `user_code` (cloud-only sign-in), the page links back to `/auth/sign-in` instead of saying "return to Oyster". The branch is decided at render time from the same state-row lookup that produced the failure.
+
+**No verified primary email** — for the GitHub `/user/emails` no-match case:
+
+> GitHub didn't return a verified primary email. Add and verify a primary email at github.com/settings/emails, or sign in with the email link below.
+
+This is the only failure path that names GitHub to the user — because the user has to take a provider-specific action to recover. Every other failure uses generic copy.
+
+## Failure modes
+
+| Stage | Trigger | Status | User sees |
+|---|---|---|---|
+| `/start` | `?d=` resolves to non-existent / expired / already-attached / already-claimed `device_codes` row | 400 | Sign-in request expired page |
+| `/start` | per-IP rate limit exceeded | 429 | "Too many sign-in attempts. Try again shortly." |
+| `/callback` | `state` missing, unknown, expired, or already consumed | 400 | Sign-in request expired page |
+| `/callback` | GitHub `access_token` exchange returns non-200 or no `access_token` | 502 | "Sign-in failed. Please try again." |
+| `/callback` | `/user` or `/user/emails` returns non-200 | 502 | "Sign-in failed. Please try again." |
+| `/callback` | no entry in `/user/emails` with `primary && verified` | 400 | No verified primary email page (only path that names GitHub) |
+| `/callback` | `oauth_states.user_code` was set but the device_codes attach UPDATE affected 0 rows (TTL ran out during OAuth round-trip) | 400 | Sign-in request expired page |
+| `/callback` | new `users` insert collides on `email` UNIQUE (concurrency) | retry STEP 2 up to 3 times, then 503 | "Sign-in failed. Please try again." |
+| Worker boundary | unhandled exception | 503 (existing single-point catch) | `service_unavailable` (JSON for clients, generic page for browsers) |
+
+User-facing copy is generic for everything except the verified-email case. No leaking of GitHub internals, response bodies, or provider names beyond the one path where the user can act on it.
+
+The structured `oauth_email_conflict` log event from STEP 1 is **not** a user-facing failure — sign-in succeeds, the event is server-side telemetry only.
+
+## Setup work (one-time, external)
+
+1. github.com/settings/developers → New OAuth App.
+2. Application name: `Oyster`.
+3. Homepage URL: `https://oyster.to`.
+4. Authorization callback URL: `https://oyster.to/auth/github/callback`.
+5. Generate a new client secret. Keep the client ID and secret accessible.
+
+That's all. No org installation, no GitHub App (different mechanism — we want OAuth App, not GitHub App).
+
+## Worker config
+
+```toml
+# infra/auth-worker/wrangler.toml — additions
+[vars]
+# ...existing FROM_ADDRESS, REPLY_TO...
+GITHUB_OAUTH_CLIENT_ID = "Iv1.xxxxxxxxxxxxxxxx"
+```
+
+```sh
+wrangler secret put GITHUB_OAUTH_CLIENT_SECRET
+```
+
+## Dev story (deliberate trade-off)
+
+**No local live OAuth testing for 0.7.0.** Local development uses mocked GitHub responses (`/user`, `/user/emails`) at the test boundary; the real OAuth round-trip is verified after deploying the Worker.
+
+GitHub OAuth Apps register exactly one callback URL, with subdirectory matching only — host and port must exactly match. `localhost:8787` is not a subdirectory of `oyster.to`, so live local testing would require a second OAuth App. We accept a slower feedback loop in exchange for not maintaining a second app's secrets and not deviating from prod config. Magic-link's existing `if (!env.RESEND_API_KEY) console.log(verifyURL)` dev fallback continues to cover local sign-in development.
+
+If we later need live local OAuth, registering a second OAuth App is a 10-minute change.
+
+## PR sequencing
+
+Three PRs, each independently reviewable and deployable.
+
+1. **Schema + scaffolding.** `0002_oauth.sql` (`oauth_states` + `user_identities`). Helper functions (`pkceVerifier()`, `pickPrimaryVerifiedEmail()`, `resolveIdentity()`). Unit tests against mocked GitHub responses. `/auth/github/start` returns a 503 stub. Mergeable in isolation; verifies the resolution rule against fixtures with zero blast radius.
+2. **`/auth/github/start` + `/auth/github/callback` end-to-end.** Both endpoints fully wired, `oauth_states` integration, device-code attach, `WELCOME_HTML` reuse. Sign-in page still email-only — endpoints reachable by direct URL but unsurfaced. After deploy, the maintainer **smoke-tests both paths**:
+   - **Cloud-only sign-in:** visit `https://oyster.to/auth/github/start` directly in a browser.
+   - **Local handoff:** start sign-in from local Oyster (so `?d=<user_code>` is present) and confirm the local app picks up the session via the existing poll loop.
+3. **Sign-in page + `auth.md` doc update.** GitHub button promoted to primary, magic-link demoted to fallback below the divider. `docs/plans/auth.md` updated to drop "OAuth deferred" framing, add a "Providers" section pointing here, and revise wording about which path is primary.
+
+The order is chosen so PR 1 verifies the resolution rule with zero blast radius, PR 2 ships the live OAuth code path *invisibly* (URL-only access for smoke testing), and PR 3 is a UI flip. If any PR exposes a problem, the previous PR(s) are still safely merged — there's no point at which the system is in a half-broken state.
+
+## What this does NOT include
+
+- **Google.** Deferred until GitHub lands cleanly. Same Worker, same schema, same resolution rule — adds `/auth/google/start` and `/auth/google/callback`. New issue at that time.
+- **Account-management UI.** No "linked accounts" page, no unlink button, no profile/avatar/display-name surface.
+- **Multi-identity merge tooling.** The `oauth_email_conflict` event is logged; resolution is a manual D1 query if it ever fires.
+- **GitHub email-change webhooks.** The known stale-email window above stays known.
+- **Org/SAML SSO.** GitHub orgs that enforce SAML still let OAuth Apps sign individual users in by their personal email; we get whatever that personal account exposes. Enterprise SSO isn't on the near roadmap.
+- **MFA, passwords, password reset.** Not relevant — same as `auth.md`.
+
+## Followups (file as issues after #340 ships)
+
+- **Magic-link silent-degrade fix.** Pre-existing UX bug: `handleMagicLink` resolves `user_code` at send-time and proceeds with `deviceCode = null` if it's bad. Same browser-says-success / local-keeps-polling split-brain that the `/start` validation fixes for OAuth. Bring magic-link in line with the same fail-closed rule.
+- **Local-server token rotation on cloud 401.** Carried forward from `auth.md`'s open questions. Settle when the first cloud-touching feature lands (publish, #315).
+- **`oauth_email_conflict` observability.** Currently a structured log event; if it ever fires in real traffic, surface it via Workers Logs filter or a small admin endpoint.
+
+## How to update this doc
+
+Replace, don't append, when a decision changes. If we ever fork providers (different Worker, different schema), that's a fork in this doc — and a check against R1–R7 to make sure the requirements still hold under the new shape.

--- a/docs/superpowers/plans/2026-05-02-340-oauth-github.md
+++ b/docs/superpowers/plans/2026-05-02-340-oauth-github.md
@@ -1,0 +1,1551 @@
+# OAuth (GitHub primary) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub as the primary sign-in path on the existing `oyster-auth` Cloudflare Worker, resolving identity through a new `user_identities` table, reusing the local sign-in handoff that #339 already shipped. Magic-link stays as a secondary fallback.
+
+**Architecture:** Cloud-first OAuth at `oyster.to/auth/github/{start,callback}`. State + PKCE round-trip through a new `oauth_states` D1 table. Identity is keyed on `(provider, provider_user_id)` in a new `user_identities` table — provider IDs are stable across email changes; email is not. The `oyster_session` cookie set on success is the *same* cookie magic-link sets, so all downstream cloud surfaces (publish, viewer #316, future cloud memory) work unchanged. Spec: [`docs/plans/auth-oauth.md`](../../plans/auth-oauth.md).
+
+**Tech Stack:** TypeScript, Cloudflare Workers, D1 (SQLite), Vitest (introduced in Phase 1).
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `infra/auth-worker/migrations/0002_oauth.sql` | DDL for `user_identities` + `oauth_states` |
+| Create | `infra/auth-worker/src/oauth-helpers.ts` | Pure helpers: `pkceVerifier()`, `codeChallengeS256()`, `pickPrimaryVerifiedEmail()`, GitHub response types |
+| Create | `infra/auth-worker/test/oauth-helpers.test.ts` | Vitest unit tests for the pure helpers |
+| Create | `infra/auth-worker/vitest.config.ts` | Vitest config (Node environment, `test/` glob) |
+| Modify | `infra/auth-worker/package.json` | Add vitest dep + `test` script + `db:migrate:0002` script |
+| Modify | `infra/auth-worker/src/worker.ts` | Add `handleGithubStart`, `handleGithubCallback`, `resolveIdentity`, two router matches; expand `SIGN_IN_HTML` for the GitHub button + divider; add a small `RETURN_TO_OYSTER_HTML` template |
+| Modify | `infra/auth-worker/wrangler.toml` | Add `GITHUB_OAUTH_CLIENT_ID` to `[vars]` |
+| Modify | `infra/auth-worker/README.md` | Add "GitHub OAuth setup" section + `db:migrate:0002` step |
+| Modify | `docs/plans/auth.md` | Drop "OAuth deferred" framing in PR 3, add a "Providers" section pointing at `auth-oauth.md` |
+
+**Decisions encoded in the structure:**
+
+- **Pure helpers split out into `oauth-helpers.ts`.** Keeps the testable surface importable by Vitest without dragging in the `Env` interface or the request handler. Route handlers and `resolveIdentity` (which holds a `D1Database`) stay in `worker.ts` to match the existing `handleMagicLink` / `handleVerify` placement.
+- **No unit tests for D1-touching code.** D1's `prepare/bind/first/run/batch` chain is awkward to mock cleanly, and the existing magic-link path is verified by smoke test only — the OAuth path follows the same precedent. The pure-function unit tests cover what can be tested fast; the live OAuth round-trip is verified post-deploy.
+- **No new files in the local server.** `server/src/auth-service.ts` already speaks only to `/auth/device-init`, `/auth/sign-in?d=...`, and `/auth/device/<code>` — none of which know which provider produced the session. The whole change is contained in `infra/auth-worker/`.
+
+---
+
+## Phase 1 — Schema + scaffolding (PR 1)
+
+End state: `0002_oauth.sql` applied to remote D1, pure helpers shipped with passing unit tests, `/auth/github/start` returns a 503 stub, `wrangler.toml` and README list the new config.
+
+### Task 1.1: Add Vitest to `infra/auth-worker/`
+
+**Files:**
+- Modify: `infra/auth-worker/package.json`
+- Create: `infra/auth-worker/vitest.config.ts`
+- Create: `infra/auth-worker/test/.gitkeep` (placeholder so the dir exists for the next task)
+
+- [ ] **Step 1: Add vitest as a devDependency and a `test` script.**
+
+Edit `infra/auth-worker/package.json`. Add `"test": "vitest run"` to `scripts` and `"vitest": "^2.1.0"` to `devDependencies`:
+
+```json
+{
+  "name": "oyster-auth-worker",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Cloudflare Worker handling Oyster magic-link auth + device-flow bridge",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "db:migrate": "wrangler d1 execute oyster-auth --file=migrations/0001_init.sql --remote",
+    "db:migrate:local": "wrangler d1 execute oyster-auth --file=migrations/0001_init.sql --local",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.1.0",
+    "wrangler": "^4.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `vitest.config.ts`.**
+
+```ts
+// infra/auth-worker/vitest.config.ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 3: Create the `test/` directory.**
+
+```bash
+mkdir -p infra/auth-worker/test
+touch infra/auth-worker/test/.gitkeep
+```
+
+- [ ] **Step 4: Install + verify.**
+
+```bash
+cd infra/auth-worker && npm install
+npm run test -- --reporter=verbose
+```
+
+Expected: `No test files found, exiting with code 0` (or similar — vitest exits cleanly with no tests). If the install fails, fix before continuing.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/auth-worker/package.json infra/auth-worker/package-lock.json \
+        infra/auth-worker/vitest.config.ts infra/auth-worker/test/.gitkeep
+git commit -m "chore(auth-worker): add vitest for unit tests"
+```
+
+---
+
+### Task 1.2: `pkceVerifier()` and `codeChallengeS256()` (TDD)
+
+**Files:**
+- Create: `infra/auth-worker/src/oauth-helpers.ts`
+- Create: `infra/auth-worker/test/oauth-helpers.test.ts`
+
+PKCE verifier is 43 base64url chars (32 random bytes, URL-safe). Code challenge is `base64url(sha256(verifier))`. Both must round-trip cleanly because GitHub validates the challenge against the verifier we'll send at token-exchange time.
+
+- [ ] **Step 1: Write the failing tests.**
+
+Create `infra/auth-worker/test/oauth-helpers.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { pkceVerifier, codeChallengeS256 } from "../src/oauth-helpers";
+
+describe("pkceVerifier", () => {
+  it("is 43 base64url characters (32 bytes, no padding)", () => {
+    const v = pkceVerifier();
+    expect(v).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("produces a different value on each call", () => {
+    const a = pkceVerifier();
+    const b = pkceVerifier();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("codeChallengeS256", () => {
+  // Reference vector from RFC 7636 Appendix B.
+  it("matches the RFC 7636 example", async () => {
+    const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const challenge = await codeChallengeS256(verifier);
+    expect(challenge).toBe("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+  });
+
+  it("is 43 base64url characters", async () => {
+    const challenge = await codeChallengeS256(pkceVerifier());
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+```bash
+cd infra/auth-worker && npm run test
+```
+
+Expected: FAIL — `Cannot find module '../src/oauth-helpers'`.
+
+- [ ] **Step 3: Write the minimal implementation.**
+
+Create `infra/auth-worker/src/oauth-helpers.ts`:
+
+```ts
+// Pure helpers for the OAuth flow. Kept separate from worker.ts so the
+// unit tests can import them without dragging in the Env interface or
+// the fetch handler.
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// 32 random bytes → 43 base64url characters. Matches RFC 7636's
+// recommended length for high-entropy verifiers.
+export function pkceVerifier(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return bytesToBase64Url(bytes);
+}
+
+// SHA-256 of the verifier, base64url-encoded. Must match the verifier
+// GitHub will receive at token exchange — any divergence (padding,
+// alphabet) means GitHub rejects the call.
+export async function codeChallengeS256(verifier: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return bytesToBase64Url(new Uint8Array(buf));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+```bash
+cd infra/auth-worker && npm run test
+```
+
+Expected: PASS — all four assertions green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/auth-worker/src/oauth-helpers.ts infra/auth-worker/test/oauth-helpers.test.ts
+git commit -m "feat(auth-worker): pkceVerifier + codeChallengeS256 (RFC 7636)"
+```
+
+---
+
+### Task 1.3: `pickPrimaryVerifiedEmail()` (TDD)
+
+**Files:**
+- Modify: `infra/auth-worker/src/oauth-helpers.ts`
+- Modify: `infra/auth-worker/test/oauth-helpers.test.ts`
+
+GitHub's `/user/emails` returns an array of `{ email, primary, verified, visibility }`. Our rule: pick the entry where `primary && verified`; otherwise return `null` (caller fails the sign-in). Lowercase the email on the way out so all downstream comparisons are case-folded.
+
+- [ ] **Step 1: Append failing tests.**
+
+Add to `infra/auth-worker/test/oauth-helpers.test.ts` (under the existing imports — keep the same import line and extend it):
+
+```ts
+// Adjust the import line at the top of the file to:
+//   import { pkceVerifier, codeChallengeS256, pickPrimaryVerifiedEmail } from "../src/oauth-helpers";
+
+describe("pickPrimaryVerifiedEmail", () => {
+  it("returns the primary && verified entry, lowercased", () => {
+    const result = pickPrimaryVerifiedEmail([
+      { email: "Other@Example.com", primary: false, verified: true, visibility: null },
+      { email: "Main@Example.com", primary: true, verified: true, visibility: "public" },
+    ]);
+    expect(result).toBe("main@example.com");
+  });
+
+  it("returns null when primary is unverified", () => {
+    const result = pickPrimaryVerifiedEmail([
+      { email: "main@example.com", primary: true, verified: false, visibility: null },
+      { email: "other@example.com", primary: false, verified: true, visibility: null },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no primary entry exists", () => {
+    const result = pickPrimaryVerifiedEmail([
+      { email: "a@example.com", primary: false, verified: true, visibility: null },
+      { email: "b@example.com", primary: false, verified: true, visibility: null },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null on an empty array", () => {
+    expect(pickPrimaryVerifiedEmail([])).toBeNull();
+  });
+
+  it("ignores entries with missing fields", () => {
+    const result = pickPrimaryVerifiedEmail([
+      { email: "main@example.com", primary: true, verified: true, visibility: null },
+      { email: "broken@example.com" } as never,
+    ]);
+    expect(result).toBe("main@example.com");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail.**
+
+```bash
+cd infra/auth-worker && npm run test
+```
+
+Expected: FAIL — `pickPrimaryVerifiedEmail is not a function` or import error.
+
+- [ ] **Step 3: Implement and export.**
+
+Append to `infra/auth-worker/src/oauth-helpers.ts`:
+
+```ts
+export interface GitHubEmail {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+  visibility: string | null;
+}
+
+export function pickPrimaryVerifiedEmail(emails: GitHubEmail[]): string | null {
+  for (const e of emails) {
+    if (e?.primary === true && e?.verified === true && typeof e.email === "string") {
+      return e.email.toLowerCase();
+    }
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+```bash
+cd infra/auth-worker && npm run test
+```
+
+Expected: PASS — all assertions green (4 from prior task + 5 new).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/auth-worker/src/oauth-helpers.ts infra/auth-worker/test/oauth-helpers.test.ts
+git commit -m "feat(auth-worker): pickPrimaryVerifiedEmail with verified-primary rule"
+```
+
+---
+
+### Task 1.4: D1 migration `0002_oauth.sql`
+
+**Files:**
+- Create: `infra/auth-worker/migrations/0002_oauth.sql`
+- Modify: `infra/auth-worker/package.json` (add `db:migrate:0002` + `db:migrate:0002:local` scripts)
+
+- [ ] **Step 1: Write the migration.**
+
+Create `infra/auth-worker/migrations/0002_oauth.sql`:
+
+```sql
+-- Oyster auth — OAuth schema delta (see docs/plans/auth-oauth.md).
+-- Two new tables, both additive. Existing tables (users, sessions,
+-- device_codes, magic_link_tokens) are unchanged.
+
+CREATE TABLE IF NOT EXISTS user_identities (
+  provider           TEXT NOT NULL,                  -- 'github' (later: 'google')
+  provider_user_id   TEXT NOT NULL,                  -- GitHub's stable numeric id, as text
+  user_id            TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider_email     TEXT,                           -- informational; current verified primary at last sign-in
+  linked_at          INTEGER NOT NULL,               -- unix ms
+  last_seen_at       INTEGER NOT NULL,               -- unix ms; bumped per sign-in
+  PRIMARY KEY (provider, provider_user_id)
+);
+CREATE INDEX IF NOT EXISTS user_identities_user ON user_identities(user_id);
+
+CREATE TABLE IF NOT EXISTS oauth_states (
+  state              TEXT PRIMARY KEY,               -- 32-byte base64url, single-use CSRF token
+  provider           TEXT NOT NULL,
+  pkce_verifier      TEXT NOT NULL,                  -- 43-char base64url, S256-only
+  user_code          TEXT,                           -- nullable; ties this flow to a local-sign-in handoff
+  created_at         INTEGER NOT NULL,
+  expires_at         INTEGER NOT NULL,               -- 5 min from created_at
+  consumed_at        INTEGER                         -- set on /callback; replay defence
+);
+```
+
+- [ ] **Step 2: Add migrate scripts.**
+
+Edit `infra/auth-worker/package.json` `scripts` block:
+
+```json
+"db:migrate": "wrangler d1 execute oyster-auth --file=migrations/0001_init.sql --remote",
+"db:migrate:local": "wrangler d1 execute oyster-auth --file=migrations/0001_init.sql --local",
+"db:migrate:0002": "wrangler d1 execute oyster-auth --file=migrations/0002_oauth.sql --remote",
+"db:migrate:0002:local": "wrangler d1 execute oyster-auth --file=migrations/0002_oauth.sql --local",
+```
+
+- [ ] **Step 3: Apply locally and verify.**
+
+```bash
+cd infra/auth-worker
+npm run db:migrate:0002:local
+npx wrangler d1 execute oyster-auth --local --command "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+```
+
+Expected output includes:
+```
+device_codes
+magic_link_tokens
+oauth_states
+sessions
+user_identities
+users
+```
+
+If `user_identities` or `oauth_states` is missing, debug before continuing.
+
+- [ ] **Step 4: Apply to remote D1.**
+
+```bash
+cd infra/auth-worker && npm run db:migrate:0002
+```
+
+Expected: `🌀 Executing on remote database oyster-auth ... ✅ Successfully executed`. Re-running is safe (every CREATE has `IF NOT EXISTS`).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/auth-worker/migrations/0002_oauth.sql infra/auth-worker/package.json
+git commit -m "feat(auth-worker): D1 migration 0002 — user_identities + oauth_states"
+```
+
+---
+
+### Task 1.5: `GITHUB_OAUTH_CLIENT_ID` config + Env type
+
+**Files:**
+- Modify: `infra/auth-worker/wrangler.toml`
+- Modify: `infra/auth-worker/src/worker.ts` (Env interface only)
+
+- [ ] **Step 1: Add to `wrangler.toml` `[vars]`.**
+
+Edit `infra/auth-worker/wrangler.toml`. Append to the `[vars]` block:
+
+```toml
+[vars]
+FROM_ADDRESS = "noreply@oyster.to"
+REPLY_TO = "matthew@slight.me"
+GITHUB_OAUTH_CLIENT_ID = ""
+```
+
+The empty string means `wrangler dev` and the deployed Worker both load the var with no value — endpoints can detect "OAuth not configured" and 503 cleanly until you fill in the real client ID. We'll fill it in after the GitHub OAuth App is registered (Task 2.0).
+
+- [ ] **Step 2: Extend the `Env` interface.**
+
+Edit `infra/auth-worker/src/worker.ts`. Replace the existing `Env` interface (currently around line 18) with:
+
+```ts
+export interface Env {
+  DB: D1Database;
+  MAGIC_LINK_LIMIT: RateLimit;
+  // Optional so wrangler dev works without a Resend secret — sendMagicLink()
+  // logs the verify URL to the Worker console when this is unset.
+  RESEND_API_KEY?: string;
+  FROM_ADDRESS?: string;
+  REPLY_TO?: string;
+  // GitHub OAuth. Both empty until the OAuth App is registered; handlers
+  // check both and 503 if either is missing (handled in Phase 2).
+  GITHUB_OAUTH_CLIENT_ID?: string;
+  GITHUB_OAUTH_CLIENT_SECRET?: string;
+}
+```
+
+- [ ] **Step 3: Verify type-check.**
+
+```bash
+cd infra/auth-worker && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/wrangler.toml infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): wire GITHUB_OAUTH_CLIENT_ID + Env extensions"
+```
+
+---
+
+### Task 1.6: Stub `/auth/github/start` returning 503
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+Stub keeps the route reachable so a typo'd GitHub OAuth App callback URL returns something useful instead of 404. Real implementation lands in Phase 2.
+
+- [ ] **Step 1: Add the stub handler.**
+
+Edit `infra/auth-worker/src/worker.ts`. Add this function above the `export default { fetch ... }` block (anywhere in the function-definition area is fine — keep it near the existing handlers):
+
+```ts
+async function handleGithubStart(_req: Request, env: Env): Promise<Response> {
+  if (!env.GITHUB_OAUTH_CLIENT_ID || !env.GITHUB_OAUTH_CLIENT_SECRET) {
+    return json({ error: "oauth_not_configured" }, 503, NO_STORE);
+  }
+  // Phase 2 wires the real start flow.
+  return json({ error: "not_implemented" }, 503, NO_STORE);
+}
+```
+
+- [ ] **Step 2: Wire the route.**
+
+Edit `infra/auth-worker/src/worker.ts` inside the `fetch` handler's router (the `if/else if` chain near the bottom). Add a new branch above the existing `/auth/device-init` match:
+
+```ts
+if (url.pathname === "/auth/github/start" && req.method === "GET") {
+  return await handleGithubStart(req, env);
+}
+```
+
+- [ ] **Step 3: Verify type-check + smoke test.**
+
+```bash
+cd infra/auth-worker
+npm run typecheck
+# In another shell, optional: npm run dev, then:
+#   curl -i http://localhost:8787/auth/github/start
+# Expected: HTTP/1.1 503 Service Unavailable
+#           {"error":"oauth_not_configured"}
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): /auth/github/start route stub (503 until Phase 2)"
+```
+
+---
+
+### Task 1.7: README update
+
+**Files:**
+- Modify: `infra/auth-worker/README.md`
+
+- [ ] **Step 1: Add the OAuth setup section.**
+
+Edit `infra/auth-worker/README.md`. Find the "## One-time setup" section. After the existing "### 6. Deploy" subsection (and before "### 7. Smoke test the full flow"), insert a new subsection:
+
+```markdown
+### 6.5. (Optional) Register a GitHub OAuth App
+
+Required only once GitHub sign-in is being implemented (Phase 2 of [`docs/plans/auth-oauth.md`](../../docs/plans/auth-oauth.md)). Skip if you only need magic-link to work.
+
+1. github.com/settings/developers → **New OAuth App**.
+2. Application name: `Oyster`.
+3. Homepage URL: `https://oyster.to`.
+4. Authorization callback URL: `https://oyster.to/auth/github/callback`.
+5. Click **Register application**, then **Generate a new client secret**. Keep the client ID and the secret accessible.
+6. Edit `wrangler.toml` and set `GITHUB_OAUTH_CLIENT_ID = "<the client id>"` in the `[vars]` block.
+7. `npx wrangler secret put GITHUB_OAUTH_CLIENT_SECRET` and paste the secret when prompted.
+8. Apply the OAuth schema migration: `npm run db:migrate:0002`.
+9. Redeploy: `npm run deploy`.
+```
+
+Also update the existing "## Day-to-day" section to mention the new test script. Find:
+
+```markdown
+```bash
+npm run typecheck   # tsc --noEmit
+npm run dev         # local Worker on localhost:8787 with a local D1
+npm run tail        # stream Worker logs from production
+```
+```
+
+Replace with:
+
+```markdown
+```bash
+npm run typecheck   # tsc --noEmit
+npm run test        # vitest run — unit tests for pure helpers
+npm run dev         # local Worker on localhost:8787 with a local D1
+npm run tail        # stream Worker logs from production
+```
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add infra/auth-worker/README.md
+git commit -m "docs(auth-worker): GitHub OAuth setup steps + test script"
+```
+
+---
+
+### Task 1.8: Open PR 1
+
+- [ ] **Step 1: Push branch and open PR.**
+
+Branch should already be `feat/auth-oauth-scaffolding` if you're following the conventional naming. If you're on a different branch name, that's fine — just push it.
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(auth-worker): OAuth schema + scaffolding (#340 PR 1/3)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds vitest to `infra/auth-worker/`, with passing unit tests for `pkceVerifier`, `codeChallengeS256`, and `pickPrimaryVerifiedEmail`.
+- Ships D1 migration `0002_oauth.sql` (`user_identities` + `oauth_states`).
+- Stubs `GET /auth/github/start` → 503 until Phase 2 wires the real flow.
+- Adds `GITHUB_OAUTH_CLIENT_ID` to `[vars]` and extends the `Env` interface; `GITHUB_OAUTH_CLIENT_SECRET` is wired via `wrangler secret put`.
+- README documents the OAuth-App registration steps for whoever picks up Phase 2.
+
+Spec: docs/plans/auth-oauth.md
+
+Part of #340.
+
+## Test plan
+
+- [x] `npm run test` in `infra/auth-worker/` — all helper unit tests pass
+- [x] `npm run typecheck` — no errors
+- [x] `npm run db:migrate:0002` — applied to remote D1; `sqlite_master` now lists `user_identities` and `oauth_states`
+- [x] `curl https://oyster.to/auth/github/start` (after deploy) returns `{"error":"oauth_not_configured"}` 503
+- [x] Magic-link flow still works end-to-end (regression check)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for review and merge.** Address any review comments via additional commits on the same branch. Do not proceed to Phase 2 until PR 1 is merged.
+
+---
+
+## Phase 2 — Endpoints end-to-end (PR 2)
+
+End state: GitHub OAuth round-trip is fully wired. Endpoints are reachable but unsurfaced — the sign-in page is still email-only, so users see no behavioural change. The maintainer smoke-tests both the cloud-only and local-handoff paths post-deploy. Sign-in page UI flip is Phase 3.
+
+### Task 2.0: Register the GitHub OAuth App + set secrets
+
+This is the human-only setup step that has to happen before Phase 2 code can run live.
+
+- [ ] **Step 1: Register the OAuth App on GitHub.**
+
+Follow `infra/auth-worker/README.md` section "6.5. (Optional) Register a GitHub OAuth App" exactly. Result: a client ID like `Iv1.xxxxxxxxxxxxxxxx` and a client secret string.
+
+- [ ] **Step 2: Fill in `wrangler.toml`.**
+
+```bash
+# Edit infra/auth-worker/wrangler.toml — set:
+#   GITHUB_OAUTH_CLIENT_ID = "Iv1.xxxxxxxxxxxxxxxx"   (your real value)
+```
+
+- [ ] **Step 3: Set the secret.**
+
+```bash
+cd infra/auth-worker
+npx wrangler secret put GITHUB_OAUTH_CLIENT_SECRET
+# Paste the secret when prompted.
+```
+
+- [ ] **Step 4: Commit the wrangler.toml change.**
+
+```bash
+git add infra/auth-worker/wrangler.toml
+git commit -m "chore(auth-worker): set GITHUB_OAUTH_CLIENT_ID"
+```
+
+---
+
+### Task 2.1: `handleGithubStart` — full implementation
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+Replace the Phase 1 stub with the real implementation. Validates `?d=<user_code>`, generates state + PKCE, inserts an `oauth_states` row, 302s to GitHub.
+
+- [ ] **Step 1: Add new imports and constants near the top of the file.**
+
+At the top of `infra/auth-worker/src/worker.ts`, just below the existing imports section (around the constants block with `MAGIC_LINK_TTL_MS` etc.), add:
+
+```ts
+import { pkceVerifier, codeChallengeS256 } from "./oauth-helpers";
+
+const OAUTH_STATE_TTL_MS = 5 * 60 * 1000;
+const MAX_USER_CODE_LEN = 32;
+```
+
+Also add a small helper near the other `randomToken`/`randomUserCode` helpers — used by both Phase 2 handlers:
+
+```ts
+function randomState(): string {
+  return randomToken(32);  // existing helper produces 43-char base64url; reusable as state.
+}
+```
+
+- [ ] **Step 2: Replace the stub `handleGithubStart` with the real one.**
+
+Locate the existing stub from Task 1.6 and replace it with:
+
+```ts
+async function handleGithubStart(req: Request, env: Env, url: URL): Promise<Response> {
+  if (!env.GITHUB_OAUTH_CLIENT_ID || !env.GITHUB_OAUTH_CLIENT_SECRET) {
+    return json({ error: "oauth_not_configured" }, 503, NO_STORE);
+  }
+
+  // Per-IP gate. Reuses MAGIC_LINK_LIMIT — same auth-attempt budget as
+  // /auth/magic-link and /auth/device-init.
+  const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
+  const ipGate = await env.MAGIC_LINK_LIMIT.limit({ key: ip });
+  if (!ipGate.success) {
+    return htmlResponse(
+      SIGN_IN_ERROR_HTML("Too many sign-in attempts. Please try again shortly."),
+      429,
+      NO_STORE,
+    );
+  }
+
+  const userCode = url.searchParams.get("d");
+  const now = Date.now();
+
+  // If ?d= is present, validate before redirecting to GitHub. Saves a
+  // wasted OAuth round-trip when the local handoff is already dead.
+  if (userCode) {
+    if (userCode.length > MAX_USER_CODE_LEN) {
+      return htmlResponse(SIGN_IN_EXPIRED_HTML(false), 400, NO_STORE);
+    }
+    const dc = await env.DB
+      .prepare("SELECT device_code, session_id, claimed_at, expires_at FROM device_codes WHERE user_code = ?")
+      .bind(userCode)
+      .first<{ device_code: string; session_id: string | null; claimed_at: number | null; expires_at: number }>();
+    if (!dc || dc.expires_at <= now || dc.session_id !== null || dc.claimed_at !== null) {
+      return htmlResponse(SIGN_IN_EXPIRED_HTML(true), 400, NO_STORE);
+    }
+  }
+
+  const state = randomState();
+  const verifier = pkceVerifier();
+  const challenge = await codeChallengeS256(verifier);
+
+  await env.DB
+    .prepare(
+      "INSERT INTO oauth_states (state, provider, pkce_verifier, user_code, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(state, "github", verifier, userCode, now, now + OAUTH_STATE_TTL_MS)
+    .run();
+
+  const githubUrl = new URL("https://github.com/login/oauth/authorize");
+  githubUrl.searchParams.set("client_id", env.GITHUB_OAUTH_CLIENT_ID);
+  githubUrl.searchParams.set("redirect_uri", `${url.origin}/auth/github/callback`);
+  githubUrl.searchParams.set("scope", "user:email");
+  githubUrl.searchParams.set("state", state);
+  githubUrl.searchParams.set("code_challenge", challenge);
+  githubUrl.searchParams.set("code_challenge_method", "S256");
+  githubUrl.searchParams.set("allow_signup", "true");
+
+  return new Response(null, {
+    status: 302,
+    headers: { location: githubUrl.toString(), ...NO_STORE },
+  });
+}
+```
+
+- [ ] **Step 3: Update the router to pass `url`.**
+
+In the `fetch` handler's router, change the existing `/auth/github/start` line to pass the new arg:
+
+```ts
+if (url.pathname === "/auth/github/start" && req.method === "GET") {
+  return await handleGithubStart(req, env, url);
+}
+```
+
+- [ ] **Step 4: Add the `SIGN_IN_EXPIRED_HTML` template.**
+
+Add this new HTML helper near the existing `SIGN_IN_ERROR_HTML` definition:
+
+```ts
+const SIGN_IN_EXPIRED_HTML = (hadLocalHandoff: boolean) => `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign-in request expired</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 28rem; margin: 6rem auto; padding: 0 1.5rem; line-height: 1.5; text-align: center; }
+  h1 { font-size: 1.5rem; }
+  button, .btn { padding: 0.6rem 1rem; font-size: 1rem; font-weight: 600; border: 0; border-radius: 0.4rem; background: #6750a4; color: #fff; cursor: pointer; text-decoration: none; display: inline-block; }
+</style>
+</head><body>
+<h1>Sign-in request expired</h1>
+${hadLocalHandoff
+  ? "<p>Return to the Oyster app and start sign-in again.</p><button onclick=\"window.close()\" class=\"btn\">Close this window</button>"
+  : "<p>This sign-in link is no longer valid.</p><a href=\"/auth/sign-in\" class=\"btn\">Sign in again</a>"}
+</body></html>`;
+```
+
+- [ ] **Step 5: Type-check + commit.**
+
+```bash
+cd infra/auth-worker && npm run typecheck
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): /auth/github/start full implementation"
+```
+
+---
+
+### Task 2.2: `handleGithubCallback` — state validation + token exchange
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+Lands the first three steps of the callback: atomic state consume, GitHub token exchange, identity fetch. Identity resolution + session creation come in Task 2.3.
+
+- [ ] **Step 1: Add the callback handler skeleton.**
+
+Add `handleGithubCallback` near `handleGithubStart`. This task implements steps 1–3; later tasks fill in the rest.
+
+```ts
+interface GitHubUser {
+  id: number;
+  login: string;
+}
+
+async function exchangeGithubCode(env: Env, code: string, verifier: string, redirectUri: string): Promise<string | null> {
+  const res = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: env.GITHUB_OAUTH_CLIENT_ID,
+      client_secret: env.GITHUB_OAUTH_CLIENT_SECRET,
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    }),
+  });
+  if (!res.ok) {
+    console.error("github_token_exchange_failed", res.status);
+    return null;
+  }
+  const body = await res.json().catch(() => null) as { access_token?: string } | null;
+  return body?.access_token ?? null;
+}
+
+async function fetchGithubUser(token: string): Promise<GitHubUser | null> {
+  const res = await fetch("https://api.github.com/user", {
+    headers: {
+      authorization: `Bearer ${token}`,
+      "user-agent": "oyster-auth",
+      accept: "application/vnd.github+json",
+    },
+  });
+  if (!res.ok) {
+    console.error("github_user_fetch_failed", res.status);
+    return null;
+  }
+  const body = await res.json().catch(() => null) as { id?: number; login?: string } | null;
+  if (!body || typeof body.id !== "number" || typeof body.login !== "string") return null;
+  return { id: body.id, login: body.login };
+}
+
+async function fetchGithubEmails(token: string): Promise<GitHubEmail[] | null> {
+  const res = await fetch("https://api.github.com/user/emails", {
+    headers: {
+      authorization: `Bearer ${token}`,
+      "user-agent": "oyster-auth",
+      accept: "application/vnd.github+json",
+    },
+  });
+  if (!res.ok) {
+    console.error("github_emails_fetch_failed", res.status);
+    return null;
+  }
+  return await res.json().catch(() => null) as GitHubEmail[] | null;
+}
+
+async function handleGithubCallback(req: Request, env: Env, url: URL): Promise<Response> {
+  if (!env.GITHUB_OAUTH_CLIENT_ID || !env.GITHUB_OAUTH_CLIENT_SECRET) {
+    return json({ error: "oauth_not_configured" }, 503, NO_STORE);
+  }
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state || state.length > 200) {
+    return htmlResponse(SIGN_IN_EXPIRED_HTML(false), 400, NO_STORE);
+  }
+
+  const now = Date.now();
+
+  // Atomic state consume. Two concurrent callbacks for the same state
+  // cannot both pass — only one sees the RETURNING row.
+  const stateRow = await env.DB
+    .prepare(
+      `UPDATE oauth_states
+          SET consumed_at = ?
+        WHERE state = ? AND consumed_at IS NULL AND expires_at > ?
+        RETURNING provider, pkce_verifier, user_code`,
+    )
+    .bind(now, state, now)
+    .first<{ provider: string; pkce_verifier: string; user_code: string | null }>();
+
+  if (!stateRow || stateRow.provider !== "github") {
+    return htmlResponse(SIGN_IN_EXPIRED_HTML(false), 400, NO_STORE);
+  }
+
+  const redirectUri = `${url.origin}/auth/github/callback`;
+  const accessToken = await exchangeGithubCode(env, code, stateRow.pkce_verifier, redirectUri);
+  if (!accessToken) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("Sign-in failed. Please try again."), 502, NO_STORE);
+  }
+
+  const ghUser = await fetchGithubUser(accessToken);
+  if (!ghUser) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("Sign-in failed. Please try again."), 502, NO_STORE);
+  }
+
+  const ghEmails = await fetchGithubEmails(accessToken);
+  if (!ghEmails) {
+    return htmlResponse(SIGN_IN_ERROR_HTML("Sign-in failed. Please try again."), 502, NO_STORE);
+  }
+
+  const primaryEmail = pickPrimaryVerifiedEmail(ghEmails);
+  if (!primaryEmail) {
+    return htmlResponse(
+      SIGN_IN_ERROR_HTML("GitHub didn't return a verified primary email. Add and verify a primary email at github.com/settings/emails, or sign in with the email link below."),
+      400,
+      NO_STORE,
+    );
+  }
+
+  // TASK 2.3 fills in identity resolution, session creation, and the
+  // device-code attach. For now, return a placeholder so the type-check
+  // passes and integration can be tested step-by-step.
+  return json(
+    { stage: "callback_pre_resolve", provider_user_id: String(ghUser.id), primary_email: primaryEmail, has_user_code: stateRow.user_code !== null },
+    200,
+    NO_STORE,
+  );
+}
+```
+
+- [ ] **Step 2: Update the imports at the top of `worker.ts`.**
+
+Extend the existing oauth-helpers import line:
+
+```ts
+import { pkceVerifier, codeChallengeS256, pickPrimaryVerifiedEmail, type GitHubEmail } from "./oauth-helpers";
+```
+
+- [ ] **Step 3: Wire the callback route.**
+
+In the router, add this branch right after the `/auth/github/start` match:
+
+```ts
+if (url.pathname === "/auth/github/callback" && req.method === "GET") {
+  return await handleGithubCallback(req, env, url);
+}
+```
+
+- [ ] **Step 4: Type-check + commit.**
+
+```bash
+cd infra/auth-worker && npm run typecheck
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): /auth/github/callback — state + token + identity (1/2)"
+```
+
+---
+
+### Task 2.3: `resolveIdentity` + session create + device-code attach
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+Replaces the placeholder JSON response with the real STEP 1/2/3 resolution from the spec, plus session creation and device-code attach. End of this task: the live OAuth round-trip works end-to-end.
+
+- [ ] **Step 1: Add the `resolveIdentity` helper.**
+
+Add this function above `handleGithubCallback` in `worker.ts`:
+
+```ts
+interface ResolvedIdentity {
+  user_id: string;
+  email_for_session: string;  // the email we'll show on the welcome page (current users.email after STEP 1's update)
+}
+
+async function resolveIdentity(
+  db: D1Database,
+  provider: string,
+  providerUserId: string,
+  providerEmail: string,
+  now: number,
+): Promise<ResolvedIdentity> {
+  // STEP 1 — identity match. provider_user_id is the truth.
+  const identityRow = await db
+    .prepare("SELECT user_id FROM user_identities WHERE provider = ? AND provider_user_id = ?")
+    .bind(provider, providerUserId)
+    .first<{ user_id: string }>();
+
+  if (identityRow) {
+    await db
+      .prepare(
+        "UPDATE user_identities SET provider_email = ?, last_seen_at = ? WHERE provider = ? AND provider_user_id = ?",
+      )
+      .bind(providerEmail, now, provider, providerUserId)
+      .run();
+
+    // Try to update users.email to the current verified primary. If
+    // another users row already owns this email, keep ours unchanged
+    // and log the conflict — sign-in still succeeds.
+    let emailForSession = providerEmail;
+    try {
+      const updateRes = await db
+        .prepare("UPDATE users SET email = ?, last_seen_at = ? WHERE id = ?")
+        .bind(providerEmail, now, identityRow.user_id)
+        .run();
+      // Note: D1 lets the UPDATE succeed even if the new value equals
+      // the old; meta.changes reflects rows actually changed by storage.
+      // We don't need to branch on that.
+      void updateRes;
+    } catch (err) {
+      const message = (err as Error)?.message ?? String(err);
+      if (/UNIQUE constraint failed/.test(message)) {
+        const conflictRow = await db
+          .prepare("SELECT id, email FROM users WHERE email = ?")
+          .bind(providerEmail)
+          .first<{ id: string; email: string }>();
+        const ourRow = await db
+          .prepare("SELECT email FROM users WHERE id = ?")
+          .bind(identityRow.user_id)
+          .first<{ email: string }>();
+        console.warn(JSON.stringify({
+          kind: "oauth_email_conflict",
+          provider,
+          provider_user_id: providerUserId,
+          user_id: identityRow.user_id,
+          conflicting_user_id: conflictRow?.id ?? null,
+          attempted_email: providerEmail,
+          kept_email: ourRow?.email ?? null,
+        }));
+        emailForSession = ourRow?.email ?? providerEmail;
+      } else {
+        throw err;
+      }
+    }
+
+    return { user_id: identityRow.user_id, email_for_session: emailForSession };
+  }
+
+  // STEP 2 — first-time link, email match. With a short retry on the
+  // STEP 3 INSERT to handle the rare concurrent first-link race for
+  // the same email.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const userRow = await db
+      .prepare("SELECT id FROM users WHERE email = ?")
+      .bind(providerEmail)
+      .first<{ id: string }>();
+
+    if (userRow) {
+      // Existing user — link the GitHub identity to it.
+      await db
+        .prepare(
+          `INSERT INTO user_identities
+             (provider, provider_user_id, user_id, provider_email, linked_at, last_seen_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(provider, providerUserId, userRow.id, providerEmail, now, now)
+        .run();
+      return { user_id: userRow.id, email_for_session: providerEmail };
+    }
+
+    // STEP 3 — first-time link, no existing user.
+    const newUserId = crypto.randomUUID();
+    try {
+      await db.batch([
+        db.prepare("INSERT INTO users (id, email, created_at, last_seen_at) VALUES (?, ?, ?, ?)")
+          .bind(newUserId, providerEmail, now, now),
+        db.prepare(
+          `INSERT INTO user_identities
+             (provider, provider_user_id, user_id, provider_email, linked_at, last_seen_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+        ).bind(provider, providerUserId, newUserId, providerEmail, now, now),
+      ]);
+      return { user_id: newUserId, email_for_session: providerEmail };
+    } catch (err) {
+      const message = (err as Error)?.message ?? String(err);
+      if (!/UNIQUE constraint failed/.test(message)) throw err;
+      // Concurrent first-link by email — retry, STEP 2 will hit this time.
+    }
+  }
+
+  throw new Error("identity_resolution_failed_after_retries");
+}
+```
+
+- [ ] **Step 2: Replace the placeholder return at the end of `handleGithubCallback`.**
+
+Find this block in `handleGithubCallback`:
+
+```ts
+  // TASK 2.3 fills in identity resolution, session creation, and the
+  // device-code attach. For now, return a placeholder so the type-check
+  // passes and integration can be tested step-by-step.
+  return json(
+    { stage: "callback_pre_resolve", provider_user_id: String(ghUser.id), primary_email: primaryEmail, has_user_code: stateRow.user_code !== null },
+    200,
+    NO_STORE,
+  );
+```
+
+Replace with:
+
+```ts
+  let resolved: ResolvedIdentity;
+  try {
+    resolved = await resolveIdentity(env.DB, "github", String(ghUser.id), primaryEmail, now);
+  } catch (err) {
+    console.error("resolve_identity_failed", err);
+    return htmlResponse(SIGN_IN_ERROR_HTML("Sign-in failed. Please try again."), 503, NO_STORE);
+  }
+
+  const sessionId = crypto.randomUUID();
+  const sessionExpires = now + SESSION_TTL_MS;
+  await env.DB.batch([
+    env.DB.prepare("INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)")
+      .bind(sessionId, resolved.user_id, now, sessionExpires),
+    env.DB.prepare("UPDATE users SET last_seen_at = ? WHERE id = ?").bind(now, resolved.user_id),
+  ]);
+
+  // If the original /start carried a user_code, attach the new session
+  // to that device_codes row. Atomic UPDATE — if 0 rows changed, the
+  // device_codes TTL ran out during the OAuth round-trip.
+  let attachedDeviceCode = false;
+  if (stateRow.user_code) {
+    const dc = await env.DB
+      .prepare("SELECT device_code FROM device_codes WHERE user_code = ?")
+      .bind(stateRow.user_code)
+      .first<{ device_code: string }>();
+    if (dc) {
+      const attachRes = await env.DB
+        .prepare(
+          "UPDATE device_codes SET session_id = ? WHERE device_code = ? AND session_id IS NULL AND expires_at > ?",
+        )
+        .bind(sessionId, dc.device_code, now)
+        .run();
+      attachedDeviceCode = (attachRes.meta?.changes ?? 0) === 1;
+      if (!attachedDeviceCode) {
+        // Race: device_codes TTL'd during the OAuth round-trip. Session
+        // is valid for the browser cookie; the local app missed the
+        // window. Surface the error rather than silent split-brain.
+        const cookie = sessionCookie(sessionId, url.host);
+        return htmlResponse(SIGN_IN_EXPIRED_HTML(true), 400, {
+          "set-cookie": cookie,
+          ...NO_STORE,
+        });
+      }
+    } else {
+      // user_code disappeared (TTL'd and gc'd) — same UX outcome.
+      const cookie = sessionCookie(sessionId, url.host);
+      return htmlResponse(SIGN_IN_EXPIRED_HTML(true), 400, {
+        "set-cookie": cookie,
+        ...NO_STORE,
+      });
+    }
+  }
+
+  const cookie = sessionCookie(sessionId, url.host);
+
+  // Browser-only: 302 to /auth/welcome (matches handleVerify shape).
+  // Local-handoff: render WELCOME_HTML directly with the "you can close
+  // this window" copy so the user doesn't see a flash of /auth/welcome.
+  if (attachedDeviceCode) {
+    return htmlResponse(WELCOME_HTML(resolved.email_for_session, true), 200, {
+      "set-cookie": cookie,
+      ...NO_STORE,
+    });
+  }
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: "/auth/welcome",
+      "set-cookie": cookie,
+      ...NO_STORE,
+    },
+  });
+```
+
+- [ ] **Step 3: Type-check.**
+
+```bash
+cd infra/auth-worker && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): /auth/github/callback — resolve + session + attach (2/2)"
+```
+
+---
+
+### Task 2.4: Smoke test post-deploy
+
+- [ ] **Step 1: Deploy.**
+
+```bash
+cd infra/auth-worker && npm run deploy
+```
+
+Expected: deploy succeeds, Worker is live at `oyster.to/auth/*`.
+
+- [ ] **Step 2: Smoke test the cloud-only path.**
+
+In a private/incognito browser window, open `https://oyster.to/auth/github/start` directly (no `?d=`).
+
+Expected sequence:
+1. 302 to `https://github.com/login/oauth/authorize?...`
+2. GitHub consent screen — click Authorize.
+3. 302 back to `https://oyster.to/auth/github/callback?code=...&state=...`
+4. 302 to `/auth/welcome`.
+5. `/auth/welcome` page displays "Signed in as <your-email>".
+
+Verify the cookie:
+
+```bash
+curl -i https://oyster.to/auth/whoami -H "cookie: oyster_session=<paste from devtools>"
+# → HTTP/2 200
+# → {"id":"...","email":"<your-email>"}
+```
+
+- [ ] **Step 3: Smoke test the local-handoff path.**
+
+This requires a running local Oyster (port 4444) that already wires GitHub via #339's existing AuthService — which it does, because AuthService just opens `/auth/sign-in?d=<user_code>` and polls `/auth/device/<code>`, both untouched.
+
+```bash
+# In one terminal:
+cd /Users/Matthew.Slight/Dev/oyster-os
+npm run dev   # starts the local Oyster at localhost:3333 (dev mode)
+```
+
+In the local Oyster UI, click the sign-in button. Expected:
+1. Browser opens `https://oyster.to/auth/sign-in?d=<user_code>`.
+2. (Phase 3 will surface the GitHub button here. For Phase 2's smoke test, navigate manually:) Manually visit `https://oyster.to/auth/github/start?d=<user_code>` (paste the same `user_code` from the URL bar).
+3. GitHub consent → Authorize.
+4. Land on `WELCOME_HTML` showing "Signed in as <email>" + "You can close this window".
+5. Within ~2 seconds, the local Oyster UI flips to signed-in state (`AuthService` poll picks up the attached session).
+
+Verify locally:
+
+```bash
+cat ~/Oyster/config/auth.json
+# Expected: { "session_token": "...", "user_id": "...", "email": "...", "signed_in_at": ... }
+```
+
+- [ ] **Step 4: Verify D1 state.**
+
+```bash
+cd infra/auth-worker
+npx wrangler d1 execute oyster-auth --remote --command "SELECT provider, provider_user_id, user_id, provider_email, linked_at, last_seen_at FROM user_identities ORDER BY linked_at DESC LIMIT 5;"
+```
+
+Expected: at least one row with `provider='github'` and `provider_user_id` matching your GitHub numeric ID.
+
+```bash
+npx wrangler d1 execute oyster-auth --remote --command "SELECT count(*) as n FROM oauth_states WHERE consumed_at IS NOT NULL;"
+```
+
+Expected: `n` >= 2 (one for cloud-only, one for local-handoff smoke test).
+
+- [ ] **Step 5: If anything fails, debug before opening PR 2.** Common failure modes:
+  - `oauth_not_configured` 503: secrets/vars not set; re-run Task 2.0.
+  - GitHub redirects back with `error=redirect_uri_mismatch`: callback URL in the OAuth App doesn't match what the Worker is sending. Check the OAuth App settings.
+  - GitHub returns `bad_verification_code`: PKCE mismatch. Verify `codeChallengeS256(verifier)` returns the same value with and without padding (the helper test catches this).
+  - "GitHub didn't return a verified primary email": check that your GitHub account has a verified primary email at github.com/settings/emails.
+
+---
+
+### Task 2.5: Open PR 2
+
+- [ ] **Step 1: Push branch and open PR.**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(auth-worker): GitHub OAuth start + callback (#340 PR 2/3)" --body "$(cat <<'EOF'
+## Summary
+
+- `/auth/github/start` and `/auth/github/callback` fully wired against GitHub's OAuth web flow with PKCE + state.
+- Identity resolved through the `user_identities` table per the design doc — `provider_user_id` is the truth, `users.email` is opportunistically updated to close the magic-link footgun on email change (with conflict guard).
+- Sessions attach to the existing `device_codes` row when `?d=<user_code>` is set on `/start`; cloud-only sign-in works without a `?d=`.
+- Sign-in page is **not** changed yet — endpoints are reachable by direct URL only. Phase 3 surfaces the GitHub button.
+
+Spec: docs/plans/auth-oauth.md
+Setup: see Task 2.0 in docs/superpowers/plans/2026-05-02-340-oauth-github.md
+
+Part of #340.
+
+## Test plan
+
+- [x] `npm run typecheck` clean
+- [x] `npm run test` clean (helper unit tests still pass)
+- [x] Cloud-only smoke test: visit `https://oyster.to/auth/github/start` → consent → land on `/auth/welcome`, cookie set
+- [x] Local-handoff smoke test: start sign-in from local Oyster → manually navigate to `/auth/github/start?d=<user_code>` → consent → local Oyster picks up the session via existing poll loop (~2s)
+- [x] D1 inspection: `user_identities` has the new GitHub row; `oauth_states` shows consumed entries
+- [x] Magic-link path still works (regression check via the existing email form)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for review and merge.** Address review comments via additional commits on the same branch.
+
+---
+
+## Phase 3 — Sign-in page UI + auth.md update (PR 3)
+
+End state: GitHub button is the primary CTA on `/auth/sign-in`; magic-link drops to a fallback under "or use email"; `auth.md` no longer says OAuth is deferred.
+
+### Task 3.1: Add the GitHub button to `SIGN_IN_HTML`
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+The existing `SIGN_IN_HTML(userCode)` template renders the email form only. Add a button row above the form, plus a divider with "or use email".
+
+- [ ] **Step 1: Replace `SIGN_IN_HTML`.**
+
+Find the existing `SIGN_IN_HTML = (userCode: string | null) => ...` constant and replace its entire body with:
+
+```ts
+const GITHUB_MARK_SVG = `<svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20" fill="currentColor" style="vertical-align: -4px; margin-right: 0.5rem;"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>`;
+
+const SIGN_IN_HTML = (userCode: string | null) => {
+  const githubHref = userCode
+    ? `/auth/github/start?d=${encodeURIComponent(userCode)}`
+    : "/auth/github/start";
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in to Oyster</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 28rem; margin: 6rem auto; padding: 0 1.5rem; line-height: 1.5; }
+  h1 { font-size: 1.5rem; margin: 0 0 1.5rem; }
+  .gh-button { display: flex; align-items: center; justify-content: center; padding: 0.7rem 1rem; font-size: 1rem; font-weight: 600; border: 0; border-radius: 0.4rem; background: #24292f; color: #ffffff; text-decoration: none; cursor: pointer; }
+  .gh-button:hover { background: #32383f; }
+  .divider { display: flex; align-items: center; gap: 0.75rem; margin: 1.5rem 0; font-size: 0.85rem; opacity: 0.6; }
+  .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: currentColor; opacity: 0.25; }
+  form { display: flex; flex-direction: column; gap: 0.75rem; }
+  label { font-size: 0.85rem; opacity: 0.7; }
+  input[type=email] { padding: 0.6rem 0.75rem; font-size: 1rem; border: 1px solid #888; border-radius: 0.4rem; background: transparent; color: inherit; }
+  button[type=submit] { padding: 0.6rem 0.75rem; font-size: 1rem; font-weight: 500; border: 0; border-radius: 0.4rem; background: transparent; color: inherit; border: 1px solid #888; cursor: pointer; }
+  button[type=submit]:disabled { opacity: 0.5; cursor: not-allowed; }
+  #status { margin-top: 1rem; font-size: 0.9rem; }
+  .ok { color: #2e7d32; }
+  .err { color: #c62828; }
+</style>
+</head><body>
+<h1>Sign in to Oyster</h1>
+<a class="gh-button" href="${githubHref}">${GITHUB_MARK_SVG}Continue with GitHub</a>
+<div class="divider">or use email</div>
+<form id="f">
+  <label for="email">Email</label>
+  <input id="email" name="email" type="email" required autocomplete="email">
+  <button type="submit">Send magic link</button>
+</form>
+<p id="status" hidden></p>
+<script>
+const f = document.getElementById('f');
+const s = document.getElementById('status');
+const userCode = ${userCode ? JSON.stringify(userCode) : "null"};
+f.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = f.email.value.trim();
+  const btn = f.querySelector('button');
+  btn.disabled = true;
+  btn.textContent = 'Sending…';
+  try {
+    const res = await fetch('/auth/magic-link', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, user_code: userCode }),
+    });
+    if (res.ok) {
+      f.style.display = 'none';
+      s.hidden = false;
+      s.className = 'ok';
+      s.textContent = 'Check your inbox for a sign-in link. The link expires in 15 minutes.';
+    } else {
+      s.hidden = false;
+      s.className = 'err';
+      s.textContent = 'Could not send the link. Check the email and try again.';
+      btn.disabled = false;
+      btn.textContent = 'Send magic link';
+    }
+  } catch {
+    s.hidden = false;
+    s.className = 'err';
+    s.textContent = 'Network error. Try again.';
+    btn.disabled = false;
+    btn.textContent = 'Send magic link';
+  }
+});
+</script>
+</body></html>`;
+};
+```
+
+Three substantive changes vs the existing template:
+1. The GitHub button (`<a class="gh-button">`) is the primary CTA above the form.
+2. A "or use email" divider.
+3. The submit button's style is muted (transparent background, just a border) so the GitHub button is clearly the primary action. The magic-link form itself is unchanged.
+
+The `autofocus` attribute is removed from the email input so it doesn't pull focus past the GitHub button on page load.
+
+- [ ] **Step 2: Type-check.**
+
+```bash
+cd infra/auth-worker && npm run typecheck
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): sign-in page — GitHub primary, email fallback"
+```
+
+---
+
+### Task 3.2: Update `docs/plans/auth.md`
+
+**Files:**
+- Modify: `docs/plans/auth.md`
+
+Drop the "OAuth providers (Google/GitHub)" bullet from the "What 0.7.0 does NOT include" section, add a "Providers" section that points at `auth-oauth.md`, revise the "Decision" stanza so it no longer claims "No OAuth providers in 0.7.0".
+
+- [ ] **Step 1: Update the "Decision" stanza.**
+
+Find this line near the top of `docs/plans/auth.md`:
+
+```markdown
+**Cloudflare-native magic-link auth.** D1 for users + sessions, a Worker at `oyster.to/auth/*` for the flow, Resend for transactional email, OAuth device-authorization-grant pattern to bridge the browser sign-in to the local server at `localhost:4444`. No passwords. No OAuth providers in 0.7.0. No MFA in 0.7.0.
+```
+
+Replace with:
+
+```markdown
+**Cloudflare-native auth.** D1 for users + sessions, a Worker at `oyster.to/auth/*` for the flow, Resend for transactional email, an Oyster-internal device-code handoff to bridge the browser sign-in to the local server at `localhost:4444`. **GitHub OAuth is the primary sign-in path** as of #340 (see [`auth-oauth.md`](./auth-oauth.md)); magic-link is the secondary fallback documented below. No passwords. No MFA in 0.7.0.
+```
+
+- [ ] **Step 2: Replace the "OAuth providers" bullet in the NOT-included section.**
+
+Find the section "## What 0.7.0 does NOT include" and the bullet:
+
+```markdown
+- **OAuth providers (Google/GitHub).** Magic-link is the funnel; Google sign-in is a launch optimisation that can land later as `/auth/google` on the same Worker without schema changes.
+```
+
+Replace with:
+
+```markdown
+- **Google sign-in.** Deferred until GitHub lands cleanly. Same Worker, same schema, same identity-resolution rule — adds `/auth/google/start` and `/auth/google/callback`. See [`auth-oauth.md`](./auth-oauth.md) for the OAuth design.
+```
+
+- [ ] **Step 3: Add a "Providers" section.**
+
+Add this section just before "## What 0.7.0 does NOT include":
+
+```markdown
+## Providers
+
+GitHub OAuth is the primary sign-in path. The full design — endpoints, schema delta (`user_identities`, `oauth_states`), identity-resolution rules, and PR sequencing — lives in [`auth-oauth.md`](./auth-oauth.md). The magic-link substrate documented in this doc is unchanged; OAuth ships alongside it as the primary CTA, with magic-link as the secondary fallback.
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add docs/plans/auth.md
+git commit -m "docs(auth): drop OAuth-deferred framing, point at auth-oauth.md"
+```
+
+---
+
+### Task 3.3: Smoke test post-deploy
+
+- [ ] **Step 1: Deploy.**
+
+```bash
+cd infra/auth-worker && npm run deploy
+```
+
+- [ ] **Step 2: Verify the sign-in page in a browser.**
+
+Open `https://oyster.to/auth/sign-in` in a private window. Expected:
+- Heading: "Sign in to Oyster".
+- Primary button: "Continue with GitHub" (dark fill, GitHub mark glyph).
+- Divider: "or use email".
+- Below the divider: the existing email input + muted "Send magic link" button.
+- Click "Continue with GitHub" → consent → land on `/auth/welcome` signed in.
+
+- [ ] **Step 3: Verify the local-handoff full flow.**
+
+In the local Oyster UI, click sign-in. Expected:
+1. Browser opens `https://oyster.to/auth/sign-in?d=<user_code>`.
+2. Click **Continue with GitHub**.
+3. GitHub consent → Authorize.
+4. Land on `WELCOME_HTML` ("Signed in as <email>", "You can close this window").
+5. Local Oyster UI flips to signed-in state within ~2s.
+
+- [ ] **Step 4: Verify magic-link still works.**
+
+Same page, "Send magic link". Email arrives, click the link, land on `/auth/welcome`. (Existing flow regression check.)
+
+---
+
+### Task 3.4: Open PR 3
+
+- [ ] **Step 1: Push branch and open PR.**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(auth): sign-in page — GitHub primary CTA + auth.md update (#340 PR 3/3)" --body "$(cat <<'EOF'
+## Summary
+
+- Promotes "Continue with GitHub" to the primary CTA on `https://oyster.to/auth/sign-in`. Magic-link drops below an "or use email" divider as the fallback.
+- Updates `docs/plans/auth.md` to drop the "OAuth deferred" framing and point at `auth-oauth.md` for the OAuth design.
+- No new endpoints — all wiring shipped in PR 2 (#340).
+
+Closes #340.
+
+## Test plan
+
+- [x] `https://oyster.to/auth/sign-in` shows the GitHub button as primary, email form as fallback under "or use email"
+- [x] "Continue with GitHub" works for cloud-only sign-in (no `?d=`) → lands on `/auth/welcome`
+- [x] "Continue with GitHub" works for the local-handoff path (with `?d=<user_code>` from local Oyster) → local app picks up the session within ~2s
+- [x] Magic-link form still works (regression)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for review and merge.**
+
+- [ ] **Step 3: Close issue #340.**
+
+After PR 3 merges, the issue is auto-closed by the PR body's `Closes #340`. Verify in the GitHub UI that the issue is closed and the project board reflects "Done".
+
+---
+
+## Followups (file as new issues after #340 ships)
+
+These are deliberately out of scope for #340. File them as separate GitHub issues once the three PRs are merged:
+
+1. **Magic-link silent-degrade fix.** `handleMagicLink` resolves `user_code` at send-time and proceeds with `deviceCode = null` if it's bad. Same browser-says-success / local-keeps-polling split-brain that the OAuth `/start` validation fixes. Bring magic-link in line by validating the `user_code` against the same predicates and returning an error response when invalid.
+2. **Google OAuth.** Same Worker, same schema, same identity-resolution rule — adds `/auth/google/start` and `/auth/google/callback`. Use Google's discovery endpoint (`https://accounts.google.com/.well-known/openid-configuration`) for the authorize/token URLs and `https://openidconnect.googleapis.com/v1/userinfo` for identity. Google's email is verified by default; no separate `/user/emails` call needed.
+3. **`oauth_email_conflict` observability.** Surface the structured log event via Workers Logs filter or a small admin endpoint. No-op until it actually fires in real traffic.
+4. **Local-server token rotation on cloud 401.** Carried over from `auth.md`'s open questions. Settle when the first cloud-touching feature lands (publish, #315).
+
+---
+
+## Spec coverage check
+
+| Spec section | Implementation tasks |
+|---|---|
+| Decision (cloud-first, GitHub-only, magic-link fallback) | Phases 1–3 |
+| User-facing flow (3 clicks, no inbox) | Tasks 2.1, 2.3, 3.1 |
+| D1 schema delta (`user_identities`, `oauth_states`) | Task 1.4 |
+| `GET /auth/github/start` | Tasks 1.6 (stub), 2.1 (full) |
+| `GET /auth/github/callback` | Tasks 2.2, 2.3 |
+| Identity resolution (STEP 1/2/3 + email-update conflict) | Task 2.3 (`resolveIdentity`) |
+| Concurrency retry on STEP 3 INSERT | Task 2.3 (`for (let attempt = 0; attempt < 3; ...)`) |
+| Sign-in page (GitHub button + "or use email") | Task 3.1 |
+| `SIGN_IN_EXPIRED_HTML` (both branches) | Task 2.1 |
+| No-verified-email error copy | Task 2.2 |
+| Failure-mode catalogue | Tasks 2.1 (rate-limit, `?d=` validate), 2.2 (state, token, identity, no-email), 2.3 (attach race, retry exhaustion) |
+| Setup work (OAuth App registration) | Task 2.0 |
+| Worker config (`GITHUB_OAUTH_CLIENT_ID`, secret) | Tasks 1.5, 2.0 |
+| Dev story (no live local OAuth, mocked tests only) | Task 1.1 (vitest setup), Tasks 1.2/1.3 (helper unit tests) |
+| PR sequencing (3 PRs) | Phases 1, 2, 3 → Tasks 1.8, 2.5, 3.4 |
+| `auth.md` update | Task 3.2 |
+| Followups | "Followups" section above |


### PR DESCRIPTION
## Summary

- Captures the cloud-first OAuth design for 0.7.0 (#340): GitHub OAuth via the existing `oyster-auth` Worker, identity resolved through a new `user_identities` table keyed on `(provider, provider_user_id)`, reusing the local sign-in handoff shipped in #339.
- Magic-link stays as a secondary fallback. Google deferred to a follow-up issue.
- Supplements `docs/plans/auth.md`; the auth.md update to drop "OAuth deferred" framing lands in PR 3 of the implementation sequence (alongside the sign-in page UI flip).

## What's in the doc

- D1 schema delta: `user_identities` (with `ON DELETE CASCADE`) + `oauth_states` (state + PKCE verifier, single-use, replay-defended via `consumed_at`)
- Worker endpoints: `GET /auth/github/start?d=<user_code>` and `GET /auth/github/callback?code=...&state=...`, both with explicit fail-closed rules
- Identity resolution (provider_user_id is the truth; users.email is updated opportunistically with a conflict guard to close the magic-link footgun on email change)
- Sign-in page change: GitHub button promoted to primary, magic-link demoted to fallback under "or use email"
- Failure-mode catalogue (generic copy throughout; only the `/user/emails` no-verified-primary case names GitHub, because the user has to take provider-specific action to recover)
- Three-PR implementation sequence with smoke-test scope per PR (cloud-only sign-in *and* local-handoff sign-in)
- Followups (incl. magic-link's pre-existing silent-degrade bug to bring in line with the new fail-closed rule)

## Test plan

- [ ] Skim end-to-end: scope, schema, endpoints, resolution rule, failure modes, sequencing
- [ ] Verify D1 FK + GitHub PKCE / `user:email` claims still match upstream docs (links called out inline)
- [ ] Confirm three-PR sequencing matches the agreed shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)