### PR TITLE
chore(refactor): http helper + useFetched hook + dedupe UiCommand

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import { SpaceService } from "./space-service.js";
 import { slugify } from "./utils.js";
 import { IconGenerator } from "./icon-generator.js";
 import { injectBridge } from "./error-bridge.js";
+import type { UiCommand } from "../../shared/types.js";
 import {
   scanExistingArtifacts,
   startGenerationTimer,
@@ -622,13 +623,6 @@ process.on("unhandledRejection", (err) => {
 });
 
 // ── UI push events (SSE) ──
-
-interface UiCommand {
-  version: 1;
-  command: string;
-  payload: unknown;
-  correlationId?: string;
-}
 
 const uiClients = new Set<ServerResponse>();
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -9,7 +9,7 @@ import type { SpaceService } from "./space-service.js";
 import type { MemoryProvider } from "./memory-store.js";
 import { registerMemoryTools } from "./memory-store.js";
 import type { SessionStore } from "./session-store.js";
-import type { ArtifactKind } from "../../shared/types.js";
+import type { ArtifactKind, UiCommand } from "../../shared/types.js";
 import { debug } from "./debug.js";
 import { slugify } from "./utils.js";
 import { recordToolCall } from "./mcp-client-tracker.js";
@@ -106,13 +106,6 @@ function gatherRepoContext(repoPath: string): { content: string; suggestions: Ar
   const header = `# Repo context: ${root}\nFiles included: ${includedPaths.length} / ${allFiles.length} (${skippedCount} skipped — over budget or unreadable)\n\n`;
 
   return { content: header + sections.join("\n\n"), suggestions };
-}
-
-interface UiCommand {
-  version: 1;
-  command: string;
-  payload: unknown;
-  correlationId?: string;
 }
 
 interface McpDeps {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -140,8 +140,10 @@ export interface Space {
 }
 
 /** SSE message broadcast on /api/ui/events. The web app subscribes via
- *  subscribeUiEvents and routes by `command`. Versioned so we can evolve
- *  the envelope without breaking older browsers mid-session. */
+ *  subscribeUiEvents and routes by `command`. The `version` field is
+ *  reserved for future envelope evolution — today's client (ui-events.ts)
+ *  uses a narrower `{command, payload}` shape and doesn't gate on version,
+ *  so any non-additive change still requires a coordinated client update. */
 export interface UiCommand {
   version: 1;
   command: string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -138,3 +138,13 @@ export interface Space {
   createdAt: string;
   updatedAt: string;
 }
+
+/** SSE message broadcast on /api/ui/events. The web app subscribes via
+ *  subscribeUiEvents and routes by `command`. Versioned so we can evolve
+ *  the envelope without breaking older browsers mid-session. */
+export interface UiCommand {
+  version: 1;
+  command: string;
+  payload: unknown;
+  correlationId?: string;
+}

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -1,22 +1,14 @@
 export type { Artifact, ArtifactKind, ArtifactStatus, IconStatus, SessionJoinedForArtifact } from "../../../shared/types";
 import type { Artifact, SessionJoinedForArtifact } from "../../../shared/types";
-
-// Our mutation endpoints return `{error: "…"}` on failure. Surface that
-// message in thrown Error objects so UI alert()s show something actionable.
-// Callers add their own action context (e.g. "Rename failed:") on the
-// alert side — this helper just carries the reason, so we don't get
-// double-prefixed messages like "Rename failed: Rename failed: 400".
-async function throwFromResponse(res: Response): Promise<never> {
-  const body = await res.json().catch(() => null) as { error?: string } | null;
-  throw new Error(body?.error || `HTTP ${res.status}`);
-}
+import { getJson, patchJson, postJson, postEmpty } from "./http";
 
 export async function fetchArtifacts(): Promise<Artifact[]> {
-  const res = await fetch("/api/artifacts");
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<Artifact[]>("/api/artifacts");
 }
 
+// startApp/stopApp keep their bespoke shape: server routes are GETs and the
+// callers in App.tsx tolerate any response (no throw on non-OK). Promoting
+// to getJson would change that contract — out of scope for this refactor.
 export async function startApp(name: string): Promise<{ status: string; port?: number }> {
   const res = await fetch(`/api/apps/${name}/start`);
   return res.json();
@@ -31,39 +23,27 @@ export async function updateArtifact(
   id: string,
   fields: { label?: string; group_name?: string | null },
 ): Promise<Artifact> {
-  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(fields),
-  });
-  if (!res.ok) await throwFromResponse(res);
-  return res.json();
+  return patchJson<Artifact>(`/api/artifacts/${encodeURIComponent(id)}`, fields);
 }
 
 export async function archiveArtifact(id: string): Promise<void> {
-  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/archive`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res);
+  return postEmpty(`/api/artifacts/${encodeURIComponent(id)}/archive`);
 }
 
 export async function listArchivedArtifacts(): Promise<Artifact[]> {
-  const res = await fetch("/api/artifacts/archived");
-  if (!res.ok) await throwFromResponse(res);
-  return res.json();
+  return getJson<Artifact[]>("/api/artifacts/archived");
 }
 
 export async function restoreArtifact(id: string): Promise<void> {
-  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/restore`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res);
+  return postEmpty(`/api/artifacts/${encodeURIComponent(id)}/restore`);
 }
 
 export async function uninstallPlugin(id: string): Promise<void> {
-  const res = await fetch(`/api/plugins/${encodeURIComponent(id)}/uninstall`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res);
+  return postEmpty(`/api/plugins/${encodeURIComponent(id)}/uninstall`);
 }
 
 export async function regenerateIcon(id: string): Promise<void> {
-  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/icon/regenerate`, { method: "POST" });
-  if (!res.ok) await throwFromResponse(res);
+  return postEmpty(`/api/artifacts/${encodeURIComponent(id)}/icon/regenerate`);
 }
 
 export async function renameGroup(
@@ -71,30 +51,24 @@ export async function renameGroup(
   oldName: string,
   newName: string,
 ): Promise<{ updated: number }> {
-  const res = await fetch("/api/groups", {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ space_id: spaceId, old_name: oldName, new_name: newName }),
+  return patchJson<{ updated: number }>("/api/groups", {
+    space_id: spaceId,
+    old_name: oldName,
+    new_name: newName,
   });
-  if (!res.ok) await throwFromResponse(res);
-  return res.json();
 }
 
 export async function archiveGroup(spaceId: string, name: string): Promise<{ archived: number }> {
-  const res = await fetch("/api/groups/archive", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ space_id: spaceId, name }),
-  });
-  if (!res.ok) await throwFromResponse(res);
-  return res.json();
+  return postJson<{ archived: number }>("/api/groups/archive", { space_id: spaceId, name });
 }
 
 export async function fetchSessionsForArtifact(
   id: string,
   signal?: AbortSignal,
 ): Promise<SessionJoinedForArtifact[]> {
-  const res = await fetch(`/api/artifacts/${encodeURIComponent(id)}/sessions`, { signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<SessionJoinedForArtifact[]>(
+    `/api/artifacts/${encodeURIComponent(id)}/sessions`,
+    signal,
+  );
 }
+

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -58,7 +58,8 @@ export async function patchJson<T>(
   return res.json() as Promise<T>;
 }
 
-/** POST with no JSON response body (e.g. archive/restore endpoints).
+/** POST whose response body the caller doesn't need (e.g. archive/restore
+ *  endpoints — the server may return JSON status, but it's discarded here).
  *  Throws ApiError on non-2xx; resolves to void otherwise. */
 export async function postEmpty(
   url: string,

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -1,0 +1,91 @@
+// Shared fetch helpers. Every data module used to roll its own
+// error decoder (`throwFromResponse` / `readErr` / inline shapes); now
+// they share one. The server's mutation endpoints return `{error: "…"}`
+// on failure — ApiError surfaces that string so UI alert()s show
+// something actionable instead of `HTTP 400`.
+
+export class ApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = "ApiError";
+  }
+}
+
+async function decodeError(res: Response): Promise<ApiError> {
+  let message = `HTTP ${res.status}`;
+  try {
+    const body = await res.json() as { error?: string } | null;
+    if (body && typeof body.error === "string") message = body.error;
+  } catch { /* not JSON */ }
+  return new ApiError(res.status, message);
+}
+
+export async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw await decodeError(res);
+  return res.json() as Promise<T>;
+}
+
+export async function postJson<T>(
+  url: string,
+  body?: unknown,
+  opts?: { signal?: AbortSignal },
+): Promise<T> {
+  const init: RequestInit = { method: "POST", signal: opts?.signal };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, init);
+  if (!res.ok) throw await decodeError(res);
+  return res.json() as Promise<T>;
+}
+
+export async function patchJson<T>(
+  url: string,
+  body: unknown,
+  opts?: { signal?: AbortSignal },
+): Promise<T> {
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: opts?.signal,
+  });
+  if (!res.ok) throw await decodeError(res);
+  return res.json() as Promise<T>;
+}
+
+/** POST with no JSON response body (e.g. archive/restore endpoints).
+ *  Throws ApiError on non-2xx; resolves to void otherwise. */
+export async function postEmpty(
+  url: string,
+  body?: unknown,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
+  const init: RequestInit = { method: "POST", signal: opts?.signal };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, init);
+  if (!res.ok) throw await decodeError(res);
+}
+
+/** DELETE, optionally with a JSON body (deleteSpace passes folderName).
+ *  Throws ApiError on non-2xx; resolves to void otherwise. */
+export async function del(
+  url: string,
+  body?: unknown,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
+  const init: RequestInit = { method: "DELETE", signal: opts?.signal };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, init);
+  if (!res.ok) throw await decodeError(res);
+}

--- a/web/src/data/memories-api.ts
+++ b/web/src/data/memories-api.ts
@@ -1,5 +1,6 @@
 // Surfaces memories created via mcp__oyster__remember. v1 is read-only —
 // writes still go through the MCP tool surface.
+import { getJson, postJson } from "./http";
 
 export interface Memory {
   id: string;
@@ -16,9 +17,7 @@ export async function fetchMemories(spaceId?: string | null, signal?: AbortSigna
   const url = spaceId
     ? `/api/memories?space_id=${encodeURIComponent(spaceId)}`
     : "/api/memories";
-  const res = await fetch(url, { signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<Memory[]>(url, signal);
 }
 
 export interface CreateMemoryInput {
@@ -28,23 +27,9 @@ export interface CreateMemoryInput {
 }
 
 export async function createMemory(input: CreateMemoryInput): Promise<Memory> {
-  const res = await fetch("/api/memories", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      content: input.content,
-      space_id: input.space_id || undefined,
-      tags: input.tags?.length ? input.tags : undefined,
-    }),
+  return postJson<Memory>("/api/memories", {
+    content: input.content,
+    space_id: input.space_id || undefined,
+    tags: input.tags?.length ? input.tags : undefined,
   });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    let message = `Server returned ${res.status}`;
-    try {
-      const err = JSON.parse(text);
-      if (typeof err.error === "string") message = err.error;
-    } catch { /* not JSON */ }
-    throw new Error(message);
-  }
-  return res.json();
 }

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -14,18 +14,23 @@ import type {
   SessionEvent,
   SessionArtifactJoined,
 } from "../../../shared/types";
+import { ApiError, getJson } from "./http";
 
 export async function fetchSessions(): Promise<Session[]> {
-  const res = await fetch("/api/sessions");
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<Session[]>("/api/sessions");
 }
 
 export async function fetchSession(id: string, signal?: AbortSignal): Promise<Session> {
-  const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`, { signal });
-  if (res.status === 404) throw new SessionNotFoundError(id);
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  try {
+    return await getJson<Session>(`/api/sessions/${encodeURIComponent(id)}`, signal);
+  } catch (err) {
+    // Callers (SessionInspector) branch on this to render a "no longer
+    // available" state vs. a generic error banner.
+    if (err instanceof ApiError && err.status === 404) {
+      throw new SessionNotFoundError(id);
+    }
+    throw err;
+  }
 }
 
 export interface FetchSessionEventsOpts {
@@ -55,15 +60,11 @@ export async function fetchSessionEvents(
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
   const qs = params.toString();
   const url = `/api/sessions/${encodeURIComponent(id)}/events${qs ? `?${qs}` : ""}`;
-  const res = await fetch(url, { signal: opts.signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<SessionEvent[]>(url, opts.signal);
 }
 
 export async function fetchSessionArtifacts(id: string, signal?: AbortSignal): Promise<SessionArtifactJoined[]> {
-  const res = await fetch(`/api/sessions/${encodeURIComponent(id)}/artifacts`, { signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<SessionArtifactJoined[]>(`/api/sessions/${encodeURIComponent(id)}/artifacts`, signal);
 }
 
 /** R6 traceable recall: memories tied to this session — written by it
@@ -88,9 +89,7 @@ export interface SessionMemory {
 }
 
 export async function fetchSessionMemory(id: string, signal?: AbortSignal): Promise<SessionMemory> {
-  const res = await fetch(`/api/sessions/${encodeURIComponent(id)}/memory`, { signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<SessionMemory>(`/api/sessions/${encodeURIComponent(id)}/memory`, signal);
 }
 
 /** A transcript-search hit returned by GET /api/sessions/search.
@@ -111,9 +110,7 @@ export async function searchTranscripts(
 ): Promise<TranscriptHit[]> {
   const params = new URLSearchParams({ q: query });
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
-  const res = await fetch(`/api/sessions/search?${params.toString()}`, { signal: opts.signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
+  return getJson<TranscriptHit[]>(`/api/sessions/search?${params.toString()}`, opts.signal);
 }
 
 // The list endpoint strips `raw` from every event to keep the payload
@@ -125,18 +122,18 @@ export async function fetchSessionEventRaw(
   eventId: number,
   signal?: AbortSignal,
 ): Promise<string | null> {
-  const res = await fetch(
+  const ev = await getJson<SessionEvent>(
     `/api/sessions/${encodeURIComponent(sessionId)}/events/${eventId}`,
-    { signal },
+    signal,
   );
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  const ev = (await res.json()) as SessionEvent;
   return ev.raw;
 }
 
 export class SessionNotFoundError extends Error {
-  constructor(public sessionId: string) {
+  sessionId: string;
+  constructor(sessionId: string) {
     super(`Session not found: ${sessionId}`);
+    this.sessionId = sessionId;
     this.name = "SessionNotFoundError";
   }
 }

--- a/web/src/data/spaces-api.ts
+++ b/web/src/data/spaces-api.ts
@@ -1,48 +1,26 @@
 import type { Space } from "../../../shared/types";
+import { getJson, patchJson, postJson, del } from "./http";
 
 export async function fetchSpaces(): Promise<Space[]> {
-  const res = await fetch("/api/spaces");
-  if (!res.ok) return [];
-  return res.json();
+  // Returns [] on failure rather than throwing — callers (App bootstrap)
+  // expect a list, and a missing /api/spaces shouldn't crash the surface.
+  try {
+    return await getJson<Space[]>("/api/spaces");
+  } catch {
+    return [];
+  }
 }
 
 export async function updateSpace(spaceId: string, fields: { displayName?: string; color?: string }): Promise<Space> {
-  const res = await fetch(`/api/spaces/${spaceId}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(fields),
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? `HTTP ${res.status}`);
-  }
-  return res.json();
+  return patchJson<Space>(`/api/spaces/${spaceId}`, fields);
 }
 
 export async function convertFolderToSpace(folderName: string, sourceSpaceId: string = "home", merge?: boolean): Promise<Space> {
-  const res = await fetch("/api/spaces/from-folder", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ folderName, sourceSpaceId, merge }),
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? `HTTP ${res.status}`);
-  }
-  return res.json();
+  return postJson<Space>("/api/spaces/from-folder", { folderName, sourceSpaceId, merge });
 }
 
 export async function promoteFolderToSpace(path: string, name?: string): Promise<Space> {
-  const res = await fetch("/api/spaces/from-path", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, name }),
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? `HTTP ${res.status}`);
-  }
-  return res.json();
+  return postJson<Space>("/api/spaces/from-path", { path, name });
 }
 
 // Sources = linked folders attached to a space. The UI can list, attach,
@@ -59,46 +37,17 @@ export interface SpaceSource {
 }
 
 export async function fetchSpaceSources(spaceId: string, signal?: AbortSignal): Promise<SpaceSource[]> {
-  const res = await fetch(`/api/spaces/${encodeURIComponent(spaceId)}/sources`, { signal });
-  if (!res.ok) throw new Error(`Server returned ${res.status}`);
-  return res.json();
-}
-
-async function readErr(res: Response): Promise<string> {
-  try {
-    const body = await res.json() as { error?: string };
-    if (typeof body.error === "string") return body.error;
-  } catch { /* not JSON */ }
-  return `HTTP ${res.status}`;
+  return getJson<SpaceSource[]>(`/api/spaces/${encodeURIComponent(spaceId)}/sources`, signal);
 }
 
 export async function addSpaceSource(spaceId: string, path: string): Promise<SpaceSource> {
-  const res = await fetch(`/api/spaces/${encodeURIComponent(spaceId)}/sources`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path }),
-  });
-  if (!res.ok) throw new Error(await readErr(res));
-  return res.json();
+  return postJson<SpaceSource>(`/api/spaces/${encodeURIComponent(spaceId)}/sources`, { path });
 }
 
 export async function removeSpaceSource(spaceId: string, sourceId: string): Promise<void> {
-  const res = await fetch(
-    `/api/spaces/${encodeURIComponent(spaceId)}/sources/${encodeURIComponent(sourceId)}`,
-    { method: "DELETE" },
-  );
-  if (!res.ok) throw new Error(await readErr(res));
+  return del(`/api/spaces/${encodeURIComponent(spaceId)}/sources/${encodeURIComponent(sourceId)}`);
 }
 
 export async function deleteSpace(spaceId: string, folderName?: string): Promise<void> {
-  const opts: RequestInit = { method: "DELETE" };
-  if (folderName) {
-    opts.headers = { "Content-Type": "application/json" };
-    opts.body = JSON.stringify({ folderName });
-  }
-  const res = await fetch(`/api/spaces/${spaceId}`, opts);
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({})) as { error?: string };
-    throw new Error(body.error ?? `HTTP ${res.status}`);
-  }
+  return del(`/api/spaces/${spaceId}`, folderName ? { folderName } : undefined);
 }

--- a/web/src/hooks/useFetched.ts
+++ b/web/src/hooks/useFetched.ts
@@ -1,0 +1,93 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { subscribeUiEvents } from "../data/ui-events";
+
+// Generic "fetch + tick + abort + (optional) SSE refresh" hook.
+//
+// Used to be three near-identical hooks (useSessions / useMemories /
+// useSpaceSources). The shared shape:
+// 1. Fetch on mount (and when `key` or `tick` changes).
+// 2. Stash a monotonically-increasing reqId so an out-of-order resolve
+//    from a slower earlier fetch doesn't overwrite a fresh one.
+// 3. AbortController scoped to each effect run, cancelled on cleanup.
+// 4. Optional SSE event name — firing the named UI command bumps tick
+//    and triggers a refetch.
+// 5. Optional `key` for parameterised fetches (e.g. spaceId). Changing
+//    the key clears stale data pre-paint so the previous payload doesn't
+//    flash before the new fetch resolves.
+// 6. Optional `enabled` flag — when false, resets to `initial` and
+//    skips fetching (used by useSpaceSources for the null-space case).
+
+interface UseFetchedOpts {
+  /** Refetch when this value changes; clears prior data pre-paint. */
+  key?: unknown;
+  /** When false, skip fetching and hold `initial`. Default true. */
+  enabled?: boolean;
+  /** UI SSE command name; firing it triggers a refetch. */
+  ssEvent?: string;
+}
+
+export function useFetched<T>(
+  fetcher: (signal: AbortSignal) => Promise<T>,
+  initial: T,
+  opts: UseFetchedOpts = {},
+): { data: T; loading: boolean; error: Error | null; refresh: () => void } {
+  const { key, enabled = true, ssEvent } = opts;
+  const [data, setData] = useState<T>(initial);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<Error | null>(null);
+  const [tick, setTick] = useState(0);
+  const latestReqId = useRef(0);
+  // Hold initial in a ref so callers can pass `[]` literally without
+  // tripping the deps array; the effects below read .current on demand.
+  const initialRef = useRef(initial);
+
+  // Pre-paint clear on key change. Without this, switching from one
+  // keyed view to another briefly shows the previous payload before
+  // the new fetch resolves.
+  useLayoutEffect(() => {
+    if (key !== undefined) {
+      setData(initialRef.current);
+      setError(null);
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(initialRef.current);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const reqId = ++latestReqId.current;
+    setLoading(true);
+    const ac = new AbortController();
+    fetcher(ac.signal)
+      .then((value) => {
+        if (reqId !== latestReqId.current) return;
+        setData(value);
+        setError(null);
+      })
+      .catch((err) => {
+        if (reqId !== latestReqId.current || ac.signal.aborted) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (reqId !== latestReqId.current) return;
+        setLoading(false);
+      });
+    return () => ac.abort();
+    // fetcher is intentionally omitted — callers commonly pass an inline
+    // arrow, which would re-trigger on every render. tick + key + enabled
+    // are the real refetch triggers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick, key, enabled]);
+
+  useEffect(() => {
+    if (!ssEvent) return;
+    return subscribeUiEvents((event) => {
+      if (event.command === ssEvent) setTick((n) => n + 1);
+    });
+  }, [ssEvent]);
+
+  return { data, loading, error, refresh: () => setTick((n) => n + 1) };
+}

--- a/web/src/hooks/useFetched.ts
+++ b/web/src/hooks/useFetched.ts
@@ -39,7 +39,11 @@ export function useFetched<T>(
   const latestReqId = useRef(0);
   // Hold initial in a ref so callers can pass `[]` literally without
   // tripping the deps array; the effects below read .current on demand.
+  // Sync on every render so a derived `initial` (e.g. memoised from props)
+  // doesn't get frozen at the first-render value — without this, a later
+  // reset on `key` change would revert to a stale empty.
   const initialRef = useRef(initial);
+  initialRef.current = initial;
 
   // Pre-paint clear on key change. Without this, switching from one
   // keyed view to another briefly shows the previous payload before

--- a/web/src/hooks/useMemories.ts
+++ b/web/src/hooks/useMemories.ts
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from "react";
 import { fetchMemories } from "../data/memories-api";
 import type { Memory } from "../data/memories-api";
-import { subscribeUiEvents } from "../data/ui-events";
+import { useFetched } from "./useFetched";
 
 // Mirror of useSessions. Memories list rarely changes during a session —
 // they're written by an agent calling `remember`, infrequent — so a single
@@ -17,36 +16,10 @@ export function useMemories(): {
   error: Error | null;
   refresh: () => void;
 } {
-  const [memories, setMemories] = useState<Memory[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [tick, setTick] = useState(0);
-  const latestReqId = useRef(0);
-
-  useEffect(() => {
-    const reqId = ++latestReqId.current;
-    setLoading(true);
-    fetchMemories()
-      .then((rows) => {
-        if (reqId !== latestReqId.current) return;
-        setMemories(rows);
-        setError(null);
-      })
-      .catch((err) => {
-        if (reqId !== latestReqId.current) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
-      })
-      .finally(() => {
-        if (reqId !== latestReqId.current) return;
-        setLoading(false);
-      });
-  }, [tick]);
-
-  useEffect(() => {
-    return subscribeUiEvents((event) => {
-      if (event.command === "memory_changed") setTick((n) => n + 1);
-    });
-  }, []);
-
-  return { memories, loading, error, refresh: () => setTick((n) => n + 1) };
+  const { data, loading, error, refresh } = useFetched<Memory[]>(
+    () => fetchMemories(),
+    [],
+    { ssEvent: "memory_changed" },
+  );
+  return { memories: data, loading, error, refresh };
 }

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from "react";
 import { fetchSessions } from "../data/sessions-api";
 import type { Session } from "../data/sessions-api";
-import { subscribeUiEvents } from "../data/ui-events";
+import { useFetched } from "./useFetched";
 
 // Fetches /api/sessions on mount and refetches whenever the server emits a
 // `session_changed` SSE event (state transition, new event row, etc.).
@@ -10,47 +9,16 @@ import { subscribeUiEvents } from "../data/ui-events";
 // already orders sessions by last_event_at and the payload is small. If the
 // list ever grows enough to make a round-trip noticeable, we'll switch to
 // per-id deltas — but that's #257-and-friends territory, not v1.
-//
-// A monotonically-increasing request id guards against an out-of-order
-// resolve when several `session_changed` events fire in quick succession.
-// Only the response from the latest in-flight fetch is allowed to update
-// state; older replies are discarded.
 export function useSessions(): {
   sessions: Session[];
   loading: boolean;
   error: Error | null;
   refresh: () => void;
 } {
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [tick, setTick] = useState(0);
-  const latestReqId = useRef(0);
-
-  useEffect(() => {
-    const reqId = ++latestReqId.current;
-    setLoading(true);
-    fetchSessions()
-      .then((rows) => {
-        if (reqId !== latestReqId.current) return;
-        setSessions(rows);
-        setError(null);
-      })
-      .catch((err) => {
-        if (reqId !== latestReqId.current) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
-      })
-      .finally(() => {
-        if (reqId !== latestReqId.current) return;
-        setLoading(false);
-      });
-  }, [tick]);
-
-  useEffect(() => {
-    return subscribeUiEvents((event) => {
-      if (event.command === "session_changed") setTick((n) => n + 1);
-    });
-  }, []);
-
-  return { sessions, loading, error, refresh: () => setTick((n) => n + 1) };
+  const { data, loading, error, refresh } = useFetched<Session[]>(
+    () => fetchSessions(),
+    [],
+    { ssEvent: "session_changed" },
+  );
+  return { sessions: data, loading, error, refresh };
 }

--- a/web/src/hooks/useSpaceSources.ts
+++ b/web/src/hooks/useSpaceSources.ts
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { fetchSpaceSources } from "../data/spaces-api";
 import type { SpaceSource } from "../data/spaces-api";
+import { useFetched } from "./useFetched";
 
 // Per-space sources. The Home UI can attach/detach via REST endpoints,
 // so call `refresh()` after those mutations to pick up the new list.
@@ -12,49 +12,10 @@ export function useSpaceSources(spaceId: string | null): {
   error: Error | null;
   refresh: () => void;
 } {
-  const [sources, setSources] = useState<SpaceSource[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-  const [tick, setTick] = useState(0);
-  const latestReqId = useRef(0);
-  // Clear stale `sources`/`error` when the user navigates to a different
-  // space — without this, switching from a 6-source space to a 0-source
-  // one would briefly show the previous list (or a stale error masking
-  // the loading state). useLayoutEffect with [spaceId] deps fires
-  // pre-paint so the wipe is invisible; refresh() ticks change `tick`
-  // but not `spaceId`, so they retain the current data while the new
-  // request is in flight.
-  useLayoutEffect(() => {
-    setSources([]);
-    setError(null);
-  }, [spaceId]);
-
-  useEffect(() => {
-    if (!spaceId) {
-      setSources([]);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const reqId = ++latestReqId.current;
-    setLoading(true);
-    const ac = new AbortController();
-    fetchSpaceSources(spaceId, ac.signal)
-      .then((rows) => {
-        if (reqId !== latestReqId.current) return;
-        setSources(rows);
-        setError(null);
-      })
-      .catch((err) => {
-        if (reqId !== latestReqId.current || ac.signal.aborted) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
-      })
-      .finally(() => {
-        if (reqId !== latestReqId.current) return;
-        setLoading(false);
-      });
-    return () => ac.abort();
-  }, [spaceId, tick]);
-
-  return { sources, loading, error, refresh: () => setTick((n) => n + 1) };
+  const { data, loading, error, refresh } = useFetched<SpaceSource[]>(
+    (signal) => spaceId ? fetchSpaceSources(spaceId, signal) : Promise.resolve([]),
+    [],
+    { key: spaceId, enabled: !!spaceId },
+  );
+  return { sources: data, loading, error, refresh };
 }


### PR DESCRIPTION
## Summary

Three small hygiene wins from the audit. **No user-visible behaviour change** — net **-196 lines**.

### `web/src/data/http.ts` (new)
- `getJson` / `postJson` / `patchJson` / `postEmpty` / `del` + a typed `ApiError`.
- Every data module used to roll its own error decoder (`throwFromResponse`, `readErr`, three flavours of inline `body.error` parsing). Migrated `artifacts-api`, `spaces-api`, `memories-api`, `sessions-api`.
- `chat-api` keeps its specialised `ChatSendError` (carries body for diagnostic banners).
- `startApp` / `stopApp` keep their bespoke no-throw GET shape — server routes are GETs and the App.tsx callers tolerate any response. Out of scope for this PR.

### `web/src/hooks/useFetched.ts` (new)
- Generic "fetch + tick + abort + (optional) SSE refresh" hook covering both unkeyed (sessions, memories) and keyed/abortable (spaceSources) cases.
- `useSessions`, `useMemories`, `useSpaceSources` collapse to thin wrappers (~7 lines each).

### `shared/types.ts`
- `UiCommand` interface was declared twice (`server/src/index.ts` + `server/src/mcp-server.ts`). Single source of truth now.

### Side effect
- `SessionNotFoundError`'s constructor parameter property was the only thing tripping `erasableSyntaxOnly` in the web tsconfig. The rewrite uses an explicit field, so that pre-existing TS1294 is gone.

## Test plan

- [x] `npm run build` clean (web bundle + server tsc)
- [x] `tsc -b` in web → only the pre-existing `lastActivityBySpace` warning remains
- [ ] Manual: open Home, click into a session inspector, attach/detach a folder source on a space, archive an artefact — anywhere the migrated fetchers get exercised
- [ ] Manual: failure path — force a server 500 and verify the alert text comes from `body.error` (not `HTTP 500`)

## What's next

Per the audit, the planned sequencing is: this PR → MCP tool wrapper (~80 lines saved) → multi-PR series extracting `server/src/index.ts` route buckets. Holding off on the Home / SessionInspector splits until the server side is calm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)