### PR TITLE
chore(refactor): extract /api/memories into routes/memories.ts

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,6 +28,7 @@ import { makeRouteCtx } from "./http-utils.js";
 import { tryHandleSessionRoute } from "./routes/sessions.js";
 import { tryHandleArtifactRoute } from "./routes/artifacts.js";
 import { tryHandleSpaceRoute } from "./routes/spaces.js";
+import { tryHandleMemoryRoute } from "./routes/memories.js";
 import type { UiCommand } from "../../shared/types.js";
 import {
   scanExistingArtifacts,
@@ -676,6 +677,9 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     spaceService, broadcastUiEvent,
   })) return;
 
+  // /api/memories
+  if (await tryHandleMemoryRoute(req, res, url, ctx, { memoryProvider })) return;
+
   // GET /api/resolve-path?url=...  — resolve a serving URL to a filesystem path
   if (url.startsWith("/api/resolve-path")) {
     const params = new URL(url, "http://localhost").searchParams;
@@ -757,48 +761,6 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       sendError(err, 500);
     }
     return;
-  }
-
-  // GET /api/memories — list memories, optionally scoped to a space.
-  // Local-origin only: memory contents are private user notes. Strip the
-  // query string before path-matching (same trap the events route had —
-  // `$`-anchored regex would silently reject `?space_id=…`).
-  {
-    const memoriesPath = url.split("?")[0];
-    if (memoriesPath === "/api/memories" && req.method === "GET") {
-      if (rejectIfNonLocalOrigin()) return;
-      const parsed = new URL(req.url ?? "/", "http://localhost");
-      const spaceId = parsed.searchParams.get("space_id");
-      try {
-        const memories = await memoryProvider.list(spaceId ?? undefined);
-        sendJson(memories);
-      } catch (err) {
-        sendError(err, 500);
-      }
-      return;
-    }
-    // POST /api/memories — user-authored memory. Mirrors the MCP `remember`
-    // tool: empty content rejected, exact-content dedupe, space optional.
-    if (memoriesPath === "/api/memories" && req.method === "POST") {
-      if (rejectIfNonLocalOrigin()) return;
-      try {
-        const body = await readJsonBody();
-        const content = typeof body.content === "string" ? body.content.trim() : "";
-        if (!content) {
-          sendJson({ error: "content is required" }, 400);
-          return;
-        }
-        const space_id = typeof body.space_id === "string" && body.space_id ? body.space_id : undefined;
-        const tags = Array.isArray(body.tags)
-          ? body.tags.filter((t): t is string => typeof t === "string" && t.length > 0)
-          : undefined;
-        const memory = await memoryProvider.remember({ content, space_id, tags });
-        sendJson(memory, 201);
-      } catch (err) {
-        sendError(err);
-      }
-      return;
-    }
   }
 
   // GET /api/ui/events — SSE stream for UI commands.

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -1,0 +1,65 @@
+// /api/memories — extracted from index.ts. Two endpoints, both
+// local-origin only (memory contents are private user notes).
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { MemoryProvider } from "../memory-store.js";
+import type { RouteCtx } from "../http-utils.js";
+
+export interface MemoryRouteDeps {
+  memoryProvider: MemoryProvider;
+}
+
+export async function tryHandleMemoryRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: MemoryRouteDeps,
+): Promise<boolean> {
+  const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
+  const { memoryProvider } = deps;
+
+  // GET /api/memories — list memories, optionally scoped to a space.
+  // Strip the query string before path-matching (same trap the events
+  // route had — `$`-anchored regex would silently reject `?space_id=…`).
+  const memoriesPath = url.split("?")[0];
+  if (memoriesPath !== "/api/memories") return false;
+
+  if (req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return true;
+    const parsed = new URL(req.url ?? "/", "http://localhost");
+    const spaceId = parsed.searchParams.get("space_id");
+    try {
+      const memories = await memoryProvider.list(spaceId ?? undefined);
+      sendJson(memories);
+    } catch (err) {
+      sendError(err, 500);
+    }
+    return true;
+  }
+
+  // POST /api/memories — user-authored memory. Mirrors the MCP `remember`
+  // tool: empty content rejected, exact-content dedupe, space optional.
+  if (req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return true;
+    try {
+      const body = await readJsonBody();
+      const content = typeof body.content === "string" ? body.content.trim() : "";
+      if (!content) {
+        sendJson({ error: "content is required" }, 400);
+        return true;
+      }
+      const space_id = typeof body.space_id === "string" && body.space_id ? body.space_id : undefined;
+      const tags = Array.isArray(body.tags)
+        ? body.tags.filter((t): t is string => typeof t === "string" && t.length > 0)
+        : undefined;
+      const memory = await memoryProvider.remember({ content, space_id, tags });
+      sendJson(memory, 201);
+    } catch (err) {
+      sendError(err);
+    }
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Fourth bucket of the **`server/src/index.ts` route extraction** series. Tiny — only 2 endpoints:

```
GET  /api/memories            (list, optional ?space_id=)
POST /api/memories            (user-authored memory; mirrors MCP `remember`)
```

Same pattern as sessions/artifacts/spaces. Both still local-origin gated.

## LOC

- `index.ts`: **−42 lines** (1486 → 1444)
- `routes/memories.ts`: +65 lines (new)
- Net: +23 lines

**Cumulative across the audit:** `index.ts` now **down 774 lines (−35%)** from the pre-audit baseline of 2218.

## Test plan

- [x] `npm run build` clean
- [x] `tsc --noEmit` in server: no errors
- [x] Manual: open Home, scroll to Memories section, verify the list renders
- [x] Manual: add a memory via the inline form (POST `/api/memories`); verify it appears
- [x] Manual: scope by space (`?space_id=tokinvest`); verify filtering works

## Sequencing

Remaining buckets per the audit: auth · oauth-mcp · import · vault. Then the Home.tsx / SessionInspector.tsx splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)