### PR TITLE
fix(auth-worker): magic-link fail-closed + resolveIdentity cleanup

### DIFF
--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -215,9 +215,13 @@ f.addEventListener('submit', async (e) => {
       s.className = 'ok';
       s.textContent = 'Check your inbox for a sign-in link. The link expires in 15 minutes.';
     } else {
+      let errorCode = '';
+      try { errorCode = ((await res.json()) || {}).error || ''; } catch {}
       s.hidden = false;
       s.className = 'err';
-      s.textContent = 'Could not send the link. Check the email and try again.';
+      s.textContent = errorCode === 'handoff_expired'
+        ? 'This sign-in request expired. Return to the Oyster app and start sign-in again.'
+        : 'Could not send the link. Check the email and try again.';
       btn.disabled = false;
       btn.textContent = 'Send magic link';
     }
@@ -360,15 +364,24 @@ async function handleMagicLink(req: Request, env: Env, ctx: ExecutionContext, ur
     return json({ ok: true });
   }
 
-  // Resolve user_code → device_code if present. Unknown user_codes are
-  // ignored silently (degrades gracefully to a non-device login).
+  // Resolve user_code → device_code if present. Mirrors the fail-closed
+  // rule on /auth/github/start: an invalid/expired/already-attached/
+  // already-claimed user_code aborts here with handoff_expired rather
+  // than degrading to a non-device login (which would split-brain the
+  // browser-says-success / local-keeps-polling UX).
   let deviceCode: string | null = null;
   if (userCode) {
+    if (userCode.length > MAX_USER_CODE_LEN) {
+      return json({ error: "handoff_expired" }, 400, NO_STORE);
+    }
     const dc = await env.DB
-      .prepare("SELECT device_code FROM device_codes WHERE user_code = ? AND expires_at > ? AND session_id IS NULL")
-      .bind(userCode, now)
-      .first<{ device_code: string }>();
-    deviceCode = dc?.device_code ?? null;
+      .prepare("SELECT device_code, session_id, claimed_at, expires_at FROM device_codes WHERE user_code = ?")
+      .bind(userCode)
+      .first<{ device_code: string; session_id: string | null; claimed_at: number | null; expires_at: number }>();
+    if (!dc || dc.expires_at <= now || dc.session_id !== null || dc.claimed_at !== null) {
+      return json({ error: "handoff_expired" }, 400, NO_STORE);
+    }
+    deviceCode = dc.device_code;
   }
 
   const rawToken = randomToken(32);
@@ -800,12 +813,14 @@ async function resolveIdentity(
 
     // Try to update users.email to the current verified primary. If
     // another users row already owns this email, keep ours unchanged
-    // and log the conflict — sign-in still succeeds.
+    // and log the conflict — sign-in still succeeds. last_seen_at is
+    // bumped by the session-create batch in handleGithubCallback, not
+    // here, so this UPDATE is email-only.
     let emailForSession = providerEmail;
     try {
       const updateRes = await db
-        .prepare("UPDATE users SET email = ?, last_seen_at = ? WHERE id = ?")
-        .bind(providerEmail, now, identityRow.user_id)
+        .prepare("UPDATE users SET email = ? WHERE id = ?")
+        .bind(providerEmail, identityRow.user_id)
         .run();
       // Note: D1 lets the UPDATE succeed even if the new value equals
       // the old; meta.changes reflects rows actually changed by storage.

--- a/infra/auth-worker/wrangler.toml
+++ b/infra/auth-worker/wrangler.toml
@@ -29,7 +29,15 @@ type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 20, period = 3600 }
 
-# Non-secret config. Secrets (RESEND_API_KEY) go via `wrangler secret put`.
+# Non-secret config. Secrets (RESEND_API_KEY, GITHUB_OAUTH_CLIENT_SECRET)
+# go via `wrangler secret put`. GITHUB_OAUTH_CLIENT_ID is committed
+# in-tree even though the repo is public because (a) it isn't secret
+# per OAuth — it's exposed in every redirect URL, and (b) GitHub
+# enforces the registered callback URL (oyster.to/auth/github/callback),
+# so a fork that grabbed this id can't complete sign-in: GitHub
+# redirects to oyster.to, which 400s on the unknown state. The worst
+# case for a forker is a confusing dev UX; they should register their
+# own OAuth App for local work.
 [vars]
 FROM_ADDRESS = "noreply@oyster.to"
 REPLY_TO = "matthew@slight.me"


### PR DESCRIPTION
Two #340 follow-ups + a wrangler.toml comment.

## Changes

- **Magic-link silent-degrade fix.** `handleMagicLink` now mirrors the OAuth `/start` fail-closed rule when `?d=<user_code>` is invalid/expired/already-attached/already-claimed. Returns `{error: "handoff_expired"}` 400 instead of silently degrading to a non-device sign-in. The sign-in form's inline JS surfaces tailored copy ("This sign-in request expired. Return to the Oyster app and start sign-in again.") so the user knows to retry from the local app rather than waiting on a poll that will never resolve.
- **`resolveIdentity` STEP 1 `last_seen_at` cleanup.** Drops the redundant `UPDATE users SET ... last_seen_at = ?` from STEP 1. The session-create batch in `handleGithubCallback` already bumps `users.last_seen_at` across all three steps; STEP 1's bump was a duplicate write.
- **`wrangler.toml` comment.** Documents why `GITHUB_OAUTH_CLIENT_ID` is committed in-tree with a public repo: it isn't secret per OAuth, and GitHub enforces the registered callback URL — a fork can't complete sign-in with our id even if they grab it. Worst case for a forker is a confusing dev UX; they should register their own OAuth App.

## Test plan

- [x] npm run typecheck clean
- [x] npm run test clean (9/9 helper unit tests)
- [ ] Live smoke test post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)