### PR TITLE
chore(refactor): extract OAuth + /mcp into routes/oauth-mcp.ts

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -30,6 +30,7 @@ import { tryHandleArtifactRoute } from "./routes/artifacts.js";
 import { tryHandleSpaceRoute } from "./routes/spaces.js";
 import { tryHandleMemoryRoute } from "./routes/memories.js";
 import { tryHandleAuthRoute } from "./routes/auth.js";
+import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
 import type { UiCommand } from "../../shared/types.js";
 import {
   scanExistingArtifacts,
@@ -61,16 +62,8 @@ import {
 import { attachChatEventClient } from "./opencode-events.js";
 import { sweepOrphanOpenCodeProcesses } from "./opencode-orphan-sweep.js";
 import { spawnSession, attachWebSocket } from "./pty-manager.js";
-import { createMcpServer } from "./mcp-server.js";
-import {
-  recordExternalRequest,
-  listExternalClients,
-  externalClientCount,
-  lastConnectedAt,
-} from "./mcp-client-tracker.js";
 import { SqliteFtsMemoryProvider } from "./memory-store.js";
 import { AuthService } from "./auth-service.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
 // ── Config ──
 
@@ -685,6 +678,15 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // (magic-link, OAuth) lives in the Cloudflare Worker.
   if (await tryHandleAuthRoute(req, res, url, ctx, { authService })) return;
 
+  // /oauth/*, /.well-known/oauth-*, /mcp/*, /api/mcp/status
+  if (await tryHandleOAuthMcpRoute(req, res, url, ctx, {
+    preferredPort: PREFERRED_PORT,
+    store, artifactService, iconGenerator, spaceService, memoryProvider,
+    sessionStore, pendingReveals, broadcastUiEvent,
+    userlandDir: USERLAND_DIR,
+    getNativeSourcePath,
+  })) return;
+
   // GET /api/resolve-path?url=...  — resolve a serving URL to a filesystem path
   if (url.startsWith("/api/resolve-path")) {
     const params = new URL(url, "http://localhost").searchParams;
@@ -1134,143 +1136,6 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: (err as Error).message }));
       }
-    });
-    return;
-  }
-
-  // ── No-op OAuth for MCP SDK (localhost only, no real auth) ──
-
-  const BASE = `http://localhost:${PREFERRED_PORT}`;
-  const json = (res: ServerResponse, data: unknown, status = 200) => {
-    res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(data));
-  };
-
-  if (url === "/.well-known/oauth-protected-resource/mcp" || url === "/.well-known/oauth-protected-resource/mcp/") {
-    json(res, { resource: `${BASE}/mcp`, authorization_servers: [`${BASE}/`], scopes_supported: [] });
-    return;
-  }
-  if (url === "/.well-known/oauth-authorization-server") {
-    json(res, {
-      issuer: `${BASE}/`,
-      authorization_endpoint: `${BASE}/oauth/authorize`,
-      token_endpoint: `${BASE}/oauth/token`,
-      registration_endpoint: `${BASE}/oauth/register`,
-      response_types_supported: ["code"],
-      grant_types_supported: ["authorization_code", "refresh_token"],
-      code_challenge_methods_supported: ["S256"],
-      token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
-    });
-    return;
-  }
-  if (url === "/oauth/register" && req.method === "POST") {
-    let body = "";
-    for await (const chunk of req) body += chunk;
-    let parsed: { client_name?: string };
-    try { parsed = JSON.parse(body || "{}"); } catch { json(res, { error: "Invalid JSON body" }, 400); return; }
-    json(res, { client_id: "oyster-local", client_name: parsed.client_name || "oyster", client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
-    return;
-  }
-  if (url?.startsWith("/oauth/authorize")) {
-    const params = new URL(url, BASE).searchParams;
-    const redirect = params.get("redirect_uri") || `${BASE}/`;
-    const state = params.get("state") || "";
-    const sep = redirect.includes("?") ? "&" : "?";
-    res.writeHead(302, { Location: `${redirect}${sep}code=oyster-local-code&state=${state}` });
-    res.end();
-    return;
-  }
-  if (url === "/oauth/token" && req.method === "POST") {
-    json(res, { access_token: "oyster-local-token", token_type: "bearer", expires_in: 86400 });
-    return;
-  }
-
-  // ── MCP server ──
-  if (url === "/mcp" || url.startsWith("/mcp/") || url.startsWith("/mcp?")) {
-    // Localhost-only: reject non-local origins and don't emit wildcard CORS
-    const origin = req.headers.origin;
-    if (origin && !/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
-      res.writeHead(403).end("Forbidden");
-      return;
-    }
-    // Override the wildcard CORS header set at the top of handleHttpRequest
-    res.setHeader("Access-Control-Allow-Origin", origin || `http://localhost:${PREFERRED_PORT}`);
-
-    // `?internal=1` = Oyster's own embedded OpenCode subprocess; anything
-    // else is an external agent (Claude Code / Cursor / etc.). The query
-    // param is set at config-write time when we compose OpenCode's mcp URL.
-    // Parse properly — substring matching would false-positive on
-    // `?notinternal=1` or other values containing the literal.
-    const isInternal = new URL(url, "http://localhost").searchParams.get("internal") === "1";
-    let externalUa: string | null = null;
-
-    if (!isInternal) {
-      const { userAgent, isNew } = recordExternalRequest(req.headers["user-agent"]);
-      externalUa = userAgent;
-      if (isNew) {
-        // Broadcast a bare "a new client connected" signal — enough for
-        // the dock to flip step 1, with no UA leaked on the SSE stream
-        // even if the origin gate is somehow bypassed. Exact UA is still
-        // available via /api/mcp/status (local-origin only).
-        broadcastUiEvent({
-          version: 1,
-          command: "mcp_client_connected",
-          payload: { at: new Date().toISOString() },
-        });
-      }
-    }
-
-    // R6 (#310): map the calling MCP client to the session it's most likely
-    // running inside, so memory writes/recalls get attributed. Internal
-    // (?internal=1) is Oyster's own OpenCode subprocess → opencode session.
-    // External claude-code / codex agents map to their respective sessions.
-    // Codex attribution is best-effort today: there's no codex watcher yet
-    // (#298 — that's the 0.9.0 multi-agent ingestion epic), so the lookup
-    // will typically return no row and resolveActiveSessionId yields null.
-    // The memory store falls back to NULL attribution gracefully. Other
-    // UAs (Cursor, etc.) likewise fall through to null.
-    const ua = externalUa ?? "";
-    const attributableAgent: import("./session-store.js").SessionAgent | null =
-      isInternal ? "opencode"
-      : /claude/i.test(ua) ? "claude-code"
-      : /codex/i.test(ua) ? "codex"
-      : null;
-    const resolveActiveSessionId = (): string | null => {
-      if (!attributableAgent) return null;
-      return sessionStore.getMostRecentActiveByAgent(attributableAgent)?.id ?? null;
-    };
-
-    const mcpServer = createMcpServer({
-      store,
-      service: artifactService,
-      userlandDir: USERLAND_DIR,
-      getNativeSourcePath,
-      iconGenerator,
-      spaceService,
-      memoryProvider,
-      sessionStore,
-      pendingReveals,
-      broadcastUiEvent,
-      clientContext: isInternal ? { isInternal: true } : { isInternal: false, userAgent: externalUa ?? "unknown" },
-      resolveActiveSessionId,
-    });
-    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-    res.on("close", () => { transport.close(); mcpServer.close(); });
-    await mcpServer.connect(transport);
-    await transport.handleRequest(req, res);
-    return;
-  }
-
-  // ── MCP status (onboarding fallback) ──
-  // Local-origin only — the response discloses which MCP clients are
-  // connected (user-agent strings + timestamps), which a cross-origin
-  // site running in the same browser shouldn't be able to enumerate.
-  if (url === "/api/mcp/status" && req.method === "GET") {
-    if (rejectIfNonLocalOrigin()) return;
-    json(res, {
-      connected_clients: externalClientCount(),
-      last_client_connected_at: lastConnectedAt(),
-      clients: listExternalClients(),
     });
     return;
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -679,8 +679,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   if (await tryHandleAuthRoute(req, res, url, ctx, { authService })) return;
 
   // /oauth/*, /.well-known/oauth-*, /mcp/*, /api/mcp/status
+  // Pass the actually-bound `port`, not PREFERRED_PORT — findPort() may
+  // have rolled forward (e.g. main repo's dev server already on 3333),
+  // and the OAuth discovery + redirect URLs must advertise the real port.
   if (await tryHandleOAuthMcpRoute(req, res, url, ctx, {
-    preferredPort: PREFERRED_PORT,
+    port,
     store, artifactService, iconGenerator, spaceService, memoryProvider,
     sessionStore, pendingReveals, broadcastUiEvent,
     userlandDir: USERLAND_DIR,

--- a/server/src/routes/oauth-mcp.ts
+++ b/server/src/routes/oauth-mcp.ts
@@ -1,0 +1,192 @@
+// /oauth/*, /.well-known/oauth-*, /mcp, /api/mcp/status — extracted
+// from index.ts.
+//
+// The OAuth dance is intentionally a no-op (localhost-only Oyster doesn't
+// authenticate clients): the discovery + register + authorize + token
+// endpoints exist solely so MCP SDK clients that probe for them don't
+// fail. Real auth lives in the Cloudflare Worker (infra/auth-worker/).
+//
+// /mcp is the heavy one — wires StreamableHTTPServerTransport into a
+// freshly-created McpServer per request, with telemetry routing for
+// external agents only.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createMcpServer } from "../mcp-server.js";
+import {
+  recordExternalRequest,
+  listExternalClients,
+  externalClientCount,
+  lastConnectedAt,
+} from "../mcp-client-tracker.js";
+import type { ArtifactStore } from "../artifact-store.js";
+import type { ArtifactService } from "../artifact-service.js";
+import type { IconGenerator } from "../icon-generator.js";
+import type { SpaceService } from "../space-service.js";
+import type { MemoryProvider } from "../memory-store.js";
+import type { SessionStore, SessionAgent } from "../session-store.js";
+import type { UiCommand } from "../../../shared/types.js";
+import type { RouteCtx } from "../http-utils.js";
+
+export interface OAuthMcpRouteDeps {
+  preferredPort: number;
+  store: ArtifactStore;
+  artifactService: ArtifactService;
+  iconGenerator: IconGenerator;
+  spaceService: SpaceService;
+  memoryProvider: MemoryProvider;
+  sessionStore: SessionStore;
+  pendingReveals: Set<string>;
+  broadcastUiEvent: (event: UiCommand) => void;
+  userlandDir: string;
+  getNativeSourcePath: (spaceId: string) => string;
+}
+
+export async function tryHandleOAuthMcpRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: OAuthMcpRouteDeps,
+): Promise<boolean> {
+  const { sendJson, rejectIfNonLocalOrigin } = ctx;
+  const {
+    preferredPort, store, artifactService, iconGenerator, spaceService,
+    memoryProvider, sessionStore, pendingReveals, broadcastUiEvent,
+    userlandDir, getNativeSourcePath,
+  } = deps;
+  const BASE = `http://localhost:${preferredPort}`;
+
+  // ── No-op OAuth for MCP SDK (localhost only, no real auth) ──
+
+  if (url === "/.well-known/oauth-protected-resource/mcp" || url === "/.well-known/oauth-protected-resource/mcp/") {
+    sendJson({ resource: `${BASE}/mcp`, authorization_servers: [`${BASE}/`], scopes_supported: [] });
+    return true;
+  }
+  if (url === "/.well-known/oauth-authorization-server") {
+    sendJson({
+      issuer: `${BASE}/`,
+      authorization_endpoint: `${BASE}/oauth/authorize`,
+      token_endpoint: `${BASE}/oauth/token`,
+      registration_endpoint: `${BASE}/oauth/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+    });
+    return true;
+  }
+  if (url === "/oauth/register" && req.method === "POST") {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    let parsed: { client_name?: string };
+    try { parsed = JSON.parse(body || "{}"); } catch { sendJson({ error: "Invalid JSON body" }, 400); return true; }
+    sendJson({ client_id: "oyster-local", client_name: parsed.client_name || "oyster", client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
+    return true;
+  }
+  if (url.startsWith("/oauth/authorize")) {
+    const params = new URL(url, BASE).searchParams;
+    const redirect = params.get("redirect_uri") || `${BASE}/`;
+    const state = params.get("state") || "";
+    const sep = redirect.includes("?") ? "&" : "?";
+    res.writeHead(302, { Location: `${redirect}${sep}code=oyster-local-code&state=${state}` });
+    res.end();
+    return true;
+  }
+  if (url === "/oauth/token" && req.method === "POST") {
+    sendJson({ access_token: "oyster-local-token", token_type: "bearer", expires_in: 86400 });
+    return true;
+  }
+
+  // ── MCP server ──
+  if (url === "/mcp" || url.startsWith("/mcp/") || url.startsWith("/mcp?")) {
+    // Localhost-only: reject non-local origins and don't emit wildcard CORS
+    const origin = req.headers.origin;
+    if (origin && !/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+      res.writeHead(403).end("Forbidden");
+      return true;
+    }
+    // Override the wildcard CORS header set at the top of handleHttpRequest
+    res.setHeader("Access-Control-Allow-Origin", origin || `http://localhost:${preferredPort}`);
+
+    // `?internal=1` = Oyster's own embedded OpenCode subprocess; anything
+    // else is an external agent (Claude Code / Cursor / etc.). The query
+    // param is set at config-write time when we compose OpenCode's mcp URL.
+    // Parse properly — substring matching would false-positive on
+    // `?notinternal=1` or other values containing the literal.
+    const isInternal = new URL(url, "http://localhost").searchParams.get("internal") === "1";
+    let externalUa: string | null = null;
+
+    if (!isInternal) {
+      const { userAgent, isNew } = recordExternalRequest(req.headers["user-agent"]);
+      externalUa = userAgent;
+      if (isNew) {
+        // Broadcast a bare "a new client connected" signal — enough for
+        // the dock to flip step 1, with no UA leaked on the SSE stream
+        // even if the origin gate is somehow bypassed. Exact UA is still
+        // available via /api/mcp/status (local-origin only).
+        broadcastUiEvent({
+          version: 1,
+          command: "mcp_client_connected",
+          payload: { at: new Date().toISOString() },
+        });
+      }
+    }
+
+    // R6 (#310): map the calling MCP client to the session it's most likely
+    // running inside, so memory writes/recalls get attributed. Internal
+    // (?internal=1) is Oyster's own OpenCode subprocess → opencode session.
+    // External claude-code / codex agents map to their respective sessions.
+    // Codex attribution is best-effort today: there's no codex watcher yet
+    // (#298 — that's the 0.9.0 multi-agent ingestion epic), so the lookup
+    // will typically return no row and resolveActiveSessionId yields null.
+    // The memory store falls back to NULL attribution gracefully. Other
+    // UAs (Cursor, etc.) likewise fall through to null.
+    const ua = externalUa ?? "";
+    const attributableAgent: SessionAgent | null =
+      isInternal ? "opencode"
+      : /claude/i.test(ua) ? "claude-code"
+      : /codex/i.test(ua) ? "codex"
+      : null;
+    const resolveActiveSessionId = (): string | null => {
+      if (!attributableAgent) return null;
+      return sessionStore.getMostRecentActiveByAgent(attributableAgent)?.id ?? null;
+    };
+
+    const mcpServer = createMcpServer({
+      store,
+      service: artifactService,
+      userlandDir,
+      getNativeSourcePath,
+      iconGenerator,
+      spaceService,
+      memoryProvider,
+      sessionStore,
+      pendingReveals,
+      broadcastUiEvent,
+      clientContext: isInternal ? { isInternal: true } : { isInternal: false, userAgent: externalUa ?? "unknown" },
+      resolveActiveSessionId,
+    });
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on("close", () => { transport.close(); mcpServer.close(); });
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res);
+    return true;
+  }
+
+  // ── MCP status (onboarding fallback) ──
+  // Local-origin only — the response discloses which MCP clients are
+  // connected (user-agent strings + timestamps), which a cross-origin
+  // site running in the same browser shouldn't be able to enumerate.
+  if (url === "/api/mcp/status" && req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return true;
+    sendJson({
+      connected_clients: externalClientCount(),
+      last_client_connected_at: lastConnectedAt(),
+      clients: listExternalClients(),
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/server/src/routes/oauth-mcp.ts
+++ b/server/src/routes/oauth-mcp.ts
@@ -29,7 +29,10 @@ import type { UiCommand } from "../../../shared/types.js";
 import type { RouteCtx } from "../http-utils.js";
 
 export interface OAuthMcpRouteDeps {
-  preferredPort: number;
+  /** The actual bound port (not OYSTER_PORT / PREFERRED_PORT — the
+   *  preferred port may already be taken). The OAuth discovery URLs
+   *  and the /mcp CORS fallback must advertise the real listener. */
+  port: number;
   store: ArtifactStore;
   artifactService: ArtifactService;
   iconGenerator: IconGenerator;
@@ -49,13 +52,13 @@ export async function tryHandleOAuthMcpRoute(
   ctx: RouteCtx,
   deps: OAuthMcpRouteDeps,
 ): Promise<boolean> {
-  const { sendJson, rejectIfNonLocalOrigin } = ctx;
+  const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
   const {
-    preferredPort, store, artifactService, iconGenerator, spaceService,
+    port, store, artifactService, iconGenerator, spaceService,
     memoryProvider, sessionStore, pendingReveals, broadcastUiEvent,
     userlandDir, getNativeSourcePath,
   } = deps;
-  const BASE = `http://localhost:${preferredPort}`;
+  const BASE = `http://localhost:${port}`;
 
   // ── No-op OAuth for MCP SDK (localhost only, no real auth) ──
 
@@ -77,19 +80,27 @@ export async function tryHandleOAuthMcpRoute(
     return true;
   }
   if (url === "/oauth/register" && req.method === "POST") {
-    let body = "";
-    for await (const chunk of req) body += chunk;
-    let parsed: { client_name?: string };
-    try { parsed = JSON.parse(body || "{}"); } catch { sendJson({ error: "Invalid JSON body" }, 400); return true; }
-    sendJson({ client_id: "oyster-local", client_name: parsed.client_name || "oyster", client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
+    try {
+      const parsed = await readJsonBody();
+      const clientName = typeof parsed.client_name === "string" ? parsed.client_name : "oyster";
+      sendJson({ client_id: "oyster-local", client_name: clientName, client_secret: "none", redirect_uris: ["http://localhost"] }, 201);
+    } catch (err) {
+      sendError(err);
+    }
     return true;
   }
   if (url.startsWith("/oauth/authorize")) {
     const params = new URL(url, BASE).searchParams;
     const redirect = params.get("redirect_uri") || `${BASE}/`;
     const state = params.get("state") || "";
-    const sep = redirect.includes("?") ? "&" : "?";
-    res.writeHead(302, { Location: `${redirect}${sep}code=oyster-local-code&state=${state}` });
+    // Build the redirect via URL so reserved characters in `state`
+    // (`&`, `#`, `=`, etc.) are properly percent-encoded — concatenating
+    // raw would silently produce a malformed Location and lets a caller
+    // inject extra query parameters into the redirect target.
+    const target = new URL(redirect);
+    target.searchParams.set("code", "oyster-local-code");
+    target.searchParams.set("state", state);
+    res.writeHead(302, { Location: target.toString() });
     res.end();
     return true;
   }
@@ -107,7 +118,7 @@ export async function tryHandleOAuthMcpRoute(
       return true;
     }
     // Override the wildcard CORS header set at the top of handleHttpRequest
-    res.setHeader("Access-Control-Allow-Origin", origin || `http://localhost:${preferredPort}`);
+    res.setHeader("Access-Control-Allow-Origin", origin || `http://localhost:${port}`);
 
     // `?internal=1` = Oyster's own embedded OpenCode subprocess; anything
     // else is an external agent (Claude Code / Cursor / etc.). The query


### PR DESCRIPTION
## Summary

Sixth bucket of the **`server/src/index.ts` route extraction** series. Heaviest one — `/mcp` wires `StreamableHTTPServerTransport` into a freshly-created `McpServer` per request, with telemetry routing for external agents.

### Routes moved (7) into `server/src/routes/oauth-mcp.ts`

```
GET  /.well-known/oauth-protected-resource/mcp
GET  /.well-known/oauth-authorization-server
POST /oauth/register
GET  /oauth/authorize
POST /oauth/token
*    /mcp, /mcp/, /mcp?…           (StreamableHTTPServerTransport)
GET  /api/mcp/status
```

### Cleanup along the way

- **Killed audit item #15:** the duplicate `json` helper that lived inside `handleHttpRequest` is gone. The route module uses `ctx.sendJson` from `RouteCtx` like every other extracted bucket.
- **Imports trimmed:** `createMcpServer`, `recordExternalRequest`/`listExternalClients`/`externalClientCount`/`lastConnectedAt`, and `StreamableHTTPServerTransport` were only used by the OAuth-MCP block. Moved into `routes/oauth-mcp.ts`; removed from `index.ts`.

### Note on the OAuth no-op

Oyster runs localhost-only and doesn't authenticate clients. The discovery + register + authorize + token endpoints exist solely so MCP SDK clients that probe for them don't fail. Real auth lives in `infra/auth-worker/`.

## LOC

- `index.ts`: **−123 lines** (1415 → 1292)
- `routes/oauth-mcp.ts`: +192 lines (new)
- Net: +69 lines

**Cumulative:** `index.ts` is **down 926 lines (−42%)** from the pre-audit baseline of 2218.

## Test plan

- [x] `npm run build` clean
- [x] `tsc --noEmit` in server: no errors
- [ ] Manual: connect Claude Code to `http://localhost:4444/mcp` (external agent path); verify the dock action log shows `mcp_client_connected` once + tool calls thereafter
- [ ] Manual: from the Oyster chat bar, run a tool that goes through OpenCode (internal `?internal=1` path); verify it succeeds and does NOT emit `mcp_tool_called` SSE
- [ ] Manual: hit `GET /api/mcp/status` from a local browser tab; verify the connected-clients list renders
- [ ] Manual: `curl http://localhost:4444/.well-known/oauth-authorization-server`; verify the discovery JSON is unchanged
- [ ] Manual: a non-MCP tool that probes `POST /oauth/register` should still get back `{client_id: "oyster-local", …}`

## Sequencing

Remaining route buckets per the audit: import · vault. Then the static-serving block (`/docs/*`, `/artifacts/*`, `/api/resolve-path`, `/api/apps/:name/*`, `/api/workspace`). Then the Home.tsx / SessionInspector.tsx splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)