### PR TITLE
chore(changelog): reflect GitHub OAuth as primary sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Added
 
-- **Sign in to Oyster.** A free account in three clicks — enter email, click the link, you're signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. ([#295](https://github.com/mattslight/oyster/issues/295))
+- **Sign in to Oyster.** A free account in three clicks — Continue with GitHub, or send a sign-in link to your email as a fallback. The badge in the top-left corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. ([#295](https://github.com/mattslight/oyster/issues/295), [#340](https://github.com/mattslight/oyster/issues/340))
 
 ### Fixed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -326,7 +326,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.6.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Added</h3>
 <ul>
-<li><strong>Sign in to Oyster.</strong> A free account in three clicks — enter email, click the link, you&#39;re signed in. The badge in the top-right corner shows your address; sign-out is one click. The same identity will unlock Publish &amp; share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. (<a href="https://github.com/mattslight/oyster/issues/295" rel="noopener noreferrer">#295</a>)</li>
+<li><strong>Sign in to Oyster.</strong> A free account in three clicks — Continue with GitHub, or send a sign-in link to your email as a fallback. The badge in the top-left corner shows your address; sign-out is one click. The same identity will unlock Publish &amp; share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. (<a href="https://github.com/mattslight/oyster/issues/295" rel="noopener noreferrer">#295</a>, <a href="https://github.com/mattslight/oyster/issues/340" rel="noopener noreferrer">#340</a>)</li>
 </ul>
 <h3>Fixed</h3>
 <ul>


### PR DESCRIPTION
The [Unreleased] sign-in bullet still described only the magic-link path and said \"top-right\" badge (stale — moved to top-left in #339's review). Update to reflect what shipped via #340: GitHub OAuth as the primary CTA, magic-link as the fallback. Regenerate docs/changelog.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)