### PR TITLE
chore(refactor): extract /api/import/* into routes/import.ts

### DIFF
--- a/server/src/http-utils.ts
+++ b/server/src/http-utils.ts
@@ -54,18 +54,27 @@ export function makeRouteCtx(req: IncomingMessage, res: ServerResponse): RouteCt
 
   async function readJsonBody(opts?: { maxBytes?: number }): Promise<Record<string, unknown>> {
     const maxBytes = opts?.maxBytes ?? MAX_MUTATION_BODY;
-    let body = "";
+    // Track bytes, not characters. The previous shape (body += chunk +
+    // body.length > maxBytes) coerced each Buffer chunk to a string and
+    // counted code units, which under-counts multi-byte UTF-8 — a payload
+    // of N maxBytes-allowed code units could be 4× that in actual bytes.
+    // Buffer.length is the byte count.
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
     for await (const chunk of req) {
-      body += chunk;
-      if (body.length > maxBytes) {
+      const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+      totalBytes += buf.length;
+      if (totalBytes > maxBytes) {
         // Destroy the socket so we stop reading further bytes from an
         // oversized payload — unlike a plain throw, which lets the rest
         // of the stream keep draining.
         req.destroy();
         throw new HttpError("Payload too large", 413);
       }
+      chunks.push(buf);
     }
-    if (!body) return {};
+    if (totalBytes === 0) return {};
+    const body = Buffer.concat(chunks).toString("utf8");
     try { return JSON.parse(body) as Record<string, unknown>; }
     catch { throw new HttpError("Invalid JSON body", 400); }
   }

--- a/server/src/http-utils.ts
+++ b/server/src/http-utils.ts
@@ -31,8 +31,10 @@ export interface RouteCtx {
    *  status; everything else falls back to the supplied default (400). */
   sendError: (err: unknown, fallback?: number) => void;
   /** Read and parse a JSON request body. Throws HttpError(413) if it
-   *  exceeds MAX_MUTATION_BODY, HttpError(400) if it isn't valid JSON. */
-  readJsonBody: () => Promise<Record<string, unknown>>;
+   *  exceeds the cap (default MAX_MUTATION_BODY), HttpError(400) if it
+   *  isn't valid JSON. Pass `{ maxBytes }` for endpoints that legitimately
+   *  accept larger payloads (e.g. /api/import/* takes pasted AI output). */
+  readJsonBody: (opts?: { maxBytes?: number }) => Promise<Record<string, unknown>>;
   /** Refuse callers from non-loopback origins. Sets the CORS allow-origin
    *  to the request's origin on success. Returns true if the request was
    *  rejected (caller should `return` immediately). */
@@ -50,14 +52,15 @@ export function makeRouteCtx(req: IncomingMessage, res: ServerResponse): RouteCt
     else sendJson({ error: err instanceof Error ? err.message : String(err) }, fallback);
   };
 
-  async function readJsonBody(): Promise<Record<string, unknown>> {
+  async function readJsonBody(opts?: { maxBytes?: number }): Promise<Record<string, unknown>> {
+    const maxBytes = opts?.maxBytes ?? MAX_MUTATION_BODY;
     let body = "";
     for await (const chunk of req) {
       body += chunk;
-      if (body.length > MAX_MUTATION_BODY) {
+      if (body.length > maxBytes) {
         // Destroy the socket so we stop reading further bytes from an
         // oversized payload — unlike a plain throw, which lets the rest
-        // of the stream keep draining. Matches the /api/import/* pattern.
+        // of the stream keep draining.
         req.destroy();
         throw new HttpError("Payload too large", 413);
       }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -31,6 +31,7 @@ import { tryHandleSpaceRoute } from "./routes/spaces.js";
 import { tryHandleMemoryRoute } from "./routes/memories.js";
 import { tryHandleAuthRoute } from "./routes/auth.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
+import { tryHandleImportRoute } from "./routes/import.js";
 import type { UiCommand } from "../../shared/types.js";
 import {
   scanExistingArtifacts,
@@ -40,17 +41,7 @@ import {
   inferName,
 } from "./artifact-detector.js";
 import { runStartupBackup } from "./backup.js";
-import {
-  generatePrompt,
-  parseImportPayload,
-  buildImportPlan,
-  executeImportPlan,
-  getPlan,
-  setImportStatePath,
-  type PromptContext,
-  type PreviewDeps,
-  type ExecuteDeps,
-} from "./import.js";
+import { setImportStatePath } from "./import.js";
 import {
   spawnOpenCodeServe,
   getOpenCodePort,
@@ -523,17 +514,6 @@ const sessionStore = new SqliteSessionStore(db);
 // linked-source path for tiles whose `source_id` is non-null.
 const artifactService = new ArtifactService(store, OYSTER_HOME, spaceStore);
 
-// Shared resolver: try raw id, then slugified id, then case-insensitive display_name.
-// Used by import preview + execute so an agent-emitted space name (possibly
-// whitespace-padded or referring to a renamed space) resolves consistently.
-function resolveSpaceRow(name: string) {
-  const trimmed = name.trim();
-  return (
-    spaceStore.getById(trimmed) ??
-    spaceStore.getById(slugify(trimmed)) ??
-    spaceStore.getByDisplayName(trimmed)
-  );
-}
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore);
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);
 await memoryProvider.init();
@@ -688,6 +668,12 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     sessionStore, pendingReveals, broadcastUiEvent,
     userlandDir: USERLAND_DIR,
     getNativeSourcePath,
+  })) return;
+
+  // /api/import/* — paste-from-another-AI flow
+  if (await tryHandleImportRoute(req, res, url, ctx, {
+    store, spaceStore, spaceService, artifactService, memoryProvider,
+    getNativeSourcePath, getOpenCodePort,
   })) return;
 
   // GET /api/resolve-path?url=...  — resolve a serving URL to a filesystem path
@@ -972,174 +958,6 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
       res.writeHead(200, { "Content-Type": mime });
       res.end(readFileSync(filePath));
     }
-    return;
-  }
-
-  // ── Import routes ──
-
-  if (url.startsWith("/api/import/prompt") && req.method === "GET") {
-    const params = new URL(url, "http://localhost").searchParams;
-    const provider = params.get("provider") || "chatgpt";
-    const spaceId = params.get("spaceId");
-
-    const allSpaces = spaceStore.getAll()
-      .filter((s) => s.id !== "home" && s.id !== "__all__")
-      .map((s) => ({ id: s.id, displayName: s.display_name }));
-
-    const knownProjects = new Map<string, string[]>();
-    for (const s of allSpaces) {
-      const artifacts = store.getBySpaceId(s.id)
-        .filter((a) => a.source_ref?.startsWith("import:") && !a.removed_at);
-      if (artifacts.length > 0) {
-        knownProjects.set(s.id, artifacts.map((a) => a.label));
-      }
-    }
-
-    const targetSpace = spaceId
-      ? allSpaces.find((s) => s.id === spaceId) ?? undefined
-      : undefined;
-
-    const prompt = generatePrompt({ provider, spaces: allSpaces, knownProjects, targetSpace });
-    res.writeHead(200, { "Content-Type": "text/plain" });
-    res.end(prompt);
-    return;
-  }
-
-  if (url === "/api/import/preview" && req.method === "POST") {
-    let body = "";
-    req.on("data", (chunk: Buffer) => {
-      body += chunk;
-      if (body.length > 500_000) { res.writeHead(413); res.end("Payload too large"); req.destroy(); }
-    });
-    req.on("end", async () => {
-      try {
-        const { raw, provider, targetSpaceId } = JSON.parse(body) as { raw: string; provider: string; targetSpaceId?: string };
-
-        const convertFn = async (text: string): Promise<string | null> => {
-          try {
-            const port = getOpenCodePort();
-            if (!port) {
-              console.log("[import] OpenCode not ready yet");
-              return null;
-            }
-
-            const sessRes = await fetch(`http://localhost:${port}/session`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: "{}",
-            });
-            const sess = await sessRes.json() as { id: string };
-            console.log("[import] OpenCode session:", sess.id);
-
-            const prompt = `Convert this text into valid JSON. Output ONLY the raw JSON object, nothing else. No markdown fences. No explanation.\n\nRequired schema:\n{\n  "schema_version": 1,\n  "mode": "fresh" | "augment",\n  "source": { "provider": "string", "generated_at": "ISO string" },\n  "spaces": [{ "name": "string", "projects": [{ "name": "string", "summary": "string" }] }],\n  "summaries": [{ "space": "string", "title": "string", "content": "string" }],\n  "memories": [{ "content": "string", "tags": ["string"], "space": "string" }]\n}\n\nText to convert:\n${text.slice(0, 12000)}`;
-
-            const msgRes = await fetch(`http://localhost:${port}/session/${sess.id}/message`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ parts: [{ type: "text", text: prompt }], agent: "oyster" }),
-            });
-
-            const resBody = await msgRes.json() as {
-              info?: { error?: unknown };
-              parts?: Array<{ type: string; text?: string }>;
-            };
-
-            if (resBody.info?.error) {
-              console.error("[import] OpenCode error:", JSON.stringify(resBody.info.error).slice(0, 300));
-              return null;
-            }
-
-            for (const part of resBody.parts ?? []) {
-              if (part.type === "text" && part.text?.includes("{")) {
-                console.log("[import] AI conversion succeeded, length:", part.text.length);
-                return part.text;
-              }
-            }
-            console.log("[import] OpenCode returned", resBody.parts?.length ?? 0, "parts, none with JSON");
-          } catch (err) {
-            console.error("[import] AI conversion failed:", err);
-          }
-          return null;
-        };
-
-        const parseResult = await parseImportPayload(raw, convertFn);
-        if (!parseResult.success || !parseResult.payload) {
-          res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: parseResult.error }));
-          return;
-        }
-
-        const generatedAt = parseResult.payload.source?.generated_at || new Date().toISOString();
-
-        const previewDeps: PreviewDeps = {
-          resolveSpaceByName: (name) => {
-            const row = resolveSpaceRow(name);
-            return row ? { id: row.id, displayName: row.display_name } : null;
-          },
-          getArtifactsBySpace: (spaceId) => {
-            return store.getBySpaceId(spaceId)
-              .filter((a) => !a.removed_at)
-              .map((a) => ({ source_ref: a.source_ref, label: a.label }));
-          },
-          findMemory: (content, spaceId) => {
-            return memoryProvider.findExact(content, spaceId ?? undefined);
-          },
-        };
-
-        const plan = buildImportPlan(parseResult.payload, provider, generatedAt, previewDeps, targetSpaceId);
-        if (plan.actions.length === 0) {
-          res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Nothing found to import. Make sure you pasted the AI's response, not the prompt you sent it." }));
-          return;
-        }
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(plan));
-      } catch (err) {
-        res.writeHead(500, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: (err as Error).message }));
-      }
-    });
-    return;
-  }
-
-  if (url === "/api/import/execute" && req.method === "POST") {
-    let body = "";
-    req.on("data", (chunk: Buffer) => {
-      body += chunk;
-      if (body.length > 100_000) { res.writeHead(413); res.end("Payload too large"); req.destroy(); }
-    });
-    req.on("end", async () => {
-      try {
-        const { plan_id, approved_action_ids } = JSON.parse(body) as {
-          plan_id: string;
-          approved_action_ids: string[];
-        };
-
-        if (!getPlan(plan_id)) {
-          res.writeHead(404, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Plan not found or expired" }));
-          return;
-        }
-
-        const executeDeps: ExecuteDeps = {
-          createSpace: (name) => spaceService.createSpace({ name }),
-          createArtifact: (params) => artifactService.createArtifact(params, getNativeSourcePath(params.space_id)),
-          remember: (input) => memoryProvider.remember(input),
-          findMemory: (content, spaceId) => memoryProvider.findExact(content, spaceId ?? undefined),
-          resolveSpaceByName: (name) => {
-            const row = resolveSpaceRow(name);
-            return row ? { id: row.id } : null;
-          },
-        };
-
-        const result = await executeImportPlan(plan_id, approved_action_ids, executeDeps);
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(result));
-      } catch (err) {
-        res.writeHead(500, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: (err as Error).message }));
-      }
-    });
     return;
   }
 

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -49,6 +49,10 @@ export interface MemoryProvider {
   recall(input: RecallInput): Promise<Memory[]>;
   forget(id: string): Promise<void>;
   list(space_id?: string): Promise<Memory[]>;
+  /** Synchronous existence check used by the import flow's dedupe — true
+   *  when an active memory with this exact (content, space_id) already
+   *  exists. Implementations are expected to do a single equality lookup. */
+  findExact(content: string, spaceId?: string): boolean;
   exportMemories(): Promise<Memory[]>;
   importMemories(memories: Memory[]): Promise<void>;
   // R6: memories *written* during the given session.

--- a/server/src/routes/import.ts
+++ b/server/src/routes/import.ts
@@ -1,0 +1,217 @@
+// /api/import/* — extracted from index.ts. Three endpoints powering
+// the "import context from another AI" flow:
+//   GET  /api/import/prompt   — generate the prompt the user pastes to ChatGPT/etc.
+//   POST /api/import/preview  — convert pasted output into a plan + preview it
+//   POST /api/import/execute  — apply an approved plan
+//
+// The preview endpoint accepts pasted AI output (large) and runs it
+// through OpenCode for JSON normalisation — see convertFn below.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ArtifactStore } from "../artifact-store.js";
+import type { ArtifactService } from "../artifact-service.js";
+import type { SqliteSpaceStore } from "../space-store.js";
+import type { SpaceService } from "../space-service.js";
+import type { MemoryProvider } from "../memory-store.js";
+import type { RouteCtx } from "../http-utils.js";
+import {
+  generatePrompt,
+  parseImportPayload,
+  buildImportPlan,
+  executeImportPlan,
+  getPlan,
+  type PreviewDeps,
+  type ExecuteDeps,
+} from "../import.js";
+import { slugify } from "../utils.js";
+
+export interface ImportRouteDeps {
+  store: ArtifactStore;
+  spaceStore: SqliteSpaceStore;
+  spaceService: SpaceService;
+  artifactService: ArtifactService;
+  memoryProvider: MemoryProvider;
+  /** Native filesystem path for a space (writes go under here). */
+  getNativeSourcePath: (spaceId: string) => string;
+  /** OpenCode HTTP port — null when the subprocess hasn't bound yet.
+   *  Preview uses it to ask OpenCode to JSON-normalise pasted text. */
+  getOpenCodePort: () => number | null;
+}
+
+export async function tryHandleImportRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: ImportRouteDeps,
+): Promise<boolean> {
+  const { sendJson, sendError, readJsonBody } = ctx;
+  const {
+    store, spaceStore, spaceService, artifactService, memoryProvider,
+    getNativeSourcePath, getOpenCodePort,
+  } = deps;
+
+  // Try raw id, then slugified id, then case-insensitive display_name.
+  // Used by preview + execute so an agent-emitted space name (possibly
+  // whitespace-padded or referring to a renamed space) resolves
+  // consistently.
+  const resolveSpaceRow = (name: string) => {
+    const trimmed = name.trim();
+    return (
+      spaceStore.getById(trimmed) ??
+      spaceStore.getById(slugify(trimmed)) ??
+      spaceStore.getByDisplayName(trimmed)
+    );
+  };
+
+  if (url.startsWith("/api/import/prompt") && req.method === "GET") {
+    const params = new URL(url, "http://localhost").searchParams;
+    const provider = params.get("provider") || "chatgpt";
+    const spaceId = params.get("spaceId");
+
+    const allSpaces = spaceStore.getAll()
+      .filter((s) => s.id !== "home" && s.id !== "__all__")
+      .map((s) => ({ id: s.id, displayName: s.display_name }));
+
+    const knownProjects = new Map<string, string[]>();
+    for (const s of allSpaces) {
+      const artifacts = store.getBySpaceId(s.id)
+        .filter((a) => a.source_ref?.startsWith("import:") && !a.removed_at);
+      if (artifacts.length > 0) {
+        knownProjects.set(s.id, artifacts.map((a) => a.label));
+      }
+    }
+
+    const targetSpace = spaceId
+      ? allSpaces.find((s) => s.id === spaceId) ?? undefined
+      : undefined;
+
+    const prompt = generatePrompt({ provider, spaces: allSpaces, knownProjects, targetSpace });
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(prompt);
+    return true;
+  }
+
+  if (url === "/api/import/preview" && req.method === "POST") {
+    try {
+      const body = await readJsonBody({ maxBytes: 500_000 });
+      const raw = typeof body.raw === "string" ? body.raw : "";
+      const provider = typeof body.provider === "string" ? body.provider : "";
+      const targetSpaceId = typeof body.targetSpaceId === "string" ? body.targetSpaceId : undefined;
+
+      const convertFn = async (text: string): Promise<string | null> => {
+        try {
+          const port = getOpenCodePort();
+          if (!port) {
+            console.log("[import] OpenCode not ready yet");
+            return null;
+          }
+
+          const sessRes = await fetch(`http://localhost:${port}/session`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+          });
+          const sess = await sessRes.json() as { id: string };
+          console.log("[import] OpenCode session:", sess.id);
+
+          const prompt = `Convert this text into valid JSON. Output ONLY the raw JSON object, nothing else. No markdown fences. No explanation.\n\nRequired schema:\n{\n  "schema_version": 1,\n  "mode": "fresh" | "augment",\n  "source": { "provider": "string", "generated_at": "ISO string" },\n  "spaces": [{ "name": "string", "projects": [{ "name": "string", "summary": "string" }] }],\n  "summaries": [{ "space": "string", "title": "string", "content": "string" }],\n  "memories": [{ "content": "string", "tags": ["string"], "space": "string" }]\n}\n\nText to convert:\n${text.slice(0, 12000)}`;
+
+          const msgRes = await fetch(`http://localhost:${port}/session/${sess.id}/message`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ parts: [{ type: "text", text: prompt }], agent: "oyster" }),
+          });
+
+          const resBody = await msgRes.json() as {
+            info?: { error?: unknown };
+            parts?: Array<{ type: string; text?: string }>;
+          };
+
+          if (resBody.info?.error) {
+            console.error("[import] OpenCode error:", JSON.stringify(resBody.info.error).slice(0, 300));
+            return null;
+          }
+
+          for (const part of resBody.parts ?? []) {
+            if (part.type === "text" && part.text?.includes("{")) {
+              console.log("[import] AI conversion succeeded, length:", part.text.length);
+              return part.text;
+            }
+          }
+          console.log("[import] OpenCode returned", resBody.parts?.length ?? 0, "parts, none with JSON");
+        } catch (err) {
+          console.error("[import] AI conversion failed:", err);
+        }
+        return null;
+      };
+
+      const parseResult = await parseImportPayload(raw, convertFn);
+      if (!parseResult.success || !parseResult.payload) {
+        sendJson({ error: parseResult.error }, 400);
+        return true;
+      }
+
+      const generatedAt = parseResult.payload.source?.generated_at || new Date().toISOString();
+
+      const previewDeps: PreviewDeps = {
+        resolveSpaceByName: (name) => {
+          const row = resolveSpaceRow(name);
+          return row ? { id: row.id, displayName: row.display_name } : null;
+        },
+        getArtifactsBySpace: (spaceId) => {
+          return store.getBySpaceId(spaceId)
+            .filter((a) => !a.removed_at)
+            .map((a) => ({ source_ref: a.source_ref, label: a.label }));
+        },
+        findMemory: (content, spaceId) => {
+          return memoryProvider.findExact(content, spaceId ?? undefined);
+        },
+      };
+
+      const plan = buildImportPlan(parseResult.payload, provider, generatedAt, previewDeps, targetSpaceId);
+      if (plan.actions.length === 0) {
+        sendJson({ error: "Nothing found to import. Make sure you pasted the AI's response, not the prompt you sent it." }, 400);
+        return true;
+      }
+      sendJson(plan);
+    } catch (err) {
+      sendError(err, 500);
+    }
+    return true;
+  }
+
+  if (url === "/api/import/execute" && req.method === "POST") {
+    try {
+      const body = await readJsonBody({ maxBytes: 100_000 });
+      const plan_id = typeof body.plan_id === "string" ? body.plan_id : "";
+      const approved_action_ids = Array.isArray(body.approved_action_ids)
+        ? body.approved_action_ids.filter((s): s is string => typeof s === "string")
+        : [];
+
+      if (!getPlan(plan_id)) {
+        sendJson({ error: "Plan not found or expired" }, 404);
+        return true;
+      }
+
+      const executeDeps: ExecuteDeps = {
+        createSpace: (name) => spaceService.createSpace({ name }),
+        createArtifact: (params) => artifactService.createArtifact(params, getNativeSourcePath(params.space_id)),
+        remember: (input) => memoryProvider.remember(input),
+        findMemory: (content, spaceId) => memoryProvider.findExact(content, spaceId ?? undefined),
+        resolveSpaceByName: (name) => {
+          const row = resolveSpaceRow(name);
+          return row ? { id: row.id } : null;
+        },
+      };
+
+      const result = await executeImportPlan(plan_id, approved_action_ids, executeDeps);
+      sendJson(result);
+    } catch (err) {
+      sendError(err, 500);
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/server/src/routes/import.ts
+++ b/server/src/routes/import.ts
@@ -45,7 +45,7 @@ export async function tryHandleImportRoute(
   ctx: RouteCtx,
   deps: ImportRouteDeps,
 ): Promise<boolean> {
-  const { sendJson, sendError, readJsonBody } = ctx;
+  const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
   const {
     store, spaceStore, spaceService, artifactService, memoryProvider,
     getNativeSourcePath, getOpenCodePort,
@@ -64,7 +64,13 @@ export async function tryHandleImportRoute(
     );
   };
 
+  // Strip query string before path matching — preview/execute callers
+  // could harmlessly add `?t=…` cache-busters, and exact equality would
+  // silently fall through.
+  const path = url.split("?")[0];
+
   if (url.startsWith("/api/import/prompt") && req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return true;
     const params = new URL(url, "http://localhost").searchParams;
     const provider = params.get("provider") || "chatgpt";
     const spaceId = params.get("spaceId");
@@ -92,7 +98,8 @@ export async function tryHandleImportRoute(
     return true;
   }
 
-  if (url === "/api/import/preview" && req.method === "POST") {
+  if (path === "/api/import/preview" && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return true;
     try {
       const body = await readJsonBody({ maxBytes: 500_000 });
       const raw = typeof body.raw === "string" ? body.raw : "";
@@ -112,6 +119,11 @@ export async function tryHandleImportRoute(
             headers: { "Content-Type": "application/json" },
             body: "{}",
           });
+          if (!sessRes.ok) {
+            const errBody = await sessRes.text().catch(() => "");
+            console.error(`[import] OpenCode /session ${sessRes.status}:`, errBody.slice(0, 300));
+            return null;
+          }
           const sess = await sessRes.json() as { id: string };
           console.log("[import] OpenCode session:", sess.id);
 
@@ -122,6 +134,11 @@ export async function tryHandleImportRoute(
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ parts: [{ type: "text", text: prompt }], agent: "oyster" }),
           });
+          if (!msgRes.ok) {
+            const errBody = await msgRes.text().catch(() => "");
+            console.error(`[import] OpenCode /session/:id/message ${msgRes.status}:`, errBody.slice(0, 300));
+            return null;
+          }
 
           const resBody = await msgRes.json() as {
             info?: { error?: unknown };
@@ -181,7 +198,8 @@ export async function tryHandleImportRoute(
     return true;
   }
 
-  if (url === "/api/import/execute" && req.method === "POST") {
+  if (path === "/api/import/execute" && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return true;
     try {
       const body = await readJsonBody({ maxBytes: 100_000 });
       const plan_id = typeof body.plan_id === "string" ? body.plan_id : "";


### PR DESCRIPTION
## Summary

Seventh bucket of the **`server/src/index.ts` route extraction** series. **`index.ts` crosses the 50% milestone** — down from 2218 → 1115 lines (−1103, **−50%**).

### Routes moved (3) into `server/src/routes/import.ts`

```
GET  /api/import/prompt       generate the prompt the user pastes to ChatGPT/etc.
POST /api/import/preview      convert pasted output → import plan
POST /api/import/execute      apply an approved plan
```

### Two collateral changes worth flagging

1. **`http-utils.readJsonBody` now accepts an optional `{ maxBytes }` cap.** Default stays `MAX_MUTATION_BODY` (64 KB). Import raises it (preview = 500 KB, execute = 100 KB) — it accepts pasted AI output that's legitimately larger. Kills the duplicate body-cap parsing the audit called out (item 11) and migrates both endpoints off the legacy `req.on('data')` callback shape.

2. **`MemoryProvider` interface gained `findExact(content, spaceId?): boolean`.** The method existed on the concrete `SqliteFtsMemoryProvider` class, but `index.ts` was reaching past the interface to call it (TS was happy because `index` instantiated the concrete type directly). Adding it to the interface is the right place — the import dedupe relies on it, and any future provider must support it.

### Drive-by

Dropped the `resolveSpaceRow` helper from `index.ts` (moved into `routes/import.ts` as a local closure — only the import flow used it). Trimmed the `import.ts` named imports down to `setImportStatePath` (the only one still needed at module-init time).

## LOC

- `index.ts`: **−190 lines** (1305 → 1115)
- `routes/import.ts`: +217 lines (new)
- `http-utils.ts`: +6 lines (the optional `maxBytes` parameter)
- `memory-store.ts`: +4 lines (interface gained `findExact`)
- Net: +37 lines

**Cumulative across the audit:** `index.ts` is **down 1103 lines (−50%)** from the pre-audit baseline.

## Test plan

- [x] `npm run build` clean
- [x] `tsc --noEmit` in server: no errors
- [ ] Manual: open Import dialog, copy the prompt (`GET /api/import/prompt`)
- [ ] Manual: paste raw output back, click Preview (`POST /api/import/preview` ← 500 KB cap)
- [ ] Manual: approve some actions, click Execute (`POST /api/import/execute`); verify spaces / memories / artefacts created
- [ ] Manual: try a >500 KB paste — verify a clean 413 response (was: 413 with HTML body; now: 413 with `{error: "Payload too large"}`)

## Sequencing

Remaining route bucket: vault + static-serving (`/docs/*`, `/artifacts/*`, `/api/workspace`, `/api/resolve-path`, `/api/apps/:name/*`, `/api/vault/inventory`). Then the Home.tsx / SessionInspector.tsx splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)