### PR TITLE
chore: PR CI, root↔server dep sync, audit fix, tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Action versions pinned to exact tags (matches release.yml convention).
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+            server/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          cd web && npm ci && cd ..
+          cd server && npm ci && cd ..
+
+      - name: Verify root deps mirror server runtime deps
+        run: node scripts/sync-published-deps.mjs --check
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint web
+        # Non-blocking until the existing lint debt is resolved. Output is
+        # visible in PR checks; flip to blocking by removing this flag.
+        continue-on-error: true
+        run: cd web && npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.6.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@fal-ai/client": "^1.9.4",
-        "@modelcontextprotocol/sdk": "^1.28.0",
-        "better-sqlite3": "^12.8.0",
+        "@fal-ai/client": "^1.10.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "better-sqlite3": "^12.9.0",
         "chokidar": "^4.0.3",
-        "marked": "^18.0.2",
-        "opencode-ai": "^1.2.26",
-        "ws": "^8.18.0"
+        "marked": "^18.0.3",
+        "opencode-ai": "^1.14.31",
+        "ws": "^8.20.0"
       },
       "bin": {
         "oyster": "bin/oyster.mjs"
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1177,9 +1177,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/marked": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
-      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -1346,33 +1346,33 @@
       }
     },
     "node_modules/opencode-ai": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.14.25.tgz",
-      "integrity": "sha512-xlcuGQWsaN/BZ1Bo9+Pk7X7zMYz2BMnzkKFzZMn/Q9D7SEvdVx+ycjK5Wf8Wq/7niv0t1nFkAQZ85T3tCRWVxg==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.14.33.tgz",
+      "integrity": "sha512-eB0VcDh4up1NoY4efBwRz4DAa8gnvnv9Dm0WAGVEq7bQCgSytMM9TEpX94vENJTqzxBANS4Pxcegb/ZG6JMA2g==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "opencode": "bin/opencode"
       },
       "optionalDependencies": {
-        "opencode-darwin-arm64": "1.14.25",
-        "opencode-darwin-x64": "1.14.25",
-        "opencode-darwin-x64-baseline": "1.14.25",
-        "opencode-linux-arm64": "1.14.25",
-        "opencode-linux-arm64-musl": "1.14.25",
-        "opencode-linux-x64": "1.14.25",
-        "opencode-linux-x64-baseline": "1.14.25",
-        "opencode-linux-x64-baseline-musl": "1.14.25",
-        "opencode-linux-x64-musl": "1.14.25",
-        "opencode-windows-arm64": "1.14.25",
-        "opencode-windows-x64": "1.14.25",
-        "opencode-windows-x64-baseline": "1.14.25"
+        "opencode-darwin-arm64": "1.14.33",
+        "opencode-darwin-x64": "1.14.33",
+        "opencode-darwin-x64-baseline": "1.14.33",
+        "opencode-linux-arm64": "1.14.33",
+        "opencode-linux-arm64-musl": "1.14.33",
+        "opencode-linux-x64": "1.14.33",
+        "opencode-linux-x64-baseline": "1.14.33",
+        "opencode-linux-x64-baseline-musl": "1.14.33",
+        "opencode-linux-x64-musl": "1.14.33",
+        "opencode-windows-arm64": "1.14.33",
+        "opencode-windows-x64": "1.14.33",
+        "opencode-windows-x64-baseline": "1.14.33"
       }
     },
     "node_modules/opencode-darwin-arm64": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.14.25.tgz",
-      "integrity": "sha512-hOTygBfFPAJeo1nGHLi4bqHoJQSQBRNZsKTsyhmflUlGkb+VuXGlxs7PpcN5yPitbnB+EUySEOaJmTlcZf73yg==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.14.33.tgz",
+      "integrity": "sha512-MDQgymI5Wla7uicU6gbcFOoryHjl8CRz6fXsWGsEp8R+hjqfKSrZ6ChNJlK93UsC9hl8bVvCbVcq7FR87guaKw==",
       "cpu": [
         "arm64"
       ],
@@ -1382,9 +1382,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.14.25.tgz",
-      "integrity": "sha512-34FTz0Yh2FY+E+TzQHQVPO1w2jXMkLDt/hdlluqBrFdwBxJRKCvrHv+RGPDJJrYiFjyr9GGJfNYQJmxRfrGEdg==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.14.33.tgz",
+      "integrity": "sha512-pHdUaNJZ0KDJxoqTLvgUJPt7l/CG2CniIcrc6Cg5rNP6ZRP1NtpeONCRkB5YfmanDvQzDWwVFa3+5ULRDfyrnA==",
       "cpu": [
         "x64"
       ],
@@ -1394,9 +1394,9 @@
       ]
     },
     "node_modules/opencode-darwin-x64-baseline": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.14.25.tgz",
-      "integrity": "sha512-Cqedwl6GIUAbZModPvKNMcLFG95ROSqamDomx89VjwTX68Lg8GjdOqGWO4A66XfohBemMtEyigbgE6fMcFM0vA==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.14.33.tgz",
+      "integrity": "sha512-2QQNX3kTx/f5utUpwjFxIxOke618EUxyDR9mTaGOzEoWCV/Hrs4CtEkpxsA8ImA8Ffehbrsg861haVLCdeuwVQ==",
       "cpu": [
         "x64"
       ],
@@ -1406,9 +1406,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.14.25.tgz",
-      "integrity": "sha512-PdeyTRE10OwAPTpLVmKE3hSGncxxeHJC7iN1FVf+yRFBzp9SPYe5mlP7+O4ETj/J2j64peftuI0RYz44R9oisw==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.14.33.tgz",
+      "integrity": "sha512-IxesoCtjC4I/f9cUPov5KZeF6EEHiiDa9rHXNY3ogYjyBEtTCo5dTy07riENftzEnCA5u/EsYJO2eFyaGTrWtw==",
       "cpu": [
         "arm64"
       ],
@@ -1418,9 +1418,9 @@
       ]
     },
     "node_modules/opencode-linux-arm64-musl": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.14.25.tgz",
-      "integrity": "sha512-aRAzikWpeXZrTfqdR0Nnqta3IV9NQgmTP7r81tMQOw5vNEyuHeBXGPoXnaV0U/8WDqhp7msIOpAd9qQ/kfm8gw==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.14.33.tgz",
+      "integrity": "sha512-m7AiRtiDtm+nKsS9TXcqa3BF58yl3QMg82Dq68EF8x2LjwuaI+qETwGuGJz4d9QqvtySPfK7bF0dgSMnNTVlBQ==",
       "cpu": [
         "arm64"
       ],
@@ -1430,9 +1430,9 @@
       ]
     },
     "node_modules/opencode-linux-x64": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.14.25.tgz",
-      "integrity": "sha512-gUTRsniZv91V4VO1eYa7QThDMVQkqClI2yiyhrN7L0xF95Oi4xzbYFvYdWbkmvaO85MKLaNsFNgdyYHEqhQ4wg==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.14.33.tgz",
+      "integrity": "sha512-rE0moyGzCayR/XadwdPeEeD9Efw/mtPjFUntdHlaF73BygNMgiTtgxBsFdyEOaYCO8ZFhW9XvIjsloYcg99Twg==",
       "cpu": [
         "x64"
       ],
@@ -1442,9 +1442,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.14.25.tgz",
-      "integrity": "sha512-/Mp8uGLzM1TIxU7MLnQZb9Xi79k78SibezxQhRzXUABCKbi2fDwIlX1Pi0UfjnBapIVknaRO8VML284nIhV9Lw==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.14.33.tgz",
+      "integrity": "sha512-gC7xFrN2UEmWx4eq8lgQvuwPL1vF9+t484YpZPc8bbkS3sbyxvjmrKtHXIanhU2BWwFbmUmZYW78/gMWooAfTw==",
       "cpu": [
         "x64"
       ],
@@ -1454,9 +1454,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-baseline-musl": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.14.25.tgz",
-      "integrity": "sha512-6geh3YcHJmEI946pBODj96s9mFuC/kI5MXftC07k2+o61H2ehL22QA5k6vc1T/DiH09HHvXZpFpe4YjbehCfXg==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.14.33.tgz",
+      "integrity": "sha512-8LEhnEc0n5LbohgLqXPDssLXAc0QqUf2Dhw7OYfaUFo/FjBKYi9WktQ6uaIAxa7qMe26ZU23dNMCmnSO81b5kQ==",
       "cpu": [
         "x64"
       ],
@@ -1466,9 +1466,9 @@
       ]
     },
     "node_modules/opencode-linux-x64-musl": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.14.25.tgz",
-      "integrity": "sha512-5Z/S5lCbdiT96fcT6aFpetGen8NaHrFNne/2QLYrHYfI2fIzT2uvtIT9c4MyBpN7Mx1TSHeq0Wol5b7D4QLznA==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.14.33.tgz",
+      "integrity": "sha512-WZYtKjFYxhPUZcADklVg4MXPDJM7Gtg/rKikZk5vPIhz0POrhrTCK/43i1PM6rg2kVLNdxsjtmbIdab0frz9Xw==",
       "cpu": [
         "x64"
       ],
@@ -1478,9 +1478,9 @@
       ]
     },
     "node_modules/opencode-windows-arm64": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.14.25.tgz",
-      "integrity": "sha512-HeJxvqJdsbGxTKna9zMaaEhDgSvKJDJofC9qLGEledYxH9HUVHd9CFUmuYpO7KKcQZvClcAEJWRu0DOhUKTHDA==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.14.33.tgz",
+      "integrity": "sha512-uisW4Hc6j8UH8TgQiVNBUrCtuBSMVOdziohWJtVzN9DG8/3x/pjAVsqG+Du5V5ljgJpvwZeeO+Vvx8XXupGp+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1490,9 +1490,9 @@
       ]
     },
     "node_modules/opencode-windows-x64": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.14.25.tgz",
-      "integrity": "sha512-o2LjSo2/2meUlUD37oYX8H9KQUu9z8wRiyS0jAahnlgIQwmHHJ//FLgoPPxrnTqhk+eM7/lv24wckxJ8T7y12g==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.14.33.tgz",
+      "integrity": "sha512-0HDW/My00nlTYMpQX2JYIQExDX3RKSWncurpNf3lzPPjeCmZq9Vtf6XvzEmxDTEBEr+VG4fZYUd3udAq8gNJ+w==",
       "cpu": [
         "x64"
       ],
@@ -1502,9 +1502,9 @@
       ]
     },
     "node_modules/opencode-windows-x64-baseline": {
-      "version": "1.14.25",
-      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.14.25.tgz",
-      "integrity": "sha512-HPtLBjM5Ox5saLGM9UQ9jyfeebgKL6C/zMte0TX7RBkib/D0lv8fwGC7fnBXbUUzGaLlLz0yixVlvllragfViw==",
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.14.33.tgz",
+      "integrity": "sha512-lPbg3UEBfP3P7jmKQkMzTsuPC3oJvXhMzVjsd5BRbYUBfuiW6k0+cOJL6orijbPmqZx/8B6iquRnGY3AAbLtng==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "opencode.json"
   ],
   "scripts": {
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "node scripts/sync-published-deps.mjs --check && npm run build",
+    "sync-published-deps": "node scripts/sync-published-deps.mjs",
     "build:web": "cd web && npx vite build",
     "build:server": "cd server && npm run build",
     "build": "npm run build:web && npm run build:server && node -e \"const fs=require('fs');fs.cpSync('web/dist','server/dist/public',{recursive:true})\"",
@@ -41,19 +42,18 @@
     "url": "https://github.com/mattslight/oyster.git"
   },
   "dependencies": {
-    "@fal-ai/client": "^1.9.4",
-    "@modelcontextprotocol/sdk": "^1.28.0",
-    "better-sqlite3": "^12.8.0",
+    "@fal-ai/client": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "better-sqlite3": "^12.9.0",
     "chokidar": "^4.0.3",
-    "marked": "^18.0.2",
-    "opencode-ai": "^1.2.26",
-    "ws": "^8.18.0"
+    "marked": "^18.0.3",
+    "opencode-ai": "^1.14.31",
+    "ws": "^8.20.0"
   },
   "optionalDependencies": {
     "@lydell/node-pty": "^1.2.0-beta.12"
   },
   "devDependencies": {
     "concurrently": "^9.2.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/scripts/sync-published-deps.mjs
+++ b/scripts/sync-published-deps.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Mirror server/package.json's runtime dependencies into the root package.json.
+//
+// Why: the published `oyster-os` tarball ships `server/dist/` but not `server/
+// package.json`, so a global install resolves runtime deps against ROOT
+// node_modules. If root and server pins drift, dev/CI tests one combination
+// and end-users get a different one. This script enforces a single source of
+// truth (server) and lets root stay generated.
+//
+// Usage:
+//   node scripts/sync-published-deps.mjs          rewrites root package.json
+//   node scripts/sync-published-deps.mjs --check  exits 1 if a rewrite would change it
+//
+// Packages already in root's optionalDependencies are skipped (e.g. @lydell/
+// node-pty, which is intentionally optional at install time on root).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const rootPkgPath = path.join(root, "package.json");
+const serverPkgPath = path.join(root, "server", "package.json");
+
+const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, "utf8"));
+const serverPkg = JSON.parse(fs.readFileSync(serverPkgPath, "utf8"));
+
+const serverDeps = serverPkg.dependencies ?? {};
+const rootOptional = rootPkg.optionalDependencies ?? {};
+
+const synced = Object.fromEntries(
+  Object.entries(serverDeps)
+    .filter(([name]) => !(name in rootOptional))
+    .sort(([a], [b]) => a.localeCompare(b)),
+);
+
+const updated = { ...rootPkg, dependencies: synced };
+const before = fs.readFileSync(rootPkgPath, "utf8");
+const after = JSON.stringify(updated, null, 2) + "\n";
+
+const checkOnly = process.argv.includes("--check");
+if (before === after) {
+  console.log("root package.json dependencies already in sync with server.");
+  process.exit(0);
+}
+
+if (checkOnly) {
+  console.error("root package.json dependencies are out of sync with server/package.json.");
+  console.error("Run: node scripts/sync-published-deps.mjs");
+  process.exit(1);
+}
+
+fs.writeFileSync(rootPkgPath, after);
+console.log("root package.json dependencies synced from server/package.json.");

--- a/scripts/sync-published-deps.mjs
+++ b/scripts/sync-published-deps.mjs
@@ -11,8 +11,10 @@
 //   node scripts/sync-published-deps.mjs          rewrites root package.json
 //   node scripts/sync-published-deps.mjs --check  exits 1 if a rewrite would change it
 //
-// Packages already in root's optionalDependencies are skipped (e.g. @lydell/
-// node-pty, which is intentionally optional at install time on root).
+// Packages already in root.optionalDependencies stay there (so a fragile prebuilt
+// like @lydell/node-pty doesn't hard-fail global installs on platforms without
+// a binary), but their VERSION pin is still synced from server. Without that,
+// drift in optional-only packages would slip past --check.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -26,15 +28,30 @@ const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, "utf8"));
 const serverPkg = JSON.parse(fs.readFileSync(serverPkgPath, "utf8"));
 
 const serverDeps = serverPkg.dependencies ?? {};
-const rootOptional = rootPkg.optionalDependencies ?? {};
+const currentOptional = rootPkg.optionalDependencies ?? {};
 
-const synced = Object.fromEntries(
-  Object.entries(serverDeps)
-    .filter(([name]) => !(name in rootOptional))
-    .sort(([a], [b]) => a.localeCompare(b)),
-);
+const newDeps = {};
+const newOptional = { ...currentOptional };
 
-const updated = { ...rootPkg, dependencies: synced };
+for (const [name, version] of Object.entries(serverDeps)) {
+  if (name in newOptional) {
+    newOptional[name] = version;
+  } else {
+    newDeps[name] = version;
+  }
+}
+
+const sortByName = (obj) =>
+  Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)));
+
+const updated = {
+  ...rootPkg,
+  dependencies: sortByName(newDeps),
+  ...(Object.keys(newOptional).length > 0
+    ? { optionalDependencies: sortByName(newOptional) }
+    : {}),
+};
+
 const before = fs.readFileSync(rootPkgPath, "utf8");
 const after = JSON.stringify(updated, null, 2) + "\n";
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -482,9 +482,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,6 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
-        "@types/dompurify": "^3.2.0",
         "@types/three": "^0.184.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -856,16 +855,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
       }
     },
     "node_modules/@types/esrecurse": {
@@ -1748,9 +1737,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@types/dompurify": "^3.2.0",
     "@types/three": "^0.184.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -249,13 +249,11 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   }, [folderScopedSessions, stateFilter]);
 
   // Per-space session counts + a separate orphan tally (sessions with
-  // spaceId === null) + a grand total for the Home card, plus the most
-  // recent lastEventAt per space so we can sort the cards by activity.
-  const { sessionCountsBySpace, orphanCounts, totalCounts, lastActivityBySpace } = useMemo(() => {
+  // spaceId === null) + a grand total for the Home card.
+  const { sessionCountsBySpace, orphanCounts, totalCounts } = useMemo(() => {
     const bySpace: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
     const orphans = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     const total = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
-    const lastActivity: Record<string, number> = {};
     for (const s of sessions) {
       total.total++;
       total[s.state]++;
@@ -264,16 +262,12 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
         c.total++;
         c[s.state]++;
         bySpace[s.spaceId] = c;
-        const t = parseTimestamp(s.lastEventAt);
-        if (Number.isFinite(t) && t > (lastActivity[s.spaceId] ?? 0)) {
-          lastActivity[s.spaceId] = t;
-        }
       } else {
         orphans.total++;
         orphans[s.state]++;
       }
     }
-    return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total, lastActivityBySpace: lastActivity };
+    return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total };
   }, [sessions]);
 
   // Active projects on Home: collapse sessions by sourceId, count


### PR DESCRIPTION
## Summary

Lands the recommendations from the post-merge audit. Three commits:

1. **`fix(web)`** — drop unused `lastActivityBySpace` destructure in `Home/index.tsx`. Fixes the pre-existing `TS6133` build break on main and the matching `@typescript-eslint/no-unused-vars` lint error.

2. **`ci`** — add `.github/workflows/ci.yml` running on `pull_request` + push-to-main. Until now PRs landed unverified (only `release.yml` and `build-changelog.yml` existed). The new job:
   - `npm ci` in /, /web, /server (with action-pinned cache)
   - runs `node scripts/sync-published-deps.mjs --check` to catch drift
   - `npm run build` (web + server + copy)
   - `cd web && npm run lint` — `continue-on-error: true` while existing lint debt is unresolved; flip when ready

3. **`chore(deps)`** — three related dependency-hygiene changes:
   - **Root↔server sync.** The published tarball ships `server/dist/` but not `server/package.json`, so global installs resolve runtime deps against root. Root pins were drifting (e.g. `opencode-ai: ^1.2.26` vs server's `^1.14.31`). New `scripts/sync-published-deps.mjs` mirrors `server.dependencies` into root (skipping anything in `optionalDependencies`), wired into `prepublishOnly` and CI.
   - **`npm audit fix`** in all three workspaces — was: hono moderate, flatted high, @hono/node-server moderate, hono cookie moderate; **now: 0 vulnerabilities** in /, /web, /server. Lockfile-only.
   - **Tidies:** drop `@types/dompurify` (`dompurify` 3.x ships own types), remove obsolete `packageManager: yarn@1.22.22` field (every script and CLAUDE.md uses npm).

## Test plan
- [x] `npm run build` (root) — clean
- [x] `node scripts/sync-published-deps.mjs --check` — passes, idempotent
- [x] `npm audit` in /, /web, /server — 0 vulnerabilities each
- [x] CI workflow runs on this PR (green if everything above holds)

## Follow-ups (not in this PR)
- Resolve the existing web lint debt (22 errors) — surgical plan: drop the unused expression in `TranscriptSearchBar.tsx`, add per-line disables for the 3 intentional ref-mutation patterns (`useFetched.ts`, `SessionInspector/index.tsx`), and downgrade `react-hooks/set-state-in-effect` to `'warn'` until the 16 sites are refactored. Then flip `continue-on-error: false`.
- Align `web` and `server` on `marked` (web is on 17, server on 18) and `typescript` (web `~5.9.3`, server `^6.0.3`) once `typescript-eslint` confirms TS 6 support.
- Decide on chokidar 4→5 (PRs #343/#345 were closed — likely deferred for the Node 20.19+ requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)