### PR TITLE
feat(publish): Worker scaffold + D1 migration + R2 bucket (#315 PR 1/3)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-r5-publish-backend.md
+++ b/docs/superpowers/plans/2026-05-03-r5-publish-backend.md
@@ -1,0 +1,2979 @@
+# R5 Publish Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the backend that turns an Oyster artefact into a published share URL — `publish_artifact` / `unpublish_artifact` MCP tools, matching HTTP routes on the local server, and a new `oyster-publish` Cloudflare Worker that owns the cloud publication state and R2 object storage.
+
+**Architecture:** New Cloudflare Worker at `oyster.to/api/publish/*` (admin) and `oyster.to/p/*` (viewer; scaffolded as `501` here, body lands in #316). The Worker shares the existing `oyster-auth` D1 binding so it can read `sessions` and own a new `published_artifacts` table. The local server proxies upload bytes from `~/Oyster/spaces/...` to the Worker, derives PBKDF2 password hashes locally so plaintext never crosses the wire, and mirrors the Worker's response into `artifacts` row columns for fast UI render. Spec: [`docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`](../specs/2026-05-03-r5-publish-backend-design.md).
+
+**Tech Stack:** TypeScript, Cloudflare Workers, D1 (SQLite), R2 (object store), Vitest + `@cloudflare/vitest-pool-workers` for Worker integration tests, Node `crypto` (PBKDF2) on the local server.
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `infra/auth-worker/migrations/0003_publish.sql` | DDL: `ALTER users ADD tier`, `CREATE published_artifacts` + indexes + CHECK |
+| Modify | `infra/auth-worker/package.json` | Add `db:migrate:0003` + `db:migrate:0003:local` scripts |
+| Create | `infra/oyster-publish/package.json` | Worker package manifest + scripts |
+| Create | `infra/oyster-publish/wrangler.toml` | Worker config: name, routes, D1 + R2 bindings |
+| Create | `infra/oyster-publish/tsconfig.json` | TypeScript config |
+| Create | `infra/oyster-publish/vitest.config.ts` | Vitest with `@cloudflare/vitest-pool-workers` |
+| Create | `infra/oyster-publish/README.md` | Setup + deploy instructions |
+| Create | `infra/oyster-publish/src/types.ts` | `Env` interface + shared types |
+| Create | `infra/oyster-publish/src/publish-helpers.ts` | Pure helpers: `generateShareToken`, `parseMetadataHeader`, `r2KeyFor`, `CAPS` |
+| Create | `infra/oyster-publish/src/worker.ts` | Router + handlers + D1/R2 ops |
+| Create | `infra/oyster-publish/test/publish-helpers.test.ts` | Unit tests for pure helpers |
+| Create | `infra/oyster-publish/test/publish-handler.test.ts` | Integration tests for `POST /api/publish/upload` |
+| Create | `infra/oyster-publish/test/unpublish-handler.test.ts` | Integration tests for `DELETE /api/publish/:token` |
+| Create | `infra/oyster-publish/test/fixtures/seed.ts` | D1 seed helpers (insert user / session / publication rows) |
+| Modify | `server/src/db.ts` | Idempotent `ALTER TABLE artifacts ADD COLUMN share_updated_at` |
+| Create | `server/src/password-hash.ts` | `hashPassword(plaintext)` using Node `crypto.pbkdf2` |
+| Create | `server/src/publish-service.ts` | `publishArtifact()` / `unpublishArtifact()` — single helper called by HTTP route + MCP tool |
+| Create | `server/src/routes/publish.ts` | `POST` / `DELETE /api/artifacts/:id/publish` |
+| Modify | `server/src/index.ts` | Wire `tryHandlePublishRoute` |
+| Modify | `server/src/mcp-server.ts` | Register `publish_artifact` + `unpublish_artifact` MCP tools |
+| Create | `server/test/password-hash.test.ts` | Hash format + PBKDF2 round-trip tests |
+| Create | `server/test/publish-service.test.ts` | Service-level tests with a mocked Worker fetch |
+| Modify | `CHANGELOG.md` | One-line entry under `[Unreleased] / Added` |
+
+**Decisions encoded in the structure:**
+
+- **Pure helpers split out into `publish-helpers.ts`.** Same precedent as auth-worker's `oauth-helpers.ts` — keeps unit tests fast and importable without dragging in `Env` or `D1Database`. Token generation, header parsing, R2 key derivation, and the `CAPS` map all live here.
+- **Single `worker.ts` for routing + handlers + D1/R2 ops.** Mirrors auth-worker's shape. Keeps the integration surface in one file so the integration tests cover whole-handler behaviour, not artificial seams.
+- **Integration tests use `@cloudflare/vitest-pool-workers`.** Spec calls for a real D1 + R2 round-trip; the pool runs tests inside a Workers runtime with a real (in-memory) D1 and R2. Auth-worker chose pure-unit + smoke; we override here because the spec explicitly requires integration coverage of cap, race recovery, CHECK constraint, etc.
+- **Local server: `publish-service.ts` is the *only* place that knows the Worker URL.** Both `routes/publish.ts` and the MCP tool import it. No duplicate proxy logic.
+- **No tests for the local server's HTTP route.** Same precedent as `routes/auth.ts` and the other extracted routes — the route file is a thin glue layer; the tested unit is `publish-service.ts`.
+
+---
+
+## Phase 1 — Schema + Worker scaffold (PR 1)
+
+End state: `0003_publish.sql` applied to remote D1 (`users.tier` column live, `published_artifacts` empty), `oyster-publish` Worker deployed at `oyster.to/api/publish/*` and `oyster.to/p/*` returning `501 Not Implemented` for everything, R2 bucket `oyster-artifacts` provisioned, README documents setup.
+
+### Task 1.1: D1 migration `0003_publish.sql`
+
+**Files:**
+- Create: `infra/auth-worker/migrations/0003_publish.sql`
+- Modify: `infra/auth-worker/package.json`
+
+- [ ] **Step 1: Write the migration.**
+
+Create `infra/auth-worker/migrations/0003_publish.sql`:
+
+```sql
+-- 0003_publish.sql — R5 Publish: tier hook on users + published_artifacts table.
+-- Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
+-- D1 supports ALTER TABLE ADD COLUMN; both bindings (oyster-auth + oyster-publish)
+-- read/write this DB.
+
+-- Tier hook for entitlement checks. Always 'free' in 0.7.0; Pro values land in 0.8.0+.
+ALTER TABLE users ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
+
+CREATE TABLE published_artifacts (
+  share_token       TEXT    PRIMARY KEY,
+  owner_user_id     TEXT    NOT NULL REFERENCES users(id),
+  artifact_id       TEXT    NOT NULL,
+  artifact_kind     TEXT    NOT NULL,
+  mode              TEXT    NOT NULL CHECK (mode IN ('open','password','signin')),
+  password_hash     TEXT,
+  r2_key            TEXT    NOT NULL,
+  content_type      TEXT    NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  published_at      INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  unpublished_at    INTEGER,
+  CHECK (
+    (mode = 'password' AND password_hash IS NOT NULL) OR
+    (mode <> 'password' AND password_hash IS NULL)
+  )
+);
+
+CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
+
+-- Active-publication uniqueness scoped to (owner, artefact). artifact_id alone
+-- is not globally unique across users.
+CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
+  ON published_artifacts(owner_user_id, artifact_id)
+  WHERE unpublished_at IS NULL;
+```
+
+- [ ] **Step 2: Add migrate scripts to `infra/auth-worker/package.json`.**
+
+Add the two scripts inside `"scripts"` (keep alongside the existing `db:migrate:0002` pair):
+
+```json
+"db:migrate:0003": "wrangler d1 execute oyster-auth --file=migrations/0003_publish.sql --remote",
+"db:migrate:0003:local": "wrangler d1 execute oyster-auth --file=migrations/0003_publish.sql --local",
+```
+
+- [ ] **Step 3: Apply locally and verify.**
+
+```bash
+cd infra/auth-worker
+npm run db:migrate:0003:local
+wrangler d1 execute oyster-auth --local --command "SELECT name, sql FROM sqlite_master WHERE type IN ('table','index') AND name LIKE '%pubart%' OR name='published_artifacts';"
+wrangler d1 execute oyster-auth --local --command "SELECT name FROM pragma_table_info('users') WHERE name='tier';"
+```
+
+Expected: the `SELECT` returns the `published_artifacts` table DDL plus both indexes; the second returns one row with `name='tier'`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/migrations/0003_publish.sql infra/auth-worker/package.json
+git commit -m "feat(auth-worker): D1 migration 0003 — published_artifacts + users.tier (#315)"
+```
+
+---
+
+### Task 1.2: Apply migration to remote D1
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Run the remote migration.**
+
+```bash
+cd infra/auth-worker
+npm run db:migrate:0003
+```
+
+Expected: `Executed N commands` with no error.
+
+- [ ] **Step 2: Verify remote schema.**
+
+```bash
+wrangler d1 execute oyster-auth --remote --command "SELECT name FROM sqlite_master WHERE name IN ('published_artifacts','idx_pubart_owner','idx_pubart_active_per_owner_artifact');"
+wrangler d1 execute oyster-auth --remote --command "SELECT name FROM pragma_table_info('users') WHERE name='tier';"
+```
+
+Expected: three rows for the schema, one row for the column.
+
+- [ ] **Step 3: Backfill `users.tier` (no-op confirmation).**
+
+The `DEFAULT 'free'` populates new rows. Existing rows pre-migration may have `NULL` if SQLite's default-on-add doesn't fill back. Run an explicit backfill to be safe:
+
+```bash
+wrangler d1 execute oyster-auth --remote --command "UPDATE users SET tier = 'free' WHERE tier IS NULL;"
+```
+
+Expected: report of rows changed (likely 1 — `matthew@slight.me` from the existing fixture).
+
+(No commit — this is a remote DB op, not a code change.)
+
+---
+
+### Task 1.3: Provision R2 bucket
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Create the bucket.**
+
+```bash
+wrangler r2 bucket create oyster-artifacts
+```
+
+Expected: `Successfully created bucket 'oyster-artifacts'`.
+
+- [ ] **Step 2: Confirm bucket exists.**
+
+```bash
+wrangler r2 bucket list
+```
+
+Expected: `oyster-artifacts` appears in the list.
+
+(No commit.)
+
+---
+
+### Task 1.4: Bootstrap `infra/oyster-publish/` skeleton
+
+**Files:**
+- Create: `infra/oyster-publish/package.json`
+- Create: `infra/oyster-publish/tsconfig.json`
+- Create: `infra/oyster-publish/.gitignore`
+- Create: `infra/oyster-publish/src/types.ts`
+- Create: `infra/oyster-publish/src/worker.ts`
+
+- [ ] **Step 1: Create `package.json`.**
+
+```json
+{
+  "name": "oyster-publish-worker",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Cloudflare Worker for R5 publish: artefact upload + publication state + R2 storage",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.1.0",
+    "wrangler": "^4.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `tsconfig.json`.**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}
+```
+
+- [ ] **Step 3: Create `.gitignore`.**
+
+```
+node_modules/
+.dev.vars
+.wrangler/
+```
+
+- [ ] **Step 4: Create `src/types.ts`.**
+
+```ts
+// Env interface for the oyster-publish Worker.
+// Bindings declared in wrangler.toml.
+
+export interface Env {
+  DB: D1Database;          // shared with oyster-auth (same database_id)
+  ARTIFACTS: R2Bucket;     // oyster-artifacts
+}
+
+// Decoded X-Publish-Metadata payload — produced by the local server.
+export interface PublishMetadata {
+  artifact_id: string;
+  artifact_kind: string;
+  mode: "open" | "password" | "signin";
+  password_hash?: string;  // present iff mode === 'password'
+}
+
+// Row shape for published_artifacts.
+export interface PublicationRow {
+  share_token: string;
+  owner_user_id: string;
+  artifact_id: string;
+  artifact_kind: string;
+  mode: "open" | "password" | "signin";
+  password_hash: string | null;
+  r2_key: string;
+  content_type: string;
+  size_bytes: number;
+  published_at: number;
+  updated_at: number;
+  unpublished_at: number | null;
+}
+```
+
+- [ ] **Step 5: Create `src/worker.ts` with stub handlers.**
+
+```ts
+// oyster-publish — R5 publish endpoints + viewer scaffold.
+// All real handler bodies land in Phase 2 (#315 PR 2).
+
+import type { Env } from "./types";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    // POST /api/publish/upload
+    if (url.pathname === "/api/publish/upload" && req.method === "POST") {
+      return notImplemented("publish_upload");
+    }
+
+    // DELETE /api/publish/:share_token
+    if (url.pathname.startsWith("/api/publish/") && req.method === "DELETE") {
+      return notImplemented("publish_unpublish");
+    }
+
+    // GET /p/:share_token — viewer body lands in #316.
+    if (url.pathname.startsWith("/p/") && req.method === "GET") {
+      return notImplemented("publish_viewer");
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};
+
+function notImplemented(handler: string): Response {
+  return new Response(
+    JSON.stringify({ error: "not_implemented", handler }),
+    { status: 501, headers: { "content-type": "application/json" } },
+  );
+}
+```
+
+- [ ] **Step 6: Install + typecheck.**
+
+```bash
+cd infra/oyster-publish
+npm install
+npm run typecheck
+```
+
+Expected: install succeeds; `typecheck` produces no output (success).
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add infra/oyster-publish/package.json \
+        infra/oyster-publish/package-lock.json \
+        infra/oyster-publish/tsconfig.json \
+        infra/oyster-publish/.gitignore \
+        infra/oyster-publish/src/types.ts \
+        infra/oyster-publish/src/worker.ts
+git commit -m "feat(oyster-publish): scaffold Worker with 501 stub handlers (#315)"
+```
+
+---
+
+### Task 1.5: `wrangler.toml` with bindings
+
+**Files:**
+- Create: `infra/oyster-publish/wrangler.toml`
+
+- [ ] **Step 1: Write the config.**
+
+```toml
+name = "oyster-publish"
+main = "src/worker.ts"
+compatibility_date = "2026-04-01"
+
+# Shared D1 binding — same database_id as oyster-auth so we can read sessions/users
+# and own the published_artifacts table inside the same DB. Single source of truth.
+[[d1_databases]]
+binding = "DB"
+database_name = "oyster-auth"
+database_id = "44086805-fbfa-4446-8626-126af7e2ec19"
+
+# R2 bucket for published artefact bytes.
+[[r2_buckets]]
+binding = "ARTIFACTS"
+bucket_name = "oyster-artifacts"
+
+# Routes: admin API + public viewer. Both apex and www so the Worker is
+# reachable from either origin (matches auth-worker pattern).
+[[routes]]
+pattern = "oyster.to/api/publish/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "www.oyster.to/api/publish/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "oyster.to/p/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "www.oyster.to/p/*"
+zone_name = "oyster.to"
+```
+
+- [ ] **Step 2: Verify with `wrangler deploy --dry-run`.**
+
+```bash
+cd infra/oyster-publish
+npx wrangler deploy --dry-run
+```
+
+Expected: `Dry run, the following changes would be applied`, listing the four routes, the D1 binding, and the R2 binding. No errors.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/wrangler.toml
+git commit -m "feat(oyster-publish): wrangler config with D1 + R2 bindings (#315)"
+```
+
+---
+
+### Task 1.6: Vitest + `@cloudflare/vitest-pool-workers` setup
+
+**Files:**
+- Create: `infra/oyster-publish/vitest.config.ts`
+- Create: `infra/oyster-publish/test/.gitkeep`
+
+The pool runs tests inside a Workers runtime against a real (in-memory) D1 + R2. We seed the test D1 from the same SQL files used in production so schema parity is guaranteed.
+
+- [ ] **Step 1: Create `vitest.config.ts`.**
+
+```ts
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // Use isolated in-memory D1 + R2 per test file.
+          d1Databases: ["DB"],
+          r2Buckets: ["ARTIFACTS"],
+        },
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 2: Create `test/.gitkeep`.**
+
+```bash
+mkdir -p infra/oyster-publish/test
+touch infra/oyster-publish/test/.gitkeep
+```
+
+- [ ] **Step 3: Verify Vitest discovers no tests but exits clean.**
+
+```bash
+cd infra/oyster-publish
+npm run test -- --reporter=verbose
+```
+
+Expected: vitest reports `No test files found` and exits with code 0 (or similar). If install missed something, fix before continuing.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/vitest.config.ts \
+        infra/oyster-publish/test/.gitkeep
+git commit -m "chore(oyster-publish): vitest with workers pool (#315)"
+```
+
+---
+
+### Task 1.7: First deploy + smoke test
+
+**Files:** none.
+
+- [ ] **Step 1: Deploy.**
+
+```bash
+cd infra/oyster-publish
+npm run deploy
+```
+
+Expected: `Deployed oyster-publish triggers...` listing the four routes. Note the deployment id from the output.
+
+- [ ] **Step 2: Smoke-test the four routes.**
+
+```bash
+curl -s -o /dev/null -w "POST upload:    %{http_code}\n" -X POST  https://oyster.to/api/publish/upload
+curl -s -o /dev/null -w "DELETE token:   %{http_code}\n" -X DELETE https://oyster.to/api/publish/anytoken
+curl -s -o /dev/null -w "GET viewer:     %{http_code}\n"          https://oyster.to/p/anytoken
+curl -s -o /dev/null -w "GET unmatched:  %{http_code}\n"          https://oyster.to/api/publish/
+```
+
+Expected:
+```
+POST upload:    501
+DELETE token:   501
+GET viewer:     501
+GET unmatched:  404
+```
+
+- [ ] **Step 3: Confirm 501 body.**
+
+```bash
+curl -s -X POST https://oyster.to/api/publish/upload
+```
+
+Expected: `{"error":"not_implemented","handler":"publish_upload"}`.
+
+(No commit — operational verification only.)
+
+---
+
+### Task 1.8: README
+
+**Files:**
+- Create: `infra/oyster-publish/README.md`
+
+- [ ] **Step 1: Write the README.**
+
+```markdown
+# oyster-publish Worker
+
+Cloudflare Worker for R5 publish (#315 spec):
+- `POST /api/publish/upload` — server-to-server upload from the local Oyster server.
+- `DELETE /api/publish/:share_token` — retire a publication.
+- `GET /p/:share_token` — public viewer (501 here; body lands in #316).
+
+Spec: [`docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`](../../docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md).
+
+## Setup (one-time)
+
+```bash
+# 1. Apply the D1 migration (creates published_artifacts in the shared
+#    oyster-auth DB, adds users.tier).
+cd infra/auth-worker
+npm run db:migrate:0003
+
+# 2. Provision the R2 bucket.
+wrangler r2 bucket create oyster-artifacts
+```
+
+## Deploy
+
+```bash
+cd infra/oyster-publish
+npm install
+npm run deploy
+```
+
+## Local dev
+
+```bash
+npm run dev   # runs wrangler dev with miniflare D1 + R2 in-memory
+npm test      # vitest with @cloudflare/vitest-pool-workers
+```
+
+## Notes
+
+- Bindings: `DB` (shared with oyster-auth), `ARTIFACTS` (R2 bucket `oyster-artifacts`).
+- No secrets: nothing in `wrangler secret put`. Sessions are validated by reading the
+  shared `sessions` table.
+- R2 key shape: `published/{owner_user_id}/{share_token}`.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add infra/oyster-publish/README.md
+git commit -m "docs(oyster-publish): setup + deploy README (#315)"
+```
+
+---
+
+### Task 1.9: Open Phase 1 PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch.**
+
+```bash
+git push -u origin feat/r5-publish-backend
+```
+
+- [ ] **Step 2: Open the PR.**
+
+```bash
+gh pr create --title "feat(publish): Worker scaffold + D1 migration + R2 bucket (#315 PR 1/3)" --body "$(cat <<'EOF'
+## Summary
+
+- New `oyster-publish` Cloudflare Worker, deployed at `oyster.to/api/publish/*` and `oyster.to/p/*`. All endpoints currently return `501` — bodies land in PRs 2 + 3.
+- D1 migration `0003_publish.sql` against the shared `oyster-auth` DB: adds `users.tier` (default `'free'`) and creates `published_artifacts` with the spec's indexes + CHECK.
+- R2 bucket `oyster-artifacts` provisioned.
+
+Spec: `docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`.
+Plan: `docs/superpowers/plans/2026-05-03-r5-publish-backend.md`.
+
+## Test plan
+
+- [ ] `wrangler d1 execute oyster-auth --remote --command "SELECT * FROM published_artifacts;"` returns no rows, no error.
+- [ ] `wrangler r2 bucket list` shows `oyster-artifacts`.
+- [ ] `curl -X POST https://oyster.to/api/publish/upload` returns `501 {"error":"not_implemented","handler":"publish_upload"}`.
+- [ ] `curl https://oyster.to/p/anything` returns `501`.
+- [ ] No regression in `oyster-auth` — sign-in still works at `oyster.to/auth/sign-in`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm CI is green and request review.**
+
+(Pause here for review/merge before starting Phase 2.)
+
+---
+
+## Phase 2 — Worker publish + unpublish endpoints (PR 2)
+
+End state: `oyster-publish` Worker fully implements the spec's `POST /api/publish/upload` (with race recovery + stream-size enforcement + cap + CHECK) and `DELETE /api/publish/:share_token`. Vitest pool-workers integration suite passes. Local server is still untouched — calls are smoke-tested with `curl` only.
+
+### Task 2.1: `generateShareToken` + `r2KeyFor` + `CAPS` (TDD, pure helpers)
+
+**Files:**
+- Create: `infra/oyster-publish/src/publish-helpers.ts`
+- Create: `infra/oyster-publish/test/publish-helpers.test.ts`
+
+- [ ] **Step 1: Write the failing tests.**
+
+Create `infra/oyster-publish/test/publish-helpers.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { generateShareToken, r2KeyFor, CAPS, parseMetadataHeader } from "../src/publish-helpers";
+
+describe("generateShareToken", () => {
+  it("is 32 base64url characters (24 bytes, no padding)", () => {
+    const t = generateShareToken();
+    expect(t).toMatch(/^[A-Za-z0-9_-]{32}$/);
+  });
+
+  it("produces a different value on each call", () => {
+    const a = generateShareToken();
+    const b = generateShareToken();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("r2KeyFor", () => {
+  it("composes published/{owner}/{token}", () => {
+    expect(r2KeyFor("user_abc", "tok_xyz")).toBe("published/user_abc/tok_xyz");
+  });
+});
+
+describe("CAPS.free", () => {
+  it("max_active is 5", () => {
+    expect(CAPS.free.max_active).toBe(5);
+  });
+
+  it("max_size_bytes is exactly 10 MB", () => {
+    expect(CAPS.free.max_size_bytes).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe("parseMetadataHeader", () => {
+  function encode(payload: object): string {
+    const json = JSON.stringify(payload);
+    return Buffer.from(json).toString("base64url");
+  }
+
+  it("decodes a valid 'open' payload", () => {
+    const blob = encode({ artifact_id: "a", artifact_kind: "notes", mode: "open" });
+    const result = parseMetadataHeader(blob);
+    expect(result).toEqual({ artifact_id: "a", artifact_kind: "notes", mode: "open" });
+  });
+
+  it("decodes a 'password' payload with hash", () => {
+    const blob = encode({
+      artifact_id: "a", artifact_kind: "notes", mode: "password",
+      password_hash: "pbkdf2$100000$xx$yy",
+    });
+    const result = parseMetadataHeader(blob);
+    expect(result.mode).toBe("password");
+    expect(result.password_hash).toBe("pbkdf2$100000$xx$yy");
+  });
+
+  it("throws 'invalid_metadata' for malformed base64url", () => {
+    expect(() => parseMetadataHeader("!!! not base64 !!!")).toThrow("invalid_metadata");
+  });
+
+  it("throws 'invalid_metadata' for missing required fields", () => {
+    const blob = encode({ artifact_id: "a", mode: "open" });
+    expect(() => parseMetadataHeader(blob)).toThrow("invalid_metadata");
+  });
+
+  it("throws 'invalid_metadata' for invalid mode value", () => {
+    const blob = encode({ artifact_id: "a", artifact_kind: "k", mode: "weird" });
+    expect(() => parseMetadataHeader(blob)).toThrow("invalid_metadata");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail.**
+
+```bash
+cd infra/oyster-publish
+npm run test -- --reporter=verbose publish-helpers
+```
+
+Expected: failures because `publish-helpers.ts` doesn't exist yet.
+
+- [ ] **Step 3: Implement `publish-helpers.ts`.**
+
+```ts
+// Pure helpers for oyster-publish. No D1, no R2, no Workers globals beyond
+// crypto.getRandomValues / atob — safe to unit-test under any runtime.
+
+import type { PublishMetadata } from "./types";
+
+export const CAPS = {
+  free: { max_active: 5, max_size_bytes: 10 * 1024 * 1024 },
+  // pro: { … }   ← lands in 0.8.0+
+} as const;
+
+export type Tier = keyof typeof CAPS;
+
+export function generateShareToken(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return base64urlEncode(bytes);
+}
+
+export function r2KeyFor(ownerUserId: string, shareToken: string): string {
+  return `published/${ownerUserId}/${shareToken}`;
+}
+
+export function parseMetadataHeader(blob: string): PublishMetadata {
+  let json: string;
+  try {
+    json = base64urlDecodeToString(blob);
+  } catch {
+    throw new Error("invalid_metadata");
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new Error("invalid_metadata");
+  }
+
+  if (!raw || typeof raw !== "object") throw new Error("invalid_metadata");
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.artifact_id !== "string" || r.artifact_id.length === 0) throw new Error("invalid_metadata");
+  if (typeof r.artifact_kind !== "string" || r.artifact_kind.length === 0) throw new Error("invalid_metadata");
+  if (r.mode !== "open" && r.mode !== "password" && r.mode !== "signin") throw new Error("invalid_metadata");
+  if (r.password_hash !== undefined && typeof r.password_hash !== "string") throw new Error("invalid_metadata");
+
+  return {
+    artifact_id: r.artifact_id,
+    artifact_kind: r.artifact_kind,
+    mode: r.mode,
+    password_hash: r.password_hash as string | undefined,
+  };
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let str = "";
+  for (const b of bytes) str += String.fromCharCode(b);
+  const b64 = btoa(str);
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecodeToString(s: string): string {
+  // Restore standard base64 padding/alphabet for atob.
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (s.length % 4)) % 4);
+  const decoded = atob(padded);
+  // atob returns a "binary string" (one char per byte). For UTF-8 JSON we need
+  // to round-trip through bytes → TextDecoder.
+  const bytes = new Uint8Array(decoded.length);
+  for (let i = 0; i < decoded.length; i++) bytes[i] = decoded.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass.**
+
+```bash
+npm run test -- publish-helpers
+```
+
+Expected: 9 tests pass (3 generate + 1 r2Key + 2 CAPS + 5 parseMetadata, allowing for grouping).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/oyster-publish/src/publish-helpers.ts \
+        infra/oyster-publish/test/publish-helpers.test.ts
+git commit -m "feat(oyster-publish): pure helpers — token, R2 key, CAPS, metadata parse (#315)"
+```
+
+---
+
+### Task 2.2: Test fixtures (D1 seed helpers)
+
+**Files:**
+- Create: `infra/oyster-publish/test/fixtures/seed.ts`
+
+Each integration test starts with an empty D1 (the workers pool gives isolated bindings per test file). We need helpers that apply the schema and seed users + sessions so handlers can resolve auth.
+
+- [ ] **Step 1: Write the seed helpers.**
+
+```ts
+// Test fixtures for oyster-publish integration tests.
+// Each test file gets isolated D1 + R2 bindings via @cloudflare/vitest-pool-workers.
+
+import { env } from "cloudflare:test";
+
+const SCHEMA_SQL = `
+-- Mirror of oyster-auth's relevant schema for tests. Keep in sync with:
+--   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
+--   infra/auth-worker/migrations/0003_publish.sql (users.tier, published_artifacts)
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,
+  email         TEXT NOT NULL UNIQUE,
+  created_at    INTEGER NOT NULL,
+  last_seen_at  INTEGER,
+  tier          TEXT NOT NULL DEFAULT 'free'
+);
+CREATE TABLE sessions (
+  session_token TEXT PRIMARY KEY,
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  created_at    INTEGER NOT NULL,
+  expires_at    INTEGER NOT NULL
+);
+CREATE TABLE published_artifacts (
+  share_token       TEXT    PRIMARY KEY,
+  owner_user_id     TEXT    NOT NULL REFERENCES users(id),
+  artifact_id       TEXT    NOT NULL,
+  artifact_kind     TEXT    NOT NULL,
+  mode              TEXT    NOT NULL CHECK (mode IN ('open','password','signin')),
+  password_hash     TEXT,
+  r2_key            TEXT    NOT NULL,
+  content_type      TEXT    NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  published_at      INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  unpublished_at    INTEGER,
+  CHECK (
+    (mode = 'password' AND password_hash IS NOT NULL) OR
+    (mode <> 'password' AND password_hash IS NULL)
+  )
+);
+CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
+CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
+  ON published_artifacts(owner_user_id, artifact_id)
+  WHERE unpublished_at IS NULL;
+`;
+
+export async function applySchema(): Promise<void> {
+  // D1 .exec runs multi-statement SQL but ignores comments inconsistently;
+  // split on semicolons and run each non-empty statement.
+  const stmts = SCHEMA_SQL.split(";").map(s => s.trim()).filter(Boolean);
+  for (const s of stmts) {
+    await env.DB.prepare(s).run();
+  }
+}
+
+export interface SeededUser {
+  id: string;
+  email: string;
+  sessionToken: string;
+}
+
+export async function seedUser(opts: { id?: string; email?: string; tier?: string } = {}): Promise<SeededUser> {
+  const id = opts.id ?? `user_${crypto.randomUUID().slice(0, 8)}`;
+  const email = opts.email ?? `${id}@example.com`;
+  const tier = opts.tier ?? "free";
+  const now = Date.now();
+  await env.DB.prepare(
+    "INSERT INTO users (id, email, created_at, last_seen_at, tier) VALUES (?, ?, ?, ?, ?)"
+  ).bind(id, email, now, now, tier).run();
+
+  const sessionToken = `sess_${crypto.randomUUID()}`;
+  const expiresAt = now + 30 * 86400 * 1000;
+  await env.DB.prepare(
+    "INSERT INTO sessions (session_token, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)"
+  ).bind(sessionToken, id, now, expiresAt).run();
+
+  return { id, email, sessionToken };
+}
+
+export async function seedActivePublication(opts: {
+  ownerUserId: string;
+  artifactId: string;
+  shareToken?: string;
+  mode?: "open" | "password" | "signin";
+  passwordHash?: string | null;
+  publishedAt?: number;
+}): Promise<string> {
+  const token = opts.shareToken ?? `seeded_${crypto.randomUUID().slice(0, 8)}`;
+  const mode = opts.mode ?? "open";
+  const passwordHash = mode === "password" ? (opts.passwordHash ?? "pbkdf2$100000$x$y") : null;
+  const now = opts.publishedAt ?? Date.now();
+  await env.DB.prepare(
+    `INSERT INTO published_artifacts
+     (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+      r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+     VALUES (?, ?, ?, 'notes', ?, ?, ?, 'text/plain', 5, ?, ?, NULL)`
+  ).bind(token, opts.ownerUserId, opts.artifactId, mode, passwordHash,
+         `published/${opts.ownerUserId}/${token}`, now, now).run();
+  return token;
+}
+
+export function authHeader(sessionToken: string): { Cookie: string } {
+  return { Cookie: `oyster_session=${sessionToken}` };
+}
+
+export function metadataHeader(payload: object): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+```
+
+- [ ] **Step 2: Commit (no test yet — fixtures are exercised by Task 2.4 onward).**
+
+```bash
+git add infra/oyster-publish/test/fixtures/seed.ts
+git commit -m "test(oyster-publish): D1 seed helpers for integration tests (#315)"
+```
+
+---
+
+### Task 2.3: Implement `worker.ts` — session resolution + router skeleton
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+
+We start by adding the shared infrastructure (session resolution, JSON error helper, router) before the handler bodies. Handlers stay 501 stubs at this point.
+
+- [ ] **Step 1: Replace `worker.ts` with the router skeleton.**
+
+```ts
+// oyster-publish — R5 publish endpoints + viewer scaffold.
+// Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
+
+import type { Env } from "./types";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/api/publish/upload" && req.method === "POST") {
+      return handlePublishUpload(req, env);
+    }
+
+    if (url.pathname.startsWith("/api/publish/") && req.method === "DELETE") {
+      const token = url.pathname.slice("/api/publish/".length);
+      return handlePublishDelete(req, env, token);
+    }
+
+    if (url.pathname.startsWith("/p/") && req.method === "GET") {
+      // Viewer body lands in #316.
+      return jsonError(501, "not_implemented", "viewer lands in #316");
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};
+
+// ─── Handlers (bodies in tasks 2.5 and 2.6) ────────────────────────────────
+
+async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
+  return jsonError(501, "not_implemented", "publish_upload — body in Task 2.5");
+}
+
+async function handlePublishDelete(req: Request, env: Env, shareToken: string): Promise<Response> {
+  return jsonError(501, "not_implemented", "publish_unpublish — body in Task 2.6");
+}
+
+// ─── Shared helpers ────────────────────────────────────────────────────────
+
+interface SessionUser {
+  id: string;
+  email: string;
+  tier: string;
+}
+
+/**
+ * Resolve the session cookie to a user. Returns null on missing/expired session.
+ * Reads from the shared sessions + users tables.
+ */
+export async function resolveSession(req: Request, env: Env): Promise<SessionUser | null> {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const m = cookie.match(/(?:^|;\s*)oyster_session=([^;]+)/);
+  if (!m) return null;
+  const token = m[1];
+
+  const row = await env.DB.prepare(
+    `SELECT u.id AS id, u.email AS email, u.tier AS tier, s.expires_at AS expires_at
+       FROM sessions s
+       JOIN users u ON u.id = s.user_id
+      WHERE s.session_token = ?`
+  ).bind(token).first<{ id: string; email: string; tier: string; expires_at: number }>();
+
+  if (!row) return null;
+  if (row.expires_at <= Date.now()) return null;
+  return { id: row.id, email: row.email, tier: row.tier };
+}
+
+export function jsonError(status: number, code: string, message?: string, extra: Record<string, unknown> = {}): Response {
+  const body: Record<string, unknown> = { error: code, ...extra };
+  if (message) body.message = message;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function jsonOk(payload: object, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+```
+
+- [ ] **Step 2: Typecheck.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: no output (success).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/src/worker.ts
+git commit -m "feat(oyster-publish): session resolver + router skeleton (#315)"
+```
+
+---
+
+### Task 2.4: Auth + metadata validation tests (set the test pattern)
+
+**Files:**
+- Create: `infra/oyster-publish/test/publish-handler.test.ts`
+
+This task lays down the test file with the easiest cases (auth, metadata validation). Subsequent tasks add cases for cap, race, etc.
+
+- [ ] **Step 1: Write the auth + metadata test cases.**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, authHeader, metadataHeader } from "./fixtures/seed";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function uploadRequest(opts: {
+  cookieHeader?: Record<string, string>;
+  metadata?: string;
+  contentType?: string;
+  contentLength?: string | null;
+  body?: BodyInit | null;
+} = {}): Request {
+  const headers = new Headers();
+  if (opts.cookieHeader?.Cookie) headers.set("Cookie", opts.cookieHeader.Cookie);
+  if (opts.metadata !== undefined) headers.set("X-Publish-Metadata", opts.metadata);
+  if (opts.contentType) headers.set("Content-Type", opts.contentType);
+  if (opts.contentLength !== null) {
+    const len = opts.contentLength ?? (opts.body ? String((opts.body as string).length) : "0");
+    headers.set("Content-Length", len);
+  }
+  return new Request("https://oyster.to/api/publish/upload", {
+    method: "POST",
+    headers,
+    body: opts.body ?? null,
+  });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("POST /api/publish/upload — auth", () => {
+  it("returns 401 sign_in_required when cookie is missing", async () => {
+    const res = await call(uploadRequest());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "sign_in_required" });
+  });
+
+  it("returns 401 sign_in_required when cookie has unknown token", async () => {
+    const res = await call(uploadRequest({ cookieHeader: { Cookie: "oyster_session=fake" } }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/publish/upload — metadata + size validation", () => {
+  it("returns 400 invalid_metadata when X-Publish-Metadata is missing", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({ cookieHeader: authHeader(u.sessionToken) }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+
+  it("returns 400 invalid_metadata when payload is malformed", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: "!!!not-base64!!!",
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 password_required when mode=password and hash absent", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "password" }),
+    }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "password_required" });
+  });
+
+  it("returns 411 content_length_required when Content-Length missing", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "open" }),
+      contentLength: null,
+      contentType: "text/plain",
+    }));
+    expect(res.status).toBe(411);
+    expect(await res.json()).toMatchObject({ error: "content_length_required" });
+  });
+
+  it("returns 413 artifact_too_large when Content-Length > cap", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(11 * 1024 * 1024),
+      body: "x",
+    }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ error: "artifact_too_large", limit_bytes: 10 * 1024 * 1024 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the suite — expect all to fail (501 responses).**
+
+```bash
+cd infra/oyster-publish
+npm test -- publish-handler
+```
+
+Expected: every test fails with `expected 501 to be …`.
+
+(No commit yet — implementing the validation in the next task makes them pass.)
+
+---
+
+### Task 2.5: Implement `handlePublishUpload` — validation + early errors
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+
+This task implements steps 1–5 of the spec (auth, metadata parse, password presence, content-length presence + cap). It does *not* yet handle the find-or-claim, R2 PUT, or D1 upsert — those come in Task 2.6.
+
+- [ ] **Step 1: Update `handlePublishUpload` to handle validation.**
+
+Replace the stub with the validation phase:
+
+```ts
+async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
+  // Step 1: session.
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required", "Sign in to publish artefacts.");
+
+  // Step 2: metadata.
+  const metaHeader = req.headers.get("X-Publish-Metadata");
+  if (!metaHeader) return jsonError(400, "invalid_metadata");
+  let meta;
+  try {
+    meta = parseMetadataHeader(metaHeader);
+  } catch {
+    return jsonError(400, "invalid_metadata");
+  }
+
+  // Step 3: password presence iff mode=password (defence in depth — local server already checked).
+  if (meta.mode === "password" && (!meta.password_hash || meta.password_hash.length === 0)) {
+    return jsonError(400, "password_required");
+  }
+  if (meta.mode !== "password" && meta.password_hash) {
+    // Local server bug: hash sent for non-password mode. Reject.
+    return jsonError(400, "invalid_metadata");
+  }
+
+  // Step 4: Content-Length present.
+  const lenHeader = req.headers.get("Content-Length");
+  if (!lenHeader) return jsonError(411, "content_length_required");
+  const contentLength = Number(lenHeader);
+  if (!Number.isFinite(contentLength) || contentLength < 0) {
+    return jsonError(411, "content_length_required");
+  }
+
+  // Step 5: tier + size cap.
+  const tier = (user.tier in CAPS ? user.tier : "free") as Tier;
+  const cap = CAPS[tier];
+  if (contentLength > cap.max_size_bytes) {
+    return jsonError(413, "artifact_too_large", "Free tier allows published artefacts up to 10 MB.", {
+      limit_bytes: cap.max_size_bytes,
+    });
+  }
+
+  // Steps 6–9 land in Task 2.6.
+  return jsonError(501, "not_implemented", "find-or-claim + R2 PUT + D1 upsert — Task 2.6");
+}
+```
+
+- [ ] **Step 2: Add the imports at the top of `worker.ts`.**
+
+```ts
+import type { Env, PublicationRow } from "./types";
+import { CAPS, generateShareToken, parseMetadataHeader, r2KeyFor, type Tier } from "./publish-helpers";
+```
+
+(Adjust the existing import line if a partial one is already present.)
+
+- [ ] **Step 3: Run the validation tests.**
+
+```bash
+npm test -- publish-handler
+```
+
+Expected: all 7 tests in the auth + validation describe blocks pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/worker.ts
+git commit -m "feat(oyster-publish): publish_upload validation + cap pre-check (#315)"
+```
+
+---
+
+### Task 2.6: Implement `handlePublishUpload` — find-or-claim + R2 PUT + D1 upsert
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+- Modify: `infra/oyster-publish/test/publish-handler.test.ts`
+
+This is the heart of the spec: steps 6–9, including race recovery and stream-size enforcement.
+
+- [ ] **Step 1: Add the happy-path tests first.**
+
+Append to `publish-handler.test.ts`:
+
+```ts
+describe("POST /api/publish/upload — first publish (open mode)", () => {
+  it("creates a row, writes R2, returns 200 with token + URL", async () => {
+    const u = await seedUser();
+    const body = "# Hello world";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_1", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/markdown",
+      contentLength: String(new TextEncoder().encode(body).byteLength),
+      body,
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { share_token: string; share_url: string; mode: string; published_at: number; updated_at: number };
+    expect(json.share_token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(json.share_url).toBe(`https://oyster.to/p/${json.share_token}`);
+    expect(json.mode).toBe("open");
+    expect(json.published_at).toBeTypeOf("number");
+    expect(json.updated_at).toBe(json.published_at);
+
+    // D1 row exists.
+    const row = await env.DB.prepare("SELECT * FROM published_artifacts WHERE share_token = ?")
+      .bind(json.share_token).first();
+    expect(row).toBeTruthy();
+    expect((row as any).owner_user_id).toBe(u.id);
+    expect((row as any).artifact_id).toBe("art_1");
+    expect((row as any).unpublished_at).toBeNull();
+
+    // R2 object exists with the right bytes.
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${json.share_token}`);
+    expect(obj).toBeTruthy();
+    expect(await obj!.text()).toBe(body);
+  });
+});
+
+describe("POST /api/publish/upload — re-publish (upsert)", () => {
+  it("keeps share_token, refreshes bytes + mode, preserves published_at", async () => {
+    const u = await seedUser();
+    const firstBody = "v1";
+    const first = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_1", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(firstBody.length),
+      body: firstBody,
+    }));
+    const firstJson = await first.json() as any;
+    expect(first.status).toBe(200);
+
+    // Wait a beat so updated_at can plausibly differ from published_at.
+    await new Promise(r => setTimeout(r, 5));
+
+    const secondBody = "v2 with hash";
+    const second = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({
+        artifact_id: "art_1", artifact_kind: "notes",
+        mode: "password", password_hash: "pbkdf2$100000$x$y",
+      }),
+      contentType: "text/plain",
+      contentLength: String(secondBody.length),
+      body: secondBody,
+    }));
+    expect(second.status).toBe(200);
+    const secondJson = await second.json() as any;
+    expect(secondJson.share_token).toBe(firstJson.share_token);  // stable
+    expect(secondJson.mode).toBe("password");
+    expect(secondJson.published_at).toBe(firstJson.published_at);  // preserved
+    expect(secondJson.updated_at).toBeGreaterThanOrEqual(firstJson.updated_at);
+
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${firstJson.share_token}`);
+    expect(await obj!.text()).toBe(secondBody);
+
+    const row = await env.DB.prepare("SELECT mode, password_hash FROM published_artifacts WHERE share_token = ?")
+      .bind(firstJson.share_token).first<any>();
+    expect(row.mode).toBe("password");
+    expect(row.password_hash).toBe("pbkdf2$100000$x$y");
+  });
+});
+
+describe("POST /api/publish/upload — cap enforcement", () => {
+  it("returns 402 publish_cap_exceeded on 6th distinct artefact", async () => {
+    const u = await seedUser();
+    for (let i = 0; i < 5; i++) {
+      const body = `body ${i}`;
+      const res = await call(uploadRequest({
+        cookieHeader: authHeader(u.sessionToken),
+        metadata: metadataHeader({ artifact_id: `art_${i}`, artifact_kind: "notes", mode: "open" }),
+        contentType: "text/plain",
+        contentLength: String(body.length),
+        body,
+      }));
+      expect(res.status).toBe(200);
+    }
+    const body = "boom";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_6", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(res.status).toBe(402);
+    const json = await res.json() as any;
+    expect(json.error).toBe("publish_cap_exceeded");
+    expect(json.current).toBe(5);
+    expect(json.limit).toBe(5);
+  });
+
+  it("does not count unpublished rows toward the cap", async () => {
+    const u = await seedUser();
+    // Seed 5 unpublished rows directly.
+    const now = Date.now();
+    for (let i = 0; i < 5; i++) {
+      const tok = `seeded_${i}`;
+      await env.DB.prepare(
+        `INSERT INTO published_artifacts
+         (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+          r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+         VALUES (?, ?, ?, 'notes', 'open', NULL, ?, 'text/plain', 5, ?, ?, ?)`
+      ).bind(tok, u.id, `seeded_art_${i}`, `published/${u.id}/${tok}`, now, now, now).run();
+    }
+    const body = "fresh";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "fresh_art", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Implement steps 6–9 of `handlePublishUpload`.**
+
+Replace the trailing `return jsonError(501, …)` with:
+
+```ts
+  // Step 6: find-or-claim final share_token.
+  type ActiveRow = { share_token: string; published_at: number };
+  const existing = await env.DB.prepare(
+    `SELECT share_token, published_at FROM published_artifacts
+      WHERE owner_user_id = ? AND artifact_id = ? AND unpublished_at IS NULL`
+  ).bind(user.id, meta.artifact_id).first<ActiveRow>();
+
+  let shareToken: string;
+  let publishedAt: number;
+  let path: "first-publish" | "upsert";
+
+  if (existing) {
+    shareToken = existing.share_token;
+    publishedAt = existing.published_at;
+    path = "upsert";
+  } else {
+    // Cap check before generating a token.
+    const countRow = await env.DB.prepare(
+      `SELECT COUNT(*) AS n FROM published_artifacts
+        WHERE owner_user_id = ? AND unpublished_at IS NULL`
+    ).bind(user.id).first<{ n: number }>();
+    const current = countRow?.n ?? 0;
+    if (current >= cap.max_active) {
+      return jsonError(402, "publish_cap_exceeded",
+        `Free tier allows ${cap.max_active} active published artefacts. Unpublish one first.`,
+        { current, limit: cap.max_active });
+    }
+
+    // Generate token and try to claim it.
+    const candidate = generateShareToken();
+    const now = Date.now();
+    try {
+      await env.DB.prepare(
+        `INSERT INTO published_artifacts
+         (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+          r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`
+      ).bind(
+        candidate, user.id, meta.artifact_id, meta.artifact_kind, meta.mode,
+        meta.password_hash ?? null,
+        r2KeyFor(user.id, candidate),
+        req.headers.get("Content-Type") ?? "application/octet-stream",
+        contentLength, now, now,
+      ).run();
+      shareToken = candidate;
+      publishedAt = now;
+      path = "first-publish";
+    } catch (err) {
+      // Race recovery: concurrent first-publish for the same (owner, artifact) won.
+      // Re-SELECT and treat as upsert.
+      const won = await env.DB.prepare(
+        `SELECT share_token, published_at FROM published_artifacts
+          WHERE owner_user_id = ? AND artifact_id = ? AND unpublished_at IS NULL`
+      ).bind(user.id, meta.artifact_id).first<ActiveRow>();
+      if (!won) {
+        // Some other constraint failed; surface as 500.
+        console.error("[publish] insert failed and no winning row found:", err);
+        return jsonError(500, "internal_error");
+      }
+      shareToken = won.share_token;
+      publishedAt = won.published_at;
+      path = "upsert";
+    }
+  }
+
+  // Step 7: stream body to R2 with size enforcement.
+  const r2Key = r2KeyFor(user.id, shareToken);
+  let putError: Error | null = null;
+  try {
+    const stream = req.body;
+    if (!stream) {
+      // No body; size 0 is allowed.
+      await env.ARTIFACTS.put(r2Key, "", {
+        httpMetadata: { contentType: req.headers.get("Content-Type") ?? "application/octet-stream" },
+      });
+    } else {
+      const enforced = streamWithSizeCap(stream, cap.max_size_bytes);
+      await env.ARTIFACTS.put(r2Key, enforced.stream, {
+        httpMetadata: { contentType: req.headers.get("Content-Type") ?? "application/octet-stream" },
+      });
+      if (enforced.exceeded) {
+        putError = new Error("artifact_too_large");
+      }
+    }
+  } catch (err) {
+    putError = err as Error;
+  }
+
+  if (putError) {
+    // Rollback: delete the speculatively-inserted row only if first-publish.
+    if (path === "first-publish") {
+      await env.DB.prepare("DELETE FROM published_artifacts WHERE share_token = ?")
+        .bind(shareToken).run();
+    }
+    // Best-effort R2 cleanup.
+    try { await env.ARTIFACTS.delete(r2Key); } catch { /* swallow */ }
+
+    if (putError.message === "artifact_too_large") {
+      return jsonError(413, "artifact_too_large",
+        "Free tier allows published artefacts up to 10 MB.",
+        { limit_bytes: cap.max_size_bytes });
+    }
+    console.error("[publish] R2 put failed:", putError);
+    return jsonError(502, "upload_failed");
+  }
+
+  // Step 8: D1 commit.
+  const updatedAt = Date.now();
+  if (path === "upsert") {
+    await env.DB.prepare(
+      `UPDATE published_artifacts
+          SET mode = ?, password_hash = ?, content_type = ?, size_bytes = ?, updated_at = ?
+        WHERE share_token = ?`
+    ).bind(
+      meta.mode, meta.password_hash ?? null,
+      req.headers.get("Content-Type") ?? "application/octet-stream",
+      contentLength, updatedAt, shareToken,
+    ).run();
+  } else {
+    // First-publish: row already inserted; bump updated_at if R2 PUT took meaningful time.
+    await env.DB.prepare(
+      `UPDATE published_artifacts SET updated_at = ? WHERE share_token = ?`
+    ).bind(updatedAt, shareToken).run();
+  }
+
+  // Step 9: respond.
+  return jsonOk({
+    share_token: shareToken,
+    share_url: `https://oyster.to/p/${shareToken}`,
+    mode: meta.mode,
+    published_at: publishedAt,
+    updated_at: updatedAt,
+  });
+}
+
+// streamWithSizeCap wraps a ReadableStream so that if total bytes exceed `max`
+// the stream errors out, the consumer (R2.put) aborts, and `exceeded` flips true.
+function streamWithSizeCap(input: ReadableStream<Uint8Array>, max: number): {
+  stream: ReadableStream<Uint8Array>;
+  exceeded: boolean;
+} {
+  let total = 0;
+  const handle = { exceeded: false };
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = input.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          total += value.byteLength;
+          if (total > max) {
+            handle.exceeded = true;
+            controller.error(new Error("artifact_too_large"));
+            return;
+          }
+          controller.enqueue(value);
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+  });
+  return { stream, get exceeded() { return handle.exceeded; } };
+}
+```
+
+- [ ] **Step 3: Run the suite.**
+
+```bash
+npm test -- publish-handler
+```
+
+Expected: validation cases (Task 2.4) still pass, and the new first-publish, re-publish, cap, and unpublished-not-counted tests pass too.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/worker.ts \
+        infra/oyster-publish/test/publish-handler.test.ts
+git commit -m "feat(oyster-publish): publish_upload — find-or-claim, R2 PUT, D1 upsert (#315)"
+```
+
+---
+
+### Task 2.7: Race recovery + cross-owner non-conflict + CHECK constraint tests
+
+**Files:**
+- Modify: `infra/oyster-publish/test/publish-handler.test.ts`
+
+- [ ] **Step 1: Add the three remaining integration cases.**
+
+Append:
+
+```ts
+describe("POST /api/publish/upload — race recovery", () => {
+  it("two concurrent first-publishes return the same share_token, one D1 row, one R2 object", async () => {
+    const u = await seedUser();
+    const body = "racing";
+
+    function call6() {
+      return call(uploadRequest({
+        cookieHeader: authHeader(u.sessionToken),
+        metadata: metadataHeader({ artifact_id: "art_race", artifact_kind: "notes", mode: "open" }),
+        contentType: "text/plain",
+        contentLength: String(body.length),
+        body,
+      }));
+    }
+
+    const [r1, r2] = await Promise.all([call6(), call6()]);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    const j1 = await r1.json() as any;
+    const j2 = await r2.json() as any;
+    expect(j1.share_token).toBe(j2.share_token);
+
+    // Exactly one row.
+    const rows = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM published_artifacts WHERE owner_user_id = ? AND artifact_id = ? AND unpublished_at IS NULL"
+    ).bind(u.id, "art_race").first<{ n: number }>();
+    expect(rows?.n).toBe(1);
+
+    // R2 object exists at the winning token.
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${j1.share_token}`);
+    expect(obj).toBeTruthy();
+  });
+});
+
+describe("POST /api/publish/upload — cross-owner non-conflict", () => {
+  it("two users may publish artefacts that share an artifact_id without conflict", async () => {
+    const a = await seedUser({ id: "user_a", email: "a@example.com" });
+    const b = await seedUser({ id: "user_b", email: "b@example.com" });
+
+    const body = "shared";
+    const ra = await call(uploadRequest({
+      cookieHeader: authHeader(a.sessionToken),
+      metadata: metadataHeader({ artifact_id: "shared_id", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    const rb = await call(uploadRequest({
+      cookieHeader: authHeader(b.sessionToken),
+      metadata: metadataHeader({ artifact_id: "shared_id", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(ra.status).toBe(200);
+    expect(rb.status).toBe(200);
+    const ja = await ra.json() as any;
+    const jb = await rb.json() as any;
+    expect(ja.share_token).not.toBe(jb.share_token);
+
+    const rows = await env.DB.prepare(
+      "SELECT owner_user_id FROM published_artifacts WHERE artifact_id = ? AND unpublished_at IS NULL ORDER BY owner_user_id"
+    ).bind("shared_id").all<{ owner_user_id: string }>();
+    expect(rows.results.map(r => r.owner_user_id)).toEqual(["user_a", "user_b"]);
+  });
+});
+
+describe("POST /api/publish/upload — D1 CHECK enforcement", () => {
+  it("rejects an open-mode publish that smuggles a password_hash", async () => {
+    const u = await seedUser();
+    const body = "x";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({
+        artifact_id: "art_check", artifact_kind: "notes", mode: "open",
+        password_hash: "pbkdf2$100000$x$y",  // illegal for open mode
+      }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    // Caught by the handler's defence-in-depth (Task 2.5) before reaching D1.
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+});
+
+describe("POST /api/publish/upload — streamed-size enforcement", () => {
+  it("aborts mid-stream when streamed bytes exceed cap despite Content-Length under cap", async () => {
+    const u = await seedUser();
+    const liedLength = 10;  // claim 10 bytes
+    const realBody = new Uint8Array(11 * 1024 * 1024);  // actually send 11 MB
+    realBody.fill(0x41);
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_stream", artifact_kind: "notes", mode: "open" }),
+      contentType: "application/octet-stream",
+      contentLength: String(liedLength),
+      body: realBody,
+    }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ error: "artifact_too_large" });
+    // No D1 row left behind.
+    const row = await env.DB.prepare(
+      "SELECT * FROM published_artifacts WHERE owner_user_id = ? AND artifact_id = ?"
+    ).bind(u.id, "art_stream").first();
+    expect(row).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the suite.**
+
+```bash
+npm test -- publish-handler
+```
+
+Expected: all describe blocks pass.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/test/publish-handler.test.ts
+git commit -m "test(oyster-publish): race recovery + cross-owner + CHECK + stream-cap (#315)"
+```
+
+---
+
+### Task 2.8: Implement `handlePublishDelete`
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+- Create: `infra/oyster-publish/test/unpublish-handler.test.ts`
+
+- [ ] **Step 1: Write the unpublish tests.**
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, seedActivePublication, authHeader, metadataHeader } from "./fixtures/seed";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function deleteRequest(token: string, sessionToken?: string): Request {
+  const headers = new Headers();
+  if (sessionToken) headers.set("Cookie", `oyster_session=${sessionToken}`);
+  return new Request(`https://oyster.to/api/publish/${token}`, { method: "DELETE", headers });
+}
+
+describe("DELETE /api/publish/:share_token", () => {
+  it("returns 401 sign_in_required without a session cookie", async () => {
+    const res = await call(deleteRequest("anytoken"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 publication_not_found for an unknown token", async () => {
+    const u = await seedUser();
+    const res = await call(deleteRequest("ghost", u.sessionToken));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "publication_not_found" });
+  });
+
+  it("returns 403 not_publication_owner when caller is not the owner", async () => {
+    const owner = await seedUser({ id: "owner", email: "owner@example.com" });
+    const stranger = await seedUser({ id: "stranger", email: "stranger@example.com" });
+    const tok = await seedActivePublication({ ownerUserId: owner.id, artifactId: "art_x" });
+    const res = await call(deleteRequest(tok, stranger.sessionToken));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "not_publication_owner" });
+  });
+
+  it("returns 200 and marks unpublished_at on first call", async () => {
+    const u = await seedUser();
+    const tok = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_x" });
+    // Seed an R2 object so we can verify the delete.
+    await env.ARTIFACTS.put(`published/${u.id}/${tok}`, "bytes");
+
+    const res = await call(deleteRequest(tok, u.sessionToken));
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.ok).toBe(true);
+    expect(json.share_token).toBe(tok);
+    expect(json.unpublished_at).toBeTypeOf("number");
+
+    const row = await env.DB.prepare("SELECT unpublished_at FROM published_artifacts WHERE share_token = ?")
+      .bind(tok).first<{ unpublished_at: number | null }>();
+    expect(row?.unpublished_at).toBeTypeOf("number");
+
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${tok}`);
+    expect(obj).toBeNull();
+  });
+
+  it("is idempotent on a second call (already unpublished)", async () => {
+    const u = await seedUser();
+    const tok = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_x" });
+    await call(deleteRequest(tok, u.sessionToken));
+    const second = await call(deleteRequest(tok, u.sessionToken));
+    expect(second.status).toBe(200);
+    const json = await second.json() as any;
+    expect(json.ok).toBe(true);
+  });
+});
+
+describe("publish → unpublish → publish round-trip", () => {
+  // This test crosses both handlers; it lives here because the lifecycle is
+  // anchored by unpublish (without it, the second publish would be an upsert).
+  it("issues a new share_token after unpublish; old R2 object gone, new R2 object present", async () => {
+    const u = await seedUser();
+    const body = "first-bytes";
+
+    // 1. First publish via the handler so we get a real generated token.
+    const headers = new Headers();
+    headers.set("Cookie", `oyster_session=${u.sessionToken}`);
+    headers.set("X-Publish-Metadata", Buffer.from(JSON.stringify({
+      artifact_id: "art_cycle", artifact_kind: "notes", mode: "open",
+    })).toString("base64url"));
+    headers.set("Content-Type", "text/plain");
+    headers.set("Content-Length", String(body.length));
+    const first = await call(new Request("https://oyster.to/api/publish/upload", {
+      method: "POST", headers, body,
+    }));
+    expect(first.status).toBe(200);
+    const firstJson = await first.json() as { share_token: string };
+
+    // 2. Unpublish.
+    const del = await call(deleteRequest(firstJson.share_token, u.sessionToken));
+    expect(del.status).toBe(200);
+
+    // 3. Republish.
+    const second = await call(new Request("https://oyster.to/api/publish/upload", {
+      method: "POST", headers, body: "second-bytes",
+    }));
+    expect(second.status).toBe(200);
+    const secondJson = await second.json() as { share_token: string; share_url: string };
+
+    // New token (not the same as first).
+    expect(secondJson.share_token).not.toBe(firstJson.share_token);
+
+    // Old R2 object gone (deleted by unpublish).
+    const oldObj = await env.ARTIFACTS.get(`published/${u.id}/${firstJson.share_token}`);
+    expect(oldObj).toBeNull();
+
+    // New R2 object present with new bytes.
+    const newObj = await env.ARTIFACTS.get(`published/${u.id}/${secondJson.share_token}`);
+    expect(newObj).toBeTruthy();
+    expect(await newObj!.text()).toBe("second-bytes");
+
+    // Old D1 row marked unpublished; new row live.
+    const oldRow = await env.DB.prepare("SELECT unpublished_at FROM published_artifacts WHERE share_token = ?")
+      .bind(firstJson.share_token).first<{ unpublished_at: number | null }>();
+    expect(oldRow?.unpublished_at).toBeTypeOf("number");
+    const newRow = await env.DB.prepare("SELECT unpublished_at FROM published_artifacts WHERE share_token = ?")
+      .bind(secondJson.share_token).first<{ unpublished_at: number | null }>();
+    expect(newRow?.unpublished_at).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `handlePublishDelete`.**
+
+Replace the stub in `worker.ts`:
+
+```ts
+async function handlePublishDelete(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+
+  type Row = { owner_user_id: string; r2_key: string; unpublished_at: number | null };
+  const row = await env.DB.prepare(
+    "SELECT owner_user_id, r2_key, unpublished_at FROM published_artifacts WHERE share_token = ?"
+  ).bind(shareToken).first<Row>();
+
+  if (!row) return jsonError(404, "publication_not_found");
+  if (row.owner_user_id !== user.id) return jsonError(403, "not_publication_owner");
+
+  if (row.unpublished_at !== null) {
+    return jsonOk({ ok: true, share_token: shareToken, unpublished_at: row.unpublished_at });
+  }
+
+  const now = Date.now();
+  await env.DB.prepare("UPDATE published_artifacts SET unpublished_at = ? WHERE share_token = ?")
+    .bind(now, shareToken).run();
+
+  // Best-effort R2 delete; D1 is the source of truth.
+  try { await env.ARTIFACTS.delete(row.r2_key); } catch (err) {
+    console.warn("[publish] R2 delete failed (orphan accepted):", err);
+  }
+
+  return jsonOk({ ok: true, share_token: shareToken, unpublished_at: now });
+}
+```
+
+- [ ] **Step 3: Run the suite.**
+
+```bash
+npm test
+```
+
+Expected: all publish + unpublish describe blocks pass (publish-handler.test.ts and unpublish-handler.test.ts).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/worker.ts \
+        infra/oyster-publish/test/unpublish-handler.test.ts
+git commit -m "feat(oyster-publish): unpublish endpoint + tests (#315)"
+```
+
+---
+
+### Task 2.9: Deploy + smoke test against the live Worker
+
+**Files:** none.
+
+- [ ] **Step 1: Deploy.**
+
+```bash
+cd infra/oyster-publish
+npm run deploy
+```
+
+- [ ] **Step 2: Smoke-test publish.**
+
+You need a real `oyster_session` cookie value. Sign in once at `https://oyster.to/auth/sign-in` in a browser, then copy the `oyster_session` cookie value (DevTools → Application → Cookies → `oyster.to`).
+
+```bash
+SESSION=<paste-here>
+META=$(printf '%s' '{"artifact_id":"smoke_test","artifact_kind":"notes","mode":"open"}' | base64 | tr '+/' '-_' | tr -d '=')
+echo "# Hello from smoke test" > /tmp/smoke.md
+curl -s -X POST https://oyster.to/api/publish/upload \
+  -H "Cookie: oyster_session=$SESSION" \
+  -H "X-Publish-Metadata: $META" \
+  -H "Content-Type: text/markdown" \
+  --data-binary @/tmp/smoke.md
+```
+
+Expected: `{"share_token":"…","share_url":"https://oyster.to/p/…","mode":"open","published_at":…,"updated_at":…}`.
+
+- [ ] **Step 3: Verify D1 + R2.**
+
+```bash
+SHARE_TOKEN=<from step 2 response>
+wrangler d1 execute oyster-auth --remote --command "SELECT share_token, owner_user_id, mode, size_bytes FROM published_artifacts WHERE share_token = '$SHARE_TOKEN';"
+wrangler r2 object get oyster-artifacts published/<your-user-id>/$SHARE_TOKEN -- /tmp/check.md
+diff /tmp/smoke.md /tmp/check.md && echo "R2 bytes match"
+```
+
+- [ ] **Step 4: Smoke-test unpublish.**
+
+```bash
+curl -s -X DELETE https://oyster.to/api/publish/$SHARE_TOKEN \
+  -H "Cookie: oyster_session=$SESSION"
+```
+
+Expected: `{"ok":true,"share_token":"…","unpublished_at":…}`.
+
+- [ ] **Step 5: Confirm `unpublished_at` set + R2 object gone.**
+
+```bash
+wrangler d1 execute oyster-auth --remote --command "SELECT unpublished_at FROM published_artifacts WHERE share_token = '$SHARE_TOKEN';"
+wrangler r2 object get oyster-artifacts published/<your-user-id>/$SHARE_TOKEN -- /tmp/should-fail.md 2>&1 || echo "R2 object deleted (expected)"
+```
+
+(No commit.)
+
+---
+
+### Task 2.10: Open Phase 2 PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push.**
+
+```bash
+git push
+```
+
+- [ ] **Step 2: Open the PR.**
+
+```bash
+gh pr create --title "feat(publish): Worker upload + unpublish endpoints (#315 PR 2/3)" --body "$(cat <<'EOF'
+## Summary
+
+- `POST /api/publish/upload`: full spec implementation — auth, metadata parse, password presence check, Content-Length + tier-cap pre-check, find-or-claim with race recovery on the partial unique index, streamed R2 upload with size cap (defence against lying Content-Length), D1 upsert, response with stable token.
+- `DELETE /api/publish/:share_token`: idempotent unpublish; updates `unpublished_at`, best-effort R2 delete.
+- Vitest pool-workers integration suite covers: auth, metadata validation, first publish, re-publish (stable token + bytes refresh + mode change), cap (with unpublished rows correctly ignored), race recovery, cross-owner non-conflict, streamed-size enforcement, owner-scoped delete, idempotent delete.
+
+Spec: `docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`.
+Plan: `docs/superpowers/plans/2026-05-03-r5-publish-backend.md`.
+
+## Test plan
+
+- [ ] `cd infra/oyster-publish && npm test` passes.
+- [ ] Smoke test from the plan (Task 2.9) round-trips publish → row + R2 object exist → unpublish → `unpublished_at` set → R2 object gone.
+- [ ] `oyster.to/p/anything` still returns `501` (viewer is #316).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Pause for review/merge before Phase 3.**
+
+---
+
+## Phase 3 — Local server + MCP tool (PR 3)
+
+End state: an Oyster user (signed in) calling `publish_artifact` via MCP — or hitting `POST /api/artifacts/:id/publish` from the web UI — gets a working `share_url` from the deployed Worker. Local SQLite mirrors the response. CHANGELOG entry under `[Unreleased]`.
+
+### Task 3.1: Local SQLite migration — `share_updated_at`
+
+**Files:**
+- Modify: `server/src/db.ts`
+
+- [ ] **Step 1: Find the existing R5 column ALTERs (added in #314) and add the new one alongside.**
+
+Search for `share_token` in `server/src/db.ts`. Add the new ALTER in the same try/catch block pattern (idempotent — the codebase convention is to swallow "duplicate column" errors so re-running on a populated DB is safe):
+
+```ts
+try { db.prepare(`ALTER TABLE artifacts ADD COLUMN share_updated_at INTEGER`).run(); } catch { /* idempotent */ }
+```
+
+- [ ] **Step 2: Restart the dev server and verify schema.**
+
+```bash
+cd ~/Dev/oyster-os.worktrees/315-r5-publish-backend
+npm run dev   # in another terminal
+# In the first terminal:
+sqlite3 ./userland/db/oyster.db "SELECT name FROM pragma_table_info('artifacts') WHERE name='share_updated_at';"
+```
+
+Expected: one row with `name=share_updated_at`. Stop the dev server.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add server/src/db.ts
+git commit -m "feat(server): artifacts.share_updated_at for R5 publish mirror (#315)"
+```
+
+---
+
+### Task 3.2: `password-hash.ts` — Node PBKDF2 helper (TDD)
+
+**Files:**
+- Create: `server/src/password-hash.ts`
+- Create: `server/test/password-hash.test.ts`
+
+- [ ] **Step 1: Write failing tests.**
+
+```ts
+// server/test/password-hash.test.ts
+import { describe, it, expect } from "vitest";
+import { hashPassword } from "../src/password-hash";
+
+describe("hashPassword", () => {
+  it("returns format pbkdf2$100000$<salt>$<hash>", async () => {
+    const h = await hashPassword("hunter2");
+    const parts = h.split("$");
+    expect(parts).toHaveLength(4);
+    expect(parts[0]).toBe("pbkdf2");
+    expect(parts[1]).toBe("100000");
+    expect(parts[2]).toMatch(/^[A-Za-z0-9_-]+$/);  // base64url salt
+    expect(parts[3]).toMatch(/^[A-Za-z0-9_-]+$/);  // base64url hash
+  });
+
+  it("uses a different salt each call (so identical plaintexts hash differently)", async () => {
+    const a = await hashPassword("same");
+    const b = await hashPassword("same");
+    expect(a).not.toBe(b);
+  });
+
+  it("rejects empty plaintext", async () => {
+    await expect(hashPassword("")).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Add Vitest to `server/` if not already wired.**
+
+Check `server/package.json`. If `vitest` is not in `devDependencies`, add it and a `test` script:
+
+```bash
+cd server
+npm install --save-dev vitest@^2.1.0
+```
+
+Then add to `package.json` scripts:
+
+```json
+"test": "vitest run"
+```
+
+(Skip this step if Vitest is already configured.)
+
+- [ ] **Step 3: Run tests to verify they fail.**
+
+```bash
+cd server
+npm test -- password-hash
+```
+
+Expected: cannot find module `../src/password-hash`.
+
+- [ ] **Step 4: Implement.**
+
+```ts
+// server/src/password-hash.ts — PBKDF2-SHA256 password hashing.
+// Format: pbkdf2$<iter>$<salt_b64url>$<hash_b64url>
+// Verifier (Web Crypto in oyster-publish viewer #316) reads the same format.
+
+import { pbkdf2, randomBytes } from "node:crypto";
+import { promisify } from "node:util";
+
+const pbkdf2Async = promisify(pbkdf2);
+
+const ITERATIONS = 100_000;
+const SALT_BYTES = 16;
+const HASH_BYTES = 32;
+
+export async function hashPassword(plaintext: string): Promise<string> {
+  if (plaintext.length === 0) throw new Error("password_required");
+  const salt = randomBytes(SALT_BYTES);
+  const hash = await pbkdf2Async(plaintext, salt, ITERATIONS, HASH_BYTES, "sha256");
+  return `pbkdf2$${ITERATIONS}$${b64url(salt)}$${b64url(hash)}`;
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass.**
+
+```bash
+npm test -- password-hash
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add server/src/password-hash.ts server/test/password-hash.test.ts \
+        server/package.json server/package-lock.json
+git commit -m "feat(server): PBKDF2 password hash helper for publish (#315)"
+```
+
+---
+
+### Task 3.3: `publish-service.ts` — internal helper (TDD against a mocked Worker)
+
+**Files:**
+- Create: `server/src/publish-service.ts`
+- Create: `server/test/publish-service.test.ts`
+
+The service is the single place that knows the Worker URL, applies owner-attribution to local SQLite, and mirrors the Worker response into the `artifacts` row. Both the HTTP route and the MCP tool import from it.
+
+- [ ] **Step 1: Write failing tests.**
+
+```ts
+// server/test/publish-service.test.ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { createPublishService } from "../src/publish-service";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE artifacts (
+      id                   TEXT PRIMARY KEY,
+      kind                 TEXT NOT NULL,
+      owner_id             TEXT,
+      created_at           INTEGER NOT NULL,
+      updated_at           INTEGER NOT NULL,
+      content_path         TEXT,
+      share_token          TEXT,
+      share_mode           TEXT,
+      share_password_hash  TEXT,
+      published_at         INTEGER,
+      share_updated_at     INTEGER,
+      unpublished_at       INTEGER
+    );
+  `);
+  return db;
+}
+
+function seedArtifact(db: Database.Database, opts: { id?: string; kind?: string; owner_id?: string | null } = {}) {
+  const id = opts.id ?? "art_1";
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO artifacts (id, kind, owner_id, created_at, updated_at, content_path)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(id, opts.kind ?? "notes", opts.owner_id ?? null, now, now, "/tmp/fake.md");
+  return id;
+}
+
+describe("publishArtifact", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("returns 401 when there is no signed-in user", async () => {
+    const db = makeDb();
+    seedArtifact(db);
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array([1, 2, 3]),
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "pbkdf2$x",
+      fetch: vi.fn(),
+    });
+    await expect(svc.publishArtifact({ artifact_id: "art_1", mode: "open" }))
+      .rejects.toMatchObject({ status: 401, code: "sign_in_required" });
+  });
+
+  it("returns 404 when the local artefact does not exist", async () => {
+    const db = makeDb();
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array([1, 2, 3]),
+      currentUser: () => ({ id: "u1", email: "a@a" }),
+      sessionToken: () => "s1",
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "pbkdf2$x",
+      fetch: vi.fn(),
+    });
+    await expect(svc.publishArtifact({ artifact_id: "missing", mode: "open" }))
+      .rejects.toMatchObject({ status: 404, code: "artifact_not_found" });
+  });
+
+  it("returns 403 when caller is not the local artefact owner", async () => {
+    const db = makeDb();
+    seedArtifact(db, { id: "art_1", owner_id: "other_user" });
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array([1, 2, 3]),
+      currentUser: () => ({ id: "u1", email: "a@a" }),
+      sessionToken: () => "s1",
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "pbkdf2$x",
+      fetch: vi.fn(),
+    });
+    await expect(svc.publishArtifact({ artifact_id: "art_1", mode: "open" }))
+      .rejects.toMatchObject({ status: 403, code: "not_artifact_owner" });
+  });
+
+  it("happy path: hashes password, posts to worker, mirrors response into local SQLite, sets owner_id", async () => {
+    const db = makeDb();
+    seedArtifact(db, { id: "art_1", owner_id: null });
+
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      // Assert the request shape.
+      const headers = new Headers(init.headers);
+      expect(headers.get("Cookie")).toBe("oyster_session=s1");
+      expect(headers.get("Content-Type")).toBe("application/octet-stream");
+      const meta = headers.get("X-Publish-Metadata");
+      expect(meta).toBeTruthy();
+      const decoded = JSON.parse(Buffer.from(meta!, "base64url").toString());
+      expect(decoded.artifact_id).toBe("art_1");
+      expect(decoded.mode).toBe("password");
+      expect(decoded.password_hash).toBe("pbkdf2$test");
+      // The plaintext password must never appear anywhere in the proxied request.
+      expect(decoded.password).toBeUndefined();
+      const allHeaders = [...new Headers(init.headers).entries()].map(([k, v]) => `${k}=${v}`).join("|");
+      expect(allHeaders).not.toContain("hunter2");
+      return new Response(JSON.stringify({
+        share_token: "tok123",
+        share_url: "https://oyster.to/p/tok123",
+        mode: "password",
+        published_at: 1700000000000,
+        updated_at: 1700000005000,
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array([1, 2, 3]),
+      currentUser: () => ({ id: "u1", email: "a@a" }),
+      sessionToken: () => "s1",
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "pbkdf2$test",
+      fetch: fetchMock as any,
+    });
+
+    const out = await svc.publishArtifact({ artifact_id: "art_1", mode: "password", password: "hunter2" });
+    expect(out.share_token).toBe("tok123");
+    expect(out.share_url).toBe("https://oyster.to/p/tok123");
+
+    const row = db.prepare("SELECT * FROM artifacts WHERE id = 'art_1'").get() as any;
+    expect(row.owner_id).toBe("u1");                 // set on first publish
+    expect(row.share_token).toBe("tok123");
+    expect(row.share_mode).toBe("password");
+    expect(row.share_password_hash).toBe("pbkdf2$test");
+    expect(row.published_at).toBe(1700000000000);    // from response
+    expect(row.share_updated_at).toBe(1700000005000); // from response
+    expect(row.unpublished_at).toBeNull();
+  });
+
+  it("propagates worker error responses (cap, size, etc.) verbatim", async () => {
+    const db = makeDb();
+    seedArtifact(db, { id: "art_1", owner_id: "u1" });
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: "publish_cap_exceeded", current: 5, limit: 5, message: "cap" }),
+      { status: 402, headers: { "content-type": "application/json" } },
+    ));
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array([1]),
+      currentUser: () => ({ id: "u1", email: "a@a" }),
+      sessionToken: () => "s1",
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "pbkdf2$x",
+      fetch: fetchMock as any,
+    });
+    await expect(svc.publishArtifact({ artifact_id: "art_1", mode: "open" }))
+      .rejects.toMatchObject({ status: 402, code: "publish_cap_exceeded", details: { current: 5, limit: 5 } });
+  });
+});
+
+describe("unpublishArtifact", () => {
+  it("returns 404 publication_not_found when local row has no live share_token", async () => {
+    const db = makeDb();
+    seedArtifact(db, { id: "art_1", owner_id: "u1" });
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array(),
+      currentUser: () => ({ id: "u1", email: "a@a" }),
+      sessionToken: () => "s1",
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "",
+      fetch: vi.fn(),
+    });
+    await expect(svc.unpublishArtifact({ artifact_id: "art_1" }))
+      .rejects.toMatchObject({ status: 404, code: "publication_not_found" });
+  });
+
+  it("happy path: posts DELETE, mirrors unpublished_at into local SQLite", async () => {
+    const db = makeDb();
+    seedArtifact(db, { id: "art_1", owner_id: "u1" });
+    db.prepare(`UPDATE artifacts SET share_token='tokABC', share_mode='open', published_at=1, share_updated_at=1 WHERE id='art_1'`).run();
+
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe("https://oyster.to/api/publish/tokABC");
+      expect(init.method).toBe("DELETE");
+      return new Response(JSON.stringify({ ok: true, share_token: "tokABC", unpublished_at: 1700000099000 }),
+        { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const svc = createPublishService({
+      db,
+      readArtifactBytes: async () => new Uint8Array(),
+      currentUser: () => ({ id: "u1", email: "a@a" }),
+      sessionToken: () => "s1",
+      workerBase: "https://oyster.to",
+      hashPassword: async () => "",
+      fetch: fetchMock as any,
+    });
+
+    const out = await svc.unpublishArtifact({ artifact_id: "art_1" });
+    expect(out.unpublished_at).toBe(1700000099000);
+
+    const row = db.prepare("SELECT share_token, unpublished_at FROM artifacts WHERE id='art_1'").get() as any;
+    expect(row.share_token).toBe("tokABC");           // retained
+    expect(row.unpublished_at).toBe(1700000099000);   // mirrored from response
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail.**
+
+```bash
+npm test -- publish-service
+```
+
+Expected: cannot find module `../src/publish-service`.
+
+- [ ] **Step 3: Implement.**
+
+```ts
+// server/src/publish-service.ts — single source of truth for publish/unpublish.
+// Called by both routes/publish.ts (HTTP) and mcp-server.ts (MCP tool).
+
+import type Database from "better-sqlite3";
+
+export interface PublishUser {
+  id: string;
+  email: string;
+}
+
+export interface PublishServiceDeps {
+  db: Database.Database;
+  readArtifactBytes: (artifactId: string) => Promise<Uint8Array>;
+  currentUser: () => PublishUser | null;
+  sessionToken: () => string | null;
+  workerBase: string;        // e.g. "https://oyster.to"
+  hashPassword: (plaintext: string) => Promise<string>;
+  fetch: typeof fetch;
+}
+
+export interface PublishArgs {
+  artifact_id: string;
+  mode: "open" | "password" | "signin";
+  password?: string;
+}
+
+export interface PublishResult {
+  share_token: string;
+  share_url: string;
+  mode: "open" | "password" | "signin";
+  published_at: number;
+  updated_at: number;
+}
+
+export interface UnpublishResult {
+  ok: true;
+  share_token: string;
+  unpublished_at: number;
+}
+
+export class PublishError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+    public readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+  }
+}
+
+export interface PublishService {
+  publishArtifact(args: PublishArgs): Promise<PublishResult>;
+  unpublishArtifact(args: { artifact_id: string }): Promise<UnpublishResult>;
+}
+
+interface ArtifactRow {
+  id: string;
+  kind: string;
+  owner_id: string | null;
+  share_token: string | null;
+  unpublished_at: number | null;
+}
+
+export function createPublishService(deps: PublishServiceDeps): PublishService {
+  return {
+    async publishArtifact(args) {
+      const user = deps.currentUser();
+      const token = deps.sessionToken();
+      if (!user || !token) throw new PublishError(401, "sign_in_required", "Sign in to publish artefacts.");
+
+      const row = deps.db.prepare(
+        "SELECT id, kind, owner_id, share_token, unpublished_at FROM artifacts WHERE id = ?"
+      ).get(args.artifact_id) as ArtifactRow | undefined;
+      if (!row) throw new PublishError(404, "artifact_not_found", `No artefact with id ${args.artifact_id}`);
+
+      if (row.owner_id !== null && row.owner_id !== user.id) {
+        throw new PublishError(403, "not_artifact_owner", "This artefact belongs to a different account.");
+      }
+
+      if (args.mode === "password" && (!args.password || args.password.length === 0)) {
+        throw new PublishError(400, "password_required", "Password mode requires a non-empty password.");
+      }
+
+      const passwordHash = args.mode === "password" ? await deps.hashPassword(args.password!) : undefined;
+      const bytes = await deps.readArtifactBytes(args.artifact_id);
+
+      const meta = {
+        artifact_id: args.artifact_id,
+        artifact_kind: row.kind,
+        mode: args.mode,
+        ...(passwordHash ? { password_hash: passwordHash } : {}),
+      };
+      const metaHeader = Buffer.from(JSON.stringify(meta)).toString("base64url");
+
+      const res = await deps.fetch(`${deps.workerBase}/api/publish/upload`, {
+        method: "POST",
+        headers: {
+          Cookie: `oyster_session=${token}`,
+          "X-Publish-Metadata": metaHeader,
+          "Content-Type": "application/octet-stream",
+          "Content-Length": String(bytes.byteLength),
+        },
+        body: bytes,
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+        const code = (typeof body.error === "string" ? body.error : "upload_failed");
+        const { error: _e, message: _m, ...details } = body;
+        throw new PublishError(res.status, code, (body.message as string) ?? code, details);
+      }
+
+      const result = await res.json() as PublishResult;
+
+      // Mirror response into local SQLite. owner_id set on first publish.
+      const ownerToSet = row.owner_id ?? user.id;
+      deps.db.prepare(
+        `UPDATE artifacts
+            SET owner_id = ?, share_token = ?, share_mode = ?, share_password_hash = ?,
+                published_at = ?, share_updated_at = ?, unpublished_at = NULL
+          WHERE id = ?`
+      ).run(
+        ownerToSet, result.share_token, result.mode, passwordHash ?? null,
+        result.published_at, result.updated_at, args.artifact_id,
+      );
+
+      return result;
+    },
+
+    async unpublishArtifact({ artifact_id }) {
+      const user = deps.currentUser();
+      const token = deps.sessionToken();
+      if (!user || !token) throw new PublishError(401, "sign_in_required", "Sign in to unpublish artefacts.");
+
+      const row = deps.db.prepare(
+        "SELECT id, owner_id, share_token, unpublished_at FROM artifacts WHERE id = ?"
+      ).get(artifact_id) as ArtifactRow | undefined;
+      if (!row) throw new PublishError(404, "artifact_not_found");
+      if (row.owner_id && row.owner_id !== user.id) {
+        throw new PublishError(403, "not_publication_owner");
+      }
+      if (!row.share_token || row.unpublished_at !== null) {
+        throw new PublishError(404, "publication_not_found");
+      }
+
+      const res = await deps.fetch(`${deps.workerBase}/api/publish/${row.share_token}`, {
+        method: "DELETE",
+        headers: { Cookie: `oyster_session=${token}` },
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as Record<string, unknown>;
+        const code = (typeof body.error === "string" ? body.error : "unpublish_failed");
+        throw new PublishError(res.status, code, (body.message as string) ?? code);
+      }
+
+      const result = await res.json() as UnpublishResult;
+      deps.db.prepare(
+        `UPDATE artifacts SET unpublished_at = ? WHERE id = ?`
+      ).run(result.unpublished_at, artifact_id);
+
+      return result;
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests.**
+
+```bash
+npm test -- publish-service
+```
+
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add server/src/publish-service.ts server/test/publish-service.test.ts
+git commit -m "feat(server): publish-service with owner attribution + response mirror (#315)"
+```
+
+---
+
+### Task 3.4: `routes/publish.ts` — HTTP routes
+
+**Files:**
+- Create: `server/src/routes/publish.ts`
+- Modify: `server/src/index.ts`
+
+- [ ] **Step 1: Write the route handler.**
+
+```ts
+// server/src/routes/publish.ts — POST/DELETE /api/artifacts/:id/publish
+// Thin glue layer over publish-service. Same precedent as routes/auth.ts.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { PublishService, PublishError } from "../publish-service.js";
+import type { RouteCtx } from "../http-utils.js";
+
+export interface PublishRouteDeps {
+  publishService: PublishService;
+}
+
+const PATH_RE = /^\/api\/artifacts\/([^/]+)\/publish$/;
+
+export async function tryHandlePublishRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: PublishRouteDeps,
+): Promise<boolean> {
+  const m = url.match(PATH_RE);
+  if (!m) return false;
+  const artifactId = decodeURIComponent(m[1]);
+  const { sendJson, rejectIfNonLocalOrigin, readJsonBody } = ctx;
+
+  if (req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return true;
+    const body = await readJsonBody<{ mode?: string; password?: string }>(req);
+    const mode = body?.mode;
+    if (mode !== "open" && mode !== "password" && mode !== "signin") {
+      sendJson({ error: "invalid_mode", message: "mode must be open, password, or signin" }, 400);
+      return true;
+    }
+    try {
+      const result = await deps.publishService.publishArtifact({
+        artifact_id: artifactId,
+        mode,
+        password: body?.password,
+      });
+      sendJson(result);
+    } catch (err) {
+      writePublishError(sendJson, err);
+    }
+    return true;
+  }
+
+  if (req.method === "DELETE") {
+    if (rejectIfNonLocalOrigin()) return true;
+    try {
+      const result = await deps.publishService.unpublishArtifact({ artifact_id: artifactId });
+      sendJson(result);
+    } catch (err) {
+      writePublishError(sendJson, err);
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function writePublishError(sendJson: RouteCtx["sendJson"], err: unknown): void {
+  if (err && typeof err === "object" && "status" in err && "code" in err) {
+    const e = err as PublishError;
+    sendJson({ error: e.code, message: e.message, ...e.details }, e.status);
+    return;
+  }
+  console.error("[publish] unexpected error:", err);
+  sendJson({ error: "internal_error" }, 500);
+}
+```
+
+- [ ] **Step 2: Wire the route into `server/src/index.ts`.**
+
+Find where `tryHandleAuthRoute` is called (look for `routes/auth`). Add the publish wiring next to it:
+
+1. At the top with the other route imports:
+   ```ts
+   import { tryHandlePublishRoute } from "./routes/publish.js";
+   import { createPublishService } from "./publish-service.js";
+   import { hashPassword } from "./password-hash.js";
+   import { readFileSync } from "node:fs";
+   ```
+
+2. After `authService` is constructed, build the publish service:
+   ```ts
+   const WORKER_BASE = process.env.OYSTER_AUTH_BASE ?? "https://oyster.to";
+   const publishService = createPublishService({
+     db,
+     readArtifactBytes: async (artifactId) => {
+       // The artefact's content_path is set by createArtifact. For 0.7.0
+       // single-file scope, read it directly off disk.
+       const row = db.prepare("SELECT content_path FROM artifacts WHERE id = ?")
+         .get(artifactId) as { content_path: string | null } | undefined;
+       if (!row?.content_path) throw new Error(`artefact ${artifactId} has no content_path`);
+       return new Uint8Array(readFileSync(row.content_path));
+     },
+     currentUser: () => {
+       const u = authService.getState().user;
+       return u ? { id: u.id, email: u.email } : null;
+     },
+     sessionToken: () => authService.getState().sessionToken,
+     workerBase: WORKER_BASE,
+     hashPassword,
+     fetch,
+   });
+   ```
+
+3. Inside the request router (next to `tryHandleAuthRoute(...)`):
+   ```ts
+   if (await tryHandlePublishRoute(req, res, url, ctx, { publishService })) return;
+   ```
+
+(If `WORKER_BASE` already exists from `auth-service`, reuse the same constant rather than redeclaring.)
+
+- [ ] **Step 3: Manual smoke from the worktree.**
+
+```bash
+cd ~/Dev/oyster-os.worktrees/315-r5-publish-backend
+npm run dev
+# In another terminal:
+# Sign in via the web UI at http://localhost:7337 (Vite proxies to 3333).
+# Then create an artefact via the UI, copy its id from the URL.
+# Then:
+ARTIFACT_ID=<paste>
+curl -s -X POST "http://localhost:3333/api/artifacts/$ARTIFACT_ID/publish" \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"open"}'
+```
+
+Expected: JSON `{"share_token":"…","share_url":"…","mode":"open","published_at":…,"updated_at":…}`. If you get `not_artifact_owner`, this is a previously-created artefact whose `owner_id` is non-NULL and points at a different user; create a new one and try again.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add server/src/routes/publish.ts server/src/index.ts
+git commit -m "feat(server): /api/artifacts/:id/publish HTTP routes (#315)"
+```
+
+---
+
+### Task 3.5: MCP tool registration
+
+**Files:**
+- Modify: `server/src/mcp-server.ts`
+
+- [ ] **Step 1: Find the tool-registration block.**
+
+Search `mcp-server.ts` for `tool(` or `registerTool` to locate the existing tool definitions. The convention is `server.tool("name", { schema }, async (input) => {...})` or similar — match the existing style.
+
+- [ ] **Step 2: Register `publish_artifact`.**
+
+Add inside the tool-registration block (adapt to the existing pattern — the snippet below is the expected shape):
+
+```ts
+server.tool(
+  "publish_artifact",
+  {
+    description: "Publish an artefact to a public share URL. Mode 'open' = anyone with the link; 'password' = link plus shared password (you must supply `password`); 'signin' = viewer must be signed into a free Oyster account. Returns a stable share_token and share_url; calling again on the same artefact upserts (same URL, fresh bytes + mode).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        artifact_id:  { type: "string", description: "The local artefact id (uuid)." },
+        mode:         { type: "string", enum: ["open", "password", "signin"] },
+        password:     { type: "string", description: "Required and non-empty when mode='password'." },
+      },
+      required: ["artifact_id", "mode"],
+    },
+  },
+  async (input: { artifact_id: string; mode: "open" | "password" | "signin"; password?: string }) => {
+    try {
+      const result = await deps.publishService.publishArtifact(input);
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      const e = err as { status?: number; code?: string; message?: string; details?: Record<string, unknown> };
+      return {
+        isError: true,
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            error: e.code ?? "internal_error",
+            message: e.message,
+            ...(e.details ?? {}),
+          }, null, 2),
+        }],
+      };
+    }
+  },
+);
+```
+
+- [ ] **Step 3: Register `unpublish_artifact` (same shape, simpler input).**
+
+```ts
+server.tool(
+  "unpublish_artifact",
+  {
+    description: "Retire a previously-published artefact. The share URL returns 410. Republishing later issues a new token.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        artifact_id: { type: "string", description: "The local artefact id (uuid)." },
+      },
+      required: ["artifact_id"],
+    },
+  },
+  async (input: { artifact_id: string }) => {
+    try {
+      const result = await deps.publishService.unpublishArtifact(input);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (err) {
+      const e = err as { status?: number; code?: string; message?: string };
+      return {
+        isError: true,
+        content: [{
+          type: "text",
+          text: JSON.stringify({ error: e.code ?? "internal_error", message: e.message }, null, 2),
+        }],
+      };
+    }
+  },
+);
+```
+
+- [ ] **Step 4: Add `publishService` to the `McpDeps` interface.**
+
+Find the existing `McpDeps` interface in `mcp-server.ts` and add:
+
+```ts
+publishService: import("./publish-service.js").PublishService;
+```
+
+- [ ] **Step 5: Pass `publishService` through to MCP construction in `index.ts`.**
+
+Find where MCP server is constructed (search for `McpDeps` in `index.ts`) and add `publishService` to the deps object passed in.
+
+- [ ] **Step 6: Manual MCP smoke.**
+
+Restart `npm run dev`. From another terminal:
+
+```bash
+curl -s http://localhost:3333/mcp/list-tools | grep -E '"name":"(publish|unpublish)_artifact"'
+```
+
+Expected: both tool names appear. (The exact endpoint may differ — check the existing MCP route to confirm the listing path.)
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add server/src/mcp-server.ts server/src/index.ts
+git commit -m "feat(mcp): publish_artifact + unpublish_artifact tools (#315)"
+```
+
+---
+
+### Task 3.6: End-to-end smoke test against deployed Worker
+
+**Files:** none.
+
+- [ ] **Step 1: Sign in via the dev UI.**
+
+Start `npm run dev`. Open `http://localhost:7337/auth/sign-in`, complete the GitHub OAuth flow, return to the app.
+
+- [ ] **Step 2: Create an artefact.**
+
+In the chat bar, ask the agent to create a markdown artefact in the current space, e.g. *"create a notes artefact called 'publish smoke' with content '# Hello R5 publish'"*.
+
+- [ ] **Step 3: Ask the agent to publish it.**
+
+*"publish this artefact"* — the agent should call `publish_artifact`. Observe in the dev console / SSE stream:
+
+Expected: a JSON response with `share_token`, `share_url`, `mode: "open"`. The share_url is `https://oyster.to/p/<token>`.
+
+- [ ] **Step 4: Verify cloud state.**
+
+```bash
+SHARE_TOKEN=<from step 3>
+wrangler d1 execute oyster-auth --remote --command "SELECT share_token, owner_user_id, mode, size_bytes FROM published_artifacts WHERE share_token='$SHARE_TOKEN';"
+```
+
+Expected: one row with the right owner.
+
+- [ ] **Step 5: Verify local mirror.**
+
+```bash
+sqlite3 ./userland/db/oyster.db "SELECT id, owner_id, share_token, share_mode, published_at, share_updated_at FROM artifacts WHERE share_token='$SHARE_TOKEN';"
+```
+
+Expected: matching row, `owner_id` set, `share_updated_at` matches the cloud's `updated_at`.
+
+- [ ] **Step 6: Ask the agent to unpublish.**
+
+*"unpublish that artefact"* — observe `{"ok":true,"share_token":"…","unpublished_at":…}`.
+
+- [ ] **Step 7: Verify both stores reflect the unpublish.**
+
+```bash
+wrangler d1 execute oyster-auth --remote --command "SELECT unpublished_at FROM published_artifacts WHERE share_token='$SHARE_TOKEN';"
+sqlite3 ./userland/db/oyster.db "SELECT share_token, unpublished_at FROM artifacts WHERE share_token='$SHARE_TOKEN';"
+```
+
+Expected: cloud has `unpublished_at` set; local row retains `share_token` and has `unpublished_at` set (per spec — local mirror keeps the retired token).
+
+(No commit.)
+
+---
+
+### Task 3.7: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add an entry under `[Unreleased] / Added`.**
+
+```markdown
+- **Publish artefacts.** Turn any single-file artefact into a `oyster.to/p/...` share URL via the chat bar — open, password-protected, or sign-in-required. Free accounts can publish up to 5 artefacts at a time.
+```
+
+(Bullet style: user-visible outcome, no file paths or MCP tool names — per `feedback_changelog_style.md`.)
+
+- [ ] **Step 2: Regenerate the rendered changelog.**
+
+```bash
+npm run build:changelog
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add CHANGELOG.md docs/changelog.html
+git commit -m "docs(changelog): publish artefacts (#315)"
+```
+
+---
+
+### Task 3.8: Open Phase 3 PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push.**
+
+```bash
+git push
+```
+
+- [ ] **Step 2: Open the PR.**
+
+```bash
+gh pr create --title "feat(publish): MCP tools + local server route + SQLite mirror (#315 PR 3/3)" --body "$(cat <<'EOF'
+## Summary
+
+- New MCP tools: `publish_artifact({artifact_id, mode, password?})` and `unpublish_artifact({artifact_id})`.
+- New HTTP routes: `POST /api/artifacts/:id/publish` and `DELETE /api/artifacts/:id/publish`.
+- Local `artifacts` row mirrors the cloud response — `share_token`, `share_mode`, `share_password_hash`, `published_at`, `share_updated_at`, `unpublished_at` — using the Worker's timestamps verbatim. `owner_id` is set on first publish; subsequent publishes by a different account are rejected 403.
+- Plaintext password is hashed locally (PBKDF2-SHA256, 100k iter) and only the hash crosses the wire.
+- CHANGELOG entry under [Unreleased].
+
+Closes #315.
+
+Spec: `docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`.
+Plan: `docs/superpowers/plans/2026-05-03-r5-publish-backend.md`.
+
+## Test plan
+
+- [ ] `cd server && npm test` passes (publish-service + password-hash).
+- [ ] End-to-end smoke from the plan (Task 3.6) round-trips publish → cloud + local mirror match → unpublish → both reflect retirement.
+- [ ] No regression in existing `/api/auth/*` or other extracted routes.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Decisions (encoded in this plan, recap from spec)
+
+- One Worker per concern: `oyster-publish` is separate from `oyster-auth` for blast-radius isolation, even though they share a D1 binding.
+- Race recovery via INSERT-then-recover: simpler than locking, atomic via the partial unique index, cheap because the race is rare.
+- Local SQLite uses Worker timestamps verbatim — no clock-drift between local and cloud.
+- Pure helpers split out for unit testing; D1 + R2 paths covered by integration tests via `@cloudflare/vitest-pool-workers`.
+- Smoke tests sit alongside automated coverage; they catch regressions in the deployed environment that integration tests can't (DNS, real R2 latency, real D1 commit semantics).
+
+## Anchor references
+
+- Spec: `docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`
+- R5 requirement: `docs/requirements/oyster-cloud.md`
+- Roadmap (0.7.0 milestone): `docs/plans/roadmap.md`
+- Auth substrate this builds on: `infra/auth-worker/` (`docs/plans/auth-oauth.md`)
+- Issue #315

--- a/docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
+++ b/docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
@@ -1,0 +1,413 @@
+# R5 Publish Backend — Design Spec
+
+**Date:** 2026-05-03
+**Status:** Approved for implementation
+**Scope:** Backend only — `publish_artifact` / `unpublish_artifact` MCP tools, the matching HTTP routes on the local server, and a new `oyster-publish` Cloudflare Worker that owns the cloud publication state and R2 object storage. Public viewer (`GET /p/:token`) is scaffolded as `501 Not Implemented`; the viewer body lands in #316. UI lands in #317.
+
+**Tracks:** Issue #315. Part of R5 in [`docs/requirements/oyster-cloud.md`](../../requirements/oyster-cloud.md).
+
+---
+
+## Problem
+
+A user can produce an artefact in Oyster (markdown plan, single-file HTML mockup, mermaid diagram, deck-as-HTML) but has no way to share it. R5 requires *Publish* to turn any artefact into a resolvable URL with three access modes: open / password-protected / sign-in-required. The free account tier exists primarily to make this work — identity is needed both to publish and to view sign-in-gated content.
+
+The R5 schema columns (`share_token`, `share_mode`, `share_password_hash`, `published_at`, `unpublished_at`) landed on the local `artifacts` table in #314. What's missing is the action that turns those columns from inert into populated: an MCP tool, an HTTP API, and the cloud infrastructure that actually serves bytes.
+
+---
+
+## Goals
+
+- An agent calling `publish_artifact({ artifact_id, mode, password? })` gets back a working `share_url`.
+- The same call from the web UI (`POST /api/artifacts/:id/publish`) does the same thing — single internal helper, two callers.
+- Publishing is upsert-by-artefact: stable URL across content edits and mode changes, only `unpublish_artifact` retires the token.
+- Free-tier caps are enforced authoritatively (5 active publications per account, 10 MB per artefact).
+- Plaintext passwords never leave the local server.
+
+## Out of Scope
+
+- Public viewer at `/p/:token` (#316). Worker scaffolds the route as `501 Not Implemented`.
+- Publish UI in the artefact panel (#317).
+- Multi-file bundles. Single-file artefacts only — bundles are #242–#248.
+- Bandwidth metering. Count cap only.
+- Token rotation as a distinct operation. The unpublish-then-republish path is the rotation primitive for 0.7.0.
+- Pro-tier limits. 0.8.0+.
+- Cross-device sync of publication state. Local SQLite mirror is single-machine; cloud D1 is the source of truth if local ever needs to be rebuilt (rebuilding is itself out of scope here).
+- Automatic R2 orphan cleanup. See *Known limitations*.
+
+---
+
+## Topology
+
+```
+Local agent (MCP) ──┐
+                    ├──> oyster-os local server  (server/src/routes/publish.ts)
+Web UI ─────────────┘         │
+                              │ - resolves current_user_id from oyster_session cookie
+                              │ - reads artefact bytes from filesystem (~/Oyster/spaces/...)
+                              │ - validates size locally (cheap pre-check, 10 MB)
+                              │ - applies/validates artifacts.owner_id assignment
+                              │ - if mode=password: derives password_hash (PBKDF2-SHA256, Node crypto)
+                              │ - assembles X-Publish-Metadata blob
+                              │ - proxies POST with raw bytes
+                              ▼
+              oyster-publish Worker  (NEW: infra/oyster-publish/)
+                              │ - re-validates oyster_session via D1 sessions table (defence in depth)
+                              │ - re-validates Content-Length ≤ 10 MB (authoritative)
+                              │ - re-validates publish cap (authoritative)
+                              │ - upserts published_artifacts row in D1
+                              │ - PUTs bytes to R2 at published/{owner_user_id}/{share_token}
+                              ▼
+              D1 (oyster-auth DB, shared binding)
+              R2 (oyster-artifacts bucket, NEW)
+```
+
+Three load-bearing topology decisions:
+
+- **New Worker, not extension of `oyster-auth`.** Different failure domains (an R2 outage shouldn't take down sign-in), different deploy cadence (publish will iterate faster), cleaner secrets surface. Trade extra-binding for blast-radius isolation.
+- **Shared D1 binding.** Both Workers bind to the same `oyster-auth` D1. `oyster-publish` reads `sessions` for auth and owns the new `published_artifacts` table. Avoids a service-to-service hop on every request.
+- **Local server proxies the upload.** Client → local server → Worker. Not signed PUT URLs direct from client to R2. Single-file artefacts are small (≤ 10 MB); the round-trip cost is negligible and the hop lets the local server do owner-attribution against the local SQLite before bytes leave the machine.
+
+---
+
+## Schema
+
+### Cloud — D1 migration `0003_publish.sql` (in `infra/auth-worker/migrations/`)
+
+The migration lives with the auth-worker migration history because it shares the DB. The `oyster-publish` Worker doesn't manage its own migrations; it only binds and reads/writes.
+
+```sql
+-- Tier hook for entitlement checks. Always 'free' in 0.7.0; Pro lands in 0.8.0+.
+ALTER TABLE users ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
+
+CREATE TABLE published_artifacts (
+  share_token       TEXT    PRIMARY KEY,
+  owner_user_id     TEXT    NOT NULL REFERENCES users(id),
+  artifact_id       TEXT    NOT NULL,            -- the source artefact id from local Oyster (uuid)
+  artifact_kind     TEXT    NOT NULL,            -- denormalised for viewer rendering hints
+  mode              TEXT    NOT NULL CHECK (mode IN ('open','password','signin')),
+  password_hash     TEXT,                        -- "pbkdf2$100000$<salt_b64u>$<hash_b64u>", only when mode='password'
+  r2_key            TEXT    NOT NULL,            -- "published/{owner_user_id}/{share_token}"
+  content_type      TEXT    NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  published_at      INTEGER NOT NULL,            -- unix ms — first publication of this token (preserved across upserts)
+  updated_at        INTEGER NOT NULL,            -- unix ms — last publish call
+  unpublished_at    INTEGER                      -- NULL while live; unix ms when retired
+);
+
+CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
+
+-- Active-publication uniqueness is scoped to (owner, artefact). artifact_id alone is not
+-- globally unique across all users — two users can independently publish artefacts that
+-- happen to share an id.
+CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
+  ON published_artifacts(owner_user_id, artifact_id)
+  WHERE unpublished_at IS NULL;
+```
+
+Historical rows are retained on unpublish (set `unpublished_at`, leave the row in place). This keeps token lookup correct: an old retired token resolves to a row whose `unpublished_at IS NOT NULL`, which the viewer (in #316) will render as `410 Gone`.
+
+### Local — additive migration in `server/src/db.ts`
+
+```sql
+ALTER TABLE artifacts ADD COLUMN share_updated_at INTEGER;
+-- existing R5 columns from #314: share_token, share_mode, share_password_hash, published_at, unpublished_at
+```
+
+**Local mirror semantics:**
+
+- On successful publish: write `share_token`, `share_mode`, `share_password_hash`, `published_at` (preserved if already set), `share_updated_at = now`, `unpublished_at = NULL`.
+- On successful unpublish: set `unpublished_at = now`, **retain** `share_token`, `share_mode`, etc. The badge query is `share_token IS NOT NULL AND unpublished_at IS NULL`. Retaining the retired token gives the UI later affordances like *"Was published at /p/abc, now offline."*
+- The local mirror is a fast-render cache. Cloud D1 is source of truth.
+
+---
+
+## Ownership rules
+
+Two different ownership concepts; keep them separated:
+
+- **Local artefact ownership** is `artifacts.owner_id` in the local SQLite. The local server enforces it.
+  - On `publish_artifact`: if `owner_id IS NULL`, set it to the current signed-in user. If `owner_id` is non-NULL and `!= current_user.id`, reject with 403.
+  - Once set, never overwrite.
+- **Cloud publication ownership** is `published_artifacts.owner_user_id` in the cloud D1. The Worker enforces it.
+  - On `publish_artifact` upsert: if an active row exists for `(owner_user_id=current, artifact_id=requested)`, keep its `share_token` and update fields. If an active row exists for the same `artifact_id` under a *different* owner, that's the partial-unique-index violation case — reject with 409 (should never happen in practice because the local server has already filtered by local-owner).
+  - On `unpublish_artifact`: row's `owner_user_id` must equal the calling session's user — else 403.
+
+The Worker does not (and cannot) check local artefact ownership. The local server has already done that before bytes leave the machine.
+
+---
+
+## MCP tools
+
+Registered in `server/src/mcp-server.ts`. Both call into a shared internal helper (`server/src/publish-service.ts` or similar — exact module name to be settled in the plan) so the HTTP routes don't duplicate logic.
+
+```ts
+publish_artifact({
+  artifact_id: string,
+  mode: 'open' | 'password' | 'signin',
+  password?: string,                  // required & non-empty when mode='password'
+}) → {
+  share_token: string,
+  share_url: string,                  // "https://oyster.to/p/{token}"
+  mode: 'open' | 'password' | 'signin',
+  published_at: number,               // unix ms — first publication
+  updated_at: number,                 // unix ms — this call
+}
+
+unpublish_artifact({
+  artifact_id: string,
+}) → {
+  ok: true,
+  share_token: string,                // for caller's confirmation; echoes the retired token
+  unpublished_at: number,             // unix ms
+}
+```
+
+Password is never echoed in any response — only `mode === 'password'` is observable.
+
+---
+
+## HTTP routes (local server)
+
+In a new `server/src/routes/publish.ts`, following the extraction pattern from `routes/oauth-mcp.ts`, `routes/import.ts`, `routes/static.ts`.
+
+```
+POST   /api/artifacts/:id/publish
+  Headers: Cookie: oyster_session=…
+  Body:    JSON { mode: 'open'|'password'|'signin', password?: string }
+  → 200 { share_token, share_url, mode, published_at, updated_at }
+  → 401 sign_in_required
+  → 403 not_artifact_owner
+  → 404 artifact_not_found
+  → 402 publish_cap_exceeded
+  → 413 artifact_too_large
+  → 400 password_required | invalid_mode
+
+DELETE /api/artifacts/:id/publish
+  Headers: Cookie: oyster_session=…
+  → 200 { ok: true, share_token, unpublished_at }
+  → 401 sign_in_required
+  → 403 not_publication_owner
+  → 404 publication_not_found    (local artefact has no live share_token in mirror)
+```
+
+The local server derives `share_token` from the local SQLite mirror (`artifacts.share_token` of the row matching `:id`), then calls `DELETE /api/publish/:share_token` on the Worker. If the local row has no `share_token`, or `unpublished_at IS NOT NULL`, the local server returns 404 `publication_not_found` without contacting the Worker.
+
+---
+
+## Worker endpoints (`oyster-publish`)
+
+Two real endpoints in #315; viewer is scaffolded.
+
+```
+POST /api/publish/upload
+  Headers:
+    Cookie: oyster_session=…                       (required)
+    X-Publish-Metadata: <base64url(json)>          (required — see schema below)
+    Content-Type: <mime>                           (recorded as content_type)
+    Content-Length: <bytes>                        (REQUIRED — 411 if missing)
+  Body: raw bytes (≤ 10 MB)
+
+  X-Publish-Metadata payload (decoded from base64url):
+    {
+      "artifact_id":   string,
+      "artifact_kind": string,
+      "mode":          "open" | "password" | "signin",
+      "password_hash": string                       // only when mode='password';
+                                                    // format "pbkdf2$100000$<salt_b64u>$<hash_b64u>"
+                                                    // produced by the local server
+    }
+
+  Steps:
+    1. resolveSession(cookie) → owner_user_id, or 401 sign_in_required
+    2. parse + validate X-Publish-Metadata → 400 invalid_metadata if malformed
+    3. assert mode='password' implies password_hash present → 400 password_required
+    4. assert Content-Length present → 411 content_length_required
+    5. assert Content-Length ≤ 10 MB → 413 artifact_too_large
+    6. SELECT existing active row for (owner_user_id, artifact_id)
+       - if exists: keep share_token (upsert path; cap check skipped — this is not a new publication)
+       - if not exists: SELECT user.tier; lookup CAPS[tier];
+                        count active publications for owner_user_id;
+                        if count ≥ CAPS[tier].max_active → 402 publish_cap_exceeded;
+                        else generate new 32-char base64url token via crypto.getRandomValues(24)
+    7. PUT bytes to R2 at published/{owner_user_id}/{share_token}, capped at 10 MB
+       (defence; upstream pre-check is the primary)
+    8. UPSERT D1 row:
+       - INSERT if new: published_at = updated_at = now
+       - UPDATE if upsert: mode, password_hash, content_type, size_bytes, updated_at = now
+                          (published_at preserved)
+    9. Return 200 { share_token, share_url, mode, published_at, updated_at }
+
+DELETE /api/publish/:share_token
+  Headers: Cookie: oyster_session=…                (required)
+  Steps:
+    1. resolveSession → user_id, or 401
+    2. SELECT row WHERE share_token = ? → 404 publication_not_found if missing
+    3. If row.owner_user_id != user_id → 403 not_publication_owner
+    4. If row.unpublished_at IS NOT NULL → 200 idempotent (no-op, return current state)
+    5. UPDATE row SET unpublished_at = now()
+    6. R2 DELETE published/{owner_user_id}/{share_token} — best effort
+       (D1 is source of truth; R2 orphan is acceptable, see Known limitations)
+    7. Return 200 { ok: true, share_token, unpublished_at }
+
+GET /p/:share_token
+  → 501 Not Implemented (viewer body lands in #316)
+```
+
+**`signin` mode in #315 is metadata-only.** The mode is stored in D1 by `POST /api/publish/upload`; viewer enforcement (rejecting unsigned visitors, accepting signed ones) is implemented in #316. Storing it now means the viewer in #316 can land without a schema change.
+
+---
+
+## Password handling
+
+Plaintext passwords never leave the local server. Two reasons: (a) headers are routinely captured in logs / traces / proxies / dev tooling, (b) the Worker doesn't need the plaintext — verification happens later in the viewer (#316).
+
+**Hash format:** `pbkdf2$<iter>$<salt_b64url>$<hash_b64url>`
+
+| Param | Value |
+|---|---|
+| Algorithm | PBKDF2-SHA256 |
+| Iterations | 100000 |
+| Salt | 16 random bytes (`crypto.randomBytes(16)` in Node) |
+| Hash length | 32 bytes |
+| Encoding | base64url (no padding) |
+
+Local server uses Node's `crypto.pbkdf2` and `crypto.randomBytes`. Worker viewer (in #316) verifies via Web Crypto's `subtle.deriveBits` with PBKDF2 — same parameters, same output, portable.
+
+Empty password with `mode='password'` is rejected at the local server with 400 `password_required`. The Worker also rejects (defence in depth) if the `password_hash` field is missing from the metadata blob.
+
+---
+
+## Tier caps
+
+A single source of truth in the Worker:
+
+```ts
+const CAPS = {
+  free: { max_active: 5, max_size_bytes: 10 * 1024 * 1024 },  // 10 MB
+  // pro: { … }   ← lands in 0.8.0+
+} as const;
+```
+
+Per-tier values are read off `users.tier` and used at the Worker for both `publish_cap_exceeded` (402) and `artifact_too_large` (413). Local server pre-checks size against the free-tier value (the only tier that exists in 0.7.0); if the user is on a higher tier it'll just be a smaller-than-needed pre-check (always safe — the Worker is authoritative).
+
+## Token generation
+
+```
+crypto.getRandomValues(new Uint8Array(24))  →  base64url-encode  →  32-char string
+```
+
+~192 bits of entropy. URL-safe by construction. No charset translation.
+
+---
+
+## R2
+
+- **Bucket:** `oyster-artifacts` (provisioned via `wrangler r2 bucket create oyster-artifacts` as part of the deploy step).
+- **Key shape:** `published/{owner_user_id}/{share_token}`.
+- **Object metadata:** content-type recorded both on the R2 object (HTTP serve hint) and in D1 (source of truth).
+- **Lifecycle rules:** none. Unpublish triggers explicit `R2 DELETE`. Orphan cleanup is deferred (see Known limitations).
+
+---
+
+## Error matrix
+
+All errors return JSON `{ error: <code>, message: <human-readable>, ... }`. The local server proxies Worker error responses verbatim so MCP callers and HTTP callers see the same shapes.
+
+| Condition | HTTP | `error` code | Notes |
+|---|---|---|---|
+| Missing/invalid `oyster_session` cookie | 401 | `sign_in_required` | "Sign in to publish artefacts." |
+| Wrong owner on existing local artefact | 403 | `not_artifact_owner` | Local server enforced. |
+| Wrong owner on existing cloud publication | 403 | `not_publication_owner` | Worker enforced. |
+| Local artefact not found | 404 | `artifact_not_found` | Local server. |
+| Cloud publication not found (DELETE) | 404 | `publication_not_found` | Worker. |
+| Cap exceeded | 402 | `publish_cap_exceeded` | `{current, limit:5, message:"Free tier allows 5 active published artefacts. Unpublish one first."}`. Authoritative at Worker. |
+| `Content-Length` missing | 411 | `content_length_required` | Worker. |
+| Body > 10 MB | 413 | `artifact_too_large` | `{limit_bytes:10485760, message:"Free tier allows published artefacts up to 10 MB."}`. Local server pre-checks; Worker is authoritative. |
+| `mode='password'` with empty password | 400 | `password_required` | Local server. |
+| Invalid `mode` value | 400 | `invalid_mode` | Local server (and Worker, defence in depth). |
+| Invalid metadata blob | 400 | `invalid_metadata` | Worker only — happens if local server is buggy. |
+| R2 PUT failure (transient) | 502 | `upload_failed` | Worker logs cause; client retry-safe. |
+| Mode change conflict (same artefact, different owner — unreachable in practice) | 409 | `publication_conflict` | Worker only. |
+
+---
+
+## Testing
+
+### Unit (Worker, Vitest + miniflare)
+
+- Token generation: format conforms to base64url, length 32, entropy via 24-byte buffer.
+- PBKDF2 verify round-trip: hash a known plaintext via Node's `crypto.pbkdf2`, verify via Web Crypto in the Worker, assert match.
+- Cap calculation: count of active publications correctly ignores rows with `unpublished_at IS NOT NULL`.
+
+### Integration (Worker, Vitest + miniflare D1 + R2 mock)
+
+- Publish → re-publish: same `share_token`, fresh bytes in R2, `published_at` preserved, `updated_at` bumped, `mode` change reflected.
+- Publish → unpublish → publish: new `share_token`, old row marked `unpublished_at`, R2 object for old token deleted, R2 object for new token present.
+- 6th publish hits 402: 5 active rows in fixture, attempt to publish a 6th unrelated artefact returns `publish_cap_exceeded`.
+- 11 MB body returns 413.
+- Wrong-owner attempt on existing publication returns 403 `not_publication_owner`.
+- DELETE on already-unpublished row is idempotent (returns 200, doesn't change `unpublished_at`).
+
+### Local server (server/tests, existing pattern)
+
+- `routes/publish.ts` correctly assembles `X-Publish-Metadata` (decoded matches expected JSON for each mode).
+- Plaintext password is hashed before forwarding; raw password never appears in any header or proxied byte stream.
+- `artifacts.owner_id` set on first publish, preserved thereafter, rejected if mismatched.
+- Worker error responses (status code + JSON body) propagate verbatim to the HTTP caller.
+
+### Smoke (post-deploy, manual)
+
+- `curl` round-trip against `oyster.to`: publish a 1 KB markdown, fetch the row from D1 (`wrangler d1 execute`), unpublish, confirm `unpublished_at` set, confirm R2 object gone (`wrangler r2 object list oyster-artifacts`).
+
+---
+
+## Known limitations (explicit deferrals)
+
+1. **R2 orphan cleanup is deferred.** Order of operations is `R2 PUT → D1 upsert`. If D1 upsert fails after R2 PUT succeeds, the bytes are orphaned. D1 is source of truth — orphans are invisible to users (no row → no token → no URL). Cleanup is deferred to a future janitor (could be a Cron Trigger that lists R2, joins to D1, deletes objects with no live row).
+2. **Cap pre-check is skipped at the local server.** The local server has no live view of the publish cap; it would have to call the Worker. The local server still pre-checks size, owner attribution, and password validity (all local), but the cap check happens authoritatively at the Worker. A user may upload bytes only to learn at the Worker that they're over cap — acceptable tradeoff (10 MB max upload, single round-trip).
+3. **Cross-device awareness of publish state.** Local SQLite mirror is single-machine. If a user publishes from machine A and signs in on machine B, machine B's UI will not show the publication until R3 sync arrives in 0.8.0+. Cloud D1 retains the truth; the Worker can serve the public URL regardless.
+4. **No bandwidth metering.** Free-tier abuse vector is bounded by the count cap (5 × 10 MB = 50 MB total bytes published per free user). Bandwidth metering is a future concern.
+5. **Token rotation requires unpublish + republish.** No dedicated rotate operation. If anyone needs token rotation as a discrete action, a future `rotate_share_token` MCP tool can be added.
+
+---
+
+## Decisions log (for future-me)
+
+| Question | Decision | Reason |
+|---|---|---|
+| New Worker vs. extend `oyster-auth`? | New `oyster-publish` Worker. | Blast-radius isolation; different deploy cadence; cleaner secrets. |
+| Free tier max active publications? | 5. | Bounds bandwidth via cap × size limit. |
+| Free tier max artefact size? | 10 MB. | Comfortably covers prose markdown, single-HTML, mermaid, lightweight decks. Image-heavy is a Pro concern. |
+| Token format? | base64url, 32 chars, 192-bit entropy. | URL-safe by construction; no charset translation. |
+| Re-publish semantics? | Upsert by artifact_id, stable token, fresh bytes + mode every call. `published_at` preserved; `updated_at` bumped. | Matches user mental model: "publish my updated mockup" → same URL, fresh content. |
+| Where is plaintext password? | Stays at the local server; PBKDF2-hashed before transit. | Headers are routinely logged. Worker doesn't need plaintext. |
+| Active-publication uniqueness? | Scoped to `(owner_user_id, artifact_id)`. | `artifact_id` alone is not globally unique across users. |
+| Local DB on unpublish? | Retain `share_token`; mark `unpublished_at`. Badge query is `share_token IS NOT NULL AND unpublished_at IS NULL`. | Enables "Was published at /p/abc, now offline" affordances later. |
+| R2 PUT vs. D1 upsert order? | R2 first, then D1. Accept orphan risk. | Avoids D1 row pointing at missing bytes. D1 is source of truth. |
+| `signin` mode in #315? | Stored as metadata only. Viewer enforcement is #316. | Lets the viewer ship without a schema change. |
+| Upload payload format? | Raw bytes in body, JSON metadata in `X-Publish-Metadata` header (base64url). | Simpler than multipart; lets metadata extend without more headers; keeps body purely bytes. |
+| Cap pre-check at local server? | Skipped (size-only pre-check). | No live cap view at local server; one extra round-trip not worth it. Worker is authoritative. |
+| Tier hook in 0.7.0? | Yes — `users.tier TEXT NOT NULL DEFAULT 'free'` + `CAPS` map at the Worker. | One-line schema add. Avoids a 0.8.0 backfill migration on every existing user. Pro values land in 0.8.0. |
+
+---
+
+## Implementation sequence (for the plan that follows)
+
+This spec is single-PR-able but heavy. Suggested split (will be settled by `superpowers:writing-plans`):
+
+1. **PR 1 — `oyster-publish` Worker scaffold + D1 migration + R2 bucket.** Empty endpoints (`501`), wrangler.toml, Vitest setup, deploy. No client integration.
+2. **PR 2 — Worker publish + unpublish endpoints.** Real upload + storage + cap + size enforcement. Contract tests against the Worker only. Local server still untouched.
+3. **PR 3 — Local server `routes/publish.ts` + `publish-service.ts`.** HTTP route + MCP tool registration + ALTER on local SQLite. End-to-end against the deployed Worker.
+
+Anchors: `infra/auth-worker/` is the template for PR 1's Worker shape (Vitest setup, D1 + secret patterns, route registration, structured console error logging). Route extraction pattern (`routes/oauth-mcp.ts`, `routes/import.ts`, `routes/static.ts`) is the template for PR 3.
+
+---
+
+## Anchor docs
+
+- [`docs/requirements/oyster-cloud.md`](../../requirements/oyster-cloud.md) — R5 canonical requirement.
+- [`docs/plans/roadmap.md`](../../plans/roadmap.md) — 0.7.0 milestone scope.
+- [`docs/plans/0.5.0-gap-matrix.md`](../../plans/0.5.0-gap-matrix.md) — R5 section.
+- [`docs/plans/auth.md`](../../plans/auth.md) and [`docs/plans/auth-oauth.md`](../../plans/auth-oauth.md) — identity substrate this builds on.
+- Issue #315.

--- a/docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
+++ b/docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
@@ -18,7 +18,7 @@ The R5 schema columns (`share_token`, `share_mode`, `share_password_hash`, `publ
 
 ## Goals
 
-- An agent calling `publish_artifact({ artifact_id, mode, password? })` gets back a working `share_url`.
+- An agent calling `publish_artifact({ artifact_id, mode, password? })` gets back a **reserved** `share_url`. The URL becomes viewable when the public viewer (`GET /p/:token`) lands in #316; #315 reserves the token, stores the bytes in R2, and persists publication state in D1. Acceptance for #315 is that the token + R2 object + D1 row exist correctly, not that the URL serves bytes.
 - The same call from the web UI (`POST /api/artifacts/:id/publish`) does the same thing — single internal helper, two callers.
 - Publishing is upsert-by-artefact: stable URL across content edits and mode changes, only `unpublish_artifact` retires the token.
 - Free-tier caps are enforced authoritatively (5 active publications per account, 10 MB per artefact).
@@ -92,7 +92,11 @@ CREATE TABLE published_artifacts (
   size_bytes        INTEGER NOT NULL,
   published_at      INTEGER NOT NULL,            -- unix ms — first publication of this token (preserved across upserts)
   updated_at        INTEGER NOT NULL,            -- unix ms — last publish call
-  unpublished_at    INTEGER                      -- NULL while live; unix ms when retired
+  unpublished_at    INTEGER,                     -- NULL while live; unix ms when retired
+  CHECK (
+    (mode = 'password' AND password_hash IS NOT NULL) OR
+    (mode <> 'password' AND password_hash IS NULL)
+  )
 );
 
 CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
@@ -116,9 +120,10 @@ ALTER TABLE artifacts ADD COLUMN share_updated_at INTEGER;
 
 **Local mirror semantics:**
 
-- On successful publish: write `share_token`, `share_mode`, `share_password_hash`, `published_at` (preserved if already set), `share_updated_at = now`, `unpublished_at = NULL`.
-- On successful unpublish: set `unpublished_at = now`, **retain** `share_token`, `share_mode`, etc. The badge query is `share_token IS NOT NULL AND unpublished_at IS NULL`. Retaining the retired token gives the UI later affordances like *"Was published at /p/abc, now offline."*
-- The local mirror is a fast-render cache. Cloud D1 is source of truth.
+- The Worker's response is the source of truth for timestamps. Local SQLite copies them verbatim — never derives `now()` locally for publish-lifecycle fields.
+- On successful publish: write `share_token` ← `response.share_token`, `share_mode` ← `response.mode`, `share_password_hash` ← (the hash the local server forwarded — Worker doesn't echo it back), `published_at` ← `response.published_at`, `share_updated_at` ← `response.updated_at`, `unpublished_at` ← `NULL`.
+- On successful unpublish: `unpublished_at` ← `response.unpublished_at`; **retain** `share_token`, `share_mode`, etc. The badge query is `share_token IS NOT NULL AND unpublished_at IS NULL`. Retaining the retired token gives the UI later affordances like *"Was published at /p/abc, now offline."*
+- The local mirror is a fast-render cache. Cloud D1 is source of truth (which is exactly why timestamps come from the Worker, not from the local clock).
 
 ---
 
@@ -130,7 +135,7 @@ Two different ownership concepts; keep them separated:
   - On `publish_artifact`: if `owner_id IS NULL`, set it to the current signed-in user. If `owner_id` is non-NULL and `!= current_user.id`, reject with 403.
   - Once set, never overwrite.
 - **Cloud publication ownership** is `published_artifacts.owner_user_id` in the cloud D1. The Worker enforces it.
-  - On `publish_artifact` upsert: if an active row exists for `(owner_user_id=current, artifact_id=requested)`, keep its `share_token` and update fields. If an active row exists for the same `artifact_id` under a *different* owner, that's the partial-unique-index violation case — reject with 409 (should never happen in practice because the local server has already filtered by local-owner).
+  - On `publish_artifact` upsert: every active-row lookup is scoped to the calling session's `owner_user_id`. The unique index is `(owner_user_id, artifact_id) WHERE unpublished_at IS NULL`, so different users may publish artefacts that happen to share an `artifact_id` without conflict — they live as separate rows with different tokens. The Worker never queries by `artifact_id` alone.
   - On `unpublish_artifact`: row's `owner_user_id` must equal the calling session's user — else 403.
 
 The Worker does not (and cannot) check local artefact ownership. The local server has already done that before bytes leave the machine.
@@ -223,19 +228,36 @@ POST /api/publish/upload
     2. parse + validate X-Publish-Metadata → 400 invalid_metadata if malformed
     3. assert mode='password' implies password_hash present → 400 password_required
     4. assert Content-Length present → 411 content_length_required
-    5. assert Content-Length ≤ 10 MB → 413 artifact_too_large
-    6. SELECT existing active row for (owner_user_id, artifact_id)
-       - if exists: keep share_token (upsert path; cap check skipped — this is not a new publication)
-       - if not exists: SELECT user.tier; lookup CAPS[tier];
-                        count active publications for owner_user_id;
-                        if count ≥ CAPS[tier].max_active → 402 publish_cap_exceeded;
-                        else generate new 32-char base64url token via crypto.getRandomValues(24)
-    7. PUT bytes to R2 at published/{owner_user_id}/{share_token}, capped at 10 MB
-       (defence; upstream pre-check is the primary)
-    8. UPSERT D1 row:
-       - INSERT if new: published_at = updated_at = now
-       - UPDATE if upsert: mode, password_hash, content_type, size_bytes, updated_at = now
-                          (published_at preserved)
+    5. SELECT user.tier; lookup CAPS[tier];
+       assert Content-Length ≤ CAPS[tier].max_size_bytes → 413 artifact_too_large
+    6. Determine final share_token via "find or claim":
+       a. SELECT existing active row WHERE owner_user_id = current AND artifact_id = requested
+          (queries are always scoped to current owner_user_id — the unique index is per
+           (owner, artifact), so different owners never collide)
+       b. if exists: share_token = existing.share_token; path = 'upsert';
+                     preserve existing published_at
+       c. if not exists:
+          i.   count active publications for owner_user_id
+          ii.  if count ≥ CAPS[tier].max_active → 402 publish_cap_exceeded
+          iii. generate candidate_token via crypto.getRandomValues(new Uint8Array(24)) → base64url
+          iv.  try INSERT new published_artifacts row with candidate_token, metadata from
+               headers, size_bytes from Content-Length, r2_key derived from candidate_token,
+               published_at = updated_at = now
+               - on success: share_token = candidate_token; path = 'first-publish'
+               - on unique-constraint violation (race with concurrent first-publish):
+                 re-SELECT existing active row for (owner_user_id, artifact_id);
+                 share_token = existing.share_token; path = 'upsert' (race-recovered);
+                 preserve existing published_at
+    7. Stream body to R2 at published/{owner_user_id}/{share_token}; abort + return 413
+       artifact_too_large if streamed bytes exceed CAPS[tier].max_size_bytes (defence
+       against a lying or absent Content-Length); on abort, if path = 'first-publish',
+       DELETE the speculatively-inserted D1 row; if path = 'upsert', leave existing row
+       untouched (no UPDATE was applied yet).
+    8. D1 commit:
+       - if path = 'upsert': UPDATE row — mode, password_hash, content_type, size_bytes,
+                             updated_at = now (published_at preserved)
+       - if path = 'first-publish': row already inserted in step 6; no-op (or UPDATE
+                                    updated_at if step 7 took meaningful time)
     9. Return 200 { share_token, share_url, mode, published_at, updated_at }
 
 DELETE /api/publish/:share_token
@@ -328,7 +350,6 @@ All errors return JSON `{ error: <code>, message: <human-readable>, ... }`. The 
 | Invalid `mode` value | 400 | `invalid_mode` | Local server (and Worker, defence in depth). |
 | Invalid metadata blob | 400 | `invalid_metadata` | Worker only — happens if local server is buggy. |
 | R2 PUT failure (transient) | 502 | `upload_failed` | Worker logs cause; client retry-safe. |
-| Mode change conflict (same artefact, different owner — unreachable in practice) | 409 | `publication_conflict` | Worker only. |
 
 ---
 
@@ -345,7 +366,11 @@ All errors return JSON `{ error: <code>, message: <human-readable>, ... }`. The 
 - Publish → re-publish: same `share_token`, fresh bytes in R2, `published_at` preserved, `updated_at` bumped, `mode` change reflected.
 - Publish → unpublish → publish: new `share_token`, old row marked `unpublished_at`, R2 object for old token deleted, R2 object for new token present.
 - 6th publish hits 402: 5 active rows in fixture, attempt to publish a 6th unrelated artefact returns `publish_cap_exceeded`.
-- 11 MB body returns 413.
+- 11 MB Content-Length returns 413 before any body is read.
+- Streamed body exceeds 10 MB despite Content-Length under 10 MB: stream is aborted, 413 returned, no D1 row left behind.
+- Two concurrent first-publish calls for the same `(owner, artifact_id)` both return 200 with the *same* `share_token`; D1 has exactly one row; R2 has one object; loser's bytes win (last-write-wins).
+- Two different users publish artefacts that share an `artifact_id`: both succeed, two distinct rows, two distinct tokens, no conflict.
+- D1 CHECK constraint rejects an INSERT with `mode='open'` and a non-NULL `password_hash`, and rejects `mode='password'` with NULL `password_hash`.
 - Wrong-owner attempt on existing publication returns 403 `not_publication_owner`.
 - DELETE on already-unpublished row is idempotent (returns 200, doesn't change `unpublished_at`).
 
@@ -389,6 +414,10 @@ All errors return JSON `{ error: <code>, message: <human-readable>, ... }`. The 
 | Upload payload format? | Raw bytes in body, JSON metadata in `X-Publish-Metadata` header (base64url). | Simpler than multipart; lets metadata extend without more headers; keeps body purely bytes. |
 | Cap pre-check at local server? | Skipped (size-only pre-check). | No live cap view at local server; one extra round-trip not worth it. Worker is authoritative. |
 | Tier hook in 0.7.0? | Yes — `users.tier TEXT NOT NULL DEFAULT 'free'` + `CAPS` map at the Worker. | One-line schema add. Avoids a 0.8.0 backfill migration on every existing user. Pro values land in 0.8.0. |
+| First-publish concurrency? | INSERT-then-recover. Race losers re-SELECT the active row, treat as upsert path, return 200 with the winning token. | Atomic claim via the partial unique index; cleaner than pre-locking. Last-write-wins for body bytes. |
+| Local SQLite timestamps? | Mirror Worker response verbatim (`response.published_at`, `response.updated_at`, `response.unpublished_at`). | Avoids clock drift between local and cloud; cloud is source of truth for publication state. |
+| D1 CHECK on `password_hash`? | Yes — `(mode='password' AND password_hash NOT NULL) OR (mode≠'password' AND password_hash NULL)`. | Catches metadata-tampering bugs and mode/hash drift at the schema level. |
+| Stream-size enforcement? | Yes — Worker aborts the R2 upload if streamed bytes exceed `CAPS[tier].max_size_bytes`, regardless of `Content-Length`. | `Content-Length` is client-controlled; trust it for the pre-check, enforce it for real on the stream. |
 
 ---
 

--- a/infra/auth-worker/migrations/0003_publish.sql
+++ b/infra/auth-worker/migrations/0003_publish.sql
@@ -1,0 +1,34 @@
+-- 0003_publish.sql — R5 Publish: tier hook on users + published_artifacts table.
+-- Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
+-- D1 supports ALTER TABLE ADD COLUMN; both bindings (oyster-auth + oyster-publish)
+-- read/write this DB.
+
+-- Tier hook for entitlement checks. Always 'free' in 0.7.0; Pro values land in 0.8.0+.
+ALTER TABLE users ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
+
+CREATE TABLE published_artifacts (
+  share_token       TEXT    PRIMARY KEY,
+  owner_user_id     TEXT    NOT NULL REFERENCES users(id),
+  artifact_id       TEXT    NOT NULL,
+  artifact_kind     TEXT    NOT NULL,
+  mode              TEXT    NOT NULL CHECK (mode IN ('open','password','signin')),
+  password_hash     TEXT,
+  r2_key            TEXT    NOT NULL,
+  content_type      TEXT    NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  published_at      INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  unpublished_at    INTEGER,
+  CHECK (
+    (mode = 'password' AND password_hash IS NOT NULL) OR
+    (mode <> 'password' AND password_hash IS NULL)
+  )
+);
+
+CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
+
+-- Active-publication uniqueness scoped to (owner, artefact). artifact_id alone
+-- is not globally unique across users.
+CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
+  ON published_artifacts(owner_user_id, artifact_id)
+  WHERE unpublished_at IS NULL;

--- a/infra/auth-worker/migrations/0003_publish.sql
+++ b/infra/auth-worker/migrations/0003_publish.sql
@@ -6,7 +6,7 @@
 -- Tier hook for entitlement checks. Always 'free' in 0.7.0; Pro values land in 0.8.0+.
 ALTER TABLE users ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
 
-CREATE TABLE published_artifacts (
+CREATE TABLE IF NOT EXISTS published_artifacts (
   share_token       TEXT    PRIMARY KEY,
   owner_user_id     TEXT    NOT NULL REFERENCES users(id),
   artifact_id       TEXT    NOT NULL,
@@ -25,10 +25,10 @@ CREATE TABLE published_artifacts (
   )
 );
 
-CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_pubart_owner ON published_artifacts(owner_user_id);
 
 -- Active-publication uniqueness scoped to (owner, artefact). artifact_id alone
 -- is not globally unique across users.
-CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pubart_active_per_owner_artifact
   ON published_artifacts(owner_user_id, artifact_id)
   WHERE unpublished_at IS NULL;

--- a/infra/auth-worker/package.json
+++ b/infra/auth-worker/package.json
@@ -11,6 +11,8 @@
     "db:migrate:local": "wrangler d1 execute oyster-auth --file=migrations/0001_init.sql --local",
     "db:migrate:0002": "wrangler d1 execute oyster-auth --file=migrations/0002_oauth.sql --remote",
     "db:migrate:0002:local": "wrangler d1 execute oyster-auth --file=migrations/0002_oauth.sql --local",
+    "db:migrate:0003": "wrangler d1 execute oyster-auth --file=migrations/0003_publish.sql --remote",
+    "db:migrate:0003:local": "wrangler d1 execute oyster-auth --file=migrations/0003_publish.sql --local",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/infra/oyster-publish/.gitignore
+++ b/infra/oyster-publish/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.dev.vars
+.wrangler/

--- a/infra/oyster-publish/README.md
+++ b/infra/oyster-publish/README.md
@@ -30,8 +30,8 @@ npm run deploy
 ## Local dev
 
 ```bash
-npm run dev   # runs wrangler dev with miniflare D1 + R2 in-memory
-npm test      # vitest with @cloudflare/vitest-pool-workers
+npm run dev   # runs wrangler dev; D1 + R2 state persists locally under .wrangler/
+npm test      # vitest with @cloudflare/vitest-pool-workers — D1 + R2 are per-test in-memory
 ```
 
 ## Notes

--- a/infra/oyster-publish/README.md
+++ b/infra/oyster-publish/README.md
@@ -1,0 +1,42 @@
+# oyster-publish Worker
+
+Cloudflare Worker for R5 publish (#315 spec):
+- `POST /api/publish/upload` — server-to-server upload from the local Oyster server.
+- `DELETE /api/publish/:share_token` — retire a publication.
+- `GET /p/:share_token` — public viewer (501 here; body lands in #316).
+
+Spec: [`docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`](../../docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md).
+
+## Setup (one-time)
+
+```bash
+# 1. Apply the D1 migration (creates published_artifacts in the shared
+#    oyster-auth DB, adds users.tier).
+cd infra/auth-worker
+npm run db:migrate:0003
+
+# 2. Provision the R2 bucket.
+wrangler r2 bucket create oyster-artifacts
+```
+
+## Deploy
+
+```bash
+cd infra/oyster-publish
+npm install
+npm run deploy
+```
+
+## Local dev
+
+```bash
+npm run dev   # runs wrangler dev with miniflare D1 + R2 in-memory
+npm test      # vitest with @cloudflare/vitest-pool-workers
+```
+
+## Notes
+
+- Bindings: `DB` (shared with oyster-auth), `ARTIFACTS` (R2 bucket `oyster-artifacts`).
+- No secrets: nothing in `wrangler secret put`. Sessions are validated by reading the
+  shared `sessions` table.
+- R2 key shape: `published/{owner_user_id}/{share_token}`.

--- a/infra/oyster-publish/package-lock.json
+++ b/infra/oyster-publish/package-lock.json
@@ -1,0 +1,4253 @@
+{
+  "name": "oyster-publish-worker",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oyster-publish-worker",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.0",
+        "@cloudflare/workers-types": "^4.20260101.0",
+        "typescript": "^5.4.0",
+        "vitest": "^2.1.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
+      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20241230.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.100.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 2.1.x",
+        "@vitest/snapshot": "2.0.x - 2.1.x",
+        "vitest": "2.0.x - 2.1.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241218-183400-5d6aec3",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
+      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.3",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
+      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
+      "deprecated": "Downgrade to 3.99.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^4.0.1",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241230.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
+        "workerd": "1.20241230.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
+      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
+      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
+      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260503.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260503.1.tgz",
+      "integrity": "sha512-8VKtafR4fNMtddutOnam3yq3AQvrl9bzuMio3B3AEAfrdx7xaaDV0Oyxz54P07lODwX0jydukGLC1rpDdYXAAA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20241230.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
+      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241230.0",
+        "ws": "^8.18.0",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
+      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241230.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
+        "@cloudflare/workerd-linux-64": "1.20241230.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
+        "@cloudflare/workerd-windows-64": "1.20241230.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.87.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.87.0.tgz",
+      "integrity": "sha512-lfhfKwLfQlowwgV0xhlYgE9fU3n0I30d4ccGY/rTCEm/n42Mjvlr0Ng3ZPNqlsrsKBcDR531V7dsPkgELvrk/Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260430.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260430.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260430.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260430.1.tgz",
+      "integrity": "sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260430.1.tgz",
+      "integrity": "sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260430.1.tgz",
+      "integrity": "sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260430.1.tgz",
+      "integrity": "sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz",
+      "integrity": "sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "4.20260430.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
+      "integrity": "sha512-MWvMm3Siho9Yj7lbJZidLs8hbrRvIcOrif2mnsHQZdvoKfedpea+GaN8XJxbpRcq0B2WzNI1BB1ihdnqes3/ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260430.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260430.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260430.1.tgz",
+      "integrity": "sha512-KEgIWyiw3Jmn+DCd/L3ePo5fmiiYb/UcwKvDWPf/nLLOiwShDFzDSsegU5NY/JcwgvO/QsLHVi2FYrbkcXNY5Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260430.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260430.1",
+        "@cloudflare/workerd-linux-64": "1.20260430.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260430.1",
+        "@cloudflare/workerd-windows-64": "1.20260430.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/infra/oyster-publish/package.json
+++ b/infra/oyster-publish/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "oyster-publish-worker",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Cloudflare Worker for R5 publish: artefact upload + publication state + R2 storage",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.1.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/infra/oyster-publish/src/types.ts
+++ b/infra/oyster-publish/src/types.ts
@@ -1,0 +1,31 @@
+// Env interface for the oyster-publish Worker.
+// Bindings declared in wrangler.toml.
+
+export interface Env {
+  DB: D1Database;          // shared with oyster-auth (same database_id)
+  ARTIFACTS: R2Bucket;     // oyster-artifacts
+}
+
+// Decoded X-Publish-Metadata payload — produced by the local server.
+export interface PublishMetadata {
+  artifact_id: string;
+  artifact_kind: string;
+  mode: "open" | "password" | "signin";
+  password_hash?: string;  // present iff mode === 'password'
+}
+
+// Row shape for published_artifacts.
+export interface PublicationRow {
+  share_token: string;
+  owner_user_id: string;
+  artifact_id: string;
+  artifact_kind: string;
+  mode: "open" | "password" | "signin";
+  password_hash: string | null;
+  r2_key: string;
+  content_type: string;
+  size_bytes: number;
+  published_at: number;
+  updated_at: number;
+  unpublished_at: number | null;
+}

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -1,0 +1,34 @@
+// oyster-publish — R5 publish endpoints + viewer scaffold.
+// All real handler bodies land in Phase 2 (#315 PR 2).
+
+import type { Env } from "./types";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    // POST /api/publish/upload
+    if (url.pathname === "/api/publish/upload" && req.method === "POST") {
+      return notImplemented("publish_upload");
+    }
+
+    // DELETE /api/publish/:share_token
+    if (url.pathname.startsWith("/api/publish/") && req.method === "DELETE") {
+      return notImplemented("publish_unpublish");
+    }
+
+    // GET /p/:share_token — viewer body lands in #316.
+    if (url.pathname.startsWith("/p/") && req.method === "GET") {
+      return notImplemented("publish_viewer");
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};
+
+function notImplemented(handler: string): Response {
+  return new Response(
+    JSON.stringify({ error: "not_implemented", handler }),
+    { status: 501, headers: { "content-type": "application/json" } },
+  );
+}

--- a/infra/oyster-publish/tsconfig.json
+++ b/infra/oyster-publish/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/infra/oyster-publish/vitest.config.ts
+++ b/infra/oyster-publish/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    passWithNoTests: true,
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // Use isolated in-memory D1 + R2 per test file.
+          d1Databases: ["DB"],
+          r2Buckets: ["ARTIFACTS"],
+        },
+      },
+    },
+  },
+});

--- a/infra/oyster-publish/vitest.config.ts
+++ b/infra/oyster-publish/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 export default defineWorkersConfig({
   test: {
     include: ["test/**/*.test.ts"],
-    passWithNoTests: true,
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.toml" },

--- a/infra/oyster-publish/wrangler.toml
+++ b/infra/oyster-publish/wrangler.toml
@@ -1,0 +1,33 @@
+name = "oyster-publish"
+main = "src/worker.ts"
+compatibility_date = "2026-04-01"
+
+# Shared D1 binding — same database_id as oyster-auth so we can read sessions/users
+# and own the published_artifacts table inside the same DB. Single source of truth.
+[[d1_databases]]
+binding = "DB"
+database_name = "oyster-auth"
+database_id = "44086805-fbfa-4446-8626-126af7e2ec19"
+
+# R2 bucket for published artefact bytes.
+[[r2_buckets]]
+binding = "ARTIFACTS"
+bucket_name = "oyster-artifacts"
+
+# Routes: admin API + public viewer. Both apex and www so the Worker is
+# reachable from either origin (matches auth-worker pattern).
+[[routes]]
+pattern = "oyster.to/api/publish/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "www.oyster.to/api/publish/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "oyster.to/p/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "www.oyster.to/p/*"
+zone_name = "oyster.to"


### PR DESCRIPTION
## Summary

- New `oyster-publish` Cloudflare Worker, deployed at `oyster.to/api/publish/*` and `oyster.to/p/*`. All endpoints currently return `501` — bodies land in PRs 2 + 3.
- D1 migration `0003_publish.sql` against the shared `oyster-auth` DB: adds `users.tier` (default `'free'`) and creates `published_artifacts` with the spec's indexes + CHECK.
- R2 bucket `oyster-artifacts` provisioned.

Spec: `docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`.
Plan: `docs/superpowers/plans/2026-05-03-r5-publish-backend.md`.

## Test plan

- [x] `wrangler d1 execute oyster-auth --remote --command "SELECT * FROM published_artifacts;"` returns no rows, no error.
- [x] `wrangler r2 bucket list` shows `oyster-artifacts`.
- [x] `curl -X POST https://oyster.to/api/publish/upload` returns `501 {"error":"not_implemented","handler":"publish_upload"}`.
- [x] `curl https://oyster.to/p/anything` returns `501`.
- [x] No regression in `oyster-auth` — sign-in still works at `oyster.to/auth/sign-in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)