### PR TITLE
feat(publish): Worker upload + unpublish endpoints (#315 PR 2/3)

### DIFF
--- a/infra/oyster-publish/src/publish-helpers.ts
+++ b/infra/oyster-publish/src/publish-helpers.ts
@@ -1,0 +1,70 @@
+// Pure helpers for oyster-publish. No D1, no R2, no Workers globals beyond
+// crypto.getRandomValues / atob — safe to unit-test under any runtime.
+
+import type { PublishMetadata } from "./types";
+
+export const CAPS = {
+  free: { max_active: 5, max_size_bytes: 10 * 1024 * 1024 },
+  // pro: { … }   ← lands in 0.8.0+
+} as const;
+
+export type Tier = keyof typeof CAPS;
+
+export function generateShareToken(): string {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return base64urlEncode(bytes);
+}
+
+export function r2KeyFor(ownerUserId: string, shareToken: string): string {
+  return `published/${ownerUserId}/${shareToken}`;
+}
+
+export function parseMetadataHeader(blob: string): PublishMetadata {
+  let json: string;
+  try {
+    json = base64urlDecodeToString(blob);
+  } catch {
+    throw new Error("invalid_metadata");
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new Error("invalid_metadata");
+  }
+
+  if (!raw || typeof raw !== "object") throw new Error("invalid_metadata");
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.artifact_id !== "string" || r.artifact_id.length === 0) throw new Error("invalid_metadata");
+  if (typeof r.artifact_kind !== "string" || r.artifact_kind.length === 0) throw new Error("invalid_metadata");
+  if (r.mode !== "open" && r.mode !== "password" && r.mode !== "signin") throw new Error("invalid_metadata");
+  if (r.password_hash !== undefined && typeof r.password_hash !== "string") throw new Error("invalid_metadata");
+
+  return {
+    artifact_id: r.artifact_id,
+    artifact_kind: r.artifact_kind,
+    mode: r.mode,
+    password_hash: r.password_hash as string | undefined,
+  };
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let str = "";
+  for (const b of bytes) str += String.fromCharCode(b);
+  const b64 = btoa(str);
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecodeToString(s: string): string {
+  // Restore standard base64 padding/alphabet for atob.
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (s.length % 4)) % 4);
+  const decoded = atob(padded);
+  // atob returns a "binary string" (one char per byte). For UTF-8 JSON we need
+  // to round-trip through bytes → TextDecoder.
+  const bytes = new Uint8Array(decoded.length);
+  for (let i = 0; i < decoded.length; i++) bytes[i] = decoded.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -256,15 +256,18 @@ export async function resolveSession(req: Request, env: Env): Promise<SessionUse
   if (!m) return null;
   const token = m[1];
 
+  // Production sessions schema (infra/auth-worker/migrations/0001_init.sql):
+  //   id TEXT PRIMARY KEY (the cookie value), user_id, created_at,
+  //   expires_at, revoked_at. Live-row predicate matches auth-worker exactly:
+  //   revoked_at IS NULL AND expires_at > now.
   const row = await env.DB.prepare(
-    `SELECT u.id AS id, u.email AS email, u.tier AS tier, s.expires_at AS expires_at
+    `SELECT u.id AS id, u.email AS email, u.tier AS tier
        FROM sessions s
        JOIN users u ON u.id = s.user_id
-      WHERE s.session_token = ?`
-  ).bind(token).first<{ id: string; email: string; tier: string; expires_at: number }>();
+      WHERE s.id = ? AND s.revoked_at IS NULL AND s.expires_at > ?`
+  ).bind(token, Date.now()).first<{ id: string; email: string; tier: string }>();
 
   if (!row) return null;
-  if (row.expires_at <= Date.now()) return null;
   return { id: row.id, email: row.email, tier: row.tier };
 }
 

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -1,10 +1,11 @@
 // oyster-publish — R5 publish endpoints + viewer scaffold.
 // Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
 
-import type { Env } from "./types";
+import type { Env, PublicationRow } from "./types";
+import { CAPS, generateShareToken, parseMetadataHeader, r2KeyFor, type Tier } from "./publish-helpers";
 
 export default {
-  async fetch(req: Request, env: Env): Promise<Response> {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
 
     if (url.pathname === "/api/publish/upload" && req.method === "POST") {
@@ -28,7 +29,48 @@ export default {
 // ─── Handlers (bodies in tasks 2.5 and 2.6) ────────────────────────────────
 
 async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
-  return jsonError(501, "not_implemented", "publish_upload — body in Task 2.5");
+  // Step 1: session.
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required", "Sign in to publish artefacts.");
+
+  // Step 2: metadata.
+  const metaHeader = req.headers.get("X-Publish-Metadata");
+  if (!metaHeader) return jsonError(400, "invalid_metadata");
+  let meta;
+  try {
+    meta = parseMetadataHeader(metaHeader);
+  } catch {
+    return jsonError(400, "invalid_metadata");
+  }
+
+  // Step 3: password presence iff mode=password (defence in depth — local server already checked).
+  if (meta.mode === "password" && (!meta.password_hash || meta.password_hash.length === 0)) {
+    return jsonError(400, "password_required");
+  }
+  if (meta.mode !== "password" && meta.password_hash) {
+    // Local server bug: hash sent for non-password mode. Reject.
+    return jsonError(400, "invalid_metadata");
+  }
+
+  // Step 4: Content-Length present.
+  const lenHeader = req.headers.get("Content-Length");
+  if (!lenHeader) return jsonError(411, "content_length_required");
+  const contentLength = Number(lenHeader);
+  if (!Number.isFinite(contentLength) || contentLength < 0) {
+    return jsonError(411, "content_length_required");
+  }
+
+  // Step 5: tier + size cap.
+  const tier = (user.tier in CAPS ? user.tier : "free") as Tier;
+  const cap = CAPS[tier];
+  if (contentLength > cap.max_size_bytes) {
+    return jsonError(413, "artifact_too_large", "Free tier allows published artefacts up to 10 MB.", {
+      limit_bytes: cap.max_size_bytes,
+    });
+  }
+
+  // Steps 6–9 land in Task 2.6.
+  return jsonError(501, "not_implemented", "find-or-claim + R2 PUT + D1 upsert — Task 2.6");
 }
 
 async function handlePublishDelete(req: Request, env: Env, shareToken: string): Promise<Response> {

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -69,8 +69,144 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
     });
   }
 
-  // Steps 6–9 land in Task 2.6.
-  return jsonError(501, "not_implemented", "find-or-claim + R2 PUT + D1 upsert — Task 2.6");
+  // Step 6: find-or-claim final share_token.
+  type ActiveRow = { share_token: string; published_at: number };
+  const existing = await env.DB.prepare(
+    `SELECT share_token, published_at FROM published_artifacts
+      WHERE owner_user_id = ? AND artifact_id = ? AND unpublished_at IS NULL`
+  ).bind(user.id, meta.artifact_id).first<ActiveRow>();
+
+  let shareToken: string;
+  let publishedAt: number;
+  let path: "first-publish" | "upsert";
+
+  if (existing) {
+    shareToken = existing.share_token;
+    publishedAt = existing.published_at;
+    path = "upsert";
+  } else {
+    // Cap check before generating a token.
+    const countRow = await env.DB.prepare(
+      `SELECT COUNT(*) AS n FROM published_artifacts
+        WHERE owner_user_id = ? AND unpublished_at IS NULL`
+    ).bind(user.id).first<{ n: number }>();
+    const current = countRow?.n ?? 0;
+    if (current >= cap.max_active) {
+      return jsonError(402, "publish_cap_exceeded",
+        `Free tier allows ${cap.max_active} active published artefacts. Unpublish one first.`,
+        { current, limit: cap.max_active });
+    }
+
+    // Generate token and try to claim it.
+    const candidate = generateShareToken();
+    const now = Date.now();
+    try {
+      await env.DB.prepare(
+        `INSERT INTO published_artifacts
+         (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+          r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`
+      ).bind(
+        candidate, user.id, meta.artifact_id, meta.artifact_kind, meta.mode,
+        meta.password_hash ?? null,
+        r2KeyFor(user.id, candidate),
+        req.headers.get("Content-Type") ?? "application/octet-stream",
+        contentLength, now, now,
+      ).run();
+      shareToken = candidate;
+      publishedAt = now;
+      path = "first-publish";
+    } catch (err) {
+      // Race recovery: concurrent first-publish for the same (owner, artifact) won.
+      // Re-SELECT and treat as upsert.
+      const won = await env.DB.prepare(
+        `SELECT share_token, published_at FROM published_artifacts
+          WHERE owner_user_id = ? AND artifact_id = ? AND unpublished_at IS NULL`
+      ).bind(user.id, meta.artifact_id).first<ActiveRow>();
+      if (!won) {
+        // Some other constraint failed; surface as 500.
+        console.error("[publish] insert failed and no winning row found:", err);
+        return jsonError(500, "internal_error");
+      }
+      shareToken = won.share_token;
+      publishedAt = won.published_at;
+      path = "upsert";
+    }
+  }
+
+  // Step 7: read body with size enforcement, then PUT to R2.
+  const r2Key = r2KeyFor(user.id, shareToken);
+  let putError: Error | null = null;
+  let bodyBytes: Uint8Array = new Uint8Array(0);
+  try {
+    const stream = req.body;
+    if (stream) {
+      const result = await collectWithSizeCap(stream, cap.max_size_bytes);
+      if (result.exceeded) {
+        putError = new Error("artifact_too_large");
+      } else {
+        bodyBytes = result.bytes;
+      }
+    }
+    if (!putError) {
+      await env.ARTIFACTS.put(r2Key, bodyBytes, {
+        httpMetadata: { contentType: req.headers.get("Content-Type") ?? "application/octet-stream" },
+      });
+    }
+  } catch (err) {
+    putError = err as Error;
+  }
+
+  if (putError) {
+    // Rollback: delete the speculatively-inserted row only if first-publish.
+    if (path === "first-publish") {
+      await env.DB.prepare("DELETE FROM published_artifacts WHERE share_token = ?")
+        .bind(shareToken).run();
+    }
+    // Best-effort R2 cleanup.
+    try { await env.ARTIFACTS.delete(r2Key); } catch { /* swallow */ }
+
+    if (putError.message === "artifact_too_large") {
+      return jsonError(413, "artifact_too_large",
+        "Free tier allows published artefacts up to 10 MB.",
+        { limit_bytes: cap.max_size_bytes });
+    }
+    console.error("[publish] R2 put failed:", putError);
+    return jsonError(502, "upload_failed");
+  }
+
+  // Step 8: D1 commit.
+  if (path === "upsert") {
+    const updatedAt = Date.now();
+    await env.DB.prepare(
+      `UPDATE published_artifacts
+          SET mode = ?, password_hash = ?, content_type = ?, size_bytes = ?, updated_at = ?
+        WHERE share_token = ?`
+    ).bind(
+      meta.mode, meta.password_hash ?? null,
+      req.headers.get("Content-Type") ?? "application/octet-stream",
+      contentLength, updatedAt, shareToken,
+    ).run();
+
+    // Step 9: respond (upsert path).
+    return jsonOk({
+      share_token: shareToken,
+      share_url: `https://oyster.to/p/${shareToken}`,
+      mode: meta.mode,
+      published_at: publishedAt,
+      updated_at: updatedAt,
+    });
+  } else {
+    // First-publish: row already inserted with published_at = updated_at = now.
+    // Return the same timestamp for both so published_at === updated_at on the wire.
+    return jsonOk({
+      share_token: shareToken,
+      share_url: `https://oyster.to/p/${shareToken}`,
+      mode: meta.mode,
+      published_at: publishedAt,
+      updated_at: publishedAt,
+    });
+  }
 }
 
 async function handlePublishDelete(req: Request, env: Env, shareToken: string): Promise<Response> {
@@ -122,4 +258,37 @@ export function jsonOk(payload: object, status = 200): Response {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+// collectWithSizeCap reads a ReadableStream into a Uint8Array, aborting if
+// total bytes exceed `max`. Returns { bytes, exceeded }.
+async function collectWithSizeCap(
+  input: ReadableStream<Uint8Array>,
+  max: number,
+): Promise<{ bytes: Uint8Array; exceeded: boolean }> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = input.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > max) {
+        reader.cancel();
+        return { bytes: new Uint8Array(0), exceeded: true };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  // Concatenate all chunks.
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { bytes: out, exceeded: false };
 }

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -210,7 +210,31 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
 }
 
 async function handlePublishDelete(req: Request, env: Env, shareToken: string): Promise<Response> {
-  return jsonError(501, "not_implemented", "publish_unpublish — body in Task 2.6");
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+
+  type Row = { owner_user_id: string; r2_key: string; unpublished_at: number | null };
+  const row = await env.DB.prepare(
+    "SELECT owner_user_id, r2_key, unpublished_at FROM published_artifacts WHERE share_token = ?"
+  ).bind(shareToken).first<Row>();
+
+  if (!row) return jsonError(404, "publication_not_found");
+  if (row.owner_user_id !== user.id) return jsonError(403, "not_publication_owner");
+
+  if (row.unpublished_at !== null) {
+    return jsonOk({ ok: true, share_token: shareToken, unpublished_at: row.unpublished_at });
+  }
+
+  const now = Date.now();
+  await env.DB.prepare("UPDATE published_artifacts SET unpublished_at = ? WHERE share_token = ?")
+    .bind(now, shareToken).run();
+
+  // Best-effort R2 delete; D1 is the source of truth.
+  try { await env.ARTIFACTS.delete(row.r2_key); } catch (err) {
+    console.warn("[publish] R2 delete failed (orphan accepted):", err);
+  }
+
+  return jsonOk({ ok: true, share_token: shareToken, unpublished_at: now });
 }
 
 // ─── Shared helpers ────────────────────────────────────────────────────────

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -1,5 +1,5 @@
 // oyster-publish — R5 publish endpoints + viewer scaffold.
-// All real handler bodies land in Phase 2 (#315 PR 2).
+// Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
 
 import type { Env } from "./types";
 
@@ -7,28 +7,77 @@ export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
 
-    // POST /api/publish/upload
     if (url.pathname === "/api/publish/upload" && req.method === "POST") {
-      return notImplemented("publish_upload");
+      return handlePublishUpload(req, env);
     }
 
-    // DELETE /api/publish/:share_token
     if (url.pathname.startsWith("/api/publish/") && req.method === "DELETE") {
-      return notImplemented("publish_unpublish");
+      const token = url.pathname.slice("/api/publish/".length);
+      return handlePublishDelete(req, env, token);
     }
 
-    // GET /p/:share_token — viewer body lands in #316.
     if (url.pathname.startsWith("/p/") && req.method === "GET") {
-      return notImplemented("publish_viewer");
+      // Viewer body lands in #316.
+      return jsonError(501, "not_implemented", "viewer lands in #316");
     }
 
     return new Response("Not Found", { status: 404 });
   },
 };
 
-function notImplemented(handler: string): Response {
-  return new Response(
-    JSON.stringify({ error: "not_implemented", handler }),
-    { status: 501, headers: { "content-type": "application/json" } },
-  );
+// ─── Handlers (bodies in tasks 2.5 and 2.6) ────────────────────────────────
+
+async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
+  return jsonError(501, "not_implemented", "publish_upload — body in Task 2.5");
+}
+
+async function handlePublishDelete(req: Request, env: Env, shareToken: string): Promise<Response> {
+  return jsonError(501, "not_implemented", "publish_unpublish — body in Task 2.6");
+}
+
+// ─── Shared helpers ────────────────────────────────────────────────────────
+
+interface SessionUser {
+  id: string;
+  email: string;
+  tier: string;
+}
+
+/**
+ * Resolve the session cookie to a user. Returns null on missing/expired session.
+ * Reads from the shared sessions + users tables.
+ */
+export async function resolveSession(req: Request, env: Env): Promise<SessionUser | null> {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const m = cookie.match(/(?:^|;\s*)oyster_session=([^;]+)/);
+  if (!m) return null;
+  const token = m[1];
+
+  const row = await env.DB.prepare(
+    `SELECT u.id AS id, u.email AS email, u.tier AS tier, s.expires_at AS expires_at
+       FROM sessions s
+       JOIN users u ON u.id = s.user_id
+      WHERE s.session_token = ?`
+  ).bind(token).first<{ id: string; email: string; tier: string; expires_at: number }>();
+
+  if (!row) return null;
+  if (row.expires_at <= Date.now()) return null;
+  return { id: row.id, email: row.email, tier: row.tier };
+}
+
+export function jsonError(status: number, code: string, message?: string, extra: Record<string, unknown> = {}): Response {
+  const body: Record<string, unknown> = { error: code, ...extra };
+  if (message) body.message = message;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function jsonOk(payload: object, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 }

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -1,7 +1,7 @@
 // oyster-publish — R5 publish endpoints + viewer scaffold.
 // Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
 
-import type { Env, PublicationRow } from "./types";
+import type { Env } from "./types";
 import { CAPS, generateShareToken, parseMetadataHeader, r2KeyFor, type Tier } from "./publish-helpers";
 
 export default {
@@ -52,16 +52,19 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
     return jsonError(400, "invalid_metadata");
   }
 
-  // Step 4: Content-Length present.
+  // Step 4: Content-Length present and well-formed.
+  // Reject non-digit headers (e.g. "1.5", "1e6", "-3", " 42 ") — these would slip
+  // past Number() but corrupt size_bytes. The spec wants an explicit decimal-digit
+  // string. Final source of truth for size_bytes is the actual streamed byteLength
+  // (set in step 8); contentLength here is just the cap-check estimate.
   const lenHeader = req.headers.get("Content-Length");
-  if (!lenHeader) return jsonError(411, "content_length_required");
+  if (!lenHeader || !/^\d+$/.test(lenHeader)) return jsonError(411, "content_length_required");
   const contentLength = Number(lenHeader);
-  if (!Number.isFinite(contentLength) || contentLength < 0) {
-    return jsonError(411, "content_length_required");
-  }
+  if (!Number.isSafeInteger(contentLength)) return jsonError(411, "content_length_required");
 
-  // Step 5: tier + size cap.
-  const tier = (user.tier in CAPS ? user.tier : "free") as Tier;
+  // Step 5: tier + size cap. Use Object.hasOwn so prototype keys (toString etc.)
+  // can't masquerade as a tier and produce an undefined cap.
+  const tier = (Object.hasOwn(CAPS, user.tier) ? user.tier : "free") as Tier;
   const cap = CAPS[tier];
   if (contentLength > cap.max_size_bytes) {
     return jsonError(413, "artifact_too_large", "Free tier allows published artefacts up to 10 MB.", {
@@ -175,7 +178,10 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
     return jsonError(502, "upload_failed");
   }
 
-  // Step 8: D1 commit.
+  // Step 8: D1 commit. size_bytes is reconciled to the actual number of bytes
+  // we just wrote to R2 (Content-Length is client-controlled and may have lied
+  // within the cap; bodyBytes.byteLength is what's actually in the bucket).
+  const actualSize = bodyBytes.byteLength;
   if (path === "upsert") {
     const updatedAt = Date.now();
     await env.DB.prepare(
@@ -185,7 +191,7 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
     ).bind(
       meta.mode, meta.password_hash ?? null,
       req.headers.get("Content-Type") ?? "application/octet-stream",
-      contentLength, updatedAt, shareToken,
+      actualSize, updatedAt, shareToken,
     ).run();
 
     // Step 9: respond (upsert path).
@@ -197,7 +203,14 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
       updated_at: updatedAt,
     });
   } else {
-    // First-publish: row already inserted with published_at = updated_at = now.
+    // First-publish: row was inserted in step 6 with size_bytes = contentLength
+    // (the header value). Reconcile to actual streamed byteLength so D1 matches
+    // what's in R2.
+    if (actualSize !== contentLength) {
+      await env.DB.prepare(
+        `UPDATE published_artifacts SET size_bytes = ? WHERE share_token = ?`
+      ).bind(actualSize, shareToken).run();
+    }
     // Return the same timestamp for both so published_at === updated_at on the wire.
     return jsonOk({
       share_token: shareToken,

--- a/infra/oyster-publish/test/env.d.ts
+++ b/infra/oyster-publish/test/env.d.ts
@@ -1,0 +1,9 @@
+// Tell TypeScript what the test runtime's `env` looks like.
+// @cloudflare/vitest-pool-workers exports `env: ProvidedEnv` which is
+// otherwise empty until augmented here.
+
+import type { Env } from "../src/types";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -1,0 +1,108 @@
+// Test fixtures for oyster-publish integration tests.
+// Each test file gets isolated D1 + R2 bindings via @cloudflare/vitest-pool-workers.
+
+import { env } from "cloudflare:test";
+
+const SCHEMA_SQL = `
+-- Mirror of oyster-auth's relevant schema for tests. Keep in sync with:
+--   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
+--   infra/auth-worker/migrations/0003_publish.sql (users.tier, published_artifacts)
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,
+  email         TEXT NOT NULL UNIQUE,
+  created_at    INTEGER NOT NULL,
+  last_seen_at  INTEGER,
+  tier          TEXT NOT NULL DEFAULT 'free'
+);
+CREATE TABLE sessions (
+  session_token TEXT PRIMARY KEY,
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  created_at    INTEGER NOT NULL,
+  expires_at    INTEGER NOT NULL
+);
+CREATE TABLE published_artifacts (
+  share_token       TEXT    PRIMARY KEY,
+  owner_user_id     TEXT    NOT NULL REFERENCES users(id),
+  artifact_id       TEXT    NOT NULL,
+  artifact_kind     TEXT    NOT NULL,
+  mode              TEXT    NOT NULL CHECK (mode IN ('open','password','signin')),
+  password_hash     TEXT,
+  r2_key            TEXT    NOT NULL,
+  content_type      TEXT    NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  published_at      INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  unpublished_at    INTEGER,
+  CHECK (
+    (mode = 'password' AND password_hash IS NOT NULL) OR
+    (mode <> 'password' AND password_hash IS NULL)
+  )
+);
+CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
+CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
+  ON published_artifacts(owner_user_id, artifact_id)
+  WHERE unpublished_at IS NULL;
+`;
+
+export async function applySchema(): Promise<void> {
+  // D1 .exec runs multi-statement SQL but ignores comments inconsistently;
+  // split on semicolons and run each non-empty statement.
+  const stmts = SCHEMA_SQL.split(";").map(s => s.trim()).filter(Boolean);
+  for (const s of stmts) {
+    await env.DB.prepare(s).run();
+  }
+}
+
+export interface SeededUser {
+  id: string;
+  email: string;
+  sessionToken: string;
+}
+
+export async function seedUser(opts: { id?: string; email?: string; tier?: string } = {}): Promise<SeededUser> {
+  const id = opts.id ?? `user_${crypto.randomUUID().slice(0, 8)}`;
+  const email = opts.email ?? `${id}@example.com`;
+  const tier = opts.tier ?? "free";
+  const now = Date.now();
+  await env.DB.prepare(
+    "INSERT INTO users (id, email, created_at, last_seen_at, tier) VALUES (?, ?, ?, ?, ?)"
+  ).bind(id, email, now, now, tier).run();
+
+  const sessionToken = `sess_${crypto.randomUUID()}`;
+  const expiresAt = now + 30 * 86400 * 1000;
+  await env.DB.prepare(
+    "INSERT INTO sessions (session_token, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)"
+  ).bind(sessionToken, id, now, expiresAt).run();
+
+  return { id, email, sessionToken };
+}
+
+export async function seedActivePublication(opts: {
+  ownerUserId: string;
+  artifactId: string;
+  shareToken?: string;
+  mode?: "open" | "password" | "signin";
+  passwordHash?: string | null;
+  publishedAt?: number;
+}): Promise<string> {
+  const token = opts.shareToken ?? `seeded_${crypto.randomUUID().slice(0, 8)}`;
+  const mode = opts.mode ?? "open";
+  const passwordHash = mode === "password" ? (opts.passwordHash ?? "pbkdf2$100000$x$y") : null;
+  const now = opts.publishedAt ?? Date.now();
+  await env.DB.prepare(
+    `INSERT INTO published_artifacts
+     (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+      r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+     VALUES (?, ?, ?, 'notes', ?, ?, ?, 'text/plain', 5, ?, ?, NULL)`
+  ).bind(token, opts.ownerUserId, opts.artifactId, mode, passwordHash,
+         `published/${opts.ownerUserId}/${token}`, now, now).run();
+  return token;
+}
+
+export function authHeader(sessionToken: string): { Cookie: string } {
+  return { Cookie: `oyster_session=${sessionToken}` };
+}
+
+export function metadataHeader(payload: object): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -15,10 +15,11 @@ CREATE TABLE users (
   tier          TEXT NOT NULL DEFAULT 'free'
 );
 CREATE TABLE sessions (
-  session_token TEXT PRIMARY KEY,
+  id            TEXT PRIMARY KEY,                  -- cookie value (mirrors production)
   user_id       TEXT NOT NULL REFERENCES users(id),
   created_at    INTEGER NOT NULL,
-  expires_at    INTEGER NOT NULL
+  expires_at    INTEGER NOT NULL,
+  revoked_at    INTEGER                            -- NULL while active
 );
 CREATE TABLE published_artifacts (
   share_token       TEXT    PRIMARY KEY,
@@ -71,7 +72,7 @@ export async function seedUser(opts: { id?: string; email?: string; tier?: strin
   const sessionToken = `sess_${crypto.randomUUID()}`;
   const expiresAt = now + 30 * 86400 * 1000;
   await env.DB.prepare(
-    "INSERT INTO sessions (session_token, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)"
+    "INSERT INTO sessions (id, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)"
   ).bind(sessionToken, id, now, expiresAt).run();
 
   return { id, email, sessionToken };

--- a/infra/oyster-publish/test/publish-handler.test.ts
+++ b/infra/oyster-publish/test/publish-handler.test.ts
@@ -236,30 +236,24 @@ describe("POST /api/publish/upload — cap enforcement", () => {
 });
 
 describe("POST /api/publish/upload — race recovery", () => {
-  it("two sequential first-publishes with same artifact_id return the same share_token, one D1 row", async () => {
+  it("two concurrent first-publishes return the same share_token, one D1 row, one R2 object", async () => {
     const u = await seedUser();
     const body = "racing";
 
-    // First publish for art_race.
-    const r1 = await call(uploadRequest({
-      cookieHeader: authHeader(u.sessionToken),
-      metadata: metadataHeader({ artifact_id: "art_race", artifact_kind: "notes", mode: "open" }),
-      contentType: "text/plain",
-      contentLength: String(body.length),
-      body,
-    }));
-    expect(r1.status).toBe(200);
-    const j1 = await r1.json() as any;
+    function call6() {
+      return call(uploadRequest({
+        cookieHeader: authHeader(u.sessionToken),
+        metadata: metadataHeader({ artifact_id: "art_race", artifact_kind: "notes", mode: "open" }),
+        contentType: "text/plain",
+        contentLength: String(body.length),
+        body,
+      }));
+    }
 
-    // Second publish for same artifact_id (upsert, not first-publish race).
-    const r2 = await call(uploadRequest({
-      cookieHeader: authHeader(u.sessionToken),
-      metadata: metadataHeader({ artifact_id: "art_race", artifact_kind: "notes", mode: "open" }),
-      contentType: "text/plain",
-      contentLength: String(body.length),
-      body,
-    }));
+    const [r1, r2] = await Promise.all([call6(), call6()]);
+    expect(r1.status).toBe(200);
     expect(r2.status).toBe(200);
+    const j1 = await r1.json() as any;
     const j2 = await r2.json() as any;
 
     // Both return the same share_token.

--- a/infra/oyster-publish/test/publish-handler.test.ts
+++ b/infra/oyster-publish/test/publish-handler.test.ts
@@ -234,3 +234,125 @@ describe("POST /api/publish/upload — cap enforcement", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("POST /api/publish/upload — race recovery", () => {
+  it("two sequential first-publishes with same artifact_id return the same share_token, one D1 row", async () => {
+    const u = await seedUser();
+    const body = "racing";
+
+    // First publish for art_race.
+    const r1 = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_race", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(r1.status).toBe(200);
+    const j1 = await r1.json() as any;
+
+    // Second publish for same artifact_id (upsert, not first-publish race).
+    const r2 = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_race", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(r2.status).toBe(200);
+    const j2 = await r2.json() as any;
+
+    // Both return the same share_token.
+    expect(j1.share_token).toBe(j2.share_token);
+
+    // Exactly one row.
+    const rows = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM published_artifacts WHERE owner_user_id = ? AND artifact_id = ? AND unpublished_at IS NULL"
+    ).bind(u.id, "art_race").first<{ n: number }>();
+    expect(rows?.n).toBe(1);
+
+    // R2 object exists at the winning token (check existence only, don't consume stream).
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${j1.share_token}`);
+    if (obj) {
+      // Consume any stream to ensure cleanup happens
+      await obj.text().catch(() => {});
+    }
+    expect(obj).toBeTruthy();
+  });
+});
+
+describe("POST /api/publish/upload — cross-owner non-conflict", () => {
+  it("two users may publish artefacts that share an artifact_id without conflict", async () => {
+    const a = await seedUser({ id: "user_a", email: "a@example.com" });
+    const b = await seedUser({ id: "user_b", email: "b@example.com" });
+
+    const body = "shared";
+    const ra = await call(uploadRequest({
+      cookieHeader: authHeader(a.sessionToken),
+      metadata: metadataHeader({ artifact_id: "shared_id", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    const rb = await call(uploadRequest({
+      cookieHeader: authHeader(b.sessionToken),
+      metadata: metadataHeader({ artifact_id: "shared_id", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(ra.status).toBe(200);
+    expect(rb.status).toBe(200);
+    const ja = await ra.json() as any;
+    const jb = await rb.json() as any;
+    expect(ja.share_token).not.toBe(jb.share_token);
+
+    const rows = await env.DB.prepare(
+      "SELECT owner_user_id FROM published_artifacts WHERE artifact_id = ? AND unpublished_at IS NULL ORDER BY owner_user_id"
+    ).bind("shared_id").all<{ owner_user_id: string }>();
+    expect(rows.results.map(r => r.owner_user_id)).toEqual(["user_a", "user_b"]);
+  });
+});
+
+describe("POST /api/publish/upload — D1 CHECK enforcement", () => {
+  it("rejects an open-mode publish that smuggles a password_hash", async () => {
+    const u = await seedUser();
+    const body = "x";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({
+        artifact_id: "art_check", artifact_kind: "notes", mode: "open",
+        password_hash: "pbkdf2$100000$x$y",  // illegal for open mode
+      }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    // Caught by the handler's defence-in-depth (Task 2.5) before reaching D1.
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+});
+
+describe("POST /api/publish/upload — streamed-size enforcement", () => {
+  it("aborts mid-stream when streamed bytes exceed cap despite Content-Length under cap", async () => {
+    const u = await seedUser();
+    const liedLength = 10;  // claim 10 bytes
+    const realBody = new Uint8Array(11 * 1024 * 1024);  // actually send 11 MB
+    realBody.fill(0x41);
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_stream", artifact_kind: "notes", mode: "open" }),
+      contentType: "application/octet-stream",
+      contentLength: String(liedLength),
+      body: realBody,
+    }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ error: "artifact_too_large" });
+    // No D1 row left behind.
+    const row = await env.DB.prepare(
+      "SELECT * FROM published_artifacts WHERE owner_user_id = ? AND artifact_id = ?"
+    ).bind(u.id, "art_stream").first();
+    expect(row).toBeNull();
+  });
+});

--- a/infra/oyster-publish/test/publish-handler.test.ts
+++ b/infra/oyster-publish/test/publish-handler.test.ts
@@ -100,6 +100,23 @@ describe("POST /api/publish/upload — metadata + size validation", () => {
     expect(res.status).toBe(413);
     expect(await res.json()).toMatchObject({ error: "artifact_too_large", limit_bytes: 10 * 1024 * 1024 });
   });
+
+  it("rejects Content-Length that isn't a decimal integer", async () => {
+    const u = await seedUser();
+    // Whitespace ("  42  ") is normalised by the Workers runtime before our
+    // regex sees it, so it isn't included here.
+    for (const lied of ["1.5", "1e6", "-3", "abc", ""]) {
+      const res = await call(uploadRequest({
+        cookieHeader: authHeader(u.sessionToken),
+        metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "open" }),
+        contentType: "text/plain",
+        contentLength: lied,
+        body: "x",
+      }));
+      expect(res.status, `lied=${JSON.stringify(lied)}`).toBe(411);
+      expect(await res.json()).toMatchObject({ error: "content_length_required" });
+    }
+  });
 });
 
 describe("POST /api/publish/upload — first publish (open mode)", () => {
@@ -325,6 +342,57 @@ describe("POST /api/publish/upload — D1 CHECK enforcement", () => {
     // Caught by the handler's defence-in-depth (Task 2.5) before reaching D1.
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+});
+
+describe("POST /api/publish/upload — size_bytes reconciliation", () => {
+  it("D1 size_bytes records actual streamed bytes, not Content-Length, when client lies under the cap", async () => {
+    const u = await seedUser();
+    const realBody = "exactly twelve!"; // 15 bytes
+    const lied = "999"; // claim 999 bytes
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_size", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: lied,
+      body: realBody,
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { share_token: string };
+
+    const row = await env.DB.prepare(
+      "SELECT size_bytes FROM published_artifacts WHERE share_token = ?"
+    ).bind(json.share_token).first<{ size_bytes: number }>();
+    expect(row?.size_bytes).toBe(new TextEncoder().encode(realBody).byteLength);
+  });
+
+  it("upsert path also records actual streamed bytes", async () => {
+    const u = await seedUser();
+    // First publish (no lie).
+    const first = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_size_2", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: "5",
+      body: "hello",
+    }));
+    expect(first.status).toBe(200);
+
+    // Re-publish with lying Content-Length.
+    const second = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_size_2", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: "100",
+      body: "no",
+    }));
+    expect(second.status).toBe(200);
+    const j = await second.json() as { share_token: string };
+
+    const row = await env.DB.prepare(
+      "SELECT size_bytes FROM published_artifacts WHERE share_token = ?"
+    ).bind(j.share_token).first<{ size_bytes: number }>();
+    expect(row?.size_bytes).toBe(2);
   });
 });
 

--- a/infra/oyster-publish/test/publish-handler.test.ts
+++ b/infra/oyster-publish/test/publish-handler.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, authHeader, metadataHeader } from "./fixtures/seed";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function uploadRequest(opts: {
+  cookieHeader?: Record<string, string>;
+  metadata?: string;
+  contentType?: string;
+  contentLength?: string | null;
+  body?: BodyInit | null;
+} = {}): Request {
+  const headers = new Headers();
+  if (opts.cookieHeader?.Cookie) headers.set("Cookie", opts.cookieHeader.Cookie);
+  if (opts.metadata !== undefined) headers.set("X-Publish-Metadata", opts.metadata);
+  if (opts.contentType) headers.set("Content-Type", opts.contentType);
+  if (opts.contentLength !== null) {
+    const len = opts.contentLength ?? (opts.body ? String((opts.body as string).length) : "0");
+    headers.set("Content-Length", len);
+  }
+  return new Request("https://oyster.to/api/publish/upload", {
+    method: "POST",
+    headers,
+    body: opts.body ?? null,
+  });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("POST /api/publish/upload — auth", () => {
+  it("returns 401 sign_in_required when cookie is missing", async () => {
+    const res = await call(uploadRequest());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "sign_in_required" });
+  });
+
+  it("returns 401 sign_in_required when cookie has unknown token", async () => {
+    const res = await call(uploadRequest({ cookieHeader: { Cookie: "oyster_session=fake" } }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/publish/upload — metadata + size validation", () => {
+  it("returns 400 invalid_metadata when X-Publish-Metadata is missing", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({ cookieHeader: authHeader(u.sessionToken) }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+
+  it("returns 400 invalid_metadata when payload is malformed", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: "!!!not-base64!!!",
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 password_required when mode=password and hash absent", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "password" }),
+    }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "password_required" });
+  });
+
+  it("returns 411 content_length_required when Content-Length missing", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "open" }),
+      contentLength: null,
+      contentType: "text/plain",
+    }));
+    expect(res.status).toBe(411);
+    expect(await res.json()).toMatchObject({ error: "content_length_required" });
+  });
+
+  it("returns 413 artifact_too_large when Content-Length > cap", async () => {
+    const u = await seedUser();
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "a", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(11 * 1024 * 1024),
+      body: "x",
+    }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toMatchObject({ error: "artifact_too_large", limit_bytes: 10 * 1024 * 1024 });
+  });
+});

--- a/infra/oyster-publish/test/publish-handler.test.ts
+++ b/infra/oyster-publish/test/publish-handler.test.ts
@@ -101,3 +101,136 @@ describe("POST /api/publish/upload — metadata + size validation", () => {
     expect(await res.json()).toMatchObject({ error: "artifact_too_large", limit_bytes: 10 * 1024 * 1024 });
   });
 });
+
+describe("POST /api/publish/upload — first publish (open mode)", () => {
+  it("creates a row, writes R2, returns 200 with token + URL", async () => {
+    const u = await seedUser();
+    const body = "# Hello world";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_1", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/markdown",
+      contentLength: String(new TextEncoder().encode(body).byteLength),
+      body,
+    }));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { share_token: string; share_url: string; mode: string; published_at: number; updated_at: number };
+    expect(json.share_token).toMatch(/^[A-Za-z0-9_-]{32}$/);
+    expect(json.share_url).toBe(`https://oyster.to/p/${json.share_token}`);
+    expect(json.mode).toBe("open");
+    expect(json.published_at).toBeTypeOf("number");
+    expect(json.updated_at).toBe(json.published_at);
+
+    // D1 row exists.
+    const row = await env.DB.prepare("SELECT * FROM published_artifacts WHERE share_token = ?")
+      .bind(json.share_token).first();
+    expect(row).toBeTruthy();
+    expect((row as any).owner_user_id).toBe(u.id);
+    expect((row as any).artifact_id).toBe("art_1");
+    expect((row as any).unpublished_at).toBeNull();
+
+    // R2 object exists with the right bytes.
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${json.share_token}`);
+    expect(obj).toBeTruthy();
+    expect(await obj!.text()).toBe(body);
+  });
+});
+
+describe("POST /api/publish/upload — re-publish (upsert)", () => {
+  it("keeps share_token, refreshes bytes + mode, preserves published_at", async () => {
+    const u = await seedUser();
+    const firstBody = "v1";
+    const first = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_1", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(firstBody.length),
+      body: firstBody,
+    }));
+    const firstJson = await first.json() as any;
+    expect(first.status).toBe(200);
+
+    // Wait a beat so updated_at can plausibly differ from published_at.
+    await new Promise(r => setTimeout(r, 5));
+
+    const secondBody = "v2 with hash";
+    const second = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({
+        artifact_id: "art_1", artifact_kind: "notes",
+        mode: "password", password_hash: "pbkdf2$100000$x$y",
+      }),
+      contentType: "text/plain",
+      contentLength: String(secondBody.length),
+      body: secondBody,
+    }));
+    expect(second.status).toBe(200);
+    const secondJson = await second.json() as any;
+    expect(secondJson.share_token).toBe(firstJson.share_token);  // stable
+    expect(secondJson.mode).toBe("password");
+    expect(secondJson.published_at).toBe(firstJson.published_at);  // preserved
+    expect(secondJson.updated_at).toBeGreaterThanOrEqual(firstJson.updated_at);
+
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${firstJson.share_token}`);
+    expect(await obj!.text()).toBe(secondBody);
+
+    const row = await env.DB.prepare("SELECT mode, password_hash FROM published_artifacts WHERE share_token = ?")
+      .bind(firstJson.share_token).first<any>();
+    expect(row.mode).toBe("password");
+    expect(row.password_hash).toBe("pbkdf2$100000$x$y");
+  });
+});
+
+describe("POST /api/publish/upload — cap enforcement", () => {
+  it("returns 402 publish_cap_exceeded on 6th distinct artefact", async () => {
+    const u = await seedUser();
+    for (let i = 0; i < 5; i++) {
+      const body = `body ${i}`;
+      const res = await call(uploadRequest({
+        cookieHeader: authHeader(u.sessionToken),
+        metadata: metadataHeader({ artifact_id: `art_${i}`, artifact_kind: "notes", mode: "open" }),
+        contentType: "text/plain",
+        contentLength: String(body.length),
+        body,
+      }));
+      expect(res.status).toBe(200);
+    }
+    const body = "boom";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "art_6", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(res.status).toBe(402);
+    const json = await res.json() as any;
+    expect(json.error).toBe("publish_cap_exceeded");
+    expect(json.current).toBe(5);
+    expect(json.limit).toBe(5);
+  });
+
+  it("does not count unpublished rows toward the cap", async () => {
+    const u = await seedUser();
+    // Seed 5 unpublished rows directly.
+    const now = Date.now();
+    for (let i = 0; i < 5; i++) {
+      const tok = `seeded_${i}`;
+      await env.DB.prepare(
+        `INSERT INTO published_artifacts
+         (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+          r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+         VALUES (?, ?, ?, 'notes', 'open', NULL, ?, 'text/plain', 5, ?, ?, ?)`
+      ).bind(tok, u.id, `seeded_art_${i}`, `published/${u.id}/${tok}`, now, now, now).run();
+    }
+    const body = "fresh";
+    const res = await call(uploadRequest({
+      cookieHeader: authHeader(u.sessionToken),
+      metadata: metadataHeader({ artifact_id: "fresh_art", artifact_kind: "notes", mode: "open" }),
+      contentType: "text/plain",
+      contentLength: String(body.length),
+      body,
+    }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/infra/oyster-publish/test/publish-helpers.test.ts
+++ b/infra/oyster-publish/test/publish-helpers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { generateShareToken, r2KeyFor, CAPS, parseMetadataHeader } from "../src/publish-helpers";
+
+describe("generateShareToken", () => {
+  it("is 32 base64url characters (24 bytes, no padding)", () => {
+    const t = generateShareToken();
+    expect(t).toMatch(/^[A-Za-z0-9_-]{32}$/);
+  });
+
+  it("produces a different value on each call", () => {
+    const a = generateShareToken();
+    const b = generateShareToken();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("r2KeyFor", () => {
+  it("composes published/{owner}/{token}", () => {
+    expect(r2KeyFor("user_abc", "tok_xyz")).toBe("published/user_abc/tok_xyz");
+  });
+});
+
+describe("CAPS.free", () => {
+  it("max_active is 5", () => {
+    expect(CAPS.free.max_active).toBe(5);
+  });
+
+  it("max_size_bytes is exactly 10 MB", () => {
+    expect(CAPS.free.max_size_bytes).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe("parseMetadataHeader", () => {
+  function encode(payload: object): string {
+    const json = JSON.stringify(payload);
+    return Buffer.from(json).toString("base64url");
+  }
+
+  it("decodes a valid 'open' payload", () => {
+    const blob = encode({ artifact_id: "a", artifact_kind: "notes", mode: "open" });
+    const result = parseMetadataHeader(blob);
+    expect(result).toEqual({ artifact_id: "a", artifact_kind: "notes", mode: "open" });
+  });
+
+  it("decodes a 'password' payload with hash", () => {
+    const blob = encode({
+      artifact_id: "a", artifact_kind: "notes", mode: "password",
+      password_hash: "pbkdf2$100000$xx$yy",
+    });
+    const result = parseMetadataHeader(blob);
+    expect(result.mode).toBe("password");
+    expect(result.password_hash).toBe("pbkdf2$100000$xx$yy");
+  });
+
+  it("throws 'invalid_metadata' for malformed base64url", () => {
+    expect(() => parseMetadataHeader("!!! not base64 !!!")).toThrow("invalid_metadata");
+  });
+
+  it("throws 'invalid_metadata' for missing required fields", () => {
+    const blob = encode({ artifact_id: "a", mode: "open" });
+    expect(() => parseMetadataHeader(blob)).toThrow("invalid_metadata");
+  });
+
+  it("throws 'invalid_metadata' for invalid mode value", () => {
+    const blob = encode({ artifact_id: "a", artifact_kind: "k", mode: "weird" });
+    expect(() => parseMetadataHeader(blob)).toThrow("invalid_metadata");
+  });
+});

--- a/infra/oyster-publish/test/unpublish-handler.test.ts
+++ b/infra/oyster-publish/test/unpublish-handler.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, seedActivePublication, authHeader, metadataHeader } from "./fixtures/seed";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function deleteRequest(token: string, sessionToken?: string): Request {
+  const headers = new Headers();
+  if (sessionToken) headers.set("Cookie", `oyster_session=${sessionToken}`);
+  return new Request(`https://oyster.to/api/publish/${token}`, { method: "DELETE", headers });
+}
+
+describe("DELETE /api/publish/:share_token", () => {
+  it("returns 401 sign_in_required without a session cookie", async () => {
+    const res = await call(deleteRequest("anytoken"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 publication_not_found for an unknown token", async () => {
+    const u = await seedUser();
+    const res = await call(deleteRequest("ghost", u.sessionToken));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "publication_not_found" });
+  });
+
+  it("returns 403 not_publication_owner when caller is not the owner", async () => {
+    const owner = await seedUser({ id: "owner", email: "owner@example.com" });
+    const stranger = await seedUser({ id: "stranger", email: "stranger@example.com" });
+    const tok = await seedActivePublication({ ownerUserId: owner.id, artifactId: "art_x" });
+    const res = await call(deleteRequest(tok, stranger.sessionToken));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "not_publication_owner" });
+  });
+
+  it("returns 200 and marks unpublished_at on first call", async () => {
+    const u = await seedUser();
+    const tok = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_x" });
+    // Seed an R2 object so we can verify the delete.
+    await env.ARTIFACTS.put(`published/${u.id}/${tok}`, "bytes");
+
+    const res = await call(deleteRequest(tok, u.sessionToken));
+    expect(res.status).toBe(200);
+    const json = await res.json() as any;
+    expect(json.ok).toBe(true);
+    expect(json.share_token).toBe(tok);
+    expect(json.unpublished_at).toBeTypeOf("number");
+
+    const row = await env.DB.prepare("SELECT unpublished_at FROM published_artifacts WHERE share_token = ?")
+      .bind(tok).first<{ unpublished_at: number | null }>();
+    expect(row?.unpublished_at).toBeTypeOf("number");
+
+    const obj = await env.ARTIFACTS.get(`published/${u.id}/${tok}`);
+    expect(obj).toBeNull();
+  });
+
+  it("is idempotent on a second call (already unpublished)", async () => {
+    const u = await seedUser();
+    const tok = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_x" });
+    await call(deleteRequest(tok, u.sessionToken));
+    const second = await call(deleteRequest(tok, u.sessionToken));
+    expect(second.status).toBe(200);
+    const json = await second.json() as any;
+    expect(json.ok).toBe(true);
+  });
+});
+
+describe("publish → unpublish → publish round-trip", () => {
+  // This test crosses both handlers; it lives here because the lifecycle is
+  // anchored by unpublish (without it, the second publish would be an upsert).
+  it("issues a new share_token after unpublish; old R2 object gone, new R2 object present", async () => {
+    const u = await seedUser();
+    const body = "first-bytes";
+
+    // 1. First publish via the handler so we get a real generated token.
+    const headers = new Headers();
+    headers.set("Cookie", `oyster_session=${u.sessionToken}`);
+    headers.set("X-Publish-Metadata", Buffer.from(JSON.stringify({
+      artifact_id: "art_cycle", artifact_kind: "notes", mode: "open",
+    })).toString("base64url"));
+    headers.set("Content-Type", "text/plain");
+    headers.set("Content-Length", String(body.length));
+    const first = await call(new Request("https://oyster.to/api/publish/upload", {
+      method: "POST", headers, body,
+    }));
+    expect(first.status).toBe(200);
+    const firstJson = await first.json() as { share_token: string };
+
+    // 2. Unpublish.
+    const del = await call(deleteRequest(firstJson.share_token, u.sessionToken));
+    expect(del.status).toBe(200);
+
+    // 3. Republish.
+    const second = await call(new Request("https://oyster.to/api/publish/upload", {
+      method: "POST", headers, body: "second-bytes",
+    }));
+    expect(second.status).toBe(200);
+    const secondJson = await second.json() as { share_token: string; share_url: string };
+
+    // New token (not the same as first).
+    expect(secondJson.share_token).not.toBe(firstJson.share_token);
+
+    // Old R2 object gone (deleted by unpublish).
+    const oldObj = await env.ARTIFACTS.get(`published/${u.id}/${firstJson.share_token}`);
+    expect(oldObj).toBeNull();
+
+    // New R2 object present with new bytes.
+    const newObj = await env.ARTIFACTS.get(`published/${u.id}/${secondJson.share_token}`);
+    expect(newObj).toBeTruthy();
+    expect(await newObj!.text()).toBe("second-bytes");
+
+    // Old D1 row marked unpublished; new row live.
+    const oldRow = await env.DB.prepare("SELECT unpublished_at FROM published_artifacts WHERE share_token = ?")
+      .bind(firstJson.share_token).first<{ unpublished_at: number | null }>();
+    expect(oldRow?.unpublished_at).toBeTypeOf("number");
+    const newRow = await env.DB.prepare("SELECT unpublished_at FROM published_artifacts WHERE share_token = ?")
+      .bind(secondJson.share_token).first<{ unpublished_at: number | null }>();
+    expect(newRow?.unpublished_at).toBeNull();
+  });
+});

--- a/infra/oyster-publish/tsconfig.json
+++ b/infra/oyster-publish/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,

--- a/infra/oyster-publish/wrangler.toml
+++ b/infra/oyster-publish/wrangler.toml
@@ -1,6 +1,10 @@
 name = "oyster-publish"
 main = "src/worker.ts"
 compatibility_date = "2026-04-01"
+# nodejs_compat is required by @cloudflare/vitest-pool-workers (the test
+# infrastructure needs Node-style APIs inside the Worker runtime). Production
+# handlers don't depend on it — they use Web Crypto + standard Web APIs only.
+compatibility_flags = ["nodejs_compat"]
 
 # Shared D1 binding — same database_id as oyster-auth so we can read sessions/users
 # and own the published_artifacts table inside the same DB. Single source of truth.


### PR DESCRIPTION
## Summary

- `POST /api/publish/upload`: full spec implementation — auth, X-Publish-Metadata parse, password-presence check, Content-Length + tier-cap pre-check, find-or-claim with race recovery on the partial unique index, body collected into a Uint8Array with hard size cap (defence against lying Content-Length), R2 PUT, D1 upsert, response with stable token.
- `DELETE /api/publish/:share_token`: idempotent unpublish; updates `unpublished_at`, best-effort R2 delete.
- Vitest pool-workers integration suite covers: auth, metadata validation, first publish, re-publish (stable token + bytes refresh + mode change), cap (with unpublished rows correctly ignored), race recovery, cross-owner non-conflict, streamed-size enforcement, owner-scoped delete, idempotent delete, full publish→unpublish→publish round-trip. **31 tests passing.**

Spec: `docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`.
Plan: `docs/superpowers/plans/2026-05-03-r5-publish-backend.md`.

## Plan-vs-reality fixes (worth flagging in review)

Three things needed beyond the plan to make Phase 2 actually run:

- **`compatibility_flags = ["nodejs_compat"]`** in `wrangler.toml` — required by `@cloudflare/vitest-pool-workers`. Production handlers don't depend on it.
- **`@cloudflare/vitest-pool-workers` in `tsconfig.json` `types`** + a `test/env.d.ts` augmenting `ProvidedEnv` — without these, `import { env } from "cloudflare:test"` doesn't typecheck.
- **`resolveSession` query and seed-fixture schema** — plan invented `sessions.session_token`; production uses `sessions.id` (the cookie value). Surfaced by the live smoke test (`D1_ERROR: no such column`). Worker query now mirrors auth-worker's `handleWhoami` exactly: `WHERE s.id = ? AND s.revoked_at IS NULL AND s.expires_at > ?`.

## Test plan

- [x] `cd infra/oyster-publish && npm test` → 31 / 31 passing.
- [x] Smoke test: publish 19-byte markdown → D1 row + R2 object exist (`size_bytes: 19`, `etag: 14995b08…`); unpublish → `unpublished_at` set, R2 object deleted.
- [x] `oyster.to/p/anything` still returns `501` (viewer is #316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)