### PR TITLE
feat(home): attach orphan folder to an existing space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 ### Added
 
 - **Sign in to Oyster.** A free account in three clicks — Continue with GitHub, or send a sign-in link to your email as a fallback. The badge in the top-left corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. ([#295](https://github.com/mattslight/oyster/issues/295), [#340](https://github.com/mattslight/oyster/issues/340))
+- **Attach an Unsorted folder to an existing space.** The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a "Best match" hint when the folder name resembles one), or create a new space as before.
 
 ### Fixed
 
 - **Clicking an artefact in the session inspector** now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.
+- **Attaching a folder to a space** now sweeps in any sessions already running in that folder, instead of leaving them stranded under Unsorted.
 
 ## [0.6.0] - 2026-05-02
 

--- a/docs/superpowers/specs/2026-05-03-attach-orphan-to-existing-space-design.md
+++ b/docs/superpowers/specs/2026-05-03-attach-orphan-to-existing-space-design.md
@@ -1,0 +1,120 @@
+# Attach orphan folder to an existing space
+
+## Problem
+
+On the Unsorted view (Home + Elsewhere), each orphan folder tile — a `cwd` with active sessions but no attached source — has a `FolderPlus` button that one-shots the folder into a brand-new space (`promoteFolderToSpace` → `POST /api/spaces/from-path`).
+
+There is no way from this surface to attach the folder to a space that already exists. If the user has an "Oyster" space and a worktree at `~/Dev/oyster-os.worktrees` shows up under Unsorted, the only available action creates a duplicate "Oyster-os.worktrees" space instead of joining the existing one.
+
+## Goal
+
+Replace the single-shot `FolderPlus` action with a small popover that lets the user choose a destination space — existing or new — for the orphan folder, with a smart "Best match" suggestion when the folder name resembles a known space.
+
+## Non-goals
+
+- Keyboard navigation in the picker beyond Escape to close
+- Fuzzy matching across deep folder paths (only the basename participates in scoring)
+- Multi-select / bulk attach across orphan tiles
+- Changing how `/attach` works from the chat bar (only the side-effect parity fix below applies)
+- Any change to artifact tiles, Home cards, or the chat bar
+
+## UX
+
+Click `FolderPlus` on an Unsorted folder tile → popover anchored to the button, opening below the button and aligned to its right edge. If it would clip the viewport's right edge, align to the left edge instead; if it would clip the bottom, flip above the button. Clicking the same `FolderPlus` again toggles the popover closed.
+
+```
+┌─────────────────────────────────────────┐
+│ Attach …/oyster-os.worktrees to        │
+├─────────────────────────────────────────┤
+│ ● Oyster                  Best match    │
+├─────────────────────────────────────────┤
+│ ● Blunderfixer                          │
+│ ● Tokinvest                             │
+├─────────────────────────────────────────┤
+│ + New space                             │
+└─────────────────────────────────────────┘
+```
+
+Sections:
+- **Header**: `Attach <middle-truncated path> to` — the path uses middle-ellipsis so the basename always remains visible.
+- **Best match** (optional): the highest-scoring space (score ≥ 1, see Smart match below), with a `Best match` caption on the right. Omitted when there is no qualifying match.
+- **Other spaces**: every remaining non-meta space (excluding `home`, `__all__`, `__archived__`, and the best match) sorted alphabetically by `displayName`. Each row: colour dot + display name.
+- **Divider**.
+- **`+ New space`**: invokes today's promote behaviour (`promoteFolderToSpace(path)`).
+
+Behaviour:
+- Clicking a space row → `addSpaceSource(spaceId, path)`. On success, popover closes; the orphan tile disappears from Unsorted because the backend backfill (see "Backend symmetry" below) re-attributes its sessions and an SSE refresh fires.
+- Clicking `+ New space` → `promoteFolderToSpace(path)`. Same close-on-success behaviour.
+- On error, an inline error row renders inside the popover (e.g. `Path is already attached to space "Foo"`); the popover stays open so the user can pick something else.
+- During the in-flight request, every row is disabled and the picked row shows a subtle pending state (no spinner, just `aria-busy` + opacity). Only one in-flight attempt at a time per popover.
+- Closes on: outside click, `Escape`, after success.
+- Empty space list (no spaces exist yet) → popover collapses to just `+ New space` plus a one-line hint.
+
+The existing `promotingCwd` state in `Home/index.tsx` (line 159) is repurposed to gate the popover trigger and the in-flight row, so concurrent attempts across different tiles remain safely disabled.
+
+## Smart match
+
+Pure helper, no IO. Inputs: `folderBasename: string` and `spaces: { id, displayName }[]`. Output: the best-scoring space, or `null`.
+
+Algorithm:
+1. Lowercase both sides.
+2. Tokenise on `/[^a-z0-9]+/` → array of non-empty tokens.
+3. For each space, score against the folder tokens. For each folder token, take the best match across all space tokens (no double-counting per folder token):
+   - `1.0` if any space token is exactly equal.
+   - else `0.5` if any space token is a substring of the folder token, or vice versa.
+   - else `0`.
+   Sum across folder tokens.
+4. Return the space with the highest score where score ≥ 1. Ties: return the space with the shorter `displayName` (favours the more general match — "Oyster" over "Oyster-prototype"). Further ties: alphabetical, so the result is deterministic.
+
+Worked example: folder `oyster-os.worktrees` → tokens `[oyster, os, worktrees]`. Space "Oyster" → tokens `[oyster]`. `oyster == oyster` → score 1. Returns "Oyster". Space "Blunderfixer" → score 0. Filtered out.
+
+Edge cases:
+- Reserved/meta spaces (`home`, `__all__`, `__archived__`) are excluded by the caller before scoring.
+- If two spaces tie at the top, the shorter-name rule deterministically picks one — no flicker between renders.
+
+The helper lives at `web/src/components/Home/match-space.ts`. Trivial enough that a unit test is optional; if added, it sits alongside as `match-space.test.ts`.
+
+## Backend symmetry
+
+Today, `POST /api/spaces/from-path` does two things that `POST /api/spaces/:id/sources` does not:
+
+1. Calls `sessionStore.backfillSourceForCwd(resolved, spaceId, sourceId)` to re-attribute orphan sessions whose `cwd` matches.
+2. Broadcasts `session_changed` so connected clients refetch sessions.
+
+Without these, attaching a folder to an existing space leaves the orphan sessions stranded — the Unsorted tile would not disappear, defeating the whole flow.
+
+Changes:
+- `server/src/space-service.ts` — in `addSource`, after the successful insert/restore, call `this.sessionStore.backfillSourceForCwd(resolved, spaceId, source.id)`. The no-op return path (path already attached to *this* space) skips the backfill — by definition there is nothing to migrate.
+- `server/src/routes/spaces.ts` — in the `POST /api/spaces/:id/sources` handler, call `broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: "" } })` after `addSource` returns, mirroring the from-path route.
+
+This makes the side-effects of `addSource` identical to `createSpaceFromPath` (both end with backfill + broadcast). It also retroactively fixes the same gap for the chat-bar `/attach` flow and the `AttachSourceForm` UI — both currently leave orphan sessions behind, which is a latent bug rather than a deliberate behaviour.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `web/src/components/Home/index.tsx` | Replace direct promote `onClick` (~line 720–740) with popover open/close; pass `spaces` and the new attach handler down |
+| `web/src/components/Home/AttachOrphanPopover.tsx` *(new)* | Popover component: header, best-match row, alphabetical list, `+ New space` row, error row, outside/Escape close |
+| `web/src/components/Home/match-space.ts` *(new)* | Pure scoring helper described above |
+| `web/src/components/Home/Home.css` | Popover styles only; no changes to the existing `home-active-project-tile--orphan` rules |
+| `server/src/space-service.ts` | Backfill call inside `addSource` after successful insert/restore |
+| `server/src/routes/spaces.ts` | Broadcast `session_changed` after `POST /api/spaces/:id/sources` succeeds |
+| `CHANGELOG.md` | One bullet under Added / Changed |
+
+No new dependencies. No DB migrations.
+
+## Error handling
+
+The only expected error path is `addSource` rejecting because the path is already attached to a different active space — surfaced verbatim in the popover. Network / unexpected errors render a generic `Couldn't attach folder` line with the original message in `title=`, matching how the rest of `Home/index.tsx` reports failures.
+
+## Testing
+
+- Manual: start a Claude Code session in an unattached folder so it appears in Unsorted; click `FolderPlus`; verify the popover opens, smart match works for a name-matching space, picking that space attaches and removes the tile, picking `+ New space` falls back to today's flow, picking an already-owning space surfaces the inline error.
+- No automated browser tests exist for this surface today; do not add any solely for this change.
+- Unit-test `match-space.ts` if convenient; the function is small and pure.
+
+## Out of scope (explicitly)
+
+- Search-as-you-type filter inside the popover (only useful at >10–15 spaces, which no user has yet)
+- Drag-and-drop from orphan tile to a space pill (a much larger DnD investment)
+- Showing the same picker on the existing `AttachSourceForm` flow (different surface, different interaction)

--- a/server/src/routes/spaces.ts
+++ b/server/src/routes/spaces.ts
@@ -130,6 +130,11 @@ export async function tryHandleSpaceRoute(
           return true;
         }
         const source = spaceService.addSource(spaceId, path);
+        // addSource backfills orphan sessions whose cwd matches — tell
+        // connected clients to refetch so the Unsorted tile disappears
+        // immediately rather than waiting for the next watcher tick.
+        // Mirrors the from-path route.
+        broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: "" } });
         // Fire scan but don't block the response — tiles surface via SSE
         // as the watcher / scanner picks them up. A long scan would
         // otherwise hang the Folders UI for many seconds on a big repo.

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -101,7 +101,14 @@ export class SpaceService {
     // Cross-space conflict / same-space no-op check.
     const active = this.spaceStore.getActiveSourceByPath(resolved);
     if (active) {
-      if (active.space_id === spaceId) return active;
+      if (active.space_id === spaceId) {
+        // Re-attach to the same space is a no-op for the source row, but
+        // still backfill — pre-existing orphan sessions for this cwd may
+        // never have been swept (e.g. attached before the backfill behaviour
+        // existed). Idempotent, so safe to run on every retry.
+        this.sessionStore.backfillSourceForCwd(resolved, spaceId, active.id);
+        return active;
+      }
       const ownerName = this.spaceStore.getById(active.space_id)?.display_name ?? active.space_id;
       throw new Error(`Path is already attached to space "${ownerName}"`);
     }

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -109,33 +109,43 @@ export class SpaceService {
     // Reattach-restore: a soft-deleted source for the same (space, path) wins
     // over inserting a fresh row. Same id survives — its artifacts will
     // resurface on the next scan via upsertCandidate.
+    let source: Source;
     const removed = this.spaceStore.getSoftDeletedSourceByPathForSpace(spaceId, resolved);
     if (removed) {
       try {
         this.spaceStore.restoreSource(removed.id);
-        return { ...removed, removed_at: null };
+        source = { ...removed, removed_at: null };
       } catch (err) {
         // Race: between our check and the restore, another caller inserted a
         // fresh active source for the same path. Re-evaluate.
         if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE") {
-          return this.resolveSourceConflict(spaceId, resolved, err);
+          source = this.resolveSourceConflict(spaceId, resolved, err);
+        } else {
+          throw err;
         }
-        throw err;
+      }
+    } else {
+      const id = crypto.randomUUID();
+      try {
+        this.spaceStore.addSource({ id, space_id: spaceId, type: "local_folder", path: resolved });
+        source = this.spaceStore.getSourceById(id)!;
+      } catch (err) {
+        // Race: a concurrent caller inserted the same path between our check and
+        // our insert. Re-evaluate.
+        if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE") {
+          source = this.resolveSourceConflict(spaceId, resolved, err);
+        } else {
+          throw err;
+        }
       }
     }
 
-    const id = crypto.randomUUID();
-    try {
-      this.spaceStore.addSource({ id, space_id: spaceId, type: "local_folder", path: resolved });
-    } catch (err) {
-      // Race: a concurrent caller inserted the same path between our check and
-      // our insert. Re-evaluate.
-      if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE") {
-        return this.resolveSourceConflict(spaceId, resolved, err);
-      }
-      throw err;
-    }
-    return this.spaceStore.getSourceById(id)!;
+    // Re-attribute orphan sessions whose cwd matches — same side-effect as
+    // createSpaceFromPath, so the Unsorted folder tile disappears once its
+    // sessions get a home. Idempotent (only updates rows where space_id and
+    // source_id are both NULL), so safe on the race-conflict path too.
+    this.sessionStore.backfillSourceForCwd(resolved, spaceId, source.id);
+    return source;
   }
 
   // Both addSource paths can race against the partial unique index on

--- a/web/src/components/Home/AttachOrphanPopover.tsx
+++ b/web/src/components/Home/AttachOrphanPopover.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { FolderPlus } from "lucide-react";
+import type { Space } from "../../../../shared/types";
+import { bestMatchSpace } from "./match-space";
+import { homeRelative } from "./utils";
+
+interface Props {
+  /** Absolute folder path of the orphan tile. */
+  path: string;
+  /** Anchor — popover is portaled to body and pinned near this rect. */
+  anchorRect: DOMRect;
+  /** Spaces eligible to receive the folder. Caller filters out meta IDs. */
+  spaces: Space[];
+  onClose: () => void;
+  /** Pick an existing space. Resolves on success, rejects with a user-facing message. */
+  onPickSpace: (spaceId: string) => Promise<void>;
+  /** Promote to a brand-new space (existing FolderPlus behaviour). */
+  onPromoteToNew: () => Promise<void>;
+}
+
+const PAD = 8;
+const POPOVER_W = 240;
+
+function basename(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, "");
+  const i = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return i >= 0 ? trimmed.slice(i + 1) : trimmed;
+}
+
+export function AttachOrphanPopover({ path, anchorRect, spaces, onClose, onPickSpace, onPromoteToNew }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number }>({
+    left: anchorRect.right - POPOVER_W,
+    top: anchorRect.bottom + 4,
+  });
+
+  // Viewport-aware flip: align right edge of popover to the button's right
+  // edge by default; if the popover would overflow on the left, snap to
+  // the button's left edge; if it would overflow on the bottom, flip above.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    let left = anchorRect.right - r.width;
+    let top = anchorRect.bottom + 4;
+    if (left < PAD) left = Math.min(anchorRect.left, window.innerWidth - r.width - PAD);
+    if (left + r.width > window.innerWidth - PAD) left = window.innerWidth - r.width - PAD;
+    if (top + r.height > window.innerHeight - PAD) top = anchorRect.top - r.height - 4;
+    if (top < PAD) top = PAD;
+    setPos({ left, top });
+  }, [anchorRect]);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [onClose]);
+
+  const folderName = basename(path);
+  const best = bestMatchSpace(folderName, spaces);
+  const others = spaces
+    .filter((s) => s.id !== best?.id)
+    .slice()
+    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+  async function run(key: string, fn: () => Promise<void>) {
+    if (pending) return;
+    setPending(key);
+    setError(null);
+    try {
+      await fn();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't attach folder");
+      setPending(null);
+    }
+  }
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="attach-orphan-popover"
+      style={{ left: pos.left, top: pos.top, width: POPOVER_W }}
+      role="dialog"
+      aria-label={`Attach ${folderName}`}
+    >
+      <div className="attach-orphan-header" title={path}>
+        Attach <span className="attach-orphan-header-path">{homeRelative(path)}</span> to
+      </div>
+      {best && (
+        <>
+          <button
+            type="button"
+            className="attach-orphan-row"
+            disabled={Boolean(pending)}
+            aria-busy={pending === best.id}
+            onClick={() => run(best.id, () => onPickSpace(best.id))}
+          >
+            <SpaceDot color={best.color} />
+            <span className="attach-orphan-row-label">{best.displayName}</span>
+            <span className="attach-orphan-row-hint">Best match</span>
+          </button>
+          <div className="attach-orphan-sep" />
+        </>
+      )}
+      {others.length > 0 && (
+        <div className="attach-orphan-list">
+          {others.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              className="attach-orphan-row"
+              disabled={Boolean(pending)}
+              aria-busy={pending === s.id}
+              onClick={() => run(s.id, () => onPickSpace(s.id))}
+            >
+              <SpaceDot color={s.color} />
+              <span className="attach-orphan-row-label">{s.displayName}</span>
+            </button>
+          ))}
+        </div>
+      )}
+      {(best || others.length > 0) && <div className="attach-orphan-sep" />}
+      <button
+        type="button"
+        className="attach-orphan-row attach-orphan-row--new"
+        disabled={Boolean(pending)}
+        aria-busy={pending === "__new__"}
+        onClick={() => run("__new__", onPromoteToNew)}
+      >
+        <FolderPlus size={14} strokeWidth={2} aria-hidden="true" />
+        <span className="attach-orphan-row-label">New space</span>
+      </button>
+      {error && <div className="attach-orphan-error" title={error}>{error}</div>}
+      {!best && others.length === 0 && (
+        <div className="attach-orphan-hint">No spaces yet — promote this folder to start one.</div>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
+function SpaceDot({ color }: { color: string | null }) {
+  return (
+    <span
+      className="attach-orphan-dot"
+      style={{ background: color ?? "var(--fg-dim, #888)" }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/components/Home/AttachOrphanPopover.tsx
+++ b/web/src/components/Home/AttachOrphanPopover.tsx
@@ -55,7 +55,13 @@ export function AttachOrphanPopover({ path, anchorRect, spaces, onClose, onPickS
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      if (ref.current?.contains(e.target as Node)) return;
+      // Ignore mousedowns on the anchor button so the toggle-close branch
+      // in the parent runs cleanly — otherwise mousedown closes the popover
+      // before the button's onClick fires, and onClick reopens it.
+      const r = anchorRect;
+      if (e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom) return;
+      onClose();
     }
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
@@ -66,7 +72,7 @@ export function AttachOrphanPopover({ path, anchorRect, spaces, onClose, onPickS
       window.removeEventListener("mousedown", handleClick);
       window.removeEventListener("keydown", handleKey);
     };
-  }, [onClose]);
+  }, [onClose, anchorRect]);
 
   const folderName = basename(path);
   const best = bestMatchSpace(folderName, spaces);

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1699,8 +1699,16 @@
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   min-width: 0;
   flex: 1;
+  /* Truncate from the LEFT so the basename always stays visible —
+     `~/Dev/oyster-os.worktrees` becomes `…oyster-os.worktrees`, not
+     `~/Dev/oyster-…`. Plaintext bidi keeps the path itself rendering
+     LTR within the rtl flow. */
+  direction: rtl;
+  text-align: left;
+  unicode-bidi: plaintext;
 }
 .attach-orphan-list {
   max-height: 260px;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1669,3 +1669,101 @@
   font-size: 13px;
   margin: 0;
 }
+
+/* Orphan-folder attach picker — anchored to the FolderPlus button on an
+   Unsorted tile, portaled to body. Visual language matches space-ctx-menu
+   so the two surfaces feel like siblings. */
+.attach-orphan-popover {
+  position: fixed;
+  z-index: 9999;
+  padding: 4px;
+  background: rgba(22, 23, 40, 0.97);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.12);
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+.attach-orphan-header {
+  display: flex;
+  gap: 4px;
+  align-items: baseline;
+  padding: 8px 10px 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+}
+.attach-orphan-header-path {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+.attach-orphan-list {
+  max-height: 260px;
+  overflow-y: auto;
+}
+.attach-orphan-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.attach-orphan-row:hover:not(:disabled) {
+  background: rgba(124, 107, 255, 0.12);
+}
+.attach-orphan-row:disabled {
+  cursor: default;
+}
+.attach-orphan-row[aria-busy="true"] {
+  opacity: 0.55;
+}
+.attach-orphan-row-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.attach-orphan-row-hint {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.attach-orphan-row--new {
+  color: var(--home-accent-bright, #c4b8ff);
+}
+.attach-orphan-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.attach-orphan-sep {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 3px 8px;
+}
+.attach-orphan-error {
+  padding: 6px 10px 8px;
+  font-size: 11px;
+  color: #f87171;
+  white-space: normal;
+}
+.attach-orphan-hint {
+  padding: 6px 10px 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -20,10 +20,12 @@ import { ShowMore } from "./ShowMore";
 import { AddMemoryForm } from "./AddMemoryForm";
 import { ProjectTileGrid } from "./ProjectTileGrid";
 import { AttachFolderForm } from "./AttachFolderForm";
+import { AttachOrphanPopover } from "./AttachOrphanPopover";
 import { MemoryCard } from "./MemoryCard";
 import { VaultInfo } from "./VaultInfo";
 import { homeRelative, renderPipCounts, stateColor } from "./utils";
 import { VAULT, type ArtefactSource, type StateFilter, type ViewMode } from "./types";
+import { addSpaceSource } from "../../data/spaces-api";
 import "./Home.css";
 
 interface Props {
@@ -154,9 +156,14 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // source row, so they're keyed by cwd instead of source_id. Lives
   // alongside selectedFolderId; resets when scope changes.
   const [selectedOrphanCwd, setSelectedOrphanCwd] = useState<string | null>(null);
-  // Cwd of the orphan tile currently mid-promotion. Disables the FolderPlus
-  // button so a slow server response can't kick off a duplicate promote.
+  // Cwd of the orphan tile currently mid-promotion (or mid-attach). Disables
+  // every FolderPlus button so a slow server response can't kick off a
+  // duplicate; also gates the picker popover. Set while either flow runs.
   const [promotingCwd, setPromotingCwd] = useState<string | null>(null);
+  // Orphan attach picker. Anchored to the FolderPlus button on the matching
+  // tile; rendered via portal alongside SpaceContextMenu at the end of the
+  // tree so it overlays cleanly.
+  const [attachPicker, setAttachPicker] = useState<{ cwd: string; rect: DOMRect } | null>(null);
   // Space-delete confirm. Set to a real space id to open. Two entry points
   // share this state: the empty-shell banner button (acts on the active
   // space) and the breadcrumb-pill context menu (acts on the clicked one).
@@ -721,19 +728,19 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       <button
                         type="button"
                         className="home-active-project-tile-jump"
-                        disabled={isPromoting}
-                        onClick={async (e) => {
+                        disabled={isPromoting && attachPicker?.cwd !== p.cwd}
+                        onClick={(e) => {
                           e.stopPropagation();
-                          if (promotingCwd) return;
-                          setPromotingCwd(p.cwd);
-                          try {
-                            await onPromoteFolderToSpace(p.cwd);
-                          } finally {
-                            setPromotingCwd(null);
+                          if (promotingCwd && attachPicker?.cwd !== p.cwd) return;
+                          if (attachPicker?.cwd === p.cwd) {
+                            setAttachPicker(null);
+                            return;
                           }
+                          const rect = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
+                          setAttachPicker({ cwd: p.cwd, rect });
                         }}
-                        aria-label={`Promote ${homeRelative(p.cwd)} to its own space`}
-                        title={`Promote ${homeRelative(p.cwd)} to its own space`}
+                        aria-label={`Attach ${homeRelative(p.cwd)} to a space`}
+                        title={`Attach ${homeRelative(p.cwd)} to a space`}
                       >
                         <FolderPlus size={14} strokeWidth={2} aria-hidden="true" />
                       </button>
@@ -1057,6 +1064,37 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
           />
         )}
       </InspectorPanel>
+      {attachPicker && onPromoteFolderToSpace && (() => {
+        const meta = new Set(["home", "__all__", "__archived__"]);
+        const candidates = spaces.filter((s) => !meta.has(s.id));
+        const cwd = attachPicker.cwd;
+        return (
+          <AttachOrphanPopover
+            path={cwd}
+            anchorRect={attachPicker.rect}
+            spaces={candidates}
+            onClose={() => setAttachPicker(null)}
+            onPickSpace={async (spaceId) => {
+              if (promotingCwd) throw new Error("Another attach is already in progress");
+              setPromotingCwd(cwd);
+              try {
+                await addSpaceSource(spaceId, cwd);
+              } finally {
+                setPromotingCwd(null);
+              }
+            }}
+            onPromoteToNew={async () => {
+              if (promotingCwd) throw new Error("Another attach is already in progress");
+              setPromotingCwd(cwd);
+              try {
+                await onPromoteFolderToSpace(cwd);
+              } finally {
+                setPromotingCwd(null);
+              }
+            }}
+          />
+        );
+      })()}
       {pillCtx && (() => {
         const target = spaces.find((s) => s.id === pillCtx.spaceId);
         if (!target) return null;

--- a/web/src/components/Home/match-space.ts
+++ b/web/src/components/Home/match-space.ts
@@ -1,0 +1,54 @@
+// Score a folder basename against a list of candidate spaces and return the
+// best match (or null). Used by AttachOrphanPopover to suggest "Best match"
+// when an Unsorted folder name resembles an existing space.
+//
+// Scoring (per folder token, take the best across all space tokens):
+//   1.0  exact equal
+//   0.5  one is a substring of the other
+//   0    neither
+// Sum across folder tokens. Return the highest-scoring space with score >= 1.
+// Tie-break: shorter displayName, then alphabetical, so the result is stable.
+//
+// Caller is responsible for excluding meta spaces (home, __all__, __archived__).
+
+export interface MatchCandidate {
+  id: string;
+  displayName: string;
+}
+
+function tokenise(s: string): string[] {
+  return s.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+export function bestMatchSpace<T extends MatchCandidate>(
+  folderBasename: string,
+  candidates: readonly T[],
+): T | null {
+  const folderTokens = tokenise(folderBasename);
+  if (folderTokens.length === 0 || candidates.length === 0) return null;
+
+  let best: { space: T; score: number } | null = null;
+  for (const space of candidates) {
+    const spaceTokens = tokenise(space.displayName);
+    if (spaceTokens.length === 0) continue;
+    let score = 0;
+    for (const ft of folderTokens) {
+      let bestForToken = 0;
+      for (const st of spaceTokens) {
+        if (ft === st) { bestForToken = 1; break; }
+        if (ft.includes(st) || st.includes(ft)) bestForToken = Math.max(bestForToken, 0.5);
+      }
+      score += bestForToken;
+    }
+    if (score < 1) continue;
+    if (
+      !best ||
+      score > best.score ||
+      (score === best.score && space.displayName.length < best.space.displayName.length) ||
+      (score === best.score && space.displayName.length === best.space.displayName.length && space.displayName < best.space.displayName)
+    ) {
+      best = { space, score };
+    }
+  }
+  return best?.space ?? null;
+}


### PR DESCRIPTION
## Summary

- Replaces the one-shot **promote** button on Unsorted folder tiles with a picker: choose any existing space (with a *Best match* hint when the folder name resembles one) or fall back to creating a new space.
- Backend parity fix: `addSource` now backfills orphan sessions whose `cwd` matches and the route broadcasts `session_changed`, mirroring `createSpaceFromPath`. The Unsorted tile disappears immediately once its sessions get a home — also fixes the latent gap for the chat-bar `/attach` flow.

Spec: `docs/superpowers/specs/2026-05-03-attach-orphan-to-existing-space-design.md`

## Test plan

- [ ] Start a Claude Code session in a folder not attached to any space → folder tile appears under Unsorted.
- [ ] Click the folder+ icon on the tile → picker opens, anchored to the button, right-aligned.
- [ ] If the folder name resembles an existing space (e.g. `oyster-os.worktrees` vs *Oyster*), it appears at the top with a *Best match* caption.
- [ ] Pick an existing space → tile disappears from Unsorted, sessions appear under that space.
- [ ] Pick **+ New space** → existing promote behaviour, brand-new space created from the folder.
- [ ] Pick a space that already owns the path → inline error in the popover, popover stays open.
- [ ] Escape, outside-click, and clicking the same folder+ icon all close the popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)