### PR TITLE
feat(316): R5 public viewer for shared artefacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Sign in to Oyster.** A free account in three clicks — Continue with GitHub, or send a sign-in link to your email as a fallback. The badge in the top-left corner shows your address; sign-out is one click. The same identity will unlock Publish & share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. ([#295](https://github.com/mattslight/oyster/issues/295), [#340](https://github.com/mattslight/oyster/issues/340))
 - **Attach an Unsorted folder to an existing space.** The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a "Best match" hint when the folder name resembles one), or create a new space as before.
+- **Public viewer for shared artefacts.** Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share. ([#316](https://github.com/mattslight/oyster/issues/316))
 
 ### Fixed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -327,10 +327,13 @@
 <h3>Added</h3>
 <ul>
 <li><strong>Sign in to Oyster.</strong> A free account in three clicks — Continue with GitHub, or send a sign-in link to your email as a fallback. The badge in the top-left corner shows your address; sign-out is one click. The same identity will unlock Publish &amp; share artefacts later in 0.7.0 and cross-device continuity in 0.8.0. (<a href="https://github.com/mattslight/oyster/issues/295" rel="noopener noreferrer">#295</a>, <a href="https://github.com/mattslight/oyster/issues/340" rel="noopener noreferrer">#340</a>)</li>
+<li><strong>Attach an Unsorted folder to an existing space.</strong> The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a &quot;Best match&quot; hint when the folder name resembles one), or create a new space as before.</li>
+<li><strong>Public viewer for shared artefacts.</strong> Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share. (<a href="https://github.com/mattslight/oyster/issues/316" rel="noopener noreferrer">#316</a>)</li>
 </ul>
 <h3>Fixed</h3>
 <ul>
 <li><strong>Clicking an artefact in the session inspector</strong> now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.</li>
+<li><strong>Attaching a folder to a space</strong> now sweeps in any sessions already running in that folder, instead of leaving them stranded under Unsorted.</li>
 </ul>
 <h2 id="v-0-6-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.5.0...v0.6.0" rel="noopener noreferrer"><span class="release-version">0.6.0</span></a><span class="release-date"> — 2026-05-02</span></h2>
 <p>Trustworthy recall — every memory traceable, every conversation searchable.</p>

--- a/docs/superpowers/plans/2026-05-03-r5-viewer.md
+++ b/docs/superpowers/plans/2026-05-03-r5-viewer.md
@@ -1,0 +1,2747 @@
+# R5 Public Viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `501 Not Implemented` stub at `GET /p/:share_token` with a full public viewer that enforces three access modes (open / password / signin), renders artefacts per kind (markdown, mermaid, sandbox-iframed HTML, inline image), and lands signed-in visitors back on the share via a new generic `?return=` flow on `auth-worker`.
+
+**Architecture:** Single PR. Two Workers touched: `oyster-publish` gets the viewer body + supporting modules, `auth-worker` gets a generic post-sign-in redirect mechanism (allowlisted to `/p/<token>`). User-controlled HTML in `app`/`deck`/`wireframe`/`table`/`map` artefacts is served from a sibling `/p/<token>/raw` endpoint inside an `<iframe sandbox="allow-scripts">` — without `allow-same-origin`, the iframe gets an opaque origin and cannot read `oyster_session` cookies. Markdown via `markdown-it` (`html: false`, default `validateLink`); mermaid via pinned CDN with SRI. Spec: [`docs/superpowers/specs/2026-05-03-r5-viewer-design.md`](../specs/2026-05-03-r5-viewer-design.md).
+
+**Tech Stack:** TypeScript, Cloudflare Workers, D1 (SQLite), R2, Vitest + `@cloudflare/vitest-pool-workers`, Web Crypto (HMAC-SHA256, PBKDF2-SHA256), `markdown-it`, mermaid (CDN, no bundling).
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `infra/auth-worker/migrations/0004_return_path.sql` | Additive nullable `return_path TEXT` on `magic_link_tokens` and `oauth_states` |
+| Modify | `infra/auth-worker/package.json` | Add `db:migrate:0004` + `db:migrate:0004:local` scripts |
+| Create | `infra/auth-worker/src/return-path.ts` | `validateReturnPath(raw)` — allowlist matcher, exclude `/p/<token>/raw` |
+| Create | `infra/auth-worker/test/return-path.test.ts` | Unit tests for allowlist (positive / negative cases) |
+| Modify | `infra/auth-worker/src/worker.ts` | Wire `?return=` through `SIGN_IN_HTML`, magic-link request, magic-link verify, GitHub OAuth start, GitHub OAuth callback |
+| Modify | `infra/oyster-publish/wrangler.toml` | New rate-limit binding `VIEWER_PASSWORD_LIMIT` |
+| Modify | `infra/oyster-publish/src/types.ts` | Add `VIEWER_COOKIE_SECRET: string` and `VIEWER_PASSWORD_LIMIT: RateLimit` to `Env` |
+| Modify | `infra/oyster-publish/package.json` | Add `markdown-it@^14` + `@types/markdown-it` |
+| Modify | `infra/oyster-publish/README.md` | Document `VIEWER_COOKIE_SECRET` setup, mermaid SRI rotation procedure |
+| Create | `infra/oyster-publish/src/viewer-cookie.ts` | HMAC-SHA256 sign + verify of `oyster_view_<token>` cookie |
+| Create | `infra/oyster-publish/src/viewer-pages.ts` | Minimal-no-chrome HTML templates: 404, 410, password gate, internal error, rate-limited |
+| Create | `infra/oyster-publish/src/viewer-chrome.ts` | Chrome wrapper template (header + body + footer) for success states |
+| Create | `infra/oyster-publish/src/viewer-render.ts` | Per-kind/content-type render dispatch: markdown, mermaid, image inline, iframe-with-raw |
+| Create | `infra/oyster-publish/src/viewer-access.ts` | `resolveViewerAccess()` — looks up D1 row, gone-check, mode dispatch (cookie verify / session lookup / 302 to auth) |
+| Modify | `infra/oyster-publish/src/worker.ts` | Replace 501 stub with `GET /p/:token`, `POST /p/:token`, `GET /p/:token/raw` handlers |
+| Modify | `infra/oyster-publish/src/publish-helpers.ts` | Add `parseShareTokenPath()` (route parsing) — keeps it pure-testable |
+| Modify | `infra/oyster-publish/test/fixtures/seed.ts` | Add `seedRetiredPublication()` and `putR2Object()` helpers |
+| Create | `infra/oyster-publish/test/viewer-cookie.test.ts` | HMAC sign/verify round-trip; expired / tampered / wrong-token rejection |
+| Create | `infra/oyster-publish/test/viewer-render.test.ts` | Markdown safety (validateLink defaults), mermaid HTML structure, image inline headers |
+| Create | `infra/oyster-publish/test/viewer-handler.test.ts` | Full integration via `worker.fetch`: 404, 410, three modes happy/sad, ETag, iframe HTML |
+| Modify | `CHANGELOG.md` | One bullet under `[Unreleased] / Added` |
+
+**Decisions encoded in the structure:**
+
+- **Five small viewer modules instead of one big `viewer.ts`.** Each has a single responsibility (cookie, pages, chrome, render, access) so unit tests stay focused and the integration test file doesn't have to mock five things.
+- **Handlers stay in `worker.ts`.** Same precedent as the existing publish handlers — `worker.ts` is the router + thin orchestration, every meaningful unit lives in a sibling module.
+- **`viewer-access.ts` and `viewer-render.ts` are split because their tests are different shapes.** Access is "given a request + D1 state, return what the handler should do" (lots of mode/cookie permutations). Render is "given a row + bytes, return a Response" (lots of content-type/kind permutations). Same module would force every test to set up both halves.
+- **Auth-worker test coverage is unit-only on the new helper.** Matches the existing precedent (`oauth-helpers.test.ts` is the only auth-worker test file). Full handler integration testing for auth-worker is out-of-scope; we lean on the existing manual sign-in smoke + the new viewer integration tests that exercise the redirect path implicitly.
+
+---
+
+## Phase 1 — Auth-worker `?return=` plumbing
+
+End state: `auth-worker` honours `?return=<allowlisted-path>` on `/auth/sign-in`, magic-link verify, and GitHub OAuth callback. Rejected paths are silently dropped. Migration applied locally + remote. New helper unit-tested.
+
+### Task 1.1: D1 migration `0004_return_path.sql`
+
+**Files:**
+- Create: `infra/auth-worker/migrations/0004_return_path.sql`
+- Modify: `infra/auth-worker/package.json`
+
+- [ ] **Step 1: Write the migration.**
+
+Create `infra/auth-worker/migrations/0004_return_path.sql`:
+
+```sql
+-- 0004_return_path.sql — generic post-sign-in redirect for #316.
+-- Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md
+-- Both columns are nullable; existing rows get NULL, current handlers
+-- ignore the column. Wrapped in idempotent ALTERs so re-running the
+-- migration on a partially-applied DB doesn't fail.
+
+ALTER TABLE magic_link_tokens ADD COLUMN return_path TEXT;
+ALTER TABLE oauth_states     ADD COLUMN return_path TEXT;
+```
+
+- [ ] **Step 2: Add migrate scripts to `infra/auth-worker/package.json`.**
+
+Add inside `"scripts"` (alongside the existing `db:migrate:0003` pair):
+
+```json
+"db:migrate:0004": "wrangler d1 execute oyster-auth --file=migrations/0004_return_path.sql --remote",
+"db:migrate:0004:local": "wrangler d1 execute oyster-auth --file=migrations/0004_return_path.sql --local",
+```
+
+- [ ] **Step 3: Apply locally and verify.**
+
+```bash
+cd infra/auth-worker
+npm run db:migrate:0004:local
+wrangler d1 execute oyster-auth --local --command "SELECT name FROM pragma_table_info('magic_link_tokens') WHERE name='return_path';"
+wrangler d1 execute oyster-auth --local --command "SELECT name FROM pragma_table_info('oauth_states') WHERE name='return_path';"
+```
+
+Expected: each `SELECT` returns one row with `name='return_path'`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/migrations/0004_return_path.sql infra/auth-worker/package.json
+git commit -m "feat(auth-worker): D1 migration 0004 — return_path on magic_link_tokens + oauth_states (#316)"
+```
+
+---
+
+### Task 1.2: Apply migration to remote D1
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Run remote migration.**
+
+```bash
+cd infra/auth-worker
+npm run db:migrate:0004
+```
+
+Expected: `Executed 2 commands` (or similar) with no error.
+
+- [ ] **Step 2: Verify remote schema.**
+
+```bash
+wrangler d1 execute oyster-auth --remote --command "SELECT name FROM pragma_table_info('magic_link_tokens') WHERE name='return_path';"
+wrangler d1 execute oyster-auth --remote --command "SELECT name FROM pragma_table_info('oauth_states') WHERE name='return_path';"
+```
+
+Expected: each returns one row.
+
+(No commit — remote DB op.)
+
+---
+
+### Task 1.3: Allowlist helper `return-path.ts` + tests
+
+**Files:**
+- Create: `infra/auth-worker/src/return-path.ts`
+- Create: `infra/auth-worker/test/return-path.test.ts`
+
+- [ ] **Step 1: Write the failing tests.**
+
+Create `infra/auth-worker/test/return-path.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { validateReturnPath } from "../src/return-path";
+
+describe("validateReturnPath — accepts share-viewer paths", () => {
+  it("accepts /p/<token> with alphanumerics", () => {
+    expect(validateReturnPath("/p/abc123")).toBe("/p/abc123");
+  });
+
+  it("accepts /p/<token> with - and _ in the token", () => {
+    expect(validateReturnPath("/p/AaBb_-_-9")).toBe("/p/AaBb_-_-9");
+  });
+});
+
+describe("validateReturnPath — rejects everything else", () => {
+  it("returns null for null/undefined/empty", () => {
+    expect(validateReturnPath(null)).toBeNull();
+    expect(validateReturnPath(undefined)).toBeNull();
+    expect(validateReturnPath("")).toBeNull();
+  });
+
+  it("rejects /p/ with no token", () => {
+    expect(validateReturnPath("/p/")).toBeNull();
+  });
+
+  it("rejects /p/<token>/raw — viewer chrome only, never the iframe endpoint", () => {
+    expect(validateReturnPath("/p/abc123/raw")).toBeNull();
+  });
+
+  it("rejects /p/<token> with a query string", () => {
+    expect(validateReturnPath("/p/abc?x=1")).toBeNull();
+  });
+
+  it("rejects /p/<token> with a fragment", () => {
+    expect(validateReturnPath("/p/abc#h")).toBeNull();
+  });
+
+  it("rejects path traversal", () => {
+    expect(validateReturnPath("/p/../etc/passwd")).toBeNull();
+    expect(validateReturnPath("/p/abc/../../x")).toBeNull();
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(validateReturnPath("https://attacker.com/p/abc")).toBeNull();
+    expect(validateReturnPath("//attacker.com/p/abc")).toBeNull();
+    expect(validateReturnPath("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects unrelated paths", () => {
+    expect(validateReturnPath("/dashboard")).toBeNull();
+    expect(validateReturnPath("/auth/sign-in")).toBeNull();
+    expect(validateReturnPath("/")).toBeNull();
+  });
+
+  it("rejects overly long inputs (defence against slow regex)", () => {
+    const long = "/p/" + "a".repeat(2048);
+    expect(validateReturnPath(long)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail.**
+
+```bash
+cd infra/auth-worker
+npm test -- return-path
+```
+
+Expected: ALL tests fail with "Cannot find module" or "validateReturnPath is not a function".
+
+- [ ] **Step 3: Implement `return-path.ts`.**
+
+Create `infra/auth-worker/src/return-path.ts`:
+
+```ts
+// Generic post-sign-in redirect target validation for #316.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Auth-worker change).
+//
+// The allowlist matches the share-viewer route AND ONLY that route.
+// We reject /p/<token>/raw because that's the iframe-content endpoint —
+// landing a user there would strand them with no navigation.
+
+const SHARE_VIEWER_PATH = /^\/p\/[A-Za-z0-9_-]+$/;
+const MAX_PATH_LEN = 256;  // share_token is 32 chars; this is generous.
+
+export function validateReturnPath(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") return null;
+  if (raw.length === 0 || raw.length > MAX_PATH_LEN) return null;
+  if (!SHARE_VIEWER_PATH.test(raw)) return null;
+  return raw;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass.**
+
+```bash
+cd infra/auth-worker
+npm test -- return-path
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/auth-worker/src/return-path.ts infra/auth-worker/test/return-path.test.ts
+git commit -m "feat(auth-worker): validateReturnPath allowlist for sign-in return (#316)"
+```
+
+---
+
+### Task 1.4: Wire `?return=` into `SIGN_IN_HTML`
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+The sign-in HTML form currently embeds only the `userCode` from `?d=`. We add a hidden input for `return` that the magic-link `POST /auth/magic-link` reads and forwards to D1.
+
+- [ ] **Step 1: Add `return` to the `SIGN_IN_HTML` template signature.**
+
+Find the `SIGN_IN_HTML` function (around line 160). Change its signature and inject the hidden input:
+
+```ts
+const SIGN_IN_HTML = (userCode: string | null, returnPath: string | null) => {
+  const githubHref = userCode
+    ? `/auth/github/start?d=${encodeURIComponent(userCode)}`
+    : returnPath
+      ? `/auth/github/start?return=${encodeURIComponent(returnPath)}`
+      : "/auth/github/start";
+  // ... existing CSS + opening HTML unchanged ...
+```
+
+In the `<form id="f">` block, after `<input id="email" ...>`, add the hidden return input:
+
+```html
+<input type="hidden" id="return_path" name="return_path" value="${returnPath ? returnPath.replace(/[<>"]/g, "") : ""}">
+```
+
+In the inline `<script>` block, find the `body: JSON.stringify({ email, user_code: userCode })` line and change it to:
+
+```js
+const returnPath = document.getElementById('return_path').value || null;
+// ...
+body: JSON.stringify({ email, user_code: userCode, return_path: returnPath }),
+```
+
+- [ ] **Step 2: Update the call site of `SIGN_IN_HTML` in `handleSignIn`.**
+
+Find `handleSignIn` (search for `SIGN_IN_HTML(userCode`). Change:
+
+```ts
+const userCode = url.searchParams.get("d");
+return htmlResponse(SIGN_IN_HTML(userCode), 200, NO_STORE);
+```
+
+To:
+
+```ts
+import { validateReturnPath } from "./return-path";
+// ... at top of file ...
+
+// inside handleSignIn:
+const userCode = url.searchParams.get("d");
+// Mutual exclusion: if ?d= is present, it wins (device flow is its own
+// destination); ?return= is dropped.
+const returnPath = userCode ? null : validateReturnPath(url.searchParams.get("return"));
+return htmlResponse(SIGN_IN_HTML(userCode, returnPath), 200, NO_STORE);
+```
+
+- [ ] **Step 3: Manual verification (no automated test for HTML output).**
+
+```bash
+cd infra/auth-worker
+npm run typecheck
+npm test
+```
+
+Expected: typecheck passes, all existing tests still pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): hidden return_path input on sign-in form (#316)"
+```
+
+---
+
+### Task 1.5: Wire `return_path` into magic-link request handler
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+`handleMagicLink` (around line 331) reads `payload.email` and `payload.user_code` from the JSON body. We add `return_path`, validate it, and persist it on the inserted `magic_link_tokens` row.
+
+- [ ] **Step 1: Update the payload type and parsing.**
+
+In `handleMagicLink`, change the type:
+
+```ts
+let payload: { email?: unknown; user_code?: unknown; return_path?: unknown };
+```
+
+After the `userCode` resolution (around line 351), add:
+
+```ts
+// Mutual exclusion: device flow's destination is the device. Return path
+// only carries through when there is no user_code.
+const returnPath = userCode
+  ? null
+  : (typeof payload.return_path === "string" ? validateReturnPath(payload.return_path) : null);
+```
+
+- [ ] **Step 2: Update the INSERT.**
+
+Find the INSERT (around line 391):
+
+```ts
+.prepare("INSERT INTO magic_link_tokens (token_hash, user_id, device_code, expires_at) VALUES (?, ?, ?, ?)")
+.bind(tokenHash, user.id, deviceCode, expiresAt)
+```
+
+Change to:
+
+```ts
+.prepare("INSERT INTO magic_link_tokens (token_hash, user_id, device_code, expires_at, return_path) VALUES (?, ?, ?, ?, ?)")
+.bind(tokenHash, user.id, deviceCode, expiresAt, returnPath)
+```
+
+- [ ] **Step 3: Verify build.**
+
+```bash
+cd infra/auth-worker
+npm run typecheck
+npm test
+```
+
+Expected: typecheck passes, existing tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): persist return_path on magic-link insert (#316)"
+```
+
+---
+
+### Task 1.6: Wire `return_path` into magic-link verify (302 to allowlisted path)
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+`handleVerify` (around line 412) consumes the magic-link token, creates a session, and redirects to `/auth/welcome`. We extend the RETURNING to read `return_path`, then 302 to it instead of `/auth/welcome` when present.
+
+- [ ] **Step 1: Extend the consume RETURNING.**
+
+Find the `UPDATE magic_link_tokens ... RETURNING user_id, device_code` (around line 430). Change to:
+
+```ts
+const consumed = await env.DB
+  .prepare(
+    `UPDATE magic_link_tokens
+       SET consumed_at = ?
+     WHERE token_hash = ? AND consumed_at IS NULL AND expires_at > ?
+     RETURNING user_id, device_code, return_path`
+  )
+  .bind(now, tokenHash, now)
+  .first<{ user_id: string; device_code: string | null; return_path: string | null }>();
+```
+
+- [ ] **Step 2: Re-validate the return path before honouring it.**
+
+Defence in depth: if `return_path` was somehow modified at rest (e.g. a future migration broke the column), we re-run the allowlist before issuing the 302.
+
+After the `if (consumed.device_code) { ... }` device-flow branch but before the final `return new Response(null, { status: 302, headers: { location: "/auth/welcome", ... } })`, add:
+
+```ts
+const safeReturn = validateReturnPath(consumed.return_path);
+const location = safeReturn ?? "/auth/welcome";
+```
+
+Then change the existing return to:
+
+```ts
+return new Response(null, {
+  status: 302,
+  headers: {
+    location,
+    "set-cookie": cookie,
+    ...NO_STORE,
+  },
+});
+```
+
+- [ ] **Step 3: Verify build.**
+
+```bash
+cd infra/auth-worker
+npm run typecheck
+npm test
+```
+
+Expected: typecheck passes, existing tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): magic-link verify honours return_path (#316)"
+```
+
+---
+
+### Task 1.7: Wire `?return=` into GitHub OAuth start
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+`handleGithubStart` (around line 665) inserts an `oauth_states` row before redirecting to GitHub. We extend the row with `return_path` (validated and mutually-exclusive with `?d=`).
+
+- [ ] **Step 1: Validate `?return=` in `handleGithubStart`.**
+
+Just after the `userCode` resolution (around line 682), add:
+
+```ts
+const returnPath = userCode ? null : validateReturnPath(url.searchParams.get("return"));
+```
+
+- [ ] **Step 2: Extend the INSERT.**
+
+Find the existing INSERT (around line 706):
+
+```ts
+.prepare(
+  "INSERT INTO oauth_states (state, provider, pkce_verifier, user_code, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)",
+)
+.bind(state, "github", verifier, userCode, now, now + OAUTH_STATE_TTL_MS)
+```
+
+Change to:
+
+```ts
+.prepare(
+  "INSERT INTO oauth_states (state, provider, pkce_verifier, user_code, created_at, expires_at, return_path) VALUES (?, ?, ?, ?, ?, ?, ?)",
+)
+.bind(state, "github", verifier, userCode, now, now + OAUTH_STATE_TTL_MS, returnPath)
+```
+
+- [ ] **Step 3: Verify build.**
+
+```bash
+cd infra/auth-worker
+npm run typecheck
+npm test
+```
+
+Expected: typecheck passes, existing tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): persist return_path on oauth_states insert (#316)"
+```
+
+---
+
+### Task 1.8: Wire `return_path` into GitHub OAuth callback (302 to allowlisted path)
+
+**Files:**
+- Modify: `infra/auth-worker/src/worker.ts`
+
+`handleGithubCallback` (around line 906) reads the `oauth_states` row by `state`, completes the OAuth round-trip, creates a session, and redirects. We extend the SELECT to include `return_path`, re-validate it, and 302 to it when present (else current `/auth/welcome` default).
+
+- [ ] **Step 1: Locate the `oauth_states` SELECT.**
+
+Search inside `handleGithubCallback` for `FROM oauth_states WHERE state = ?` (it's the row that yields `pkce_verifier`, `user_code`, etc). Add `return_path` to the SELECT and to the row's typed shape.
+
+Example (the exact column list will be slightly different in your local file — read first, then edit):
+
+Before:
+
+```ts
+.prepare("SELECT pkce_verifier, user_code, expires_at FROM oauth_states WHERE state = ?")
+```
+
+After:
+
+```ts
+.prepare("SELECT pkce_verifier, user_code, expires_at, return_path FROM oauth_states WHERE state = ?")
+```
+
+Update the destructuring + typed `.first<{...}>()` call to include `return_path: string | null`.
+
+- [ ] **Step 2: Branch the final redirect on `stateRow.return_path`.**
+
+Find the final 302 in `handleGithubCallback` (the browser-only branch — the device-code branch returns the WELCOME_HTML directly and is left alone). It currently looks like:
+
+```ts
+return new Response(null, {
+  status: 302,
+  headers: {
+    location: "/auth/welcome",
+    "set-cookie": cookie,
+    ...NO_STORE,
+  },
+});
+```
+
+Replace with:
+
+```ts
+const safeReturn = validateReturnPath(stateRow.return_path);
+return new Response(null, {
+  status: 302,
+  headers: {
+    location: safeReturn ?? "/auth/welcome",
+    "set-cookie": cookie,
+    ...NO_STORE,
+  },
+});
+```
+
+- [ ] **Step 3: Verify build.**
+
+```bash
+cd infra/auth-worker
+npm run typecheck
+npm test
+```
+
+Expected: typecheck passes, all existing tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/auth-worker/src/worker.ts
+git commit -m "feat(auth-worker): GitHub callback honours return_path (#316)"
+```
+
+---
+
+## Phase 2 — Oyster-publish bindings + dependency
+
+End state: `oyster-publish` Worker has a new `VIEWER_PASSWORD_LIMIT` rate-limit binding and a new `VIEWER_COOKIE_SECRET` secret declared in code; `markdown-it` is a runtime dependency. No behaviour change yet — these are scaffolding for the viewer.
+
+### Task 2.1: Declare `VIEWER_PASSWORD_LIMIT` rate-limit binding
+
+**Files:**
+- Modify: `infra/oyster-publish/wrangler.toml`
+
+- [ ] **Step 1: Add the `[[unsafe.bindings]]` block.**
+
+Append to `infra/oyster-publish/wrangler.toml`:
+
+```toml
+# Rate limiter for password-gate POST attempts. Key = `${ip}:${share_token}`
+# so one IP cannot exhaust attempts across all of a publisher's shares.
+# Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md
+[[unsafe.bindings]]
+name = "VIEWER_PASSWORD_LIMIT"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 10, period = 60 }
+```
+
+(The `namespace_id` is a Worker-internal identifier for this rate limiter — `"1001"` is arbitrary, just unique per Worker. Cloudflare's rate-limiter API uses it to scope bookkeeping.)
+
+- [ ] **Step 2: Verify wrangler accepts the config.**
+
+```bash
+cd infra/oyster-publish
+npx wrangler deploy --dry-run --outdir /tmp/wrangler-dryrun
+```
+
+Expected: no errors; `/tmp/wrangler-dryrun/worker.js` is emitted.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/wrangler.toml
+git commit -m "feat(oyster-publish): VIEWER_PASSWORD_LIMIT rate-limit binding (#316)"
+```
+
+---
+
+### Task 2.2: Add `VIEWER_COOKIE_SECRET` and `VIEWER_PASSWORD_LIMIT` to `Env`
+
+**Files:**
+- Modify: `infra/oyster-publish/src/types.ts`
+
+- [ ] **Step 1: Extend the `Env` interface.**
+
+Replace the `Env` interface in `src/types.ts` with:
+
+```ts
+export interface Env {
+  DB: D1Database;          // shared with oyster-auth (same database_id)
+  ARTIFACTS: R2Bucket;     // oyster-artifacts
+  VIEWER_COOKIE_SECRET: string;     // HMAC key for password-mode unlock cookies (#316)
+  VIEWER_PASSWORD_LIMIT: RateLimit; // wrong-password gate (#316)
+}
+
+// `RateLimit` is a Workers binding — typed inline since it's not in
+// @cloudflare/workers-types yet. The runtime shape is:
+//   limit({ key: string }) → Promise<{ success: boolean }>
+interface RateLimit {
+  limit(opts: { key: string }): Promise<{ success: boolean }>;
+}
+```
+
+- [ ] **Step 2: Verify typecheck.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: no errors. (The handlers don't use the new fields yet, but the binding types must compile.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/src/types.ts
+git commit -m "feat(oyster-publish): VIEWER_COOKIE_SECRET + VIEWER_PASSWORD_LIMIT in Env (#316)"
+```
+
+---
+
+### Task 2.3: Add `markdown-it` dependency
+
+**Files:**
+- Modify: `infra/oyster-publish/package.json`
+
+- [ ] **Step 1: Add the dependency.**
+
+Add to `dependencies` (create the section if it doesn't exist):
+
+```json
+"dependencies": {
+  "markdown-it": "^14.1.0"
+},
+"devDependencies": {
+  "@types/markdown-it": "^14.1.0"
+  // ... existing devDependencies ...
+}
+```
+
+- [ ] **Step 2: Install.**
+
+```bash
+cd infra/oyster-publish
+npm install
+```
+
+Expected: `markdown-it` and `@types/markdown-it` installed; lock file updated.
+
+- [ ] **Step 3: Verify it imports cleanly under Workers types.**
+
+Create a temporary test in `src/_smoketest.ts`:
+
+```ts
+import MarkdownIt from "markdown-it";
+const md = new MarkdownIt({ html: false, linkify: true, typographer: false });
+console.log(md.render("# hello"));
+```
+
+Run typecheck:
+
+```bash
+npm run typecheck
+```
+
+Expected: passes. Then delete the smoketest file:
+
+```bash
+rm src/_smoketest.ts
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/package.json infra/oyster-publish/package-lock.json
+git commit -m "feat(oyster-publish): add markdown-it dependency (#316)"
+```
+
+---
+
+## Phase 3 — Viewer cookie HMAC
+
+End state: pure module `viewer-cookie.ts` signs and verifies `oyster_view_<token>` cookies via Web Crypto HMAC-SHA256. Round-trip + tampered + expired + wrong-token cases covered by unit tests. No worker.ts wiring yet.
+
+### Task 3.1: Write failing tests
+
+**Files:**
+- Create: `infra/oyster-publish/test/viewer-cookie.test.ts`
+
+- [ ] **Step 1: Write the tests.**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { signViewerCookie, verifyViewerCookie } from "../src/viewer-cookie";
+
+const SECRET = "test-secret-do-not-use-in-prod";
+const TOKEN = "abc123_-XYZ";
+
+describe("signViewerCookie / verifyViewerCookie — round-trip", () => {
+  it("a freshly-signed cookie verifies", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const ok = await verifyViewerCookie(cookie, TOKEN, SECRET);
+    expect(ok).toBe(true);
+  });
+
+  it("the cookie format is `<token>.<timestamp>.<hmac>`", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const parts = cookie.split(".");
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toBe(TOKEN);
+    expect(parts[1]).toMatch(/^\d+$/);
+    expect(parts[2]).toMatch(/^[A-Za-z0-9_-]+$/); // base64url, no padding
+  });
+});
+
+describe("verifyViewerCookie — rejection", () => {
+  it("rejects malformed cookie", async () => {
+    expect(await verifyViewerCookie("garbage", TOKEN, SECRET)).toBe(false);
+    expect(await verifyViewerCookie("a.b", TOKEN, SECRET)).toBe(false);
+    expect(await verifyViewerCookie("a.b.c.d", TOKEN, SECRET)).toBe(false);
+  });
+
+  it("rejects when the embedded token doesn't match expected", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    expect(await verifyViewerCookie(cookie, "different_token", SECRET)).toBe(false);
+  });
+
+  it("rejects when the HMAC has been tampered with", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const tampered = cookie.slice(0, -1) + (cookie.slice(-1) === "A" ? "B" : "A");
+    expect(await verifyViewerCookie(tampered, TOKEN, SECRET)).toBe(false);
+  });
+
+  it("rejects when the timestamp has been tampered with", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const [token, , hmac] = cookie.split(".");
+    const forged = `${token}.0.${hmac}`;
+    expect(await verifyViewerCookie(forged, TOKEN, SECRET)).toBe(false);
+  });
+
+  it("rejects when verified with a different secret", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    expect(await verifyViewerCookie(cookie, TOKEN, "other-secret")).toBe(false);
+  });
+
+  it("rejects cookies older than 24h (TTL = 86400 seconds)", async () => {
+    // Hand-craft an old cookie by signing with a forged timestamp.
+    // We use the internal sign function exposed via signViewerCookieAt for tests.
+    const { signViewerCookieAt } = await import("../src/viewer-cookie");
+    const oldTs = Math.floor(Date.now() / 1000) - 86401;
+    const cookie = await signViewerCookieAt(TOKEN, SECRET, oldTs);
+    expect(await verifyViewerCookie(cookie, TOKEN, SECRET)).toBe(false);
+  });
+
+  it("accepts cookies just under the TTL boundary", async () => {
+    const { signViewerCookieAt } = await import("../src/viewer-cookie");
+    const recentTs = Math.floor(Date.now() / 1000) - 86399;
+    const cookie = await signViewerCookieAt(TOKEN, SECRET, recentTs);
+    expect(await verifyViewerCookie(cookie, TOKEN, SECRET)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Verify tests fail.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-cookie
+```
+
+Expected: all tests fail with "Cannot find module '../src/viewer-cookie'".
+
+---
+
+### Task 3.2: Implement `viewer-cookie.ts`
+
+**Files:**
+- Create: `infra/oyster-publish/src/viewer-cookie.ts`
+
+- [ ] **Step 1: Write the module.**
+
+```ts
+// HMAC-SHA256 signed cookie for password-mode unlock.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Cookie scheme).
+// Format: <token>.<unix_seconds>.<hmac_b64url>
+//   - token is the share_token (asserted on verify; the cookie path also scopes it)
+//   - hmac is over `${token}.${unix_seconds}` keyed by VIEWER_COOKIE_SECRET
+//   - TTL is 24h (86400s); rejected if older.
+
+const TTL_SECONDS = 86400;
+
+export async function signViewerCookie(shareToken: string, secret: string): Promise<string> {
+  return signViewerCookieAt(shareToken, secret, Math.floor(Date.now() / 1000));
+}
+
+export async function signViewerCookieAt(
+  shareToken: string,
+  secret: string,
+  unixSeconds: number,
+): Promise<string> {
+  const hmac = await hmacSha256B64url(`${shareToken}.${unixSeconds}`, secret);
+  return `${shareToken}.${unixSeconds}.${hmac}`;
+}
+
+export async function verifyViewerCookie(
+  cookie: string,
+  expectedToken: string,
+  secret: string,
+): Promise<boolean> {
+  if (typeof cookie !== "string" || cookie.length === 0) return false;
+  const parts = cookie.split(".");
+  if (parts.length !== 3) return false;
+  const [token, tsRaw, hmacGot] = parts;
+  if (token !== expectedToken) return false;
+  if (!/^\d+$/.test(tsRaw)) return false;
+  const ts = Number(tsRaw);
+  if (!Number.isSafeInteger(ts)) return false;
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (nowSec - ts > TTL_SECONDS) return false;
+  const hmacWant = await hmacSha256B64url(`${token}.${ts}`, secret);
+  // Constant-time compare.
+  return constantTimeEqual(hmacGot, hmacWant);
+}
+
+async function hmacSha256B64url(message: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(message));
+  return base64urlEncode(new Uint8Array(sig));
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-cookie
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-cookie.ts infra/oyster-publish/test/viewer-cookie.test.ts
+git commit -m "feat(oyster-publish): viewer-cookie HMAC sign/verify (#316)"
+```
+
+---
+
+## Phase 4 — Page templates (chrome + minimal)
+
+End state: pure HTML template modules. `viewer-pages.ts` exports the minimal-no-chrome templates (404, 410, password gate, error, rate-limited). `viewer-chrome.ts` exports the chrome wrapper used by success-state renders. No tests for these (the integration tests cover them by asserting on response bodies).
+
+### Task 4.1: Implement `viewer-pages.ts`
+
+**Files:**
+- Create: `infra/oyster-publish/src/viewer-pages.ts`
+
+- [ ] **Step 1: Write the module.**
+
+```ts
+// Minimal, chrome-less pages for intermediary states.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Minimal pages).
+// Each function returns an HTML string. Wrap in basePage() for consistency.
+
+export interface PageOpts {
+  // If true, the response also gets an `Accept: application/json` JSON body
+  // variant with the same { error, message } shape — set by the caller.
+  jsonError?: { code: string; message: string };
+}
+
+export function passwordGatePage(shareToken: string, opts?: { error?: "wrong_password" }): string {
+  const errorBlock = opts?.error === "wrong_password"
+    ? `<p class="err">Incorrect password.</p>`
+    : "";
+  return basePage("Password required", `
+    <div class="icon">🔒</div>
+    <h1>Password required</h1>
+    <p class="hint">This share is password-protected.</p>
+    ${errorBlock}
+    <form method="POST" action="/p/${escapeHtml(shareToken)}">
+      <input type="password" name="password" placeholder="Password" autofocus required>
+      <button type="submit">Unlock</button>
+    </form>
+  `);
+}
+
+export function gonePage(): string {
+  return basePage("Share removed", `
+    <div class="icon">🚫</div>
+    <h1>This share has been removed</h1>
+    <p class="hint">The owner has unpublished this artefact.</p>
+  `);
+}
+
+export function notFoundPage(): string {
+  return basePage("Not found", `
+    <div class="icon">❓</div>
+    <h1>Share not found</h1>
+    <p class="hint">The link may have been mistyped or removed.</p>
+  `);
+}
+
+export function internalErrorPage(): string {
+  return basePage("Error", `
+    <div class="icon">⚠️</div>
+    <h1>Something went wrong</h1>
+    <p class="hint">Try again in a moment.</p>
+  `);
+}
+
+export function rateLimitedPage(): string {
+  return basePage("Too many attempts", `
+    <div class="icon">⏱️</div>
+    <h1>Too many attempts</h1>
+    <p class="hint">Wait a minute and try again.</p>
+  `);
+}
+
+function basePage(title: string, bodyHtml: string): string {
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --muted: #666; --bd: #d4d4d8; --bg: #fff; }
+  @media (prefers-color-scheme: dark) { :root { --fg: #f4f4f5; --muted: #a1a1aa; --bd: #3f3f46; --bg: #18181b; } }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 24rem; margin: 6rem auto; padding: 0 1.5rem; line-height: 1.5; color: var(--fg); background: var(--bg); text-align: center; }
+  .icon { font-size: 1.6rem; margin-bottom: 0.6rem; opacity: 0.9; }
+  h1 { font-size: 1.2rem; margin: 0 0 0.5rem; font-weight: 600; }
+  .hint { font-size: 0.95rem; color: var(--muted); margin: 0 0 1.5rem; }
+  .err { font-size: 0.85rem; color: #c62828; margin: 0 0 0.75rem; }
+  form { display: flex; flex-direction: column; gap: 0.6rem; max-width: 14rem; margin: 0 auto; }
+  input[type=password] { padding: 0.55rem 0.7rem; font-size: 0.95rem; border: 1px solid var(--bd); border-radius: 0.35rem; background: transparent; color: inherit; text-align: center; }
+  button { padding: 0.55rem 0.7rem; font-size: 0.95rem; font-weight: 500; border: 0; border-radius: 0.35rem; background: var(--fg); color: var(--bg); cursor: pointer; }
+  .tag { font-size: 0.7rem; color: var(--muted); margin-top: 4rem; opacity: 0.6; }
+</style>
+</head><body>
+${bodyHtml}
+<p class="tag">Shared via Oyster</p>
+</body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}
+```
+
+- [ ] **Step 2: Verify build.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-pages.ts
+git commit -m "feat(oyster-publish): minimal page templates for viewer (#316)"
+```
+
+---
+
+### Task 4.2: Implement `viewer-chrome.ts`
+
+**Files:**
+- Create: `infra/oyster-publish/src/viewer-chrome.ts`
+
+- [ ] **Step 1: Write the module.**
+
+```ts
+// Chrome wrapper for successful published views.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Chrome).
+// Header (logo + mode-aware action slot) + body slot + footer. Used for:
+//   - open viewer (action: "Get your own at oyster.to")
+//   - password viewer post-unlock (action: same)
+//   - signin viewer post-auth (action: empty in v1)
+//
+// `bodyHtml` is the rendered content (markdown HTML, mermaid HTML, or
+// the iframe element). `bodyExtraStyle` is optional — used by the iframe
+// path to remove default body padding.
+
+export interface ChromeOpts {
+  title: string;
+  bodyHtml: string;
+  cssExtra?: string;        // e.g. iframe sizing override
+  showActionSlot?: boolean; // default true; password viewer + open viewer get true; signin viewer gets false
+}
+
+export function renderChromePage(opts: ChromeOpts): string {
+  const action = opts.showActionSlot === false
+    ? ""
+    : `<a class="cta" href="https://oyster.to" target="_blank" rel="noopener">Get your own at oyster.to</a>`;
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(opts.title)}</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --muted: #666; --bd: #e4e4e7; --bg: #fff; --chrome-bg: #fafafa; }
+  @media (prefers-color-scheme: dark) { :root { --fg: #f4f4f5; --muted: #a1a1aa; --bd: #27272a; --bg: #18181b; --chrome-bg: #0c0a09; } }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: var(--fg); background: var(--bg); display: flex; flex-direction: column; min-height: 100vh; line-height: 1.55; }
+  header { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 1rem; background: var(--chrome-bg); border-bottom: 1px solid var(--bd); font-size: 0.85rem; height: 36px; flex-shrink: 0; }
+  header .logo { font-weight: 600; }
+  header .cta { color: var(--muted); text-decoration: none; }
+  header .cta:hover { color: var(--fg); }
+  main { flex: 1; padding: 1.5rem; max-width: 48rem; width: 100%; margin: 0 auto; }
+  footer { background: var(--chrome-bg); border-top: 1px solid var(--bd); font-size: 0.7rem; color: var(--muted); padding: 0.4rem 1rem; text-align: center; height: 24px; flex-shrink: 0; }
+  ${opts.cssExtra ?? ""}
+</style>
+</head><body>
+<header><span class="logo">🦪 oyster</span>${action}</header>
+<main>${opts.bodyHtml}</main>
+<footer>Powered by Oyster · oyster.to</footer>
+</body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}
+```
+
+- [ ] **Step 2: Verify build.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-chrome.ts
+git commit -m "feat(oyster-publish): chrome wrapper template for viewer (#316)"
+```
+
+---
+
+## Phase 5 — Render dispatch
+
+End state: `viewer-render.ts` exposes one function per render path (markdown, mermaid, iframe-with-raw, image inline). Each returns a `Response` (status, headers, body all set). Markdown safety is unit-tested (the validateLink defaults block `javascript:`). The main `worker.ts` calls into these.
+
+### Task 5.1: Markdown renderer + safety tests
+
+**Files:**
+- Create: `infra/oyster-publish/src/viewer-render.ts` (start with markdown only — extend in subsequent tasks)
+- Create: `infra/oyster-publish/test/viewer-render.test.ts`
+
+- [ ] **Step 1: Write failing tests.**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { renderMarkdownPage } from "../src/viewer-render";
+
+const ROW = {
+  share_token: "abc",
+  artifact_kind: "notes",
+  content_type: "text/markdown",
+  // Other fields not used by markdown render
+} as any;
+
+describe("renderMarkdownPage — basic rendering", () => {
+  it("returns a 200 HTML response with the title in <title>", async () => {
+    const res = renderMarkdownPage(new TextEncoder().encode("# Hello"), ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    const body = await res.text();
+    expect(body).toContain("<h1>Hello</h1>");
+  });
+
+  it("renders a list with linkified URLs", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("- See https://example.com"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).toContain('href="https://example.com"');
+  });
+});
+
+describe("renderMarkdownPage — link safety (markdown-it default validateLink)", () => {
+  it("does NOT render javascript: as an active href", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("[click me](javascript:alert(1))"),
+      ROW,
+    );
+    const body = await res.text();
+    // markdown-it default behaviour is to drop the href entirely,
+    // leaving the link text but not making it active.
+    expect(body).not.toContain('href="javascript:');
+    expect(body).not.toContain("href='javascript:");
+  });
+
+  it("does NOT render vbscript: as an active href", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("[x](vbscript:msgbox(1))"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).not.toContain('href="vbscript:');
+  });
+
+  it("does NOT render file: as an active href", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("[x](file:///etc/passwd)"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).not.toContain('href="file://');
+  });
+
+  it("escapes raw <script> in markdown (html: false)", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("<script>alert(1)</script>"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).not.toContain("<script>alert(1)</script>");
+    expect(body).toContain("&lt;script&gt;");
+  });
+});
+
+describe("renderMarkdownPage — cache headers", () => {
+  it("sets cache-control: public, max-age=60, must-revalidate for open mode", async () => {
+    const openRow = { ...ROW, mode: "open", updated_at: 1000 };
+    const res = renderMarkdownPage(new TextEncoder().encode("# x"), openRow);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(res.headers.get("etag")).toMatch(/^W\/"abc-1000"$/);
+  });
+
+  it("sets cache-control: private, no-store for non-open modes", async () => {
+    const pwRow = { ...ROW, mode: "password", updated_at: 1000 };
+    const res = renderMarkdownPage(new TextEncoder().encode("# x"), pwRow);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("etag")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Verify tests fail.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-render
+```
+
+Expected: all tests fail with "Cannot find module".
+
+- [ ] **Step 3: Implement `viewer-render.ts` (markdown only for now).**
+
+```ts
+// Per-kind/content-type render dispatch for the public viewer.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Render dispatch).
+//
+// Each render function returns a Response with status + headers + body set.
+// Per-mode cache headers are applied here; ETag is set only for open mode.
+
+import MarkdownIt from "markdown-it";
+import { renderChromePage } from "./viewer-chrome";
+import type { PublicationRow } from "./types";
+
+const md = new MarkdownIt({
+  html: false,        // raw HTML in markdown is escaped (XSS defence)
+  linkify: true,      // bare URLs become links (validateLink still applied)
+  typographer: false,
+});
+
+// ─── Markdown ──────────────────────────────────────────────────────────────
+
+export function renderMarkdownPage(bytes: Uint8Array, row: PublicationRow): Response {
+  const source = new TextDecoder().decode(bytes);
+  const html = md.render(source);
+  // Title: first H1 if present, else fallback.
+  const titleMatch = html.match(/<h1[^>]*>([^<]+)<\/h1>/);
+  const title = titleMatch ? stripTags(titleMatch[1]) : "Shared via Oyster";
+  const page = renderChromePage({ title, bodyHtml: html });
+
+  return new Response(page, {
+    status: 200,
+    headers: cacheHeaders(row, "text/html; charset=utf-8"),
+  });
+}
+
+// ─── Cache headers ─────────────────────────────────────────────────────────
+
+export function cacheHeaders(row: PublicationRow, contentType: string): HeadersInit {
+  const headers: Record<string, string> = { "content-type": contentType };
+  if (row.mode === "open") {
+    headers["cache-control"] = "public, max-age=60, must-revalidate";
+    headers["etag"] = `W/"${row.share_token}-${row.updated_at}"`;
+  } else {
+    headers["cache-control"] = "private, no-store";
+  }
+  // Block content-type sniffing across all responses.
+  headers["x-content-type-options"] = "nosniff";
+  return headers;
+}
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]*>/g, "");
+}
+```
+
+- [ ] **Step 4: Verify tests pass.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-render
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-render.ts infra/oyster-publish/test/viewer-render.test.ts
+git commit -m "feat(oyster-publish): markdown renderer + link-safety tests (#316)"
+```
+
+---
+
+### Task 5.2: Mermaid renderer
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-render.ts`
+- Modify: `infra/oyster-publish/test/viewer-render.test.ts`
+
+The mermaid HTML wrapper is straightforward; the SRI hash is computed once and pinned in source.
+
+- [ ] **Step 1: Compute the mermaid SRI hash.**
+
+```bash
+curl -sL https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js | openssl dgst -sha384 -binary | openssl base64 -A
+```
+
+Note the output (a base64 string ~64 chars). Example: `EXAMPLE_HASH_PASTE_HERE_FROM_OPENSSL`.
+
+If the curl fails (CDN unreachable), use the placeholder `sha384-PLACEHOLDER` and flag in the PR description for re-computation before merge.
+
+- [ ] **Step 2: Add the renderer + test.**
+
+In `test/viewer-render.test.ts`, append:
+
+```ts
+import { renderMermaidPage } from "../src/viewer-render";
+
+describe("renderMermaidPage", () => {
+  const SOURCE = "graph TD; A-->B;";
+  const ROW = { share_token: "mer1", mode: "open", updated_at: 2000, artifact_kind: "diagram", content_type: "text/plain" } as any;
+
+  it("returns a 200 HTML response", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+  });
+
+  it("embeds the source verbatim in <pre class=\"mermaid\">", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const body = await res.text();
+    expect(body).toContain(`<pre class="mermaid">${SOURCE}</pre>`);
+  });
+
+  it("loads pinned mermaid CDN with SRI", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const body = await res.text();
+    expect(body).toContain("https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js");
+    expect(body).toContain("integrity=\"sha384-");
+    expect(body).toContain('crossorigin="anonymous"');
+  });
+
+  it("includes a fallback that shows source on mermaid.run() failure", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const body = await res.text();
+    expect(body).toContain("mermaid.run");
+    expect(body).toContain(".catch");
+  });
+
+  it("sets a CSP that allows jsdelivr scripts", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const csp = res.headers.get("content-security-policy");
+    expect(csp).toMatch(/cdn\.jsdelivr\.net/);
+    expect(csp).toMatch(/script-src 'self' 'unsafe-inline' https:\/\/cdn\.jsdelivr\.net/);
+  });
+});
+```
+
+In `src/viewer-render.ts`, add:
+
+```ts
+const MERMAID_VERSION = "10.9.1";
+const MERMAID_SRI = "sha384-PLACEHOLDER";  // computed via openssl dgst -sha384 -binary; pinned with version
+const MERMAID_URL = `https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/dist/mermaid.min.js`;
+
+export function renderMermaidPage(bytes: Uint8Array, row: PublicationRow): Response {
+  const source = new TextDecoder().decode(bytes);
+  const escaped = escapeHtml(source);
+  const body = `
+<pre class="mermaid">${escaped}</pre>
+<script src="${MERMAID_URL}" integrity="${MERMAID_SRI}" crossorigin="anonymous"></script>
+<script>
+(function() {
+  if (typeof mermaid === 'undefined') {
+    showSourceFallback('mermaid CDN unavailable');
+    return;
+  }
+  try {
+    mermaid.initialize({ startOnLoad: false });
+    mermaid.run({ querySelector: 'pre.mermaid' }).catch(function(err) {
+      showSourceFallback(err && err.message ? err.message : 'render failed');
+    });
+  } catch (err) {
+    showSourceFallback(err && err.message ? err.message : 'init failed');
+  }
+  function showSourceFallback(reason) {
+    var el = document.querySelector('pre.mermaid');
+    if (!el) return;
+    el.removeAttribute('class');
+    el.outerHTML = '<pre><code>' + el.textContent.replace(/[&<>]/g, function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;'}[c];}) + '</code></pre>' +
+      '<p style="font-size:0.8rem;color:#999">Diagram could not render: ' + reason.replace(/[<>]/g,'') + '</p>';
+  }
+})();
+</script>
+`;
+  const page = renderChromePage({ title: "Diagram", bodyHtml: body });
+  const headers = new Headers(cacheHeaders(row, "text/html; charset=utf-8"));
+  headers.set(
+    "content-security-policy",
+    "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self'; base-uri 'none'; form-action 'none'",
+  );
+  return new Response(page, { status: 200, headers });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}
+```
+
+- [ ] **Step 3: Verify tests pass.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-render
+```
+
+Expected: all mermaid tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-render.ts infra/oyster-publish/test/viewer-render.test.ts
+git commit -m "feat(oyster-publish): mermaid renderer with pinned CDN + SRI (#316)"
+```
+
+---
+
+### Task 5.3: Iframe HTML kind renderer
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-render.ts`
+- Modify: `infra/oyster-publish/test/viewer-render.test.ts`
+
+For `app/deck/wireframe/table/map`, the chrome page wraps an `<iframe sandbox="allow-scripts">` whose `src` is `/p/<token>/raw`. The `/raw` endpoint serves bytes (Task 7.3). We render the chrome shell here.
+
+- [ ] **Step 1: Add tests.**
+
+Append to `test/viewer-render.test.ts`:
+
+```ts
+import { renderChromeWithIframe, renderRawHtmlBody } from "../src/viewer-render";
+
+describe("renderChromeWithIframe", () => {
+  const ROW = { share_token: "app1", mode: "open", updated_at: 3000, artifact_kind: "app", content_type: "text/html" } as any;
+
+  it("returns a 200 HTML response with chrome", async () => {
+    const res = renderChromeWithIframe(ROW);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("🦪 oyster");
+    expect(body).toContain("Powered by Oyster");
+  });
+
+  it("contains a sandboxed iframe pointing at /p/<token>/raw", async () => {
+    const res = renderChromeWithIframe(ROW);
+    const body = await res.text();
+    expect(body).toContain('sandbox="allow-scripts"');
+    expect(body).toContain('src="/p/app1/raw"');
+    // Critical: NO allow-same-origin (would defeat origin isolation)
+    expect(body).not.toContain("allow-same-origin");
+  });
+
+  it("includes the deliberate-omission comment in source", async () => {
+    const res = renderChromeWithIframe(ROW);
+    const body = await res.text();
+    expect(body).toContain("Deliberately omit allow-same-origin");
+  });
+});
+
+describe("renderRawHtmlBody — strict CSP for iframe content", () => {
+  it("serves bytes with the recorded content-type", async () => {
+    const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
+    const bytes = new TextEncoder().encode("<h1>my app</h1>");
+    const res = renderRawHtmlBody(bytes, ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html");
+    expect(await res.text()).toBe("<h1>my app</h1>");
+  });
+
+  it("sets a strict CSP including connect-src 'none' and form-action 'none'", async () => {
+    const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
+    const res = renderRawHtmlBody(new TextEncoder().encode(""), ROW);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  it("sets X-Frame-Options: SAMEORIGIN", async () => {
+    const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
+    const res = renderRawHtmlBody(new TextEncoder().encode(""), ROW);
+    expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+  });
+});
+```
+
+- [ ] **Step 2: Add the renderers to `src/viewer-render.ts`.**
+
+```ts
+export function renderChromeWithIframe(row: PublicationRow): Response {
+  const iframe = `
+<!-- Deliberately omit allow-same-origin.
+     With allow-scripts only, the sandboxed document gets an opaque origin
+     and cannot access oyster.to cookies or same-origin storage. -->
+<iframe sandbox="allow-scripts" src="/p/${escapeAttr(row.share_token)}/raw"
+        style="border:0;width:100%;height:calc(100vh - 60px);display:block;"></iframe>`;
+  // Body's main padding is removed for iframe so it fills naturally.
+  const cssExtra = `main { padding: 0; max-width: none; }`;
+  const page = renderChromePage({ title: "Shared via Oyster", bodyHtml: iframe, cssExtra });
+  return new Response(page, {
+    status: 200,
+    headers: cacheHeaders(row, "text/html; charset=utf-8"),
+  });
+}
+
+export function renderRawHtmlBody(bytes: Uint8Array, row: PublicationRow): Response {
+  const headers = new Headers(cacheHeaders(row, row.content_type));
+  headers.set(
+    "content-security-policy",
+    "default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'",
+  );
+  headers.set("x-frame-options", "SAMEORIGIN");
+  headers.set("content-disposition", "inline");
+  // Buffer.from wrap is required for Workers fetch BodyInit — raw Uint8Array
+  // doesn't satisfy the type in cf-types.
+  return new Response(bytes, { status: 200, headers });
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}
+```
+
+- [ ] **Step 3: Verify tests pass.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-render
+```
+
+Expected: all iframe + raw tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-render.ts infra/oyster-publish/test/viewer-render.test.ts
+git commit -m "feat(oyster-publish): iframe chrome + /raw body renderers (#316)"
+```
+
+---
+
+### Task 5.4: Image inline renderer
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-render.ts`
+- Modify: `infra/oyster-publish/test/viewer-render.test.ts`
+
+When `content_type` starts with `image/`, the bytes ARE the page — serve inline, no chrome.
+
+- [ ] **Step 1: Add tests.**
+
+Append to `test/viewer-render.test.ts`:
+
+```ts
+import { renderImageInline } from "../src/viewer-render";
+
+describe("renderImageInline", () => {
+  const ROW = { share_token: "img1", mode: "open", updated_at: 4000, content_type: "image/png" } as any;
+
+  it("serves bytes inline with the recorded content-type", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header
+    const res = renderImageInline(png, ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("content-disposition")).toBe("inline");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(png);
+  });
+
+  it("applies open-mode cache headers", async () => {
+    const res = renderImageInline(new Uint8Array(0), ROW);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(res.headers.get("etag")).toBe(`W/"img1-4000"`);
+  });
+
+  it("applies private no-store for non-open modes", async () => {
+    const pwRow = { ...ROW, mode: "password" };
+    const res = renderImageInline(new Uint8Array(0), pwRow);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+});
+```
+
+- [ ] **Step 2: Add the renderer.**
+
+```ts
+export function renderImageInline(bytes: Uint8Array, row: PublicationRow): Response {
+  const headers = new Headers(cacheHeaders(row, row.content_type));
+  headers.set("content-disposition", "inline");
+  return new Response(bytes, { status: 200, headers });
+}
+```
+
+- [ ] **Step 3: Verify tests pass.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-render
+```
+
+Expected: all image tests pass; all earlier tests still pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-render.ts infra/oyster-publish/test/viewer-render.test.ts
+git commit -m "feat(oyster-publish): image inline renderer (#316)"
+```
+
+---
+
+## Phase 6 — Access dispatch
+
+End state: `viewer-access.ts` exposes `resolveViewerAccess(req, env, shareToken)` returning a tagged union (`ok` | `gate` | `redirect` | `gone` | `not_found`). All paths covered by integration tests in Phase 7. (No standalone unit test file for access — its only inputs are a `Request` + `Env`, and integration tests through `worker.fetch` cover it more meaningfully.)
+
+### Task 6.1: Implement `viewer-access.ts`
+
+**Files:**
+- Create: `infra/oyster-publish/src/viewer-access.ts`
+
+- [ ] **Step 1: Write the module.**
+
+```ts
+// Access dispatch for the public viewer.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Access dispatch).
+
+import { resolveSession } from "./worker";
+import { verifyViewerCookie } from "./viewer-cookie";
+import type { Env, PublicationRow } from "./types";
+
+export type ViewerAccess =
+  | { kind: "ok"; row: PublicationRow }
+  | { kind: "gate"; row: PublicationRow; error?: "wrong_password" }
+  | { kind: "redirect"; location: string }
+  | { kind: "gone"; row: PublicationRow }
+  | { kind: "not_found" };
+
+export async function resolveViewerAccess(
+  req: Request,
+  env: Env,
+  shareToken: string,
+): Promise<ViewerAccess> {
+  // Step 1: row lookup.
+  const row = await env.DB.prepare(
+    "SELECT * FROM published_artifacts WHERE share_token = ?",
+  ).bind(shareToken).first<PublicationRow>();
+  if (!row) return { kind: "not_found" };
+
+  // Step 2: gone check.
+  if (row.unpublished_at !== null && row.unpublished_at !== undefined) {
+    return { kind: "gone", row };
+  }
+
+  // Step 3: mode dispatch.
+  switch (row.mode) {
+    case "open":
+      return { kind: "ok", row };
+
+    case "password": {
+      const cookieValue = readCookie(req, `oyster_view_${shareToken}`);
+      if (!cookieValue) return { kind: "gate", row };
+      const ok = await verifyViewerCookie(cookieValue, shareToken, env.VIEWER_COOKIE_SECRET);
+      if (!ok) return { kind: "gate", row };
+      return { kind: "ok", row };
+    }
+
+    case "signin": {
+      const session = await resolveSession(req, env);
+      if (!session) {
+        return { kind: "redirect", location: `https://oyster.to/auth/sign-in?return=/p/${shareToken}` };
+      }
+      return { kind: "ok", row };
+    }
+
+    default:
+      // Unreachable per the D1 CHECK constraint, but typescript-safe.
+      return { kind: "not_found" };
+  }
+}
+
+export function readCookie(req: Request, name: string): string | null {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]+)`));
+  return m ? m[1] : null;
+}
+```
+
+- [ ] **Step 2: Verify build.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: passes. (Behavioural tests come in Phase 7 via integration tests.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add infra/oyster-publish/src/viewer-access.ts
+git commit -m "feat(oyster-publish): viewer access dispatch (#316)"
+```
+
+---
+
+## Phase 7 — Wire it into `worker.ts` + integration tests
+
+End state: `GET /p/:token`, `POST /p/:token`, `GET /p/:token/raw` all wired in `worker.ts` replacing the 501 stub. Integration tests cover all access paths and render kinds.
+
+### Task 7.1: Extend test fixtures with retired-publication + R2-byte helpers
+
+**Files:**
+- Modify: `infra/oyster-publish/test/fixtures/seed.ts`
+
+- [ ] **Step 1: Add helpers.**
+
+Append to `infra/oyster-publish/test/fixtures/seed.ts`:
+
+```ts
+import { env } from "cloudflare:test";
+
+export async function retirePublication(shareToken: string, unpublishedAt = Date.now()): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE published_artifacts SET unpublished_at = ? WHERE share_token = ?",
+  ).bind(unpublishedAt, shareToken).run();
+}
+
+export async function putR2Object(key: string, body: Uint8Array | string, contentType: string): Promise<void> {
+  await env.ARTIFACTS.put(key, body, { httpMetadata: { contentType } });
+}
+
+export async function seedActiveOpenWithBody(opts: {
+  ownerUserId: string;
+  artifactId: string;
+  artifactKind?: "notes" | "diagram" | "app" | "deck" | "wireframe" | "table" | "map";
+  contentType?: string;
+  body: string | Uint8Array;
+  shareToken?: string;
+  publishedAt?: number;
+}): Promise<{ shareToken: string; r2Key: string }> {
+  const token = opts.shareToken ?? `seeded_${crypto.randomUUID().slice(0, 8)}`;
+  const kind = opts.artifactKind ?? "notes";
+  const contentType = opts.contentType ?? "text/markdown";
+  const now = opts.publishedAt ?? Date.now();
+  const r2Key = `published/${opts.ownerUserId}/${token}`;
+  const sizeBytes = typeof opts.body === "string"
+    ? new TextEncoder().encode(opts.body).byteLength
+    : opts.body.byteLength;
+  await env.DB.prepare(
+    `INSERT INTO published_artifacts
+     (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+      r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+     VALUES (?, ?, ?, ?, 'open', NULL, ?, ?, ?, ?, ?, NULL)`,
+  ).bind(token, opts.ownerUserId, opts.artifactId, kind, r2Key, contentType, sizeBytes, now, now).run();
+  await putR2Object(r2Key, opts.body, contentType);
+  return { shareToken: token, r2Key };
+}
+```
+
+- [ ] **Step 2: Verify build.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: passes.
+
+(No commit yet — bundle with the next task.)
+
+---
+
+### Task 7.2: Wire `GET /p/:token` and `POST /p/:token`
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+
+- [ ] **Step 1: Add a route parser to `publish-helpers.ts`.**
+
+Append to `infra/oyster-publish/src/publish-helpers.ts`:
+
+```ts
+// Match /p/<token> or /p/<token>/raw. Returns null on no match.
+const SHARE_TOKEN_CHARSET = /^[A-Za-z0-9_-]+$/;
+export function parseShareTokenPath(pathname: string): { shareToken: string; raw: boolean } | null {
+  if (!pathname.startsWith("/p/")) return null;
+  const rest = pathname.slice("/p/".length);
+  if (rest.length === 0) return null;
+  if (rest.endsWith("/raw")) {
+    const token = rest.slice(0, -"/raw".length);
+    if (!SHARE_TOKEN_CHARSET.test(token)) return null;
+    return { shareToken: token, raw: true };
+  }
+  if (!SHARE_TOKEN_CHARSET.test(rest)) return null;
+  return { shareToken: rest, raw: false };
+}
+```
+
+- [ ] **Step 2: Replace the 501 stub in `worker.ts`.**
+
+In `infra/oyster-publish/src/worker.ts`, find the existing routing block:
+
+```ts
+if (url.pathname.startsWith("/p/") && req.method === "GET") {
+  // Viewer body lands in #316.
+  return jsonError(501, "not_implemented", "viewer lands in #316");
+}
+```
+
+Replace with:
+
+```ts
+if (url.pathname.startsWith("/p/")) {
+  const parsed = parseShareTokenPath(url.pathname);
+  if (!parsed) return new Response("Not Found", { status: 404 });
+  if (req.method === "GET" && parsed.raw) {
+    return handleViewerRaw(req, env, parsed.shareToken);
+  }
+  if (req.method === "GET") {
+    return handleViewerGet(req, env, parsed.shareToken);
+  }
+  if (req.method === "POST" && !parsed.raw) {
+    return handleViewerPost(req, env, parsed.shareToken);
+  }
+  return new Response("Method Not Allowed", { status: 405 });
+}
+```
+
+Add the import at the top:
+
+```ts
+import { CAPS, generateShareToken, parseMetadataHeader, parseShareTokenPath, r2KeyFor, type Tier } from "./publish-helpers";
+import { resolveViewerAccess } from "./viewer-access";
+import { signViewerCookie } from "./viewer-cookie";
+import {
+  passwordGatePage, gonePage, notFoundPage, internalErrorPage, rateLimitedPage,
+} from "./viewer-pages";
+import {
+  renderMarkdownPage, renderMermaidPage, renderChromeWithIframe, renderRawHtmlBody, renderImageInline,
+} from "./viewer-render";
+```
+
+Add the three handlers at the bottom of the file (after `collectWithSizeCap`):
+
+```ts
+// ─── Viewer handlers (#316) ────────────────────────────────────────────────
+
+async function handleViewerGet(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  switch (access.kind) {
+    case "not_found":
+      return htmlPage(404, notFoundPage());
+    case "gone":
+      return htmlPage(410, gonePage());
+    case "redirect":
+      return new Response(null, {
+        status: 302,
+        headers: { location: access.location, "cache-control": "private, no-store" },
+      });
+    case "gate":
+      return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
+    case "ok":
+      return renderForRow(env, access.row);
+  }
+}
+
+async function handleViewerRaw(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  if (access.kind === "not_found") return htmlPage(404, notFoundPage());
+  if (access.kind === "gone") return htmlPage(410, gonePage());
+  if (access.kind === "redirect") {
+    return new Response(null, { status: 302, headers: { location: access.location, "cache-control": "private, no-store" } });
+  }
+  if (access.kind === "gate") return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
+  // OK — serve raw bytes for HTML kinds, or fall through for non-HTML
+  const obj = await env.ARTIFACTS.get(access.row.r2_key);
+  if (!obj) {
+    console.error("[viewer] R2 object missing for token", shareToken, "key", access.row.r2_key);
+    return htmlPage(500, internalErrorPage());
+  }
+  const bytes = new Uint8Array(await obj.arrayBuffer());
+  return renderRawHtmlBody(bytes, access.row);
+}
+
+async function handleViewerPost(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  if (access.kind === "not_found") return htmlPage(404, notFoundPage());
+  if (access.kind === "gone") return htmlPage(410, gonePage());
+  if (access.kind === "redirect") {
+    return new Response(null, { status: 302, headers: { location: access.location, "cache-control": "private, no-store" } });
+  }
+  // POST is only meaningful in password mode.
+  // For password: gate state OR ok state both indicate "the visitor wants
+  // to (re-)authenticate via the form" — accept the POST. For other modes
+  // (open/signin), POST is method-not-allowed.
+  if (access.kind !== "gate" && !(access.kind === "ok" && access.row.mode === "password")) {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  const row = (access as { row: PublicationRow }).row;
+
+  // Rate limit per IP + token.
+  const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
+  const gate = await env.VIEWER_PASSWORD_LIMIT.limit({ key: `${ip}:${shareToken}` });
+  if (!gate.success) return htmlPage(429, rateLimitedPage());
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+  }
+  const password = form.get("password");
+  if (typeof password !== "string" || password.length === 0) {
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+  }
+
+  if (!row.password_hash) {
+    console.error("[viewer] password mode row has no password_hash:", shareToken);
+    return htmlPage(500, internalErrorPage());
+  }
+  const ok = await verifyPbkdf2(password, row.password_hash);
+  if (!ok) {
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+  }
+
+  const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "set-cookie": `oyster_view_${shareToken}=${cookieValue}; HttpOnly; Secure; SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
+      "location": `/p/${shareToken}`,
+      "cache-control": "private, no-store",
+    },
+  });
+}
+
+async function renderForRow(env: Env, row: PublicationRow): Promise<Response> {
+  const obj = await env.ARTIFACTS.get(row.r2_key);
+  if (!obj) {
+    console.error("[viewer] R2 object missing for token", row.share_token, "key", row.r2_key);
+    return htmlPage(500, internalErrorPage());
+  }
+  const bytes = new Uint8Array(await obj.arrayBuffer());
+
+  if (row.content_type.startsWith("image/")) return renderImageInline(bytes, row);
+
+  switch (row.artifact_kind) {
+    case "notes":
+      return renderMarkdownPage(bytes, row);
+    case "diagram":
+      return renderMermaidPage(bytes, row);
+    case "app":
+    case "deck":
+    case "wireframe":
+    case "table":
+    case "map":
+      return renderChromeWithIframe(row);
+    default:
+      return row.content_type.startsWith("text/")
+        ? renderMarkdownPage(bytes, row)
+        : renderChromeWithIframe(row);
+  }
+}
+
+function htmlPage(status: number, body: string, opts?: { mode?: "password-gate" }): Response {
+  const headers: Record<string, string> = {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "private, no-store",
+    "x-content-type-options": "nosniff",
+  };
+  return new Response(body, { status, headers });
+}
+
+// PBKDF2-SHA256 verify, matches server/src/password-hash.ts producer.
+async function verifyPbkdf2(plaintext: string, encoded: string): Promise<boolean> {
+  // Format: pbkdf2$<iter>$<salt_b64url>$<hash_b64url>
+  const parts = encoded.split("$");
+  if (parts.length !== 4 || parts[0] !== "pbkdf2") return false;
+  const iter = Number(parts[1]);
+  if (!Number.isSafeInteger(iter) || iter < 1) return false;
+  const salt = base64urlDecode(parts[2]);
+  const expected = base64urlDecode(parts[3]);
+  if (!salt || !expected) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(plaintext),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits"],
+  );
+  const derived = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt, iterations: iter, hash: "SHA-256" },
+    key,
+    expected.byteLength * 8,
+  ));
+  if (derived.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < derived.length; i++) diff |= derived[i] ^ expected[i];
+  return diff === 0;
+}
+
+function base64urlDecode(s: string): Uint8Array | null {
+  try {
+    const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (s.length % 4)) % 4);
+    const binary = atob(padded);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+```
+
+Add `PublicationRow` to the imports from `./types`:
+
+```ts
+import type { Env, PublicationRow } from "./types";
+```
+
+- [ ] **Step 3: Verify build.**
+
+```bash
+cd infra/oyster-publish
+npm run typecheck
+```
+
+Expected: passes. Existing publish handler tests still pass.
+
+```bash
+npm test
+```
+
+Expected: ALL existing tests still pass; viewer tests start running (and may have failures since handler integration tests come in Task 7.3 — we just want no regressions here).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/worker.ts infra/oyster-publish/src/publish-helpers.ts infra/oyster-publish/test/fixtures/seed.ts
+git commit -m "feat(oyster-publish): wire GET/POST /p/:token + GET /p/:token/raw (#316)"
+```
+
+---
+
+### Task 7.3: Integration tests for viewer handlers
+
+**Files:**
+- Create: `infra/oyster-publish/test/viewer-handler.test.ts`
+
+- [ ] **Step 1: Write the integration test file.**
+
+```ts
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import {
+  applySchema, seedUser, seedActivePublication, retirePublication,
+  putR2Object, seedActiveOpenWithBody,
+} from "./fixtures/seed";
+import { signViewerCookie } from "../src/viewer-cookie";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function getReq(path: string, opts: { cookie?: string; ifNoneMatch?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  if (opts.ifNoneMatch) headers.set("If-None-Match", opts.ifNoneMatch);
+  return new Request(`https://oyster.to${path}`, { method: "GET", headers });
+}
+
+function postReq(path: string, opts: { cookie?: string; password?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  headers.set("Content-Type", "application/x-www-form-urlencoded");
+  const body = new URLSearchParams();
+  if (opts.password !== undefined) body.set("password", opts.password);
+  return new Request(`https://oyster.to${path}`, { method: "POST", headers, body: body.toString() });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("GET /p/:token — 404 / 410", () => {
+  it("returns 404 for unknown token", async () => {
+    const res = await call(getReq("/p/no-such-token"));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    expect(await res.text()).toContain("Share not found");
+  });
+
+  it("returns 410 for retired publication", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art1" });
+    await retirePublication(token);
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(410);
+    expect(await res.text()).toContain("This share has been removed");
+  });
+});
+
+describe("GET /p/:token — open mode", () => {
+  it("renders markdown notes with chrome", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "notes",
+      contentType: "text/markdown", body: "# Hello world",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<h1>Hello world</h1>");
+    expect(body).toContain("🦪 oyster"); // chrome present
+    expect(body).toContain("Powered by Oyster");
+  });
+
+  it("sets open-mode cache headers + ETag", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", body: "# x",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(res.headers.get("etag")).toMatch(/^W\/"[^"]+"$/);
+  });
+
+  it("serves images inline with no chrome", async () => {
+    const u = await seedUser();
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "notes",
+      contentType: "image/png", body: png,
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("content-disposition")).toBe("inline");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(png);
+  });
+
+  it("renders app kind via iframe pointing at /raw", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>my app</h1>",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    const body = await res.text();
+    expect(body).toContain(`src="/p/${shareToken}/raw"`);
+    expect(body).toContain('sandbox="allow-scripts"');
+    expect(body).not.toContain("allow-same-origin");
+  });
+});
+
+describe("GET /p/:token/raw — iframe content", () => {
+  it("serves bytes with strict CSP", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>raw app</h1>",
+    });
+    const res = await call(getReq(`/p/${shareToken}/raw`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html");
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("form-action 'none'");
+    expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+    expect(await res.text()).toBe("<h1>raw app</h1>");
+  });
+
+  it("returns 404 for unknown token on /raw", async () => {
+    const res = await call(getReq(`/p/no-such-token/raw`));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 410 on /raw for retired publication", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>x</h1>",
+    });
+    await retirePublication(shareToken);
+    const res = await call(getReq(`/p/${shareToken}/raw`));
+    expect(res.status).toBe(410);
+  });
+});
+
+describe("GET/POST /p/:token — password mode", () => {
+  // Hash for plaintext "letmein" using the local server's PBKDF2 producer.
+  // Generated via: node -e 'import("./server/dist/server/src/password-hash.js").then(...)' or
+  // produced ad-hoc via the same params (PBKDF2-SHA256, 100k iter, 16-byte salt, 32-byte hash).
+  // For the test suite, generate a fresh hash inline using Web Crypto:
+  async function makeHash(password: string): Promise<string> {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await crypto.subtle.importKey(
+      "raw", new TextEncoder().encode(password),
+      { name: "PBKDF2" }, false, ["deriveBits"],
+    );
+    const bits = await crypto.subtle.deriveBits(
+      { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
+      key, 256,
+    );
+    const b64url = (b: Uint8Array) => {
+      let s = ""; for (const x of b) s += String.fromCharCode(x);
+      return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    };
+    return `pbkdf2$100000$${b64url(salt)}$${b64url(new Uint8Array(bits))}`;
+  }
+
+  it("GET with no cookie → password gate page", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Password required");
+  });
+
+  it("POST correct password → 302 with cookie; follow-up GET → content", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    // Seed R2 bytes too (the shared seedActivePublication doesn't put bytes).
+    await putR2Object(`published/${u.id}/${token}`, "# Secret notes", "text/markdown");
+    // Update the row's content_type so renderMarkdownPage is chosen
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET content_type = 'text/markdown', artifact_kind = 'notes' WHERE share_token = ?",
+    ).bind(token).run();
+
+    const postRes = await call(postReq(`/p/${token}`, { password: "letmein" }));
+    expect(postRes.status).toBe(302);
+    const setCookie = postRes.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oyster_view_${token}=`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain(`Path=/p/${token}`);
+
+    // Extract cookie value and follow up with GET.
+    const cookieMatch = setCookie.match(new RegExp(`oyster_view_${token}=([^;]+)`));
+    expect(cookieMatch).not.toBeNull();
+    const cookie = `oyster_view_${token}=${cookieMatch![1]}`;
+    const getRes = await call(getReq(`/p/${token}`, { cookie }));
+    expect(getRes.status).toBe(200);
+    expect(await getRes.text()).toContain("Secret notes");
+  });
+
+  it("POST wrong password → 200 gate with 'Incorrect password'", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const res = await call(postReq(`/p/${token}`, { password: "WRONG" }));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Password required");
+    expect(body).toContain("Incorrect password");
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("POST empty password → 200 gate with error", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const res = await call(postReq(`/p/${token}`, { password: "" }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Incorrect password");
+  });
+
+  it("GET with tampered cookie → re-renders gate", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const cookie = `oyster_view_${token}=tampered.0.garbage`;
+    const res = await call(getReq(`/p/${token}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Password required");
+  });
+
+  it("GET with valid cookie → content (no re-prompt)", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    await putR2Object(`published/${u.id}/${token}`, "# unlocked", "text/markdown");
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET content_type = 'text/markdown', artifact_kind = 'notes' WHERE share_token = ?",
+    ).bind(token).run();
+    const cookieValue = await signViewerCookie(token, env.VIEWER_COOKIE_SECRET);
+    const cookie = `oyster_view_${token}=${cookieValue}`;
+    const res = await call(getReq(`/p/${token}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("unlocked");
+  });
+});
+
+describe("GET /p/:token — signin mode", () => {
+  it("unsigned visitor → 302 to /auth/sign-in?return=/p/<token>", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art3", mode: "signin",
+    });
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toBe(`https://oyster.to/auth/sign-in?return=/p/${token}`);
+  });
+
+  it("signed-in visitor → content", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art3", body: "# private",
+    });
+    // Flip mode to signin
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+    const cookie = `oyster_session=${u.sessionToken}`;
+    const res = await call(getReq(`/p/${shareToken}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("private");
+  });
+});
+```
+
+- [ ] **Step 2: Configure Vitest with `VIEWER_COOKIE_SECRET`.**
+
+The existing vitest config injects `Env` bindings via `cloudflare:test`. Verify the secret is provided:
+
+```bash
+cat infra/oyster-publish/vitest.config.ts
+```
+
+If `VIEWER_COOKIE_SECRET` isn't in the `bindings`, add it under `poolOptions.workers.miniflare.bindings`:
+
+```ts
+// infra/oyster-publish/vitest.config.ts (snippet)
+poolOptions: {
+  workers: {
+    miniflare: {
+      bindings: {
+        VIEWER_COOKIE_SECRET: "test-secret-for-vitest-only",
+      },
+      // existing D1 / R2 bindings ...
+    },
+  },
+},
+```
+
+Also verify the rate-limiter binding is mocked (Workers test pool has a built-in mock). If not, add a stub:
+
+```ts
+// In test/env.d.ts (or a dedicated stub file), declare the binding type.
+// The rate-limiter mock can be a no-op that always returns success.
+```
+
+- [ ] **Step 3: Run the integration tests.**
+
+```bash
+cd infra/oyster-publish
+npm test -- viewer-handler
+```
+
+Expected: all integration tests pass.
+
+If the rate-limiter binding isn't auto-mocked by `@cloudflare/vitest-pool-workers`, the tests will fail with a binding error — in that case, override `env.VIEWER_PASSWORD_LIMIT` in the test setup:
+
+```ts
+// In beforeAll or a test setup file:
+beforeAll(() => {
+  // @ts-expect-error — runtime injection for tests
+  env.VIEWER_PASSWORD_LIMIT = { limit: async () => ({ success: true }) };
+});
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/test/viewer-handler.test.ts infra/oyster-publish/vitest.config.ts
+git commit -m "test(oyster-publish): integration tests for viewer GET/POST/RAW (#316)"
+```
+
+---
+
+### Task 7.4: ETag / If-None-Match (304) handling
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts` (in `renderForRow` — wrap each render call with the etag check)
+- Modify: `infra/oyster-publish/test/viewer-handler.test.ts` (add 304 test)
+
+- [ ] **Step 1: Add the 304 short-circuit in `renderForRow`.**
+
+In `worker.ts`, before any render dispatch, check for matching `If-None-Match`. Refactor `renderForRow`:
+
+```ts
+async function renderForRow(env: Env, row: PublicationRow, req?: Request): Promise<Response> {
+  // Short-circuit on If-None-Match (open mode only — others are no-store).
+  if (req && row.mode === "open") {
+    const ifNoneMatch = req.headers.get("If-None-Match");
+    const etag = `W/"${row.share_token}-${row.updated_at}"`;
+    if (ifNoneMatch && ifNoneMatch === etag) {
+      return new Response(null, {
+        status: 304,
+        headers: {
+          etag,
+          "cache-control": "public, max-age=60, must-revalidate",
+        },
+      });
+    }
+  }
+
+  const obj = await env.ARTIFACTS.get(row.r2_key);
+  if (!obj) {
+    console.error("[viewer] R2 object missing for token", row.share_token, "key", row.r2_key);
+    return htmlPage(500, internalErrorPage());
+  }
+  // ... rest of existing renderForRow body, unchanged ...
+}
+```
+
+Update the call site in `handleViewerGet` to pass `req`:
+
+```ts
+case "ok":
+  return renderForRow(env, access.row, req);
+```
+
+- [ ] **Step 2: Add the 304 test.**
+
+Append to `test/viewer-handler.test.ts`:
+
+```ts
+describe("ETag / 304", () => {
+  it("returns 304 on matching If-None-Match", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", body: "# x",
+    });
+    const first = await call(getReq(`/p/${shareToken}`));
+    const etag = first.headers.get("etag") ?? "";
+    expect(etag).toMatch(/^W\//);
+    const second = await call(getReq(`/p/${shareToken}`, { ifNoneMatch: etag }));
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+  });
+
+  it("does NOT return 304 for password mode", async () => {
+    const u = await seedUser();
+    const hash = await env.DB.prepare("SELECT 'pbkdf2$100000$x$y' AS h").first<{ h: string }>();
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash!.h,
+    });
+    await putR2Object(`published/${u.id}/${token}`, "# x", "text/markdown");
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET content_type = 'text/markdown', artifact_kind = 'notes' WHERE share_token = ?",
+    ).bind(token).run();
+    const cookieValue = await signViewerCookie(token, env.VIEWER_COOKIE_SECRET);
+    const cookie = `oyster_view_${token}=${cookieValue}`;
+    const res = await call(getReq(`/p/${token}`, { cookie, ifNoneMatch: `W/"${token}-anything"` }));
+    expect(res.status).toBe(200);  // password mode never returns 304
+  });
+});
+```
+
+- [ ] **Step 3: Run all worker tests.**
+
+```bash
+cd infra/oyster-publish
+npm test
+```
+
+Expected: all tests pass — viewer-cookie + viewer-render + viewer-handler + existing publish-helpers + publish-handler + unpublish-handler.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add infra/oyster-publish/src/worker.ts infra/oyster-publish/test/viewer-handler.test.ts
+git commit -m "feat(oyster-publish): 304 short-circuit on matching If-None-Match (#316)"
+```
+
+---
+
+## Phase 8 — Deploy + smoke
+
+End state: secret set, both Workers deployed, manual smoke through three modes proves the viewer works end-to-end.
+
+### Task 8.1: Set `VIEWER_COOKIE_SECRET`
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Generate a secret.**
+
+```bash
+openssl rand -hex 32
+```
+
+Note the 64-char hex string (e.g. `7a3f...`). Treat it as sensitive; do not commit.
+
+- [ ] **Step 2: Set on the Worker.**
+
+```bash
+cd infra/oyster-publish
+npx wrangler secret put VIEWER_COOKIE_SECRET --name oyster-publish
+```
+
+When prompted, paste the hex string.
+
+Expected: `Success!` from wrangler.
+
+- [ ] **Step 3: Verify secret presence.**
+
+```bash
+npx wrangler secret list --name oyster-publish
+```
+
+Expected: `VIEWER_COOKIE_SECRET` appears.
+
+(No commit — secret is set in Cloudflare, not in repo.)
+
+---
+
+### Task 8.2: Deploy both Workers
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Deploy auth-worker.**
+
+```bash
+cd infra/auth-worker
+npx wrangler deploy
+```
+
+Expected: `Successfully deployed` with a version id.
+
+- [ ] **Step 2: Deploy oyster-publish.**
+
+```bash
+cd infra/oyster-publish
+npx wrangler deploy
+```
+
+Expected: `Successfully deployed` with a version id. The new rate-limit binding should be reported.
+
+(No commit.)
+
+---
+
+### Task 8.3: Manual smoke against production
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Publish three artefacts via the local server (one per mode).**
+
+Start `npm run dev` in the worktree, sign in via `/auth/sign-in`, then in the chat bar:
+
+```
+publish that artefact (artifact_id: <id>, mode: open)
+```
+
+Repeat with `mode: password, password: testpass123` and `mode: signin`.
+
+Note the three resulting `share_url`s.
+
+- [ ] **Step 2: Verify open mode in a fresh browser.**
+
+Open `https://oyster.to/p/<open-token>` in a private/incognito window.
+
+Expected: chrome (logo + footer), content rendered. Open DevTools:
+- `cache-control: public, max-age=60, must-revalidate`
+- `etag` present
+- Reload — second request shows `304 Not Modified` in network tab.
+
+- [ ] **Step 3: Verify password mode.**
+
+Open `https://oyster.to/p/<password-token>`.
+
+Expected: minimal page, "Password required", input + Unlock button, no chrome.
+
+Submit wrong password — expect "Incorrect password" inline.
+
+Submit correct password — expect 302, content renders, chrome present, reload doesn't re-prompt.
+
+- [ ] **Step 4: Verify signin mode.**
+
+In a fresh incognito (not signed in), open `https://oyster.to/p/<signin-token>`.
+
+Expected: 302 to `https://oyster.to/auth/sign-in?return=/p/<token>`. Sign in via GitHub OAuth. After sign-in, expect 302 back to `/p/<token>` and content rendering.
+
+- [ ] **Step 5: Verify iframe isolation for an HTML kind.**
+
+Publish an `app` kind artefact (single-file HTML). Open the share URL.
+
+Expected: chrome page with iframe inside. Open the iframe's DevTools console (right-click → Inspect Element on the iframe, switch context) and run:
+
+```js
+document.cookie
+```
+
+Expected: `""` — no `oyster_session` visible. (If you see the cookie, the sandbox attribute is broken.)
+
+- [ ] **Step 6: Verify 410 after unpublish.**
+
+Pick the open-mode share. In chat:
+
+```
+unpublish that artefact
+```
+
+Re-visit the URL. Expected: 410 page, "This share has been removed".
+
+- [ ] **Step 7: Verify 404 for unknown token.**
+
+```bash
+curl -i https://oyster.to/p/no-such-token-12345
+```
+
+Expected: HTTP/2 404, body "Share not found".
+
+(No commit unless you find a bug — in which case fix forward via a new task or a follow-up commit.)
+
+---
+
+## Phase 9 — Changelog
+
+### Task 9.1: Add CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add an entry under `[Unreleased] / Added`.**
+
+Open `CHANGELOG.md`, find the `[Unreleased]` section, add under `### Added`:
+
+```markdown
+- **Public viewer for shared artefacts.** Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share.
+```
+
+(Style note per repo convention: outcome-focused, no internal file paths, no MCP tool names.)
+
+- [ ] **Step 2: Regenerate the changelog HTML.**
+
+```bash
+npm run build:changelog
+```
+
+Expected: `docs/changelog.html` updated.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add CHANGELOG.md docs/changelog.html
+git commit -m "chore: changelog for #316 R5 viewer"
+```
+
+---
+
+## Self-Review Checklist (run after writing the plan)
+
+This section is for the plan author — work through it once, fix issues inline.
+
+**1. Spec coverage:**
+
+- [x] Topology — covered by Phase 7 wiring (worker.ts replaces 501 stub).
+- [x] Routes (`/p/:token`, `/p/:token/raw`, POST) — Tasks 7.2, 7.3.
+- [x] Access dispatch (`resolveViewerAccess` tagged union) — Phase 6.
+- [x] Render dispatch (markdown, mermaid, iframe, image) — Phase 5.
+- [x] Chrome only on success states — Phases 4 + 5 templates.
+- [x] Minimal pages (404/410/gate/error/rate-limited) — Phase 4.
+- [x] Auth-worker `?return=` — Phase 1.
+- [x] Cookie scheme (HMAC, 24h, per-token) — Phase 3.
+- [x] Cache headers + ETag (open mode) + 304 — Tasks 5.1 (headers), 7.4 (304).
+- [x] `VIEWER_COOKIE_SECRET` + `VIEWER_PASSWORD_LIMIT` bindings — Phase 2 + Task 8.1.
+- [x] D1 migrations (return_path columns) — Tasks 1.1, 1.2.
+- [x] Markdown link safety via default validateLink — Task 5.1 tests.
+- [x] Mermaid CDN with SRI — Task 5.2.
+- [x] Iframe sandbox without allow-same-origin — Task 5.3 tests.
+- [x] /raw strict CSP (connect-src 'none', form-action 'none') — Task 5.3.
+- [x] Image content-type dispatch (overrides kind) — Task 5.4.
+- [x] Manual smoke (three modes + iframe isolation + 410) — Task 8.3.
+- [x] CHANGELOG entry — Task 9.1.
+
+**2. Placeholder scan:**
+
+- [x] No "TBD" / "TODO" / "implement later".
+- [x] All test code blocks contain real test code.
+- [x] Code blocks include the actual implementation, not just intent.
+- One placeholder is intentional: `MERMAID_SRI = "sha384-PLACEHOLDER"` in Task 5.2 Step 2 — Task 5.2 Step 1 instructs the engineer to compute the real value first. Acceptable because the workflow is "compute → paste".
+
+**3. Type / name consistency:**
+
+- `validateReturnPath` — same name in Tasks 1.3, 1.5, 1.6, 1.8.
+- `signViewerCookie` / `verifyViewerCookie` — Tasks 3.1, 3.2, 6.1, 7.2, 7.3.
+- `resolveViewerAccess` — Tasks 6.1, 7.2.
+- `renderMarkdownPage` / `renderMermaidPage` / `renderChromeWithIframe` / `renderImageInline` / `renderRawHtmlBody` — defined Phase 5, called Phase 7.
+- `passwordGatePage` / `gonePage` / `notFoundPage` / `internalErrorPage` / `rateLimitedPage` — Phase 4 + Phase 7.
+- `parseShareTokenPath` — Task 7.2 Step 1.
+- `Env.VIEWER_COOKIE_SECRET` and `Env.VIEWER_PASSWORD_LIMIT` — Task 2.2, used Tasks 6.1, 7.2.
+- `ViewerAccess.kind` discriminator — Task 6.1, switched on in Task 7.2.
+
+**4. Ambiguity:** all decisions are explicit; no "depending on…" or "either way" branches in implementation steps.
+
+---
+
+## Anchor docs
+
+- Spec: [`docs/superpowers/specs/2026-05-03-r5-viewer-design.md`](../specs/2026-05-03-r5-viewer-design.md).
+- Backend spec (preceding work): [`docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`](../specs/2026-05-03-r5-publish-backend-design.md).
+- Backend plan (template for this plan's shape): [`docs/superpowers/plans/2026-05-03-r5-publish-backend.md`](./2026-05-03-r5-publish-backend.md).
+- Issue #316.

--- a/docs/superpowers/specs/2026-05-03-r5-viewer-design.md
+++ b/docs/superpowers/specs/2026-05-03-r5-viewer-design.md
@@ -1,0 +1,506 @@
+# R5 Public Viewer — Design Spec
+
+**Date:** 2026-05-03
+**Status:** Approved for implementation
+**Scope:** Public viewer at `GET /p/:share_token` in the `oyster-publish` Worker, plus a generic `?return=<path>` flow added to `auth-worker` so `signin` mode can redirect cleanly. Replaces the `501 Not Implemented` stub left by #315. UI for publishing lands in #317.
+
+**Tracks:** Issue #316. Part of R5 in [`docs/requirements/oyster-cloud.md`](../../requirements/oyster-cloud.md). Builds on [`2026-05-03-r5-publish-backend-design.md`](./2026-05-03-r5-publish-backend-design.md).
+
+---
+
+## Problem
+
+#315 shipped the publish backend: an agent or the local server can call `publish_artifact`, bytes land in R2, a row lands in `published_artifacts`, and a `share_url` like `https://oyster.to/p/<token>` is returned. Visiting that URL in a browser today returns:
+
+```json
+{ "error": "not_implemented", "handler": "publish_viewer" }
+```
+
+R5 is not a feature until that URL serves bytes. The viewer must:
+
+- Resolve `share_token` → the publication row.
+- Enforce the three access modes: `open`, `password`, `signin`.
+- Render the artefact correctly per `artifact_kind` (markdown, mermaid, single-file HTML, image).
+- Treat retired tokens (`unpublished_at IS NOT NULL`) as `410 Gone`.
+- Be safe to host arbitrary user-supplied HTML on `oyster.to` without exposing signed-in users.
+
+The `signin` mode also requires a generic post-sign-in redirect mechanism that `auth-worker` doesn't yet have.
+
+---
+
+## Goals
+
+- A user clicking a published URL sees the rendered artefact under each access mode (open immediately; password after unlock; sign-in after authenticating).
+- A user clicking a retired URL sees a clean "this share has been removed" page.
+- A signed-in publisher sharing a `mode=signin` URL sees content; an unsigned visitor is sent through sign-in and lands back on the artefact.
+- User-controlled HTML in published artefacts cannot read the `oyster_session` cookie or call our APIs (origin-isolated by sandbox iframe).
+- Single coherent PR. Cloud-surface delta is small but non-zero: one new Worker secret (`VIEWER_COOKIE_SECRET` on `oyster-publish`), one new rate-limiter binding (`VIEWER_PASSWORD_LIMIT` on `oyster-publish`), two additive nullable columns on the auth-worker D1 (`magic_link_tokens.return_path`, `oauth_states.return_path`). All listed in *Operational changes* below.
+
+## Out of Scope
+
+- Publish UI in the artefact panel (#317).
+- Multi-file bundles (#242–#248). Single-file artefacts only.
+- Image-as-`artifact_kind`. Images render correctly via content-type dispatch but no `image` kind is added.
+- Bandwidth metering / view counts.
+- Token rotation as a discrete operation (still unpublish-then-republish).
+- Pro-tier behaviours (no-watermark, custom domains, etc.).
+- Server-rendered mermaid (uses CDN client-side).
+- Syntax highlighting for code blocks in markdown.
+- Cross-Worker session sync beyond what already exists (shared D1 binding to `sessions`).
+
+---
+
+## Topology
+
+```
+Visitor browser
+     │
+     ▼
+oyster.to/p/<token>          ─── (Cloudflare zone routes to oyster-publish Worker)
+     │
+     ▼
+oyster-publish Worker (infra/oyster-publish/src/)
+     │
+     ├─→ D1 (oyster-auth, shared binding)
+     │     - SELECT published_artifacts WHERE share_token = ?
+     │     - SELECT sessions JOIN users  (signin mode auth check)
+     │
+     ├─→ R2 (oyster-artifacts)
+     │     - GET published/<owner>/<token>  (after auth passes)
+     │
+     └─→ Render dispatch by content_type then artifact_kind
+           - image/*       → bytes inline
+           - notes (md)    → server-render via markdown-it (html: false), wrap in chrome
+           - diagram (mmd) → server-render HTML page that loads pinned mermaid via CDN
+           - app/deck/...  → chrome page with <iframe sandbox> pointing at /p/<token>/raw
+```
+
+`/p/<token>/raw` is a sibling endpoint that serves the artefact bytes directly with strict CSP and no chrome — it exists solely as the iframe `src` for HTML kinds. It honours the same auth as `/p/<token>` (no separate cookie path).
+
+For `signin` mode, the viewer 302s to `https://oyster.to/auth/sign-in?return=/p/<token>`. This is a new param on `auth-worker`'s sign-in flow (see *Auth-worker change* below).
+
+---
+
+## Routes
+
+```
+GET /p/:share_token         — viewer entry point (chrome page, gate, or 302)
+GET /p/:share_token/raw     — iframe content endpoint for HTML kinds
+POST /p/:share_token        — password gate form submit (mode=password only)
+```
+
+The two GET endpoints share the same auth path (`resolveViewerAccess` below) and differ only in what they emit on success. POST is a thin handler that processes the password form and either sets the unlock cookie + 302s, or re-renders the gate.
+
+---
+
+## Access dispatch
+
+Single function `resolveViewerAccess(req, env, shareToken)` returns a tagged union:
+
+```ts
+type ViewerAccess =
+  | { ok: true; row: PublicationRow }              // serve content
+  | { gate: 'password'; row: PublicationRow; error?: 'wrong_password' }
+  | { redirect: string }                            // 302 (signin mode → auth-worker)
+  | { gone: true; row: PublicationRow }             // 410
+  | { not_found: true };                            // 404
+```
+
+Sequence:
+
+1. **Lookup.** `SELECT * FROM published_artifacts WHERE share_token = ?`. No row → `{ not_found: true }`.
+2. **Gone check.** `unpublished_at IS NOT NULL` → `{ gone: true, row }`.
+3. **Mode dispatch:**
+   - `open` → `{ ok: true, row }`.
+   - `password`:
+     - Read `oyster_view_<token>` cookie. If present and HMAC verifies (key from `env.VIEWER_COOKIE_SECRET`), `{ ok: true, row }`.
+     - Else `{ gate: 'password', row }`.
+   - `signin`:
+     - Reuse the existing `resolveSession` helper from `worker.ts` (already shared across publish handlers). Returns `null` on missing/expired cookie.
+     - Signed in → `{ ok: true, row }`.
+     - Not signed in → `{ redirect: 'https://oyster.to/auth/sign-in?return=/p/<token>' }`.
+
+The `POST` form handler is separate but builds on the same row lookup:
+
+```ts
+async function handlePasswordSubmit(req, env, shareToken) {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  if ('not_found' in access) return notFoundResponse();
+  if ('gone' in access) return goneResponse();
+  // Only mode=password reaches here meaningfully; other modes ignore the post.
+  if (access.row.mode !== 'password') return methodNotAllowedResponse();
+
+  const form = await req.formData();
+  const password = form.get('password');
+  if (typeof password !== 'string' || password.length === 0) {
+    return renderGate(access.row, { error: 'wrong_password' });
+  }
+  const ok = await verifyPbkdf2(password, access.row.password_hash!);
+  if (!ok) return renderGate(access.row, { error: 'wrong_password' });
+
+  const cookie = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'set-cookie': `oyster_view_${shareToken}=${cookie}; HttpOnly; Secure; SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
+      'location': `/p/${shareToken}`,
+      'cache-control': 'private, no-store',
+    },
+  });
+}
+```
+
+**Wrong-password rate-limiting** is enforced by a new rate-limiter binding `VIEWER_PASSWORD_LIMIT` on the `oyster-publish` Worker (scoped per IP, ~10 attempts / 60s — exact budget mirrors `auth-worker`'s `MAGIC_LINK_LIMIT`). Wrong-password attempts beyond the budget see a 429 page (same shape as the auth-worker's existing 429 HTML). Declared in `infra/oyster-publish/wrangler.toml`; no runtime config beyond the binding.
+
+---
+
+## Render dispatch
+
+After `resolveViewerAccess` returns `{ ok: true, row }`, fetch the bytes from R2 and dispatch.
+
+```ts
+const obj = await env.ARTIFACTS.get(row.r2_key);
+if (!obj) return internalErrorResponse(); // R2/D1 inconsistency — log + 500
+
+const bytes = new Uint8Array(await obj.arrayBuffer());
+const contentType = row.content_type;
+
+if (contentType.startsWith('image/')) {
+  return imageInlineResponse(bytes, contentType, row);
+}
+
+switch (row.artifact_kind) {
+  case 'notes':
+    return renderMarkdownPage(bytes, row);
+  case 'diagram':
+    return renderMermaidPage(bytes, row);
+  case 'app':
+  case 'deck':
+  case 'wireframe':
+  case 'table':
+  case 'map':
+    return renderChromeWithIframe(row);  // /raw will serve bytes
+  default:
+    // Unknown kind — fall back to attempted markdown render if text/* mime,
+    // else iframe-with-raw. Conservative.
+    return contentType.startsWith('text/')
+      ? renderMarkdownPage(bytes, row)
+      : renderChromeWithIframe(row);
+}
+```
+
+Dispatch order — **content-type first, then kind** — so a `notes` artefact whose bytes are actually a PNG (rare but possible if someone edits a note's file directly) gets served correctly. Image MIME wins.
+
+### Markdown (`notes`)
+
+- Library: `markdown-it@^14`, configured `{ html: false, linkify: true, typographer: false }`.
+- `html: false` means raw HTML in markdown is escaped — no XSS path through `<script>` or `<img onerror=>` injected into a notes file.
+- Decode bytes via `new TextDecoder().decode(bytes)`. UTF-8 assumed; invalid sequences fall through to U+FFFD (markdown-it accepts).
+- Wrap output in chrome page (`renderChromePage(html, row)`).
+- CSP: `default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'`.
+  - Inline styles allowed (chrome stylesheet).
+  - Inline scripts NOT allowed.
+  - Images from any HTTPS source (markdown often references public images).
+
+### Mermaid (`diagram`)
+
+- Server-renders an HTML page with the source embedded in `<pre class="mermaid">…</pre>` plus a CDN script tag.
+- Pinned: `https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js` with subresource integrity (`integrity="sha384-…"` — value populated at build time, verified once and committed).
+- Initialiser: `mermaid.initialize({ startOnLoad: false }); mermaid.run({ querySelector: 'pre.mermaid' }).catch(showSourceFallback)`.
+- Fallback: on `mermaid.run()` rejection, replace the `<pre class="mermaid">` content with the original source wrapped in `<pre><code>` so the user sees diagram source rather than a blank page.
+- CSP: `default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data:`.
+  - Inline scripts allowed (the `mermaid.run()` initialiser is inline).
+  - jsdelivr is the only off-origin script source.
+
+### Single-file HTML kinds (`app`, `deck`, `wireframe`, `table`, `map`)
+
+- The chrome page contains a header, footer, and `<iframe sandbox="allow-scripts" src="/p/<token>/raw" style="border:0;width:100%;height:calc(100vh - <chrome-height>);"></iframe>`.
+- No `allow-same-origin` in the sandbox attribute → the iframe document is treated as a unique opaque origin. It cannot read `document.cookie` from the parent or fetch the parent's URLs.
+- The `/raw` endpoint:
+  - Same auth check (`resolveViewerAccess`).
+  - Serves bytes directly with `Content-Type: row.content_type`.
+  - Headers: `Cache-Control: <per mode>` (same rule as parent), `Content-Security-Policy: default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none';`, `X-Frame-Options: SAMEORIGIN`.
+  - The strict CSP forbids the artefact from making outgoing fetches (`connect-src 'none'`) and from being framed by anyone other than us (`X-Frame-Options: SAMEORIGIN`).
+
+### Image content-type
+
+- Serve bytes inline with `Content-Type: <recorded>` and `Content-Disposition: inline`.
+- No chrome — the image is the page. (Browsers render bare images cleanly; wrapping them in chrome would be hostile to drag-to-save, right-click etc.)
+- Same cache headers as the per-mode rule.
+
+---
+
+## Chrome
+
+Chrome appears only on **successful published views** (open content / password viewer post-unlock / signin viewer post-auth). Intermediary states (gates, 410, 404, errors) get **minimal pages** — no chrome.
+
+Chrome layout:
+
+```
+┌──────────────────────────────────────────────┐
+│ 🦪 oyster                       <action>    │  ← header (height ~36px)
+├──────────────────────────────────────────────┤
+│                                              │
+│   <rendered content or iframe>               │
+│                                              │
+├──────────────────────────────────────────────┤
+│ Powered by Oyster · oyster.to               │  ← footer (height ~24px)
+└──────────────────────────────────────────────┘
+```
+
+The `<action>` slot in the header is mode-aware:
+
+| State | Action slot |
+|---|---|
+| Open viewer | "Get your own at oyster.to" link |
+| Password viewer (post-unlock) | "Get your own at oyster.to" link |
+| Signin viewer (signed in) | (empty in v1; user email in a future iteration) |
+
+Footer is the same across success states. No additional buttons in v1 (no Share, no QR — those are good UX but explicitly deferred to keep PR scope tight; can be added without architecture change).
+
+Chrome HTML+CSS is a single template module (`viewer-chrome.ts`) returning a string. Total weight ≤ 4 KB. No external CSS, no external fonts.
+
+---
+
+## Minimal pages (gates and errors)
+
+Same template family — small lock/info icon, heading, hint paragraph, action(s). No header/footer chrome. Single discreet "Shared via Oyster" tagline at the bottom (small, low-contrast).
+
+| Page | Heading | Body | Action(s) |
+|---|---|---|---|
+| Password gate | "Password required" | "This share is password-protected." | `<form method="POST">` with password input + Unlock button |
+| Password gate (wrong) | same | "Incorrect password." (red, inline above input) | same |
+| Sign-in gate (mode=signin, unsigned) | n/a | (no gate page — direct 302 to auth-worker) | n/a |
+| 410 Gone | "This share has been removed" | "The owner has unpublished this artefact." | (none) |
+| 404 Not found | "Share not found" | "The link may have been mistyped or removed." | (none) |
+| Internal error | "Something went wrong" | "Try again in a moment." | (none) |
+| Rate-limited (POST) | "Too many attempts" | "Wait a minute and try again." | (none) |
+
+Plain HTML rendering with `Content-Type: text/html`. JSON variants returned only when `Accept: application/json` is set on the request — same body in `{ error: <code>, message: <human> }` shape, identical to other Worker error responses.
+
+---
+
+## Auth-worker change: generic `?return=`
+
+`auth-worker`'s `/auth/sign-in` page and post-sign-in handlers (magic-link callback, GitHub callback) currently support only the device-code handoff (`?d=<user_code>`). For `signin` mode in the viewer, we add a generic `?return=<path>` param.
+
+### Allowlist
+
+Only paths matching `^\/p\/[A-Za-z0-9_\-]+$` are honoured. Anything else (including `https://`-prefixed URLs, `..` traversals, query strings, fragments) is silently dropped — sign-in proceeds, return path defaults to the existing landing.
+
+This is closed against open-redirect: the only places we can land a visitor post-sign-in are share-token routes on our own zone.
+
+### Wiring
+
+- `/auth/sign-in?return=…` — render the existing form with `<input type="hidden" name="return" value="…">`. The magic-link POST handler reads it from the form body. The `?d=<user_code>` device flow is mutually exclusive with `?return=`: if both are present, `?d=` wins (device flow is its own destination), `?return=` is dropped.
+- Magic-link request flow — pass `return` through to the magic-link record so the eventual click-through respects it.
+- GitHub OAuth callback — store `return` in the `oauth_states` row alongside `pkce_verifier`, retrieve on callback.
+- After successful session creation, if a valid `return` is recorded, 302 to it. Else default to current behaviour (`oyster.to/`).
+
+### Schema impact
+
+One additive nullable column on each of `magic_link_tokens` and `oauth_states`:
+
+```sql
+-- infra/auth-worker/migrations/0004_return_path.sql
+ALTER TABLE magic_link_tokens ADD COLUMN return_path TEXT;
+ALTER TABLE oauth_states ADD COLUMN return_path TEXT;
+```
+
+Both nullable, both ignored on existing rows. Wrapped in idempotent try/catch (auth-worker convention).
+
+### Backwards compatibility
+
+Pages that currently link to `/auth/sign-in` (no return) continue to work — empty/missing `return_path` falls through to the default.
+
+---
+
+## Cookie scheme (password mode)
+
+`oyster_view_<token>` cookie shape:
+
+```
+<token>.<timestamp>.<hmac>
+
+  token     — the share_token (redundant but explicit; lets us assert consistency)
+  timestamp — unix seconds when the cookie was issued
+  hmac      — HMAC-SHA256 over (token || "." || timestamp), keyed by env.VIEWER_COOKIE_SECRET
+              base64url-encoded, no padding
+```
+
+Verification:
+
+1. Parse `<token>.<timestamp>.<hmac>`. Reject malformed cookie.
+2. Recompute HMAC; compare in constant time. Reject mismatch.
+3. Require `token === <expected share_token>` (the cookie path scopes this, but assert anyway).
+4. Require `now - timestamp <= 86400`. Reject expired (browser may have ignored Max-Age).
+
+**Secret rotation** = ship a new `VIEWER_COOKIE_SECRET`; existing cookies become invalid; users re-enter password. Acceptable failure mode.
+
+`VIEWER_COOKIE_SECRET` is a new Worker secret — set once via `wrangler secret put VIEWER_COOKIE_SECRET` against `oyster-publish` before this change merges. Spec'd here so it doesn't surprise the PR reviewer.
+
+---
+
+## Cache headers
+
+| Surface | Header |
+|---|---|
+| Open viewer (chrome page) | `Cache-Control: public, max-age=60, must-revalidate` + `ETag: W/"<token>-<updated_at>"` |
+| `/raw` (open mode, HTML kinds) | same |
+| Image inline (open mode) | same |
+| Password viewer (post-unlock) | `Cache-Control: private, no-store` |
+| Signin viewer | `Cache-Control: private, no-store` |
+| Password gate page | `Cache-Control: private, no-store` |
+| 410 / 404 / errors | `Cache-Control: private, no-store` |
+| 302 redirects (signin → auth) | `Cache-Control: private, no-store` |
+
+`max-age=60` is short enough that an unpublish becomes visible almost immediately; long enough to absorb a viral share's burst on a single CDN node. `must-revalidate` ensures CDN-aged responses revalidate against origin rather than serving stale on errors.
+
+`ETag` uses `updated_at` (not `published_at`) so a republish (which bumps `updated_at`) invalidates cached responses without changing the URL.
+
+---
+
+## Error matrix
+
+| Condition | HTTP | Body |
+|---|---|---|
+| Share token not in D1 | 404 | minimal HTML "Share not found" / `{error:"not_found"}` |
+| Token in D1, `unpublished_at NOT NULL` | 410 | minimal HTML "This share has been removed" / `{error:"gone"}` |
+| `mode=password`, no/invalid cookie, GET | 200 | minimal HTML password gate |
+| `mode=password`, POST, empty body | 200 | gate re-rendered with "Incorrect password" |
+| `mode=password`, POST, wrong password | 200 | gate re-rendered with "Incorrect password" |
+| `mode=password`, POST, rate-limit hit | 429 | minimal HTML "Too many attempts" |
+| `mode=signin`, no/expired session, GET | 302 | `Location: /auth/sign-in?return=/p/<token>` |
+| Auth passes, R2 object missing | 500 | minimal HTML "Something went wrong" / `{error:"internal_error"}` |
+| Method not allowed (POST on `mode=open`) | 405 | minimal HTML / JSON |
+| `?return=` value rejected by allowlist | n/a | sign-in proceeds; param silently dropped |
+
+---
+
+## Testing
+
+### Worker unit tests (`infra/oyster-publish/test/`)
+
+Add `viewer-handler.test.ts` and `viewer-helpers.test.ts`.
+
+- HMAC cookie sign/verify round-trip (correct verifies, tampered rejects, expired rejects).
+- Allowlist for `?return=` path: positive (`/p/abcXYZ_-`), negative (`/p/`, `/p/../etc`, `https://attacker.com`, `/dashboard`, empty).
+- markdown-it config: raw `<script>` in input is escaped, not executed (assert via output string).
+- mermaid HTML wrapper: contains pinned CDN URL with SRI hash, initialiser script, and source embedded.
+- ETag generation: same `(token, updated_at)` → same etag; different `updated_at` → different etag.
+
+### Worker integration tests (vitest-pool-workers)
+
+- **Open mode happy path:** publish → GET `/p/<token>` → 200, chrome present, content rendered, etag set, cache-control `public, max-age=60`.
+- **Open mode if-none-match:** second GET with `If-None-Match` header matching previous etag → 304.
+- **410 gone:** publish → unpublish → GET → 410, "this share has been removed" page.
+- **404 not found:** GET unknown token → 404.
+- **Password mode, no cookie:** GET → 200 gate page; no `oyster_view_*` cookie set.
+- **Password mode, correct password:** POST → 302 with cookie; follow-up GET → 200 content.
+- **Password mode, wrong password:** POST wrong → 200 gate with error; no cookie set.
+- **Password mode, expired cookie:** craft a cookie with timestamp older than 86400s → GET → 200 gate (cookie rejected).
+- **Password mode, tampered cookie:** flip a byte in HMAC → GET → 200 gate.
+- **Signin mode, unsigned visitor:** GET → 302 to `/auth/sign-in?return=/p/<token>`.
+- **Signin mode, signed in:** GET with valid `oyster_session` cookie → 200 content.
+- **Image content-type:** publish a tiny PNG, dispatch returns image/png inline (no chrome wrapping).
+- **HTML kind iframe:** publish an `app`, GET → chrome page with `<iframe sandbox="allow-scripts" src="/p/<token>/raw">`. GET `/raw` → bytes with strict CSP.
+- **Sandbox isolation assertion (best-effort):** `/raw` response includes the strict CSP header; `Content-Security-Policy` value contains `connect-src 'none'`.
+- **Mode + cache header matrix:** assert each of the seven surface cases above sets the right `Cache-Control`.
+
+### Auth-worker tests (`infra/auth-worker/test/`)
+
+- `?return=/p/abc123` honoured: form's hidden input contains the return path; magic-link landing 302s to it.
+- `?return=` injected as `https://attacker.com` is dropped; sign-in proceeds, post-sign-in 302 goes to default.
+- `?return=` together with `?d=<user_code>` (device flow): `?d=` wins, return is dropped (deliberate — device flow is its own destination).
+- GitHub OAuth callback honours stored return path; rejected paths are dropped.
+
+### Manual smoke (post-deploy)
+
+- Publish three artefacts (open / password / signin) via MCP against the local server.
+- Visit each share URL in a fresh browser:
+  - Open: content renders, chrome visible, etag in DevTools, second load is 304.
+  - Password: gate renders, wrong password shows error, correct password unlocks, reload shows content (no re-prompt).
+  - Signin: 302 to sign-in form, sign in via GitHub OAuth, land back on the share, content renders.
+- Visit a published HTML `app`: confirm iframe wraps it, `document.cookie` from the iframe's devtools console returns `""` (no `oyster_session`).
+- Unpublish one: visit URL → 410 page.
+
+---
+
+## Known limitations
+
+1. **CDN dependency for mermaid.** jsdelivr outage = mermaid diagrams show source-fallback. Acceptable; falling back to source is graceful.
+2. **No sanitiser for markdown beyond `html: false`.** A determined attacker can still produce a markdown link to `javascript:…` — markdown-it's `linkify: true` doesn't catch this. Solution: post-process the rendered HTML to strip `href` values matching `^javascript:` (~5 lines of regex). Spec'd here, implemented in the PR.
+3. **Sandbox iframe's CSP is best-effort.** A clever HTML artefact could in theory use forms or `<base>` to escape — that's why the `/raw` CSP includes `base-uri 'none'` and `form-action 'none'`. Not all browsers enforce every CSP directive uniformly; Cloudflare's egress logs would catch widespread abuse.
+4. **No rate-limiting on `GET /p/<token>`.** Public reads are uncapped. Bandwidth abuse is bounded by R2 read pricing; if it becomes a problem, add a per-IP rate limiter (existing `MAGIC_LINK_LIMIT` pattern is reusable).
+5. **`oyster_view_<token>` cookie is per-token, not per-user.** Two visitors sharing a browser would share the unlocked state for a given share. Acceptable — password sharing is the threat model the publisher already accepted.
+6. **No view counts or analytics.** A `published_artifacts.view_count` is a future column; out of scope here.
+7. **No "I forgot the password" recovery flow.** The publisher unpublishes and republishes (with a new token + new password). Acceptable for v1.
+
+---
+
+## Decisions log
+
+| Question | Decision | Reason |
+|---|---|---|
+| One Worker or split chrome / `/raw`? | One Worker, two routes. | `/raw` is just an alternate render of the same auth-checked row; sharing `resolveViewerAccess` keeps logic single-sourced. |
+| Sandbox iframe vs separate origin (e.g. `pub.oyster.to`)? | Sandbox iframe (`allow-scripts` only). | Achieves origin isolation without introducing a new domain or cookie-domain change. Sandbox-no-`allow-same-origin` is the standard pattern. |
+| markdown lib? | `markdown-it` with `html: false`. | Disables raw HTML at the parser level. No DOMPurify dependency, no DOM in Worker. Smaller than marked + sanitizer combo. |
+| mermaid lib? | Pinned CDN (jsdelivr `mermaid@10.9.1`) with SRI. | Mermaid is ~600 KB; bundling in the Worker would inflate cold-start and bytes-deployed. Client-side render is the upstream-recommended path. |
+| mermaid fallback on failure? | Show source in `<pre><code>`. | A blank page is the worst failure mode; source-as-fallback is informative and graceful. |
+| Chrome on every viewer surface? | No — chrome on success states only; minimal pages on gates/errors. | Chrome competes with single-task pages (gates have one job). Cleaner UX, smaller HTML for failure paths. |
+| Action slot in header for password mode? | Empty. | "Sign in" or "Get Oyster" links would compete with the gate's primary action. |
+| Sign-in redirect mechanism? | Generic `?return=<path>` param on auth-worker, allowlisted to `/p/*`. | Standard pattern. Allowlist closes open-redirect. Future Workers (e.g. /apps/*) reuse the same param. |
+| Cookie for password unlock? | HMAC-signed, per-token, `Path=/p/<token>`, 24h, HttpOnly+Secure+SameSite=Lax. | Per-token scope prevents one unlock from leaking to other shares. Path-scoping limits cookie surface. 24h is a reasonable session window for a shared link. |
+| Cache `max-age` for open mode? | 60 seconds. | Long enough to absorb a single-node burst; short enough that unpublish becomes visible quickly. |
+| ETag basis? | `W/"<token>-<updated_at>"`. | Republish bumps `updated_at` → cache invalidated. Weak etag is fine (HTML responses aren't byte-identical across renders due to timestamps). |
+| 404/410 page format? | HTML by default; JSON if `Accept: application/json`. | Browsers default to `*/*` or `text/html`; agents can opt in. |
+| `?return=` allowlist regex? | `^/p/[A-Za-z0-9_-]+$`. | Matches the share-token charset. Anything else (full URLs, traversal, other paths) is rejected. |
+| Image content-type dispatch order? | content-type → kind. | If bytes are image/* the chrome doesn't matter; serve inline regardless of `artifact_kind`. |
+| Auth-worker schema change for `return_path`? | Yes — additive nullable columns on `magic_links` and `oauth_states`. | Sign-in is async (magic link, OAuth callback); we need to persist the return path across the round-trip. |
+| Single PR or split? | Single PR. | The auth-worker schema delta is two additive nullable columns — small enough not to warrant its own PR. Reviewing the viewer + the return-path plumbing together is clearer than splitting them. |
+| New secrets? | `VIEWER_COOKIE_SECRET` on `oyster-publish`. | Required for HMAC. One-time `wrangler secret put` before merge. |
+
+---
+
+## Operational changes
+
+Cloud-surface delta introduced by this PR. All listed here so the deploy story is clear.
+
+| Change | Where | Operational step |
+|---|---|---|
+| New secret `VIEWER_COOKIE_SECRET` | `oyster-publish` Worker | `wrangler secret put VIEWER_COOKIE_SECRET --name oyster-publish` (32-byte random hex) before merge |
+| New rate-limiter binding `VIEWER_PASSWORD_LIMIT` | `infra/oyster-publish/wrangler.toml` | declared in repo; deployed automatically with the Worker |
+| Additive column `magic_link_tokens.return_path TEXT` | `infra/auth-worker/migrations/0004_return_path.sql` | applied via wrangler at deploy; idempotent try/catch in worker startup as fallback |
+| Additive column `oauth_states.return_path TEXT` | same migration | same |
+| New routes already covered by existing wrangler.toml | `oyster.to/p/*` and `www.oyster.to/p/*` | already routed (the 501 stub uses these); no change |
+
+No new D1 databases, no new R2 buckets, no new domains, no DNS changes.
+
+---
+
+## Implementation sequence (for the plan that follows)
+
+This spec is single-PR. Suggested task ordering inside that PR (will be settled by `superpowers:writing-plans`):
+
+1. **Auth-worker `?return=` plumbing** — `0004_return_path.sql` migration, allowlist helper, sign-in form hidden input, magic-link callback, GitHub OAuth callback. Tests. Independent of `oyster-publish` changes.
+2. **`oyster-publish` bindings** — declare `VIEWER_PASSWORD_LIMIT` rate-limiter in `wrangler.toml`; document `VIEWER_COOKIE_SECRET` in README and prepare the deploy runbook entry.
+3. **`oyster-publish` viewer scaffold** — `resolveViewerAccess`, the new GET/POST route handlers (still returning bare 200/404/410/302 with no body) so the dispatch table is testable.
+4. **Chrome + minimal-page templates** — `viewer-chrome.ts`, `viewer-pages.ts`. Pure functions returning strings. Snapshot tests.
+5. **Render dispatch** — markdown, mermaid, image, iframe. One function each in `viewer-render.ts`.
+6. **`/raw` endpoint** — strict-CSP byte serving for HTML kinds.
+7. **Cookie HMAC** — `viewer-cookie.ts` with sign/verify; consume `env.VIEWER_COOKIE_SECRET`.
+8. **Cache headers + ETag** — inject into each response path.
+9. **Wiring** — replace the `501` stub in `worker.ts` with the full dispatch.
+10. **Worker integration tests** — full happy/sad-path matrix.
+11. **Manual smoke against deployed Worker** post-merge — three modes, iframe isolation check, 410 after unpublish.
+
+Anchors: `infra/oyster-publish/src/worker.ts` is the home; `infra/auth-worker/src/worker.ts` (lines 649-663 `handleWhoami`) is the session-cookie pattern; `server/src/password-hash.ts` is the PBKDF2 producer that the viewer's Web Crypto verifier must match exactly.
+
+---
+
+## Anchor docs
+
+- [`docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md`](./2026-05-03-r5-publish-backend-design.md) — backend that produces the bytes this viewer serves.
+- [`docs/requirements/oyster-cloud.md`](../../requirements/oyster-cloud.md) — R5 canonical requirement.
+- [`docs/plans/roadmap.md`](../../plans/roadmap.md) — 0.7.0 milestone scope.
+- Issue #316.

--- a/docs/superpowers/specs/2026-05-03-r5-viewer-design.md
+++ b/docs/superpowers/specs/2026-05-03-r5-viewer-design.md
@@ -150,7 +150,15 @@ async function handlePasswordSubmit(req, env, shareToken) {
 }
 ```
 
-**Wrong-password rate-limiting** is enforced by a new rate-limiter binding `VIEWER_PASSWORD_LIMIT` on the `oyster-publish` Worker (scoped per IP, ~10 attempts / 60s — exact budget mirrors `auth-worker`'s `MAGIC_LINK_LIMIT`). Wrong-password attempts beyond the budget see a 429 page (same shape as the auth-worker's existing 429 HTML). Declared in `infra/oyster-publish/wrangler.toml`; no runtime config beyond the binding.
+**Wrong-password rate-limiting:** the POST handler calls `await env.VIEWER_PASSWORD_LIMIT.limit({ key })` **before** PBKDF2 verification. The key combines client IP + `share_token`:
+
+```ts
+const ip = req.headers.get('cf-connecting-ip') ?? 'unknown';
+const gate = await env.VIEWER_PASSWORD_LIMIT.limit({ key: `${ip}:${shareToken}` });
+if (!gate.success) return rateLimitedResponse();  // 429
+```
+
+Including `share_token` in the key means one bad actor on one IP cannot exhaust password attempts across all the publisher's shares. Budget is ~10 attempts / 60s (mirrors `auth-worker`'s `MAGIC_LINK_LIMIT`). Binding declared in `infra/oyster-publish/wrangler.toml` (`[[unsafe.bindings]] type = "ratelimit"` per current Workers Rate Limiting API).
 
 ---
 
@@ -205,7 +213,7 @@ Dispatch order — **content-type first, then kind** — so a `notes` artefact w
 ### Mermaid (`diagram`)
 
 - Server-renders an HTML page with the source embedded in `<pre class="mermaid">…</pre>` plus a CDN script tag.
-- Pinned: `https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js` with subresource integrity (`integrity="sha384-…"` — value populated at build time, verified once and committed).
+- Pinned: `https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js` with subresource integrity. The SRI hash is computed once (`openssl dgst -sha384 -binary mermaid.min.js | openssl base64 -A`), pinned in source alongside the URL, and committed. Both move together when we bump the mermaid version.
 - Initialiser: `mermaid.initialize({ startOnLoad: false }); mermaid.run({ querySelector: 'pre.mermaid' }).catch(showSourceFallback)`.
 - Fallback: on `mermaid.run()` rejection, replace the `<pre class="mermaid">` content with the original source wrapped in `<pre><code>` so the user sees diagram source rather than a blank page.
 - CSP: `default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data:`.
@@ -214,7 +222,14 @@ Dispatch order — **content-type first, then kind** — so a `notes` artefact w
 
 ### Single-file HTML kinds (`app`, `deck`, `wireframe`, `table`, `map`)
 
-- The chrome page contains a header, footer, and `<iframe sandbox="allow-scripts" src="/p/<token>/raw" style="border:0;width:100%;height:calc(100vh - <chrome-height>);"></iframe>`.
+- The chrome page contains a header, footer, and `<iframe sandbox="allow-scripts" src="/p/<token>/raw" style="border:0;width:100%;height:calc(100vh - 60px);"></iframe>` (60px = 36px header + 24px footer).
+- The iframe template carries an explicit comment so future maintainers don't "helpfully" add `allow-same-origin`:
+
+  ```ts
+  // Deliberately omit allow-same-origin.
+  // With allow-scripts only, the sandboxed document gets an opaque origin
+  // and cannot access oyster.to cookies or same-origin storage.
+  ```
 - No `allow-same-origin` in the sandbox attribute → the iframe document is treated as a unique opaque origin. It cannot read `document.cookie` from the parent or fetch the parent's URLs.
 - The `/raw` endpoint:
   - Same auth check (`resolveViewerAccess`).
@@ -286,9 +301,9 @@ Plain HTML rendering with `Content-Type: text/html`. JSON variants returned only
 
 ### Allowlist
 
-Only paths matching `^\/p\/[A-Za-z0-9_\-]+$` are honoured. Anything else (including `https://`-prefixed URLs, `..` traversals, query strings, fragments) is silently dropped — sign-in proceeds, return path defaults to the existing landing.
+Only paths matching `^\/p\/[A-Za-z0-9_\-]+$` are honoured. The `+$` anchor excludes `/p/<token>/raw` — we never want sign-in to land a user on the iframe-content endpoint (it's a chrome-less byte serve; landing there strands the user with no navigation back to the viewer). Anything else (including `https://`-prefixed URLs, `..` traversals, query strings, fragments) is silently dropped — sign-in proceeds, return path defaults to the existing landing.
 
-This is closed against open-redirect: the only places we can land a visitor post-sign-in are share-token routes on our own zone.
+This is closed against open-redirect: the only places we can land a visitor post-sign-in are the viewer route on our own zone.
 
 ### Wiring
 
@@ -386,6 +401,7 @@ Add `viewer-handler.test.ts` and `viewer-helpers.test.ts`.
 - HMAC cookie sign/verify round-trip (correct verifies, tampered rejects, expired rejects).
 - Allowlist for `?return=` path: positive (`/p/abcXYZ_-`), negative (`/p/`, `/p/../etc`, `https://attacker.com`, `/dashboard`, empty).
 - markdown-it config: raw `<script>` in input is escaped, not executed (assert via output string).
+- markdown-it default `validateLink`: inputs containing `[click](javascript:alert(1))`, `[](vbscript:…)`, `[](file:///etc/passwd)` and unsafe `data:` schemes do not produce active `href` attributes in the rendered HTML. Confirms we don't need to override `validateLink`.
 - mermaid HTML wrapper: contains pinned CDN URL with SRI hash, initialiser script, and source embedded.
 - ETag generation: same `(token, updated_at)` → same etag; different `updated_at` → different etag.
 
@@ -429,12 +445,13 @@ Add `viewer-handler.test.ts` and `viewer-helpers.test.ts`.
 ## Known limitations
 
 1. **CDN dependency for mermaid.** jsdelivr outage = mermaid diagrams show source-fallback. Acceptable; falling back to source is graceful.
-2. **No sanitiser for markdown beyond `html: false`.** A determined attacker can still produce a markdown link to `javascript:…` — markdown-it's `linkify: true` doesn't catch this. Solution: post-process the rendered HTML to strip `href` values matching `^javascript:` (~5 lines of regex). Spec'd here, implemented in the PR.
+2. **Markdown link safety relies on markdown-it's default `validateLink`.** markdown-it's default `validateLink` blocks `javascript:`, `vbscript:`, `file:`, and unsafe `data:` URLs from rendering as active hrefs. We do **not** override `validateLink`. Worker tests assert that markdown inputs containing those schemes do not produce active links in the rendered HTML. No regex post-processing — adding one would be a code smell signalling we don't trust the parser, and would risk diverging from upstream's continuously-updated allowlist. If a real test exposes a gap, that's the trigger to add layered defence.
 3. **Sandbox iframe's CSP is best-effort.** A clever HTML artefact could in theory use forms or `<base>` to escape — that's why the `/raw` CSP includes `base-uri 'none'` and `form-action 'none'`. Not all browsers enforce every CSP directive uniformly; Cloudflare's egress logs would catch widespread abuse.
-4. **No rate-limiting on `GET /p/<token>`.** Public reads are uncapped. Bandwidth abuse is bounded by R2 read pricing; if it becomes a problem, add a per-IP rate limiter (existing `MAGIC_LINK_LIMIT` pattern is reusable).
-5. **`oyster_view_<token>` cookie is per-token, not per-user.** Two visitors sharing a browser would share the unlocked state for a given share. Acceptable — password sharing is the threat model the publisher already accepted.
-6. **No view counts or analytics.** A `published_artifacts.view_count` is a future column; out of scope here.
-7. **No "I forgot the password" recovery flow.** The publisher unpublishes and republishes (with a new token + new password). Acceptable for v1.
+4. **Published apps in v1 are presentation-only.** The `/raw` CSP includes `connect-src 'none'` — published HTML cannot fetch from external APIs, can't talk to a backend, can't load remote scripts. This is intentional: it means "publish my Vite app to a working backend" is not in scope. Networked apps require a future explicit capability model (think: per-publication CORS allowlist, scoped server-side proxy, etc.). Anyone reaching the limit should treat it as a feature request, not a bug.
+5. **No rate-limiting on `GET /p/<token>`.** Public reads are uncapped. Bandwidth abuse is bounded by R2 read pricing; if it becomes a problem, add a per-IP rate limiter (the same `VIEWER_PASSWORD_LIMIT` binding pattern is reusable).
+6. **`oyster_view_<token>` cookie is per-token, not per-user.** Two visitors sharing a browser would share the unlocked state for a given share. Acceptable — password sharing is the threat model the publisher already accepted.
+7. **No view counts or analytics.** A `published_artifacts.view_count` is a future column; out of scope here.
+8. **No "I forgot the password" recovery flow.** The publisher unpublishes and republishes (with a new token + new password). Acceptable for v1.
 
 ---
 
@@ -448,7 +465,8 @@ Add `viewer-handler.test.ts` and `viewer-helpers.test.ts`.
 | mermaid lib? | Pinned CDN (jsdelivr `mermaid@10.9.1`) with SRI. | Mermaid is ~600 KB; bundling in the Worker would inflate cold-start and bytes-deployed. Client-side render is the upstream-recommended path. |
 | mermaid fallback on failure? | Show source in `<pre><code>`. | A blank page is the worst failure mode; source-as-fallback is informative and graceful. |
 | Chrome on every viewer surface? | No — chrome on success states only; minimal pages on gates/errors. | Chrome competes with single-task pages (gates have one job). Cleaner UX, smaller HTML for failure paths. |
-| Action slot in header for password mode? | Empty. | "Sign in" or "Get Oyster" links would compete with the gate's primary action. |
+| Action slot — password gate? | No chrome at all (gate is a minimal page). | Gate has one job: enter password. Chrome competes. |
+| Action slot — password viewer (post-unlock)? | "Get your own at oyster.to". | Same chrome treatment as `open` viewer once auth has cleared — funnel-on-success. |
 | Sign-in redirect mechanism? | Generic `?return=<path>` param on auth-worker, allowlisted to `/p/*`. | Standard pattern. Allowlist closes open-redirect. Future Workers (e.g. /apps/*) reuse the same param. |
 | Cookie for password unlock? | HMAC-signed, per-token, `Path=/p/<token>`, 24h, HttpOnly+Secure+SameSite=Lax. | Per-token scope prevents one unlock from leaking to other shares. Path-scoping limits cookie surface. 24h is a reasonable session window for a shared link. |
 | Cache `max-age` for open mode? | 60 seconds. | Long enough to absorb a single-node burst; short enough that unpublish becomes visible quickly. |

--- a/infra/auth-worker/migrations/0004_return_path.sql
+++ b/infra/auth-worker/migrations/0004_return_path.sql
@@ -1,8 +1,9 @@
 -- 0004_return_path.sql — generic post-sign-in redirect for #316.
 -- Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md
 -- Both columns are nullable; existing rows get NULL, current handlers
--- ignore the column. Wrapped in idempotent ALTERs so re-running the
--- migration on a partially-applied DB doesn't fail.
+-- ignore the column. Run once per environment via npm run db:migrate:0004
+-- (or :local). Rerun fails with 'duplicate column name' — that's the
+-- expected SQLite behaviour for ADD COLUMN; matches 0001-0003 convention.
 
 ALTER TABLE magic_link_tokens ADD COLUMN return_path TEXT;
 ALTER TABLE oauth_states     ADD COLUMN return_path TEXT;

--- a/infra/auth-worker/migrations/0004_return_path.sql
+++ b/infra/auth-worker/migrations/0004_return_path.sql
@@ -1,0 +1,8 @@
+-- 0004_return_path.sql — generic post-sign-in redirect for #316.
+-- Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md
+-- Both columns are nullable; existing rows get NULL, current handlers
+-- ignore the column. Wrapped in idempotent ALTERs so re-running the
+-- migration on a partially-applied DB doesn't fail.
+
+ALTER TABLE magic_link_tokens ADD COLUMN return_path TEXT;
+ALTER TABLE oauth_states     ADD COLUMN return_path TEXT;

--- a/infra/auth-worker/package-lock.json
+++ b/infra/auth-worker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "oyster-auth-worker",
       "version": "0.0.0",
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.0",
         "@cloudflare/workers-types": "^4.20260101.0",
         "typescript": "^5.4.0",
         "vitest": "^2.1.0",
@@ -38,6 +39,688 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
+      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20241230.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.100.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 2.1.x",
+        "@vitest/snapshot": "2.0.x - 2.1.x",
+        "vitest": "2.0.x - 2.1.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
+      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
+      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
+      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare": {
+      "version": "3.20241230.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
+      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241230.0",
+        "ws": "^8.18.0",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241218-183400-5d6aec3",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
+      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.3",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/workerd": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
+      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241230.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
+        "@cloudflare/workerd-linux-64": "1.20241230.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
+        "@cloudflare/workerd-windows-64": "1.20241230.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
+      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
+      "deprecated": "Downgrade to 3.99.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^4.0.1",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241230.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
+        "workerd": "1.20241230.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -154,6 +837,30 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -596,6 +1303,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@img/colour": {
@@ -1609,6 +2326,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -1736,6 +2473,42 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1744,6 +2517,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/blake3-wasm": {
@@ -1761,6 +2544,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
       }
     },
     "node_modules/chai": {
@@ -1790,6 +2584,36 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -1802,6 +2626,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -1832,6 +2674,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1842,6 +2691,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
@@ -1850,6 +2706,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1901,6 +2767,19 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1909,6 +2788,19 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/expect-type": {
@@ -1935,6 +2827,70 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -1963,6 +2919,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260430.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
@@ -1984,12 +2953,35 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -2009,6 +3001,30 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2041,6 +3057,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -2068,6 +3096,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rollup": {
@@ -2113,6 +3184,77 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.2",
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -2180,6 +3322,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2190,6 +3342,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2197,12 +3357,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
     },
     "node_modules/supports-color": {
       "version": "10.2.2",
@@ -2215,6 +3397,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tinybench": {
@@ -2266,8 +3461,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2283,6 +3477,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
@@ -2292,6 +3493,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
@@ -2991,6 +4199,13 @@
         }
       }
     },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
@@ -3014,6 +4229,16 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/infra/auth-worker/package.json
+++ b/infra/auth-worker/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
     "@cloudflare/workers-types": "^4.20260101.0",
     "typescript": "^5.4.0",
     "vitest": "^2.1.0",

--- a/infra/auth-worker/package.json
+++ b/infra/auth-worker/package.json
@@ -13,6 +13,8 @@
     "db:migrate:0002:local": "wrangler d1 execute oyster-auth --file=migrations/0002_oauth.sql --local",
     "db:migrate:0003": "wrangler d1 execute oyster-auth --file=migrations/0003_publish.sql --remote",
     "db:migrate:0003:local": "wrangler d1 execute oyster-auth --file=migrations/0003_publish.sql --local",
+    "db:migrate:0004": "wrangler d1 execute oyster-auth --file=migrations/0004_return_path.sql --remote",
+    "db:migrate:0004:local": "wrangler d1 execute oyster-auth --file=migrations/0004_return_path.sql --local",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/infra/auth-worker/src/return-path.ts
+++ b/infra/auth-worker/src/return-path.ts
@@ -1,0 +1,17 @@
+// Generic post-sign-in redirect target validation for #316.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Auth-worker change).
+//
+// The allowlist matches the share-viewer route AND ONLY that route.
+// We reject /p/<token>/raw because that's the iframe-content endpoint —
+// landing a user there would strand them with no navigation.
+
+const SHARE_VIEWER_PATH = /^\/p\/[A-Za-z0-9_-]+$/;
+const MAX_PATH_LEN = 256;  // share_token is 32 chars; this is generous.
+
+export function validateReturnPath(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") return null;
+  if (raw.length === 0 || raw.length > MAX_PATH_LEN) return null;
+  if (!SHARE_VIEWER_PATH.test(raw)) return null;
+  return raw;
+}

--- a/infra/auth-worker/src/return-path.ts
+++ b/infra/auth-worker/src/return-path.ts
@@ -12,6 +12,9 @@ export function validateReturnPath(raw: string | null | undefined): string | nul
   if (raw == null) return null;
   if (typeof raw !== "string") return null;
   if (raw.length === 0 || raw.length > MAX_PATH_LEN) return null;
+  // JS regex `$` matches before a trailing newline; reject any control
+  // chars (especially CR/LF) explicitly so they never reach a Location header.
+  if (/[\x00-\x1f\x7f]/.test(raw)) return null;
   if (!SHARE_VIEWER_PATH.test(raw)) return null;
   return raw;
 }

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -441,10 +441,10 @@ async function handleVerify(env: Env, url: URL): Promise<Response> {
       `UPDATE magic_link_tokens
          SET consumed_at = ?
        WHERE token_hash = ? AND consumed_at IS NULL AND expires_at > ?
-       RETURNING user_id, device_code`
+       RETURNING user_id, device_code, return_path`
     )
     .bind(now, tokenHash, now)
-    .first<{ user_id: string; device_code: string | null }>();
+    .first<{ user_id: string; device_code: string | null; return_path: string | null }>();
 
   if (!consumed) {
     return htmlResponse(
@@ -494,10 +494,12 @@ async function handleVerify(env: Env, url: URL): Promise<Response> {
       ...NO_STORE,
     });
   }
+  const safeReturn = validateReturnPath(consumed.return_path);
+  const location = safeReturn ?? "/auth/welcome";
   return new Response(null, {
     status: 302,
     headers: {
-      location: "/auth/welcome",
+      location,
       "set-cookie": cookie,
       ...NO_STORE,
     },

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -3,6 +3,7 @@
 // docs/plans/auth.md for the full design.
 
 import { pkceVerifier, codeChallengeS256, pickPrimaryVerifiedEmail, type GitHubEmail } from "./oauth-helpers";
+import { validateReturnPath } from "./return-path";
 //
 // PR 2 endpoints:
 //   GET  /auth/sign-in       HTML form (also accepts ?d=<user_code> for the device flow)
@@ -157,10 +158,12 @@ const NO_STORE: Record<string, string> = { "cache-control": "no-store" };
 
 const GITHUB_MARK_SVG = `<svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20" fill="currentColor" style="vertical-align: -4px; margin-right: 0.5rem;"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>`;
 
-const SIGN_IN_HTML = (userCode: string | null) => {
+const SIGN_IN_HTML = (userCode: string | null, returnPath: string | null) => {
   const githubHref = userCode
     ? `/auth/github/start?d=${encodeURIComponent(userCode)}`
-    : "/auth/github/start";
+    : returnPath
+      ? `/auth/github/start?return=${encodeURIComponent(returnPath)}`
+      : "/auth/github/start";
   return `<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
@@ -190,6 +193,7 @@ const SIGN_IN_HTML = (userCode: string | null) => {
 <form id="f">
   <label for="email">Email</label>
   <input id="email" name="email" type="email" required autocomplete="email">
+  <input type="hidden" id="return_path" name="return_path" value="${returnPath ? returnPath.replace(/[<>"]/g, "") : ""}">
   <button type="submit">Send magic link</button>
 </form>
 <p id="status" hidden></p>
@@ -200,6 +204,7 @@ const userCode = ${userCode ? JSON.stringify(userCode) : "null"};
 f.addEventListener('submit', async (e) => {
   e.preventDefault();
   const email = f.email.value.trim();
+  const returnPath = document.getElementById('return_path').value || null;
   const btn = f.querySelector('button');
   btn.disabled = true;
   btn.textContent = 'Sending…';
@@ -207,7 +212,7 @@ f.addEventListener('submit', async (e) => {
     const res = await fetch('/auth/magic-link', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ email, user_code: userCode }),
+      body: JSON.stringify({ email, user_code: userCode, return_path: returnPath }),
     });
     if (res.ok) {
       f.style.display = 'none';
@@ -1042,7 +1047,11 @@ export default {
         // /auth/sign-in carries an optional ?d=<user_code> for the device
         // flow; no-store stops browsers and intermediaries from caching a
         // URL that contains a login-related code.
-        return htmlResponse(SIGN_IN_HTML(url.searchParams.get("d")), 200, NO_STORE);
+        const userCode = url.searchParams.get("d");
+        // Mutual exclusion: if ?d= is present, it wins (device flow is its own
+        // destination); ?return= is dropped.
+        const returnPath = userCode ? null : validateReturnPath(url.searchParams.get("return"));
+        return htmlResponse(SIGN_IN_HTML(userCode, returnPath), 200, NO_STORE);
       }
       if (url.pathname === "/auth/magic-link" && req.method === "POST") {
         return await handleMagicLink(req, env, ctx, url);

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -340,7 +340,7 @@ async function handleMagicLink(req: Request, env: Env, ctx: ExecutionContext, ur
   const ipGate = await env.MAGIC_LINK_LIMIT.limit({ key: ip });
   if (!ipGate.success) return json({ error: "rate_limited" }, 429);
 
-  let payload: { email?: unknown; user_code?: unknown };
+  let payload: { email?: unknown; user_code?: unknown; return_path?: unknown };
   try {
     payload = await req.json();
   } catch {
@@ -389,12 +389,18 @@ async function handleMagicLink(req: Request, env: Env, ctx: ExecutionContext, ur
     deviceCode = dc.device_code;
   }
 
+  // Mutual exclusion: device flow's destination is the device. Return path
+  // only carries through when there is no user_code.
+  const returnPath = userCode
+    ? null
+    : (typeof payload.return_path === "string" ? validateReturnPath(payload.return_path) : null);
+
   const rawToken = randomToken(32);
   const tokenHash = await sha256Hex(rawToken);
   const expiresAt = now + MAGIC_LINK_TTL_MS;
   await env.DB
-    .prepare("INSERT INTO magic_link_tokens (token_hash, user_id, device_code, expires_at) VALUES (?, ?, ?, ?)")
-    .bind(tokenHash, user.id, deviceCode, expiresAt)
+    .prepare("INSERT INTO magic_link_tokens (token_hash, user_id, device_code, expires_at, return_path) VALUES (?, ?, ?, ?, ?)")
+    .bind(tokenHash, user.id, deviceCode, expiresAt, returnPath)
     .run();
 
   const verifyUrl = `${url.origin}/auth/verify?t=${encodeURIComponent(rawToken)}`;

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -70,7 +70,7 @@ function htmlEscape(s: string): string {
   )[c]!);
 }
 
-async function sha256Hex(s: string): Promise<string> {
+export async function sha256Hex(s: string): Promise<string> {
   const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
   return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -710,15 +710,17 @@ async function handleGithubStart(req: Request, env: Env, url: URL): Promise<Resp
     }
   }
 
+  const returnPath = userCode ? null : validateReturnPath(url.searchParams.get("return"));
+
   const state = randomState();
   const verifier = pkceVerifier();
   const challenge = await codeChallengeS256(verifier);
 
   await env.DB
     .prepare(
-      "INSERT INTO oauth_states (state, provider, pkce_verifier, user_code, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)",
+      "INSERT INTO oauth_states (state, provider, pkce_verifier, user_code, created_at, expires_at, return_path) VALUES (?, ?, ?, ?, ?, ?, ?)",
     )
-    .bind(state, "github", verifier, userCode, now, now + OAUTH_STATE_TTL_MS)
+    .bind(state, "github", verifier, userCode, now, now + OAUTH_STATE_TTL_MS, returnPath)
     .run();
 
   const githubUrl = new URL("https://github.com/login/oauth/authorize");

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -941,10 +941,10 @@ async function handleGithubCallback(req: Request, env: Env, url: URL): Promise<R
       `UPDATE oauth_states
           SET consumed_at = ?
         WHERE state = ? AND provider = ? AND consumed_at IS NULL AND expires_at > ?
-        RETURNING pkce_verifier, user_code`,
+        RETURNING pkce_verifier, user_code, return_path`,
     )
     .bind(now, state, "github", now)
-    .first<{ pkce_verifier: string; user_code: string | null }>();
+    .first<{ pkce_verifier: string; user_code: string | null; return_path: string | null }>();
 
   if (!stateRow) {
     return htmlResponse(SIGN_IN_EXPIRED_HTML(false), 400, NO_STORE);
@@ -1039,10 +1039,11 @@ async function handleGithubCallback(req: Request, env: Env, url: URL): Promise<R
       ...NO_STORE,
     });
   }
+  const safeReturn = validateReturnPath(stateRow.return_path);
   return new Response(null, {
     status: 302,
     headers: {
-      location: "/auth/welcome",
+      location: safeReturn ?? "/auth/welcome",
       "set-cookie": cookie,
       ...NO_STORE,
     },

--- a/infra/auth-worker/test/env.d.ts
+++ b/infra/auth-worker/test/env.d.ts
@@ -1,0 +1,9 @@
+// Tell TypeScript what the test runtime's `env` looks like.
+// @cloudflare/vitest-pool-workers exports `env: ProvidedEnv` which is
+// otherwise empty until augmented here.
+
+import type { Env } from "../src/worker";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}

--- a/infra/auth-worker/test/fixtures/seed.ts
+++ b/infra/auth-worker/test/fixtures/seed.ts
@@ -1,0 +1,107 @@
+// Test fixtures for auth-worker integration tests.
+// Each test file gets an isolated in-memory D1 binding via
+// @cloudflare/vitest-pool-workers.
+
+import { env } from "cloudflare:test";
+
+// Full schema from all four migrations, collapsed for tests.
+// Keep in sync with:
+//   infra/auth-worker/migrations/0001_init.sql  (users, sessions, device_codes, magic_link_tokens)
+//   infra/auth-worker/migrations/0002_oauth.sql (user_identities, oauth_states)
+//   infra/auth-worker/migrations/0003_publish.sql (users.tier, published_artifacts)
+//   infra/auth-worker/migrations/0004_return_path.sql (return_path columns)
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS users (
+  id            TEXT PRIMARY KEY,
+  email         TEXT NOT NULL UNIQUE COLLATE NOCASE,
+  created_at    INTEGER NOT NULL,
+  last_seen_at  INTEGER NOT NULL,
+  tier          TEXT NOT NULL DEFAULT 'free'
+);
+CREATE TABLE IF NOT EXISTS sessions (
+  id            TEXT PRIMARY KEY,
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  created_at    INTEGER NOT NULL,
+  expires_at    INTEGER NOT NULL,
+  revoked_at    INTEGER
+);
+CREATE INDEX IF NOT EXISTS sessions_user ON sessions(user_id);
+CREATE TABLE IF NOT EXISTS device_codes (
+  device_code   TEXT PRIMARY KEY,
+  user_code     TEXT NOT NULL UNIQUE,
+  session_id    TEXT REFERENCES sessions(id),
+  expires_at    INTEGER NOT NULL,
+  claimed_at    INTEGER
+);
+CREATE TABLE IF NOT EXISTS magic_link_tokens (
+  token_hash    TEXT PRIMARY KEY,
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  device_code   TEXT REFERENCES device_codes(device_code),
+  expires_at    INTEGER NOT NULL,
+  consumed_at   INTEGER,
+  return_path   TEXT
+);
+CREATE INDEX IF NOT EXISTS magic_link_tokens_user_expires
+  ON magic_link_tokens(user_id, expires_at);
+CREATE TABLE IF NOT EXISTS user_identities (
+  provider           TEXT NOT NULL,
+  provider_user_id   TEXT NOT NULL,
+  user_id            TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider_email     TEXT,
+  linked_at          INTEGER NOT NULL,
+  last_seen_at       INTEGER NOT NULL,
+  PRIMARY KEY (provider, provider_user_id)
+);
+CREATE INDEX IF NOT EXISTS user_identities_user ON user_identities(user_id);
+CREATE TABLE IF NOT EXISTS oauth_states (
+  state              TEXT PRIMARY KEY,
+  provider           TEXT NOT NULL,
+  pkce_verifier      TEXT NOT NULL,
+  user_code          TEXT,
+  created_at         INTEGER NOT NULL,
+  expires_at         INTEGER NOT NULL,
+  consumed_at        INTEGER,
+  return_path        TEXT
+);
+CREATE TABLE IF NOT EXISTS published_artifacts (
+  share_token       TEXT    PRIMARY KEY,
+  owner_user_id     TEXT    NOT NULL REFERENCES users(id),
+  artifact_id       TEXT    NOT NULL,
+  artifact_kind     TEXT    NOT NULL,
+  mode              TEXT    NOT NULL CHECK (mode IN ('open','password','signin')),
+  password_hash     TEXT,
+  r2_key            TEXT    NOT NULL,
+  content_type      TEXT    NOT NULL,
+  size_bytes        INTEGER NOT NULL,
+  published_at      INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL,
+  unpublished_at    INTEGER,
+  CHECK (
+    (mode = 'password' AND password_hash IS NOT NULL) OR
+    (mode <> 'password' AND password_hash IS NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS idx_pubart_owner ON published_artifacts(owner_user_id);
+`;
+
+export async function applySchema(): Promise<void> {
+  // D1 .exec runs multi-statement SQL but ignores comments inconsistently;
+  // split on semicolons and run each non-empty statement.
+  const stmts = SCHEMA_SQL.split(";").map(s => s.trim()).filter(Boolean);
+  for (const s of stmts) {
+    await env.DB.prepare(s).run();
+  }
+}
+
+export async function seedUserCode(opts: {
+  userCode: string;
+  deviceCode?: string;
+  expiresAt?: number;
+}): Promise<string> {
+  const deviceCode = opts.deviceCode ?? `dev_${crypto.randomUUID().replace(/-/g, "")}`;
+  const expiresAt = opts.expiresAt ?? Date.now() + 10 * 60 * 1000;
+  await env.DB.prepare(
+    "INSERT INTO device_codes (device_code, user_code, expires_at) VALUES (?, ?, ?)"
+  ).bind(deviceCode, opts.userCode, expiresAt).run();
+  return deviceCode;
+}

--- a/infra/auth-worker/test/return-path-integration.test.ts
+++ b/infra/auth-worker/test/return-path-integration.test.ts
@@ -1,0 +1,215 @@
+// Integration tests for return_path threading through auth-worker handlers.
+// Uses @cloudflare/vitest-pool-workers (miniflare) for a real D1 + Worker
+// runtime; no external HTTP calls are made (RESEND_API_KEY is unset so
+// sendMagicLink no-ops, and /auth/github/callback is not tested here — see
+// the gap note at the bottom of this file).
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { sha256Hex } from "../src/worker";
+import { applySchema, seedUserCode } from "./fixtures/seed";
+
+// MAGIC_LINK_LIMIT is a Cloudflare rate-limit binding; miniflare doesn't
+// auto-mock it. Inject a stub that always succeeds so handler logic is
+// reachable in tests.
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (env as any).MAGIC_LINK_LIMIT = { limit: async () => ({ success: true }) };
+});
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeReq(method: string, path: string, opts: {
+  body?: unknown;
+  headers?: Record<string, string>;
+} = {}): Request {
+  const headers = new Headers(opts.headers ?? {});
+  let body: BodyInit | undefined;
+  if (opts.body !== undefined) {
+    headers.set("content-type", "application/json");
+    body = JSON.stringify(opts.body);
+  }
+  return new Request(`https://oyster.to${path}`, { method, headers, body });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+// ─── POST /auth/magic-link ──────────────────────────────────────────────────
+
+describe("POST /auth/magic-link — return_path threading", () => {
+  it("valid return_path is stored on the magic_link_tokens row", async () => {
+    const res = await call(makeReq("POST", "/auth/magic-link", {
+      body: { email: "test@example.com", return_path: "/p/abc123" },
+    }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+
+    const row = await env.DB
+      .prepare("SELECT return_path FROM magic_link_tokens LIMIT 1")
+      .first<{ return_path: string | null }>();
+    expect(row).not.toBeNull();
+    expect(row!.return_path).toBe("/p/abc123");
+  });
+
+  it("invalid return_path (absolute URL) is silently dropped — row gets NULL", async () => {
+    const res = await call(makeReq("POST", "/auth/magic-link", {
+      body: { email: "test2@example.com", return_path: "https://attacker.com/steal" },
+    }));
+    expect(res.status).toBe(200);
+
+    const row = await env.DB
+      .prepare("SELECT return_path FROM magic_link_tokens LIMIT 1")
+      .first<{ return_path: string | null }>();
+    expect(row).not.toBeNull();
+    expect(row!.return_path).toBeNull();
+  });
+
+  it("user_code AND return_path → mutual exclusion: row gets NULL (device flow wins)", async () => {
+    const userCode = "ABCD-1234";
+    await seedUserCode({ userCode });
+
+    const res = await call(makeReq("POST", "/auth/magic-link", {
+      body: { email: "test3@example.com", user_code: userCode, return_path: "/p/abc123" },
+    }));
+    expect(res.status).toBe(200);
+
+    const row = await env.DB
+      .prepare("SELECT return_path FROM magic_link_tokens LIMIT 1")
+      .first<{ return_path: string | null }>();
+    expect(row).not.toBeNull();
+    expect(row!.return_path).toBeNull();
+  });
+});
+
+// ─── GET /auth/verify ───────────────────────────────────────────────────────
+
+describe("GET /auth/verify — return_path redirect", () => {
+  async function seedToken(email: string, returnPath: string | null): Promise<string> {
+    const rawToken = "test-raw-token-" + Math.random().toString(36).slice(2);
+    const tokenHash = await sha256Hex(rawToken);
+    const now = Date.now();
+    const expiresAt = now + 15 * 60 * 1000;
+
+    // Ensure the user exists.
+    const userId = crypto.randomUUID();
+    await env.DB
+      .prepare("INSERT OR IGNORE INTO users (id, email, created_at, last_seen_at) VALUES (?, ?, ?, ?)")
+      .bind(userId, email, now, now)
+      .run();
+    const user = await env.DB
+      .prepare("SELECT id FROM users WHERE email = ?")
+      .bind(email)
+      .first<{ id: string }>();
+
+    await env.DB
+      .prepare(
+        "INSERT INTO magic_link_tokens (token_hash, user_id, device_code, expires_at, return_path) VALUES (?, ?, ?, ?, ?)"
+      )
+      .bind(tokenHash, user!.id, null, expiresAt, returnPath)
+      .run();
+
+    return rawToken;
+  }
+
+  it("row with return_path → 302 to that path, with session cookie", async () => {
+    const rawToken = await seedToken("verify1@example.com", "/p/abc123");
+    const res = await call(makeReq("GET", `/auth/verify?t=${encodeURIComponent(rawToken)}`));
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/p/abc123");
+    const cookie = res.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("oyster_session=");
+  });
+
+  it("row WITHOUT return_path → 302 to /auth/welcome", async () => {
+    const rawToken = await seedToken("verify2@example.com", null);
+    const res = await call(makeReq("GET", `/auth/verify?t=${encodeURIComponent(rawToken)}`));
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/auth/welcome");
+    const cookie = res.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("oyster_session=");
+  });
+});
+
+// ─── GET /auth/github/start ─────────────────────────────────────────────────
+
+describe("GET /auth/github/start — return_path threading", () => {
+  it("?return=/p/abc123 → oauth_states row has return_path = '/p/abc123'", async () => {
+    const res = await call(makeReq("GET", "/auth/github/start?return=/p/abc123"));
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("github.com/login/oauth/authorize");
+
+    // Extract the state param from the redirect URL.
+    const redirectUrl = new URL(location);
+    const state = redirectUrl.searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    const row = await env.DB
+      .prepare("SELECT return_path FROM oauth_states WHERE state = ?")
+      .bind(state)
+      .first<{ return_path: string | null }>();
+    expect(row).not.toBeNull();
+    expect(row!.return_path).toBe("/p/abc123");
+  });
+
+  it("?return=... AND ?d=USERCODE → mutual exclusion: oauth_states row gets NULL", async () => {
+    const userCode = "WXYZ-5678";
+    await seedUserCode({ userCode });
+
+    const res = await call(
+      makeReq("GET", `/auth/github/start?return=/p/abc123&d=${encodeURIComponent(userCode)}`)
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("github.com/login/oauth/authorize");
+
+    const redirectUrl = new URL(location);
+    const state = redirectUrl.searchParams.get("state");
+    expect(state).toBeTruthy();
+
+    const row = await env.DB
+      .prepare("SELECT return_path FROM oauth_states WHERE state = ?")
+      .bind(state)
+      .first<{ return_path: string | null }>();
+    expect(row).not.toBeNull();
+    expect(row!.return_path).toBeNull();
+  });
+});
+
+// ─── GET /auth/sign-in — HTML round-trip ────────────────────────────────────
+
+describe("GET /auth/sign-in — return_path HTML round-trip", () => {
+  it("?return=/p/abc123 → HTML form contains value='/p/abc123' in hidden input", async () => {
+    const res = await call(makeReq("GET", "/auth/sign-in?return=/p/abc123"));
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // The hidden return_path input should carry the value through.
+    expect(body).toContain('value="/p/abc123"');
+  });
+});
+
+// ─── Gap note ────────────────────────────────────────────────────────────────
+// GET /auth/github/callback is NOT tested here.
+// The callback handler requires mocking GitHub's token-exchange
+// (https://github.com/login/oauth/access_token) and user-info
+// (https://api.github.com/user + /user/emails) HTTP endpoints. Miniflare
+// doesn't intercept outbound fetch by default; adding fetch-mock
+// infrastructure is deferred. The start-side tests above confirm that
+// return_path is threaded into oauth_states correctly; the callback side
+// reads it back via the same RETURNING clause pattern (already unit-tested
+// indirectly through handleVerify's analogous consume flow).

--- a/infra/auth-worker/test/return-path.test.ts
+++ b/infra/auth-worker/test/return-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { validateReturnPath } from "../src/return-path";
+
+describe("validateReturnPath — accepts share-viewer paths", () => {
+  it("accepts /p/<token> with alphanumerics", () => {
+    expect(validateReturnPath("/p/abc123")).toBe("/p/abc123");
+  });
+
+  it("accepts /p/<token> with - and _ in the token", () => {
+    expect(validateReturnPath("/p/AaBb_-_-9")).toBe("/p/AaBb_-_-9");
+  });
+});
+
+describe("validateReturnPath — rejects everything else", () => {
+  it("returns null for null/undefined/empty", () => {
+    expect(validateReturnPath(null)).toBeNull();
+    expect(validateReturnPath(undefined)).toBeNull();
+    expect(validateReturnPath("")).toBeNull();
+  });
+
+  it("rejects /p/ with no token", () => {
+    expect(validateReturnPath("/p/")).toBeNull();
+  });
+
+  it("rejects /p/<token>/raw — viewer chrome only, never the iframe endpoint", () => {
+    expect(validateReturnPath("/p/abc123/raw")).toBeNull();
+  });
+
+  it("rejects /p/<token> with a query string", () => {
+    expect(validateReturnPath("/p/abc?x=1")).toBeNull();
+  });
+
+  it("rejects /p/<token> with a fragment", () => {
+    expect(validateReturnPath("/p/abc#h")).toBeNull();
+  });
+
+  it("rejects path traversal", () => {
+    expect(validateReturnPath("/p/../etc/passwd")).toBeNull();
+    expect(validateReturnPath("/p/abc/../../x")).toBeNull();
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(validateReturnPath("https://attacker.com/p/abc")).toBeNull();
+    expect(validateReturnPath("//attacker.com/p/abc")).toBeNull();
+    expect(validateReturnPath("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects unrelated paths", () => {
+    expect(validateReturnPath("/dashboard")).toBeNull();
+    expect(validateReturnPath("/auth/sign-in")).toBeNull();
+    expect(validateReturnPath("/")).toBeNull();
+  });
+
+  it("rejects overly long inputs (defence against slow regex)", () => {
+    const long = "/p/" + "a".repeat(2048);
+    expect(validateReturnPath(long)).toBeNull();
+  });
+});

--- a/infra/auth-worker/test/return-path.test.ts
+++ b/infra/auth-worker/test/return-path.test.ts
@@ -55,4 +55,17 @@ describe("validateReturnPath — rejects everything else", () => {
     const long = "/p/" + "a".repeat(2048);
     expect(validateReturnPath(long)).toBeNull();
   });
+
+  it("rejects trailing newline (defence against JS regex $ semantics)", () => {
+    expect(validateReturnPath("/p/abc\n")).toBeNull();
+  });
+
+  it("rejects embedded CR/LF", () => {
+    expect(validateReturnPath("/p/abc\r\nLocation: evil")).toBeNull();
+  });
+
+  it("rejects tab and other control chars", () => {
+    expect(validateReturnPath("/p/ab\tc")).toBeNull();
+    expect(validateReturnPath("/p/ab\x00c")).toBeNull();
+  });
 });

--- a/infra/auth-worker/tsconfig.json
+++ b/infra/auth-worker/tsconfig.json
@@ -4,10 +4,10 @@
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/infra/auth-worker/vitest.config.ts
+++ b/infra/auth-worker/vitest.config.ts
@@ -1,8 +1,32 @@
-import { defineConfig } from "vitest/config";
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
-export default defineConfig({
+export default defineWorkersConfig({
   test: {
-    environment: "node",
     include: ["test/**/*.test.ts"],
+    // The integration test file needs the workers pool; the two existing
+    // pure-unit test files (oauth-helpers, return-path) import nothing
+    // Cloudflare-specific so they run fine in the workers pool too.
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // Isolated in-memory D1 per test file.
+          d1Databases: ["DB"],
+          bindings: {
+            GITHUB_OAUTH_CLIENT_ID: "test-client-id",
+            GITHUB_OAUTH_CLIENT_SECRET: "test-client-secret",
+            FROM_ADDRESS: "noreply@example.com",
+            REPLY_TO: "test@example.com",
+          },
+          // wrangler.toml declares MAGIC_LINK_LIMIT with period = 3600 which
+          // miniflare only accepts as 10 | 60. Override here with a valid
+          // period so miniflare starts; tests stub the binding anyway via
+          // `(env as any).MAGIC_LINK_LIMIT = { limit: async () => … }`.
+          ratelimits: {
+            MAGIC_LINK_LIMIT: { simple: { limit: 20, period: 60 } },
+          },
+        },
+      },
+    },
   },
 });

--- a/infra/auth-worker/wrangler.toml
+++ b/infra/auth-worker/wrangler.toml
@@ -1,6 +1,10 @@
 name = "oyster-auth"
 main = "src/worker.ts"
 compatibility_date = "2026-04-01"
+# nodejs_compat is required by @cloudflare/vitest-pool-workers (the test
+# infrastructure needs Node-style APIs inside the Worker runtime). Production
+# handlers don't depend on it — they use Web Crypto + standard Web APIs only.
+compatibility_flags = ["nodejs_compat"]
 
 # Bind the D1 database. Run `wrangler d1 create oyster-auth` once,
 # then paste the returned database_id here.

--- a/infra/oyster-publish/package-lock.json
+++ b/infra/oyster-publish/package-lock.json
@@ -7,9 +7,13 @@
     "": {
       "name": "oyster-publish-worker",
       "version": "0.0.0",
+      "dependencies": {
+        "markdown-it": "^14.1.0"
+      },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.5.0",
         "@cloudflare/workers-types": "^4.20260101.0",
+        "@types/markdown-it": "^14.1.0",
         "typescript": "^5.4.0",
         "vitest": "^2.1.0",
         "wrangler": "^4.0.0"
@@ -1723,6 +1727,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -1881,6 +1910,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/as-table": {
       "version": "1.0.55",
@@ -2076,6 +2111,18 @@
       "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
@@ -2277,6 +2324,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2293,6 +2349,29 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -2499,6 +2578,15 @@
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -2871,6 +2959,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.4",

--- a/infra/oyster-publish/package.json
+++ b/infra/oyster-publish/package.json
@@ -10,9 +10,13 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "markdown-it": "^14.1.0"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260101.0",
     "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "@types/markdown-it": "^14.1.0",
     "typescript": "^5.4.0",
     "vitest": "^2.1.0",
     "wrangler": "^4.0.0"

--- a/infra/oyster-publish/src/publish-helpers.ts
+++ b/infra/oyster-publish/src/publish-helpers.ts
@@ -73,6 +73,13 @@ export function parseShareTokenPath(pathname: string): { shareToken: string; raw
   return { shareToken: rest, raw: false };
 }
 
+// Mirror of auth-worker's isLocalHost helper. Omit Secure on loopback so
+// wrangler dev (http://localhost:8787) can exercise the password-unlock flow.
+export function isLoopback(host: string): boolean {
+  return host === "localhost" || host === "127.0.0.1" ||
+    host.startsWith("localhost:") || host.startsWith("127.0.0.1:");
+}
+
 function base64urlDecodeToString(s: string): string {
   // Restore standard base64 padding/alphabet for atob.
   const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (s.length % 4)) % 4);

--- a/infra/oyster-publish/src/publish-helpers.ts
+++ b/infra/oyster-publish/src/publish-helpers.ts
@@ -58,6 +58,21 @@ function base64urlEncode(bytes: Uint8Array): string {
   return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+// Match /p/<token> or /p/<token>/raw. Returns null on no match.
+const SHARE_TOKEN_CHARSET = /^[A-Za-z0-9_-]+$/;
+export function parseShareTokenPath(pathname: string): { shareToken: string; raw: boolean } | null {
+  if (!pathname.startsWith("/p/")) return null;
+  const rest = pathname.slice("/p/".length);
+  if (rest.length === 0) return null;
+  if (rest.endsWith("/raw")) {
+    const token = rest.slice(0, -"/raw".length);
+    if (!SHARE_TOKEN_CHARSET.test(token)) return null;
+    return { shareToken: token, raw: true };
+  }
+  if (!SHARE_TOKEN_CHARSET.test(rest)) return null;
+  return { shareToken: rest, raw: false };
+}
+
 function base64urlDecodeToString(s: string): string {
   // Restore standard base64 padding/alphabet for atob.
   const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (s.length % 4)) % 4);

--- a/infra/oyster-publish/src/publish-helpers.ts
+++ b/infra/oyster-publish/src/publish-helpers.ts
@@ -73,6 +73,11 @@ export function parseShareTokenPath(pathname: string): { shareToken: string; raw
   return { shareToken: rest, raw: false };
 }
 
+// Kinds whose artifact bytes are served via /raw inside a sandboxed iframe.
+// Used in both handleViewerRaw (to 404 non-iframe kinds) and renderForRow
+// (to dispatch to renderChromeWithIframe). Keep in sync — single source of truth.
+export const IFRAME_KINDS: ReadonlySet<string> = new Set(["app", "deck", "wireframe", "table", "map"]);
+
 // Mirror of auth-worker's isLocalHost helper. Omit Secure on loopback so
 // wrangler dev (http://localhost:8787) can exercise the password-unlock flow.
 export function isLoopback(host: string): boolean {

--- a/infra/oyster-publish/src/types.ts
+++ b/infra/oyster-publish/src/types.ts
@@ -4,6 +4,15 @@
 export interface Env {
   DB: D1Database;          // shared with oyster-auth (same database_id)
   ARTIFACTS: R2Bucket;     // oyster-artifacts
+  VIEWER_COOKIE_SECRET: string;     // HMAC key for password-mode unlock cookies (#316)
+  VIEWER_PASSWORD_LIMIT: RateLimit; // wrong-password gate (#316)
+}
+
+// `RateLimit` is a Workers binding — typed inline since it's not in
+// @cloudflare/workers-types yet. The runtime shape is:
+//   limit({ key: string }) → Promise<{ success: boolean }>
+interface RateLimit {
+  limit(opts: { key: string }): Promise<{ success: boolean }>;
 }
 
 // Decoded X-Publish-Metadata payload — produced by the local server.

--- a/infra/oyster-publish/src/viewer-access.ts
+++ b/infra/oyster-publish/src/viewer-access.ts
@@ -1,0 +1,64 @@
+// Access dispatch for the public viewer.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Access dispatch).
+
+import { resolveSession } from "./worker";
+import { verifyViewerCookie } from "./viewer-cookie";
+import type { Env, PublicationRow } from "./types";
+
+export type ViewerAccess =
+  | { kind: "ok"; row: PublicationRow }
+  | { kind: "gate"; row: PublicationRow; error?: "wrong_password" }
+  | { kind: "redirect"; location: string }
+  | { kind: "gone"; row: PublicationRow }
+  | { kind: "not_found" };
+
+export async function resolveViewerAccess(
+  req: Request,
+  env: Env,
+  shareToken: string,
+): Promise<ViewerAccess> {
+  // Step 1: row lookup.
+  const row = await env.DB.prepare(
+    "SELECT * FROM published_artifacts WHERE share_token = ?",
+  ).bind(shareToken).first<PublicationRow>();
+  if (!row) return { kind: "not_found" };
+
+  // Step 2: gone check.
+  if (row.unpublished_at !== null && row.unpublished_at !== undefined) {
+    return { kind: "gone", row };
+  }
+
+  // Step 3: mode dispatch.
+  switch (row.mode) {
+    case "open":
+      return { kind: "ok", row };
+
+    case "password": {
+      const cookieValue = readCookie(req, `oyster_view_${shareToken}`);
+      if (!cookieValue) return { kind: "gate", row };
+      const ok = await verifyViewerCookie(cookieValue, shareToken, env.VIEWER_COOKIE_SECRET);
+      if (!ok) return { kind: "gate", row };
+      return { kind: "ok", row };
+    }
+
+    case "signin": {
+      const session = await resolveSession(req, env);
+      if (!session) {
+        return { kind: "redirect", location: `https://oyster.to/auth/sign-in?return=/p/${shareToken}` };
+      }
+      return { kind: "ok", row };
+    }
+
+    default:
+      // Unreachable per the D1 CHECK constraint, but typescript-safe.
+      return { kind: "not_found" };
+  }
+}
+
+export function readCookie(req: Request, name: string): string | null {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]+)`));
+  return m && m[1] ? m[1] : null;
+}

--- a/infra/oyster-publish/src/viewer-chrome.ts
+++ b/infra/oyster-publish/src/viewer-chrome.ts
@@ -1,0 +1,53 @@
+// Chrome wrapper for successful published views.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Chrome).
+// Header (logo + mode-aware action slot) + body slot + footer. Used for:
+//   - open viewer (action: "Get your own at oyster.to")
+//   - password viewer post-unlock (action: same)
+//   - signin viewer post-auth (action: empty in v1)
+//
+// `bodyHtml` is the rendered content (markdown HTML, mermaid HTML, or
+// the iframe element). `bodyExtraStyle` is optional — used by the iframe
+// path to remove default body padding.
+
+export interface ChromeOpts {
+  title: string;
+  bodyHtml: string;
+  cssExtra?: string;        // e.g. iframe sizing override
+  showActionSlot?: boolean; // default true; password viewer + open viewer get true; signin viewer gets false
+}
+
+export function renderChromePage(opts: ChromeOpts): string {
+  const action = opts.showActionSlot === false
+    ? ""
+    : `<a class="cta" href="https://oyster.to" target="_blank" rel="noopener">Get your own at oyster.to</a>`;
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(opts.title)}</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --muted: #666; --bd: #e4e4e7; --bg: #fff; --chrome-bg: #fafafa; }
+  @media (prefers-color-scheme: dark) { :root { --fg: #f4f4f5; --muted: #a1a1aa; --bd: #27272a; --bg: #18181b; --chrome-bg: #0c0a09; } }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: var(--fg); background: var(--bg); display: flex; flex-direction: column; min-height: 100vh; line-height: 1.55; }
+  header { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 1rem; background: var(--chrome-bg); border-bottom: 1px solid var(--bd); font-size: 0.85rem; height: 36px; flex-shrink: 0; }
+  header .logo { font-weight: 600; }
+  header .cta { color: var(--muted); text-decoration: none; }
+  header .cta:hover { color: var(--fg); }
+  main { flex: 1; padding: 1.5rem; max-width: 48rem; width: 100%; margin: 0 auto; }
+  footer { background: var(--chrome-bg); border-top: 1px solid var(--bd); font-size: 0.7rem; color: var(--muted); padding: 0.4rem 1rem; text-align: center; height: 24px; flex-shrink: 0; }
+  ${opts.cssExtra ?? ""}
+</style>
+</head><body>
+<header><span class="logo">🦪 oyster</span>${action}</header>
+<main>${opts.bodyHtml}</main>
+<footer>Powered by Oyster · oyster.to</footer>
+</body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}

--- a/infra/oyster-publish/src/viewer-cookie.ts
+++ b/infra/oyster-publish/src/viewer-cookie.ts
@@ -1,0 +1,67 @@
+// HMAC-SHA256 signed cookie for password-mode unlock.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Cookie scheme).
+// Format: <token>.<unix_seconds>.<hmac_b64url>
+//   - token is the share_token (asserted on verify; the cookie path also scopes it)
+//   - hmac is over `${token}.${unix_seconds}` keyed by VIEWER_COOKIE_SECRET
+//   - TTL is 24h (86400s); rejected if older.
+
+const TTL_SECONDS = 86400;
+
+export async function signViewerCookie(shareToken: string, secret: string): Promise<string> {
+  return signViewerCookieAt(shareToken, secret, Math.floor(Date.now() / 1000));
+}
+
+export async function signViewerCookieAt(
+  shareToken: string,
+  secret: string,
+  unixSeconds: number,
+): Promise<string> {
+  const hmac = await hmacSha256B64url(`${shareToken}.${unixSeconds}`, secret);
+  return `${shareToken}.${unixSeconds}.${hmac}`;
+}
+
+export async function verifyViewerCookie(
+  cookie: string,
+  expectedToken: string,
+  secret: string,
+): Promise<boolean> {
+  if (typeof cookie !== "string" || cookie.length === 0) return false;
+  const parts = cookie.split(".");
+  if (parts.length !== 3) return false;
+  const [token, tsRaw, hmacGot] = parts;
+  if (token !== expectedToken) return false;
+  if (!/^\d+$/.test(tsRaw)) return false;
+  const ts = Number(tsRaw);
+  if (!Number.isSafeInteger(ts)) return false;
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (nowSec - ts > TTL_SECONDS) return false;
+  const hmacWant = await hmacSha256B64url(`${token}.${ts}`, secret);
+  // Constant-time compare.
+  return constantTimeEqual(hmacGot, hmacWant);
+}
+
+async function hmacSha256B64url(message: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(message));
+  return base64urlEncode(new Uint8Array(sig));
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/infra/oyster-publish/src/viewer-cookie.ts
+++ b/infra/oyster-publish/src/viewer-cookie.ts
@@ -28,7 +28,9 @@ export async function verifyViewerCookie(
   if (typeof cookie !== "string" || cookie.length === 0) return false;
   const parts = cookie.split(".");
   if (parts.length !== 3) return false;
-  const [token, tsRaw, hmacGot] = parts;
+  // tsconfig has noUncheckedIndexedAccess; the length check above guarantees
+  // these three are defined, but TS doesn't narrow array length. Assert.
+  const [token, tsRaw, hmacGot] = parts as [string, string, string];
   if (token !== expectedToken) return false;
   if (!/^\d+$/.test(tsRaw)) return false;
   const ts = Number(tsRaw);

--- a/infra/oyster-publish/src/viewer-pages.ts
+++ b/infra/oyster-publish/src/viewer-pages.ts
@@ -1,0 +1,88 @@
+// Minimal, chrome-less pages for intermediary states.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Minimal pages).
+// Each function returns an HTML string. Wrap in basePage() for consistency.
+
+export interface PageOpts {
+  // If true, the response also gets an `Accept: application/json` JSON body
+  // variant with the same { error, message } shape — set by the caller.
+  jsonError?: { code: string; message: string };
+}
+
+export function passwordGatePage(shareToken: string, opts?: { error?: "wrong_password" }): string {
+  const errorBlock = opts?.error === "wrong_password"
+    ? `<p class="err">Incorrect password.</p>`
+    : "";
+  return basePage("Password required", `
+    <div class="icon">🔒</div>
+    <h1>Password required</h1>
+    <p class="hint">This share is password-protected.</p>
+    ${errorBlock}
+    <form method="POST" action="/p/${escapeHtml(shareToken)}">
+      <input type="password" name="password" placeholder="Password" autofocus required>
+      <button type="submit">Unlock</button>
+    </form>
+  `);
+}
+
+export function gonePage(): string {
+  return basePage("Share removed", `
+    <div class="icon">🚫</div>
+    <h1>This share has been removed</h1>
+    <p class="hint">The owner has unpublished this artefact.</p>
+  `);
+}
+
+export function notFoundPage(): string {
+  return basePage("Not found", `
+    <div class="icon">❓</div>
+    <h1>Share not found</h1>
+    <p class="hint">The link may have been mistyped or removed.</p>
+  `);
+}
+
+export function internalErrorPage(): string {
+  return basePage("Error", `
+    <div class="icon">⚠️</div>
+    <h1>Something went wrong</h1>
+    <p class="hint">Try again in a moment.</p>
+  `);
+}
+
+export function rateLimitedPage(): string {
+  return basePage("Too many attempts", `
+    <div class="icon">⏱️</div>
+    <h1>Too many attempts</h1>
+    <p class="hint">Wait a minute and try again.</p>
+  `);
+}
+
+function basePage(title: string, bodyHtml: string): string {
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --muted: #666; --bd: #d4d4d8; --bg: #fff; }
+  @media (prefers-color-scheme: dark) { :root { --fg: #f4f4f5; --muted: #a1a1aa; --bd: #3f3f46; --bg: #18181b; } }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; max-width: 24rem; margin: 6rem auto; padding: 0 1.5rem; line-height: 1.5; color: var(--fg); background: var(--bg); text-align: center; }
+  .icon { font-size: 1.6rem; margin-bottom: 0.6rem; opacity: 0.9; }
+  h1 { font-size: 1.2rem; margin: 0 0 0.5rem; font-weight: 600; }
+  .hint { font-size: 0.95rem; color: var(--muted); margin: 0 0 1.5rem; }
+  .err { font-size: 0.85rem; color: #c62828; margin: 0 0 0.75rem; }
+  form { display: flex; flex-direction: column; gap: 0.6rem; max-width: 14rem; margin: 0 auto; }
+  input[type=password] { padding: 0.55rem 0.7rem; font-size: 0.95rem; border: 1px solid var(--bd); border-radius: 0.35rem; background: transparent; color: inherit; text-align: center; }
+  button { padding: 0.55rem 0.7rem; font-size: 0.95rem; font-weight: 500; border: 0; border-radius: 0.35rem; background: var(--fg); color: var(--bg); cursor: pointer; }
+  .tag { font-size: 0.7rem; color: var(--muted); margin-top: 4rem; opacity: 0.6; }
+</style>
+</head><body>
+${bodyHtml}
+<p class="tag">Shared via Oyster</p>
+</body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -100,3 +100,40 @@ function escapeHtml(s: string): string {
     { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
   ));
 }
+
+// ─── Iframe chrome (app / deck / wireframe / table / map) ──────────────────
+
+export function renderChromeWithIframe(row: PublicationRow): Response {
+  const iframe = `
+<!-- Deliberately omit allow-same-origin.
+     With allow-scripts only, the sandboxed document gets an opaque origin
+     and cannot access oyster.to cookies or same-origin storage. -->
+<iframe sandbox="allow-scripts" src="/p/${escapeAttr(row.share_token)}/raw"
+        style="border:0;width:100%;height:calc(100vh - 60px);display:block;"></iframe>`;
+  // Body's main padding is removed for iframe so it fills naturally.
+  const cssExtra = `main { padding: 0; max-width: none; }`;
+  const page = renderChromePage({ title: "Shared via Oyster", bodyHtml: iframe, cssExtra });
+  return new Response(page, {
+    status: 200,
+    headers: cacheHeaders(row, "text/html; charset=utf-8"),
+  });
+}
+
+export function renderRawHtmlBody(bytes: Uint8Array, row: PublicationRow): Response {
+  const headers = new Headers(cacheHeaders(row, row.content_type));
+  headers.set(
+    "content-security-policy",
+    "default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'",
+  );
+  headers.set("x-frame-options", "SAMEORIGIN");
+  headers.set("content-disposition", "inline");
+  // Buffer.from wrap is required for Workers fetch BodyInit — raw Uint8Array
+  // doesn't satisfy the type in cf-types.
+  return new Response(bytes, { status: 200, headers });
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -145,5 +145,6 @@ function escapeAttr(s: string): string {
 export function renderImageInline(bytes: Uint8Array, row: PublicationRow): Response {
   const headers = new Headers(cacheHeaders(row, row.content_type));
   headers.set("content-disposition", "inline");
+  headers.set("content-security-policy", "default-src 'none'; img-src 'self' data:");
   return new Response(bytes, { status: 200, headers });
 }

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -38,7 +38,7 @@ export function cacheHeaders(row: PublicationRow, contentType: string): HeadersI
   const headers: Record<string, string> = { "content-type": contentType };
   if (row.mode === "open") {
     headers["cache-control"] = "public, max-age=60, must-revalidate";
-    headers["etag"] = `W/"${row.share_token}-${row.updated_at}"`;
+    headers["etag"] = `"${row.share_token}-${row.updated_at}"`;
   } else {
     headers["cache-control"] = "private, no-store";
   }

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -1,0 +1,50 @@
+// Per-kind/content-type render dispatch for the public viewer.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Render dispatch).
+//
+// Each render function returns a Response with status + headers + body set.
+// Per-mode cache headers are applied here; ETag is set only for open mode.
+
+import MarkdownIt from "markdown-it";
+import { renderChromePage } from "./viewer-chrome";
+import type { PublicationRow } from "./types";
+
+const md = new MarkdownIt({
+  html: false,        // raw HTML in markdown is escaped (XSS defence)
+  linkify: true,      // bare URLs become links (validateLink still applied)
+  typographer: false,
+});
+
+// ─── Markdown ──────────────────────────────────────────────────────────────
+
+export function renderMarkdownPage(bytes: Uint8Array, row: PublicationRow): Response {
+  const source = new TextDecoder().decode(bytes);
+  const html = md.render(source);
+  // Title: first H1 if present, else fallback.
+  const titleMatch = html.match(/<h1[^>]*>([^<]+)<\/h1>/);
+  const title = titleMatch ? stripTags(titleMatch[1]!) : "Shared via Oyster";
+  const page = renderChromePage({ title, bodyHtml: html });
+
+  return new Response(page, {
+    status: 200,
+    headers: cacheHeaders(row, "text/html; charset=utf-8"),
+  });
+}
+
+// ─── Cache headers ─────────────────────────────────────────────────────────
+
+export function cacheHeaders(row: PublicationRow, contentType: string): HeadersInit {
+  const headers: Record<string, string> = { "content-type": contentType };
+  if (row.mode === "open") {
+    headers["cache-control"] = "public, max-age=60, must-revalidate";
+    headers["etag"] = `W/"${row.share_token}-${row.updated_at}"`;
+  } else {
+    headers["cache-control"] = "private, no-store";
+  }
+  // Block content-type sniffing across all responses.
+  headers["x-content-type-options"] = "nosniff";
+  return headers;
+}
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]*>/g, "");
+}

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -22,7 +22,7 @@ export function renderMarkdownPage(bytes: Uint8Array, row: PublicationRow): Resp
   // Title: first H1 if present, else fallback.
   const titleMatch = html.match(/<h1[^>]*>([^<]+)<\/h1>/);
   const title = titleMatch ? stripTags(titleMatch[1]!) : "Shared via Oyster";
-  const page = renderChromePage({ title, bodyHtml: html });
+  const page = renderChromePage({ title, bodyHtml: html, showActionSlot: row.mode !== "signin" });
 
   const headers = new Headers(cacheHeaders(row, "text/html; charset=utf-8"));
   headers.set(
@@ -88,7 +88,7 @@ export function renderMermaidPage(bytes: Uint8Array, row: PublicationRow): Respo
 })();
 </script>
 `;
-  const page = renderChromePage({ title: "Diagram", bodyHtml: body });
+  const page = renderChromePage({ title: "Diagram", bodyHtml: body, showActionSlot: row.mode !== "signin" });
   const headers = new Headers(cacheHeaders(row, "text/html; charset=utf-8"));
   headers.set(
     "content-security-policy",
@@ -114,7 +114,7 @@ export function renderChromeWithIframe(row: PublicationRow): Response {
         style="border:0;width:100%;height:calc(100vh - 60px);display:block;"></iframe>`;
   // Body's main padding is removed for iframe so it fills naturally.
   const cssExtra = `main { padding: 0; max-width: none; }`;
-  const page = renderChromePage({ title: "Shared via Oyster", bodyHtml: iframe, cssExtra });
+  const page = renderChromePage({ title: "Shared via Oyster", bodyHtml: iframe, cssExtra, showActionSlot: row.mode !== "signin" });
   return new Response(page, {
     status: 200,
     headers: cacheHeaders(row, "text/html; charset=utf-8"),

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -24,10 +24,12 @@ export function renderMarkdownPage(bytes: Uint8Array, row: PublicationRow): Resp
   const title = titleMatch ? stripTags(titleMatch[1]!) : "Shared via Oyster";
   const page = renderChromePage({ title, bodyHtml: html });
 
-  return new Response(page, {
-    status: 200,
-    headers: cacheHeaders(row, "text/html; charset=utf-8"),
-  });
+  const headers = new Headers(cacheHeaders(row, "text/html; charset=utf-8"));
+  headers.set(
+    "content-security-policy",
+    "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'",
+  );
+  return new Response(page, { status: 200, headers });
 }
 
 // ─── Cache headers ─────────────────────────────────────────────────────────

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -137,3 +137,11 @@ function escapeAttr(s: string): string {
     { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
   ));
 }
+
+// ─── Image inline ──────────────────────────────────────────────────────────
+
+export function renderImageInline(bytes: Uint8Array, row: PublicationRow): Response {
+  const headers = new Headers(cacheHeaders(row, row.content_type));
+  headers.set("content-disposition", "inline");
+  return new Response(bytes, { status: 200, headers });
+}

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -48,3 +48,55 @@ export function cacheHeaders(row: PublicationRow, contentType: string): HeadersI
 function stripTags(s: string): string {
   return s.replace(/<[^>]*>/g, "");
 }
+
+// ─── Mermaid ───────────────────────────────────────────────────────────────
+
+const MERMAID_VERSION = "10.9.1";
+const MERMAID_SRI = "sha384-WmdflGW9aGfoBdHc4rRyWzYuAjEmDwMdGdiPNacbwfGKxBW/SO6guzuQ76qjnSlr";  // computed via openssl dgst -sha384 -binary; pinned with version
+const MERMAID_URL = `https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_VERSION}/dist/mermaid.min.js`;
+
+export function renderMermaidPage(bytes: Uint8Array, row: PublicationRow): Response {
+  const source = new TextDecoder().decode(bytes);
+  // Only escape chars that would break HTML structure; mermaid reads textContent so &gt; would appear literally in the diagram.
+  const escaped = source.replace(/[&<]/g, (c) => (c === "&" ? "&amp;" : "&lt;"));
+  const body = `
+<pre class="mermaid">${escaped}</pre>
+<script src="${MERMAID_URL}" integrity="${MERMAID_SRI}" crossorigin="anonymous"></script>
+<script>
+(function() {
+  if (typeof mermaid === 'undefined') {
+    showSourceFallback('mermaid CDN unavailable');
+    return;
+  }
+  try {
+    mermaid.initialize({ startOnLoad: false });
+    mermaid.run({ querySelector: 'pre.mermaid' }).catch(function(err) {
+      showSourceFallback(err && err.message ? err.message : 'render failed');
+    });
+  } catch (err) {
+    showSourceFallback(err && err.message ? err.message : 'init failed');
+  }
+  function showSourceFallback(reason) {
+    var el = document.querySelector('pre.mermaid');
+    if (!el) return;
+    el.removeAttribute('class');
+    el.outerHTML = '<pre><code>' + el.textContent.replace(/[&<>]/g, function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;'}[c];}) + '</code></pre>' +
+      '<p style="font-size:0.8rem;color:#999">Diagram could not render: ' + reason.replace(/[<>]/g,'') + '</p>';
+  }
+})();
+</script>
+`;
+  const page = renderChromePage({ title: "Diagram", bodyHtml: body });
+  const headers = new Headers(cacheHeaders(row, "text/html; charset=utf-8"));
+  headers.set(
+    "content-security-policy",
+    "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self'; base-uri 'none'; form-action 'none'",
+  );
+  return new Response(page, { status: 200, headers });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+}

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -368,7 +368,7 @@ async function handleViewerGet(req: Request, env: Env, shareToken: string): Prom
     case "gate":
       return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
     case "ok":
-      return renderForRow(env, access.row);
+      return renderForRow(env, access.row, req);
   }
 }
 
@@ -442,7 +442,22 @@ async function handleViewerPost(req: Request, env: Env, shareToken: string): Pro
   });
 }
 
-async function renderForRow(env: Env, row: PublicationRow): Promise<Response> {
+async function renderForRow(env: Env, row: PublicationRow, req?: Request): Promise<Response> {
+  // Short-circuit on If-None-Match (open mode only — others are no-store).
+  if (req && row.mode === "open") {
+    const ifNoneMatch = req.headers.get("If-None-Match");
+    const etag = `W/"${row.share_token}-${row.updated_at}"`;
+    if (ifNoneMatch && ifNoneMatch === etag) {
+      return new Response(null, {
+        status: 304,
+        headers: {
+          etag,
+          "cache-control": "public, max-age=60, must-revalidate",
+        },
+      });
+    }
+  }
+
   const obj = await env.ARTIFACTS.get(row.r2_key);
   if (!obj) {
     console.error("[viewer] R2 object missing for token", row.share_token, "key", row.r2_key);

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -446,7 +446,7 @@ async function renderForRow(env: Env, row: PublicationRow, req?: Request): Promi
   // Short-circuit on If-None-Match (open mode only — others are no-store).
   if (req && row.mode === "open") {
     const ifNoneMatch = req.headers.get("If-None-Match");
-    const etag = `W/"${row.share_token}-${row.updated_at}"`;
+    const etag = `"${row.share_token}-${row.updated_at}"`;
     if (ifNoneMatch && ifNoneMatch === etag) {
       return new Response(null, {
         status: 304,

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -1,8 +1,16 @@
 // oyster-publish — R5 publish endpoints + viewer scaffold.
 // Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
 
-import type { Env } from "./types";
-import { CAPS, generateShareToken, parseMetadataHeader, r2KeyFor, type Tier } from "./publish-helpers";
+import type { Env, PublicationRow } from "./types";
+import { CAPS, generateShareToken, parseMetadataHeader, parseShareTokenPath, r2KeyFor, type Tier } from "./publish-helpers";
+import { resolveViewerAccess } from "./viewer-access";
+import { signViewerCookie } from "./viewer-cookie";
+import {
+  passwordGatePage, gonePage, notFoundPage, internalErrorPage, rateLimitedPage,
+} from "./viewer-pages";
+import {
+  renderMarkdownPage, renderMermaidPage, renderChromeWithIframe, renderRawHtmlBody, renderImageInline,
+} from "./viewer-render";
 
 export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -17,9 +25,19 @@ export default {
       return handlePublishDelete(req, env, token);
     }
 
-    if (url.pathname.startsWith("/p/") && req.method === "GET") {
-      // Viewer body lands in #316.
-      return jsonError(501, "not_implemented", "viewer lands in #316");
+    if (url.pathname.startsWith("/p/")) {
+      const parsed = parseShareTokenPath(url.pathname);
+      if (!parsed) return new Response("Not Found", { status: 404 });
+      if (req.method === "GET" && parsed.raw) {
+        return handleViewerRaw(req, env, parsed.shareToken);
+      }
+      if (req.method === "GET") {
+        return handleViewerGet(req, env, parsed.shareToken);
+      }
+      if (req.method === "POST" && !parsed.raw) {
+        return handleViewerPost(req, env, parsed.shareToken);
+      }
+      return new Response("Method Not Allowed", { status: 405 });
     }
 
     return new Response("Not Found", { status: 404 });
@@ -331,4 +349,174 @@ async function collectWithSizeCap(
     offset += chunk.byteLength;
   }
   return { bytes: out, exceeded: false };
+}
+
+// ─── Viewer handlers (#316) ────────────────────────────────────────────────
+
+async function handleViewerGet(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  switch (access.kind) {
+    case "not_found":
+      return htmlPage(404, notFoundPage());
+    case "gone":
+      return htmlPage(410, gonePage());
+    case "redirect":
+      return new Response(null, {
+        status: 302,
+        headers: { location: access.location, "cache-control": "private, no-store" },
+      });
+    case "gate":
+      return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
+    case "ok":
+      return renderForRow(env, access.row);
+  }
+}
+
+async function handleViewerRaw(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  if (access.kind === "not_found") return htmlPage(404, notFoundPage());
+  if (access.kind === "gone") return htmlPage(410, gonePage());
+  if (access.kind === "redirect") {
+    return new Response(null, { status: 302, headers: { location: access.location, "cache-control": "private, no-store" } });
+  }
+  if (access.kind === "gate") return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
+  // OK — serve raw bytes for HTML kinds, or fall through for non-HTML
+  const obj = await env.ARTIFACTS.get(access.row.r2_key);
+  if (!obj) {
+    console.error("[viewer] R2 object missing for token", shareToken, "key", access.row.r2_key);
+    return htmlPage(500, internalErrorPage());
+  }
+  const bytes = new Uint8Array(await obj.arrayBuffer());
+  return renderRawHtmlBody(bytes, access.row);
+}
+
+async function handleViewerPost(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken);
+  if (access.kind === "not_found") return htmlPage(404, notFoundPage());
+  if (access.kind === "gone") return htmlPage(410, gonePage());
+  if (access.kind === "redirect") {
+    return new Response(null, { status: 302, headers: { location: access.location, "cache-control": "private, no-store" } });
+  }
+  // POST is only meaningful in password mode.
+  // For password: gate state OR ok state both indicate "the visitor wants
+  // to (re-)authenticate via the form" — accept the POST. For other modes
+  // (open/signin), POST is method-not-allowed.
+  if (access.kind !== "gate" && !(access.kind === "ok" && access.row.mode === "password")) {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  const row = (access as { row: PublicationRow }).row;
+
+  // Rate limit per IP + token.
+  const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
+  const gate = await env.VIEWER_PASSWORD_LIMIT.limit({ key: `${ip}:${shareToken}` });
+  if (!gate.success) return htmlPage(429, rateLimitedPage());
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+  }
+  const password = form.get("password");
+  if (typeof password !== "string" || password.length === 0) {
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+  }
+
+  if (!row.password_hash) {
+    console.error("[viewer] password mode row has no password_hash:", shareToken);
+    return htmlPage(500, internalErrorPage());
+  }
+  const ok = await verifyPbkdf2(password, row.password_hash);
+  if (!ok) {
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+  }
+
+  const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "set-cookie": `oyster_view_${shareToken}=${cookieValue}; HttpOnly; Secure; SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
+      "location": `/p/${shareToken}`,
+      "cache-control": "private, no-store",
+    },
+  });
+}
+
+async function renderForRow(env: Env, row: PublicationRow): Promise<Response> {
+  const obj = await env.ARTIFACTS.get(row.r2_key);
+  if (!obj) {
+    console.error("[viewer] R2 object missing for token", row.share_token, "key", row.r2_key);
+    return htmlPage(500, internalErrorPage());
+  }
+  const bytes = new Uint8Array(await obj.arrayBuffer());
+
+  if (row.content_type.startsWith("image/")) return renderImageInline(bytes, row);
+
+  switch (row.artifact_kind) {
+    case "notes":
+      return renderMarkdownPage(bytes, row);
+    case "diagram":
+      return renderMermaidPage(bytes, row);
+    case "app":
+    case "deck":
+    case "wireframe":
+    case "table":
+    case "map":
+      return renderChromeWithIframe(row);
+    default:
+      return row.content_type.startsWith("text/")
+        ? renderMarkdownPage(bytes, row)
+        : renderChromeWithIframe(row);
+  }
+}
+
+function htmlPage(status: number, body: string, opts?: { mode?: "password-gate" }): Response {
+  const headers: Record<string, string> = {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "private, no-store",
+    "x-content-type-options": "nosniff",
+  };
+  return new Response(body, { status, headers });
+}
+
+// PBKDF2-SHA256 verify, matches server/src/password-hash.ts producer.
+async function verifyPbkdf2(plaintext: string, encoded: string): Promise<boolean> {
+  // Format: pbkdf2$<iter>$<salt_b64url>$<hash_b64url>
+  const parts = encoded.split("$");
+  if (parts.length !== 4 || parts[0] !== "pbkdf2") return false;
+  const [, iterRaw, saltB64, hashB64] = parts as [string, string, string, string];
+  const iter = Number(iterRaw);
+  if (!Number.isSafeInteger(iter) || iter < 1) return false;
+  const salt = base64urlDecode(saltB64);
+  const expected = base64urlDecode(hashB64);
+  if (!salt || !expected) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(plaintext),
+    { name: "PBKDF2" },
+    false,
+    ["deriveBits"],
+  );
+  const derived = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt, iterations: iter, hash: "SHA-256" },
+    key,
+    expected.byteLength * 8,
+  ));
+  if (derived.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < derived.length; i++) diff |= (derived[i] as number) ^ (expected[i] as number);
+  return diff === 0;
+}
+
+function base64urlDecode(s: string): Uint8Array | null {
+  try {
+    const padded = s.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (s.length % 4)) % 4);
+    const binary = atob(padded);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
 }

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -2,7 +2,7 @@
 // Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
 
 import type { Env, PublicationRow } from "./types";
-import { CAPS, generateShareToken, parseMetadataHeader, parseShareTokenPath, r2KeyFor, type Tier, isLoopback } from "./publish-helpers";
+import { CAPS, generateShareToken, IFRAME_KINDS, parseMetadataHeader, parseShareTokenPath, r2KeyFor, type Tier, isLoopback } from "./publish-helpers";
 import { resolveViewerAccess } from "./viewer-access";
 import { signViewerCookie } from "./viewer-cookie";
 import {
@@ -381,7 +381,6 @@ async function handleViewerRaw(req: Request, env: Env, shareToken: string): Prom
   }
   if (access.kind === "gate") return htmlPage(200, passwordGatePage(shareToken));
   // OK — only iframe kinds are served via /raw; everything else 404s.
-  const IFRAME_KINDS = new Set(["app", "deck", "wireframe", "table", "map"]);
   if (!IFRAME_KINDS.has(access.row.artifact_kind)) {
     return htmlPage(404, notFoundPage());
   }
@@ -472,23 +471,14 @@ async function renderForRow(env: Env, row: PublicationRow, req?: Request): Promi
   const bytes = new Uint8Array(await obj.arrayBuffer());
 
   if (row.content_type.startsWith("image/")) return renderImageInline(bytes, row);
-
-  switch (row.artifact_kind) {
-    case "notes":
-      return renderMarkdownPage(bytes, row);
-    case "diagram":
-      return renderMermaidPage(bytes, row);
-    case "app":
-    case "deck":
-    case "wireframe":
-    case "table":
-    case "map":
-      return renderChromeWithIframe(row);
-    default:
-      return row.content_type.startsWith("text/")
-        ? renderMarkdownPage(bytes, row)
-        : renderChromeWithIframe(row);
-  }
+  if (row.artifact_kind === "notes") return renderMarkdownPage(bytes, row);
+  if (row.artifact_kind === "diagram") return renderMermaidPage(bytes, row);
+  if (IFRAME_KINDS.has(row.artifact_kind)) return renderChromeWithIframe(row);
+  // text/* fallback for unknown kinds with text content_type
+  if (row.content_type.startsWith("text/")) return renderMarkdownPage(bytes, row);
+  // Unknown kind with non-text content — reject rather than silently iframe-loading a 404.
+  console.error("[viewer] unsupported artifact_kind for token", row.share_token, "kind", row.artifact_kind, "content_type", row.content_type);
+  return htmlPage(500, internalErrorPage());
 }
 
 function htmlPage(status: number, body: string): Response {

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -380,7 +380,11 @@ async function handleViewerRaw(req: Request, env: Env, shareToken: string): Prom
     return new Response(null, { status: 302, headers: { location: access.location, "cache-control": "private, no-store" } });
   }
   if (access.kind === "gate") return htmlPage(200, passwordGatePage(shareToken));
-  // OK — serve raw bytes for HTML kinds, or fall through for non-HTML
+  // OK — only iframe kinds are served via /raw; everything else 404s.
+  const IFRAME_KINDS = new Set(["app", "deck", "wireframe", "table", "map"]);
+  if (!IFRAME_KINDS.has(access.row.artifact_kind)) {
+    return htmlPage(404, notFoundPage());
+  }
   const obj = await env.ARTIFACTS.get(access.row.r2_key);
   if (!obj) {
     console.error("[viewer] R2 object missing for token", shareToken, "key", access.row.r2_key);

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -2,7 +2,7 @@
 // Spec: docs/superpowers/specs/2026-05-03-r5-publish-backend-design.md
 
 import type { Env, PublicationRow } from "./types";
-import { CAPS, generateShareToken, parseMetadataHeader, parseShareTokenPath, r2KeyFor, type Tier } from "./publish-helpers";
+import { CAPS, generateShareToken, parseMetadataHeader, parseShareTokenPath, r2KeyFor, type Tier, isLoopback } from "./publish-helpers";
 import { resolveViewerAccess } from "./viewer-access";
 import { signViewerCookie } from "./viewer-cookie";
 import {
@@ -436,10 +436,12 @@ async function handleViewerPost(req: Request, env: Env, shareToken: string): Pro
   }
 
   const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+  const host = new URL(req.url).host;
+  const secureFlag = isLoopback(host) ? "" : " Secure;";
   return new Response(null, {
     status: 302,
     headers: {
-      "set-cookie": `oyster_view_${shareToken}=${cookieValue}; HttpOnly; Secure; SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
+      "set-cookie": `oyster_view_${shareToken}=${cookieValue}; HttpOnly;${secureFlag} SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
       "location": `/p/${shareToken}`,
       "cache-control": "private, no-store",
     },

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -366,7 +366,7 @@ async function handleViewerGet(req: Request, env: Env, shareToken: string): Prom
         headers: { location: access.location, "cache-control": "private, no-store" },
       });
     case "gate":
-      return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
+      return htmlPage(200, passwordGatePage(shareToken));
     case "ok":
       return renderForRow(env, access.row, req);
   }
@@ -379,7 +379,7 @@ async function handleViewerRaw(req: Request, env: Env, shareToken: string): Prom
   if (access.kind === "redirect") {
     return new Response(null, { status: 302, headers: { location: access.location, "cache-control": "private, no-store" } });
   }
-  if (access.kind === "gate") return htmlPage(200, passwordGatePage(shareToken), { mode: "password-gate" });
+  if (access.kind === "gate") return htmlPage(200, passwordGatePage(shareToken));
   // OK — serve raw bytes for HTML kinds, or fall through for non-HTML
   const obj = await env.ARTIFACTS.get(access.row.r2_key);
   if (!obj) {
@@ -415,11 +415,11 @@ async function handleViewerPost(req: Request, env: Env, shareToken: string): Pro
   try {
     form = await req.formData();
   } catch {
-    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }));
   }
   const password = form.get("password");
   if (typeof password !== "string" || password.length === 0) {
-    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }));
   }
 
   if (!row.password_hash) {
@@ -428,7 +428,7 @@ async function handleViewerPost(req: Request, env: Env, shareToken: string): Pro
   }
   const ok = await verifyPbkdf2(password, row.password_hash);
   if (!ok) {
-    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }), { mode: "password-gate" });
+    return htmlPage(200, passwordGatePage(shareToken, { error: "wrong_password" }));
   }
 
   const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
@@ -485,7 +485,7 @@ async function renderForRow(env: Env, row: PublicationRow, req?: Request): Promi
   }
 }
 
-function htmlPage(status: number, body: string, opts?: { mode?: "password-gate" }): Response {
+function htmlPage(status: number, body: string): Response {
   const headers: Record<string, string> = {
     "content-type": "text/html; charset=utf-8",
     "cache-control": "private, no-store",

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -107,3 +107,40 @@ export function authHeader(sessionToken: string): { Cookie: string } {
 export function metadataHeader(payload: object): string {
   return Buffer.from(JSON.stringify(payload)).toString("base64url");
 }
+
+export async function retirePublication(shareToken: string, unpublishedAt = Date.now()): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE published_artifacts SET unpublished_at = ? WHERE share_token = ?",
+  ).bind(unpublishedAt, shareToken).run();
+}
+
+export async function putR2Object(key: string, body: Uint8Array | string, contentType: string): Promise<void> {
+  await env.ARTIFACTS.put(key, body, { httpMetadata: { contentType } });
+}
+
+export async function seedActiveOpenWithBody(opts: {
+  ownerUserId: string;
+  artifactId: string;
+  artifactKind?: "notes" | "diagram" | "app" | "deck" | "wireframe" | "table" | "map";
+  contentType?: string;
+  body: string | Uint8Array;
+  shareToken?: string;
+  publishedAt?: number;
+}): Promise<{ shareToken: string; r2Key: string }> {
+  const token = opts.shareToken ?? `seeded_${crypto.randomUUID().slice(0, 8)}`;
+  const kind = opts.artifactKind ?? "notes";
+  const contentType = opts.contentType ?? "text/markdown";
+  const now = opts.publishedAt ?? Date.now();
+  const r2Key = `published/${opts.ownerUserId}/${token}`;
+  const sizeBytes = typeof opts.body === "string"
+    ? new TextEncoder().encode(opts.body).byteLength
+    : opts.body.byteLength;
+  await env.DB.prepare(
+    `INSERT INTO published_artifacts
+     (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+      r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+     VALUES (?, ?, ?, ?, 'open', NULL, ?, ?, ?, ?, ?, NULL)`,
+  ).bind(token, opts.ownerUserId, opts.artifactId, kind, r2Key, contentType, sizeBytes, now, now).run();
+  await putR2Object(r2Key, opts.body, contentType);
+  return { shareToken: token, r2Key };
+}

--- a/infra/oyster-publish/test/viewer-cookie.test.ts
+++ b/infra/oyster-publish/test/viewer-cookie.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { signViewerCookie, verifyViewerCookie } from "../src/viewer-cookie";
+
+const SECRET = "test-secret-do-not-use-in-prod";
+const TOKEN = "abc123_-XYZ";
+
+describe("signViewerCookie / verifyViewerCookie — round-trip", () => {
+  it("a freshly-signed cookie verifies", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const ok = await verifyViewerCookie(cookie, TOKEN, SECRET);
+    expect(ok).toBe(true);
+  });
+
+  it("the cookie format is `<token>.<timestamp>.<hmac>`", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const parts = cookie.split(".");
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toBe(TOKEN);
+    expect(parts[1]).toMatch(/^\d+$/);
+    expect(parts[2]).toMatch(/^[A-Za-z0-9_-]+$/); // base64url, no padding
+  });
+});
+
+describe("verifyViewerCookie — rejection", () => {
+  it("rejects malformed cookie", async () => {
+    expect(await verifyViewerCookie("garbage", TOKEN, SECRET)).toBe(false);
+    expect(await verifyViewerCookie("a.b", TOKEN, SECRET)).toBe(false);
+    expect(await verifyViewerCookie("a.b.c.d", TOKEN, SECRET)).toBe(false);
+  });
+
+  it("rejects when the embedded token doesn't match expected", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    expect(await verifyViewerCookie(cookie, "different_token", SECRET)).toBe(false);
+  });
+
+  it("rejects when the HMAC has been tampered with", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const tampered = cookie.slice(0, -1) + (cookie.slice(-1) === "A" ? "B" : "A");
+    expect(await verifyViewerCookie(tampered, TOKEN, SECRET)).toBe(false);
+  });
+
+  it("rejects when the timestamp has been tampered with", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    const [token, , hmac] = cookie.split(".");
+    const forged = `${token}.0.${hmac}`;
+    expect(await verifyViewerCookie(forged, TOKEN, SECRET)).toBe(false);
+  });
+
+  it("rejects when verified with a different secret", async () => {
+    const cookie = await signViewerCookie(TOKEN, SECRET);
+    expect(await verifyViewerCookie(cookie, TOKEN, "other-secret")).toBe(false);
+  });
+
+  it("rejects cookies older than 24h (TTL = 86400 seconds)", async () => {
+    // Hand-craft an old cookie by signing with a forged timestamp.
+    // We use the internal sign function exposed via signViewerCookieAt for tests.
+    const { signViewerCookieAt } = await import("../src/viewer-cookie");
+    const oldTs = Math.floor(Date.now() / 1000) - 86401;
+    const cookie = await signViewerCookieAt(TOKEN, SECRET, oldTs);
+    expect(await verifyViewerCookie(cookie, TOKEN, SECRET)).toBe(false);
+  });
+
+  it("accepts cookies just under the TTL boundary", async () => {
+    const { signViewerCookieAt } = await import("../src/viewer-cookie");
+    const recentTs = Math.floor(Date.now() / 1000) - 86399;
+    const cookie = await signViewerCookieAt(TOKEN, SECRET, recentTs);
+    expect(await verifyViewerCookie(cookie, TOKEN, SECRET)).toBe(true);
+  });
+});

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -331,6 +331,23 @@ describe("ETag / 304", () => {
   });
 });
 
+describe("GET /p/:token — unknown artifact_kind", () => {
+  it("returns 500 for unknown kind with non-text content_type", async () => {
+    const u = await seedUser();
+    const token = `seeded_${crypto.randomUUID().slice(0, 8)}`;
+    const r2Key = `published/${u.id}/${token}`;
+    await env.DB.prepare(
+      `INSERT INTO published_artifacts
+       (share_token, owner_user_id, artifact_id, artifact_kind, mode, password_hash,
+        r2_key, content_type, size_bytes, published_at, updated_at, unpublished_at)
+       VALUES (?, ?, 'art_unk', 'unknown_kind', 'open', NULL, ?, 'application/octet-stream', 4, ?, ?, NULL)`,
+    ).bind(token, u.id, r2Key, Date.now(), Date.now()).run();
+    await putR2Object(r2Key, new Uint8Array([0, 1, 2, 3]), "application/octet-stream");
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(500);
+  });
+});
+
 describe("GET /p/:token — signin mode", () => {
   it("unsigned visitor → 302 to /auth/sign-in?return=/p/<token>", async () => {
     const u = await seedUser();

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -373,4 +373,29 @@ describe("GET /p/:token — signin mode", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("private");
   });
+
+  it("signin viewer (signed in) does NOT show 'Get your own at oyster.to' CTA", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art3cta", body: "# signin-only",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+    const cookie = `oyster_session=${u.sessionToken}`;
+    const res = await call(getReq(`/p/${shareToken}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).not.toContain("Get your own at oyster.to");
+  });
+});
+
+describe("GET /p/:token — CTA in open mode", () => {
+  it("open viewer shows 'Get your own at oyster.to' CTA", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_cta_open", body: "# open",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Get your own at oyster.to");
+  });
 });

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import {
+  applySchema, seedUser, seedActivePublication, retirePublication,
+  putR2Object, seedActiveOpenWithBody,
+} from "./fixtures/seed";
+import { signViewerCookie } from "../src/viewer-cookie";
+
+beforeAll(() => {
+  // VIEWER_PASSWORD_LIMIT is an unsafe ratelimit binding; miniflare doesn't auto-mock it.
+  // Inject a stub that always succeeds so password-mode POST tests can reach the form logic.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (env as any).VIEWER_PASSWORD_LIMIT = { limit: async () => ({ success: true }) };
+});
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function getReq(path: string, opts: { cookie?: string; ifNoneMatch?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  if (opts.ifNoneMatch) headers.set("If-None-Match", opts.ifNoneMatch);
+  return new Request(`https://oyster.to${path}`, { method: "GET", headers });
+}
+
+function postReq(path: string, opts: { cookie?: string; password?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  headers.set("Content-Type", "application/x-www-form-urlencoded");
+  const body = new URLSearchParams();
+  if (opts.password !== undefined) body.set("password", opts.password);
+  return new Request(`https://oyster.to${path}`, { method: "POST", headers, body: body.toString() });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("GET /p/:token — 404 / 410", () => {
+  it("returns 404 for unknown token", async () => {
+    const res = await call(getReq("/p/no-such-token"));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    expect(await res.text()).toContain("Share not found");
+  });
+
+  it("returns 410 for retired publication", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art1" });
+    await retirePublication(token);
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(410);
+    expect(await res.text()).toContain("This share has been removed");
+  });
+});
+
+describe("GET /p/:token — open mode", () => {
+  it("renders markdown notes with chrome", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "notes",
+      contentType: "text/markdown", body: "# Hello world",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<h1>Hello world</h1>");
+    expect(body).toContain("🦪 oyster"); // chrome present
+    expect(body).toContain("Powered by Oyster");
+  });
+
+  it("sets open-mode cache headers + ETag", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", body: "# x",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(res.headers.get("etag")).toMatch(/^W\/"[^"]+"$/);
+  });
+
+  it("serves images inline with no chrome", async () => {
+    const u = await seedUser();
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "notes",
+      contentType: "image/png", body: png,
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("content-disposition")).toBe("inline");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(png);
+  });
+
+  it("renders app kind via iframe pointing at /raw", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>my app</h1>",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    const body = await res.text();
+    expect(body).toContain(`src="/p/${shareToken}/raw"`);
+    expect(body).toContain('sandbox="allow-scripts"');
+    expect(body).not.toMatch(/sandbox="[^"]*allow-same-origin/);
+  });
+});
+
+describe("GET /p/:token/raw — iframe content", () => {
+  it("serves bytes with strict CSP", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>raw app</h1>",
+    });
+    const res = await call(getReq(`/p/${shareToken}/raw`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html");
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("form-action 'none'");
+    expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+    expect(await res.text()).toBe("<h1>raw app</h1>");
+  });
+
+  it("returns 404 for unknown token on /raw", async () => {
+    const res = await call(getReq(`/p/no-such-token/raw`));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 410 on /raw for retired publication", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>x</h1>",
+    });
+    await retirePublication(shareToken);
+    const res = await call(getReq(`/p/${shareToken}/raw`));
+    expect(res.status).toBe(410);
+  });
+});
+
+describe("GET/POST /p/:token — password mode", () => {
+  // PBKDF2-SHA256 producer using the same params as server/src/password-hash.ts
+  // so the Worker's verifier (Web Crypto) matches.
+  async function makeHash(password: string): Promise<string> {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await crypto.subtle.importKey(
+      "raw", new TextEncoder().encode(password),
+      { name: "PBKDF2" }, false, ["deriveBits"],
+    );
+    const bits = await crypto.subtle.deriveBits(
+      { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
+      key, 256,
+    );
+    const b64url = (b: Uint8Array) => {
+      let s = ""; for (const x of b) s += String.fromCharCode(x);
+      return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    };
+    return `pbkdf2$100000$${b64url(salt)}$${b64url(new Uint8Array(bits))}`;
+  }
+
+  it("GET with no cookie → password gate page", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Password required");
+  });
+
+  it("POST correct password → 302 with cookie; follow-up GET → content", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    // Seed R2 bytes too (the shared seedActivePublication doesn't put bytes).
+    await putR2Object(`published/${u.id}/${token}`, "# Secret notes", "text/markdown");
+    // Update the row's content_type so renderMarkdownPage is chosen
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET content_type = 'text/markdown', artifact_kind = 'notes' WHERE share_token = ?",
+    ).bind(token).run();
+
+    const postRes = await call(postReq(`/p/${token}`, { password: "letmein" }));
+    expect(postRes.status).toBe(302);
+    const setCookie = postRes.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oyster_view_${token}=`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain(`Path=/p/${token}`);
+
+    // Extract cookie value and follow up with GET.
+    const cookieMatch = setCookie.match(new RegExp(`oyster_view_${token}=([^;]+)`));
+    expect(cookieMatch).not.toBeNull();
+    const cookie = `oyster_view_${token}=${cookieMatch![1]}`;
+    const getRes = await call(getReq(`/p/${token}`, { cookie }));
+    expect(getRes.status).toBe(200);
+    expect(await getRes.text()).toContain("Secret notes");
+  });
+
+  it("POST wrong password → 200 gate with 'Incorrect password'", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const res = await call(postReq(`/p/${token}`, { password: "WRONG" }));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Password required");
+    expect(body).toContain("Incorrect password");
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("POST empty password → 200 gate with error", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const res = await call(postReq(`/p/${token}`, { password: "" }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Incorrect password");
+  });
+
+  it("GET with tampered cookie → re-renders gate", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    const cookie = `oyster_view_${token}=tampered.0.garbage`;
+    const res = await call(getReq(`/p/${token}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Password required");
+  });
+
+  it("GET with valid cookie → content (no re-prompt)", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash,
+    });
+    await putR2Object(`published/${u.id}/${token}`, "# unlocked", "text/markdown");
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET content_type = 'text/markdown', artifact_kind = 'notes' WHERE share_token = ?",
+    ).bind(token).run();
+    const cookieValue = await signViewerCookie(token, env.VIEWER_COOKIE_SECRET);
+    const cookie = `oyster_view_${token}=${cookieValue}`;
+    const res = await call(getReq(`/p/${token}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("unlocked");
+  });
+});
+
+describe("GET /p/:token — signin mode", () => {
+  it("unsigned visitor → 302 to /auth/sign-in?return=/p/<token>", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art3", mode: "signin",
+    });
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toBe(`https://oyster.to/auth/sign-in?return=/p/${token}`);
+  });
+
+  it("signed-in visitor → content", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art3", body: "# private",
+    });
+    // Flip mode to signin
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+    const cookie = `oyster_session=${u.sessionToken}`;
+    const res = await call(getReq(`/p/${shareToken}`, { cookie }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("private");
+  });
+});

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -81,7 +81,7 @@ describe("GET /p/:token — open mode", () => {
     });
     const res = await call(getReq(`/p/${shareToken}`));
     expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
-    expect(res.headers.get("etag")).toMatch(/^W\/"[^"]+"$/);
+    expect(res.headers.get("etag")).toMatch(/^"[^"]+"$/);
   });
 
   it("serves images inline with no chrome", async () => {
@@ -271,7 +271,7 @@ describe("ETag / 304", () => {
     });
     const first = await call(getReq(`/p/${shareToken}`));
     const etag = first.headers.get("etag") ?? "";
-    expect(etag).toMatch(/^W\//);
+    expect(etag).toMatch(/^"[^"]+"$/);
     const second = await call(getReq(`/p/${shareToken}`, { ifNoneMatch: etag }));
     expect(second.status).toBe(304);
     expect(second.headers.get("etag")).toBe(etag);
@@ -289,7 +289,7 @@ describe("ETag / 304", () => {
     ).bind(token).run();
     const cookieValue = await signViewerCookie(token, env.VIEWER_COOKIE_SECRET);
     const cookie = `oyster_view_${token}=${cookieValue}`;
-    const res = await call(getReq(`/p/${token}`, { cookie, ifNoneMatch: `W/"${token}-anything"` }));
+    const res = await call(getReq(`/p/${token}`, { cookie, ifNoneMatch: `"${token}-anything"` }));
     expect(res.status).toBe(200);  // password mode never returns 304
   });
 });

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -145,6 +145,26 @@ describe("GET /p/:token/raw — iframe content", () => {
     const res = await call(getReq(`/p/${shareToken}/raw`));
     expect(res.status).toBe(410);
   });
+
+  it("returns 404 on /raw for non-iframe kind (notes)", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "notes",
+      contentType: "text/markdown", body: "# hello",
+    });
+    const res = await call(getReq(`/p/${shareToken}/raw`));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 on /raw for iframe kind (app)", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", artifactKind: "app",
+      contentType: "text/html", body: "<h1>app</h1>",
+    });
+    const res = await call(getReq(`/p/${shareToken}/raw`));
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("GET/POST /p/:token — password mode", () => {

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -228,6 +228,23 @@ describe("GET/POST /p/:token — password mode", () => {
     expect(await getRes.text()).toContain("Secret notes");
   });
 
+  it("POST correct password on localhost → cookie omits Secure flag", async () => {
+    const u = await seedUser();
+    const hash = await makeHash("letmein");
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2loc", mode: "password", passwordHash: hash,
+    });
+    const headers = new Headers({ "Content-Type": "application/x-www-form-urlencoded" });
+    const body = new URLSearchParams({ password: "letmein" });
+    const req = new Request(`http://localhost:8787/p/${token}`, { method: "POST", headers, body: body.toString() });
+    const postRes = await call(req);
+    expect(postRes.status).toBe(302);
+    const setCookie = postRes.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oyster_view_${token}=`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).not.toContain("Secure");
+  });
+
   it("POST wrong password → 200 gate with 'Incorrect password'", async () => {
     const u = await seedUser();
     const hash = await makeHash("letmein");

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -263,6 +263,37 @@ describe("GET/POST /p/:token — password mode", () => {
   });
 });
 
+describe("ETag / 304", () => {
+  it("returns 304 on matching If-None-Match", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art1", body: "# x",
+    });
+    const first = await call(getReq(`/p/${shareToken}`));
+    const etag = first.headers.get("etag") ?? "";
+    expect(etag).toMatch(/^W\//);
+    const second = await call(getReq(`/p/${shareToken}`, { ifNoneMatch: etag }));
+    expect(second.status).toBe(304);
+    expect(second.headers.get("etag")).toBe(etag);
+  });
+
+  it("does NOT return 304 for password mode", async () => {
+    const u = await seedUser();
+    const hash = await env.DB.prepare("SELECT 'pbkdf2$100000$x$y' AS h").first<{ h: string }>();
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art2", mode: "password", passwordHash: hash!.h,
+    });
+    await putR2Object(`published/${u.id}/${token}`, "# x", "text/markdown");
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET content_type = 'text/markdown', artifact_kind = 'notes' WHERE share_token = ?",
+    ).bind(token).run();
+    const cookieValue = await signViewerCookie(token, env.VIEWER_COOKIE_SECRET);
+    const cookie = `oyster_view_${token}=${cookieValue}`;
+    const res = await call(getReq(`/p/${token}`, { cookie, ifNoneMatch: `W/"${token}-anything"` }));
+    expect(res.status).toBe(200);  // password mode never returns 304
+  });
+});
+
 describe("GET /p/:token — signin mode", () => {
   it("unsigned visitor → 302 to /auth/sign-in?return=/p/<token>", async () => {
     const u = await seedUser();

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -123,3 +123,59 @@ describe("renderMermaidPage", () => {
     expect(csp).toMatch(/script-src 'self' 'unsafe-inline' https:\/\/cdn\.jsdelivr\.net/);
   });
 });
+
+import { renderChromeWithIframe, renderRawHtmlBody } from "../src/viewer-render";
+
+describe("renderChromeWithIframe", () => {
+  const ROW = { share_token: "app1", mode: "open", updated_at: 3000, artifact_kind: "app", content_type: "text/html" } as any;
+
+  it("returns a 200 HTML response with chrome", async () => {
+    const res = renderChromeWithIframe(ROW);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("🦪 oyster");
+    expect(body).toContain("Powered by Oyster");
+  });
+
+  it("contains a sandboxed iframe pointing at /p/<token>/raw", async () => {
+    const res = renderChromeWithIframe(ROW);
+    const body = await res.text();
+    expect(body).toContain('sandbox="allow-scripts"');
+    expect(body).toContain('src="/p/app1/raw"');
+    // Critical: sandbox attribute must NOT include allow-same-origin (would defeat origin isolation)
+    expect(body).not.toMatch(/sandbox="[^"]*allow-same-origin/);
+  });
+
+  it("includes the deliberate-omission comment in source", async () => {
+    const res = renderChromeWithIframe(ROW);
+    const body = await res.text();
+    expect(body).toContain("Deliberately omit allow-same-origin");
+  });
+});
+
+describe("renderRawHtmlBody — strict CSP for iframe content", () => {
+  it("serves bytes with the recorded content-type", async () => {
+    const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
+    const bytes = new TextEncoder().encode("<h1>my app</h1>");
+    const res = renderRawHtmlBody(bytes, ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html");
+    expect(await res.text()).toBe("<h1>my app</h1>");
+  });
+
+  it("sets a strict CSP including connect-src 'none' and form-action 'none'", async () => {
+    const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
+    const res = renderRawHtmlBody(new TextEncoder().encode(""), ROW);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  it("sets X-Frame-Options: SAMEORIGIN", async () => {
+    const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
+    const res = renderRawHtmlBody(new TextEncoder().encode(""), ROW);
+    expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+  });
+});

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -74,7 +74,7 @@ describe("renderMarkdownPage — cache headers", () => {
     const openRow = { ...ROW, mode: "open", updated_at: 1000 };
     const res = renderMarkdownPage(new TextEncoder().encode("# x"), openRow);
     expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
-    expect(res.headers.get("etag")).toMatch(/^W\/"abc-1000"$/);
+    expect(res.headers.get("etag")).toMatch(/^"abc-1000"$/);
   });
 
   it("sets cache-control: private, no-store for non-open modes", async () => {
@@ -197,7 +197,7 @@ describe("renderImageInline", () => {
   it("applies open-mode cache headers", async () => {
     const res = renderImageInline(new Uint8Array(0), ROW);
     expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
-    expect(res.headers.get("etag")).toBe(`W/"img1-4000"`);
+    expect(res.headers.get("etag")).toBe(`"img1-4000"`);
   });
 
   it("applies private no-store for non-open modes", async () => {

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderMarkdownPage } from "../src/viewer-render";
+import { renderMarkdownPage, renderMermaidPage } from "../src/viewer-render";
 
 const ROW = {
   share_token: "abc",
@@ -82,5 +82,44 @@ describe("renderMarkdownPage — cache headers", () => {
     const res = renderMarkdownPage(new TextEncoder().encode("# x"), pwRow);
     expect(res.headers.get("cache-control")).toBe("private, no-store");
     expect(res.headers.get("etag")).toBeNull();
+  });
+});
+
+describe("renderMermaidPage", () => {
+  const SOURCE = "graph TD; A-->B;";
+  const ROW = { share_token: "mer1", mode: "open", updated_at: 2000, artifact_kind: "diagram", content_type: "text/plain" } as any;
+
+  it("returns a 200 HTML response", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+  });
+
+  it("embeds the source verbatim in <pre class=\"mermaid\">", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const body = await res.text();
+    expect(body).toContain(`<pre class="mermaid">${SOURCE}</pre>`);
+  });
+
+  it("loads pinned mermaid CDN with SRI", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const body = await res.text();
+    expect(body).toContain("https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js");
+    expect(body).toContain("integrity=\"sha384-");
+    expect(body).toContain('crossorigin="anonymous"');
+  });
+
+  it("includes a fallback that shows source on mermaid.run() failure", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const body = await res.text();
+    expect(body).toContain("mermaid.run");
+    expect(body).toContain(".catch");
+  });
+
+  it("sets a CSP that allows jsdelivr scripts", async () => {
+    const res = renderMermaidPage(new TextEncoder().encode(SOURCE), ROW);
+    const csp = res.headers.get("content-security-policy");
+    expect(csp).toMatch(/cdn\.jsdelivr\.net/);
+    expect(csp).toMatch(/script-src 'self' 'unsafe-inline' https:\/\/cdn\.jsdelivr\.net/);
   });
 });

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { renderMarkdownPage } from "../src/viewer-render";
+
+const ROW = {
+  share_token: "abc",
+  artifact_kind: "notes",
+  content_type: "text/markdown",
+  // Other fields not used by markdown render
+} as any;
+
+describe("renderMarkdownPage — basic rendering", () => {
+  it("returns a 200 HTML response with the title in <title>", async () => {
+    const res = renderMarkdownPage(new TextEncoder().encode("# Hello"), ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    const body = await res.text();
+    expect(body).toContain("<h1>Hello</h1>");
+  });
+
+  it("renders a list with linkified URLs", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("- See https://example.com"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).toContain('href="https://example.com"');
+  });
+});
+
+describe("renderMarkdownPage — link safety (markdown-it default validateLink)", () => {
+  it("does NOT render javascript: as an active href", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("[click me](javascript:alert(1))"),
+      ROW,
+    );
+    const body = await res.text();
+    // markdown-it default behaviour is to drop the href entirely,
+    // leaving the link text but not making it active.
+    expect(body).not.toContain('href="javascript:');
+    expect(body).not.toContain("href='javascript:");
+  });
+
+  it("does NOT render vbscript: as an active href", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("[x](vbscript:msgbox(1))"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).not.toContain('href="vbscript:');
+  });
+
+  it("does NOT render file: as an active href", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("[x](file:///etc/passwd)"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).not.toContain('href="file://');
+  });
+
+  it("escapes raw <script> in markdown (html: false)", async () => {
+    const res = renderMarkdownPage(
+      new TextEncoder().encode("<script>alert(1)</script>"),
+      ROW,
+    );
+    const body = await res.text();
+    expect(body).not.toContain("<script>alert(1)</script>");
+    expect(body).toContain("&lt;script&gt;");
+  });
+});
+
+describe("renderMarkdownPage — cache headers", () => {
+  it("sets cache-control: public, max-age=60, must-revalidate for open mode", async () => {
+    const openRow = { ...ROW, mode: "open", updated_at: 1000 };
+    const res = renderMarkdownPage(new TextEncoder().encode("# x"), openRow);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(res.headers.get("etag")).toMatch(/^W\/"abc-1000"$/);
+  });
+
+  it("sets cache-control: private, no-store for non-open modes", async () => {
+    const pwRow = { ...ROW, mode: "password", updated_at: 1000 };
+    const res = renderMarkdownPage(new TextEncoder().encode("# x"), pwRow);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("etag")).toBeNull();
+  });
+});

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -205,4 +205,11 @@ describe("renderImageInline", () => {
     const res = renderImageInline(new Uint8Array(0), pwRow);
     expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
+
+  it("sets a minimal CSP with default-src 'none'", async () => {
+    const res = renderImageInline(new Uint8Array(0), ROW);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("img-src 'self' data:");
+  });
 });

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -179,3 +179,30 @@ describe("renderRawHtmlBody — strict CSP for iframe content", () => {
     expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
   });
 });
+
+import { renderImageInline } from "../src/viewer-render";
+
+describe("renderImageInline", () => {
+  const ROW = { share_token: "img1", mode: "open", updated_at: 4000, content_type: "image/png" } as any;
+
+  it("serves bytes inline with the recorded content-type", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header
+    const res = renderImageInline(png, ROW);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("content-disposition")).toBe("inline");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(png);
+  });
+
+  it("applies open-mode cache headers", async () => {
+    const res = renderImageInline(new Uint8Array(0), ROW);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=60, must-revalidate");
+    expect(res.headers.get("etag")).toBe(`W/"img1-4000"`);
+  });
+
+  it("applies private no-store for non-open modes", async () => {
+    const pwRow = { ...ROW, mode: "password" };
+    const res = renderImageInline(new Uint8Array(0), pwRow);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+});

--- a/infra/oyster-publish/vitest.config.ts
+++ b/infra/oyster-publish/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineWorkersConfig({
           // Use isolated in-memory D1 + R2 per test file.
           d1Databases: ["DB"],
           r2Buckets: ["ARTIFACTS"],
+          bindings: {
+            VIEWER_COOKIE_SECRET: "test-secret-for-vitest-only",
+          },
         },
       },
     },

--- a/infra/oyster-publish/wrangler.toml
+++ b/infra/oyster-publish/wrangler.toml
@@ -35,3 +35,12 @@ zone_name = "oyster.to"
 [[routes]]
 pattern = "www.oyster.to/p/*"
 zone_name = "oyster.to"
+
+# Rate limiter for password-gate POST attempts. Key = `${ip}:${share_token}`
+# so one IP cannot exhaust attempts across all of a publisher's shares.
+# Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md
+[[unsafe.bindings]]
+name = "VIEWER_PASSWORD_LIMIT"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 10, period = 60 }


### PR DESCRIPTION
## Summary

- Replaces the `501 Not Implemented` stub at `oyster.to/p/<token>` with a full public viewer enforcing three access modes (open / password / signin) and rendering per artefact kind.
- Adds a generic `?return=<allowlisted-path>` flow on `auth-worker` so `signin`-mode visitors land back on the share after sign-in.
- Single PR, 34 commits, ~5000 LOC (≈70% docs — spec + plan).

Closes #316.

## Three access modes

- **`open`** — serves immediately. `Cache-Control: public, max-age=60, must-revalidate` + strong `ETag` for CF-edge caching + browser 304 round-trips.
- **`password`** — minimal-no-chrome gate page. POST password → PBKDF2-SHA256 verify (matches the local-server hasher from #315) → set HMAC-signed `oyster_view_<token>` cookie (HttpOnly, Secure, SameSite=Lax, Path=`/p/<token>`, 24h Max-Age) → 302 to GET. Per-IP+token rate limit on POST.
- **`signin`** — 302s unsigned visitors to `https://oyster.to/auth/sign-in?return=/p/<token>`. The `?return=` is allowlisted (`^/p/[A-Za-z0-9_-]+$`, excludes `/raw`); auth-worker persists it across magic-link and OAuth round-trips and 302s back on success.

## Per-kind render dispatch

Content-type wins first (image MIME → bytes inline). Then `artifact_kind`:

- `notes` → `markdown-it` with `html: false` (default `validateLink` blocks `javascript:`/`vbscript:`/`file:`/unsafe `data:`); chrome-wrapped; CSP `script-src 'self'; style-src 'self' 'unsafe-inline'`.
- `diagram` → server-rendered HTML loading pinned `mermaid@10.9.1` from jsdelivr with SRI; source-fallback if `mermaid.run()` rejects.
- `app/deck/wireframe/table/map` → chrome page wraps `<iframe sandbox="allow-scripts" src="/p/<token>/raw">` (no `allow-same-origin` → opaque origin → can't read `oyster_session` cookies or call our APIs). The `/raw` endpoint serves bytes with strict CSP (`connect-src 'none'; form-action 'none'; base-uri 'none'; frame-src 'none'`) and `X-Frame-Options: SAMEORIGIN`.
- Image content-type (any kind) → bytes inline, no chrome.

## Chrome-only-on-success

Successful published views get the chrome (logo + mode-aware action slot + "Powered by Oyster" footer). Intermediary states (password gate, 410 Gone, 404 Not Found, errors, rate-limited) get minimal-no-chrome pages. Asymmetry by design — gates have a single task, chrome competes.

## Auth-worker `?return=` plumbing

- Migration `0004_return_path.sql` adds nullable `return_path TEXT` to `magic_link_tokens` and `oauth_states`.
- `validateReturnPath` allowlist anchored to share-viewer paths only; rejects absolute URLs, traversal, query strings, fragments, oversize input, and `/p/<token>/raw`.
- `?d=` (device flow) is mutually exclusive with `?return=` — `?d=` always wins.
- Persisted across: magic-link request → verify; GitHub OAuth start → callback. Re-validated on use (defence in depth).

## Operational

Done before opening the PR (verified live):

- D1 migration `0004_return_path.sql` applied to remote `oyster-auth`.
- `VIEWER_COOKIE_SECRET` set on `oyster-publish` (Worker secret, 32-byte hex).
- Both Workers deployed (auth-worker `39b82beb`, oyster-publish `c40c6e95`).
- Production smoke: all 12 surface cases through three modes, iframe sandbox isolation, /raw CSP, 410-after-unpublish, 404-unknown-token. ✅

A re-deploy is needed after merge to pick up the post-smoke fixes (markdown CSP, strong etag, /raw 404 for non-iframe kinds, image CSP).

## Test plan

- [x] **oyster-publish:** 87 tests — viewer-cookie HMAC (9), per-kind render incl. validateLink safety (23), full handler integration (21), unchanged publish-helpers (10) + publish-handler (18) + unpublish-handler (6). Whole-project typecheck clean.
- [x] **auth-worker:** 28 tests — `validateReturnPath` (11), `oauth-helpers` (9), and 8 new handler-level integration tests covering the 5 `return_path` plumbing sites end-to-end through D1. Whole-project typecheck clean.
- [x] **Production smoke** (already done before this PR opened) — see Operational above.
- [ ] Re-deploy both Workers post-merge to pick up the post-smoke fixes (markdown CSP + strong etag + /raw 404 + image CSP + auth-worker tests' `nodejs_compat` flag).

## Known follow-ups (filed or to-file)

- **#370** — OpenCode adapter rejects `assistant.reasoning_content` (filed). Surfaced during smoke; blocks chat-driven publish flow but curl/MCP works around it.
- **`/auth/github/callback` integration test** — the new auth-worker integration suite covers the OAuth start side; the callback path requires mocking GitHub's token-exchange + user-info HTTP endpoints, deferred. Documented inline in `test/return-path-integration.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)