### PR TITLE
chore: anchor doc refresh + scanner gitignore (#281) + memory-store tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Attach an Unsorted folder to an existing space.** The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a "Best match" hint when the folder name resembles one), or create a new space as before.
 - **Public viewer for shared artefacts.** Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share. ([#316](https://github.com/mattslight/oyster/issues/316))
 
+### Changed
+
+- **Repo scanner respects `.gitignore`.** Folders and files matched by a project's `.gitignore` are now excluded from scan results, alongside the existing built-in skips. Patterns including negations and globs are honored. ([#281](https://github.com/mattslight/oyster/issues/281))
+
 ### Fixed
 
 - **Clicking an artefact in the session inspector** now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -330,6 +330,10 @@
 <li><strong>Attach an Unsorted folder to an existing space.</strong> The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a &quot;Best match&quot; hint when the folder name resembles one), or create a new space as before.</li>
 <li><strong>Public viewer for shared artefacts.</strong> Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share. (<a href="https://github.com/mattslight/oyster/issues/316" rel="noopener noreferrer">#316</a>)</li>
 </ul>
+<h3>Changed</h3>
+<ul>
+<li><strong>Repo scanner respects <code>.gitignore</code>.</strong> Folders and files matched by a project&#39;s <code>.gitignore</code> are now excluded from scan results, alongside the existing built-in skips. Patterns including negations and globs are honored. (<a href="https://github.com/mattslight/oyster/issues/281" rel="noopener noreferrer">#281</a>)</li>
+</ul>
 <h3>Fixed</h3>
 <ul>
 <li><strong>Clicking an artefact in the session inspector</strong> now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.</li>

--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -103,8 +103,8 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 **Net-new infrastructure implied** (and how many requirements each unblocks):
 
 - ~~**Identity + auth layer**~~ — **shipped** (#295 magic-link, #340 OAuth as primary). Unblocks R1 and R5; rest of Pro hangs off this.
-- ~~**Share/publish CDN or proxy**~~ — **shipped** (R2 via `infra/oyster-publish` Cloudflare Worker). R5 backend complete.
-- **Cloud data store (DB + blob)** — unblocks R1, R3, R4, R7. R5 already uses R2 for published-artefact bytes; a hosted DB for memories/sessions is the next piece.
+- ~~**Share/publish CDN or proxy**~~ — **shipped** for R5 (Cloudflare Worker at `infra/oyster-publish` with R2 object storage for artefact bytes). R5 backend complete.
+- **Cloud data store (DB + blob)** — unblocks R1, R3, R4, R7. R5 already uses Cloudflare R2 for published-artefact bytes; a hosted DB for memories/sessions is the next piece.
 - **Sync / push-pull layer** — unblocks R1, R3, R4, R7. Distinct from the storage choice.
 - **Artefact version store** — unblocks R7. Could be an `artifact_versions` SQLite table or `git` per space directory.
 

--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -1,8 +1,8 @@
 # 0.5.0 → Pro: gap matrix
 
-> **Status:** 2026-05-01 snapshot. True as of `0.5.0`; goes stale as work lands.
+> **Status:** living doc. Originally a 2026-05-01 snapshot; per-requirement sections are updated in place as work lands. Most recent edit: 2026-05-04 — auth (#295/#340) closed, R2 verbatim (#311/#328) and R6 traceable recall (#310) shipped in 0.6.0, R5 schema/backend/viewer (#314/#315/#316) shipped, only R5 Publish UI (#317) outstanding for 0.7.0.
 >
-> **Reads alongside** [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md). The requirements doc is canonical and pins observable user outcomes (R1–R7). This doc is a snapshot of where the current implementation stands against those outcomes — what survives, what changes, what's missing entirely. Architecture decisions are made *against* the requirements, evaluated against this matrix.
+> **Reads alongside** [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md). The requirements doc is canonical and pins observable user outcomes (R1–R7). This doc tracks where the current implementation stands against those outcomes — what survives, what changes, what's missing entirely. Architecture decisions are made *against* the requirements, evaluated against this matrix.
 
 ## Framing
 
@@ -16,25 +16,25 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R1. Empty-machine continuity
 
-**Current state:** No identity layer, no cloud restore. `bootstrapUserland()` (`server/src/index.ts:446`) creates the empty `~/Oyster/` tree; the SQLite DB is then created/opened by `initDb(DB_DIR)` (`index.ts:516`) at `~/Oyster/db/oyster.db`. Auto-backup (`server/src/backup.ts`) writes daily snapshots to `~/oyster-backups/auto/` — local-only, rotates at 5 days. The `/api/vault/inventory` endpoint surfaces what's in `~/Oyster/` but no pull path from any remote. Self-hosted-via-git variant: zero code.
+**Current state:** **Identity layer shipped** (#295 magic-link, then #340 OAuth as primary — see `server/src/auth-service.ts`). Cloud restore still missing. `bootstrapUserland()` creates the empty `~/Oyster/` tree; auto-backup (`server/src/backup.ts`) still writes local-only daily snapshots to `~/oyster-backups/auto/` (5-day rotation). No pull path from any remote. Self-hosted-via-git variant: zero code. Tracked for 0.8.0 as #319.
 
-**Survives:** The `~/Oyster/` layout (`db/`, `spaces/`, `apps/`, `config/`) is per-space-addressable and could serve as the restore target. `MemoryProvider.importMemories()` (`server/src/memory-store.ts:244`) already implements idempotent bulk-insert. `initDb()` migrations are additive and idempotent.
+**Survives:** The `~/Oyster/` layout (`db/`, `spaces/`, `apps/`, `config/`) is per-space-addressable and could serve as the restore target. `MemoryProvider.importMemories()` already implements idempotent bulk-insert. `initDb()` migrations are additive and idempotent. With auth landed, account-scoped tenant model is in place.
 
 **Changes:** `backup.ts` is local filesystem `cpSync` only — needs an upload hook or push/pull transport. The DB is one SQLite file (easy to snapshot) but needs a defined serialisation contract before it's portable.
 
-**Missing entirely:** Identity/auth (no user concept anywhere). Cloud storage. Restore flow (sign-in → pull → populate). Git-remote variant has zero implementation.
+**Missing entirely:** Cloud storage. Restore flow (sign-in → pull → populate). Git-remote variant has zero implementation.
 
 ---
 
 ### R2. Conversational recall
 
-**Current state:** Two surfaces. `SqliteFtsMemoryProvider` (`server/src/memory-store.ts`) does FTS5 keyword recall over `memories`; its `recall()` implementation (`memory-store.ts:183`) tokenises the query into OR-joined FTS5 terms. The `recall` MCP tool (`server/src/mcp-server.ts:285`) forwards to that provider path — same-device only, keyword-not-semantic. Session inspector (`web/src/components/SessionInspector.tsx`) browses transcript events from `session_events` but has no query interface — display only.
+**Current state:** Same-device verbatim recall **delivered in 0.6.0** (#311/#328) — FTS5 over `session_events.text` plus `recall_transcripts` MCP tool and cross-session spotlight (#331). `SqliteFtsMemoryProvider` (`server/src/memory-store.ts`) still does keyword FTS over `memories`; semantic/embedding layer not yet built. Cross-device recall pending sync infra (#321 in 0.8.0).
 
-**Survives:** The `MemoryProvider` interface (`memory-store.ts:31`) is already abstract — swap implementation without touching MCP registration. The four MCP tools (`remember` / `recall` / `forget` / `list_memories`) are the right agent-facing contract.
+**Survives:** The `MemoryProvider` interface is already abstract — swap implementation without touching MCP registration. The MCP tools (`remember` / `recall` / `forget` / `list_memories` / `recall_transcripts`) are the right agent-facing contract.
 
-**Changes:** `recall()` (`memory-store.ts:183`) does `"how OR old OR am OR I"` — brittle for natural language, no semantic match. Needs BM25 tuning at minimum, embedding-backed search ideally. For verbatim recall: `session_events.raw` already stores full event JSON (`server/src/db.ts:170`), but no query interface over it — the inspector displays known sessions but can't search across them.
+**Changes:** `recall()` over memories still does OR-joined FTS terms — brittle for natural language, no semantic match. Needs BM25 tuning at minimum, embedding-backed search ideally. The verbatim path over `session_events.text` is in place for same-device queries.
 
-**Missing entirely:** Embedding/semantic layer. FTS over `session_events.text` (current FTS index is on `memories`, not events). Cross-device recall. "Pick up here" agent priming.
+**Missing entirely:** Embedding/semantic layer. Cross-device recall (vectors live in cloud). "Pick up here" agent priming (#322).
 
 ---
 
@@ -52,7 +52,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R4. Memory that crosses agents
 
-**Current state:** Memory is MCP-accessible and agent-agnostic *by design* — any client connecting to `/mcp/` (`server/src/index.ts:1842`) gets the same four tools. Mechanically already works on a single machine: Claude Code, Cursor, Codex all share the same `memory.db`. `clientContext` on `McpDeps` (`mcp-server.ts:138`) distinguishes internal from external for telemetry only — same provider instance.
+**Current state:** Memory is MCP-accessible and agent-agnostic *by design* — any client connecting to `/mcp/` (now routed via `server/src/routes/oauth-mcp.ts`) gets the same four tools. Mechanically already works on a single machine: Claude Code, Cursor, Codex all share the same `memory.db`. `clientContext` on `McpDeps` (`mcp-server.ts`) distinguishes internal from external for telemetry only — same provider instance.
 
 **Survives:** The architecture (one MCP, one memory store, multiple agents) carries forward. `memories.space_id` already handles global vs space-scoped recall. MCP tool surface is stable.
 
@@ -64,25 +64,25 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R5. Publish & share artefacts
 
-**Current state:** No publish or share mechanism. Artefacts served at `/docs/:id` and `/artifacts/...` with no access control — entire API locked to localhost via `rejectIfNonLocalOrigin()` (`server/src/index.ts:688`). No public URL, no share token, no remote viewer. `artifacts` schema has no `published_at` / `share_token` / `share_mode`. `owner_id` exists on the schema (`server/src/db.ts:7`); current insert paths still write `owner_id: null` (`server/src/artifact-service.ts:266`, `server/src/space-service.ts:487`).
+**Current state:** **Backend, schema, and viewer delivered** (#314/#315/#316). `share_token` / `share_mode` / `share_password_hash` / `published_at` / `share_updated_at` / `unpublished_at` columns on `artifacts`. `publish-service.ts` is the single source of truth, called by both `routes/publish.ts` (HTTP) and `mcp-server.ts` (`publish_artifact` / `unpublish_artifact` MCP tools). Cloud storage = R2 via `infra/oyster-publish` Worker; public viewer at `oyster.to/p/<token>` with three access modes (open / password / sign-in). `owner_id` populated on first publish. **UI affordance still missing** (#317 in flight) — today users publish via MCP tool only.
 
-**Survives:** `artifact_kind` taxonomy and the filesystem-backed serving at `/docs/:id` could double as the canonical "view" route — the published URL becomes a cloud proxy to the same content. `source_origin` provenance would surface in a published view.
+**Survives:** Everything that landed survives. R5 cycles back into the matrix only when version-history (R7) introduces published-version pinning.
 
-**Changes:** Nothing. R5 is greenfield. The `owner_id` stub is the only forward-pointing artefact.
+**Changes:** None remaining for the backend. UI work is the last 0.7.0 gap.
 
-**Missing entirely:** Publish action (UI + MCP tool + API). Share URL routing. Three access modes. Remote viewer. Identity. `share_token` / `share_mode` / `published_at` columns.
+**Missing entirely:** UI action surface (modal, mode picker, copy-to-clipboard, tile chip). Tracked as #317.
 
 ---
 
 ### R6. Traceable recall
 
-**Current state:** **The data model for provenance is substantially in place.** `session_artifacts` (`db.ts:175`) is an M:N join with `role` (create / modify / read) + `when_at`. `artifacts.source_origin` (`manual` / `discovered` / `ai_generated`) tracks origin. Memory rows carry `space_id` / `created_at` / `tags` (`memory-store.ts:10–17`). `/api/artifacts/:id/sessions` and `/api/sessions/:id/artifacts` (`index.ts:1100`, `1076`) form a bidirectional graph. The session inspector renders the "Artefacts" tab.
+**Current state:** **Delivered in 0.6.0** (#310 pt1 schema + MCP plumbing, #310 pt2 inspector Memory tab + recall click-through). `memories.source_session_id` populated by the watcher and surfaced in `recall` result rows. Inspector renders "Pulled into / Written by this session" and the Home memories list clicks through to the originating session. `session_artifacts` M:N graph carries forward unchanged.
 
-**Survives:** `session_artifacts` with `role` + `when_at` is the right primitive. Bidirectional API routes carry forward. `memories.space_id` is the right scope shape. Inspector as UI entry point.
+**Survives:** All of the above. R6 is a closed loop end-to-end on a single device.
 
-**Changes:** `recall()` returns `{id, content, space_id, tags, created_at}` — no `source_session_id` or `linked_artifact_ids`. Today there's no way to trace "this memory came from that conversation." The watcher (`server/src/watchers/claude-code.ts`) doesn't write memories — `remember` is agent-called, so the originating session isn't recorded at write time.
+**Changes:** None outstanding.
 
-**Missing entirely:** `source_session_id` field on memory rows. Click-through provenance from recall result → originating conversation. UI affordance for "memories written during this session."
+**Missing entirely:** Cross-device provenance — depends on R4 cloud memory store (#318, 0.8.0), so that the source-session pointer remains valid after a memory syncs to another device.
 
 ---
 
@@ -102,28 +102,29 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 **Net-new infrastructure implied** (and how many requirements each unblocks):
 
-- **Identity + auth layer** — zero today. Unblocks R1, R5, and is the precondition for any data being attributed to a user. Every Pro requirement depends on it.
-- **Cloud data store (DB + blob)** — unblocks R1, R3, R4, R7. One hosted DB + blob store, OR user-controlled git remote (R1's variant).
+- ~~**Identity + auth layer**~~ — **shipped** (#295 magic-link, #340 OAuth as primary). Unblocks R1 and R5; rest of Pro hangs off this.
+- ~~**Share/publish CDN or proxy**~~ — **shipped** (R2 via `infra/oyster-publish` Cloudflare Worker). R5 backend complete.
+- **Cloud data store (DB + blob)** — unblocks R1, R3, R4, R7. R5 already uses R2 for published-artefact bytes; a hosted DB for memories/sessions is the next piece.
 - **Sync / push-pull layer** — unblocks R1, R3, R4, R7. Distinct from the storage choice.
 - **Artefact version store** — unblocks R7. Could be an `artifact_versions` SQLite table or `git` per space directory.
-- **Share/publish CDN or proxy** — unblocks R5 entirely. The only piece with no local-only stepping stone.
 
-**Hard-coded localhost / single-device assumptions:**
+**Hard-coded localhost / single-device assumptions** (still true post-refactor):
 
-- `httpServer.listen(port, "127.0.0.1")` (`index.ts:2013`) plus per-route `rejectIfNonLocalOrigin()`. Multi-device callers can't reach the local API; a separate channel is needed.
-- `SqliteFtsMemoryProvider` initialised with `DB_DIR = ~/Oyster/db/` (`index.ts:538`) — no env var or config point for remote backing.
-- `ClaudeCodeWatcher` watches `~/.claude/projects/` (`watchers/claude-code.ts:26`) — inherently per-device. Cross-device session recall requires `session_events` rows to be synced, not just that the watcher runs everywhere.
+- `httpServer.listen(port, "127.0.0.1")` (`server/src/index.ts:640`) plus per-route `rejectIfNonLocalOrigin()` (now in `server/src/http-utils.ts`, called from each `routes/*.ts`). Multi-device callers can't reach the local API; a separate channel is needed.
+- `SqliteFtsMemoryProvider` initialised against `~/Oyster/db/` — no env var or config point for remote backing.
+- `ClaudeCodeWatcher` watches `~/.claude/projects/` (`server/src/watchers/claude-code.ts`) — inherently per-device. Cross-device session recall requires `session_events` rows to be synced, not just that the watcher runs everywhere.
 - `backup.ts` copies to `~/oyster-backups/` — entirely local, no upload hook.
-- Artefact bytes served via `readFileSync` from `~/Oyster/spaces/` (`index.ts:1502–1514`).
+- Artefact bytes served via `readFileSync` from `~/Oyster/spaces/` (now via `server/src/routes/static.ts`).
 
 **Code already pointing in the right direction:**
 
-- `artifacts.owner_id` (schema at `db.ts:7`; insert sites pass `null` at `artifact-service.ts:266` and `space-service.ts:487`) — always NULL today, but the column slot exists.
-- `artifacts.source_origin` — provenance tracked at write time throughout MCP. R6's foundation is already there.
+- `artifacts.owner_id` — populated on first publish via `publish-service.ts`; still NULL for never-published artefacts. The column slot already carries identity through R5.
+- `artifacts.source_origin` — provenance tracked at write time throughout MCP. R6 built on this.
 - `session_artifacts` M:N with `role` + `when_at`, populated by the watcher, plus the bidirectional API routes — the artefact provenance graph already works.
+- `memories.source_session_id` — added in #310, populated by the watcher; powers R6 click-through. Same pattern extends to cross-device once R4 lands.
 - `MemoryProvider` interface with `exportMemories()` / `importMemories()` — explicit escape hatches for backup/restore. A cloud-backed provider can implement the same interface.
 - MCP being agent-agnostic — R4 is a structural property, not a feature to build (single-device case already works).
-- `sources.type` CHECK constraint reads `'local_folder'` with a comment noting "and future cloud sources" (`db.ts:76`) — the CHECK is the only thing that needs relaxing.
+- `sources.type` CHECK constraint reads `'local_folder'` with a comment noting "and future cloud sources" — the CHECK is the only thing that needs relaxing.
 
 ---
 

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -12,18 +12,18 @@ The free account tier is the **identity and publishing substrate**. Pro is the *
 
 Each milestone from here delivers one or more requirements. Polish, refactors, and clever local features may still happen — they ride on top of the spine, not in front of it.
 
-## 0.6.0 — Trustworthy recall
+## 0.6.0 — Trustworthy recall ✅ shipped
 
-**Delivers:** R6 (traceable recall) + R2 same-device verbatim.
+**Delivered:** R6 (traceable recall) + R2 same-device verbatim.
 
-**Purpose:** make recall trustworthy *before* the heavier sync work scales it. Two tickets, ships fast.
+**Purpose:** make recall trustworthy *before* the heavier sync work scales it. Two tickets, shipped fast.
 
-**Ships:**
+**Shipped:**
 
-- **R6 traceable recall** (#310) — `memories.source_session_id` schema + watcher plumbing + `recall()` returns the originating session + inspector Memory tab renders "Pulled into / Written by this session" + Home memories list clicks through to the source session. Closes the loop: every recalled memory is traceable to the conversation that produced it.
-- **R2 verbatim recall, same-device** (#311) — FTS5 over `session_events.text` so the *"what FTS5 schema did we settle on?"* / *"what were the exact specs we agreed for the render server?"* case resolves locally. The cross-device extension lands in 0.8.0.
+- ✅ **R6 traceable recall** (#310) — `memories.source_session_id` schema + watcher plumbing + `recall()` returns the originating session + inspector Memory tab renders "Pulled into / Written by this session" + Home memories list clicks through to the source session. Closes the loop: every recalled memory is traceable to the conversation that produced it.
+- ✅ **R2 verbatim recall, same-device** (#311 / #328) — FTS5 over `session_events.text` plus `recall_transcripts` MCP tool. Cross-session spotlight (#331) added the in-transcript find experience. The cross-device extension lands in 0.8.0.
 
-**Won't ship:** anything else. No bundles, no empty-state coach-mark, no waitlist pill, no broad error-handling sweep, no schema speculation for sync. Those were on prior drafts of this milestone — all deferred to where they actually deliver value.
+**Didn't ship:** anything else. Deferred items remain deferred.
 
 ## 0.7.0 — Free account + Publish/Share
 
@@ -31,14 +31,16 @@ Each milestone from here delivers one or more requirements. Polish, refactors, a
 
 **Purpose:** first visible Cloud wedge. Convert the waitlist into a free-account funnel. The pricing page promise of *"Sync · Memory · Publish"* starts being true with **Publish**.
 
+**Status:** auth + R5 backend + viewer all shipped. Only the Publish UI affordance (#317) remains.
+
 **Ships:**
 
-- **Magic-link auth** (#295) — sign-up + sign-in. Account state surfaced in-app. Pattern from `~/Dev/oyster-crm`.
-- **R5 schema** (#314) — `share_token`, `share_mode`, `share_password_hash`, `published_at`, `unpublished_at` columns on artefacts.
-- **R5 backend** (#315) — `publish_artifact` MCP tool, `POST /api/artifacts/:id/publish`, cloud upload to R2 object store.
-- **R5 viewer** (#316) — public route at `/s/<share_token>` with three access modes (open, password, sign-in-required).
-- **R5 UI** (#317) — Publish action in the artefact UI (modal, mode picker, URL display, copy-to-clipboard).
-- **Entitlement / caps model** — free tier caps (artefact count, bandwidth); Pro tier unlocks higher caps. The substrate that all later Pro features ride on. Folds into the work above; not a separate ticket unless it grows.
+- ✅ **Auth** — magic-link (#295) shipped first; **OAuth Google + GitHub (#340) replaced it as the primary path**, magic-link demoted to fallback. Account state surfaced in-app. Pattern adapted from `~/Dev/oyster-crm`.
+- ✅ **R5 schema** (#314) — `share_token`, `share_mode`, `share_password_hash`, `published_at`, `share_updated_at`, `unpublished_at` columns on artefacts.
+- ✅ **R5 backend** (#315) — `publish_artifact` / `unpublish_artifact` MCP tools, `POST /api/artifacts/:id/publish` + unpublish, cloud upload to R2 via `infra/oyster-publish` Worker. Single source of truth in `server/src/publish-service.ts`.
+- ✅ **R5 viewer** (#316) — public viewer at `oyster.to/p/<token>` with three access modes (open, password, sign-in-required). Implemented as a Cloudflare Worker route with markdown rendering.
+- ⏳ **R5 UI** (#317) — Publish action in the artefact UI (modal, mode picker, URL display, copy-to-clipboard). **In flight.**
+- **Entitlement / caps model** — free-tier caps for published-artefact size enforced in the Worker (10 MB ceiling); Pro tier unlocks higher. Folded into the work above.
 
 **Won't ship:** sync, durability, cloud memory store, semantic recall, cross-device anything, artefact-byte sync, version history. Those are 0.8.0+. Multi-file bundles also out of scope — single-file artefacts are sufficient for R5; richer Publish lives in 0.9.0+ if it earns its keep.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
         "chokidar": "^4.0.3",
+        "ignore": "^7.0.5",
         "marked": "^18.0.3",
         "opencode-ai": "^1.14.31",
         "ws": "^8.20.0"
@@ -1102,6 +1103,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
     "chokidar": "^4.0.3",
+    "ignore": "^7.0.5",
     "marked": "^18.0.3",
     "opencode-ai": "^1.14.31",
     "ws": "^8.20.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.9.0",
         "chokidar": "^4.0.3",
+        "ignore": "^7.0.5",
         "marked": "^18.0.3",
         "opencode-ai": "^1.14.31",
         "ws": "^8.20.0"
@@ -2089,6 +2090,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.9.0",
     "chokidar": "^4.0.3",
+    "ignore": "^7.0.5",
     "marked": "^18.0.3",
     "opencode-ai": "^1.14.31",
     "ws": "^8.20.0"

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -2,12 +2,31 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, relative, sep } from "node:path";
 import { homedir } from "node:os";
 import crypto from "node:crypto";
+import ignore, { type Ignore } from "ignore";
 import type { SpaceStore, SpaceRow, Source } from "./space-store.js";
 import type { ArtifactStore } from "./artifact-store.js";
 import type { ArtifactService } from "./artifact-service.js";
 import type { SessionStore } from "./session-store.js";
 import type { Space, ScanResult } from "../../shared/types.js";
 import { slugify, toScanStatus } from "./utils.js";
+
+// Build a gitignore matcher from .gitignore at the scan root, if one exists.
+// Returns null when there's nothing to honor — callers can skip the per-entry
+// check entirely. Only the root .gitignore is read; nested .gitignore files
+// are not layered (the 80% case for repo scanning, parity with
+// `git check-ignore` for top-level patterns). Errors reading the file are
+// swallowed — a malformed gitignore should not break the scan.
+export function loadGitignore(rootDir: string): Ignore | null {
+  const gitignorePath = join(rootDir, ".gitignore");
+  if (!existsSync(gitignorePath)) return null;
+  try {
+    const contents = readFileSync(gitignorePath, "utf8");
+    if (!contents.trim()) return null;
+    return ignore().add(contents);
+  } catch {
+    return null;
+  }
+}
 
 // Last non-empty path component, normalised. Same logic used at scan time and
 // (if ever needed again) for slug-based migration backfill — single source of
@@ -324,7 +343,8 @@ export class SpaceService {
           continue;
         }
         const slug = folderSlug(folderPath);
-        const candidates = this.walk(folderPath);
+        const gitignore = loadGitignore(folderPath);
+        const candidates = this.walk(folderPath, 0, folderPath, gitignore);
         for (const c of candidates) {
           // Namespace sourceRef with the folder's basename — reduces (but does
           // not eliminate) collisions when a space has multiple paths. Two
@@ -353,7 +373,7 @@ export class SpaceService {
   }
 
   private walk(
-    dir: string, depth = 0, root = dir,
+    dir: string, depth = 0, root = dir, gitignore: Ignore | null = null,
   ): Array<{ absPath: string; sourceRef: string; kind: "app" | "notes" | "diagram" }> {
     if (depth > MAX_DEPTH) return [];
     const results: ReturnType<typeof this.walk> = [];
@@ -398,11 +418,22 @@ export class SpaceService {
       let stat: ReturnType<typeof statSync>;
       try { stat = statSync(absPath); } catch { continue; }
 
+      // Path used for gitignore matching — must be relative to the root
+      // (which is the gitignore's directory) and use posix separators. The
+      // `ignore` package requires a trailing "/" for directories so the
+      // pattern e.g. `dist/` matches a directory named `dist`.
+      const relForIgnore = posixRelDir
+        ? `${posixRelDir}/${entry}${stat.isDirectory() ? "/" : ""}`
+        : `${entry}${stat.isDirectory() ? "/" : ""}`;
+
       if (stat.isDirectory()) {
-        if (!SKIP_DIRS.has(entry) && !entry.startsWith(".")) results.push(...this.walk(absPath, depth + 1, root));
+        if (SKIP_DIRS.has(entry) || entry.startsWith(".")) continue;
+        if (gitignore?.ignores(relForIgnore)) continue;
+        results.push(...this.walk(absPath, depth + 1, root, gitignore));
         continue;
       }
       if (SKIP_FILE_PATTERNS.some((p) => p.test(entry))) continue;
+      if (gitignore?.ignores(relForIgnore)) continue;
 
       const posixRelFile = (posixRelDir ? posixRelDir + "/" : "") + entry;
 

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SqliteFtsMemoryProvider } from "../src/memory-store.js";
+
+// SqliteFtsMemoryProvider does its own schema/migrations on init().
+// We just hand it a fresh tmp dir per test.
+async function makeProvider() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-memory-test-"));
+  const provider = new SqliteFtsMemoryProvider(dir);
+  await provider.init();
+  return { provider, dir };
+}
+
+describe("SqliteFtsMemoryProvider", () => {
+  let provider: SqliteFtsMemoryProvider;
+  let dir: string;
+
+  beforeEach(async () => {
+    ({ provider, dir } = await makeProvider());
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("remember", () => {
+    it("returns the existing row when same content + same space is remembered twice", async () => {
+      const a = await provider.remember({ content: "matt likes coffee", space_id: "home" });
+      const b = await provider.remember({ content: "matt likes coffee", space_id: "home" });
+      expect(b.id).toBe(a.id);
+    });
+
+    it("returns the existing row when content matches and both are global (NULL space)", async () => {
+      const a = await provider.remember({ content: "global fact" });
+      const b = await provider.remember({ content: "global fact" });
+      expect(b.id).toBe(a.id);
+    });
+
+    it("creates a new row when same content lands in different spaces", async () => {
+      const a = await provider.remember({ content: "duplicate", space_id: "home" });
+      const b = await provider.remember({ content: "duplicate", space_id: "work" });
+      expect(b.id).not.toBe(a.id);
+    });
+
+    it("persists tags as an array", async () => {
+      const m = await provider.remember({ content: "tagged", tags: ["preference", "work"] });
+      expect(m.tags).toEqual(["preference", "work"]);
+    });
+
+    it("persists source_session_id when provided", async () => {
+      const m = await provider.remember({ content: "from-session", source_session_id: "sess_abc" });
+      const written = await provider.getBySourceSession("sess_abc");
+      expect(written).toHaveLength(1);
+      expect(written[0].id).toBe(m.id);
+    });
+  });
+
+  describe("recall query parsing", () => {
+    beforeEach(async () => {
+      await provider.remember({ content: "matt likes coffee in the morning" });
+      await provider.remember({ content: "the cat sat on the mat" });
+      await provider.remember({ content: "secrets and passwords" });
+    });
+
+    it("returns nothing for an empty query", async () => {
+      expect(await provider.recall({ query: "" })).toEqual([]);
+    });
+
+    it("returns nothing for a whitespace-only query", async () => {
+      expect(await provider.recall({ query: "   " })).toEqual([]);
+    });
+
+    it("returns nothing for a single-character query (filtered as too short)", async () => {
+      // tokens of length 1 are filtered in tokenisation
+      expect(await provider.recall({ query: "a" })).toEqual([]);
+    });
+
+    it("matches a single multi-character token", async () => {
+      const hits = await provider.recall({ query: "coffee" });
+      expect(hits.map((h) => h.content)).toContain("matt likes coffee in the morning");
+    });
+
+    it("OR-joins multi-word queries — any matching token is enough", async () => {
+      const hits = await provider.recall({ query: "coffee passwords" });
+      const contents = hits.map((h) => h.content);
+      expect(contents).toContain("matt likes coffee in the morning");
+      expect(contents).toContain("secrets and passwords");
+    });
+
+    it("strips punctuation when tokenising", async () => {
+      const hits = await provider.recall({ query: "coffee?!" });
+      expect(hits.map((h) => h.content)).toContain("matt likes coffee in the morning");
+    });
+
+    it("respects the limit parameter", async () => {
+      const hits = await provider.recall({ query: "the", limit: 1 });
+      expect(hits.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("recall scoping and soft-delete", () => {
+    it("surfaces global memories in any space-scoped query", async () => {
+      await provider.remember({ content: "global rule" });
+      const hits = await provider.recall({ query: "global", space_id: "home" });
+      expect(hits.map((h) => h.content)).toContain("global rule");
+    });
+
+    it("excludes other-space memories from a space-scoped query", async () => {
+      await provider.remember({ content: "work-only secret", space_id: "work" });
+      const hits = await provider.recall({ query: "secret", space_id: "home" });
+      expect(hits.map((h) => h.content)).not.toContain("work-only secret");
+    });
+
+    it("forgotten memories do not surface in subsequent recall", async () => {
+      const m = await provider.remember({ content: "forget me" });
+      await provider.forget(m.id);
+      const hits = await provider.recall({ query: "forget" });
+      expect(hits.map((h) => h.id)).not.toContain(m.id);
+    });
+  });
+
+  describe("forget", () => {
+    it("is a no-op for an unknown id (does not throw)", async () => {
+      await expect(provider.forget("does-not-exist")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("R6 recall provenance", () => {
+    it("getRecalledBySession returns each memory once even after multiple recalls", async () => {
+      const m = await provider.remember({ content: "recall me twice" });
+      await provider.recall({ query: "recall", recalling_session_id: "sess_x" });
+      await provider.recall({ query: "recall", recalling_session_id: "sess_x" });
+      const recalled = await provider.getRecalledBySession("sess_x");
+      const ids = recalled.map((r) => r.id);
+      expect(ids.filter((id) => id === m.id)).toHaveLength(1);
+    });
+
+    it("getRecalledBySession does not record recalls without a session id", async () => {
+      await provider.remember({ content: "anonymous recall" });
+      await provider.recall({ query: "anonymous" });
+      const recalled = await provider.getRecalledBySession("sess_y");
+      expect(recalled).toHaveLength(0);
+    });
+  });
+});

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -22,7 +22,10 @@ describe("SqliteFtsMemoryProvider", () => {
   });
 
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+    // Close the SQLite handle first so the WAL/shm files can be removed —
+    // matters on Windows where unlink fails while the connection is open.
+    provider?.close();
+    if (dir) rmSync(dir, { recursive: true, force: true });
   });
 
   describe("remember", () => {

--- a/server/test/scanner-gitignore.test.ts
+++ b/server/test/scanner-gitignore.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadGitignore } from "../src/space-service.js";
+
+describe("loadGitignore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-gitignore-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null when no .gitignore exists", () => {
+    expect(loadGitignore(dir)).toBeNull();
+  });
+
+  it("returns null for an empty .gitignore", () => {
+    writeFileSync(join(dir, ".gitignore"), "");
+    expect(loadGitignore(dir)).toBeNull();
+  });
+
+  it("matches simple patterns", () => {
+    writeFileSync(join(dir, ".gitignore"), "secrets.txt\nbuild/\n");
+    const ig = loadGitignore(dir)!;
+    expect(ig.ignores("secrets.txt")).toBe(true);
+    expect(ig.ignores("build/")).toBe(true);
+    expect(ig.ignores("README.md")).toBe(false);
+  });
+
+  it("matches glob patterns including nested paths", () => {
+    writeFileSync(join(dir, ".gitignore"), "*.log\nnode_modules/\n");
+    const ig = loadGitignore(dir)!;
+    expect(ig.ignores("foo.log")).toBe(true);
+    expect(ig.ignores("nested/dir/foo.log")).toBe(true);
+    expect(ig.ignores("node_modules/")).toBe(true);
+    expect(ig.ignores("src/index.ts")).toBe(false);
+  });
+
+  it("honors negation patterns", () => {
+    writeFileSync(join(dir, ".gitignore"), "*.md\n!README.md\n");
+    const ig = loadGitignore(dir)!;
+    expect(ig.ignores("notes.md")).toBe(true);
+    expect(ig.ignores("README.md")).toBe(false);
+  });
+
+  it("ignores comments and blank lines", () => {
+    writeFileSync(join(dir, ".gitignore"), "# top comment\n\n*.tmp\n   \n# trailing\n");
+    const ig = loadGitignore(dir)!;
+    expect(ig.ignores("foo.tmp")).toBe(true);
+    expect(ig.ignores("foo.txt")).toBe(false);
+  });
+
+  it("returns null on unreadable .gitignore (swallows errors)", () => {
+    // .gitignore is a directory rather than a file → readFileSync throws.
+    // The helper should swallow and return null rather than blow up the scan.
+    mkdirSync(join(dir, ".gitignore"));
+    expect(loadGitignore(dir)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Three independent hygiene/value items that don't conflict with the in-flight #317 Publish UI agent:

- **Doc refresh.** `docs/plans/0.5.0-gap-matrix.md` and `docs/plans/roadmap.md` were a 2026-05-01 snapshot — auth (#295/#340), R5 schema/backend/viewer (#314/#315/#316), and 0.6.0 (#310/#311/#328) have all shipped since. Updated each per-R section in place to reflect what's delivered, what's outstanding, and where the work routes post the recent route-extraction refactor.
- **#281 scanner honors `.gitignore`.** Adds the `ignore` package and reads the root `.gitignore` (if present) before walking. Negations and globs are honored; nested gitignores are not layered (80% case for repo scanning). Errors reading the file are swallowed so a malformed gitignore can't break a scan.
- **Memory-store tests.** 18 new vitest cases covering `remember` dedupe, `recall` query tokenisation (the gap matrix itself flagged the OR-join as brittle), space scoping, soft-delete, and R6 `getRecalledBySession` provenance plumbing.

## Note on #189

Audited as part of this work — concluded #189 (`detach_path_from_space` MCP tool) is functionally solved by the `detach_source` MCP tool that already exists at `mcp-server.ts:466`, plus `onboard_space`'s idempotent extend-existing behavior. Not changing code here; raising for closure separately.

## Test plan

- [x] `cd server && npm test` — 38 tests pass (was 13 before this branch)
- [x] `cd server && npx tsc --noEmit` — clean
- [ ] Manual scan of a repo with `.gitignore` excluding `node_modules/`, `dist/`, `*.log` — verify no scan tiles for those paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)