### PR TITLE
feat(onboarding): turn the dock into a 1-required + 3-optional checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **Set up Oyster is a checklist now.** One required item — set up your spaces — and three optional ones (publish your first artefact, connect another agent, import memories). The dock pill stops nagging once the required step is done; the optional items wait quietly in the popover for when you want them.
 - **Repo scanner respects `.gitignore`.** Folders and files matched by a project's `.gitignore` are now excluded from scan results, alongside the existing built-in skips. Patterns including negations and globs are honored. ([#281](https://github.com/mattslight/oyster/issues/281))
 
 ### Fixed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -332,6 +332,7 @@
 </ul>
 <h3>Changed</h3>
 <ul>
+<li><strong>Set up Oyster is a checklist now.</strong> One required item — set up your spaces — and three optional ones (publish your first artefact, connect another agent, import memories). The dock pill stops nagging once the required step is done; the optional items wait quietly in the popover for when you want them.</li>
 <li><strong>Repo scanner respects <code>.gitignore</code>.</strong> Folders and files matched by a project&#39;s <code>.gitignore</code> are now excluded from scan results, alongside the existing built-in skips. Patterns including negations and globs are honored. (<a href="https://github.com/mattslight/oyster/issues/281" rel="noopener noreferrer">#281</a>)</li>
 </ul>
 <h3>Fixed</h3>

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -342,6 +342,23 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
     }
   }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError]);
 
+  // Cross-component prompt trigger. Other surfaces (currently the onboarding
+  // dock's "Set up Oyster" button) dispatch `oyster:send-prompt` with a text
+  // payload to fire the same handleSend path as the hero CTA. Detail.text
+  // must be a non-empty string; we don't auto-focus the input or change the
+  // chat-expand state — handleSend manages all of that.
+  useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<{ text?: string }>).detail;
+      const text = detail?.text;
+      if (typeof text === "string" && text.length > 0) {
+        handleSend(text);
+      }
+    }
+    window.addEventListener("oyster:send-prompt", handler);
+    return () => window.removeEventListener("oyster:send-prompt", handler);
+  }, [handleSend]);
+
   function handleCopyChat() {
     const text = messages
       .filter((m) => m.content)

--- a/web/src/components/OnboardingDock.css
+++ b/web/src/components/OnboardingDock.css
@@ -31,33 +31,38 @@
   background: rgba(124, 107, 255, 0.3);
 }
 
-.onboarding-dock--done {
+/* Required step done — pill collapses to a glyph-only green check.
+   Optional items remain ticking off in the popover but the pill stops
+   drawing attention. */
+.onboarding-dock--ready {
   background: rgba(74, 222, 128, 0.12);
   border-color: rgba(74, 222, 128, 0.25);
-  /* Glyph-only pill — tighter squared-off padding since there's no label */
   padding: 5px 9px;
   gap: 0;
 }
 
-.onboarding-dock--done:hover {
+.onboarding-dock--ready:hover {
   background: rgba(74, 222, 128, 0.2);
 }
 
-.onboarding-dock--done .onboarding-dock-check {
+.onboarding-dock--ready .onboarding-dock-check {
   font-size: 11px;
 }
 
-.onboarding-dock-pulse {
+/* Pre-required-done indicator: amber dot that softly glows + winks (slower
+   and quieter than a scale-bounce) so "something still pending" carries
+   without competing with anything else in the chrome. */
+.onboarding-dock-progress {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #a597ff;
-  animation: onboarding-pulse 1.8s ease-in-out infinite;
+  background: #fbbf24;
+  animation: onboarding-glow 2.4s ease-in-out infinite;
 }
 
-@keyframes onboarding-pulse {
-  0%, 100% { transform: scale(1); opacity: 1; }
-  50%      { transform: scale(1.4); opacity: 0.4; }
+@keyframes onboarding-glow {
+  0%, 100% { opacity: 0.35; box-shadow: 0 0 3px rgba(251, 191, 36, 0.25); }
+  50%      { opacity: 1;    box-shadow: 0 0 9px rgba(251, 191, 36, 0.85); }
 }
 
 .onboarding-dock-check {
@@ -81,7 +86,7 @@
   background: rgba(20, 21, 40, 0.98);
   border: 1px solid rgba(124, 107, 255, 0.2);
   border-radius: 14px;
-  padding: 18px;
+  padding: 14px 16px 16px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
@@ -107,22 +112,138 @@
   transform: rotate(45deg);
 }
 
-.onboarding-progress {
+/* ------------------------------------------------------------------ */
+/* Checklist                                                           */
+/* ------------------------------------------------------------------ */
+
+.onboarding-checklist {
   display: flex;
-  gap: 4px;
-  margin-bottom: 16px;
+  flex-direction: column;
 }
 
-.progress-dot {
-  flex: 1;
-  height: 3px;
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.08);
-  transition: background 0.2s;
+.onboarding-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+.onboarding-item:first-child { padding-top: 6px; }
+.onboarding-item:last-child  { border-bottom: none; padding-bottom: 6px; }
+
+.onboarding-item-icon {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  margin-top: 1px;
+  font-weight: 700;
 }
 
-.progress-dot.active { background: #7c6bff; }
-.progress-dot.done   { background: #4ade80; }
+.onboarding-item-icon--required {
+  border: 1.5px solid rgba(251, 191, 36, 0.7);
+  background: rgba(251, 191, 36, 0.08);
+  box-shadow: 0 0 6px rgba(251, 191, 36, 0.3);
+}
+.onboarding-item-icon--optional {
+  border: 1.5px solid rgba(255, 255, 255, 0.18);
+}
+.onboarding-item-icon--done {
+  background: rgba(74, 222, 128, 0.18);
+  border: 1.5px solid rgba(74, 222, 128, 0.45);
+  color: #4ade80;
+}
+
+.onboarding-item-body { flex: 1; min-width: 0; }
+
+.onboarding-item-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  line-height: 1.3;
+}
+
+.onboarding-item--done .onboarding-item-title {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.onboarding-item-tag {
+  display: inline-block;
+  font-size: 9.5px;
+  margin-left: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  vertical-align: 1px;
+  font-weight: 500;
+}
+.onboarding-item-tag--required { color: #fbbf24; }
+.onboarding-item-tag--optional { color: #a597ff; }
+.onboarding-item-tag--done     { color: rgba(74, 222, 128, 0.7); }
+
+.onboarding-item-desc {
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.55);
+  margin-top: 4px;
+  line-height: 1.45;
+}
+
+.onboarding-item-action {
+  margin-top: 9px;
+  padding: 5px 11px;
+  background: rgba(124, 107, 255, 0.22);
+  border: 1px solid rgba(124, 107, 255, 0.45);
+  border-radius: 7px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.12s, border-color 0.12s;
+}
+.onboarding-item-action:hover {
+  background: rgba(124, 107, 255, 0.35);
+  border-color: rgba(124, 107, 255, 0.65);
+}
+
+.onboarding-summary {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 12.5px;
+  padding: 14px 0 4px;
+}
+
+.onboarding-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #a597ff;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.onboarding-link:hover { color: #fff; }
+
+/* ------------------------------------------------------------------ */
+/* Sub-views (publish / mcp / memories)                                */
+/* ------------------------------------------------------------------ */
+
+.onboarding-back {
+  background: none;
+  border: none;
+  color: rgba(165, 151, 255, 0.85);
+  font-family: inherit;
+  font-size: 11.5px;
+  padding: 0 0 10px;
+  cursor: pointer;
+  text-align: left;
+}
+.onboarding-back:hover { color: #fff; }
 
 /* Step content */
 
@@ -132,29 +253,11 @@
   gap: 4px;
 }
 
-.onboarding-step-header {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 11px;
-  color: #7c6bff;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-bottom: 4px;
-}
-
 .onboarding-step-title {
   font-size: 15px;
   font-weight: 600;
   margin-bottom: 4px;
   letter-spacing: -0.01em;
-}
-
-.onboarding-step-optional {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 10px;
-  font-weight: 400;
-  color: rgba(232, 233, 240, 0.35);
-  letter-spacing: 0.04em;
-  margin-left: 4px;
 }
 
 .onboarding-step-desc {
@@ -164,19 +267,7 @@
   margin-bottom: 10px;
 }
 
-.onboarding-placeholder {
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px dashed rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 10px;
-  color: rgba(232, 233, 240, 0.35);
-  margin-bottom: 12px;
-  line-height: 1.5;
-}
-
-/* Step 1 — client tabs */
+/* MCP — client tabs */
 
 .onboarding-client-tabs {
   display: inline-flex;
@@ -201,11 +292,7 @@
   cursor: pointer;
   transition: color 0.15s, background 0.15s;
 }
-
-.onboarding-client-tab:hover {
-  color: #f0f0f5;
-}
-
+.onboarding-client-tab:hover { color: #f0f0f5; }
 .onboarding-client-tab.active {
   background: rgba(124, 107, 255, 0.25);
   color: #fff;
@@ -251,9 +338,7 @@
   height: 4px;
   width: 4px;
 }
-.onboarding-code-box pre::-webkit-scrollbar-track {
-  background: transparent;
-}
+.onboarding-code-box pre::-webkit-scrollbar-track { background: transparent; }
 .onboarding-code-box pre::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.12);
   border-radius: 2px;
@@ -280,12 +365,10 @@
   flex-shrink: 0;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-
 .onboarding-code-copy:hover {
   background: rgba(124, 107, 255, 0.3);
   color: #fff;
 }
-
 .onboarding-code-copy.copied {
   background: rgba(74, 222, 128, 0.15);
   border-color: rgba(74, 222, 128, 0.25);
@@ -313,67 +396,12 @@
   50% { opacity: 0.3; }
 }
 
-/* Step 2 — action log */
-
-.onboarding-action-log {
-  background: rgba(0, 0, 0, 0.25);
-  border-radius: 8px;
-  padding: 10px 12px;
-  font-family: "Space Grotesk", -apple-system, sans-serif;
-  font-size: 12px;
-  color: rgba(232, 233, 240, 0.7);
-  max-height: 140px;
-  overflow-y: auto;
-  line-height: 1.7;
-  margin-bottom: 12px;
-}
-
-.onboarding-action-log--empty {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: rgba(232, 233, 240, 0.35);
-}
-
-.onboarding-action-line {
-  display: flex;
-  gap: 8px;
-  align-items: baseline;
-}
-
-.onboarding-action-tick {
-  color: #4ade80;
-  font-size: 9px;
-  flex-shrink: 0;
-}
-
-.onboarding-action-error {
-  color: #f87171;
-  font-size: 9px;
-  flex-shrink: 0;
-}
-
-.onboarding-trust-note {
-  background: rgba(74, 222, 128, 0.06);
-  border-radius: 8px;
-  padding: 8px 12px;
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.7);
-  margin-bottom: 10px;
-  line-height: 1.5;
-}
-
 .onboarding-disclaimer {
   font-size: 10px;
   color: rgba(232, 233, 240, 0.35);
   text-align: center;
   margin-top: 10px;
   letter-spacing: 0.02em;
-}
-
-.onboarding-trust-note strong {
-  color: #4ade80;
-  font-weight: 500;
 }
 
 .onboarding-step-actions {
@@ -395,10 +423,8 @@
   cursor: pointer;
   transition: background 0.15s;
 }
-
-.onboarding-btn-primary:hover {
-  background: rgba(124, 107, 255, 0.3);
-}
+.onboarding-btn-primary:hover { background: rgba(124, 107, 255, 0.3); }
+.onboarding-btn-primary:disabled { opacity: 0.5; cursor: default; }
 
 .onboarding-btn-ghost {
   background: none;
@@ -411,13 +437,7 @@
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
 }
-
 .onboarding-btn-ghost:hover {
   color: #f0f0f5;
   border-color: rgba(255, 255, 255, 0.15);
-}
-
-.onboarding-done-actions {
-  margin-top: 12px;
-  text-align: right;
 }

--- a/web/src/components/OnboardingDock.tsx
+++ b/web/src/components/OnboardingDock.tsx
@@ -238,12 +238,14 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
   }, []);
 
   const resetAll = useCallback(() => {
-    // Spaces auto-derives from userSpaceCount on the next render — start
-    // everything else fresh.
-    setState({ ...defaultState });
+    // Initialise spacesComplete directly from the current userSpaceCount.
+    // The [userSpaceCount] auto-derive effect won't re-fire if the count
+    // hasn't changed, so we'd otherwise leave a user with existing spaces
+    // stuck on an un-ticked required item.
+    setState({ ...defaultState, spacesComplete: userSpaceCount > 0 });
     setView("checklist");
     setPopoverOpen(true);
-  }, []);
+  }, [userSpaceCount]);
 
   const done = allDone(state);
   const requiredDone = state.spacesComplete;
@@ -251,6 +253,7 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
   return (
     <>
       <button
+        type="button"
         ref={dockRef}
         className={`onboarding-dock${requiredDone ? " onboarding-dock--ready" : ""}${popoverOpen ? " onboarding-dock--active" : ""}`}
         onClick={togglePopover}
@@ -396,9 +399,9 @@ function PublishGuide({ onBack, onMarkDone, done }: { onBack: () => void; onMark
       </div>
       <div className="onboarding-step-actions">
         {done ? (
-          <button className="onboarding-btn-ghost" onClick={onBack}>Done</button>
+          <button type="button" className="onboarding-btn-ghost" onClick={onBack}>Done</button>
         ) : (
-          <button className="onboarding-btn-ghost" onClick={onMarkDone}>I've done this</button>
+          <button type="button" className="onboarding-btn-ghost" onClick={onMarkDone}>I've done this</button>
         )}
       </div>
     </div>
@@ -445,6 +448,7 @@ function McpConnect({ onBack, onMarkDone, done }: { onBack: () => void; onMarkDo
       <div className="onboarding-client-tabs">
         {CLIENT_TABS.map((t) => (
           <button
+            type="button"
             key={t.key}
             className={`onboarding-client-tab${client === t.key ? " active" : ""}`}
             onClick={() => switchClient(t.key)}
@@ -458,6 +462,7 @@ function McpConnect({ onBack, onMarkDone, done }: { onBack: () => void; onMarkDo
       <div className="onboarding-code-box">
         <pre><code>{command}</code></pre>
         <button
+          type="button"
           className={`onboarding-code-copy${copied ? " copied" : ""}`}
           onClick={handleCopy}
         >
@@ -472,9 +477,9 @@ function McpConnect({ onBack, onMarkDone, done }: { onBack: () => void; onMarkDo
 
       <div className="onboarding-step-actions">
         {done ? (
-          <button className="onboarding-btn-ghost" onClick={onBack}>Done</button>
+          <button type="button" className="onboarding-btn-ghost" onClick={onBack}>Done</button>
         ) : (
-          <button className="onboarding-btn-ghost" onClick={onMarkDone}>I've connected it</button>
+          <button type="button" className="onboarding-btn-ghost" onClick={onMarkDone}>I've connected it</button>
         )}
       </div>
     </div>
@@ -543,10 +548,10 @@ function MemoriesImport({
           Paste into your Chat AI. Paste the response into Oyster's chat ↓
         </div>
         <div className="onboarding-step-actions">
-          <button className="onboarding-btn-primary" style={{ flex: 1 }} onClick={onMarkDone}>
+          <button type="button" className="onboarding-btn-primary" style={{ flex: 1 }} onClick={onMarkDone}>
             Done
           </button>
-          <button className="onboarding-btn-ghost" onClick={() => setSub("a")}>Back</button>
+          <button type="button" className="onboarding-btn-ghost" onClick={() => setSub("a")}>Back</button>
         </div>
         <div className="onboarding-disclaimer">Everything stays on your machine.</div>
       </div>
@@ -572,6 +577,7 @@ function MemoriesImport({
       <div className="onboarding-step-actions">
         {loadError ? (
           <button
+            type="button"
             className="onboarding-btn-primary"
             style={{ flex: 1 }}
             onClick={retry}
@@ -580,6 +586,7 @@ function MemoriesImport({
           </button>
         ) : (
           <button
+            type="button"
             className="onboarding-btn-primary"
             style={{ flex: 1 }}
             onClick={handleCopy}
@@ -588,7 +595,7 @@ function MemoriesImport({
             Copy
           </button>
         )}
-        <button className="onboarding-btn-ghost" onClick={onMarkDone}>Skip</button>
+        <button type="button" className="onboarding-btn-ghost" onClick={onMarkDone}>Skip</button>
       </div>
 
       <div className="onboarding-disclaimer">Everything stays on your machine.</div>

--- a/web/src/components/OnboardingDock.tsx
+++ b/web/src/components/OnboardingDock.tsx
@@ -52,60 +52,69 @@ const CLIENT_CONFIGS: Record<ClientKey, { hint: string; command: (mcpUrl: string
   },
 };
 
-const STORAGE_KEY = "oyster-onboarding-state";
+// v2: switched from a 3-step gated funnel (step1Complete / step2Complete /
+// step3Complete) to a 4-item checklist with one required item. Bumping the
+// key invalidates the old shape rather than migrating it — most criteria
+// re-derive on mount (userSpaceCount, MCP status), so a fresh state is
+// quickly populated to truth without bothering the user.
+const STORAGE_KEY = "oyster-onboarding-state-v2";
 
-type StepIndex = 1 | 2 | 3;
+type ItemKey = "spaces" | "publish" | "mcp" | "memories";
 
 interface OnboardingState {
-  step1Complete: boolean;
-  step2Complete: boolean;
-  step3Complete: boolean;
+  spacesComplete: boolean;
+  publishComplete: boolean;
+  mcpComplete: boolean;
+  memoriesComplete: boolean;
 }
 
 const defaultState: OnboardingState = {
-  step1Complete: false,
-  step2Complete: false,
-  step3Complete: false,
+  spacesComplete: false,
+  publishComplete: false,
+  mcpComplete: false,
+  memoriesComplete: false,
 };
 
-const ACTION_LOG_LIMIT = 50;
-
-interface ToolCall {
-  tool: string;
-  at: string;
-  isError: boolean;
+interface ChecklistItem {
+  key: ItemKey;
+  title: string;
+  required: boolean;
+  desc: string;
+  actionLabel: string;
 }
 
-// Tool names as they appear in SSE events are snake_case engineering
-// labels — useful for debugging, tedious as a status feed. Map to short
-// natural-language phrases. Unknown tools fall back to a humanised
-// version of the raw name.
-const TOOL_PHRASES: Record<string, string> = {
-  get_context: "Reading the Oyster playbook",
-  list_spaces: "Checking your spaces",
-  list_artifacts: "Looking at your artifacts",
-  onboard_space: "Creating a space",
-  set_space_summary: "Summarising a space",
-  scan_space: "Scanning for artifacts",
-  create_artifact: "Creating an artifact",
-  update_artifact: "Updating an artifact",
-  remove_artifact: "Removing an artifact",
-  read_artifact: "Reading an artifact",
-  open_artifact: "Opening an artifact",
-  reveal_artifact: "Opening on the surface",
-  gather_repo_context: "Reading a repo",
-  regenerate_icon: "Generating an icon",
-  remember: "Saving a memory",
-  recall: "Recalling a memory",
-  forget: "Forgetting a memory",
-  list_memories: "Checking your memories",
-};
-
-function humanizeTool(tool: string): string {
-  if (TOOL_PHRASES[tool]) return TOOL_PHRASES[tool];
-  const spaced = tool.replace(/_/g, " ");
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
+// Order matters: required first, then optionals in install-friction order
+// (publish = no install; MCP = config edit; memories = external AI roundtrip).
+const ITEMS: ChecklistItem[] = [
+  {
+    key: "spaces",
+    title: "Set up your spaces",
+    required: true,
+    desc: "Let Oyster scan your dev folders and group your work into spaces.",
+    actionLabel: "Set up Oyster",
+  },
+  {
+    key: "publish",
+    title: "Publish your first artefact",
+    required: false,
+    desc: "Make a thing in chat, click Publish — get a share URL.",
+    actionLabel: "Show me how",
+  },
+  {
+    key: "mcp",
+    title: "Connect another agent (MCP)",
+    required: false,
+    desc: "Drive Oyster from Claude Code, Cursor, VS Code or Windsurf.",
+    actionLabel: "Show me how",
+  },
+  {
+    key: "memories",
+    title: "Import memories",
+    required: false,
+    desc: "Bring memories from ChatGPT or Claude into Oyster.",
+    actionLabel: "Show me how",
+  },
+];
 
 function loadState(): OnboardingState {
   try {
@@ -123,31 +132,34 @@ function saveState(state: OnboardingState) {
   } catch { /* ignore quota errors */ }
 }
 
-function activeStep(state: OnboardingState): StepIndex {
-  if (!state.step1Complete) return 1;
-  if (!state.step2Complete) return 2;
-  return 3;
-}
+const COMPLETE_KEY: Record<ItemKey, keyof OnboardingState> = {
+  spaces: "spacesComplete",
+  publish: "publishComplete",
+  mcp: "mcpComplete",
+  memories: "memoriesComplete",
+};
 
-function completedCount(state: OnboardingState): number {
-  return [state.step1Complete, state.step2Complete, state.step3Complete].filter(Boolean).length;
+function isComplete(state: OnboardingState, key: ItemKey): boolean {
+  return state[COMPLETE_KEY[key]];
 }
 
 function allDone(state: OnboardingState): boolean {
-  return state.step1Complete && state.step2Complete && state.step3Complete;
+  return state.spacesComplete && state.publishComplete && state.mcpComplete && state.memoriesComplete;
 }
 
 interface OnboardingDockProps {
-  /** User-defined spaces (from App.tsx). We only look at the count of
-   *  non-system spaces as the completion signal for step 2. */
+  /** Count of user-defined spaces (excludes home / __all__ / __archived__).
+   *  Drives the bidirectional auto-tick on the required Spaces item: any
+   *  space exists → ticked; deletes back to zero → un-ticked. */
   userSpaceCount?: number;
 }
+
+type View = "checklist" | { kind: "step"; key: Exclude<ItemKey, "spaces"> };
 
 export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {}) {
   const [state, setState] = useState<OnboardingState>(loadState);
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [viewingStep, setViewingStep] = useState<StepIndex>(() => activeStep(loadState()));
-  const [toolCalls, setToolCalls] = useState<ToolCall[]>([]);
+  const [view, setView] = useState<View>("checklist");
   const dockRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
@@ -162,61 +174,28 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
       .then((data) => {
         if (cancelled || !data) return;
         if (data.connected_clients > 0) {
-          setState((s) => (s.step1Complete ? s : { ...s, step1Complete: true }));
+          setState((s) => (s.mcpComplete ? s : { ...s, mcpComplete: true }));
         }
       })
       .catch(() => { /* server may not be up yet */ });
     return () => { cancelled = true; };
   }, []);
 
-  // Listen for MCP connect + tool-call SSE events via the shared subscription
-  // (App.tsx also subscribes) so we only hold one EventSource per tab.
+  // Listen for MCP connect events via the shared SSE subscription (App.tsx
+  // also subscribes) so we only hold one EventSource per tab.
   useEffect(() => subscribeUiEvents((event) => {
     if (event.command === "mcp_client_connected") {
-      setState((s) => (s.step1Complete ? s : { ...s, step1Complete: true }));
-    }
-    if (event.command === "mcp_tool_called") {
-      const payload = event.payload as { tool?: string; at?: string; is_error?: boolean } | undefined;
-      const call: ToolCall = {
-        tool: payload?.tool ?? "unknown",
-        at: payload?.at ?? new Date().toISOString(),
-        isError: Boolean(payload?.is_error),
-      };
-      setToolCalls((prev) => {
-        const next = [...prev, call];
-        return next.length > ACTION_LOG_LIMIT ? next.slice(-ACTION_LOG_LIMIT) : next;
-      });
+      setState((s) => (s.mcpComplete ? s : { ...s, mcpComplete: true }));
     }
   }), []);
 
-  // Step 2 completion rule: at least one user-created space exists.
-  // That's the real signal the agent did useful work — works identically
-  // for external MCP clients (Claude Code, Cursor, ...) and for Oyster's
-  // own chat bar. We deliberately do NOT back-fill step 1 here: internal
-  // chatbar users haven't connected an MCP client and should still see
-  // that step offered. Step 1 gets marked complete only via an actual
-  // MCP connection event (see /api/mcp/status + mcp_client_connected).
+  // Spaces auto-tick: bidirectional. Any user-created space → ticked;
+  // deleting back to zero → un-ticked. Honest reflection of *current* setup
+  // state, not a high-water-mark from a past session.
   useEffect(() => {
-    if (userSpaceCount <= 0) return;
-    setState((s) => (s.step2Complete ? s : { ...s, step2Complete: true }));
+    const shouldBe = userSpaceCount > 0;
+    setState((s) => (s.spacesComplete === shouldBe ? s : { ...s, spacesComplete: shouldBe }));
   }, [userSpaceCount]);
-
-  // Auto-advance the popover to the next still-incomplete step whenever
-  // the currently-viewed step flips complete. Covers every path: manual
-  // "I've connected it" / "I'm done" clicks, MCP SSE events, and the
-  // userSpaceCount side effect. Keeping this in one place avoids the
-  // earlier bug where step-1 handlers jumped to step 2 unconditionally,
-  // even when step 2 was already done (should've gone to step 3).
-  useEffect(() => {
-    setViewingStep((v) => {
-      const viewingDone =
-        (v === 1 && state.step1Complete) ||
-        (v === 2 && state.step2Complete) ||
-        (v === 3 && state.step3Complete);
-      if (viewingDone && !allDone(state)) return activeStep(state);
-      return v;
-    });
-  }, [state.step1Complete, state.step2Complete, state.step3Complete]);
 
   // Click outside the popover closes it
   useEffect(() => {
@@ -239,65 +218,49 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
     };
   }, [popoverOpen]);
 
-  const openPopover = useCallback(() => {
-    setViewingStep(activeStep(state));
+  const togglePopover = useCallback(() => {
+    setView("checklist");
     setPopoverOpen((v) => !v);
-  }, [state]);
-
-  // `markStepN` just flips the state flag — the auto-advance effect above
-  // moves `viewingStep` to the next incomplete step.
-  const markStep1 = useCallback(() => {
-    setState((s) => ({ ...s, step1Complete: true }));
   }, []);
 
-  const markStep2 = useCallback(() => {
-    setState((s) => ({ ...s, step2Complete: true }));
+  const markDone = useCallback((key: ItemKey) => {
+    setState((s) => ({ ...s, [COMPLETE_KEY[key]]: true }));
   }, []);
 
-  const markStep3 = useCallback(() => {
-    setState((s) => ({ ...s, step3Complete: true }));
-    setPopoverOpen(false);
-  }, []);
-
-  const skipStep3 = useCallback(() => {
-    setState((s) => ({ ...s, step3Complete: true }));
+  const handleSetUpSpaces = useCallback(() => {
+    // Send the canonical setup prompt to the chat. ChatBar listens for this
+    // event and routes through the same handleSend path as its hero
+    // "Set up Oyster" button.
+    window.dispatchEvent(
+      new CustomEvent("oyster:send-prompt", { detail: { text: "Set up Oyster" } }),
+    );
     setPopoverOpen(false);
   }, []);
 
   const resetAll = useCallback(() => {
-    // Mirror the [userSpaceCount] effect's rule: if a user space already
-    // exists, step 2 counts as done. Step 1 (MCP connect) does NOT get
-    // auto-marked — it needs an actual MCP connection event regardless of
-    // what other setup has happened. Without this carry-forward, the
-    // reset would strand the user on step 2 forever (the effect never
-    // re-fires because `userSpaceCount` doesn't change).
-    const hasSpaces = userSpaceCount > 0;
-    setState({
-      ...defaultState,
-      step2Complete: hasSpaces,
-    });
-    setToolCalls([]);
-    setViewingStep(1);
+    // Spaces auto-derives from userSpaceCount on the next render — start
+    // everything else fresh.
+    setState({ ...defaultState });
+    setView("checklist");
     setPopoverOpen(true);
-  }, [userSpaceCount]);
+  }, []);
 
-  const count = completedCount(state);
   const done = allDone(state);
+  const requiredDone = state.spacesComplete;
 
   return (
     <>
       <button
         ref={dockRef}
-        className={`onboarding-dock${done ? " onboarding-dock--done" : ""}${popoverOpen ? " onboarding-dock--active" : ""}`}
-        onClick={openPopover}
+        className={`onboarding-dock${requiredDone ? " onboarding-dock--ready" : ""}${popoverOpen ? " onboarding-dock--active" : ""}`}
+        onClick={togglePopover}
         aria-expanded={popoverOpen}
-        aria-label={done ? "Oyster setup complete" : `Oyster setup — ${count} of 3`}
+        aria-label={requiredDone ? "Oyster setup checklist" : "Set up Oyster"}
       >
-        {!done && count === 0 && <span className="onboarding-dock-pulse" />}
-        {!done && count > 0 && <span className="onboarding-dock-check">✓</span>}
-        {done && <span className="onboarding-dock-check">✓</span>}
-        {!done && (
-          <span className="onboarding-dock-label">{`Set up Oyster · ${count}/3`}</span>
+        {!requiredDone && <span className="onboarding-dock-progress" />}
+        {requiredDone && <span className="onboarding-dock-check">✓</span>}
+        {!requiredDone && (
+          <span className="onboarding-dock-label">Set up Oyster</span>
         )}
       </button>
 
@@ -305,23 +268,33 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
         <div ref={popoverRef} className="onboarding-popover" role="dialog" aria-label="Oyster setup">
           <div className="onboarding-popover-arrow" />
 
-          {done ? (
-            <DoneSummary onReset={resetAll} />
-          ) : (
-            <>
-              <div className="onboarding-progress">
-                <div className={`progress-dot${state.step1Complete ? " done" : viewingStep === 1 ? " active" : ""}`} />
-                <div className={`progress-dot${state.step2Complete ? " done" : viewingStep === 2 ? " active" : ""}`} />
-                <div className={`progress-dot${state.step3Complete ? " done" : viewingStep === 3 ? " active" : ""}`} />
-              </div>
-
-              {viewingStep === 1 && <Step1Connect onComplete={markStep1} />}
-              {viewingStep === 2 && <Step2AgentWork onComplete={markStep2} toolCalls={toolCalls} />}
-              {viewingStep === 3 && (
-                <Step3Memories onComplete={markStep3} onSkip={skipStep3} />
-              )}
-            </>
-          )}
+          {view === "checklist" ? (
+            <Checklist
+              state={state}
+              requiredDone={requiredDone}
+              done={done}
+              onSetUpSpaces={handleSetUpSpaces}
+              onShowStep={(key) => setView({ kind: "step", key })}
+              onReset={resetAll}
+            />
+          ) : view.kind === "step" && view.key === "publish" ? (
+            <PublishGuide
+              onBack={() => setView("checklist")}
+              onMarkDone={() => { markDone("publish"); setView("checklist"); }}
+              done={state.publishComplete}
+            />
+          ) : view.kind === "step" && view.key === "mcp" ? (
+            <McpConnect
+              onBack={() => setView("checklist")}
+              onMarkDone={() => { markDone("mcp"); setView("checklist"); }}
+              done={state.mcpComplete}
+            />
+          ) : view.kind === "step" && view.key === "memories" ? (
+            <MemoriesImport
+              onBack={() => setView("checklist")}
+              onMarkDone={() => { markDone("memories"); setView("checklist"); }}
+            />
+          ) : null}
         </div>
       )}
     </>
@@ -329,12 +302,110 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
 }
 
 /* ------------------------------------------------------------------ */
-/* Step content is placeholder for A1 — real implementations land in   */
-/* stories A2 (connect), A3 (agent work), A4 (memories). Each uses a   */
-/* manual "done" button here so the flow is navigable end-to-end.      */
+/* Checklist view                                                      */
 /* ------------------------------------------------------------------ */
 
-function Step1Connect({ onComplete }: { onComplete: () => void }) {
+interface ChecklistProps {
+  state: OnboardingState;
+  requiredDone: boolean;
+  done: boolean;
+  onSetUpSpaces: () => void;
+  onShowStep: (key: Exclude<ItemKey, "spaces">) => void;
+  onReset: () => void;
+}
+
+function Checklist({ state, requiredDone, done, onSetUpSpaces, onShowStep, onReset }: ChecklistProps) {
+  return (
+    <div className="onboarding-checklist">
+      {ITEMS.map((item) => {
+        const itemDone = isComplete(state, item.key);
+        // Required: show CTA until done. Optional: show CTA only once the
+        // required step is done. Pre-required-done, optionals render as
+        // quiet preview rows so nothing competes with the one required step.
+        const showAction = item.required ? !itemDone : (requiredDone && !itemDone);
+        const tag: "required" | "optional" | "done" = itemDone
+          ? "done"
+          : item.required
+            ? "required"
+            : "optional";
+        return (
+          <div key={item.key} className={`onboarding-item${itemDone ? " onboarding-item--done" : ""}`}>
+            <span className={`onboarding-item-icon onboarding-item-icon--${tag}`}>
+              {itemDone && "✓"}
+            </span>
+            <div className="onboarding-item-body">
+              <div className="onboarding-item-title">
+                {item.title}
+                <span className={`onboarding-item-tag onboarding-item-tag--${tag}`}>
+                  {tag}
+                </span>
+              </div>
+              {!itemDone && <div className="onboarding-item-desc">{item.desc}</div>}
+              {showAction && (
+                <button
+                  type="button"
+                  className="onboarding-item-action"
+                  onClick={() => {
+                    if (item.key === "spaces") onSetUpSpaces();
+                    else onShowStep(item.key);
+                  }}
+                >
+                  {item.actionLabel}
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      {done && (
+        <div className="onboarding-summary">
+          You're all set.{" "}
+          <button type="button" className="onboarding-link" onClick={onReset}>Reset</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Sub-views — opened from "Show me how" on the optional items.       */
+/* Each renders standalone content + a Back link to the checklist.    */
+/* ------------------------------------------------------------------ */
+
+function BackBar({ onBack }: { onBack: () => void }) {
+  return (
+    <button type="button" className="onboarding-back" onClick={onBack}>
+      ← Back to checklist
+    </button>
+  );
+}
+
+function PublishGuide({ onBack, onMarkDone, done }: { onBack: () => void; onMarkDone: () => void; done: boolean }) {
+  return (
+    <div className="onboarding-step">
+      <BackBar onBack={onBack} />
+      <div className="onboarding-step-title">Publish your first artefact</div>
+      <div className="onboarding-step-desc">
+        Make a thing in chat — a deck, a doc, a mockup. It lands as a tile
+        on the surface. Open it, click Publish, pick an access mode (open,
+        password or sign-in), and you'll get a share URL on oyster.to.
+      </div>
+      <div className="onboarding-disclaimer">
+        Free includes 5 published artefacts; Oyster Pro lifts the cap.
+      </div>
+      <div className="onboarding-step-actions">
+        {done ? (
+          <button className="onboarding-btn-ghost" onClick={onBack}>Done</button>
+        ) : (
+          <button className="onboarding-btn-ghost" onClick={onMarkDone}>I've done this</button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function McpConnect({ onBack, onMarkDone, done }: { onBack: () => void; onMarkDone: () => void; done: boolean }) {
   const [client, setClient] = useState<ClientKey>("claude");
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<number | null>(null);
@@ -342,8 +413,6 @@ function Step1Connect({ onComplete }: { onComplete: () => void }) {
   const config = CLIENT_CONFIGS[client];
   const command = useMemo(() => config.command(mcpUrl), [config, mcpUrl]);
 
-  // Clear any pending "reset copied" timer if the user advances (unmount)
-  // or re-copies before the 1.8s window elapses.
   useEffect(() => () => {
     if (copiedTimerRef.current !== null) window.clearTimeout(copiedTimerRef.current);
   }, []);
@@ -358,14 +427,10 @@ function Step1Connect({ onComplete }: { onComplete: () => void }) {
         copiedTimerRef.current = null;
       }, 1800);
     } catch {
-      // Clipboard access can be denied (permissions, insecure context in
-      // some browsers). Leave `copied` false so the button still shows "copy"
-      // — the command is still visible in the code box for manual copy.
+      // Clipboard blocked; the command is still visible in the code box.
     }
   }, [command]);
 
-  // Reset the copied state when the user switches tabs so the button is
-  // truthful about whether the *currently visible* command is in the clipboard.
   const switchClient = useCallback((next: ClientKey) => {
     setClient(next);
     setCopied(false);
@@ -373,8 +438,9 @@ function Step1Connect({ onComplete }: { onComplete: () => void }) {
 
   return (
     <div className="onboarding-step">
-      <div className="onboarding-step-title">Connect Oyster to your agent</div>
-      <div className="onboarding-step-desc">Run it once — your agent takes it from there.</div>
+      <BackBar onBack={onBack} />
+      <div className="onboarding-step-title">Connect another agent</div>
+      <div className="onboarding-step-desc">Run this once — your agent takes it from there.</div>
 
       <div className="onboarding-client-tabs">
         {CLIENT_TABS.map((t) => (
@@ -405,92 +471,22 @@ function Step1Connect({ onComplete }: { onComplete: () => void }) {
       </div>
 
       <div className="onboarding-step-actions">
-        <button className="onboarding-btn-ghost" onClick={onComplete}>
-          I've connected it
-        </button>
+        {done ? (
+          <button className="onboarding-btn-ghost" onClick={onBack}>Done</button>
+        ) : (
+          <button className="onboarding-btn-ghost" onClick={onMarkDone}>I've connected it</button>
+        )}
       </div>
     </div>
   );
 }
 
-// One short prompt. The agent reads get_context from the oyster MCP to
-// learn the rest (how to discover the dev folder, what tools to call,
-// etc.). Keeping this minimal pushes the intelligence where it belongs:
-// into the server's self-description, not into the user's head.
-const AGENT_PROMPT = "Set up Oyster for me. Call the oyster MCP's get_context tool first — it explains the rest.";
-
-function Step2AgentWork({ onComplete, toolCalls }: { onComplete: () => void; toolCalls: ToolCall[] }) {
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<number | null>(null);
-
-  useEffect(() => () => {
-    if (copiedTimerRef.current !== null) window.clearTimeout(copiedTimerRef.current);
-  }, []);
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(AGENT_PROMPT);
-      setCopied(true);
-      if (copiedTimerRef.current !== null) window.clearTimeout(copiedTimerRef.current);
-      copiedTimerRef.current = window.setTimeout(() => {
-        setCopied(false);
-        copiedTimerRef.current = null;
-      }, 1800);
-    } catch {
-      // Clipboard blocked — prompt is still visible in the code box.
-    }
-  }, []);
-
-  const hasActivity = toolCalls.length > 0;
-
-  return (
-    <div className="onboarding-step">
-      <div className="onboarding-step-title">Ask your agent to set things up</div>
-      <div className="onboarding-step-desc">Paste this in your agent. Watch the desktop fill.</div>
-
-      <div className="onboarding-code-box">
-        <pre><code>{AGENT_PROMPT}</code></pre>
-        <button
-          className={`onboarding-code-copy${copied ? " copied" : ""}`}
-          onClick={handleCopy}
-        >
-          {copied ? "copied" : "copy"}
-        </button>
-      </div>
-
-      {hasActivity ? (
-        <div className="onboarding-action-log">
-          {toolCalls.slice(-10).map((call, i) => (
-            <div key={`${call.at}-${i}`} className="onboarding-action-line">
-              <span className={call.isError ? "onboarding-action-error" : "onboarding-action-tick"}>
-                {call.isError ? "✗" : "✓"}
-              </span>
-              <span>{humanizeTool(call.tool)}</span>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="onboarding-action-log onboarding-action-log--empty">
-          <span className="onboarding-waiting-dot" />
-          Watching for your agent's activity…
-        </div>
-      )}
-
-      <div className="onboarding-step-actions">
-        <button className="onboarding-btn-ghost" onClick={onComplete}>
-          I'm done with this step
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function Step3Memories({
-  onComplete,
-  onSkip,
+function MemoriesImport({
+  onBack,
+  onMarkDone,
 }: {
-  onComplete: () => void;
-  onSkip: () => void;
+  onBack: () => void;
+  onMarkDone: () => void;
 }) {
   // a = prompt ready to copy; b = copied, waiting for user to paste-in-AI
   // then paste the response into Oyster's chat.
@@ -527,9 +523,8 @@ function Step3Memories({
       await navigator.clipboard.writeText(prompt);
       setSub("b");
     } catch {
-      // Clipboard blocked (permissions / insecure context). Keep the user
-      // on sub-step "a" so the prompt is still visible to copy manually —
-      // advancing would land them on a misleading \"Copied\" screen.
+      // Clipboard blocked — keep the user on sub-step "a" so the prompt is
+      // still visible to copy manually.
     }
   }, [prompt]);
 
@@ -542,12 +537,13 @@ function Step3Memories({
   if (sub === "b") {
     return (
       <div className="onboarding-step">
+        <BackBar onBack={onBack} />
         <div className="onboarding-step-title">Copied</div>
         <div className="onboarding-step-desc">
           Paste into your Chat AI. Paste the response into Oyster's chat ↓
         </div>
         <div className="onboarding-step-actions">
-          <button className="onboarding-btn-primary" style={{ flex: 1 }} onClick={onComplete}>
+          <button className="onboarding-btn-primary" style={{ flex: 1 }} onClick={onMarkDone}>
             Done
           </button>
           <button className="onboarding-btn-ghost" onClick={() => setSub("a")}>Back</button>
@@ -559,9 +555,8 @@ function Step3Memories({
 
   return (
     <div className="onboarding-step">
-      <div className="onboarding-step-title">
-        Bring in your memories <span className="onboarding-step-optional">· optional</span>
-      </div>
+      <BackBar onBack={onBack} />
+      <div className="onboarding-step-title">Import memories</div>
       <div className="onboarding-step-desc">Copy this prompt and give it to your Chat AI.</div>
 
       <div className="onboarding-code-box">
@@ -593,28 +588,10 @@ function Step3Memories({
             Copy
           </button>
         )}
-        <button className="onboarding-btn-ghost" onClick={onSkip}>Skip</button>
+        <button className="onboarding-btn-ghost" onClick={onMarkDone}>Skip</button>
       </div>
 
       <div className="onboarding-disclaimer">Everything stays on your machine.</div>
-    </div>
-  );
-}
-
-// Rendered when the popover opens after all three steps are complete.
-// Keeps the pill's truthful "done" state honest — summary, not a dangling CTA.
-function DoneSummary({ onReset }: { onReset: () => void }) {
-  return (
-    <div className="onboarding-step">
-      <div className="onboarding-step-title">You're all set</div>
-      <div className="onboarding-step-desc">
-        Oyster's ready. Import-from-AI lives on the desktop if you want to revisit.
-      </div>
-      <div className="onboarding-step-actions">
-        <button className="onboarding-btn-ghost" onClick={onReset}>
-          Reset setup
-        </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Reshapes the onboarding dock from a 3/3 gated funnel into a **1 required + 3 optional checklist**. The pill stops nagging once the required step (Set up your spaces) is done; optional items wait quietly in the popover for when the user wants them.

This is **PR A** of two — PR B will be the structured *Set up Oyster* proposal panel (chips, drag-and-drop, inline rename, +Add space). Sequenced because PR A is contained UI; PR B touches agent-prompt shape and chat-message rendering.

## Why

The old dock implied all three steps were mandatory and kept the count visible (`Set up Oyster · 1/3`) until everything was ticked, even though *spaces* is the only thing that genuinely makes Oyster feel set up. Publish, MCP and memory import are real value, but for many users they happen later (or never) — gating "complete" on them turned legitimate optional features into a permanent nag.

## What changes

- **One required item:** *Set up your spaces* — auto-ticks bidirectionally on `userSpaceCount > 0`. Click the CTA → dispatches `oyster:send-prompt` → ChatBar fires the same `handleSend("Set up Oyster")` path as the hero button.
- **Three optional items:** Publish first artefact / Connect another agent (MCP) / Import memories. Visible from day one as a preview; their CTAs only light up after the required step is done so nothing competes with it.
- **Pill states:**
  - Pre-spaces: amber-glow dot + `Set up Oyster` label
  - Post-spaces: collapses to a quiet green ✓ (glyph-only)
- **Sub-views** for the optional items reuse the existing MCP install commands and memories import prompt; adds a short Publish guide. Each has a Back link.
- **Storage key bumped** to `oyster-onboarding-state-v2` — invalidates the old 3-step shape rather than migrating it. Signals re-derive on mount.

## Removed

- Linear `Step1Connect → Step2AgentWork → Step3Memories` navigation
- `viewingStep` / `activeStep` machinery
- The agent tool-call activity log (the surface itself is the better feedback)
- The DoneSummary modal — replaced by an inline summary line in the checklist

## Cross-component coupling

One small ChatBar addition: a `useEffect` listener on `oyster:send-prompt` that calls `handleSend(detail.text)`. Same pattern as the existing `oyster:open-session` event subscriber elsewhere in the app — decoupled, no ref handles or lifted state.

## Test plan

- [x] Both packages typecheck clean (web + server)
- [x] All 50 server tests pass (no regressions in publish-service / scanner-gitignore / memory-store / resolve-artifacts-url / password-hash)
- [x] Vite serves 200; bundle compiles
- [ ] **Visual smoke** (deferred to reviewer): refresh in browser, check the three states — pre-spaces amber-glow pill / post-spaces green ✓ / sub-views open and Back returns to checklist
- [ ] **Spaces auto-tick:** create a space → required item ticks → pill collapses; delete the space → un-ticks → pill returns to amber

## Follow-ups (out of scope here)

- **PR B — Set up Oyster proposal panel** (chips + drag-and-drop + inline rename + +Add space). The "Set up Oyster" button will continue to trigger the existing chat flow until PR B replaces the response with the new structured UI.
- **Publish auto-tick** — wire to the `share_token` issued event once #317 lands. Currently the publish item is manual-tick only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)