### PR TITLE
fix(home): drop hero on sub-views + teach first-run users from Unsorted

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -115,6 +115,10 @@ export default function App() {
   const [viewerHash, setViewerHash] = useState<string>(() => getUrlState().hash);
   const [connected, setConnected] = useState(true);
   const [aiError, setAiError] = useState<string | null>(null);
+  // True when the user is on a Home sub-view (Pro vault preview or Unsorted
+  // orphans) rather than the bare Home feed. Lifted from Home so the chat
+  // bar can drop out of hero mode and stop occluding sub-view content.
+  const [homeSubViewActive, setHomeSubViewActive] = useState(false);
 
   // Active-space-aware artifact loader. Mirrors current activeSpace via a ref
   // so callers don't have to thread it through every closure (polling,
@@ -289,7 +293,11 @@ export default function App() {
   // beneath an oversized prompt.
   const isFirstRun = FORCE_ONBOARDING ||
     spaces.filter(s => s.id !== "home" && s.id !== "__all__").length === 0;
-  const isHero = activeSpace === "home" && isFirstRun;
+  // Hero only on the bare Home feed. The Pro and Unsorted pills are sub-views
+  // *inside* Home (activeSpace stays "home"), so we also gate on the lifted
+  // sub-view flag — otherwise the centered hero chat bar would occlude the
+  // vault preview / orphan tiles behind it.
+  const isHero = activeSpace === "home" && isFirstRun && !homeSubViewActive;
 
   const viewers = windows.filter((w) => w.type === "viewer");
   const terminalWindow = windows.find((w) => w.type === "terminal");
@@ -398,6 +406,7 @@ export default function App() {
         onPromoteFolderToSpace={handlePromoteFolderToSpace}
         onSpaceDelete={handleSpaceDelete}
         onSpaceUpdate={handleSpaceUpdate}
+        onSubViewActiveChange={setHomeSubViewActive}
         desktopProps={{
           space: activeSpace,
           spaces: spaces.map((s) => s.id),

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -142,11 +142,6 @@
   color: var(--text-muted, rgba(255, 255, 255, 0.55));
 }
 
-.home-subtitle strong {
-  color: var(--text);
-  font-weight: 600;
-}
-
 .home-subtitle-glyph {
   display: inline-block;
   vertical-align: -2px;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -134,6 +134,25 @@
   color: var(--text);
 }
 
+.home-subtitle {
+  margin-top: 12px;
+  max-width: 640px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-muted, rgba(255, 255, 255, 0.55));
+}
+
+.home-subtitle strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.home-subtitle-glyph {
+  display: inline-block;
+  vertical-align: -2px;
+  color: var(--text);
+}
+
 .home-error {
   margin-top: 12px;
   font-size: 0.85rem;

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
 import { ArrowUpRight, Folder, FolderPlus, Shield } from "lucide-react";
 import type { SessionState } from "../../data/sessions-api";
@@ -199,7 +199,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // Tell App when the user is on a Home sub-view so it can drop the chat
   // bar out of hero mode (otherwise the centered overlay occludes the
   // vault preview / orphan tiles). Sub-views only exist while on Home.
-  useEffect(() => {
+  useLayoutEffect(() => {
     onSubViewActiveChange?.(isHomeView && (showVault || showElsewhere));
   }, [isHomeView, showVault, showElsewhere, onSubViewActiveChange]);
 
@@ -656,7 +656,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             <div className="home-subtitle">
               Click the
               {" "}
-              <FolderPlus size={14} strokeWidth={2} aria-hidden="true" className="home-subtitle-glyph" />
+              <FolderPlus size={14} strokeWidth={2} role="img" aria-label="folder plus" className="home-subtitle-glyph" />
               {" "}
               on a tile to set up your first space.
             </div>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -41,6 +41,11 @@ interface Props {
   onSpaceDelete?: (spaceId: string) => Promise<void> | void;
   /** Used by the breadcrumb-pill context menu (rename). */
   onSpaceUpdate?: (id: string, fields: { displayName?: string; color?: string }) => void;
+  /** Fires when the user toggles between the bare Home feed and a Home
+   *  sub-view (Pro vault preview or Unsorted orphans). App uses this to
+   *  drop the chat bar out of hero mode so it stops occluding sub-view
+   *  content. */
+  onSubViewActiveChange?: (active: boolean) => void;
 }
 
 const ARTEFACT_SOURCE_ORDER: ArtefactSource[] = ["all", "manual", "ai_generated", "discovered"];
@@ -106,7 +111,7 @@ const FILTER_LABELS: Record<StateFilter, string> = {
   all: "all",
 };
 
-export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate }: Props) {
+export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange }: Props) {
   const { sessions, error, loading } = useSessions();
   const {
     memories,
@@ -190,6 +195,13 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
       setShowVault(false);
     }
   }, [isHomeView]);
+
+  // Tell App when the user is on a Home sub-view so it can drop the chat
+  // bar out of hero mode (otherwise the centered overlay occludes the
+  // vault preview / orphan tiles). Sub-views only exist while on Home.
+  useEffect(() => {
+    onSubViewActiveChange?.(isHomeView && (showVault || showElsewhere));
+  }, [isHomeView, showVault, showElsewhere, onSubViewActiveChange]);
 
   const showVaultPage = showVault && isHomeView;
 
@@ -633,6 +645,22 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
               active scope, so a separate "HOME" / "OYSTER" label is
               redundant. */}
           <h1 className="home-title">{isHomeView ? (showElsewhere ? "Everything else." : "Everything active.") : eyebrow}</h1>
+          {/* First-run teaching line on Unsorted: orphan tiles look passive,
+              so point at the per-tile affordance. With zero spaces the action
+              is *creating* one (the popover says "promote this folder"), not
+              attaching — so frame as "set up". Drops once any real space
+              exists; by then the user has met the model. Inlines the actual
+              FolderPlus glyph (size + stroke matches the tile button) so the
+              instruction visually points at exactly the icon to click. */}
+          {isHomeView && showElsewhere && realSpaces.length === 0 && (
+            <div className="home-subtitle">
+              Click the
+              {" "}
+              <FolderPlus size={14} strokeWidth={2} aria-hidden="true" className="home-subtitle-glyph" />
+              {" "}
+              on a tile to set up your first space.
+            </div>
+          )}
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 


### PR DESCRIPTION
## Summary

Two small Home/onboarding UX fixes that have been sitting on local main for a while. Splitting from #317 / Plan B.

- **Hero / sub-view occlusion** — Lifts \`homeSubViewActive\` from Home into App so the hero chat bar drops out of centered-overlay mode when the user opens a Home sub-view (Pro vault preview, Unsorted orphans). Previously the hero overlay sat on top of those sub-views and occluded them.
- **Unsorted first-run teaching line (#312)** — On Unsorted with zero real spaces yet, render a subtitle: *"Click the [FolderPlus icon] on a tile to set up your first space."* Inlines the actual FolderPlus glyph at the same size + stroke as the per-tile button so the instruction visually points at exactly the icon to click. Drops as soon as any real space exists.

A partial step toward #312's empty-state coach-mark goal — not a complete close.

## Test plan

- [ ] \`cd web && npm run build\` — clean
- [ ] Open Home with zero spaces, click Unsorted pill — subtitle visible with FolderPlus glyph; hero chat bar drops out of centered mode
- [ ] Promote one orphan folder to a space — subtitle disappears; Unsorted view still works for further orphans
- [ ] Open Home with at least one real space, click Pro pill (vault preview) — hero drops; vault content not occluded
- [ ] Switch back to bare Home — hero returns to centered overlay (first-run only)