### PR TITLE
docs(cloud): R1 reframe — Pro is the durable copy

### DIFF
--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -16,13 +16,13 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R1. Empty-machine continuity
 
-**Current state:** **Identity layer shipped** (#295 magic-link, then #340 OAuth as primary — see `server/src/auth-service.ts`). Cloud restore still missing. `bootstrapUserland()` creates the empty `~/Oyster/` tree; auto-backup (`server/src/backup.ts`) still writes local-only daily snapshots to `~/oyster-backups/auto/` (5-day rotation). No pull path from any remote. Self-hosted-via-git variant: zero code. Tracked for 0.8.0 as #319.
+**Current state:** **Identity layer shipped** (#295 magic-link, then #340 OAuth as primary — see `server/src/auth-service.ts`). Cloud restore still missing. `bootstrapUserland()` creates the empty `~/Oyster/` tree; auto-backup (`server/src/backup.ts`) still writes local-only daily snapshots to `~/oyster-backups/auto/` (5-day rotation). No pull path from any remote.
 
 **Survives:** The `~/Oyster/` layout (`db/`, `spaces/`, `apps/`, `config/`) is per-space-addressable and could serve as the restore target. `MemoryProvider.importMemories()` already implements idempotent bulk-insert. `initDb()` migrations are additive and idempotent. With auth landed, account-scoped tenant model is in place.
 
 **Changes:** `backup.ts` is local filesystem `cpSync` only — needs an upload hook or push/pull transport. The DB is one SQLite file (easy to snapshot) but needs a defined serialisation contract before it's portable.
 
-**Missing entirely:** Cloud storage. Restore flow (sign-in → pull → populate). Git-remote variant has zero implementation.
+**Missing entirely:** Cloud storage. Restore flow (sign-in → pull → populate).
 
 ---
 

--- a/docs/requirements/oyster-cloud.md
+++ b/docs/requirements/oyster-cloud.md
@@ -24,9 +24,7 @@ A user who signs into Oyster on a fresh machine sees their full context with no 
 
 **Verify:** clean install + sign-in produces the same Home page as on the user's primary machine, modulo locally-mounted folder contents — the user must still acquire the underlying files separately (e.g. clone a git remote into a local path). No manual import, file copy, or configuration step is required between sign-in and the populated Home page rendering.
 
-**Variant — self-hosted continuity via a git remote.** Users may opt to use their own git remote as the durable copy instead of Oyster's managed cloud. Same R1 outcome, different transport, no trust handed to us. Treated as a first-class option, not a back-door.
-
-**Verify (variant):** with a self-hosted git remote configured on the primary machine, performing the equivalent setup on a fresh machine (install Oyster, point it at the same remote, pull) produces the same Home page as the managed-cloud path, with the same caveats around locally-mounted folder contents and the same no-manual-import constraint.
+Pro is how Oyster delivers R1. Power users who'd rather manage their own backup of `~/Oyster` may do so — that's their choice, not a product commitment we make.
 
 ---
 


### PR DESCRIPTION
## Summary

Drops the "self-hosted continuity via a git remote" variant of R1 from \`docs/requirements/oyster-cloud.md\`.

Before: R1 had two first-class paths — managed cloud (Pro) and a self-hosted git remote, treated as equal options. After: Pro is *the* path Oyster delivers R1 through. Users may BYO backup of \`~/Oyster\`, but that's their choice — not a product commitment.

## Why

Keeping a self-hosted variant as first-class blurs what Pro is for and complicates every R1 implementation ticket (sync, restore, conflict policy) into "how does this work without our cloud." Pro is the load-bearing path; everything else is at-your-own-risk.

## Impact

Doc-only change. No code touched. Affects how downstream tickets — #319 (R1 fresh-machine restore), #294 (Pro tracking), #296 (sync engine), #320 (cold-storage transcripts) — are scoped: they no longer need to dual-track a self-hosted variant.

## Test plan

- [ ] Read the diff in \`docs/requirements/oyster-cloud.md\` § R1 — outcome paragraph and verify clause are unchanged; only the variant + variant verify are removed; replaced with the single-line Pro framing.