### PR TITLE
feat(setup): structured proposal panel for first-run space setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **"Set up Oyster" is a panel now, not a wall of text.** When the agent finishes scanning your dev folder it surfaces a structured proposal: each suggested space with its folders as draggable chips, plus an "Everything else" bucket for the rest. Click `×` on a chip to push it back, drag chips between spaces, click a name to rename, +Add space for an empty starter, untick what you don't want — then hit Create. No open questions to answer, no copy-paste, no markdown.
 - **Set up Oyster is a checklist now.** One required item — set up your spaces — and three optional ones (publish your first artefact, connect another agent, import memories). The dock pill stops nagging once the required step is done; the optional items wait quietly in the popover for when you want them.
 - **Repo scanner respects `.gitignore`.** Folders and files matched by a project's `.gitignore` are now excluded from scan results, alongside the existing built-in skips. Patterns including negations and globs are honored. ([#281](https://github.com/mattslight/oyster/issues/281))
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -333,6 +333,7 @@
 </ul>
 <h3>Changed</h3>
 <ul>
+<li><strong>&quot;Set up Oyster&quot; is a panel now, not a wall of text.</strong> When the agent finishes scanning your dev folder it surfaces a structured proposal: each suggested space with its folders as draggable chips, plus an &quot;Everything else&quot; bucket for the rest. Click <code>×</code> on a chip to push it back, drag chips between spaces, click a name to rename, +Add space for an empty starter, untick what you don&#39;t want — then hit Create. No open questions to answer, no copy-paste, no markdown.</li>
 <li><strong>Set up Oyster is a checklist now.</strong> One required item — set up your spaces — and three optional ones (publish your first artefact, connect another agent, import memories). The dock pill stops nagging once the required step is done; the optional items wait quietly in the popover for when you want them.</li>
 <li><strong>Repo scanner respects <code>.gitignore</code>.</strong> Folders and files matched by a project&#39;s <code>.gitignore</code> are now excluded from scan results, alongside the existing built-in skips. Patterns including negations and globs are honored. (<a href="https://github.com/mattslight/oyster/issues/281" rel="noopener noreferrer">#281</a>)</li>
 </ul>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,7 @@ import { makeRouteCtx } from "./http-utils.js";
 import { tryHandleSessionRoute } from "./routes/sessions.js";
 import { tryHandleArtifactRoute } from "./routes/artifacts.js";
 import { tryHandleSpaceRoute } from "./routes/spaces.js";
+import { tryHandleSetupRoute } from "./routes/setup.js";
 import { tryHandleMemoryRoute } from "./routes/memories.js";
 import { tryHandleAuthRoute } from "./routes/auth.js";
 import { tryHandlePublishRoute } from "./routes/publish.js";
@@ -394,6 +395,12 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // /api/spaces/* — collapsed from the legacy spaces-routes.ts and the
   // inline /api/spaces/:id/sources* + /api/spaces/from-path handlers.
   if (await tryHandleSpaceRoute(req, res, url, ctx, {
+    spaceService, broadcastUiEvent,
+  })) return;
+
+  // /api/setup/apply — fans the user's confirmed SetupProposal out to
+  // onboard_space. Triggered by the SetupProposalPanel's Apply button.
+  if (await tryHandleSetupRoute(req, res, url, ctx, {
     spaceService, broadcastUiEvent,
   })) return;
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { extname, dirname, join, resolve, basename } from "node:path";
+import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ArtifactStore } from "./artifact-store.js";
@@ -9,7 +10,7 @@ import type { SpaceService } from "./space-service.js";
 import type { MemoryProvider } from "./memory-store.js";
 import { registerMemoryTools } from "./memory-store.js";
 import type { SessionStore } from "./session-store.js";
-import type { ArtifactKind, UiCommand } from "../../shared/types.js";
+import type { ArtifactKind, UiCommand, SetupProposal } from "../../shared/types.js";
 import { debug } from "./debug.js";
 import { slugify } from "./utils.js";
 import { makeTool, withStructured, type ToolTelemetry } from "./mcp-tool.js";
@@ -198,41 +199,41 @@ user's active projects.
 - Space names are short, lowercase, and human — pick whatever the user
   would actually call this part of their work.
 
-### Step 3 — Present the plan to the user in chat BEFORE applying
+### Step 3 — Send the proposal to the UI
 
-Show:
-- The proposed spaces with the folders in each and a one-sentence reason why.
-- What you'd filter as noise (with reasons).
-- Any open questions you want them to answer first.
+Call \`propose_setup\` with your grouped spaces and an \`everythingElse\` array
+for folders you considered but didn't auto-group. The user gets an interactive
+panel where they can toggle, rename, drag chips, +Add space, and apply.
 
-Don't apply silently. Don't dump raw JSON. Format it readably — the user is
-reviewing a plan, not consuming an API response.
+DO NOT write a markdown plan in chat. The panel IS the plan. After calling
+\`propose_setup\`, briefly acknowledge in chat (one short sentence — e.g.
+"Sent you a proposal — pick what looks right.") and stop. Do NOT call
+\`onboard_space\` yourself; the user applies via the panel and the server
+fans out the writes.
 
-### Step 4 — Apply once confirmed
+If you're unsure whether a folder is a real project, put it in
+\`everythingElse\` rather than asking — the user can drag it into a space
+themselves. No open questions in chat.
 
-For each confirmed space, call \`onboard_space\` with a \`name\` and a \`paths\`
-array (absolute paths). One call creates the space, attaches every path, and
-scans each. For multi-folder spaces make ONE call with all the paths in the
-array — don't loop once per folder.
+### Step 4 — Don't apply
 
-### Step 5 — Confirm back
-
-Tell the user how many spaces were created and rough artifact counts per space.
-Offer to adjust anything that looks off.
+You don't apply. The panel sends the user's confirmed selections to
+\`POST /api/setup/apply\`, which calls \`onboard_space\` per space on your
+behalf. The surface refreshes via SSE; the user sees it happen.
 
 ### If the user gave you an explicit path
 
 (e.g. *"set up Oyster with my projects at ~/foo"*)
 
-Skip the probe. Start at Step 1 for just that path — walk its subfolders, apply
-the same judgement, propose, confirm, apply.
+Skip the probe. Start at Step 1 for just that path — walk its subfolders,
+apply the same judgement, then call \`propose_setup\` for the user to confirm.
 
 ### Don't silently drop anything
 
-If you considered a folder and decided it wasn't a project, say so in the plan
-and give a short reason. Never omit folders from the plan without telling the
-user. If you're unsure whether something counts, flag it as an open question
-and let the user decide.
+If you considered a folder and decided it wasn't a project, surface it in
+\`everythingElse\` (the panel renders it as a draggable chip) rather than
+omitting it. The user can ignore it or drag it into a space — that's their
+call, not yours.
 
 ## "Here's my context from another AI" — import playbook
 
@@ -446,6 +447,52 @@ export function createMcpServer(deps: McpDeps): McpServer {
       if (!space) space = deps.spaceService.createSpace({ name });
       const updated = deps.spaceService.setSummary(space.id, title, content);
       return { space_id: updated.id, title: updated.summaryTitle, content: updated.summaryContent };
+    },
+  );
+
+  // ── propose_setup ──
+
+  tool(
+    "propose_setup",
+    "Render a structured setup proposal in the user's UI: a panel of proposed spaces (each with folders) plus an Everything-else bucket for unattached folders. Use this from Step 3 of the 'Set up Oyster for me' playbook INSTEAD of writing a markdown plan in chat — the user can toggle, rename, drag chips, and apply directly from the panel. After calling, briefly acknowledge in chat (e.g. 'Sent you a proposal — pick what looks right.') and stop. Do NOT call onboard_space yourself; the panel applies via /api/setup/apply.",
+    {
+      spaces: z.array(z.object({
+        name: z.string().describe("Display name for the space (short, lowercase, human)."),
+        reason: z.string().optional().describe("One-sentence reason this group hangs together (e.g. 'shared prefix tokinvest-*')."),
+        folders: z.array(z.object({
+          path: z.string().describe("Absolute path to the folder."),
+          label: z.string().describe("Display label for the folder (typically the leaf basename)."),
+        })).describe("Folders that belong in this space."),
+      })).describe("Proposed space groupings, ordered by confidence (highest first)."),
+      everythingElse: z.array(z.object({
+        path: z.string().describe("Absolute path to the folder."),
+        label: z.string().describe("Display label for the folder (typically the leaf basename)."),
+      })).optional().describe("Folders considered but not auto-grouped — surfaced in the panel so the user can drag them into a space if desired. Don't omit borderline folders silently."),
+    },
+    async ({ spaces, everythingElse }) => {
+      const proposalId = randomUUID();
+      const now = Date.now();
+      const proposal: SetupProposal = {
+        proposalId,
+        spaces: spaces.map((s, i) => ({
+          key: `s${now}-${i}`,
+          name: s.name,
+          reason: s.reason,
+          folders: s.folders,
+        })),
+        everythingElse: everythingElse ?? [],
+      };
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "setup_proposal_ready",
+        payload: proposal,
+      });
+      return {
+        proposal_id: proposalId,
+        space_count: spaces.length,
+        everything_else_count: everythingElse?.length ?? 0,
+        message: "Proposal sent to the user's UI. They'll pick what they want and apply it from the panel.",
+      };
     },
   );
 

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -92,6 +92,23 @@ export async function tryHandleSetupRoute(
     return true;
   }
 
+  // Reject slug-collisions in the same payload up-front. Two rows named
+  // "foo" and "Foo" both slugify to "foo"; without this check they'd merge
+  // into a single space silently while the panel showed them as separate.
+  // Surface as a single error so the user can rename one.
+  const seenSlugs = new Map<string, string>(); // slug -> first display name
+  for (const wanted of body.spaces) {
+    const id = slugify(wanted.name);
+    const prev = seenSlugs.get(id);
+    if (prev) {
+      sendJson({
+        error: `Two spaces would collapse to the same id "${id}" (from "${prev}" and "${wanted.name}"). Rename one before applying.`,
+      }, 400);
+      return true;
+    }
+    seenSlugs.set(id, wanted.name);
+  }
+
   const results: SetupApplyResult[] = [];
   for (const wanted of body.spaces) {
     const id = slugify(wanted.name);
@@ -101,22 +118,34 @@ export async function tryHandleSetupRoute(
       try {
         space = spaceService.createSpace({ name: wanted.name });
         created = true;
-      } catch {
-        // Race: a concurrent caller created it first; reuse the winner.
+      } catch (err) {
+        // Distinguish concurrent-create races (existing space appears on
+        // re-lookup) from genuine creation failures (slug invalid, storage
+        // error). The old over-broad catch reported every failure as a
+        // generic per-path issue, hiding real bugs.
         const existing = spaceService.getSpace(id);
-        if (!existing) {
-          results.push({ spaceId: id, name: wanted.name, created: false, paths: wanted.paths.map((path) => ({ path, status: "failed", error: "space create failed" })) });
+        if (existing) {
+          space = existing;
+        } else {
+          const msg = (err as Error).message || "space create failed";
+          results.push({
+            spaceId: id,
+            name: wanted.name,
+            created: false,
+            paths: wanted.paths.map((path) => ({ path, status: "failed", error: msg })),
+          });
           continue;
         }
-        space = existing;
       }
     }
 
     const pathReports: SetupApplyResult["paths"] = [];
+    let anyAttached = false;
     for (const p of wanted.paths) {
       try {
         spaceService.addSource(space.id, p);
         pathReports.push({ path: p, status: "attached" });
+        anyAttached = true;
       } catch (err) {
         const msg = (err as Error).message;
         const ownedElsewhere = /already attached/i.test(msg);
@@ -124,16 +153,25 @@ export async function tryHandleSetupRoute(
       }
     }
 
-    // Scan only when something actually attached — otherwise scanSpace would
-    // throw "no folders" on top of the per-path errors already in `paths`.
-    const anyAttached = pathReports.some((r) => r.status === "attached");
     if (anyAttached) {
-      try {
-        await spaceService.scanSpace(space.id);
-      } catch {
-        // Scan failure isn't fatal — the space + sources exist; the user can
-        // re-trigger a scan later. Per-path attach status is the source of truth.
-      }
+      // addSource backfills orphan sessions whose cwd matches the attached
+      // folder. Other attach flows broadcast `session_changed` so connected
+      // clients re-attribute those sessions immediately; without this here,
+      // newly-claimed sessions stay under Elsewhere until polling catches up.
+      broadcastUiEvent({
+        version: 1,
+        command: "session_changed",
+        payload: { id: null, reason: "setup_apply" },
+      });
+
+      // Fire-and-forget scan. The user-facing attach-folder route does the
+      // same thing for the same reason: a serial await on every space's
+      // scan blocks the apply response and is much more likely to hit
+      // client/proxy timeouts on multi-space applies with large repos.
+      void spaceService.scanSpace(space.id).catch(() => {
+        // Scan failure isn't fatal — the space + sources exist; user can
+        // re-trigger via a manual scan.
+      });
     }
 
     results.push({ spaceId: space.id, name: wanted.name, created, paths: pathReports });

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -1,0 +1,155 @@
+// /api/setup/apply — applies a SetupProposal the user has confirmed in the
+// SetupProposalPanel.
+//
+// The agent emits a proposal via the `propose_setup` MCP tool; the panel
+// renders, the user toggles/renames/drag-drops; on Apply the panel POSTs
+// the user's confirmed plan here. This route fans the writes out to
+// `space-service.onboard_space` (one call per space, with all paths in
+// the array — same convention the agent used to follow for direct calls).
+//
+// We intentionally skip a server-side proposal-id guard: the panel sends
+// the user's edited plan, not a confirmation of the original proposal.
+// Each path is validated by `addSource` (must exist on disk; not
+// already claimed by another space). Partial failures are surfaced
+// per-space so the UI can show what landed and what didn't.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { SpaceService } from "../space-service.js";
+import type { UiCommand, SetupApplyResult } from "../../../shared/types.js";
+import type { RouteCtx } from "../http-utils.js";
+import { slugify } from "../utils.js";
+
+export interface SetupRouteDeps {
+  spaceService: SpaceService;
+  /** Broadcasts SSE so connected clients refetch the spaces / artefacts
+   *  surface after batch-create. The panel itself also closes locally
+   *  when apply succeeds; the broadcast is for any other open tabs. */
+  broadcastUiEvent: (event: UiCommand) => void;
+}
+
+interface ApplyBodySpace {
+  name: string;
+  paths: string[];
+}
+
+interface ApplyBody {
+  /** Optional — included for telemetry / log correlation only; we don't
+   *  enforce it (the panel may have edited the proposal before applying). */
+  proposalId?: string;
+  spaces: ApplyBodySpace[];
+}
+
+function parseBody(body: unknown): ApplyBody | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Record<string, unknown>;
+  if (!Array.isArray(b.spaces)) return null;
+  const spaces: ApplyBodySpace[] = [];
+  for (const raw of b.spaces) {
+    if (!raw || typeof raw !== "object") return null;
+    const s = raw as Record<string, unknown>;
+    const name = typeof s.name === "string" ? s.name.trim() : "";
+    if (!name) return null;
+    if (!Array.isArray(s.paths)) return null;
+    const paths: string[] = [];
+    for (const p of s.paths) {
+      if (typeof p !== "string" || !p.trim()) return null;
+      paths.push(p);
+    }
+    spaces.push({ name, paths });
+  }
+  return {
+    proposalId: typeof b.proposalId === "string" ? b.proposalId : undefined,
+    spaces,
+  };
+}
+
+export async function tryHandleSetupRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: SetupRouteDeps,
+): Promise<boolean> {
+  const { sendJson, readJsonBody, rejectIfNonLocalOrigin } = ctx;
+  const { spaceService, broadcastUiEvent } = deps;
+
+  if (url !== "/api/setup/apply" || req.method !== "POST") return false;
+  if (rejectIfNonLocalOrigin()) return true;
+
+  let body: ApplyBody | null;
+  try {
+    body = parseBody(await readJsonBody());
+  } catch {
+    sendJson({ error: "invalid JSON body" }, 400);
+    return true;
+  }
+  if (!body) {
+    sendJson({ error: "invalid setup proposal: expected { spaces: [{ name, paths: [...] }] }" }, 400);
+    return true;
+  }
+  if (body.spaces.length === 0) {
+    sendJson({ error: "no spaces to create" }, 400);
+    return true;
+  }
+
+  const results: SetupApplyResult[] = [];
+  for (const wanted of body.spaces) {
+    const id = slugify(wanted.name);
+    let space = spaceService.getSpace(id);
+    let created = false;
+    if (!space) {
+      try {
+        space = spaceService.createSpace({ name: wanted.name });
+        created = true;
+      } catch {
+        // Race: a concurrent caller created it first; reuse the winner.
+        const existing = spaceService.getSpace(id);
+        if (!existing) {
+          results.push({ spaceId: id, name: wanted.name, created: false, paths: wanted.paths.map((path) => ({ path, status: "failed", error: "space create failed" })) });
+          continue;
+        }
+        space = existing;
+      }
+    }
+
+    const pathReports: SetupApplyResult["paths"] = [];
+    for (const p of wanted.paths) {
+      try {
+        spaceService.addSource(space.id, p);
+        pathReports.push({ path: p, status: "attached" });
+      } catch (err) {
+        const msg = (err as Error).message;
+        const ownedElsewhere = /already attached/i.test(msg);
+        pathReports.push({ path: p, status: ownedElsewhere ? "owned-by-other-space" : "failed", error: msg });
+      }
+    }
+
+    // Scan only when something actually attached — otherwise scanSpace would
+    // throw "no folders" on top of the per-path errors already in `paths`.
+    const anyAttached = pathReports.some((r) => r.status === "attached");
+    if (anyAttached) {
+      try {
+        await spaceService.scanSpace(space.id);
+      } catch {
+        // Scan failure isn't fatal — the space + sources exist; the user can
+        // re-trigger a scan later. Per-path attach status is the source of truth.
+      }
+    }
+
+    results.push({ spaceId: space.id, name: wanted.name, created, paths: pathReports });
+  }
+
+  // Notify any other connected tab (the panel itself closes locally on its
+  // own apply success).
+  broadcastUiEvent({
+    version: 1,
+    command: "setup_applied",
+    payload: {
+      proposal_id: body.proposalId ?? null,
+      space_count: results.length,
+    },
+  });
+
+  sendJson({ results });
+  return true;
+}

--- a/server/test/setup-route.test.ts
+++ b/server/test/setup-route.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import { tryHandleSetupRoute } from "../src/routes/setup.js";
+
+function fakeReqRes(method: "POST" | "GET", body: unknown = {}) {
+  const captured: { status?: number; json?: unknown } = {};
+  const ctx = {
+    sendJson: (j: unknown, s = 200) => {
+      captured.json = j;
+      captured.status = s;
+    },
+    sendError: (s: number, msg: string) => {
+      captured.status = s;
+      captured.json = { error: msg };
+    },
+    rejectIfNonLocalOrigin: () => false,
+    readJsonBody: async () => body,
+  };
+  const req = { method } as { method: string };
+  const res = {};
+  return { req, res, ctx, captured };
+}
+
+function makeSpaceService() {
+  const created: Record<string, { id: string; name: string }> = {};
+  return {
+    getSpace: vi.fn((id: string) => created[id]),
+    createSpace: vi.fn(({ name }: { name: string }) => {
+      const id = name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      const space = { id, name };
+      created[id] = space;
+      return space;
+    }),
+    addSource: vi.fn(),
+    scanSpace: vi.fn().mockResolvedValue({}),
+    _created: created,
+  };
+}
+
+describe("routes/setup — apply", () => {
+  it("returns 404-shaped false when method/url doesn't match", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    const { req, res, ctx } = fakeReqRes("GET");
+    const handled = await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("rejects an empty plan with 400", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    const { req, res, ctx, captured } = fakeReqRes("POST", { spaces: [] });
+    const handled = await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(400);
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed body (non-string path)", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    const { req, res, ctx, captured } = fakeReqRes("POST", {
+      spaces: [{ name: "ok", paths: [42] }],
+    });
+    const handled = await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(400);
+  });
+
+  it("creates spaces and attaches paths on the happy path", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    const { req, res, ctx, captured } = fakeReqRes("POST", {
+      proposalId: "p123",
+      spaces: [
+        { name: "oyster", paths: ["/abs/oyster", "/abs/oyster-os"] },
+        { name: "tokinvest", paths: ["/abs/tokinvest"] },
+      ],
+    });
+    const handled = await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(200);
+    const body = captured.json as { results: Array<{ created: boolean; paths: Array<{ status: string }> }> };
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0].created).toBe(true);
+    expect(body.results[0].paths.every((p) => p.status === "attached")).toBe(true);
+    expect(service.createSpace).toHaveBeenCalledTimes(2);
+    expect(service.addSource).toHaveBeenCalledTimes(3);
+    expect(service.scanSpace).toHaveBeenCalledTimes(2);
+    expect(broadcast).toHaveBeenCalledWith({
+      version: 1,
+      command: "setup_applied",
+      payload: { proposal_id: "p123", space_count: 2 },
+    });
+  });
+
+  it("surfaces per-path failures without aborting the whole apply", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    service.addSource.mockImplementation((_id: string, p: string) => {
+      if (p === "/abs/missing") throw new Error("path does not exist");
+    });
+    const { req, res, ctx, captured } = fakeReqRes("POST", {
+      spaces: [
+        { name: "oyster", paths: ["/abs/oyster", "/abs/missing"] },
+      ],
+    });
+    await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    const body = captured.json as { results: Array<{ paths: Array<{ status: string; error?: string }> }> };
+    expect(body.results[0].paths[0].status).toBe("attached");
+    expect(body.results[0].paths[1].status).toBe("failed");
+    expect(body.results[0].paths[1].error).toMatch(/does not exist/);
+    // Scan still runs because at least one path attached.
+    expect(service.scanSpace).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies path-already-attached as owned-by-other-space", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    service.addSource.mockImplementation(() => {
+      throw new Error("path already attached to another space");
+    });
+    const { req, res, ctx, captured } = fakeReqRes("POST", {
+      spaces: [{ name: "oyster", paths: ["/abs/p"] }],
+    });
+    await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    const body = captured.json as { results: Array<{ paths: Array<{ status: string }> }> };
+    expect(body.results[0].paths[0].status).toBe("owned-by-other-space");
+    // No paths attached → no scan.
+    expect(service.scanSpace).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing space on race / extend instead of duplicating", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    service.getSpace.mockReturnValueOnce({ id: "oyster", name: "oyster" });
+    const { req, res, ctx, captured } = fakeReqRes("POST", {
+      spaces: [{ name: "oyster", paths: ["/abs/p"] }],
+    });
+    await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    const body = captured.json as { results: Array<{ created: boolean }> };
+    expect(body.results[0].created).toBe(false);
+    expect(service.createSpace).not.toHaveBeenCalled();
+  });
+});

--- a/server/test/setup-route.test.ts
+++ b/server/test/setup-route.test.ts
@@ -169,4 +169,74 @@ describe("routes/setup — apply", () => {
     expect(body.results[0].created).toBe(false);
     expect(service.createSpace).not.toHaveBeenCalled();
   });
+
+  it("rejects two payload entries that slugify to the same id", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    const { req, res, ctx, captured } = fakeReqRes("POST", {
+      spaces: [
+        { name: "Foo", paths: ["/abs/a"] },
+        // "Foo Bar" and "foo-bar" both slugify to "foo-bar".
+        { name: "Foo Bar", paths: ["/abs/b"] },
+        { name: "foo-bar", paths: ["/abs/c"] },
+      ],
+    });
+    const handled = await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(400);
+    const body = captured.json as { error: string };
+    expect(body.error).toMatch(/foo-bar/);
+    expect(service.createSpace).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it("broadcasts session_changed when at least one path attaches", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    const { req, res, ctx } = fakeReqRes("POST", {
+      spaces: [{ name: "oyster", paths: ["/abs/p"] }],
+    });
+    await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    // Both session_changed (per-space) AND setup_applied (final) fire.
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "session_changed" }),
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "setup_applied" }),
+    );
+  });
+
+  it("does not block on scan — fires it without awaiting", async () => {
+    const broadcast = vi.fn();
+    const service = makeSpaceService();
+    let scanResolved = false;
+    service.scanSpace.mockImplementation(
+      () => new Promise<unknown>((resolve) => {
+        // Don't resolve in this tick — emulates a slow scan.
+        setTimeout(() => {
+          scanResolved = true;
+          resolve({});
+        }, 50);
+      }),
+    );
+    const { req, res, ctx } = fakeReqRes("POST", {
+      spaces: [{ name: "oyster", paths: ["/abs/p"] }],
+    });
+    await tryHandleSetupRoute(
+      req as never, res as never,
+      "/api/setup/apply", ctx as never,
+      { spaceService: service as never, broadcastUiEvent: broadcast },
+    );
+    // Response returned before scan finished — that's the point.
+    expect(scanResolved).toBe(false);
+    expect(service.scanSpace).toHaveBeenCalledTimes(1);
+  });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -188,9 +188,10 @@ export interface SetupProposalSpace {
  *  tool, broadcast over SSE as `setup_proposal_ready`, rendered by the
  *  standalone SetupProposalPanel. */
 export interface SetupProposal {
-  /** Server-issued id used to correlate apply requests with the proposal
-   *  the user reviewed (lets us reject stale applies if a newer proposal
-   *  has since arrived). */
+  /** Server-issued correlation id for telemetry / log lookup. The apply
+   *  route does NOT enforce it: the panel sends the user's edited plan,
+   *  not a ratification of the original proposal, so a stale id is fine.
+   *  Real safety lives in `addSource` validating each path on disk. */
   proposalId: string;
   spaces: SetupProposalSpace[];
   everythingElse: SetupProposalFolder[];

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -164,3 +164,44 @@ export interface UiCommand {
   payload: unknown;
   correlationId?: string;
 }
+
+/** A folder candidate in a setup proposal. Path is absolute (server-side);
+ *  label is the leaf basename for display. */
+export interface SetupProposalFolder {
+  path: string;
+  label: string;
+}
+
+/** A proposed space grouping in a setup proposal. The agent picks the name
+ *  and groups related folders; the user can edit names, toggle the space
+ *  on/off, and drag chips between spaces or to/from Everything else. */
+export interface SetupProposalSpace {
+  /** Stable client-side id used for selection / dnd. Not the slugified
+   *  space id — that's derived from the (possibly-edited) name on apply. */
+  key: string;
+  name: string;
+  reason?: string;
+  folders: SetupProposalFolder[];
+}
+
+/** Full proposal payload. Emitted by the agent via the `propose_setup` MCP
+ *  tool, broadcast over SSE as `setup_proposal_ready`, rendered by the
+ *  standalone SetupProposalPanel. */
+export interface SetupProposal {
+  /** Server-issued id used to correlate apply requests with the proposal
+   *  the user reviewed (lets us reject stale applies if a newer proposal
+   *  has since arrived). */
+  proposalId: string;
+  spaces: SetupProposalSpace[];
+  everythingElse: SetupProposalFolder[];
+}
+
+/** Per-space outcome from POST /api/setup/apply. Mirrors the shape returned
+ *  by the underlying onboard_space service so the UI can show partial
+ *  failures honestly. */
+export interface SetupApplyResult {
+  spaceId: string;
+  name: string;
+  created: boolean;
+  paths: Array<{ path: string; status: "attached" | "owned-by-other-space" | "failed"; error?: string }>;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@types/three": "^0.184.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -284,6 +285,45 @@
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@types/three": "^0.184.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -218,6 +218,13 @@ export default function App() {
     if (event.command === "setup_proposal_ready") {
       setSetupProposal(event.payload as SetupProposal);
     }
+    if (event.command === "setup_applied") {
+      // Another tab just applied a setup proposal. Refresh spaces +
+      // artefacts so this tab reflects what the apply created without
+      // waiting for the regular polling tick.
+      void fetchSpaces().then(setSpaces).catch(() => undefined);
+      void loadArtifacts().then(setArtifacts).catch(() => undefined);
+    }
   }), [loadArtifacts]);
 
   // Sync state from browser back/forward

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ViewerWindow } from "./components/ViewerWindow";
 import { TerminalWindow } from "./components/TerminalWindow";
 import { SpotlightSearch } from "./components/SpotlightSearch";
 import { OnboardingDock } from "./components/OnboardingDock";
+import { SetupProposalPanel } from "./components/SetupProposalPanel";
 import { AuthBadge } from "./components/AuthBadge";
 import { windowsReducer } from "./stores/windows";
 import {
@@ -20,7 +21,7 @@ import {
 import { subscribeUiEvents } from "./data/ui-events";
 import { shouldOpenFullscreen } from "../../shared/types";
 import { fetchSpaces, updateSpace, deleteSpace, convertFolderToSpace, promoteFolderToSpace } from "./data/spaces-api";
-import type { Space } from "../../shared/types";
+import type { Space, SetupProposal } from "../../shared/types";
 import { createSession, sendMessage } from "./data/chat-api";
 import "./App.css";
 
@@ -115,6 +116,10 @@ export default function App() {
   const [viewerHash, setViewerHash] = useState<string>(() => getUrlState().hash);
   const [connected, setConnected] = useState(true);
   const [aiError, setAiError] = useState<string | null>(null);
+  // Active proposal from the agent's `propose_setup` MCP tool (broadcast
+  // via SSE). Standalone overlay — not coupled to the chat. Triggered by
+  // the agent during first-run setup; cleared on Apply / Close.
+  const [setupProposal, setSetupProposal] = useState<SetupProposal | null>(null);
 
   // Active-space-aware artifact loader. Mirrors current activeSpace via a ref
   // so callers don't have to thread it through every closure (polling,
@@ -205,6 +210,9 @@ export default function App() {
         .then(setArtifacts)
         .catch((err) => console.warn("[oyster] artifact_changed refetch failed:", err));
       return;
+    }
+    if (event.command === "setup_proposal_ready") {
+      setSetupProposal(event.payload as SetupProposal);
     }
   }), [loadArtifacts]);
 
@@ -578,6 +586,22 @@ export default function App() {
       <OnboardingDock
         userSpaceCount={FORCE_ONBOARDING ? 0 : spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__").length}
       />
+
+      {setupProposal && (
+        <SetupProposalPanel
+          proposal={setupProposal}
+          onClose={() => setSetupProposal(null)}
+          onApplied={() => {
+            // Refresh spaces + artefacts so the surface reflects the new
+            // structure immediately. The server's `setup_applied` SSE event
+            // can also fan out to other tabs; this branch handles the apply
+            // tab itself.
+            void fetchSpaces().then(setSpaces).catch(() => undefined);
+            void loadArtifacts().then(setArtifacts).catch(() => undefined);
+            setSetupProposal(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/SetupProposalPanel.css
+++ b/web/src/components/SetupProposalPanel.css
@@ -94,10 +94,6 @@
   outline: 1px dashed rgba(124, 107, 255, 0.45);
 }
 
-.setup-row--unchecked .setup-name-btn,
-.setup-row--unchecked .setup-count,
-.setup-row--unchecked .setup-reason,
-.setup-row--unchecked .setup-chip { opacity: 0.4; }
 
 .setup-row-spacer { width: 18px; flex: 0 0 18px; }
 

--- a/web/src/components/SetupProposalPanel.css
+++ b/web/src/components/SetupProposalPanel.css
@@ -6,7 +6,11 @@
 .setup-overlay {
   position: fixed;
   inset: 0;
-  z-index: 950;
+  /* Above viewer windows (5100), Spotlight (5500), and existing modal
+     overlays (10000) defined in App.css. Setup is a blocking dialog and
+     must take precedence over anything that was open when the proposal
+     arrived. */
+  z-index: 11000;
   background: rgba(8, 9, 22, 0.78);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);

--- a/web/src/components/SetupProposalPanel.css
+++ b/web/src/components/SetupProposalPanel.css
@@ -1,0 +1,387 @@
+/* SetupProposalPanel — full-screen modal overlay rendered by App when the
+   agent emits propose_setup. Standalone primitive (not chat-coupled) so it
+   can be triggered from other surfaces later. Visual language matches the
+   mock at /tmp/setup-oyster-mock.html. */
+
+.setup-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 950;
+  background: rgba(8, 9, 22, 0.78);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 56px 24px;
+  overflow-y: auto;
+  font-family: "Space Grotesk", -apple-system, system-ui, sans-serif;
+  color: #f0f0f5;
+  animation: setup-overlay-in 0.18s ease;
+}
+
+@keyframes setup-overlay-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.setup-panel {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  background: rgba(20, 21, 40, 0.96);
+  border: 1px solid rgba(124, 107, 255, 0.22);
+  border-radius: 14px;
+  padding: 22px 22px 18px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  animation: setup-panel-in 0.22s ease;
+}
+
+@keyframes setup-panel-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.setup-header { margin-bottom: 18px; padding-right: 32px; }
+.setup-title  { font-size: 15px; font-weight: 600; margin: 0 0 4px; letter-spacing: -0.01em; }
+.setup-sub    {
+  font-size: 12.5px;
+  color: rgba(255, 255, 255, 0.55);
+  line-height: 1.5;
+  margin: 0;
+}
+.setup-sub strong { color: rgba(255, 255, 255, 0.85); font-weight: 600; }
+.setup-sub em     { color: rgba(255, 255, 255, 0.85); font-style: normal; }
+
+.setup-close {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  font-family: inherit;
+}
+.setup-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+/* Rows ------------------------------------------------------------- */
+
+.setup-rows { display: flex; flex-direction: column; }
+
+.setup-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  margin: 0 -8px;
+  transition: background 0.12s, border-color 0.12s;
+}
+.setup-row:last-of-type { border-bottom: none; }
+
+.setup-row--over {
+  background: rgba(124, 107, 255, 0.08);
+  outline: 1px dashed rgba(124, 107, 255, 0.45);
+}
+
+.setup-row--unchecked .setup-name-btn,
+.setup-row--unchecked .setup-count,
+.setup-row--unchecked .setup-reason,
+.setup-row--unchecked .setup-chip { opacity: 0.4; }
+
+.setup-row-spacer { width: 18px; flex: 0 0 18px; }
+
+/* Checkbox replica */
+.setup-check {
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1.5px solid rgba(255, 255, 255, 0.25);
+  background: transparent;
+  margin-top: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+  transition: background 0.12s, border-color 0.12s;
+}
+.setup-check--on {
+  background: rgba(124, 107, 255, 0.85);
+  border-color: rgba(124, 107, 255, 1);
+}
+.setup-check:hover { border-color: rgba(124, 107, 255, 0.9); }
+
+.setup-row-body { flex: 1; min-width: 0; }
+
+.setup-row-name {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.setup-name-btn {
+  background: none;
+  border: none;
+  padding: 1px 4px;
+  margin: 0 -4px;
+  border-radius: 5px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  cursor: text;
+  transition: background 0.1s;
+}
+.setup-name-btn:hover { background: rgba(255, 255, 255, 0.05); }
+.setup-name-empty { color: rgba(255, 255, 255, 0.4); font-style: italic; }
+
+.setup-name-static {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.72);
+  padding: 1px 0;
+}
+
+.setup-name-input {
+  background: rgba(124, 107, 255, 0.08);
+  border: 1px solid rgba(124, 107, 255, 0.5);
+  border-radius: 5px;
+  padding: 1px 7px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  outline: none;
+  width: 180px;
+}
+
+.setup-count {
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+}
+
+.setup-reason {
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.45);
+  line-height: 1.45;
+  font-style: italic;
+}
+
+/* Chips ------------------------------------------------------------ */
+
+.setup-chips {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.setup-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 4px 4px 10px;
+  background: rgba(124, 107, 255, 0.10);
+  border: 1px solid rgba(124, 107, 255, 0.22);
+  border-radius: 7px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: grab;
+  transition: background 0.12s, border-color 0.12s, transform 0.12s, box-shadow 0.12s;
+  user-select: none;
+  touch-action: none;
+}
+.setup-chip:hover {
+  background: rgba(124, 107, 255, 0.18);
+  border-color: rgba(124, 107, 255, 0.4);
+  transform: translateY(-1px);
+}
+.setup-chip:active { cursor: grabbing; }
+.setup-chip--dragging {
+  opacity: 0.4;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+}
+.setup-chip--elsewhere {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+.setup-chip--elsewhere:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+
+.setup-chip-label {
+  /* Ensures the label width holds when the × is hidden */
+  padding-right: 4px;
+}
+.setup-chip:has(.setup-chip-x) .setup-chip-label {
+  padding-right: 0;
+}
+
+.setup-chip-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+  margin-left: 1px;
+}
+.setup-chip-x:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+/* Empty space / Add space ----------------------------------------- */
+
+.setup-empty-msg {
+  margin-top: 8px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.setup-remove-btn {
+  background: transparent;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: rgba(239, 68, 68, 0.85);
+  font-family: inherit;
+  font-size: 11.5px;
+  padding: 3px 9px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.setup-remove-btn:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.55);
+}
+
+.setup-add-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 8px 14px;
+  margin: 0 -8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.setup-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px dashed rgba(124, 107, 255, 0.35);
+  color: rgba(165, 151, 255, 0.95);
+  border-radius: 7px;
+  padding: 5px 12px;
+  font-family: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.setup-add-btn:hover {
+  background: rgba(124, 107, 255, 0.08);
+  border-color: rgba(124, 107, 255, 0.55);
+  color: #fff;
+}
+
+/* Everything-else specific styling — distinct from a regular space row,
+   even though it shares the .setup-row base. */
+.setup-row--elsewhere {
+  margin-top: 4px;
+  padding-top: 14px;
+  border-top: 1px dashed rgba(255, 255, 255, 0.08);
+  border-bottom: none;
+}
+
+/* Footer ----------------------------------------------------------- */
+
+.setup-error {
+  margin-top: 14px;
+  padding: 10px 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: 8px;
+  color: rgba(255, 195, 195, 0.95);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.setup-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+  padding-top: 4px;
+}
+
+.setup-btn-primary {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  background: rgba(124, 107, 255, 0.85);
+  color: #fff;
+  border: 1px solid rgba(124, 107, 255, 1);
+  transition: background 0.12s;
+}
+.setup-btn-primary:hover:not(:disabled) {
+  background: rgba(124, 107, 255, 0.95);
+}
+.setup-btn-primary:disabled {
+  background: rgba(124, 107, 255, 0.35);
+  border-color: rgba(124, 107, 255, 0.45);
+  cursor: default;
+  opacity: 0.6;
+}
+
+.setup-btn-ghost {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.setup-btn-ghost:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.25);
+}
+.setup-btn-ghost:disabled { opacity: 0.5; cursor: default; }

--- a/web/src/components/SetupProposalPanel.tsx
+++ b/web/src/components/SetupProposalPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
+  KeyboardSensor,
   PointerSensor,
   useDraggable,
   useDroppable,
@@ -50,10 +51,14 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
 
-  // Pointer-only dnd for v1. 4px activation distance keeps regular clicks
-  // (rename, ×, toggle) from being interpreted as drag-starts.
+  // Pointer + keyboard dnd. 4px activation distance on pointer keeps
+  // regular clicks (rename, ×, toggle) from being interpreted as drag-
+  // starts. Keyboard sensor restores arrow-key chip moves so this flow
+  // isn't pointer-only — chip reassignment is core to setup, not optional
+  // polish.
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor),
   );
 
   const includedCount = useMemo(
@@ -207,8 +212,20 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
         body: JSON.stringify(body),
       });
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        throw new Error(text || `apply failed (HTTP ${res.status})`);
+        // Server returns JSON envelopes like `{ error: "..." }`. Parse
+        // when possible so the user sees the actual message instead of
+        // raw JSON. Fall through to the status text only on parse failure.
+        let message = `apply failed (HTTP ${res.status})`;
+        try {
+          const data = (await res.json()) as { error?: string };
+          if (typeof data.error === "string" && data.error.length > 0) {
+            message = data.error;
+          }
+        } catch {
+          const text = await res.text().catch(() => "");
+          if (text) message = text;
+        }
+        throw new Error(message);
       }
       const data = (await res.json()) as { results: SetupApplyResult[] };
       onApplied(data.results);
@@ -220,6 +237,19 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
     }
     // On success: stay disabled; onApplied closes the panel.
   }, [proposal.proposalId, spaces, onApplied]);
+
+  // Reset the panel state when a new proposal arrives. Without this, a
+  // second `setup_proposal_ready` event (e.g. user re-runs setup, or a
+  // future re-scan flow) would leave the panel rendering stale chips
+  // because useState only initialises on first mount. proposalId is the
+  // server-issued identity for the proposal, so a change there means new
+  // payload — clear edits and start fresh.
+  useEffect(() => {
+    setSpaces(proposal.spaces.map((s) => ({ ...s })));
+    setElsewhere(proposal.everythingElse);
+    setRenamingKey(null);
+    setApplyError(null);
+  }, [proposal.proposalId, proposal.spaces, proposal.everythingElse]);
 
   // Esc closes when not in the middle of an apply.
   useEffect(() => {
@@ -252,6 +282,11 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
               className="setup-close"
               onClick={onClose}
               aria-label="Close"
+              // Block all dismissal paths while a request is in flight —
+              // unmounting mid-apply hides applyError and the user never
+              // learns whether their write succeeded. Esc handler also
+              // gates on `applying`.
+              disabled={applying}
             >
               ×
             </button>

--- a/web/src/components/SetupProposalPanel.tsx
+++ b/web/src/components/SetupProposalPanel.tsx
@@ -114,11 +114,17 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
   const handleDemoteChip = useCallback(
     (folder: SetupProposalFolder, fromSpaceKey: string) => {
       setSpaces((s) =>
-        s.map((x) =>
-          x.key === fromSpaceKey
-            ? { ...x, folders: x.folders.filter((f) => f.path !== folder.path) }
-            : x,
-        ),
+        s
+          .map((x) =>
+            x.key === fromSpaceKey
+              ? { ...x, folders: x.folders.filter((f) => f.path !== folder.path) }
+              : x,
+          )
+          // Auto-remove on last-chip-out: an empty space mid-flow is just
+          // visual noise. The "Remove space" button is still there as an
+          // escape hatch for "+ Add space" rows the user creates and then
+          // abandons before dragging anything in.
+          .filter((x) => x.key !== fromSpaceKey || x.folders.length > 0),
       );
       setElsewhere((e) =>
         e.some((f) => f.path === folder.path) ? e : [...e, folder],
@@ -155,6 +161,14 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
             : x,
         );
       }
+      // Auto-remove the source space if the drag emptied it. Only matches
+      // the source — newly-empty target spaces don't exist (a target is
+      // either Everything else, an existing populated space, or a "+ Add"
+      // row the user is intentionally filling).
+      next = next.filter(
+        (x) =>
+          spaceDropId(x.key) !== data.fromContainer || x.folders.length > 0,
+      );
       return next;
     });
 

--- a/web/src/components/SetupProposalPanel.tsx
+++ b/web/src/components/SetupProposalPanel.tsx
@@ -1,0 +1,511 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import type {
+  SetupProposal,
+  SetupProposalFolder,
+  SetupApplyResult,
+} from "../../../shared/types";
+import "./SetupProposalPanel.css";
+
+// Container ids used by dnd-kit to identify drop targets. Spaces use the
+// proposal-space `key` (stable for the lifetime of the panel); Everything
+// else has a single fixed id.
+const ELSEWHERE_ID = "elsewhere";
+const spaceDropId = (key: string) => `space:${key}`;
+
+interface SpaceRow {
+  key: string;
+  name: string;
+  reason?: string;
+  folders: SetupProposalFolder[];
+  included: boolean;
+}
+
+interface DragData {
+  folder: SetupProposalFolder;
+  fromContainer: string;
+}
+
+interface Props {
+  proposal: SetupProposal;
+  onClose: () => void;
+  onApplied: (results: SetupApplyResult[]) => void;
+}
+
+export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
+  const [spaces, setSpaces] = useState<SpaceRow[]>(() =>
+    proposal.spaces.map((s) => ({ ...s, included: true })),
+  );
+  const [elsewhere, setElsewhere] = useState<SetupProposalFolder[]>(
+    proposal.everythingElse,
+  );
+  const [renamingKey, setRenamingKey] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  // Pointer-only dnd for v1. 4px activation distance keeps regular clicks
+  // (rename, ×, toggle) from being interpreted as drag-starts.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  );
+
+  const includedCount = useMemo(
+    () =>
+      spaces.filter(
+        (s) => s.included && s.name.trim() !== "" && s.folders.length > 0,
+      ).length,
+    [spaces],
+  );
+
+  const handleToggle = useCallback((key: string) => {
+    setSpaces((s) =>
+      s.map((x) => (x.key === key ? { ...x, included: !x.included } : x)),
+    );
+  }, []);
+
+  const handleStartRename = useCallback((key: string) => {
+    setRenamingKey(key);
+  }, []);
+
+  const handleCommitRename = useCallback((key: string, nextName: string) => {
+    const trimmed = nextName.trim();
+    setSpaces((s) =>
+      s.map((x) => (x.key === key ? { ...x, name: trimmed || x.name } : x)),
+    );
+    setRenamingKey(null);
+  }, []);
+
+  const handleAddSpace = useCallback(() => {
+    const key = `s${Date.now()}-new`;
+    setSpaces((s) => [
+      ...s,
+      { key, name: "", folders: [], included: true },
+    ]);
+    setRenamingKey(key);
+  }, []);
+
+  const handleRemoveSpace = useCallback((key: string) => {
+    // Defensive: only allow remove on empty rows. The button shouldn't be
+    // visible otherwise, but enforce it here too in case of stale DOM.
+    setSpaces((s) =>
+      s.filter((x) => x.key !== key || x.folders.length > 0),
+    );
+  }, []);
+
+  const handleDemoteChip = useCallback(
+    (folder: SetupProposalFolder, fromSpaceKey: string) => {
+      setSpaces((s) =>
+        s.map((x) =>
+          x.key === fromSpaceKey
+            ? { ...x, folders: x.folders.filter((f) => f.path !== folder.path) }
+            : x,
+        ),
+      );
+      setElsewhere((e) =>
+        e.some((f) => f.path === folder.path) ? e : [...e, folder],
+      );
+    },
+    [],
+  );
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const data = active.data.current as DragData | undefined;
+    if (!data) return;
+    const targetId = String(over.id);
+    if (data.fromContainer === targetId) return;
+
+    setSpaces((prev) => {
+      // Remove from source space (if applicable)
+      let next = prev.map((x) =>
+        spaceDropId(x.key) === data.fromContainer
+          ? {
+              ...x,
+              folders: x.folders.filter((f) => f.path !== data.folder.path),
+            }
+          : x,
+      );
+      // Add to target space (if target is a space)
+      if (targetId.startsWith("space:")) {
+        next = next.map((x) =>
+          spaceDropId(x.key) === targetId
+            ? x.folders.some((f) => f.path === data.folder.path)
+              ? x
+              : { ...x, folders: [...x.folders, data.folder] }
+            : x,
+        );
+      }
+      return next;
+    });
+
+    setElsewhere((prev) => {
+      // Remove from elsewhere if dragged out of it
+      let next =
+        data.fromContainer === ELSEWHERE_ID
+          ? prev.filter((f) => f.path !== data.folder.path)
+          : prev;
+      // Add to elsewhere if dropped there
+      if (targetId === ELSEWHERE_ID) {
+        next = next.some((f) => f.path === data.folder.path)
+          ? next
+          : [...next, data.folder];
+      }
+      return next;
+    });
+  }, []);
+
+  const handleApply = useCallback(async () => {
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const body = {
+        proposalId: proposal.proposalId,
+        spaces: spaces
+          .filter(
+            (s) => s.included && s.name.trim() !== "" && s.folders.length > 0,
+          )
+          .map((s) => ({
+            name: s.name.trim(),
+            paths: s.folders.map((f) => f.path),
+          })),
+      };
+      const res = await fetch("/api/setup/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `apply failed (HTTP ${res.status})`);
+      }
+      const data = (await res.json()) as { results: SetupApplyResult[] };
+      onApplied(data.results);
+    } catch (err) {
+      setApplyError(
+        err instanceof Error ? err.message : "Couldn't apply your setup",
+      );
+      setApplying(false);
+    }
+    // On success: stay disabled; onApplied closes the panel.
+  }, [proposal.proposalId, spaces, onApplied]);
+
+  // Esc closes when not in the middle of an apply.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && !applying) onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, applying]);
+
+  const totalProjects = proposal.spaces.length;
+  const headline =
+    totalProjects === 0
+      ? "No projects detected"
+      : `Found ${totalProjects} ${totalProjects === 1 ? "project" : "projects"} across your dev folder`;
+
+  return (
+    <div className="setup-overlay" role="dialog" aria-label="Set up Oyster" aria-modal="true">
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <div className="setup-panel" onClick={(e) => e.stopPropagation()}>
+          <header className="setup-header">
+            <h2 className="setup-title">{headline}</h2>
+            <p className="setup-sub">
+              Untick spaces you don't want, click <strong>×</strong> on a folder
+              to push it back to <em>Everything else</em>, or drag chips to
+              rearrange.
+            </p>
+            <button
+              type="button"
+              className="setup-close"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </header>
+
+          <div className="setup-rows">
+            {spaces.map((space) => (
+              <SpaceRowView
+                key={space.key}
+                space={space}
+                renaming={renamingKey === space.key}
+                onToggle={handleToggle}
+                onStartRename={handleStartRename}
+                onCommitRename={handleCommitRename}
+                onRemove={handleRemoveSpace}
+                onDemoteChip={handleDemoteChip}
+              />
+            ))}
+
+            <div className="setup-add-row">
+              <span className="setup-row-spacer" />
+              <button
+                type="button"
+                className="setup-add-btn"
+                onClick={handleAddSpace}
+              >
+                + Add space
+              </button>
+            </div>
+
+            <ElsewhereView folders={elsewhere} />
+          </div>
+
+          {applyError && <div className="setup-error">{applyError}</div>}
+
+          <div className="setup-actions">
+            <button
+              type="button"
+              className="setup-btn-primary"
+              disabled={includedCount === 0 || applying}
+              onClick={handleApply}
+            >
+              {applying
+                ? "Creating…"
+                : includedCount === 0
+                  ? "Nothing to create"
+                  : `Create ${includedCount} space${includedCount === 1 ? "" : "s"}`}
+            </button>
+            <button
+              type="button"
+              className="setup-btn-ghost"
+              onClick={onClose}
+              disabled={applying}
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      </DndContext>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Space row                                                           */
+/* ------------------------------------------------------------------ */
+
+interface SpaceRowProps {
+  space: SpaceRow;
+  renaming: boolean;
+  onToggle: (key: string) => void;
+  onStartRename: (key: string) => void;
+  onCommitRename: (key: string, nextName: string) => void;
+  onRemove: (key: string) => void;
+  onDemoteChip: (folder: SetupProposalFolder, fromSpaceKey: string) => void;
+}
+
+function SpaceRowView({
+  space,
+  renaming,
+  onToggle,
+  onStartRename,
+  onCommitRename,
+  onRemove,
+  onDemoteChip,
+}: SpaceRowProps) {
+  const dropId = spaceDropId(space.key);
+  const { isOver, setNodeRef } = useDroppable({ id: dropId });
+  const isEmpty = space.folders.length === 0;
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`setup-row${isOver ? " setup-row--over" : ""}${space.included ? "" : " setup-row--unchecked"}`}
+    >
+      <button
+        type="button"
+        className={`setup-check${space.included ? " setup-check--on" : ""}`}
+        onClick={() => onToggle(space.key)}
+        aria-label={space.included ? "Untick space" : "Tick space"}
+      >
+        {space.included && <span aria-hidden="true">✓</span>}
+      </button>
+
+      <div className="setup-row-body">
+        <div className="setup-row-name">
+          {renaming ? (
+            <RenameInput
+              initial={space.name}
+              onCommit={(v) => onCommitRename(space.key, v)}
+              onCancel={() => onCommitRename(space.key, space.name)}
+            />
+          ) : (
+            <button
+              type="button"
+              className="setup-name-btn"
+              onClick={() => onStartRename(space.key)}
+              title="Click to rename"
+            >
+              {space.name || <span className="setup-name-empty">untitled</span>}
+            </button>
+          )}
+          <span className="setup-count">
+            {isEmpty
+              ? "empty"
+              : `${space.folders.length} ${space.folders.length === 1 ? "folder" : "folders"}`}
+          </span>
+        </div>
+        {space.reason && !isEmpty && (
+          <div className="setup-reason">{space.reason}</div>
+        )}
+
+        {isEmpty ? (
+          <div className="setup-empty-msg">
+            Nothing here yet.
+            <button
+              type="button"
+              className="setup-remove-btn"
+              onClick={() => onRemove(space.key)}
+            >
+              Remove space
+            </button>
+          </div>
+        ) : (
+          <div className="setup-chips">
+            {space.folders.map((folder) => (
+              <ChipView
+                key={folder.path}
+                folder={folder}
+                fromContainer={dropId}
+                onDemote={() => onDemoteChip(folder, space.key)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Everything else                                                     */
+/* ------------------------------------------------------------------ */
+
+function ElsewhereView({ folders }: { folders: SetupProposalFolder[] }) {
+  const { isOver, setNodeRef } = useDroppable({ id: ELSEWHERE_ID });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`setup-row setup-row--elsewhere${isOver ? " setup-row--over" : ""}`}
+    >
+      <span className="setup-row-spacer" />
+      <div className="setup-row-body">
+        <div className="setup-row-name">
+          <span className="setup-name-static">Everything else</span>
+          <span className="setup-count">
+            {folders.length === 0
+              ? "0 folders"
+              : `${folders.length} ${folders.length === 1 ? "folder" : "folders"}`}
+          </span>
+        </div>
+        {folders.length > 0 && (
+          <div className="setup-chips">
+            {folders.map((folder) => (
+              <ChipView
+                key={folder.path}
+                folder={folder}
+                fromContainer={ELSEWHERE_ID}
+                hideX
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Chip                                                                */
+/* ------------------------------------------------------------------ */
+
+interface ChipProps {
+  folder: SetupProposalFolder;
+  fromContainer: string;
+  hideX?: boolean;
+  onDemote?: () => void;
+}
+
+function ChipView({ folder, fromContainer, hideX, onDemote }: ChipProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `chip:${fromContainer}:${folder.path}`,
+    data: { folder, fromContainer } satisfies DragData,
+  });
+  return (
+    <span
+      ref={setNodeRef}
+      className={`setup-chip${isDragging ? " setup-chip--dragging" : ""}${fromContainer === ELSEWHERE_ID ? " setup-chip--elsewhere" : ""}`}
+      {...listeners}
+      {...attributes}
+    >
+      <span className="setup-chip-label">{folder.label}</span>
+      {!hideX && onDemote && (
+        <button
+          type="button"
+          className="setup-chip-x"
+          // Stop dnd-kit's listeners from intercepting the click — without
+          // this, click registers as a drag-start and the demote never fires.
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDemote();
+          }}
+          title="Move to Everything else"
+        >
+          ×
+        </button>
+      )}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Inline rename input                                                 */
+/* ------------------------------------------------------------------ */
+
+function RenameInput({
+  initial,
+  onCommit,
+  onCancel,
+}: {
+  initial: string;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      className="setup-name-input"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => onCommit(value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onCommit(value);
+        if (e.key === "Escape") onCancel();
+      }}
+      placeholder="space name"
+      // Stop dnd from picking up keystrokes / pointer events on the input
+      onPointerDown={(e) => e.stopPropagation()}
+    />
+  );
+}

--- a/web/src/components/SetupProposalPanel.tsx
+++ b/web/src/components/SetupProposalPanel.tsx
@@ -26,7 +26,6 @@ interface SpaceRow {
   name: string;
   reason?: string;
   folders: SetupProposalFolder[];
-  included: boolean;
 }
 
 interface DragData {
@@ -42,7 +41,7 @@ interface Props {
 
 export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
   const [spaces, setSpaces] = useState<SpaceRow[]>(() =>
-    proposal.spaces.map((s) => ({ ...s, included: true })),
+    proposal.spaces.map((s) => ({ ...s })),
   );
   const [elsewhere, setElsewhere] = useState<SetupProposalFolder[]>(
     proposal.everythingElse,
@@ -59,16 +58,31 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
 
   const includedCount = useMemo(
     () =>
-      spaces.filter(
-        (s) => s.included && s.name.trim() !== "" && s.folders.length > 0,
-      ).length,
+      spaces.filter((s) => s.name.trim() !== "" && s.folders.length > 0).length,
     [spaces],
   );
 
+  // Untick = bulk demote. The chips drop into Everything else and the
+  // space row goes away — cleaner than the soft-dim alternative, which
+  // left chips stranded in a row that wouldn't apply anywhere. If the
+  // user changes their mind, "+ Add space" + drag-back is the path.
+  // Toggle is therefore one-way: a row only exists when it's a real
+  // candidate for creation.
   const handleToggle = useCallback((key: string) => {
-    setSpaces((s) =>
-      s.map((x) => (x.key === key ? { ...x, included: !x.included } : x)),
-    );
+    let dropped: SetupProposalFolder[] = [];
+    setSpaces((prev) => {
+      const target = prev.find((x) => x.key === key);
+      if (!target) return prev;
+      dropped = target.folders;
+      return prev.filter((x) => x.key !== key);
+    });
+    if (dropped.length > 0) {
+      setElsewhere((e) => {
+        const seen = new Set(e.map((f) => f.path));
+        const additions = dropped.filter((f) => !seen.has(f.path));
+        return additions.length > 0 ? [...e, ...additions] : e;
+      });
+    }
   }, []);
 
   const handleStartRename = useCallback((key: string) => {
@@ -85,10 +99,7 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
 
   const handleAddSpace = useCallback(() => {
     const key = `s${Date.now()}-new`;
-    setSpaces((s) => [
-      ...s,
-      { key, name: "", folders: [], included: true },
-    ]);
+    setSpaces((s) => [...s, { key, name: "", folders: [] }]);
     setRenamingKey(key);
   }, []);
 
@@ -170,9 +181,7 @@ export function SetupProposalPanel({ proposal, onClose, onApplied }: Props) {
       const body = {
         proposalId: proposal.proposalId,
         spaces: spaces
-          .filter(
-            (s) => s.included && s.name.trim() !== "" && s.folders.length > 0,
-          )
+          .filter((s) => s.name.trim() !== "" && s.folders.length > 0)
           .map((s) => ({
             name: s.name.trim(),
             paths: s.folders.map((f) => f.path),
@@ -322,15 +331,16 @@ function SpaceRowView({
   return (
     <div
       ref={setNodeRef}
-      className={`setup-row${isOver ? " setup-row--over" : ""}${space.included ? "" : " setup-row--unchecked"}`}
+      className={`setup-row${isOver ? " setup-row--over" : ""}`}
     >
       <button
         type="button"
-        className={`setup-check${space.included ? " setup-check--on" : ""}`}
+        className="setup-check setup-check--on"
         onClick={() => onToggle(space.key)}
-        aria-label={space.included ? "Untick space" : "Tick space"}
+        aria-label="Untick — drop chips into Everything else and remove this space"
+        title="Untick to drop chips into Everything else"
       >
-        {space.included && <span aria-hidden="true">✓</span>}
+        <span aria-hidden="true">✓</span>
       </button>
 
       <div className="setup-row-body">


### PR DESCRIPTION
## Summary

Replaces the agent's markdown-wall response to "Set up Oyster" with a **standalone interactive panel** — chips for folders, drag-and-drop between spaces, an Everything-else bucket, inline rename, +Add space, Remove empty space, and a single Apply button.

This is **PR B** of the two-PR onboarding overhaul. PR A (#376) reshaped the dock into a checklist; this one rebuilds the *flow that triggers from* the dock's required-step CTA.

## Why decoupled

The panel is **not** rendered inside a chat message — it's an App-mounted overlay triggered by an SSE event. Reasons:

- Re-scan after adding new folders shouldn't require a fresh chat session
- External MCP agents (Claude Code, Cursor) calling `propose_setup` should still surface a panel in Oyster's UI, not in their own chat
- "We detected your config from another machine" / "Reorganise existing spaces" — same primitive, different invocations
- A modal has the room drag-and-drop needs (stable viewport, clear drop zones, no scroll-thrash)

## Pipeline

1. User clicks "Set up Oyster" in dock or hero → chat sends the prompt
2. Agent runs the existing filesystem audit (shell tools — unchanged)
3. **New:** agent calls `propose_setup({ spaces, everythingElse })` instead of writing markdown
4. Server broadcasts `setup_proposal_ready` SSE event with the payload
5. App listens → mounts `<SetupProposalPanel>` overlay
6. User toggles / renames / drags / adds / removes / applies
7. Panel POSTs to `/api/setup/apply` — server fans writes out via existing `space-service.onboard_space`
8. SSE `setup_applied` for other tabs; apply tab refreshes spaces + artefacts and closes the panel

## What changes

- `shared/types.ts` — `SetupProposal*` + `SetupApplyResult` types
- `server/src/mcp-server.ts` — new `propose_setup` MCP tool. Rewrote the `get_context` "Set up Oyster" playbook (Steps 3 + 4) to point the agent at the tool and explicitly forbid writing markdown plans or calling `onboard_space` directly.
- `server/src/routes/setup.ts` (new) — `POST /api/setup/apply`. Validates body, fans out to onboard_space, surfaces per-path failures honestly.
- `server/test/setup-route.test.ts` (new) — **7 tests:** happy path, empty plan, malformed body (non-string path), partial path failures, owned-by-other-space classification, race-on-existing reuse, and the SSE broadcast.
- `web/src/components/SetupProposalPanel.tsx` (new) — full panel: rows, chips, dnd via `@dnd-kit/core` (~12 KB, modern React, good a11y baseline), inline rename, +Add space, Remove empty space, Apply with per-space result handling.
- `web/src/components/SetupProposalPanel.css` (new) — visual language matches the mock the user signed off on.
- `web/src/App.tsx` — listens for `setup_proposal_ready`, mounts the panel, refreshes spaces + artefacts on apply.

## Decisions worth surfacing

- **No proposal-id enforcement on apply.** The panel sends the user's *edited* plan, not a ratified original. Each path is validated by `addSource` (must exist, must not be claimed by another space). proposalId is logged for telemetry only.
- **Pointer-only dnd in v1.** 4px activation distance keeps regular clicks (rename, `×`, toggle) from being interpreted as drag-starts. Keyboard a11y is `@dnd-kit/core`-default for now; deeper polish if it earns it.
- **Empty-space removal is gated.** A space with no chips shows a `Remove space` button; populated spaces don't. Destruction is allowed when nothing's at stake. Untick is the reversible alternative for populated spaces.
- **Apply behaviour for partial failures.** Each space returns its per-path status; the apply doesn't abort. UI currently closes optimistically — partial-failure UX (showing per-space results) is a future-iteration polish.
- **Skeleton state during agent scan deferred.** Local-fs scans are <2s in practice. We'll add a placeholder if we hit pain.

## Test plan

- [x] Both packages typecheck clean (web + server)
- [x] All 63 server tests pass — 7 new in setup-route + the 56 inherited
- [x] `propose_setup` tool surfaces in MCP listing (no schema/zod errors)
- [x] Vite builds; `@dnd-kit/core` resolves
- [ ] **Visual smoke** (deferred to reviewer): force-onboarding mode → click "Set up Oyster" in dock → verify panel renders with detected proposal, drag a chip between spaces, click `×` to demote, rename a space, +Add space, Apply → spaces materialise on the surface
- [ ] **Apply error path** (also deferred): kill the server mid-apply → confirm error banner shows in the panel without blowing up state

## Follow-ups

- Per-space apply-results UI (show what landed and what didn't)
- Skeleton state during agent scan
- "Re-scan & propose" entry point in Settings (re-uses the same panel)
- Keyboard-driven dnd polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)