### PR TITLE
fix(chat): queue "Set up Oyster" prompt clicks while session boots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **"Set up Oyster" no longer ignores early clicks.** If you click the prompt before the chat has finished booting, the click is now queued and fires automatically the moment the session is ready — instead of silently doing nothing.
 - **Clicking an artefact in the session inspector** now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.
 - **Attaching a folder to a space** now sweeps in any sessions already running in that folder, instead of leaving them stranded under Unsorted.
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -338,6 +338,7 @@
 </ul>
 <h3>Fixed</h3>
 <ul>
+<li><strong>&quot;Set up Oyster&quot; no longer ignores early clicks.</strong> If you click the prompt before the chat has finished booting, the click is now queued and fires automatically the moment the session is ready — instead of silently doing nothing.</li>
 <li><strong>Clicking an artefact in the session inspector</strong> now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.</li>
 <li><strong>Attaching a folder to a space</strong> now sweeps in any sessions already running in that folder, instead of leaving them stranded under Unsorted.</li>
 </ul>

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -394,17 +394,18 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
     }
   }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts]);
 
-  // Drain any queued prompt as soon as the session is ready. This is what
-  // makes the click-while-booting case resolve correctly: handleSend
-  // captured the text into pendingPromptRef and returned; once sessionId
-  // flips truthy, we re-fire through the same code path.
+  // Drain any queued prompt as soon as the session is ready AND nothing
+  // is streaming. handleSend's other guard is `streaming`; if we drained
+  // and called through while a stream was in flight, the call would
+  // early-return and the prompt would be silently lost. Listening on
+  // `streaming` too means the effect re-fires when it flips false.
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId || streaming) return;
     const queued = pendingPromptRef.current;
     if (!queued) return;
     pendingPromptRef.current = null;
     handleSend(queued);
-  }, [sessionId, handleSend]);
+  }, [sessionId, streaming, handleSend]);
 
   // Cross-component prompt trigger. Other surfaces (currently the onboarding
   // dock's "Set up Oyster" button) dispatch `oyster:send-prompt` with a text

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -256,9 +256,21 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [expanded, setExpanded]);
 
+  // Queue for prompts dispatched before the chat session has finished
+  // initialising. createSession() can take a few seconds while OpenCode
+  // boots; without this, clicking "Set up Oyster" during the boot window
+  // silently no-ops because handleSend bails on `!sessionId`. Now we
+  // capture the latest pending text and drain it once sessionId arrives.
+  const pendingPromptRef = useRef<string | null>(null);
+
   const handleSend = useCallback(async (override?: string) => {
     const raw = override ?? input;
-    if (!raw.trim() || streaming || !sessionId) return;
+    if (!raw.trim() || streaming) return;
+    if (!sessionId) {
+      // Session still booting — queue and let the drain effect fire it.
+      pendingPromptRef.current = raw;
+      return;
+    }
     const content = raw;
 
     // ── # commands — instant space switch, no LLM call ──
@@ -382,6 +394,18 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
     }
   }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts]);
 
+  // Drain any queued prompt as soon as the session is ready. This is what
+  // makes the click-while-booting case resolve correctly: handleSend
+  // captured the text into pendingPromptRef and returned; once sessionId
+  // flips truthy, we re-fire through the same code path.
+  useEffect(() => {
+    if (!sessionId) return;
+    const queued = pendingPromptRef.current;
+    if (!queued) return;
+    pendingPromptRef.current = null;
+    handleSend(queued);
+  }, [sessionId, handleSend]);
+
   // Cross-component prompt trigger. Other surfaces (currently the onboarding
   // dock's "Set up Oyster" button) dispatch `oyster:send-prompt` with a text
   // payload to fire the same handleSend path as the hero CTA. Detail.text
@@ -432,7 +456,10 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
                   type="button"
                   className="chatbar-hero-prompt"
                   onClick={() => handleSend("Set up Oyster")}
-                  disabled={!sessionId || streaming}
+                  // Only block during an active stream — when sessionId is
+                  // null (chat still booting), the click queues and fires
+                  // automatically once the session arrives.
+                  disabled={streaming}
                   tabIndex={taglineHidden ? -1 : 0}
                   title="Click to send, or type it yourself"
                 >


### PR DESCRIPTION
## What broke

Clicking the hero "Set up Oyster" button before the chat session had finished initialising silently did nothing — the button's \`disabled={!sessionId || streaming}\` guard hid the cause. From the user's POV: clicked, nothing happened, no feedback.

\`createSession()\` takes 2-5s while OpenCode boots, so this is a real hittable window — easy to land on if you reload while talking to the agent or open Oyster fresh.

## Fix

Two minimal changes in \`ChatBar.tsx\`:

1. **handleSend queues instead of bailing** when sessionId is null. The text goes into a \`pendingPromptRef\`; a \`useEffect\` on \`[sessionId]\` drains the ref the moment the session arrives, re-firing handleSend through the same code path.
2. **Hero button drops the \`!sessionId\` guard.** Streaming still blocks (legitimately — there's a real in-flight request); the boot window doesn't.

The dock's "Set up Oyster" CTA also benefits — it dispatches the same \`oyster:send-prompt\` event which routes through handleSend.

## Test plan

- [x] Typecheck clean
- [ ] Visual smoke: hard refresh on Home; immediately click "Set up Oyster" before the session has booted; verify the agent picks it up once OpenCode is ready (no need to click again)
- [ ] Same flow via the dock pill's "Set up Oyster" CTA
- [ ] Already-booted case still works (click after session ready → fires immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)