### PR TITLE
fix(onboarding): "Continue setup" label between required-done and all-done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Setup pill no longer reads as "done" while optionals remain.** Once you set up your spaces (the required step), the pill now says *Continue setup* with a green check — invitation, not full stop. It only collapses to the silent green badge when every optional is also ticked or skipped.
 - **Clicking an artefact in the session inspector** now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.
 - **Attaching a folder to a space** now sweeps in any sessions already running in that folder, instead of leaving them stranded under Unsorted.
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -338,6 +338,7 @@
 </ul>
 <h3>Fixed</h3>
 <ul>
+<li><strong>Setup pill no longer reads as &quot;done&quot; while optionals remain.</strong> Once you set up your spaces (the required step), the pill now says <em>Continue setup</em> with a green check — invitation, not full stop. It only collapses to the silent green badge when every optional is also ticked or skipped.</li>
 <li><strong>Clicking an artefact in the session inspector</strong> now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.</li>
 <li><strong>Attaching a folder to a space</strong> now sweeps in any sessions already running in that folder, instead of leaving them stranded under Unsorted.</li>
 </ul>

--- a/web/src/components/OnboardingDock.tsx
+++ b/web/src/components/OnboardingDock.tsx
@@ -255,15 +255,28 @@ export function OnboardingDock({ userSpaceCount = 0 }: OnboardingDockProps = {})
       <button
         type="button"
         ref={dockRef}
-        className={`onboarding-dock${requiredDone ? " onboarding-dock--ready" : ""}${popoverOpen ? " onboarding-dock--active" : ""}`}
+        className={`onboarding-dock${done ? " onboarding-dock--ready" : ""}${popoverOpen ? " onboarding-dock--active" : ""}`}
         onClick={togglePopover}
         aria-expanded={popoverOpen}
-        aria-label={requiredDone ? "Oyster setup checklist" : "Set up Oyster"}
+        aria-label={
+          done
+            ? "Oyster setup complete"
+            : requiredDone
+              ? "Continue Oyster setup"
+              : "Set up Oyster"
+        }
       >
         {!requiredDone && <span className="onboarding-dock-progress" />}
         {requiredDone && <span className="onboarding-dock-check">✓</span>}
-        {!requiredDone && (
-          <span className="onboarding-dock-label">Set up Oyster</span>
+        {/* Three pill states. Pre-required: amber dot + "Set up Oyster",
+            attention-grabbing. Post-required-with-optionals-pending: green
+            check + "Continue setup", invites further exploration without
+            implying anything's broken. All-done: green-tinted pill, glyph
+            only — silent confirmation. */}
+        {!done && (
+          <span className="onboarding-dock-label">
+            {requiredDone ? "Continue setup" : "Set up Oyster"}
+          </span>
         )}
       </button>
 


### PR DESCRIPTION
## Why

Once "Set up your spaces" was done, the pill collapsed to a silent green ✓. That visual read as *"everything's complete"* even when three optional items still sat unticked in the popover — same look as the actually-all-done state. Dishonest signal; users couldn't tell if there was more to do (per [screenshot]).

## Fix

Three pill states now, distinct visuals + copy:

| State | Pill | Aria |
|-------|------|------|
| **Pre-required** (no spaces yet) | amber dot + *Set up Oyster*, purple | "Set up Oyster" |
| **Required done, optionals pending** | green ✓ + *Continue setup*, purple | "Continue Oyster setup" |
| **All done** | green ✓ glyph only, green-tinted pill | "Oyster setup complete" |

The middle state is the addition. Pill stays purple (still active) but the icon flips to green ✓ to acknowledge required is done; the *Continue setup* label invites further exploration without implying anything's broken.

The `--ready` (green-tinted, glyph-only) class now only applies on full all-done. The middle state uses the same purple base as pre-required.

## Test plan

- [x] Typecheck clean
- [ ] Visual smoke: fresh install / force-onboarding → pill says "Set up Oyster" with amber dot. Set up spaces → pill should say "Continue setup" with green check on purple background. Tick all three optionals → pill collapses to green-tinted glyph only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)