### PR TITLE
fix(boot): lazy-spawn PTY shell — chat usable in ~1.5s (was ~14s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Faster startup.** Chat is usable in ~1.5s on cold boot (was ~14s). The terminal-window backend now spawns on demand instead of at launch, so two heavyweight processes no longer fight for CPU during init. ([#385](https://github.com/mattslight/oyster/issues/385))
 - **"Set up Oyster" no longer ignores early clicks.** If you click the prompt before the chat has finished booting, the click is now queued and fires automatically the moment the session is ready — instead of silently doing nothing.
 - **Setup pill no longer reads as "done" while optionals remain.** Once you set up your spaces (the required step), the pill now says *Continue setup* with a green check — invitation, not full stop. It only collapses to the silent green badge when every optional is also ticked or skipped.
 - **Clicking an artefact in the session inspector** now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -339,6 +339,7 @@
 </ul>
 <h3>Fixed</h3>
 <ul>
+<li><strong>Faster startup.</strong> Chat is usable in ~1.5s on cold boot (was ~14s). The terminal-window backend now spawns on demand instead of at launch, so two heavyweight processes no longer fight for CPU during init. (<a href="https://github.com/mattslight/oyster/issues/385" rel="noopener noreferrer">#385</a>)</li>
 <li><strong>&quot;Set up Oyster&quot; no longer ignores early clicks.</strong> If you click the prompt before the chat has finished booting, the click is now queued and fires automatically the moment the session is ready — instead of silently doing nothing.</li>
 <li><strong>Setup pill no longer reads as &quot;done&quot; while optionals remain.</strong> Once you set up your spaces (the required step), the pill now says <em>Continue setup</em> with a green check — invitation, not full stop. It only collapses to the silent green badge when every optional is also ticked or skipped.</li>
 <li><strong>Clicking an artefact in the session inspector</strong> now opens the file viewer directly on top of the panel — the inspector stays open behind it, instead of being swapped out for a metadata sidebar that closed the session you were reading.</li>

--- a/server/src/boot-timer.ts
+++ b/server/src/boot-timer.ts
@@ -2,6 +2,8 @@
 // Logs timestamped step markers so we can see where startup wallclock goes.
 // See #385.
 
+import { performance } from "node:perf_hooks";
+
 const enabled = process.env.OYSTER_BOOT_PROFILE === "1";
 const t0 = performance.now();
 

--- a/server/src/boot-timer.ts
+++ b/server/src/boot-timer.ts
@@ -1,0 +1,32 @@
+// Boot-pipeline profiler. Enabled when OYSTER_BOOT_PROFILE=1.
+// Logs timestamped step markers so we can see where startup wallclock goes.
+// See #385.
+
+const enabled = process.env.OYSTER_BOOT_PROFILE === "1";
+const t0 = performance.now();
+
+export function bootMark(label: string): void {
+  if (!enabled) return;
+  const ms = Math.round(performance.now() - t0);
+  console.log(`[boot:+${ms}ms] ${label}`);
+}
+
+export function bootTime<T>(label: string, fn: () => T): T {
+  if (!enabled) return fn();
+  const start = performance.now();
+  const result = fn();
+  const elapsed = Math.round(performance.now() - start);
+  const since = Math.round(start - t0);
+  console.log(`[boot:+${since}ms] ${label} (${elapsed}ms)`);
+  return result;
+}
+
+export async function bootTimeAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  if (!enabled) return fn();
+  const start = performance.now();
+  const result = await fn();
+  const elapsed = Math.round(performance.now() - start);
+  const since = Math.round(start - t0);
+  console.log(`[boot:+${since}ms] ${label} (${elapsed}ms)`);
+  return result;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -55,9 +55,12 @@ import {
 } from "./opencode-manager.js";
 import { attachChatEventClient } from "./opencode-events.js";
 import { sweepOrphanOpenCodeProcesses } from "./opencode-orphan-sweep.js";
-import { spawnSession, attachWebSocket } from "./pty-manager.js";
+import { attachWebSocket } from "./pty-manager.js";
 import { SqliteFtsMemoryProvider } from "./memory-store.js";
 import { AuthService } from "./auth-service.js";
+import { bootMark, bootTime, bootTimeAsync } from "./boot-timer.js";
+
+bootMark("imports loaded");
 
 // ── Config ──
 
@@ -209,10 +212,10 @@ function bootstrapUserland() {
 }
 
 // ── Auto-backup userland before bootstrap/upgrade and before touching the DB ──
-runStartupBackup(OYSTER_HOME);
+bootTime("runStartupBackup", () => runStartupBackup(OYSTER_HOME));
 setImportStatePath(OYSTER_HOME);
 
-bootstrapUserland();
+bootTime("bootstrapUserland", () => bootstrapUserland());
 
 // ── Clean environment (no OpenAI key leak to subprocesses) ──
 
@@ -224,7 +227,7 @@ delete cleanEnv["OPENAI_API_KEY"];
 
 // ── Artifact store ──
 
-const db = initDb(DB_DIR);
+const db = bootTime("initDb (migrations)", () => initDb(DB_DIR));
 const store = new SqliteArtifactStore(db);
 const spaceStore = new SqliteSpaceStore(db);
 const sessionStore = new SqliteSessionStore(db);
@@ -240,7 +243,7 @@ const artifactService = new ArtifactService(store, WORKER_BASE, OYSTER_HOME, spa
 
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore);
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);
-await memoryProvider.init();
+await bootTimeAsync("memoryProvider.init", () => memoryProvider.init());
 
 // Auth bridge to oyster.to/auth/*. Reads ~/Oyster/config/auth.json on
 // startup so a previously-signed-in user is recognised across restarts.
@@ -285,7 +288,11 @@ const publishService = createPublishService({
 const iconGenerator = new IconGenerator(updateGeneratedArtifact);
 const pendingReveals = new Set<string>();
 
-spawnSession(SHELL, SHELL_ARGS, WORKSPACE, cleanEnv);
+// PTY shell is lazy-spawned on first WebSocket connection (i.e. when the
+// user opens the terminal window). Spawning eagerly here doubled boot time
+// because two opencode-ai processes competed for CPU during init. See #385.
+
+bootMark("subsystems init done (artifactService, spaceService, authService, publishService, iconGenerator)");
 
 // OpenCode spawn is deferred until after port resolution (see below)
 // Scan every location where app bundles can live after #207:
@@ -293,33 +300,35 @@ spawnSession(SHELL, SHELL_ARGS, WORKSPACE, cleanEnv);
 //   SPACES_DIR/<space>/    — AI-generated apps owned by a space
 //   OYSTER_HOME            — anything still at the root (legacy / newly-generated
 //                            before the agent's CWD gets re-pointed in a follow-up)
-scanExistingArtifacts(APPS_DIR, iconGenerator);
-if (existsSync(SPACES_DIR)) {
-  for (const spaceEntry of readdirSync(SPACES_DIR)) {
-    const spaceDir = join(SPACES_DIR, spaceEntry);
-    try {
-      // manifestOnly: true — space folders contain organisational
-      // subfolders (invoices/, research/) with many single-file artifacts.
-      // The fallback scan would misregister each subfolder as a bogus
-      // gen:<folder> bundle; only manifest-based AI-generated apps
-      // should be picked up here.
-      if (statSync(spaceDir).isDirectory()) scanExistingArtifacts(spaceDir, iconGenerator, { manifestOnly: true });
-    } catch { /* skip unreadable */ }
+bootTime("scanExistingArtifacts (apps + spaces + home)", () => {
+  scanExistingArtifacts(APPS_DIR, iconGenerator);
+  if (existsSync(SPACES_DIR)) {
+    for (const spaceEntry of readdirSync(SPACES_DIR)) {
+      const spaceDir = join(SPACES_DIR, spaceEntry);
+      try {
+        // manifestOnly: true — space folders contain organisational
+        // subfolders (invoices/, research/) with many single-file artifacts.
+        // The fallback scan would misregister each subfolder as a bogus
+        // gen:<folder> bundle; only manifest-based AI-generated apps
+        // should be picked up here.
+        if (statSync(spaceDir).isDirectory()) scanExistingArtifacts(spaceDir, iconGenerator, { manifestOnly: true });
+      } catch { /* skip unreadable */ }
+    }
   }
-}
-scanExistingArtifacts(ARTIFACTS_DIR, iconGenerator);
+  scanExistingArtifacts(ARTIFACTS_DIR, iconGenerator);
+});
 
 // Reconcile non-builtin ready gen: artifacts into DB (idempotent — dedupes by canonical path).
 // Load the archived-paths set once and pass it through; otherwise every
 // reconcile call would re-run the same SQL + JSON.parse over every archived row.
-{
+bootTime("reconcileGeneratedArtifacts", () => {
   const archivedPaths = artifactService.getArchivedFilePaths();
   for (const entry of getGeneratedArtifactEntries()) {
     if (!entry.builtin && entry.filePath && entry.status === "ready") {
       artifactService.reconcileGeneratedArtifact(entry, entry.filePath, USERLAND_DIR, archivedPaths);
     }
   }
-}
+});
 
 startGenerationTimer(iconGenerator, (id, filePath, builtin) => {
   if (!builtin) {
@@ -598,7 +607,7 @@ function findPort(preferred: number, maxAttempts = 10): Promise<number> {
   });
 }
 
-const port = await findPort(PREFERRED_PORT);
+const port = await bootTimeAsync("findPort", () => findPort(PREFERRED_PORT));
 
 // Write OpenCode config with the actual port so MCP URL is always correct.
 // ?internal=1 lets the /mcp handler distinguish OpenCode's own traffic from
@@ -641,10 +650,13 @@ try {
 
 writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(sourceOpencode, null, 2) + "\n");
 
+bootMark("opencode config written, about to listen");
+
 const httpServer = createServer(handleHttpRequest);
-attachWebSocket(httpServer);
+attachWebSocket(httpServer, { shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: cleanEnv });
 
 httpServer.listen(port, "127.0.0.1", () => {
+  bootMark(`httpServer listening on ${port}`);
   console.log(`Oyster server listening on http://127.0.0.1:${port}`);
   console.log(`  WebSocket: ws://127.0.0.1:${port}`);
   console.log(`  API:       http://127.0.0.1:${port}/api/artifacts`);

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -1,6 +1,7 @@
 import { type IncomingMessage, type ServerResponse } from "node:http";
 import { spawn, execSync } from "node:child_process";
 import { broadcastRaw, broadcastSynthetic } from "./opencode-events.js";
+import { bootMark } from "./boot-timer.js";
 
 let shuttingDown = false;
 let opencodeRestarts = 0;
@@ -39,6 +40,7 @@ export function spawnOpenCodeServe(
   userlandDir: string,
   cleanEnv: Record<string, string>,
 ) {
+  bootMark("spawnOpenCodeServe (process.spawn)");
   console.log(`Spawning opencode serve in ${userlandDir}`);
   resolvedPort = 0;
   const portArg = opencodePort > 0 ? String(opencodePort) : "0";
@@ -62,6 +64,7 @@ export function spawnOpenCodeServe(
     if (match && !resolvedPort) {
       resolvedPort = parseInt(match[1], 10);
       opencodeRestarts = 0;
+      bootMark(`opencode listening on ${resolvedPort} (chat usable)`);
       console.log(`[opencode-serve] resolved to port ${resolvedPort}`);
     }
   });

--- a/server/src/pty-manager.ts
+++ b/server/src/pty-manager.ts
@@ -58,6 +58,8 @@ export function spawnSession(
 
   proc.onExit(({ exitCode }: { exitCode: number }) => {
     console.log(`Session exited with code ${exitCode}`);
+    proc = null;
+    scrollback = "";
     for (const client of clients) {
       if (client.readyState === WebSocket.OPEN) {
         client.send("\r\n\x1b[90m[session ended]\x1b[0m\r\n");

--- a/server/src/pty-manager.ts
+++ b/server/src/pty-manager.ts
@@ -32,6 +32,7 @@ export function spawnSession(
   env: Record<string, string>,
 ) {
   if (!ptyAvailable) return;
+  if (proc) return proc;
 
   console.log(`Spawning ${shell} in ${cwd}`);
   const pty = ptyModule.default ?? ptyModule;
@@ -67,7 +68,10 @@ export function spawnSession(
   return proc;
 }
 
-export function attachWebSocket(httpServer: Server) {
+export function attachWebSocket(
+  httpServer: Server,
+  spawnParams?: { shell: string; shellArgs: string[]; cwd: string; env: Record<string, string> },
+) {
   const wss = new WebSocketServer({ server: httpServer });
 
   wss.on("connection", (ws: WebSocket) => {
@@ -78,6 +82,14 @@ export function attachWebSocket(httpServer: Server) {
       ws.send("\r\n\x1b[90m[terminal not available — node-pty not installed]\x1b[0m\r\n");
       ws.on("close", () => { clients.delete(ws); });
       return;
+    }
+
+    // Lazy-spawn the PTY shell on first connection. Spawning at boot doubled
+    // startup time (~11s) because two opencode-ai processes initialised in
+    // parallel and competed for CPU. The terminal window is rarely opened —
+    // most users never trigger this. See #385.
+    if (spawnParams && !proc) {
+      spawnSession(spawnParams.shell, spawnParams.shellArgs, spawnParams.cwd, spawnParams.env);
     }
 
     // Replay scrollback so reconnecting clients see current state


### PR DESCRIPTION
## Summary

- Closes #385. Chat is usable in **~1.5s on cold boot, ~2.2s on warm** — was 11-14s.
- One-line root cause: we spawned a second `opencode-ai` process at boot for the terminal window's PTY backend. It rarely gets used (terminal window is opt-in) but always paid for itself by competing with the chat-API `opencode serve` for CPU during init. Lazy-spawn it on first WebSocket connection.
- Adds an opt-in boot profiler (`OYSTER_BOOT_PROFILE=1`) under `server/src/boot-timer.ts` so future regressions are one env var away.

## Numbers

Measured on this machine (MacBook Pro), comparing before/after with \`OYSTER_BOOT_PROFILE=1\` and a fully populated userland:

| Phase | Before | After |
|---|---|---|
| Imports + all server-side init | ~580ms | ~50ms (cold) / ~890ms (warm) |
| \`httpServer.listen\` (port 3333 up) | ~580ms | ~50ms / ~890ms |
| \`opencode serve\` listening (chat usable) | ~11600-14400ms | ~1570ms (cold) / ~2200ms (warm) |

Warm is slower than cold here because \`initDb\` runs an idempotent migration sweep that touches existing tables (~860ms warm vs ~12ms cold). Filing as a separate follow-up — well within the 0.7.0 target either way.

## What changed

- \`server/src/pty-manager.ts\` — \`attachWebSocket\` now accepts spawn params and runs \`spawnSession\` on the **first** connection. \`spawnSession\` is idempotent.
- \`server/src/index.ts\` — drop the eager \`spawnSession()\` call. Pass spawn params into \`attachWebSocket\` instead.
- \`server/src/boot-timer.ts\` (new) — \`bootMark\` / \`bootTime\` / \`bootTimeAsync\` helpers, gated on \`OYSTER_BOOT_PROFILE=1\`. Zero output in normal runs.
- \`server/src/opencode-manager.ts\` — one extra mark when \`opencode serve\` confirms it's listening.
- \`CHANGELOG.md\` — user-facing entry under Fixed.

## Test plan

- [x] \`npm test\` (server) — 66 tests pass
- [x] Cold boot profile run — chat-listening at ~1570ms
- [x] Warm boot profile run — chat-listening at ~2200ms
- [ ] Manual: open the terminal window in the UI, confirm shell is interactive on first open