### PR TITLE
feat(chat): /u <artefact> slash command — symmetric to /p (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Attach an Unsorted folder to an existing space.** The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a "Best match" hint when the folder name resembles one), or create a new space as before.
 - **Public viewer for shared artefacts.** Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share. ([#316](https://github.com/mattslight/oyster/issues/316))
 - **Filter Home to your published artefacts.** A new `published` pill in the Artefacts header narrows the grid to currently-live shares; clicking it before you've published anything lands on a quick how-to instead of an empty grid. ([#374](https://github.com/mattslight/oyster/issues/374))
+- **Unpublish from the chat bar.** `/u <artefact>` mirrors `/p` — fuzzy-matches your live publications and retires the picked one in one keystroke. ([#388](https://github.com/mattslight/oyster/issues/388))
 
 ### Changed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -331,6 +331,7 @@
 <li><strong>Attach an Unsorted folder to an existing space.</strong> The folder button on each Unsorted tile now opens a picker — choose any space to take it in (with a &quot;Best match&quot; hint when the folder name resembles one), or create a new space as before.</li>
 <li><strong>Public viewer for shared artefacts.</strong> Visiting a published share URL now renders the artefact — markdown, mermaid diagrams, sandboxed HTML apps, and inline images — with three access modes: open links resolve immediately, password-protected links unlock once for 24 hours per browser, and sign-in-required links route through the standard sign-in flow and land back on the share. (<a href="https://github.com/mattslight/oyster/issues/316" rel="noopener noreferrer">#316</a>)</li>
 <li><strong>Filter Home to your published artefacts.</strong> A new <code>published</code> pill in the Artefacts header narrows the grid to currently-live shares; clicking it before you&#39;ve published anything lands on a quick how-to instead of an empty grid. (<a href="https://github.com/mattslight/oyster/issues/374" rel="noopener noreferrer">#374</a>)</li>
+<li><strong>Unpublish from the chat bar.</strong> <code>/u &lt;artefact&gt;</code> mirrors <code>/p</code> — fuzzy-matches your live publications and retires the picked one in one keystroke. (<a href="https://github.com/mattslight/oyster/issues/388" rel="noopener noreferrer">#388</a>)</li>
 </ul>
 <h3>Changed</h3>
 <ul>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ import { shouldOpenFullscreen } from "../../shared/types";
 import { fetchSpaces, updateSpace, deleteSpace, convertFolderToSpace, promoteFolderToSpace } from "./data/spaces-api";
 import type { Space, SetupProposal } from "../../shared/types";
 import { createSession, sendMessage } from "./data/chat-api";
+import { unpublishArtifact } from "./data/publish-api";
 import "./App.css";
 
 // `?onboarding=force` wipes the dock's persisted state and pretends this
@@ -377,6 +378,19 @@ export default function App() {
     if (artifact.builtin || artifact.plugin || artifact.status === "generating") return;
     setPublishingArtifact(artifact);
   }, []);
+
+  // /u path. SSE drives the surface (chip hides, count drops); on failure
+  // we surface via the same banner the chat bar already uses for AI errors —
+  // the user's last action came from the chat surface, so the banner is in
+  // their eyeline.
+  const handleArtifactUnpublish = useCallback(async (artifact: Artifact) => {
+    if (artifact.publication == null || artifact.publication.unpublishedAt != null) return;
+    try {
+      await unpublishArtifact(artifact.id);
+    } catch (err) {
+      setAiError(`Unpublish failed: ${(err as Error).message}`);
+    }
+  }, []);
   async function handleFixError(error: { title: string; path: string; message: string; stack: string; console: Array<{ type: string; message: string }> }): Promise<string> {
     // Use a fresh session so Oyster has clean context for the fix
     const session = await createSession();
@@ -587,6 +601,7 @@ export default function App() {
         artifacts={artifacts}
         onArtifactOpen={handleArtifactClick}
         onArtifactPublish={handleArtifactPublish}
+        onArtifactUnpublish={handleArtifactUnpublish}
         isFirstRun={isFirstRun}
         onAiError={setAiError}
       />

--- a/web/src/components/ChatBar.tsx
+++ b/web/src/components/ChatBar.tsx
@@ -81,6 +81,7 @@ const SLASH_COMMANDS = [
   { cmd: "/s", args: "<prefix>", desc: "Switch space", example: "/s bf → blunderfixer" },
   { cmd: "/o", args: "<search>", desc: "Open artifact", example: "/o competitor analysis" },
   { cmd: "/p", args: "<artefact>", desc: "Publish artifact", example: "/p competitor analysis" },
+  { cmd: "/u", args: "<artefact>", desc: "Unpublish artifact", example: "/u competitor analysis" },
   { cmd: "#", args: "<space>", desc: "Quick switch", example: "#bf · #all · #archived" },
 ];
 
@@ -94,11 +95,12 @@ interface Props {
   artifacts?: Artifact[];
   onArtifactOpen?: (artifact: Artifact) => void;
   onArtifactPublish?: (artifact: Artifact) => void;
+  onArtifactUnpublish?: (artifact: Artifact) => void;
   isFirstRun?: boolean;
   onAiError?: (message: string | null) => void;
 }
 
-export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activeSpace, onSpaceChange, inputRef: externalInputRef, artifacts = [], onArtifactOpen, onArtifactPublish, isFirstRun, onAiError }: Props) {
+export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activeSpace, onSpaceChange, inputRef: externalInputRef, artifacts = [], onArtifactOpen, onArtifactPublish, onArtifactUnpublish, isFirstRun, onAiError }: Props) {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [statusText, setStatusText] = useState("");
@@ -147,6 +149,11 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
 
   const publishableArtifacts = useMemo(
     () => artifacts.filter((a) => !a.builtin && !a.plugin && a.status !== "generating"),
+    [artifacts],
+  );
+
+  const livePublications = useMemo(
+    () => artifacts.filter((a) => a.publication != null && a.publication.unpublishedAt == null),
     [artifacts],
   );
 
@@ -217,6 +224,25 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
         .map(x => ({ key: x.a.id, label: x.a.label, desc: x.a.spaceId, type: "publish-artifact" as const, score: x.score }));
     }
 
+    // /u prefix — unpublish, scoped to currently-live publications
+    const unpublishArgMatch = lower.match(/^\/u(\s+(.*))?$/);
+    if (unpublishArgMatch !== null && (lower === "/u" || lower.startsWith("/u "))) {
+      const q = (unpublishArgMatch[2] || "").trim();
+      if (!q) {
+        const sorted = [...livePublications].sort((a, b) => {
+          if (a.spaceId === activeSpace && b.spaceId !== activeSpace) return -1;
+          if (b.spaceId === activeSpace && a.spaceId !== activeSpace) return 1;
+          return a.label.localeCompare(b.label);
+        });
+        return sorted.slice(0, 8).map(a => ({ key: a.id, label: a.label, desc: a.spaceId, type: "unpublish-artifact" as const, score: 0 }));
+      }
+      const allowed = new Set(livePublications.map((a) => a.id));
+      return scoreArtifacts(q)
+        .filter(({ a }) => allowed.has(a.id))
+        .slice(0, 8)
+        .map(x => ({ key: x.a.id, label: x.a.label, desc: x.a.spaceId, type: "unpublish-artifact" as const, score: x.score }));
+    }
+
     // / prefix — command list
     if (!input.includes(" ") && lower !== "/s") {
       return SLASH_COMMANDS
@@ -225,7 +251,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
     }
 
     return [];
-  }, [input, spaces, subseq, artifacts, activeSpace, scoreArtifacts, publishableArtifacts]);
+  }, [input, spaces, subseq, artifacts, activeSpace, scoreArtifacts, publishableArtifacts, livePublications]);
 
   const slashOpen = slashItems.length > 0;
 
@@ -364,6 +390,20 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
             return; // keep input, don't clear — dropdown stays open
           }
         }
+
+        if (cmd === "u" && onArtifactUnpublish) {
+          const allowed = new Set(livePublications.map((a) => a.id));
+          const scored = scoreArtifacts(q).filter(({ a }) => allowed.has(a.id));
+          if (scored.length === 0) {
+            setMessages(prev => [...prev, { role: "assistant", content: `No live publication matching "${arg.trim()}"` }]);
+            setExpanded(true);
+          } else if (scored.length === 1 || scored[0].score >= scored[1].score * 2) {
+            onArtifactUnpublish(scored[0].a);
+          } else {
+            setInput(`/u ${arg.trim()}`);
+            return; // keep input, don't clear — dropdown stays open
+          }
+        }
       }
       return;
     }
@@ -392,7 +432,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
         : "Can't reach Oyster — check that the server is running";
       onAiError?.(msg);
     }
-  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts]);
+  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts, onArtifactUnpublish, livePublications]);
 
   // Drain any queued prompt as soon as the session is ready AND nothing
   // is streaming. handleSend's other guard is `streaming`; if we drained
@@ -575,6 +615,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
                   if (item.type === "space") { setInput(""); onSpaceChange?.(item.key); }
                   else if (item.type === "artifact") { setInput(""); const a = artifacts.find(x => x.id === item.key); if (a) onArtifactOpen?.(a); }
                   else if (item.type === "publish-artifact") { setInput(""); const a = artifacts.find(x => x.id === item.key); if (a) onArtifactPublish?.(a); }
+                  else if (item.type === "unpublish-artifact") { setInput(""); const a = artifacts.find(x => x.id === item.key); if (a) onArtifactUnpublish?.(a); }
                   else { setInput(item.label + ("args" in item && item.args ? " " : "")); inputRef.current?.focus(); }
                 }}
                 onMouseEnter={() => setSlashIndex(i)}
@@ -638,6 +679,9 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
                 } else if (item.type === "publish-artifact") {
                   const a = artifacts.find((x) => x.id === item.key);
                   if (a) setInput(`/p ${a.label}`);
+                } else if (item.type === "unpublish-artifact") {
+                  const a = artifacts.find((x) => x.id === item.key);
+                  if (a) setInput(`/u ${a.label}`);
                 } else {
                   setInput(item.label + ("args" in item && item.args ? " " : ""));
                 }
@@ -650,6 +694,7 @@ export function ChatBar({ onOpenTerminal, isHero: isHeroProp, spaces = [], activ
                 if (item.type === "space") { setInput(""); onSpaceChange?.(item.key); }
                 else if (item.type === "artifact") { setInput(""); const a = artifacts.find(x => x.id === item.key); if (a) onArtifactOpen?.(a); }
                 else if (item.type === "publish-artifact") { setInput(""); const a = artifacts.find(x => x.id === item.key); if (a) onArtifactPublish?.(a); }
+                else if (item.type === "unpublish-artifact") { setInput(""); const a = artifacts.find(x => x.id === item.key); if (a) onArtifactUnpublish?.(a); }
                 else { setInput(item.label + ("args" in item && item.args ? " " : "")); }
                 return;
               }


### PR DESCRIPTION
## Summary

- New `/u <artefact>` slash command — symmetric to `/p`, scoped to currently-live publications. Picks via fuzzy match and unpublishes directly (no picker round trip), matching the right-click direct-unpublish flow from 581fd8d.
- SSE drives the rest of the surface (chip hides, count drops, published filter auto-resets if this was the last live one).

Closes #388.

## Test plan

> Note: I couldn't smoke-test in the browser — the user's dev server is currently bound to ports 3333/7337. TypeScript and full build pass; the implementation is a tight parallel of the `/p` flow.

- [ ] Type a `/` — `/u` appears in the command list with `<artefact>` arg hint and `Unpublish artifact` description.
- [ ] Type `/u ` — autocomplete lists currently-live publications, sorted active-space-first.
- [ ] Type `/u <unique substring>` and Enter — picks unambiguously and unpublishes; the chip on the tile hides.
- [ ] Type `/u <ambiguous>` — autocomplete stays open with the candidates; Tab fills the picked label, Enter executes.
- [ ] With the `published` pill active in Home, unpublish the last live publication via `/u` — pill auto-resets to `all` (existing #374 behavior).
- [ ] Type `/u nothing-matches` — chat-bubble error: `No live publication matching "nothing-matches"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)