### PR TITLE
fix(dev): bind vite proxy to its own worktree's server

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "npm run build:web && npm run build:server && node -e \"const fs=require('fs');fs.cpSync('web/dist','server/dist/public',{recursive:true})\"",
     "build:changelog": "node scripts/build-changelog.mjs",
     "serve:docs": "npm run build:changelog && npx --yes serve@14 docs",
-    "dev": "npx concurrently -n web,server -c blue,green \"npx wait-on tcp:3333 && cd web && npm run dev\" \"cd server && npm run dev\"",
+    "dev": "npx concurrently -n web,server -c blue,green \"npx wait-on file:userland/.dev-port && cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev",
     "version": "npm run build:changelog && git add docs/changelog.html",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -134,6 +134,20 @@ const BACKUPS_DIR = join(OYSTER_HOME, "backups");
 // Alias to OYSTER_HOME to minimise the surface of this PR.
 const USERLAND_DIR = OYSTER_HOME;
 
+// Dev handshake: write the actual bound port to userland/.dev-port so the
+// Vite dev server proxies to *this* backend, not whichever Oyster happens
+// to be on 3333. Each worktree has its own userland → its own file → no
+// cross-talk. Removed on shutdown so a stale file fails loud (connection
+// refused) rather than silent (talking to the wrong server). The pre-listen
+// delete closes the race where wait-on would otherwise succeed against a
+// crashed prior run's stale file. Declared up here (not next to listen())
+// so the SIGTERM/SIGINT handlers registered below don't hit a const TDZ if
+// a signal arrives mid-boot.
+const DEV_PORT_FILE = join(USERLAND_DIR, ".dev-port");
+function clearDevPortFile() {
+  try { rmSync(DEV_PORT_FILE, { force: true }); } catch { /* best effort */ }
+}
+
 // Resolver for a space's native folder (where `create_artifact` writes).
 // Every callsite that used to compute `join(USERLAND_DIR, space_id)` goes
 // through this, so swapping to a first-class sources table later (#208) is
@@ -659,17 +673,8 @@ bootMark("opencode config written, about to listen");
 const httpServer = createServer(handleHttpRequest);
 attachWebSocket(httpServer, { shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: cleanEnv });
 
-// Dev handshake: write the actual bound port to userland/.dev-port so the
-// Vite dev server proxies to *this* backend, not whichever Oyster happens
-// to be on 3333. Each worktree has its own userland → its own file → no
-// cross-talk. Removed on shutdown so a stale file fails loud (connection
-// refused) rather than silent (talking to the wrong server). The pre-listen
-// delete closes the race where wait-on would otherwise succeed against a
-// crashed prior run's stale file.
-const DEV_PORT_FILE = join(USERLAND_DIR, ".dev-port");
-function clearDevPortFile() {
-  try { rmSync(DEV_PORT_FILE, { force: true }); } catch { /* best effort */ }
-}
+// Wipe any stale .dev-port from a prior crash before we listen, so wait-on
+// can never succeed against a dead server's port. (See declaration above.)
 clearDevPortFile();
 
 httpServer.listen(port, "127.0.0.1", () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -339,8 +339,8 @@ startGenerationTimer(iconGenerator, (id, filePath, builtin) => {
 });
 startAutoApprover(getOpenCodePort, (file) => handleFileEdited(file, ARTIFACTS_DIR, iconGenerator));
 
-process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); process.exit(0); });
-process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); process.exit(0); });
+process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); process.exit(0); });
+process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); process.exit(0); });
 process.on("uncaughtException", (err) => {
   console.error(`[oyster] uncaught exception: ${err.message}`);
   markShuttingDown();
@@ -659,11 +659,25 @@ bootMark("opencode config written, about to listen");
 const httpServer = createServer(handleHttpRequest);
 attachWebSocket(httpServer, { shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: cleanEnv });
 
+// Dev handshake: write the actual bound port to userland/.dev-port so the
+// Vite dev server proxies to *this* backend, not whichever Oyster happens
+// to be on 3333. Each worktree has its own userland → its own file → no
+// cross-talk. Removed on shutdown so a stale file fails loud (connection
+// refused) rather than silent (talking to the wrong server). The pre-listen
+// delete closes the race where wait-on would otherwise succeed against a
+// crashed prior run's stale file.
+const DEV_PORT_FILE = join(USERLAND_DIR, ".dev-port");
+function clearDevPortFile() {
+  try { rmSync(DEV_PORT_FILE, { force: true }); } catch { /* best effort */ }
+}
+clearDevPortFile();
+
 httpServer.listen(port, "127.0.0.1", () => {
   bootMark(`httpServer listening on ${port}`);
   console.log(`Oyster server listening on http://127.0.0.1:${port}`);
   console.log(`  WebSocket: ws://127.0.0.1:${port}`);
   console.log(`  API:       http://127.0.0.1:${port}/api/artifacts`);
+  try { writeFileSync(DEV_PORT_FILE, String(port)); } catch { /* best effort */ }
 
   // Spawn OpenCode AFTER server is listening so MCP connection succeeds
   spawnOpenCodeServe(OPENCODE_BIN, OPENCODE_PORT, USERLAND_DIR, cleanEnv);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,24 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { readFileSync } from 'fs'
+import { readFileSync, existsSync } from 'fs'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const serverPort = process.env.OYSTER_PORT ?? '3333'
+
+// Dev handshake: the server writes its actual bound port to userland/.dev-port
+// after listen(). Reading it here means each worktree's vite always proxies to
+// its own backend, even with multiple Oysters running on auto-bumped ports.
+// Falls back to OYSTER_PORT (explicit override) then 3333 (cold-start default).
+function resolveServerPort(): string {
+  const portFile = resolve(__dirname, '..', 'userland', '.dev-port')
+  if (existsSync(portFile)) {
+    const v = readFileSync(portFile, 'utf8').trim()
+    if (/^\d+$/.test(v)) return v
+  }
+  return process.env.OYSTER_PORT ?? '3333'
+}
+const serverPort = resolveServerPort()
 const target = `http://localhost:${serverPort}`
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'))
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync } from 'fs'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
@@ -11,11 +11,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 // its own backend, even with multiple Oysters running on auto-bumped ports.
 // Falls back to OYSTER_PORT (explicit override) then 3333 (cold-start default).
 function resolveServerPort(): string {
-  const portFile = resolve(__dirname, '..', 'userland', '.dev-port')
-  if (existsSync(portFile)) {
+  // Best-effort read — if the file is missing, unreadable, or the read races
+  // with a delete, fall through to the env / default. Never let a bad hint
+  // file prevent vite from starting.
+  try {
+    const portFile = resolve(__dirname, '..', 'userland', '.dev-port')
     const v = readFileSync(portFile, 'utf8').trim()
     if (/^\d+$/.test(v)) return v
-  }
+  } catch { /* fall through */ }
   return process.env.OYSTER_PORT ?? '3333'
 }
 const serverPort = resolveServerPort()


### PR DESCRIPTION
## Summary

Each Oyster server auto-bumps from 3333 when the port is taken, but Vite unconditionally proxied to `OYSTER_PORT ?? 3333` — so any worktree booted second silently sent its API calls to the *first* worktree's backend, with no error to surface the mismatch. Symptoms looked like "my code isn't running" because the wrong server answered.

## Fix

- **Server** writes its actual bound port to `userland/.dev-port` after `listen()`, deletes it before listen and on SIGINT/SIGTERM.
- **Vite** reads that file at config time and proxies there; falls back to `OYSTER_PORT` then `3333`.
- **Dev script** `wait-on file:userland/.dev-port` instead of `tcp:3333`.

Each worktree has its own `userland/`, so each web instance always talks to its own backend regardless of how many Oysters are running concurrently. Pre-listen delete handles the stale-file case (prior crash, or `tsx watch` SIGKILL'ing the child without our SIGINT cleanup running). Worst-case failure is "connection refused" — loud — instead of "talking to the wrong server" — silent.

## Test plan

- [x] Boot worktree A on 3333, worktree B on 3334 → each web hits its own server
- [x] Stale `.dev-port` from a prior crashed run → next boot overwrites it before any client reads
- [x] Type-check passes (server + web)
- [ ] Verify on a fresh `npm run dev` from the main repo (no worktrees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)