### PR TITLE
feat(memories): per-row delete affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Filter Home to your published artefacts.** A new `published` pill in the Artefacts header narrows the grid to currently-live shares; clicking it before you've published anything lands on a quick how-to instead of an empty grid. ([#374](https://github.com/mattslight/oyster/issues/374))
 - **Unpublish from the chat bar.** `/u <artefact>` mirrors `/p` — fuzzy-matches your live publications and retires the picked one in one keystroke. ([#388](https://github.com/mattslight/oyster/issues/388))
 - **Pin artefacts to the top.** Right-click any artefact for `Pin`; pinned items sort above folder tiles and other artefacts in the active scope, most-recent pin first, with a gold pin glyph in the corner. Right-click again for `Unpin`. New `pinned` filter chip on Home to focus on just the pinned set. Filters still apply — pinning doesn't override filter visibility. ([#387](https://github.com/mattslight/oyster/issues/387))
+- **Delete a memory you didn't mean to keep.** Hover any row in the Memories list — a small trash icon appears. Click it, confirm, and the memory is gone everywhere it was visible. Other open tabs update live. ([#398](https://github.com/mattslight/oyster/issues/398))
 
 ### Changed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -333,6 +333,7 @@
 <li><strong>Filter Home to your published artefacts.</strong> A new <code>published</code> pill in the Artefacts header narrows the grid to currently-live shares; clicking it before you&#39;ve published anything lands on a quick how-to instead of an empty grid. (<a href="https://github.com/mattslight/oyster/issues/374" rel="noopener noreferrer">#374</a>)</li>
 <li><strong>Unpublish from the chat bar.</strong> <code>/u &lt;artefact&gt;</code> mirrors <code>/p</code> — fuzzy-matches your live publications and retires the picked one in one keystroke. (<a href="https://github.com/mattslight/oyster/issues/388" rel="noopener noreferrer">#388</a>)</li>
 <li><strong>Pin artefacts to the top.</strong> Right-click any artefact for <code>Pin</code>; pinned items sort above folder tiles and other artefacts in the active scope, most-recent pin first, with a gold pin glyph in the corner. Right-click again for <code>Unpin</code>. New <code>pinned</code> filter chip on Home to focus on just the pinned set. Filters still apply — pinning doesn&#39;t override filter visibility. (<a href="https://github.com/mattslight/oyster/issues/387" rel="noopener noreferrer">#387</a>)</li>
+<li><strong>Delete a memory you didn&#39;t mean to keep.</strong> Hover any row in the Memories list — a small trash icon appears. Click it, confirm, and the memory is gone everywhere it was visible. Other open tabs update live. (<a href="https://github.com/mattslight/oyster/issues/398" rel="noopener noreferrer">#398</a>)</li>
 </ul>
 <h3>Changed</h3>
 <ul>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -429,7 +429,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   })) return;
 
   // /api/memories
-  if (await tryHandleMemoryRoute(req, res, url, ctx, { memoryProvider })) return;
+  if (await tryHandleMemoryRoute(req, res, url, ctx, { memoryProvider, broadcastUiEvent })) return;
 
   // /api/auth/* — local glue (whoami / startSignIn / signOut). Real auth
   // (magic-link, OAuth) lives in the Cloudflare Worker.

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -47,7 +47,9 @@ export interface MemoryProvider {
   init(): Promise<void>;
   remember(input: RememberInput): Promise<Memory>;
   recall(input: RecallInput): Promise<Memory[]>;
-  forget(id: string): Promise<void>;
+  /** Marks a memory as forgotten. Returns true if a row was updated, false if
+   *  the id doesn't exist — callers can map false → 404. */
+  forget(id: string): Promise<boolean>;
   list(space_id?: string): Promise<Memory[]>;
   /** Synchronous existence check used by the import flow's dedupe — true
    *  when an active memory with this exact (content, space_id) already
@@ -327,10 +329,11 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     return rows.map((row) => ({ ...rowToMemory(row), recalled_at: row.recalled_at }));
   }
 
-  async forget(id: string): Promise<void> {
+  async forget(id: string): Promise<boolean> {
     const row = this.stmts.getById.get(id) as MemoryRow | undefined;
-    if (!row) return;
+    if (!row) return false;
     this.stmts.supersede.run("forgotten", id);
+    return true;
   }
 
   async list(space_id?: string): Promise<Memory[]> {

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -4,6 +4,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
+import { safeDecode } from "../http-utils.js";
 import type { UiCommand } from "../../../shared/types.js";
 
 export interface MemoryRouteDeps {
@@ -28,7 +29,11 @@ export async function tryHandleMemoryRoute(
   // missing rows from server errors.
   if (req.method === "DELETE" && memoriesPath.startsWith("/api/memories/")) {
     if (rejectIfNonLocalOrigin()) return true;
-    const id = memoriesPath.slice("/api/memories/".length);
+    const id = safeDecode(memoriesPath.slice("/api/memories/".length));
+    if (id === null) {
+      sendJson({ error: "malformed id encoding" }, 400);
+      return true;
+    }
     if (!id) {
       sendJson({ error: "id is required" }, 400);
       return true;

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -4,9 +4,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
+import type { UiCommand } from "../../../shared/types.js";
 
 export interface MemoryRouteDeps {
   memoryProvider: MemoryProvider;
+  broadcastUiEvent: (event: UiCommand) => void;
 }
 
 export async function tryHandleMemoryRoute(
@@ -17,12 +19,38 @@ export async function tryHandleMemoryRoute(
   deps: MemoryRouteDeps,
 ): Promise<boolean> {
   const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
-  const { memoryProvider } = deps;
+  const { memoryProvider, broadcastUiEvent } = deps;
+
+  const memoriesPath = url.split("?")[0];
+
+  // DELETE /api/memories/:id — soft-delete (mark forgotten). Mirrors the MCP
+  // `forget` tool. 404 if the id doesn't exist so the UI can distinguish
+  // missing rows from server errors.
+  if (req.method === "DELETE" && memoriesPath.startsWith("/api/memories/")) {
+    if (rejectIfNonLocalOrigin()) return true;
+    const id = memoriesPath.slice("/api/memories/".length);
+    if (!id) {
+      sendJson({ error: "id is required" }, 400);
+      return true;
+    }
+    try {
+      const removed = await memoryProvider.forget(id);
+      if (!removed) {
+        sendJson({ error: "memory not found" }, 404);
+        return true;
+      }
+      broadcastUiEvent({ version: 1, command: "memory_changed", payload: { id, op: "forget" } });
+      res.statusCode = 204;
+      res.end();
+    } catch (err) {
+      sendError(err);
+    }
+    return true;
+  }
 
   // GET /api/memories — list memories, optionally scoped to a space.
   // Strip the query string before path-matching (same trap the events
   // route had — `$`-anchored regex would silently reject `?space_id=…`).
-  const memoriesPath = url.split("?")[0];
   if (memoriesPath !== "/api/memories") return false;
 
   if (req.method === "GET") {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -727,6 +727,7 @@
 }
 
 .home-memory {
+  position: relative;
   padding: 12px 18px;
   border-bottom: 1px solid var(--home-border);
   display: flex;
@@ -736,6 +737,34 @@
 }
 .home-memory:hover { background: rgba(124, 107, 255, 0.05); }
 .home-memory:last-child { border-bottom: none; }
+
+.home-memory-delete {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-dim);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.home-memory:hover .home-memory-delete,
+.home-memory-delete:focus-visible { opacity: 1; }
+.home-memory-delete:hover {
+  background: rgba(255, 90, 90, 0.12);
+  color: #ff7a7a;
+}
+.home-memory-delete:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
 
 .home-memories-toggle {
   padding: 6px 14px;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -753,10 +753,14 @@
   color: var(--text-dim);
   cursor: pointer;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
 }
 .home-memory:hover .home-memory-delete,
-.home-memory-delete:focus-visible { opacity: 1; }
+.home-memory-delete:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
 .home-memory-delete:hover {
   background: rgba(255, 90, 90, 0.12);
   color: #ff7a7a;

--- a/web/src/components/Home/MemoryCard.tsx
+++ b/web/src/components/Home/MemoryCard.tsx
@@ -1,4 +1,5 @@
 // Single memory card. Extracted from Home/index.tsx.
+import { Trash2 } from "lucide-react";
 import type { Memory } from "../../data/memories-api";
 import type { Space } from "../../../../shared/types";
 import { formatRelative, spaceLabelFor } from "./utils";
@@ -8,13 +9,24 @@ interface MemoryCardProps {
   spaces: Space[];
   showSpaceChip: boolean;
   onOpenSession: (id: string) => void;
+  onRequestDelete: (memory: Memory) => void;
 }
 
-export function MemoryCard({ memory, spaces, showSpaceChip, onOpenSession }: MemoryCardProps) {
+export function MemoryCard({ memory, spaces, showSpaceChip, onOpenSession, onRequestDelete }: MemoryCardProps) {
   const spaceLabel = spaceLabelFor(memory.space_id, spaces);
   const rel = formatRelative(memory.created_at) ?? "—";
+
   return (
     <div className="home-memory">
+      <button
+        type="button"
+        className="home-memory-delete"
+        onClick={() => onRequestDelete(memory)}
+        title="Forget this memory"
+        aria-label="Forget this memory"
+      >
+        <Trash2 size={13} />
+      </button>
       <div className="home-memory-text">{memory.content}</div>
       <div className="home-memory-meta">
         {showSpaceChip && spaceLabel && <span className="home-memory-space">{spaceLabel}</span>}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -27,6 +27,7 @@ import { homeRelative, renderPipCounts, stateColor } from "./utils";
 import { VAULT, type ArtefactSource, type StateFilter, type ViewMode } from "./types";
 import { addSpaceSource } from "../../data/spaces-api";
 import { deleteMemory, type Memory } from "../../data/memories-api";
+import { ApiError } from "../../data/http";
 import "./Home.css";
 
 interface Props {
@@ -1252,10 +1253,17 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             const target = pendingMemoryDelete;
             try {
               await deleteMemory(target.id);
-              refreshMemories();
-            } finally {
-              setPendingMemoryDelete(null);
+            } catch (err) {
+              // 404 means another tab already forgot it — same end state.
+              const status = err instanceof ApiError ? err.status : null;
+              if (status !== 404) {
+                alert(`Couldn't forget memory: ${err instanceof Error ? err.message : String(err)}`);
+                setPendingMemoryDelete(null);
+                return;
+              }
             }
+            refreshMemories();
+            setPendingMemoryDelete(null);
           }}
           onCancel={() => setPendingMemoryDelete(null)}
         />

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -26,6 +26,7 @@ import { VaultInfo } from "./VaultInfo";
 import { homeRelative, renderPipCounts, stateColor } from "./utils";
 import { VAULT, type ArtefactSource, type StateFilter, type ViewMode } from "./types";
 import { addSpaceSource } from "../../data/spaces-api";
+import { deleteMemory, type Memory } from "../../data/memories-api";
 import "./Home.css";
 
 interface Props {
@@ -149,6 +150,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   const [sessionsView, setSessionsView] = useStickyView("oyster.home.sessionsView", "table");
   const [artefactsView, setArtefactsView] = useStickyView("oyster.home.artefactsView", "icons");
   const [activePanel, setActivePanel] = useState<ActivePanel | null>(null);
+  const [pendingMemoryDelete, setPendingMemoryDelete] = useState<Memory | null>(null);
 
   // Local "Elsewhere" scope: filters Sessions to those whose spaceId is null
   // (claude/codex sessions started in folders that aren't attached to any
@@ -1111,6 +1113,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                     spaces={spaces}
                     showSpaceChip={isMetaView}
                     onOpenSession={(id) => setActivePanel({ kind: "session", id })}
+                    onRequestDelete={setPendingMemoryDelete}
                   />
                 ))}
               </div>
@@ -1234,6 +1237,29 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
           />
         );
       })()}
+      {pendingMemoryDelete && (
+        <ConfirmModal
+          open={true}
+          title="Forget this memory?"
+          body={
+            <div style={{ fontSize: 13, lineHeight: 1.5, color: "var(--text)", whiteSpace: "pre-wrap" }}>
+              {pendingMemoryDelete.content}
+            </div>
+          }
+          confirmLabel="Forget"
+          destructive
+          onConfirm={async () => {
+            const target = pendingMemoryDelete;
+            try {
+              await deleteMemory(target.id);
+              refreshMemories();
+            } finally {
+              setPendingMemoryDelete(null);
+            }
+          }}
+          onCancel={() => setPendingMemoryDelete(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/data/memories-api.ts
+++ b/web/src/data/memories-api.ts
@@ -1,6 +1,6 @@
 // Surfaces memories created via mcp__oyster__remember. v1 is read-only —
 // writes still go through the MCP tool surface.
-import { getJson, postJson } from "./http";
+import { getJson, postJson, del } from "./http";
 
 export interface Memory {
   id: string;
@@ -32,4 +32,8 @@ export async function createMemory(input: CreateMemoryInput): Promise<Memory> {
     space_id: input.space_id || undefined,
     tags: input.tags?.length ? input.tags : undefined,
   });
+}
+
+export async function deleteMemory(id: string): Promise<void> {
+  return del(`/api/memories/${encodeURIComponent(id)}`);
 }


### PR DESCRIPTION
## Summary

Closes #398.

- Hover any memory row → small trash icon appears.
- Click → in-app `ConfirmModal` shows the full memory body, *Forget* (destructive) / Cancel.
- Confirming hits a new `DELETE /api/memories/:id` route which wraps the existing `forget()` provider method, broadcasts `memory_changed` over SSE, and returns 204. Missing ids return 404.
- `useMemories` already subscribes to `memory_changed` → other open tabs update without manual refresh.

Works in every space view, not just Home. The Memories list is the same component everywhere.

## Test plan

- [ ] Hover any memory in Home → trash icon fades in
- [ ] Click → modal appears with full body, Forget button is destructive (red)
- [ ] Confirm → row vanishes, count decrements, no manual refresh needed
- [ ] Open same Oyster in a second tab → row vanishes there too within an SSE tick
- [ ] Navigate into a real space → trash icon also works on space-scoped memories
- [ ] `curl -X DELETE http://localhost:3333/api/memories/does-not-exist` → 404
- [x] Type-check passes (server + web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)