### PR TITLE
feat(share): move public viewer to share.oyster.to for origin isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Sessions section on Home is capped.** Long session lists used to push Artefacts below the fold; the section now shows the first ten with a `Show more` toggle below — applies to both icon and table views. ([#389](https://github.com/mattslight/oyster/issues/389))
 - **Artefacts table view picks up the same cap.** Table view used to dump every artefact in the active scope; it now matches the icon view's `Show more` pager so spaces with dozens of artefacts stay scannable.
 - **Refreshed share-page chrome.** Public viewer pages drop the top header for a single centered footer line — *Published with [oyster.to](https://oyster.to)* with the Oyster brand mark. Dark-mode brand surface throughout (navy background with purple gradient bloom), Barlow for headings and Space Grotesk for body, matching oyster.to.
+- **Published shares now live on `share.oyster.to`.** Share URLs moved to a dedicated origin so untrusted content can't reach the main app's session, and so sandboxed apps can use real `localStorage` and `sessionStorage` instead of a no-op shim. Already-shared `oyster.to/p/...` links keep working via redirect. ([#397](https://github.com/mattslight/oyster/issues/397))
 
 ### Fixed
 
@@ -37,7 +38,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Right-click works on the artefacts list view.** Pin / Unpin, Publish settings, Unpublish, and Publish… now appear on a context menu in the table view too — previously the browser default menu took over.
 - **Manage cloud-only publications from any signed-in device.** Right-click an `On cloud` tile (or list-view row) for **Publish settings…** and **Unpublish**. Publish settings opens the regular publish modal so you can change mode, set/clear/reset the password, or switch to sign-in-required — without needing the original artefact bytes on this device.
 - **Existing publications self-heal their label + space.** Sign-in backfill now opportunistically pushes your local label and space onto cloud rows when the cloud copy is stale or missing. Older publications (made before the publish flow carried that context) populate on the next sign-in instead of forcing a re-publish — list-view space column starts showing the real space name.
-- **Published apps that read `localStorage` at boot no longer crash to a blank page.** The sandboxed iframe blocks storage access by design, but apps that touched `localStorage`/`sessionStorage` during startup (e.g. to restore a font preference) raised an uncaught `SecurityError` and halted before rendering. The viewer now injects no-op storage shims so apps boot through; persistence is still off, which is correct for sandboxed content. Plus Google Fonts is allowed in the iframe CSP so apps that pull typography from `fonts.googleapis.com` render with their intended fonts.
+- **Google Fonts loads in published apps.** The iframe CSP now allows `fonts.googleapis.com` and `fonts.gstatic.com` so AI-generated apps that pull typography render with their intended fonts.
 
 ## [0.6.0] - 2026-05-02
 

--- a/infra/auth-worker/README.md
+++ b/infra/auth-worker/README.md
@@ -119,7 +119,7 @@ npm run dev                # runs the Worker on localhost:8787
 # Open http://localhost:8787/auth/sign-in
 ```
 
-The Worker detects the `localhost` host and drops `Domain=` and `Secure` from the session cookie, so the cookie flow works end-to-end on `http://localhost:8787` — no HTTPS or hosts-file aliasing required.
+The session cookie is host-only (no `Domain=` attribute) so it can't leak to `share.oyster.to` where untrusted published content runs. The Worker also drops `Secure` on localhost so the cookie flow works end-to-end on `http://localhost:8787` — no HTTPS or hosts-file aliasing required.
 
 Without `RESEND_API_KEY` set, `/auth/magic-link` still returns `{ ok: true }` and writes the token row, but logs the verify URL to the Worker console instead of sending an email:
 

--- a/infra/auth-worker/src/worker.ts
+++ b/infra/auth-worker/src/worker.ts
@@ -135,23 +135,24 @@ function isLocalHost(host: string): boolean {
 }
 
 // Cookie shape adapts to the request host so wrangler dev (http://localhost:8787)
-// can exercise the cookie flow. Production: Domain=.oyster.to + Secure so the
-// cookie is visible on the apex and any subdomain the publish/viewer flows
-// might end up on. Localhost: omit Domain (browsers reject Domain= on
-// localhost) and omit Secure (no HTTPS). HttpOnly + SameSite=Lax stay on both.
+// can exercise the cookie flow. Production: omit Domain so the cookie is
+// host-only on the apex (oyster.to) and does NOT leak to share.oyster.to,
+// where untrusted published content runs (issue #397). Localhost: omit
+// Domain (browsers reject Domain= on localhost) and omit Secure (no HTTPS).
+// HttpOnly + SameSite=Lax stay on both.
 function sessionCookie(sessionId: string, host: string): string {
   const maxAge = Math.floor(SESSION_TTL_MS / 1000);
   if (isLocalHost(host)) {
     return `${COOKIE_NAME}=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}`;
   }
-  return `${COOKIE_NAME}=${sessionId}; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
+  return `${COOKIE_NAME}=${sessionId}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
 }
 
 function clearedCookie(host: string): string {
   if (isLocalHost(host)) {
     return `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
   }
-  return `${COOKIE_NAME}=; Domain=.oyster.to; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
+  return `${COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`;
 }
 
 const NO_STORE: Record<string, string> = { "cache-control": "no-store" };

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -106,11 +106,13 @@ function escapeHtml(s: string): string {
 // ─── Iframe chrome (app / deck / wireframe / table / map) ──────────────────
 
 export function renderChromeWithIframe(row: PublicationRow): Response {
+  // Origin isolation (issue #397) is the primary defense: this content is
+  // served from share.oyster.to, separate from the main app's cookies and
+  // storage. allow-same-origin is now safe — apps can use real localStorage
+  // / sessionStorage / IndexedDB, scoped to share.oyster.to. Sandbox stays
+  // as defense-in-depth (no plugins, no top-nav, no popups).
   const iframe = `
-<!-- Deliberately omit allow-same-origin.
-     With allow-scripts only, the sandboxed document gets an opaque origin
-     and cannot access oyster.to cookies or same-origin storage. -->
-<iframe sandbox="allow-scripts" src="/p/${escapeAttr(row.share_token)}/raw"
+<iframe sandbox="allow-scripts allow-same-origin" src="/p/${escapeAttr(row.share_token)}/raw"
         style="border:0;width:100%;flex:1;display:block;"></iframe>`;
   // Iframe view: main fills remaining flex space and stretches the iframe to it.
   // Avoids vh-math that would drift when header height changes at responsive breakpoints.
@@ -122,98 +124,6 @@ export function renderChromeWithIframe(row: PublicationRow): Response {
   });
 }
 
-// Inline shim injected into every iframe-content document. Sandboxed iframes
-// without allow-same-origin can't access localStorage/sessionStorage — every
-// access throws SecurityError. Most AI-generated apps read storage at boot
-// (e.g. to restore a font preference), and a single uncaught SecurityError
-// halts the rest of the bootstrap, leaving the iframe blank.
-//
-// The shim defines no-op replacements when the native APIs are unreachable
-// so apps boot. State doesn't persist (correct for sandboxed content — each
-// visitor gets a fresh load anyway).
-const STORAGE_SHIM = `<script>
-(function() {
-  function noop() { return {
-    getItem: function() { return null; },
-    setItem: function() {},
-    removeItem: function() {},
-    clear: function() {},
-    key: function() { return null; },
-    get length() { return 0; },
-  }; }
-  try { localStorage.length; } catch (e) {
-    Object.defineProperty(window, 'localStorage', { value: noop(), configurable: false });
-  }
-  try { sessionStorage.length; } catch (e) {
-    Object.defineProperty(window, 'sessionStorage', { value: noop(), configurable: false });
-  }
-})();
-</script>`;
-
-export function injectStorageShim(bytes: Uint8Array): Uint8Array {
-  // Byte-level splice — never decode the user's HTML to a string, so we don't
-  // corrupt non-UTF-8 (or invalid-UTF-8) payloads on the round trip. Tag names
-  // are ASCII; we case-fold the haystack bytes manually.
-  //
-  // Insertion priority: <head> > <html> > <!doctype>. Putting a <script> before
-  // an existing <!doctype> would trigger quirks mode, so we always inject AFTER
-  // any structural marker we recognise. If none are present (e.g. a bare HTML
-  // fragment), we leave the doc untouched rather than risking corruption.
-  const at = findShimInsertionPoint(bytes);
-  if (at < 0) return bytes;
-
-  const shimBytes = new TextEncoder().encode(STORAGE_SHIM);
-  const out = new Uint8Array(bytes.length + shimBytes.length);
-  out.set(bytes.subarray(0, at), 0);
-  out.set(shimBytes, at);
-  out.set(bytes.subarray(at), at + shimBytes.length);
-  return out;
-}
-
-function findShimInsertionPoint(bytes: Uint8Array): number {
-  for (const tag of ["<head", "<html", "<!doctype"]) {
-    const start = findTagOpen(bytes, tag);
-    if (start < 0) continue;
-    const close = findByte(bytes, 0x3e /* > */, start + tag.length);
-    if (close >= 0) return close + 1;
-  }
-  return -1;
-}
-
-function findTagOpen(haystack: Uint8Array, lowerNeedle: string): number {
-  // Case-insensitive ASCII match. `lowerNeedle` must already be lowercase.
-  // Also enforces a tag-name boundary after the needle so `<head` doesn't
-  // falsely match `<header>` and `<html` doesn't match `<html5>` etc.
-  const n = lowerNeedle.length;
-  outer: for (let i = 0; i + n <= haystack.length; i++) {
-    for (let j = 0; j < n; j++) {
-      const c = haystack[i + j]!;
-      const want = lowerNeedle.charCodeAt(j);
-      const cl = c >= 0x41 && c <= 0x5a ? c + 0x20 : c;
-      if (cl !== want) continue outer;
-    }
-    // Tag-name boundary: the byte after the needle must NOT be an ASCII
-    // letter or digit, otherwise this is the prefix of a longer tag.
-    const after = haystack[i + n];
-    if (after !== undefined && isTagNameByte(after)) continue outer;
-    return i;
-  }
-  return -1;
-}
-
-function isTagNameByte(byte: number): boolean {
-  return (byte >= 0x41 && byte <= 0x5a) || // A-Z
-    (byte >= 0x61 && byte <= 0x7a) || // a-z
-    (byte >= 0x30 && byte <= 0x39); // 0-9
-}
-
-function findByte(haystack: Uint8Array, byte: number, start: number): number {
-  for (let i = start; i < haystack.length; i++) {
-    if (haystack[i] === byte) return i;
-  }
-  return -1;
-}
-
 export function renderRawHtmlBody(bytes: Uint8Array, row: PublicationRow): Response {
   // Iframe kinds (app/deck/wireframe/table/map) are always HTML. Force
   // text/html regardless of the stored content_type — older publications
@@ -223,13 +133,11 @@ export function renderRawHtmlBody(bytes: Uint8Array, row: PublicationRow): Respo
   const headers = new Headers(cacheHeaders(row, "text/html; charset=utf-8"));
   headers.set(
     "content-security-policy",
-    "default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'",
+    "default-src 'self' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https:; frame-src 'none'; base-uri 'none'; form-action 'none'",
   );
   headers.set("x-frame-options", "SAMEORIGIN");
   headers.set("content-disposition", "inline");
-  // Inject the storage shim so apps that touch localStorage/sessionStorage
-  // at startup can boot rather than crashing on SecurityError.
-  return new Response(injectStorageShim(bytes), { status: 200, headers });
+  return new Response(bytes, { status: 200, headers });
 }
 
 function escapeAttr(s: string): string {

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -35,6 +35,18 @@ export default {
     }
 
     if (url.pathname.startsWith("/p/")) {
+      // Issue #397: viewer canonical origin is share.oyster.to. Anything that
+      // still hits oyster.to/p/* (or www.) gets a 301 to the new origin so
+      // already-shared links keep working. The path is unchanged.
+      if (url.hostname === "oyster.to" || url.hostname === "www.oyster.to") {
+        return new Response(null, {
+          status: 301,
+          headers: {
+            location: `https://share.oyster.to${url.pathname}${url.search}`,
+            "cache-control": "public, max-age=3600",
+          },
+        });
+      }
       const parsed = parseShareTokenPath(url.pathname);
       if (!parsed) return new Response("Not Found", { status: 404 });
       if (req.method === "GET" && parsed.raw) {
@@ -237,7 +249,7 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
     // Step 9: respond (upsert path).
     return jsonOk({
       share_token: shareToken,
-      share_url: `https://oyster.to/p/${shareToken}`,
+      share_url: `https://share.oyster.to/p/${shareToken}`,
       mode: meta.mode,
       published_at: publishedAt,
       updated_at: updatedAt,
@@ -254,7 +266,7 @@ async function handlePublishUpload(req: Request, env: Env): Promise<Response> {
     // Return the same timestamp for both so published_at === updated_at on the wire.
     return jsonOk({
       share_token: shareToken,
-      share_url: `https://oyster.to/p/${shareToken}`,
+      share_url: `https://share.oyster.to/p/${shareToken}`,
       mode: meta.mode,
       published_at: publishedAt,
       updated_at: publishedAt,
@@ -367,7 +379,7 @@ async function handlePublishPatch(req: Request, env: Env, shareToken: string): P
 
   return jsonOk({
     share_token: shareToken,
-    share_url: `https://oyster.to/p/${shareToken}`,
+    share_url: `https://share.oyster.to/p/${shareToken}`,
     mode: body.mode,
     updated_at: updatedAt,
   });

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -36,11 +36,13 @@ export default {
 
     if (url.pathname.startsWith("/p/")) {
       // Issue #397: viewer canonical origin is share.oyster.to. Anything that
-      // still hits oyster.to/p/* (or www.) gets a 301 to the new origin so
-      // already-shared links keep working. The path is unchanged.
+      // still hits oyster.to/p/* (or www.) gets a 308 to the new origin so
+      // already-shared links keep working. 308 (not 301) so the rare POST
+      // against the legacy origin — e.g. a password-form submission from a
+      // bookmarked oyster.to/p/<token> — keeps its method and body intact.
       if (url.hostname === "oyster.to" || url.hostname === "www.oyster.to") {
         return new Response(null, {
-          status: 301,
+          status: 308,
           headers: {
             location: `https://share.oyster.to${url.pathname}${url.search}`,
             "cache-control": "public, max-age=3600",

--- a/infra/oyster-publish/test/publish-handler.test.ts
+++ b/infra/oyster-publish/test/publish-handler.test.ts
@@ -133,7 +133,7 @@ describe("POST /api/publish/upload — first publish (open mode)", () => {
     expect(res.status).toBe(200);
     const json = await res.json() as { share_token: string; share_url: string; mode: string; published_at: number; updated_at: number };
     expect(json.share_token).toMatch(/^[A-Za-z0-9_-]{32}$/);
-    expect(json.share_url).toBe(`https://oyster.to/p/${json.share_token}`);
+    expect(json.share_url).toBe(`https://share.oyster.to/p/${json.share_token}`);
     expect(json.mode).toBe("open");
     expect(json.published_at).toBeTypeOf("number");
     expect(json.updated_at).toBe(json.published_at);

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -41,19 +41,33 @@ async function call(req: Request): Promise<Response> {
   return res;
 }
 
-describe("GET /p/:token — legacy origin redirect (#397)", () => {
-  it("301s oyster.to/p/<token> to share.oyster.to/p/<token>", async () => {
+describe("GET/POST /p/:token — legacy origin redirect (#397)", () => {
+  it("308s GET oyster.to/p/<token> to share.oyster.to/p/<token>", async () => {
     const req = new Request("https://oyster.to/p/abc123", { method: "GET" });
     const res = await call(req);
-    expect(res.status).toBe(301);
+    expect(res.status).toBe(308);
     expect(res.headers.get("location")).toBe("https://share.oyster.to/p/abc123");
   });
 
-  it("301s www.oyster.to/p/<token>/raw to share.oyster.to/p/<token>/raw with query preserved", async () => {
+  it("308s www.oyster.to/p/<token>/raw with query preserved", async () => {
     const req = new Request("https://www.oyster.to/p/abc123/raw?x=1", { method: "GET" });
     const res = await call(req);
-    expect(res.status).toBe(301);
+    expect(res.status).toBe(308);
     expect(res.headers.get("location")).toBe("https://share.oyster.to/p/abc123/raw?x=1");
+  });
+
+  it("308s POST so password-form submissions keep their method+body intact", async () => {
+    // 301 would coerce POST→GET in many clients, dropping the password
+    // body. 308 is method-preserving, so a stale bookmark that POSTs
+    // against the legacy origin still completes its unlock on the new one.
+    const req = new Request("https://oyster.to/p/abc123", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "password=hunter2",
+    });
+    const res = await call(req);
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("https://share.oyster.to/p/abc123");
   });
 });
 

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -22,7 +22,7 @@ function getReq(path: string, opts: { cookie?: string; ifNoneMatch?: string } = 
   const headers = new Headers();
   if (opts.cookie) headers.set("Cookie", opts.cookie);
   if (opts.ifNoneMatch) headers.set("If-None-Match", opts.ifNoneMatch);
-  return new Request(`https://oyster.to${path}`, { method: "GET", headers });
+  return new Request(`https://share.oyster.to${path}`, { method: "GET", headers });
 }
 
 function postReq(path: string, opts: { cookie?: string; password?: string } = {}): Request {
@@ -31,7 +31,7 @@ function postReq(path: string, opts: { cookie?: string; password?: string } = {}
   headers.set("Content-Type", "application/x-www-form-urlencoded");
   const body = new URLSearchParams();
   if (opts.password !== undefined) body.set("password", opts.password);
-  return new Request(`https://oyster.to${path}`, { method: "POST", headers, body: body.toString() });
+  return new Request(`https://share.oyster.to${path}`, { method: "POST", headers, body: body.toString() });
 }
 
 async function call(req: Request): Promise<Response> {
@@ -40,6 +40,22 @@ async function call(req: Request): Promise<Response> {
   await waitOnExecutionContext(ctx);
   return res;
 }
+
+describe("GET /p/:token — legacy origin redirect (#397)", () => {
+  it("301s oyster.to/p/<token> to share.oyster.to/p/<token>", async () => {
+    const req = new Request("https://oyster.to/p/abc123", { method: "GET" });
+    const res = await call(req);
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://share.oyster.to/p/abc123");
+  });
+
+  it("301s www.oyster.to/p/<token>/raw to share.oyster.to/p/<token>/raw with query preserved", async () => {
+    const req = new Request("https://www.oyster.to/p/abc123/raw?x=1", { method: "GET" });
+    const res = await call(req);
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://share.oyster.to/p/abc123/raw?x=1");
+  });
+});
 
 describe("GET /p/:token — 404 / 410", () => {
   it("returns 404 for unknown token", async () => {
@@ -109,8 +125,7 @@ describe("GET /p/:token — open mode", () => {
     expect(res.headers.get("content-type")).toMatch(/^text\/html/);
     const body = await res.text();
     expect(body).toContain(`src="/p/${shareToken}/raw"`);
-    expect(body).toContain('sandbox="allow-scripts"');
-    expect(body).not.toMatch(/sandbox="[^"]*allow-same-origin/);
+    expect(body).toContain('sandbox="allow-scripts allow-same-origin"');
   });
 });
 
@@ -125,7 +140,7 @@ describe("GET /p/:token/raw — iframe content", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
     const csp = res.headers.get("content-security-policy") ?? "";
-    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toContain("connect-src 'self' https:");
     expect(csp).toContain("form-action 'none'");
     expect(res.headers.get("x-frame-options")).toBe("SAMEORIGIN");
     expect(await res.text()).toContain("<h1>raw app</h1>");

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -141,16 +141,8 @@ describe("renderChromeWithIframe", () => {
   it("contains a sandboxed iframe pointing at /p/<token>/raw", async () => {
     const res = renderChromeWithIframe(ROW);
     const body = await res.text();
-    expect(body).toContain('sandbox="allow-scripts"');
+    expect(body).toContain('sandbox="allow-scripts allow-same-origin"');
     expect(body).toContain('src="/p/app1/raw"');
-    // Critical: sandbox attribute must NOT include allow-same-origin (would defeat origin isolation)
-    expect(body).not.toMatch(/sandbox="[^"]*allow-same-origin/);
-  });
-
-  it("includes the deliberate-omission comment in source", async () => {
-    const res = renderChromeWithIframe(ROW);
-    const body = await res.text();
-    expect(body).toContain("Deliberately omit allow-same-origin");
   });
 });
 
@@ -171,11 +163,12 @@ describe("renderRawHtmlBody — strict CSP for iframe content", () => {
     expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
   });
 
-  it("sets a strict CSP including connect-src 'none' and form-action 'none'", async () => {
+  it("sets a CSP that allows same-origin + HTTPS fetches and blocks frames + forms", async () => {
     const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
     const res = renderRawHtmlBody(new TextEncoder().encode(""), ROW);
     const csp = res.headers.get("content-security-policy") ?? "";
-    expect(csp).toContain("connect-src 'none'");
+    // Origin-isolated apps can fetch their own subdomain and any HTTPS API.
+    expect(csp).toContain("connect-src 'self' https:");
     expect(csp).toContain("frame-src 'none'");
     expect(csp).toContain("base-uri 'none'");
     expect(csp).toContain("form-action 'none'");
@@ -196,106 +189,32 @@ describe("renderRawHtmlBody — strict CSP for iframe content", () => {
   });
 });
 
-describe("renderRawHtmlBody — storage shim injection", () => {
+describe("renderRawHtmlBody — passthrough", () => {
   const ROW = { share_token: "app1", mode: "open", updated_at: 3000, content_type: "text/html" } as any;
 
-  it("injects a no-op localStorage/sessionStorage shim into the served HTML", async () => {
-    const bytes = new TextEncoder().encode("<!doctype html><html><head><title>x</title></head><body>hi</body></html>");
-    const body = await renderRawHtmlBody(bytes, ROW).text();
-    expect(body).toContain("localStorage");
-    expect(body).toContain("sessionStorage");
-    expect(body).toContain("Object.defineProperty");
+  it("passes the user's HTML through byte-for-byte (no transform)", async () => {
+    const original = "<!doctype html><html><head></head><body><p>Hello</p></body></html>";
+    const body = await renderRawHtmlBody(new TextEncoder().encode(original), ROW).text();
+    expect(body).toBe(original);
   });
 
-  it("places the shim immediately after <head> so it runs before any user script", async () => {
-    const bytes = new TextEncoder().encode(
-      "<!doctype html><html><head><script>window.userCode='ran'</script></head><body></body></html>",
-    );
-    const body = await renderRawHtmlBody(bytes, ROW).text();
-    const shimIdx = body.indexOf("Object.defineProperty");
-    const userIdx = body.indexOf("userCode");
-    expect(shimIdx).toBeGreaterThan(-1);
-    expect(userIdx).toBeGreaterThan(-1);
-    expect(shimIdx).toBeLessThan(userIdx);
-  });
-
-  it("falls back to <html> when no <head> is present", async () => {
-    const bytes = new TextEncoder().encode("<!doctype html><html><body>hi</body></html>");
-    const body = await renderRawHtmlBody(bytes, ROW).text();
-    const shimIdx = body.indexOf("Object.defineProperty");
-    const htmlIdx = body.indexOf("<html>");
-    const bodyIdx = body.indexOf("<body");
-    expect(shimIdx).toBeGreaterThan(htmlIdx); // after <html>
-    expect(shimIdx).toBeLessThan(bodyIdx); // before <body>
-  });
-
-  it("falls back to <!doctype> when neither <head> nor <html> is present (avoids quirks mode)", async () => {
-    // A <script> before <!doctype> would put the browser in quirks mode.
-    // Insert AFTER the doctype instead.
-    const bytes = new TextEncoder().encode("<!doctype html><body>fragment</body>");
-    const body = await renderRawHtmlBody(bytes, ROW).text();
-    const shimIdx = body.indexOf("Object.defineProperty");
-    expect(body.toLowerCase().startsWith("<!doctype html>")).toBe(true);
-    expect(shimIdx).toBeGreaterThan("<!doctype html>".length - 1);
-  });
-
-  it("leaves the document untouched when no <head>/<html>/<!doctype> marker is present (avoids corruption)", async () => {
-    const bytes = new TextEncoder().encode("<div>fragment</div>");
-    const out = renderRawHtmlBody(bytes, ROW);
-    const body = await out.text();
-    expect(body).toBe("<div>fragment</div>");
-    expect(body).not.toContain("Object.defineProperty");
-  });
-
-  it("does not mistake <header> for <head> (tag-name boundary check)", async () => {
-    // <header> shares a 5-char prefix with <head>; we must not pick up the
-    // wrong tag and inject mid-document. Doc has no real <head>, so the
-    // shim should fall through to <html> instead.
-    const bytes = new TextEncoder().encode(
-      "<!doctype html><html><body><header>nav</header><p>hi</p></body></html>",
-    );
-    const body = await renderRawHtmlBody(bytes, ROW).text();
-    const shimIdx = body.indexOf("Object.defineProperty");
-    const htmlOpen = body.indexOf("<html>");
-    const headerOpen = body.indexOf("<header>");
-    expect(shimIdx).toBeGreaterThan(htmlOpen);
-    expect(shimIdx).toBeLessThan(headerOpen); // not after <header>
-  });
-
-  it("does not mistake <html5> or similar for <html>", async () => {
-    // No real <html>/<head>/<!doctype>; only a fake <html5> tag-like prefix.
-    // Should leave the doc untouched.
-    const bytes = new TextEncoder().encode("<html5-not-a-tag>x</html5-not-a-tag>");
-    const out = renderRawHtmlBody(bytes, ROW);
-    const body = await out.text();
-    expect(body).not.toContain("Object.defineProperty");
-  });
-
-  it("preserves arbitrary bytes after the insertion point (no UTF-8 round-trip)", async () => {
-    // Use a payload with a non-UTF-8-safe byte after the head. A byte-level
-    // splice should leave it untouched; a TextDecoder round-trip would
-    // replace it with U+FFFD or otherwise mangle it.
-    const head = new TextEncoder().encode("<!doctype html><html><head></head><body>");
+  it("preserves invalid-UTF-8 bytes (no string round-trip)", async () => {
+    // A non-UTF-8-safe byte in the user's payload must reach the response
+    // bytes unchanged; a TextDecoder round-trip would replace it with U+FFFD.
+    const head = new TextEncoder().encode("<!doctype html><html><body>");
     const tail = new TextEncoder().encode("</body></html>");
-    const lonelyContinuation = new Uint8Array([0xc3, 0x28]); // invalid UTF-8 sequence
+    const lonelyContinuation = new Uint8Array([0xc3, 0x28]); // invalid UTF-8
     const bytes = new Uint8Array(head.length + lonelyContinuation.length + tail.length);
     bytes.set(head, 0);
     bytes.set(lonelyContinuation, head.length);
     bytes.set(tail, head.length + lonelyContinuation.length);
 
     const out = new Uint8Array(await renderRawHtmlBody(bytes, ROW).arrayBuffer());
-    // Find the lonely continuation bytes are still present, byte-for-byte.
     let found = false;
     for (let i = 0; i < out.length - 1; i++) {
       if (out[i] === 0xc3 && out[i + 1] === 0x28) { found = true; break; }
     }
     expect(found).toBe(true);
-  });
-
-  it("preserves the user's original HTML byte-for-byte after the shim", async () => {
-    const original = "<!doctype html><html><head></head><body><p>Hello</p></body></html>";
-    const body = await renderRawHtmlBody(new TextEncoder().encode(original), ROW).text();
-    expect(body).toContain("<body><p>Hello</p></body></html>");
   });
 });
 

--- a/infra/oyster-publish/wrangler.toml
+++ b/infra/oyster-publish/wrangler.toml
@@ -36,6 +36,13 @@ zone_name = "oyster.to"
 pattern = "www.oyster.to/p/*"
 zone_name = "oyster.to"
 
+# Origin-isolated public viewer. Same handler as oyster.to/p/* — the host
+# split is what gives us cookie/storage isolation between the main app and
+# untrusted published content (issue #397).
+[[routes]]
+pattern = "share.oyster.to/p/*"
+zone_name = "oyster.to"
+
 # Rate limiter for password-gate POST attempts. Key = `${ip}:${share_token}`
 # so one IP cannot exhaust attempts across all of a publisher's shares.
 # Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -105,7 +105,7 @@ export class ArtifactService {
     this.getCloudOnlyPublications = source;
   }
 
-  constructor(private store: ArtifactStore, private workerBase: string, private userlandDir?: string, private spaceStore?: SpaceStore) {}
+  constructor(private store: ArtifactStore, private workerBase: string, private viewerBase: string, private userlandDir?: string, private spaceStore?: SpaceStore) {}
 
   async getAllArtifacts(onArtifactRemoved?: (id: string, filePath: string) => void): Promise<Artifact[]> {
     const allRows = this.store.getAll();
@@ -216,7 +216,7 @@ export class ArtifactService {
     for (const pub of cloud) {
       if (localIds.has(pub.artifactId)) continue;
       const kind = toArtifactKind(pub.artifactKind);
-      const shareUrl = `${this.workerBase.replace(/\/$/, "")}/p/${pub.shareToken}`;
+      const shareUrl = `${this.viewerBase.replace(/\/$/, "")}/p/${pub.shareToken}`;
       const spaceId = pub.spaceId && localSpaceIds.has(pub.spaceId) ? pub.spaceId : "_cloud";
       const fallback = UUID_RE.test(pub.artifactId) ? `Untitled ${pub.artifactKind}` : pub.artifactId;
       out.push({
@@ -643,7 +643,7 @@ export class ArtifactService {
     const publication = row.share_token
       ? {
           shareToken: row.share_token,
-          shareUrl: `${this.workerBase}/p/${row.share_token}`,
+          shareUrl: `${this.viewerBase.replace(/\/$/, "")}/p/${row.share_token}`,
           shareMode: row.share_mode!,
           publishedAt: row.published_at!,
           updatedAt: row.share_updated_at!,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -250,11 +250,19 @@ const WORKER_BASE = process.env.OYSTER_AUTH_BASE
   ? process.env.OYSTER_AUTH_BASE.replace(/\/auth$/, "")
   : "https://oyster.to";
 
+// VIEWER_BASE is the public origin where /p/{token} renders (issue #397).
+// In production it's a separate subdomain so untrusted published content
+// can't read main-app cookies/storage. In local wrangler dev, the API and
+// viewer paths are served from the same dev server, so default to
+// WORKER_BASE when the explicit env var is unset and we're not on prod.
+const VIEWER_BASE = process.env.OYSTER_VIEWER_BASE
+  ?? (WORKER_BASE === "https://oyster.to" ? "https://share.oyster.to" : WORKER_BASE);
+
 // artifactService reads the dedicated icons dir at `<root>/icons/<id>/icon.png`
 // — that lives at OYSTER_HOME root (URL-addressable via /artifacts/icons/...),
 // not inside DB_DIR. spaceStore is passed in so rowToArtifact can resolve the
 // linked-source path for tiles whose `source_id` is non-null.
-const artifactService = new ArtifactService(store, WORKER_BASE, OYSTER_HOME, spaceStore);
+const artifactService = new ArtifactService(store, WORKER_BASE, VIEWER_BASE, OYSTER_HOME, spaceStore);
 
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore);
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);

--- a/server/test/artifact-service.test.ts
+++ b/server/test/artifact-service.test.ts
@@ -76,7 +76,7 @@ describe("artifact wire format — publication", () => {
   beforeEach(() => {
     db = makeDb();
     const store = new SqliteArtifactStore(db);
-    service = new ArtifactService(store, "https://oyster.to");
+    service = new ArtifactService(store, "https://oyster.to", "https://share.oyster.to");
   });
 
   it("omits the publication field when share_token is NULL", async () => {
@@ -95,7 +95,7 @@ describe("artifact wire format — publication", () => {
     const [a] = await service.getAllArtifacts(() => {});
     expect((a as any).publication).toEqual({
       shareToken: "Hk3qm9p_ZxN",
-      shareUrl: "https://oyster.to/p/Hk3qm9p_ZxN",
+      shareUrl: "https://share.oyster.to/p/Hk3qm9p_ZxN",
       shareMode: "open",
       publishedAt: 1717000000000,
       updatedAt: 1717000000000,
@@ -123,7 +123,7 @@ describe("artifact wire format — cloud-only ghosts", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to");
+    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("synthesises a cloudOnly ghost using the cloud label, falling back to artifact_id", async () => {
@@ -190,7 +190,7 @@ describe("artifact wire format — pin (#387)", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to");
+    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("omits pinnedAt when pinned_at is NULL", async () => {
@@ -215,7 +215,7 @@ describe("ArtifactService.pinArtifact / unpinArtifact (#387)", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to");
+    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("pinArtifact stamps pinned_at and returns the timestamp", () => {

--- a/server/test/publish-route.test.ts
+++ b/server/test/publish-route.test.ts
@@ -18,7 +18,7 @@ describe("routes/publish — SSE broadcast", () => {
     const broadcast = vi.fn();
     const publishService = {
       publishArtifact: vi.fn().mockResolvedValue({
-        share_token: "tok", share_url: "https://oyster.to/p/tok",
+        share_token: "tok", share_url: "https://share.oyster.to/p/tok",
         mode: "open", published_at: 1, updated_at: 1,
       }),
       unpublishArtifact: vi.fn(),

--- a/server/test/publish-service.test.ts
+++ b/server/test/publish-service.test.ts
@@ -112,7 +112,7 @@ describe("publishArtifact", () => {
       expect(allHeaders).not.toContain("hunter2");
       return new Response(JSON.stringify({
         share_token: "tok123",
-        share_url: "https://oyster.to/p/tok123",
+        share_url: "https://share.oyster.to/p/tok123",
         mode: "password",
         published_at: 1700000000000,
         updated_at: 1700000005000,
@@ -131,7 +131,7 @@ describe("publishArtifact", () => {
 
     const out = await svc.publishArtifact({ artifact_id: "art_1", mode: "password", password: "hunter2" });
     expect(out.share_token).toBe("tok123");
-    expect(out.share_url).toBe("https://oyster.to/p/tok123");
+    expect(out.share_url).toBe("https://share.oyster.to/p/tok123");
 
     const row = db.prepare("SELECT * FROM artifacts WHERE id = 'art_1'").get() as any;
     expect(row.owner_id).toBe("u1");                  // set on first publish
@@ -238,7 +238,7 @@ describe("publishArtifact additional coverage", () => {
     const db = makeDb();
     seedArtifact(db, { id: "art_1", owner_id: "u1" });
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      share_token: "tok123", share_url: "https://oyster.to/p/tok123",
+      share_token: "tok123", share_url: "https://share.oyster.to/p/tok123",
       mode: "open", published_at: 1, updated_at: 1,
     }), { status: 200, headers: { "content-type": "application/json" } }));
     const svc = createPublishService({
@@ -297,7 +297,7 @@ describe("publishArtifact tier mode gating", () => {
     const db = makeDb();
     seedArtifact(db, { id: "art_1", owner_id: "u1" });
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      share_token: "tok", share_url: "https://oyster.to/p/tok",
+      share_token: "tok", share_url: "https://share.oyster.to/p/tok",
       mode: "password", published_at: 1, updated_at: 1,
     }), { status: 200, headers: { "content-type": "application/json" } }));
     const svc = createPublishService({
@@ -342,7 +342,7 @@ describe("updateShareByToken", () => {
       captured = { url, method: init.method, body: JSON.parse(init.body as string) };
       return new Response(JSON.stringify({
         share_token: "tokABC",
-        share_url: "https://oyster.to/p/tokABC",
+        share_url: "https://share.oyster.to/p/tokABC",
         mode: "password",
         updated_at: 9999,
       }), { status: 200, headers: { "content-type": "application/json" } });
@@ -380,7 +380,7 @@ describe("updateShareByToken", () => {
     db.prepare(`UPDATE artifacts SET share_token='tokA', share_mode='password', share_password_hash='pbkdf2$old' WHERE id='art_local'`).run();
 
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      share_token: "tokA", share_url: "https://oyster.to/p/tokA",
+      share_token: "tokA", share_url: "https://share.oyster.to/p/tokA",
       mode: "open", updated_at: 1,
     }), { status: 200, headers: { "content-type": "application/json" } }));
     const svc = createPublishService({


### PR DESCRIPTION
## Summary

Closes #397.

- Public viewer moves from `oyster.to/p/{token}` to **`share.oyster.to/p/{token}`** so untrusted published content runs on a separate origin from the main app's session.
- `oyster.to/p/*` and `www.oyster.to/p/*` 301-redirect to the new origin; existing share URLs keep working.
- Iframe sandbox relaxes from `allow-scripts` only → `allow-scripts allow-same-origin`. Origin isolation is now the primary defense, so apps regain real `localStorage` / `sessionStorage`. The byte-splice storage shim from #396 is removed (~110 lines).
- CSP for `/raw` relaxes `connect-src 'none'` → `connect-src 'self' https:` so apps can fetch HTTPS APIs.
- Auth-worker session cookie drops `Domain=.oyster.to` → host-only on the apex. Closes the leak path that would have sent `oyster_session` to `share.oyster.to`.
- Server gains a separate `VIEWER_BASE` (defaulting to `https://share.oyster.to` in production, `WORKER_BASE` in local dev) so reconstructed share URLs match the worker's authoritative response.

## Operational steps (already partly done / pending after merge)

- [x] DNS: `share.oyster.to` CNAME → `oyster.to`, proxied (orange cloud)
- [ ] `wrangler deploy` from `infra/oyster-publish` (picks up the new route + redirect + share_url + CSP/sandbox changes)
- [ ] `wrangler deploy` from `infra/oyster-auth` (picks up the cookie scope change)

Deploy publish first so `share.oyster.to/p/*` is live before any redirect lands users there.

## Test plan

- [x] `npm test` in `infra/oyster-publish` — 114/114 pass (includes new redirect tests for both apex and www)
- [x] `npm test` in `infra/auth-worker` — 31/31 pass
- [x] `npm test` in `server` — 95/95 pass
- [x] `tsc --noEmit` clean across publish-worker, auth-worker, server, web
- [ ] Post-deploy: malicious app served at `share.oyster.to/p/<token>` cannot read `oyster.to` cookies or `localStorage` (browser devtools / test fixture)
- [ ] Post-deploy: hitting an existing `oyster.to/p/<token>` URL 301s to `share.oyster.to/p/<token>`
- [ ] Post-deploy: published apps that touch `localStorage` at boot work (no shim, real storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)