### PR TITLE
feat(spaces-sync): cloud-mirror spaces table (closes #406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Spaces now sync across signed-in devices.** Pro users see the same set of spaces — name, hierarchy, summary — on every device they sign into. Published artefacts on a fresh device resolve to their real space instead of a generic "Cloud" bucket.
+
 ## [0.7.0] - 2026-05-05
 
 Identity and the open web — sign in, publish artefacts, share them anywhere.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-7-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
       <a class="version-pill" href="#v-0-5-0">0.5</a>
@@ -323,6 +324,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.7.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>Spaces now sync across signed-in devices.</strong> Pro users see the same set of spaces — name, hierarchy, summary — on every device they sign into. Published artefacts on a fresh device resolve to their real space instead of a generic &quot;Cloud&quot; bucket.</li>
+</ul>
 <h2 id="v-0-7-0"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.6.0...v0.7.0" rel="noopener noreferrer"><span class="release-version">0.7.0</span></a><span class="release-date"> — 2026-05-05</span></h2>
 <p>Identity and the open web — sign in, publish artefacts, share them anywhere.</p>
 <h3>Added</h3>

--- a/docs/superpowers/plans/2026-05-06-spaces-sync-spinout.md
+++ b/docs/superpowers/plans/2026-05-06-spaces-sync-spinout.md
@@ -37,6 +37,8 @@
 - Create: `infra/auth-worker/migrations/0006_synced_spaces.sql`
 - Modify: `infra/oyster-publish/test/fixtures/seed.ts` (add schema + seed helpers)
 
+> **Migration ownership note:** the `oyster-publish` Worker reads/writes the *same* D1 database as `oyster-auth` (binding `DB`, db name `oyster-auth`, ID `44086805-...` per `infra/oyster-publish/wrangler.toml`). All D1 migrations for that shared DB live under `infra/auth-worker/migrations/` — adding spaces there matches the precedent set by `0003_publish.sql` (which created `published_artifacts`) and `0005_publish_context.sql`. Endpoints stay in `oyster-publish`.
+
 - [ ] **Step 1: Write the migration file**
 
 Create `infra/auth-worker/migrations/0006_synced_spaces.sql`:
@@ -46,6 +48,7 @@ Create `infra/auth-worker/migrations/0006_synced_spaces.sql`:
 -- Spec: docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
 -- Wedge of #319 (R1). Used by the local server's space-sync-service to
 -- reconcile per-user spaces across devices. Tombstones propagate deletes.
+-- Lives in the shared oyster-auth D1 (oyster-publish Worker reads/writes it).
 
 CREATE TABLE IF NOT EXISTS synced_spaces (
   owner_id        TEXT    NOT NULL,
@@ -420,7 +423,12 @@ In `worker.ts`, add this route after the GET route from Task 2:
 
 ```ts
     if (url.pathname.startsWith("/api/spaces/") && req.method === "PUT") {
-      const spaceId = url.pathname.slice("/api/spaces/".length);
+      const raw = url.pathname.slice("/api/spaces/".length);
+      // Reject any path with extra segments before decoding (defence in depth).
+      if (raw.includes("/")) return new Response("Not Found", { status: 404 });
+      let spaceId: string;
+      try { spaceId = decodeURIComponent(raw); }
+      catch { return jsonError(400, "invalid_space_id"); }
       return handleSpacesPut(req, env, spaceId);
     }
 ```
@@ -444,17 +452,31 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
   try { body = await req.json() as typeof body; }
   catch { return jsonError(400, "invalid_metadata"); }
 
-  if (typeof body.display_name !== "string" || body.display_name.length === 0) {
+  if (typeof body.display_name !== "string" || body.display_name.trim().length === 0) {
     return jsonError(400, "invalid_metadata");
   }
-  if (typeof body.updated_at !== "number" || !Number.isFinite(body.updated_at)) {
+  if (body.display_name.length > 200) {
+    // Cheap upper bound; protects D1 from pathological inputs.
     return jsonError(400, "invalid_metadata");
   }
-  // Optional fields — null is allowed; unset becomes null.
-  const color           = body.color           === undefined ? null : (body.color           as string | null);
-  const parentId        = body.parent_id       === undefined ? null : (body.parent_id       as string | null);
-  const summaryTitle    = body.summary_title   === undefined ? null : (body.summary_title   as string | null);
-  const summaryContent  = body.summary_content === undefined ? null : (body.summary_content as string | null);
+  if (typeof body.updated_at !== "number" || !Number.isFinite(body.updated_at) || body.updated_at < 0) {
+    return jsonError(400, "invalid_metadata");
+  }
+
+  // Strict optional-field validation — accept undefined (preserve), null (clear),
+  // or string (set). Anything else is a 400.
+  function validateOptional(name: string, v: unknown): { ok: true; value: string | null } | { ok: false } {
+    if (v === undefined || v === null) return { ok: true, value: null };
+    if (typeof v === "string") return { ok: true, value: v };
+    return { ok: false };
+  }
+  const color          = validateOptional("color",          body.color);
+  const parentId       = validateOptional("parent_id",      body.parent_id);
+  const summaryTitle   = validateOptional("summary_title",  body.summary_title);
+  const summaryContent = validateOptional("summary_content", body.summary_content);
+  if (!color.ok || !parentId.ok || !summaryTitle.ok || !summaryContent.ok) {
+    return jsonError(400, "invalid_metadata");
+  }
   const incomingUpdated = body.updated_at;
 
   type Row = {
@@ -488,8 +510,8 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
               summary_title = ?, summary_content = ?, updated_at = ?
         WHERE owner_id = ? AND space_id = ?`,
     ).bind(
-      body.display_name, color, parentId,
-      summaryTitle, summaryContent, incomingUpdated,
+      body.display_name.trim(), color.value, parentId.value,
+      summaryTitle.value, summaryContent.value, incomingUpdated,
       user.id, spaceId,
     ).run();
   } else {
@@ -499,8 +521,8 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
         summary_title, summary_content, updated_at, deleted_at, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
     ).bind(
-      user.id, spaceId, body.display_name, color, parentId,
-      summaryTitle, summaryContent, incomingUpdated, now,
+      user.id, spaceId, body.display_name.trim(), color.value, parentId.value,
+      summaryTitle.value, summaryContent.value, incomingUpdated, now,
     ).run();
   }
 
@@ -605,7 +627,11 @@ In `worker.ts`, add this route after the PUT route from Task 3:
 
 ```ts
     if (url.pathname.startsWith("/api/spaces/") && req.method === "DELETE") {
-      const spaceId = url.pathname.slice("/api/spaces/".length);
+      const raw = url.pathname.slice("/api/spaces/".length);
+      if (raw.includes("/")) return new Response("Not Found", { status: 404 });
+      let spaceId: string;
+      try { spaceId = decodeURIComponent(raw); }
+      catch { return jsonError(400, "invalid_space_id"); }
       return handleSpacesDelete(req, env, spaceId);
     }
 ```
@@ -623,6 +649,9 @@ async function handleSpacesDelete(req: Request, env: Env, spaceId: string): Prom
     "SELECT deleted_at, updated_at FROM synced_spaces WHERE owner_id = ? AND space_id = ?",
   ).bind(user.id, spaceId).first<Row>();
 
+  // 404 means: there's no cloud row to tombstone — the local delete is the
+  // only state that ever existed for this id. Caller treats 404 as "already
+  // gone elsewhere; mark the local tombstone synced and stop retrying."
   if (!existing) return jsonError(404, "space_not_found");
 
   // Idempotent: existing tombstone returns as-is.
@@ -662,16 +691,17 @@ git commit -m "feat(spaces-sync): DELETE /api/spaces/:id sets tombstone, idempot
 
 ---
 
-## Task 5: Local — db.ts adds cloud_synced_at + deleted_at to spaces
+## Task 5: Local — db.ts adds sync_dirty_at + cloud_synced_at + deleted_at + first-time backfill
 
 **Files:**
 - Modify: `server/src/db.ts`
 
 - [ ] **Step 1: Add ALTER TABLE statements**
 
-In `server/src/db.ts`, find the existing spaces ALTER block (lines 50-52: `ALTER TABLE spaces ADD COLUMN parent_id ...`) and append two new statements to the same array:
+In `server/src/db.ts`, find the existing spaces ALTER block (lines 50-52: `ALTER TABLE spaces ADD COLUMN parent_id ...`) and append three new statements to the same array. Order matters only insofar as `sync_dirty_at` must exist before the backfill (Step 2) reads it:
 
 ```ts
+    "ALTER TABLE spaces ADD COLUMN sync_dirty_at INTEGER",
     "ALTER TABLE spaces ADD COLUMN cloud_synced_at INTEGER",
     "ALTER TABLE spaces ADD COLUMN deleted_at INTEGER",
 ```
@@ -687,6 +717,7 @@ The full updated block:
     "ALTER TABLE spaces ADD COLUMN parent_id TEXT REFERENCES spaces(id)",
     "ALTER TABLE spaces ADD COLUMN summary_title TEXT",
     "ALTER TABLE spaces ADD COLUMN summary_content TEXT",
+    "ALTER TABLE spaces ADD COLUMN sync_dirty_at INTEGER",
     "ALTER TABLE spaces ADD COLUMN cloud_synced_at INTEGER",
     "ALTER TABLE spaces ADD COLUMN deleted_at INTEGER",
   ]) {
@@ -694,21 +725,38 @@ The full updated block:
   }
 ```
 
-- [ ] **Step 2: Verify migration is idempotent**
+- [ ] **Step 2: One-time promotion backfill — mark every existing live row dirty exactly once**
 
-Run the existing server test suite — many tests construct fresh DBs via `initDb`:
+After the ALTER block, before the `space_paths` table creation, add the backfill:
+
+```ts
+  // Promotion backfill: any pre-existing rows (created before sync existed)
+  // need to be pushed up on first Pro sign-in. Mark them dirty exactly once
+  // by setting sync_dirty_at where it's still NULL — a no-op on subsequent
+  // boots since the column will already be populated.
+  // Excludes tombstones: deleted_at IS NULL is the live-row guard.
+  db.exec(`
+    UPDATE spaces
+       SET sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+     WHERE sync_dirty_at IS NULL AND deleted_at IS NULL
+  `);
+```
+
+- [ ] **Step 3: Verify migration is idempotent**
+
+Run the existing server test suite:
 
 ```bash
 cd server && npm test
 ```
 
-Expected: PASS (no test broken; the new columns just default NULL on existing rows).
+Expected: PASS. The new columns default NULL; the backfill UPDATE on a fresh DB matches zero rows (table is empty); on existing DBs it runs once then no-ops.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
 git add server/src/db.ts
-git commit -m "feat(spaces-sync): add cloud_synced_at + deleted_at to local spaces table"
+git commit -m "feat(spaces-sync): sync_dirty_at + cloud_synced_at + deleted_at + promotion backfill"
 ```
 
 ---
@@ -744,6 +792,7 @@ function makeDb(): Database.Database {
       ai_job_error      TEXT,
       summary_title     TEXT,
       summary_content   TEXT,
+      sync_dirty_at     INTEGER,
       cloud_synced_at   INTEGER,
       deleted_at        INTEGER,
       created_at        TEXT NOT NULL DEFAULT (datetime('now')),
@@ -782,33 +831,90 @@ describe("SqliteSpaceStore — sync methods + soft-delete", () => {
     store = new SqliteSpaceStore(db);
   });
 
+  describe("markSyncDirty", () => {
+    it("sets sync_dirty_at to the given timestamp", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1234);
+      const row = db.prepare("SELECT sync_dirty_at FROM spaces WHERE id='a'")
+        .get() as { sync_dirty_at: number };
+      expect(row.sync_dirty_at).toBe(1234);
+    });
+
+    it("defaults to Date.now() when no timestamp is given", () => {
+      insertRow(store, "a");
+      const before = Date.now();
+      store.markSyncDirty("a");
+      const after = Date.now();
+      const row = db.prepare("SELECT sync_dirty_at FROM spaces WHERE id='a'")
+        .get() as { sync_dirty_at: number };
+      expect(row.sync_dirty_at).toBeGreaterThanOrEqual(before);
+      expect(row.sync_dirty_at).toBeLessThanOrEqual(after);
+    });
+  });
+
   describe("getDirtyRows", () => {
-    it("returns rows where cloud_synced_at IS NULL", () => {
+    it("excludes rows where sync_dirty_at IS NULL (no sync-relevant change yet)", () => {
       insertRow(store, "a");
-      insertRow(store, "b");
-      expect(store.getDirtyRows().map(r => r.id).sort()).toEqual(["a", "b"]);
-    });
-
-    it("returns rows where updated_at > cloud_synced_at", () => {
-      insertRow(store, "a");
-      // Mark as synced 1s ago, then bump updated_at to now.
-      db.prepare("UPDATE spaces SET cloud_synced_at = ? WHERE id = 'a'").run(Date.now() - 60_000);
-      db.prepare("UPDATE spaces SET updated_at = datetime('now') WHERE id = 'a'").run();
-      const dirty = store.getDirtyRows();
-      expect(dirty.map(r => r.id)).toEqual(["a"]);
-    });
-
-    it("excludes rows where cloud_synced_at >= updated_at", () => {
-      insertRow(store, "a");
-      // Mark synced AT or AFTER current updated_at — the row is clean.
-      db.prepare("UPDATE spaces SET cloud_synced_at = ? WHERE id = 'a'").run(Date.now() + 60_000);
+      // No markSyncDirty call → row is not dirty per the new predicate.
       expect(store.getDirtyRows()).toEqual([]);
     });
 
-    it("excludes tombstoned rows (those go via the delete-push path)", () => {
+    it("returns rows where sync_dirty_at IS NOT NULL AND cloud_synced_at IS NULL", () => {
       insertRow(store, "a");
+      insertRow(store, "b");
+      store.markSyncDirty("a", 1000);
+      store.markSyncDirty("b", 2000);
+      expect(store.getDirtyRows().map(r => r.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("returns rows where sync_dirty_at > cloud_synced_at", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 5000);
+      store.markSynced("a", 3000);  // synced state from before this dirty mark
+      expect(store.getDirtyRows().map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes rows where cloud_synced_at >= sync_dirty_at", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1000);
+      store.markSynced("a", 1000);
+      expect(store.getDirtyRows()).toEqual([]);
+    });
+
+    it("excludes tombstoned rows (those go via getPendingDeletes)", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1000);
       store.softDelete("a");
       expect(store.getDirtyRows().map(r => r.id)).toEqual([]);
+    });
+  });
+
+  describe("getPendingDeletes", () => {
+    it("returns soft-deleted rows whose deleted_at is unsynced", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 5000);
+      const pending = store.getPendingDeletes();
+      expect(pending.map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes soft-deleted rows already synced past their deleted_at", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 5000);
+      store.markSynced("a", 5000);
+      expect(store.getPendingDeletes()).toEqual([]);
+    });
+
+    it("includes soft-deleted rows where cloud_synced_at < deleted_at (peer state stale)", () => {
+      insertRow(store, "a");
+      store.markSynced("a", 1000);
+      store.softDelete("a", 5000);
+      expect(store.getPendingDeletes().map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes live rows", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1000);
+      expect(store.getPendingDeletes()).toEqual([]);
     });
   });
 
@@ -822,13 +928,21 @@ describe("SqliteSpaceStore — sync methods + soft-delete", () => {
   });
 
   describe("softDelete", () => {
-    it("sets deleted_at to now", () => {
+    it("sets deleted_at to now() by default", () => {
       insertRow(store, "a");
       const before = Date.now();
       store.softDelete("a");
       const row = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'a'")
         .get() as { deleted_at: number };
       expect(row.deleted_at).toBeGreaterThanOrEqual(before);
+    });
+
+    it("uses the provided deletedAt timestamp when given (preserves cross-device tombstone provenance)", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 12345);
+      const row = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'a'")
+        .get() as { deleted_at: number };
+      expect(row.deleted_at).toBe(12345);
     });
 
     it("excludes the soft-deleted row from getAll() and getById()", () => {
@@ -840,13 +954,11 @@ describe("SqliteSpaceStore — sync methods + soft-delete", () => {
 
     it("is idempotent — re-softDelete leaves deleted_at unchanged", () => {
       insertRow(store, "a");
-      store.softDelete("a");
-      const first = (db.prepare("SELECT deleted_at FROM spaces WHERE id='a'")
-        .get() as { deleted_at: number }).deleted_at;
-      store.softDelete("a");
-      const second = (db.prepare("SELECT deleted_at FROM spaces WHERE id='a'")
-        .get() as { deleted_at: number }).deleted_at;
-      expect(second).toBe(first);
+      store.softDelete("a", 5000);
+      store.softDelete("a", 9999);  // attempts to overwrite
+      const row = db.prepare("SELECT deleted_at FROM spaces WHERE id='a'")
+        .get() as { deleted_at: number };
+      expect(row.deleted_at).toBe(5000);
     });
   });
 
@@ -858,7 +970,7 @@ describe("SqliteSpaceStore — sync methods + soft-delete", () => {
     });
   });
 
-  describe("delete (hard delete)", () => {
+  describe("delete (hard delete — kept for failed-promotion cleanup)", () => {
     it("getAll still excludes hard-deleted rows", () => {
       insertRow(store, "a");
       store.delete("a");
@@ -880,37 +992,46 @@ Expected: FAIL — methods `getDirtyRows`, `markSynced`, `softDelete`, `getAllIn
 
 In `server/src/space-store.ts`:
 
-a) Update the `SpaceRow` interface to include the two new columns. Find:
+a) Update the `SpaceRow` interface to include the three new columns. Find the `SpaceRow` interface and add three fields (after `summary_content`, before `created_at`):
 
 ```ts
-export interface SpaceRow {
-  id: string;
-  display_name: string;
-  ...
-  updated_at: string;
-}
-```
-
-Add two fields:
-
-```ts
+  sync_dirty_at: number | null;
   cloud_synced_at: number | null;
   deleted_at: number | null;
 ```
 
-b) Update the `SpaceStore` interface (around line 30) — add four new methods after `getSourcesByIds`:
+b) Update the `SpaceStore` interface (around line 30) — add five new methods after `getSourcesByIds`:
 
 ```ts
-  /** Soft-delete a space. Sets deleted_at. Future getAll/getById excludes it.
-   *  Idempotent — re-calling on an already-deleted row is a no-op. */
-  softDelete(id: string): void;
-  /** All rows the local server is dirty against the cloud, by the predicate
-   *  cloud_synced_at IS NULL OR updated_at > cloud_synced_at. Excludes
-   *  tombstoned rows (those push via the DELETE endpoint, not PUT). */
+  /** Soft-delete a space. Sets deleted_at to the provided timestamp (or
+   *  Date.now()). Idempotent — re-call on an already-deleted row is a no-op
+   *  (preserves the original deleted_at). When applying a cross-device
+   *  tombstone, pass the cloud's deleted_at to preserve provenance. */
+  softDelete(id: string, deletedAt?: number): void;
+
+  /** Mark a row as having a sync-relevant change pending push. Bumped only
+   *  by mutations that change synced fields (display_name, color, parent_id,
+   *  summary_title, summary_content). NOT bumped by scanner/local-only
+   *  mutations — so a scanner pass can't stomp a peer's rename via LWW. */
+  markSyncDirty(id: string, dirtyAt?: number): void;
+
+  /** Live rows with pending pushes. Predicate:
+   *    deleted_at IS NULL
+   *    AND sync_dirty_at IS NOT NULL
+   *    AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at) */
   getDirtyRows(): SpaceRow[];
-  /** Mark a row as synced through to the cloud at `cloudUpdatedAt` (the
-   *  timestamp the cloud row carries — the LWW comparison key). */
+
+  /** Tombstoned rows whose deletion hasn't been confirmed by the cloud.
+   *  Predicate:
+   *    deleted_at IS NOT NULL
+   *    AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at) */
+  getPendingDeletes(): SpaceRow[];
+
+  /** Mark a row as synced through to the cloud at `cloudUpdatedAt`. For live
+   *  rows this is the cloud's updated_at; for confirmed deletes, the cloud's
+   *  deleted_at (or 404-acknowledged local deleted_at). */
   markSynced(id: string, cloudUpdatedAt: number): void;
+
   /** All rows including tombstones. Sync only — surface always uses getAll. */
   getAllIncludingDeleted(): SpaceRow[];
 ```
@@ -923,28 +1044,41 @@ c) Replace the `getAll`, `getById`, and `getByDisplayName` prepared statements t
       getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(TRIM(display_name)) = LOWER(TRIM(?)) AND deleted_at IS NULL ORDER BY updated_at DESC LIMIT 1"),
 ```
 
-d) Add the four new method implementations at the end of the class (before the closing `}`):
+d) Add the five new method implementations at the end of the class (before the closing `}`):
 
 ```ts
-  softDelete(id: string): void {
-    // datetime('now') returns text; the cloud column is unix ms. We use unix
-    // ms here too so dirty/sync timestamps are uniformly comparable across
-    // the cloud row, the local soft-delete, and cloud_synced_at.
+  softDelete(id: string, deletedAt: number = Date.now()): void {
+    // Unix ms throughout so the dirty/pending-delete predicates and the
+    // cloud column are uniformly comparable. The IS NULL guard makes this
+    // idempotent (re-call preserves the original tombstone timestamp).
     this.db.prepare(
       "UPDATE spaces SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL",
-    ).run(Date.now(), id);
+    ).run(deletedAt, id);
+  }
+
+  markSyncDirty(id: string, dirtyAt: number = Date.now()): void {
+    // Unconditional set — the caller's timestamp is the right one. (We don't
+    // guard MAX(existing, dirtyAt) because mutations always represent the
+    // user's most recent intent; a stale write would be a bug.)
+    this.db.prepare(
+      "UPDATE spaces SET sync_dirty_at = ? WHERE id = ?",
+    ).run(dirtyAt, id);
   }
 
   getDirtyRows(): SpaceRow[] {
-    // updated_at on spaces is the legacy `datetime('now')` text format —
-    // compare via strftime to unix-ms so the predicate works against the
-    // unix-ms cloud_synced_at column. SQLite returns NULL for invalid dates,
-    // which trips the IS NULL branch correctly.
     return this.db.prepare(`
       SELECT * FROM spaces
        WHERE deleted_at IS NULL
-         AND (cloud_synced_at IS NULL
-              OR (CAST(strftime('%s', updated_at) AS INTEGER) * 1000) > cloud_synced_at)
+         AND sync_dirty_at IS NOT NULL
+         AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at)
+    `).all() as SpaceRow[];
+  }
+
+  getPendingDeletes(): SpaceRow[] {
+    return this.db.prepare(`
+      SELECT * FROM spaces
+       WHERE deleted_at IS NOT NULL
+         AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at)
     `).all() as SpaceRow[];
   }
 
@@ -959,9 +1093,7 @@ d) Add the four new method implementations at the end of the class (before the c
   }
 ```
 
-e) Replace the existing `delete` method to keep hard-delete behaviour (unchanged from current — used only by failed-promotion cleanup in space-service):
-
-The existing `delete` already does cascading hard-delete via space_paths + spaces. Leave it as-is. Soft-delete is a separate path used by `space-service.deleteSpace`.
+e) The existing `delete` method (cascading hard-delete) stays unchanged — it's still used by failed-promotion cleanup in `createSpaceFromPath`. Soft-delete is a separate path used by `space-service.deleteSpace`.
 
 - [ ] **Step 4: Run tests, verify they pass**
 
@@ -969,7 +1101,7 @@ The existing `delete` already does cascading hard-delete via space_paths + space
 cd server && npm test -- space-store-sync.test.ts
 ```
 
-Expected: PASS, all 11 tests.
+Expected: PASS — all sync-store tests (markSyncDirty, getDirtyRows × 5, getPendingDeletes × 4, markSynced, softDelete × 4, getAllIncludingDeleted, delete).
 
 - [ ] **Step 5: Run full server test suite to confirm no regressions**
 
@@ -977,13 +1109,13 @@ Expected: PASS, all 11 tests.
 cd server && npm test
 ```
 
-Expected: PASS. (Existing tests don't touch `deleted_at`, so the filter clauses are a no-op for them.)
+Expected: PASS. Existing tests don't set `deleted_at` or `sync_dirty_at`, so the new filter clauses are no-ops for them.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 git add server/src/space-store.ts server/test/space-store-sync.test.ts
-git commit -m "feat(spaces-sync): SpaceStore soft-delete + dirty-row + markSynced helpers"
+git commit -m "feat(spaces-sync): SpaceStore soft-delete + dirty/pending-delete + sync helpers"
 ```
 
 ---
@@ -1020,6 +1152,7 @@ function makeDb(): Database.Database {
       ai_job_error      TEXT,
       summary_title     TEXT,
       summary_content   TEXT,
+      sync_dirty_at     INTEGER,
       cloud_synced_at   INTEGER,
       deleted_at        INTEGER,
       created_at        TEXT NOT NULL DEFAULT (datetime('now')),
@@ -1046,6 +1179,9 @@ function insertRow(
   });
 }
 
+const FREE_USER  = { id: "u1", email: "a@a", tier: "free" };
+const PRO_USER   = { id: "u1", email: "a@a", tier: "pro" };
+
 describe("createSpaceSyncService — reconcile()", () => {
   let db: Database.Database;
   let store: SqliteSpaceStore;
@@ -1056,7 +1192,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns zeros when no signed-in user", async () => {
+  it("returns zeros when no signed-in user (no network call)", async () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
@@ -1065,14 +1201,29 @@ describe("createSpaceSyncService — reconcile()", () => {
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
+    const result = await svc.reconcile();
+    expect(result).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 
+  it("returns zeros for free-tier users (sync is Pro-only — no network call)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => FREE_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
     const result = await svc.reconcile();
     expect(result).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("pulls cloud rows that don't exist locally and inserts them", async () => {
-    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith("/api/spaces/mine")) {
         return new Response(JSON.stringify({
           spaces: [{
@@ -1083,18 +1234,15 @@ describe("createSpaceSyncService — reconcile()", () => {
           }],
         }), { status: 200 });
       }
-      // No PUTs expected (no local dirty rows).
       throw new Error("unexpected fetch: " + url);
     });
-
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
-
     const result = await svc.reconcile();
     expect(result.pulled).toBe(1);
     const row = store.getById("from-cloud")!;
@@ -1102,12 +1250,10 @@ describe("createSpaceSyncService — reconcile()", () => {
     expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(5000);
   });
 
-  it("updates a local row when cloud.updated_at > local.updated_at", async () => {
+  it("updates a local row when cloud.updated_at > local.sync_dirty_at (cloud wins)", async () => {
     insertRow(store, "work", { displayName: "Old Name" });
-    // Mark synced at an old timestamp; we'll pretend cloud has a newer one.
+    store.markSyncDirty("work", 1000);
     store.markSynced("work", 1000);
-    // Bump local updated_at to be older than cloud's.
-    db.prepare("UPDATE spaces SET updated_at = '1970-01-01 00:00:01' WHERE id = 'work'").run();
 
     const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith("/api/spaces/mine")) {
@@ -1122,22 +1268,64 @@ describe("createSpaceSyncService — reconcile()", () => {
       }
       throw new Error("unexpected fetch: " + url);
     });
-
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
-
     await svc.reconcile();
     const row = store.getById("work")!;
     expect(row.display_name).toBe("New Name");
     expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(9999);
   });
 
-  it("soft-deletes a local row when cloud row carries deleted_at", async () => {
+  it("does NOT pull when local.sync_dirty_at > cloud.updated_at (local wins, will push)", async () => {
+    insertRow(store, "work", { displayName: "Local Edit" });
+    store.markSyncDirty("work", 9999);
+    store.markSynced("work", 1000);
+
+    const puts: Array<{ url: string; body: any }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "work", display_name: "Stale Cloud",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 5000, deleted_at: null, created_at: 1000,
+          }],
+        }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "PUT") {
+        puts.push({ url, body: JSON.parse(init.body as string) });
+        return new Response(JSON.stringify({
+          space: {
+            owner_id: "u1", space_id: "work", display_name: "Local Edit",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 9999, deleted_at: null, created_at: 1000,
+          },
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result.pulled).toBe(0);
+    expect(result.pushed).toBe(1);
+    expect(puts[0]!.body.updated_at).toBe(9999);   // wire ts = sync_dirty_at
+    expect(store.getById("work")!.display_name).toBe("Local Edit");  // local preserved
+  });
+
+  it("soft-deletes a local row when cloud row carries deleted_at, preserving cloud's deleted_at timestamp", async () => {
     insertRow(store, "work");
 
     const fetchMock = vi.fn(async (url: string) => {
@@ -1153,27 +1341,27 @@ describe("createSpaceSyncService — reconcile()", () => {
       }
       throw new Error("unexpected fetch: " + url);
     });
-
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
-
     const result = await svc.reconcile();
     expect(result.tombstoned).toBe(1);
-    expect(store.getById("work")).toBeUndefined(); // filter excludes deleted
-    const raw = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'work'")
-      .get() as { deleted_at: number };
-    expect(raw.deleted_at).toBe(9000);
+    expect(store.getById("work")).toBeUndefined();
+    const raw = db.prepare("SELECT deleted_at, cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { deleted_at: number; cloud_synced_at: number };
+    expect(raw.deleted_at).toBe(9000);              // cloud's tombstone preserved
+    expect(raw.cloud_synced_at).toBe(9000);         // marked synced
   });
 
-  it("pushes dirty rows to PUT /api/spaces/:id and updates cloud_synced_at", async () => {
-    insertRow(store, "work", { displayName: "Work" }); // dirty: cloud_synced_at is NULL
+  it("pushes dirty rows to PUT /api/spaces/:id with sync_dirty_at as wire updated_at", async () => {
+    insertRow(store, "work", { displayName: "Work" });
+    store.markSyncDirty("work", 7000);
 
-    const puts: Array<{ url: string; body: unknown }> = [];
+    const puts: Array<{ url: string; body: any }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith("/api/spaces/mine")) {
         return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
@@ -1185,45 +1373,99 @@ describe("createSpaceSyncService — reconcile()", () => {
             owner_id: "u1", space_id: "work", display_name: "Work",
             color: null, parent_id: null,
             summary_title: null, summary_content: null,
-            updated_at: 7777, deleted_at: null, created_at: 7777,
+            updated_at: 7000, deleted_at: null, created_at: 7000,
           },
         }), { status: 200 });
       }
       throw new Error("unexpected fetch: " + url);
     });
-
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
-
     const result = await svc.reconcile();
     expect(result.pushed).toBe(1);
-    expect(puts).toHaveLength(1);
-    expect(puts[0]!.body).toMatchObject({ display_name: "Work" });
-
+    expect(puts[0]!.body.updated_at).toBe(7000);
     const row = store.getById("work")!;
-    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(7777);
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(7000);
+  });
+
+  it("pushes pending deletes via DELETE /api/spaces/:id and marks them synced", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 8000);
+
+    const deletes: string[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "DELETE") {
+        deletes.push(url);
+        return new Response(JSON.stringify({
+          space_id: "work", deleted_at: 8000, updated_at: 8000,
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.reconcile();
+    expect(deletes).toHaveLength(1);
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(8000);
+    // Pending-delete predicate is now false → next reconcile won't re-push.
+    expect(store.getPendingDeletes()).toEqual([]);
+  });
+
+  it("treats DELETE 404 as 'already gone elsewhere' and marks the local tombstone synced", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 8000);
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "DELETE") {
+        return new Response(JSON.stringify({ error: "space_not_found" }), { status: 404 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.reconcile();
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(8000);  // local deleted_at acknowledged
+    expect(store.getPendingDeletes()).toEqual([]);
   });
 
   it("is idempotent — back-to-back reconciles with no mutations report 0/0/0", async () => {
     insertRow(store, "work");
+    store.markSyncDirty("work", 5000);
     store.markSynced("work", 5000);
-    db.prepare("UPDATE spaces SET updated_at = '1970-01-01 00:00:01' WHERE id = 'work'").run();
 
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ spaces: [] }), { status: 200 }));
-
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
-
     const first = await svc.reconcile();
     const second = await svc.reconcile();
     expect(first).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
@@ -1240,7 +1482,7 @@ cd server && npm test -- space-sync-service.test.ts
 
 Expected: FAIL — module `space-sync-service.js` does not exist.
 
-- [ ] **Step 3: Implement createSpaceSyncService — reconcile() only**
+- [ ] **Step 3: Implement createSpaceSyncService**
 
 Create `server/src/space-sync-service.ts`:
 
@@ -1248,8 +1490,9 @@ Create `server/src/space-sync-service.ts`:
 // space-sync-service.ts — cross-device sync of the local spaces table.
 // Spec: docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
 //
-// Wedge of #319 (R1). Pattern: dirty-row push + full pull on reconcile,
-// fire-and-forget pushOne after each mutation.
+// Wedge of #319 (R1). Pattern: dirty-row push + pending-delete sweep + full
+// pull on reconcile, fire-and-forget pushOne/pushDelete after each mutation.
+// Pro-only — sync is gated on user.tier === "pro".
 //
 // IMPORTANT: this is the FIRST instance of cross-device row-sync. Before
 // replicating this shape for memory (#318), session metadata, or artefact
@@ -1275,17 +1518,19 @@ export interface SpaceSyncDeps {
 }
 
 export interface SpaceSyncService {
-  /** Pull cloud → local, then push local → cloud. Idempotent. Called on
-   *  sign-in (BEFORE backfillPublications, so the headline _cloud-fallback
-   *  fix is immediate) and on app start when signed in. */
+  /** Pull cloud → local, then push live dirty rows, then push pending
+   *  deletes. Idempotent. Called on sign-in (BEFORE backfillPublications,
+   *  so the headline _cloud-fallback fix is immediate) and on app start
+   *  when signed in. Pro-only — returns zeros for free / signed-out. */
   reconcile(): Promise<{ pulled: number; pushed: number; tombstoned: number }>;
 
   /** Fire-and-forget push for one row after a local mutation. Swallows
-   *  network errors with a console.warn; the next reconcile() will retry. */
+   *  network errors with a console.warn; the next reconcile() retries.
+   *  Pro-only — no-op for free / signed-out. */
   pushOne(spaceId: string): Promise<void>;
 
   /** Fire-and-forget DELETE for a space the local server just soft-deleted.
-   *  Symmetrical to pushOne. Swallows 404 (already gone) and network errors. */
+   *  Marks the local tombstone synced on 200/404. Pro-only. */
   pushDelete(spaceId: string): Promise<void>;
 }
 
@@ -1302,28 +1547,32 @@ interface CloudSpace {
   created_at: number;
 }
 
-// Compare local SpaceRow.updated_at (text, sqlite datetime('now') format)
-// against cloud updated_at (unix ms). Returns local as unix ms.
-function localUpdatedAtMs(row: SpaceRow): number {
-  // SpaceRow.updated_at is a sqlite datetime string like "2026-05-06 12:34:56"
-  // (UTC). new Date(...) on that string is UTC-parsed by Node — verified by
-  // the surrounding store. Returns 0 (-> always-stale) if unparseable.
-  const t = Date.parse(row.updated_at + "Z");
-  return Number.isFinite(t) ? t : 0;
+interface CloudDeleteResponse {
+  space_id: string;
+  deleted_at: number;
+  updated_at: number;
+}
+
+/** Pro tier check. Spec: R1 (this wedge) is Pro-only per the requirements doc
+ *  tier mapping. Keep in one place so it's easy to change if the gate moves. */
+function isProSession(deps: SpaceSyncDeps): { user: SyncUser; token: string } | null {
+  const user = deps.currentUser();
+  const token = deps.sessionToken();
+  if (!user || !token || user.tier !== "pro") return null;
+  return { user, token };
 }
 
 export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
   return {
     async reconcile() {
-      const user = deps.currentUser();
-      const token = deps.sessionToken();
-      if (!user || !token) return { pulled: 0, pushed: 0, tombstoned: 0 };
+      const session = isProSession(deps);
+      if (!session) return { pulled: 0, pushed: 0, tombstoned: 0 };
 
       // ── Pull ──
       let res: Response;
       try {
         res = await deps.fetch(`${deps.workerBase}/api/spaces/mine`, {
-          headers: { Cookie: `oyster_session=${token}` },
+          headers: { Cookie: `oyster_session=${session.token}` },
         });
       } catch (err) {
         console.warn("[spaces] reconcile pull failed:", err);
@@ -1339,40 +1588,48 @@ export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
 
       let pulled = 0;
       let tombstoned = 0;
-      // Use raw SQL for the upsert path because store.update() filters by
-      // UPDATABLE_COLUMNS and would refuse to set cloud_synced_at via the
-      // public method (we set it directly via markSynced afterwards).
+
+      // Raw SQL for the upsert path because store.update() filters by
+      // UPDATABLE_COLUMNS and we need to set cloud_synced_at directly.
+      // Note: NOT touching sync_dirty_at — leave it whatever it was. The
+      // dirty predicate naturally goes clean because cloud_synced_at >=
+      // sync_dirty_at after this write.
       const upsertStmt = deps.db.prepare(`
         INSERT INTO spaces
           (id, display_name, color, parent_id, summary_title, summary_content,
            scan_status, cloud_synced_at, updated_at, created_at)
         VALUES (?, ?, ?, ?, ?, ?, 'none', ?, datetime('now'), datetime('now'))
         ON CONFLICT(id) DO UPDATE SET
-          display_name = excluded.display_name,
-          color = excluded.color,
-          parent_id = excluded.parent_id,
-          summary_title = excluded.summary_title,
+          display_name    = excluded.display_name,
+          color           = excluded.color,
+          parent_id       = excluded.parent_id,
+          summary_title   = excluded.summary_title,
           summary_content = excluded.summary_content,
           cloud_synced_at = excluded.cloud_synced_at,
-          updated_at = datetime('now')
+          updated_at      = datetime('now')
       `);
 
       for (const cloud of cloudRows) {
         if (cloud.deleted_at !== null) {
-          // Tombstone: soft-delete locally if not already.
+          // Tombstone application — preserve cloud's deleted_at as local's
+          // deleted_at (cross-device tombstone provenance), and mark synced
+          // so the pending-delete sweep doesn't re-push.
           const existing = deps.db.prepare(
             "SELECT id, deleted_at FROM spaces WHERE id = ?",
           ).get(cloud.space_id) as { id: string; deleted_at: number | null } | undefined;
           if (existing && existing.deleted_at === null) {
-            deps.store.softDelete(cloud.space_id);
+            deps.store.softDelete(cloud.space_id, cloud.deleted_at);
             tombstoned++;
           }
+          // Mark synced unconditionally (also covers the case where local
+          // had its own tombstone and they happen to match).
+          if (existing) deps.store.markSynced(cloud.space_id, cloud.deleted_at);
           continue;
         }
 
         const existing = deps.db.prepare(
-          "SELECT updated_at, cloud_synced_at FROM spaces WHERE id = ? AND deleted_at IS NULL",
-        ).get(cloud.space_id) as { updated_at: string; cloud_synced_at: number | null } | undefined;
+          "SELECT sync_dirty_at, cloud_synced_at FROM spaces WHERE id = ? AND deleted_at IS NULL",
+        ).get(cloud.space_id) as { sync_dirty_at: number | null; cloud_synced_at: number | null } | undefined;
 
         if (!existing) {
           upsertStmt.run(
@@ -1381,71 +1638,70 @@ export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
           );
           pulled++;
         } else {
-          const localMs = Date.parse(existing.updated_at + "Z");
-          const localComparable = Number.isFinite(localMs) ? localMs : 0;
-          if (cloud.updated_at > localComparable) {
+          // LWW pull rule: cloud wins iff local has no dirty mark, OR cloud
+          // is newer than local's dirty mark. Otherwise push step takes over.
+          const localDirty = existing.sync_dirty_at;
+          if (localDirty === null || cloud.updated_at > localDirty) {
             upsertStmt.run(
               cloud.space_id, cloud.display_name, cloud.color, cloud.parent_id,
               cloud.summary_title, cloud.summary_content, cloud.updated_at,
             );
             pulled++;
           }
-          // else: local is newer or equal; will be pushed below if dirty.
+          // else: local has unsynced changes newer than cloud; push handles it.
         }
       }
 
-      // ── Push ──
+      // ── Push live dirty rows ──
       const dirty = deps.store.getDirtyRows();
       let pushed = 0;
       for (const row of dirty) {
-        const ok = await pushRow(deps, row);
+        const ok = await pushRow(deps, session.token, row);
         if (ok) pushed++;
+      }
+
+      // ── Push pending deletes ──
+      const pending = deps.store.getPendingDeletes();
+      for (const row of pending) {
+        await pushRowDelete(deps, session.token, row);
       }
 
       return { pulled, pushed, tombstoned };
     },
 
     async pushOne(spaceId) {
-      const user = deps.currentUser();
-      const token = deps.sessionToken();
-      if (!user || !token) return;
-      // Read by id including deleted? No — pushOne handles live mutations only.
-      // Soft-deletes are pushed via the DELETE endpoint, separate path.
+      const session = isProSession(deps);
+      if (!session) return;
       const row = deps.db.prepare(
         "SELECT * FROM spaces WHERE id = ? AND deleted_at IS NULL",
       ).get(spaceId) as SpaceRow | undefined;
       if (!row) return;
-      // Skip if the row is already clean — saves a redundant PUT.
-      const localMs = localUpdatedAtMs(row);
-      const synced = (row as { cloud_synced_at: number | null }).cloud_synced_at;
-      if (synced !== null && synced >= localMs) return;
-      await pushRow(deps, row);
+      const dirtyAt = (row as { sync_dirty_at: number | null }).sync_dirty_at;
+      const synced  = (row as { cloud_synced_at: number | null }).cloud_synced_at;
+      // Clean if no dirty mark, or already synced past it.
+      if (dirtyAt === null) return;
+      if (synced !== null && synced >= dirtyAt) return;
+      await pushRow(deps, session.token, row);
     },
 
     async pushDelete(spaceId) {
-      const user = deps.currentUser();
-      const token = deps.sessionToken();
-      if (!user || !token) return;
-      try {
-        const res = await deps.fetch(
-          `${deps.workerBase}/api/spaces/${encodeURIComponent(spaceId)}`,
-          { method: "DELETE", headers: { Cookie: `oyster_session=${token}` } },
-        );
-        // 404 = already gone elsewhere; swallow quietly. Other non-OK gets a warn.
-        if (!res.ok && res.status !== 404) {
-          console.warn(`[spaces] delete ${spaceId} non-ok ${res.status}`);
-        }
-      } catch (err) {
-        console.warn(`[spaces] delete ${spaceId} failed:`, err);
-      }
+      const session = isProSession(deps);
+      if (!session) return;
+      // Read the local tombstone row (including deleted) so we know what
+      // deleted_at to use if the worker says 404.
+      const row = deps.db.prepare(
+        "SELECT id, deleted_at, cloud_synced_at FROM spaces WHERE id = ?",
+      ).get(spaceId) as { id: string; deleted_at: number | null; cloud_synced_at: number | null } | undefined;
+      if (!row || row.deleted_at === null) return;
+      await pushRowDelete(deps, session.token, row as unknown as SpaceRow);
     },
   };
 }
 
-async function pushRow(deps: SpaceSyncDeps, row: SpaceRow): Promise<boolean> {
-  const token = deps.sessionToken();
-  if (!token) return false;
-  const localMs = localUpdatedAtMs(row);
+async function pushRow(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promise<boolean> {
+  const dirtyAt = (row as { sync_dirty_at: number | null }).sync_dirty_at;
+  if (dirtyAt === null) return false;  // shouldn't happen — caller filters
+
   let res: Response;
   try {
     res = await deps.fetch(`${deps.workerBase}/api/spaces/${encodeURIComponent(row.id)}`, {
@@ -1455,14 +1711,14 @@ async function pushRow(deps: SpaceSyncDeps, row: SpaceRow): Promise<boolean> {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        display_name: row.display_name,
-        color: row.color,
-        parent_id: row.parent_id,
-        summary_title: row.summary_title,
+        display_name:    row.display_name,
+        color:           row.color,
+        parent_id:       row.parent_id,
+        summary_title:   row.summary_title,
         summary_content: row.summary_content,
-        // Use the local row's updated_at translated to unix ms — the worker
-        // uses this as the LWW comparison key.
-        updated_at: localMs,
+        // Wire LWW key = sync_dirty_at (timestamp of the last sync-relevant
+        // mutation), NOT the row's general-purpose updated_at.
+        updated_at: dirtyAt,
       }),
     });
   } catch (err) {
@@ -1481,9 +1737,37 @@ async function pushRow(deps: SpaceSyncDeps, row: SpaceRow): Promise<boolean> {
   }
 
   const body = await res.json().catch(() => null) as { space?: { updated_at?: number } } | null;
-  const cloudUpdated = body?.space?.updated_at ?? localMs;
+  const cloudUpdated = body?.space?.updated_at ?? dirtyAt;
   deps.store.markSynced(row.id, cloudUpdated);
   return true;
+}
+
+async function pushRowDelete(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promise<void> {
+  const localDeletedAt = (row as { deleted_at: number | null }).deleted_at ?? Date.now();
+  let res: Response;
+  try {
+    res = await deps.fetch(
+      `${deps.workerBase}/api/spaces/${encodeURIComponent(row.id)}`,
+      { method: "DELETE", headers: { Cookie: `oyster_session=${token}` } },
+    );
+  } catch (err) {
+    console.warn(`[spaces] delete ${row.id} failed:`, err);
+    return;
+  }
+
+  if (res.status === 404) {
+    // Cloud has no record — local tombstone is the only state; consider it
+    // acknowledged so the pending-delete sweep stops re-trying.
+    deps.store.markSynced(row.id, localDeletedAt);
+    return;
+  }
+  if (!res.ok) {
+    console.warn(`[spaces] delete ${row.id} non-ok ${res.status}`);
+    return;
+  }
+  const body = await res.json().catch(() => null) as CloudDeleteResponse | null;
+  const cloudDeletedAt = body?.deleted_at ?? localDeletedAt;
+  deps.store.markSynced(row.id, cloudDeletedAt);
 }
 ```
 
@@ -1493,13 +1777,13 @@ async function pushRow(deps: SpaceSyncDeps, row: SpaceRow): Promise<boolean> {
 cd server && npm test -- space-sync-service.test.ts
 ```
 
-Expected: PASS, all 6 reconcile tests.
+Expected: PASS — all 10 reconcile tests (signed-out no-op, free-tier no-op, pull insert, pull update, local-wins-no-pull, tombstone preserves cloud.deleted_at, push dirty with sync_dirty_at, push pending delete, DELETE 404 acknowledged, idempotent).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add server/src/space-sync-service.ts server/test/space-sync-service.test.ts
-git commit -m "feat(spaces-sync): SpaceSyncService.reconcile() + pushOne() — pull/push/LWW"
+git commit -m "feat(spaces-sync): SpaceSyncService — Pro-gated pull/push/delete with LWW"
 ```
 
 ---
@@ -1526,6 +1810,7 @@ describe("createSpaceSyncService — pushOne()", () => {
 
   it("does nothing when user is signed out", async () => {
     insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
@@ -1538,11 +1823,26 @@ describe("createSpaceSyncService — pushOne()", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("does nothing for free-tier users (Pro-only feature)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => FREE_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does nothing when row is missing", async () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
@@ -1551,15 +1851,13 @@ describe("createSpaceSyncService — pushOne()", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("does nothing when row is already clean (cloud_synced_at >= updated_at)", async () => {
+  it("does nothing when row has no sync_dirty_at (no sync-relevant change)", async () => {
     insertRow(store, "work");
-    // Mark synced way in the future — dirtiness check returns false.
-    store.markSynced("work", Date.now() + 60_000);
-
+    // No markSyncDirty — row was inserted but not flagged for sync.
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
@@ -1568,22 +1866,42 @@ describe("createSpaceSyncService — pushOne()", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("PUTs a dirty row and updates cloud_synced_at on 200", async () => {
+  it("does nothing when row is already clean (cloud_synced_at >= sync_dirty_at)", async () => {
     insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    store.markSynced("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("PUTs a dirty row with sync_dirty_at as wire updated_at, updates cloud_synced_at on 200", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 6000);
+
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       expect(init?.method).toBe("PUT");
+      const body = JSON.parse(init!.body as string) as { updated_at: number };
+      expect(body.updated_at).toBe(6000);
       return new Response(JSON.stringify({
         space: {
           owner_id: "u1", space_id: "work", display_name: "work",
           color: null, parent_id: null,
           summary_title: null, summary_content: null,
-          updated_at: 8888, deleted_at: null, created_at: 8888,
+          updated_at: 6000, deleted_at: null, created_at: 6000,
         },
       }), { status: 200 });
     });
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
@@ -1591,17 +1909,18 @@ describe("createSpaceSyncService — pushOne()", () => {
     await svc.pushOne("work");
     expect(fetchMock).toHaveBeenCalledOnce();
     const row = store.getById("work")!;
-    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(8888);
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(6000);
   });
 
   it("on 410, soft-deletes the local row (deletion wins over stale rename)", async () => {
     insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
     const fetchMock = vi.fn(async () => new Response(
       JSON.stringify({ error: "space_tombstoned" }), { status: 410 },
     ));
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
@@ -1612,11 +1931,12 @@ describe("createSpaceSyncService — pushOne()", () => {
 
   it("swallows network errors (console.warn, no throw)", async () => {
     insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
     const fetchMock = vi.fn(async () => { throw new Error("offline"); });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
@@ -1633,7 +1953,7 @@ describe("createSpaceSyncService — pushOne()", () => {
 cd server && npm test -- space-sync-service.test.ts
 ```
 
-Expected: PASS, all 12 tests (6 reconcile + 6 pushOne).
+Expected: PASS — all 18 tests (10 reconcile + 8 pushOne).
 
 If any test fails, fix in `space-sync-service.ts` and re-run.
 
@@ -1641,7 +1961,7 @@ If any test fails, fix in `space-sync-service.ts` and re-run.
 
 ```bash
 git add server/test/space-sync-service.test.ts
-git commit -m "test(spaces-sync): pushOne() — auth, dirty check, 410 tombstone, network error"
+git commit -m "test(spaces-sync): pushOne() — Pro gate, dirty marker, 410 tombstone, network error"
 ```
 
 ---
@@ -1674,23 +1994,26 @@ b) Update the constructor signature to accept the new dependency (optional so ex
   ) {}
 ```
 
-c) Add fire-and-forget push at the end of every mutation method. After each `this.spaceStore.update(...)` / `insert(...)` / soft-delete, append:
+c) After every mutation that changes a *synced* field (display_name, color, parent_id, summary_title, summary_content), call `markSyncDirty()` THEN fire-and-forget `pushOne()`. The two calls are paired — `markSyncDirty()` is what makes the row visible to `getDirtyRows()`, and `pushOne()` is the immediate push attempt.
 
-In `createSpace` (after `this.spaceStore.insert(...)`, before the `return`):
+In `createSpace`, after `this.spaceStore.insert(...)`, before the `return`:
 
 ```ts
+    this.spaceStore.markSyncDirty(id);
     void this.spaceSync?.pushOne(id);
 ```
 
-In `setSummary`, after `this.spaceStore.update(id, ...)`:
+In `setSummary`, after `this.spaceStore.update(id, { summary_title: title, summary_content: content })`:
 
 ```ts
+    this.spaceStore.markSyncDirty(id);
     void this.spaceSync?.pushOne(id);
 ```
 
 In `updateSpace`, after `this.spaceStore.update(id, dbFields)`:
 
 ```ts
+    this.spaceStore.markSyncDirty(id);
     void this.spaceSync?.pushOne(id);
 ```
 
@@ -1698,18 +2021,21 @@ In `deleteSpace`, replace the existing `this.spaceStore.delete(id)` (the very la
 
 ```ts
     // Soft-delete locally; cloud propagates the tombstone via pushDelete.
-    // (pushDelete is fire-and-forget; the next reconcile catches retries.)
+    // (pushDelete is fire-and-forget; the pending-delete sweep in the next
+    // reconcile() retries on failure.)
     this.spaceStore.softDelete(id);
     void this.spaceSync?.pushDelete(id);
 ```
 
-> **WHY soft-delete instead of hard-delete here?** Hard-delete loses the row entirely, which means the cloud DELETE isn't retried on offline → online. Soft-delete keeps the local row marked tombstoned (filtered out of getAll/getById, same effect on the surface) and lets pushDelete (or a later reconcile) propagate without re-discovering the deletion.
+> **WHY soft-delete instead of hard-delete here?** Hard-delete loses the row entirely, which means the cloud DELETE isn't retried on offline → online. Soft-delete keeps the local row marked tombstoned (filtered out of getAll/getById, same effect on the surface) and lets `pushDelete()` or the pending-delete sweep in `reconcile()` propagate without re-discovering the deletion.
 
-> **Known limit (acceptable for the wedge):** `scanSpace` updates `scan_status` etc. via `spaceStore.update()`, which bumps `updated_at`. The dirty-row predicate then fires for that row even though no synced field changed, so the next `reconcile()` pushes a no-op PUT. The worker accepts the write (LWW), bumps cloud `updated_at`, and peer devices re-pull — wasteful but not wrong. Acceptable for v1. Follow-up: split scan-status writes into a method that doesn't touch `updated_at`, or filter the dirty predicate by a `synced_dirty_at` column distinct from `updated_at`.
+> **CRITICAL — do NOT call `markSyncDirty()` in `scanSpace`.** scanSpace mutates `scan_status` / `scan_error` / `last_scanned_at` / `last_scan_summary` / `ai_job_*` — all device-local fields. Marking the row dirty would push a PUT with stale synced fields to the cloud, potentially overwriting a peer's legitimate rename. The `sync_dirty_at` column exists precisely to prevent this. Leave `scanSpace` untouched; it does not interact with sync at all.
+
+> **Known limit — soft-delete and orphaned sources/space_paths:** soft-deleting a space (vs. hard-delete) leaves its `sources` and `space_paths` rows behind. Direct readers (e.g. `spaceStore.getSources(spaceId)`) won't filter on `spaces.deleted_at IS NULL` — they take the spaceId as given. In practice, callers reach `getSources` only via paths that first checked the space exists via `getById` (which now filters), so the leak is contained. If a backend code path is added that reads `sources` without going through `getById` first, it should join on `spaces.deleted_at IS NULL`. Follow-up: cascade soft-delete to sources/space_paths (or hard-delete them at soft-delete time, since they're device-local anyway).
 
 - [ ] **Step 2: Add pushDelete tests to space-sync-service.test.ts**
 
-Append to the `pushOne()` describe block, then a sibling `describe("pushDelete()")`:
+Append a sibling `describe("pushDelete()")` block:
 
 ```ts
 describe("createSpaceSyncService — pushDelete()", () => {
@@ -1723,6 +2049,8 @@ describe("createSpaceSyncService — pushDelete()", () => {
   });
 
   it("does nothing when user is signed out", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 1000);
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
@@ -1735,46 +2063,95 @@ describe("createSpaceSyncService — pushDelete()", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("DELETEs the cloud row when signed in", async () => {
+  it("does nothing for free-tier users (Pro-only)", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => FREE_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row is not soft-deleted (live row)", async () => {
+    insertRow(store, "work");
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETEs the cloud row and marks the local tombstone synced on 200", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 5000);
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       expect(init?.method).toBe("DELETE");
       expect(url).toMatch(/\/api\/spaces\/work$/);
-      return new Response(JSON.stringify({ space_id: "work", deleted_at: 1, updated_at: 1 }), { status: 200 });
+      return new Response(JSON.stringify({
+        space_id: "work", deleted_at: 5000, updated_at: 5000,
+      }), { status: 200 });
     });
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
     await svc.pushDelete("work");
     expect(fetchMock).toHaveBeenCalledOnce();
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(5000);
+    expect(store.getPendingDeletes()).toEqual([]);
   });
 
-  it("swallows 404 (row gone elsewhere) without warning loudly", async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ error: "space_not_found" }), { status: 404 }));
+  it("on 404 (row never made it to cloud), marks the local tombstone synced anyway", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 5000);
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: "space_not_found" }), { status: 404 },
+    ));
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
     await expect(svc.pushDelete("work")).resolves.toBeUndefined();
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(5000);
+    expect(store.getPendingDeletes()).toEqual([]);
   });
 
-  it("swallows network errors (no throw)", async () => {
+  it("swallows network errors and leaves the tombstone pending (will retry next reconcile)", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 5000);
     const fetchMock = vi.fn(async () => { throw new Error("offline"); });
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const svc = createSpaceSyncService({
       db, store,
-      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
       fetch: fetchMock as unknown as typeof fetch,
     });
     await expect(svc.pushDelete("work")).resolves.toBeUndefined();
+    // Tombstone remains pending — no cloud_synced_at update on network error.
+    expect(store.getPendingDeletes().map(r => r.id)).toEqual(["work"]);
   });
 });
 ```
@@ -1785,7 +2162,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
 cd server && npm test
 ```
 
-Expected: PASS — sync service has 16 tests now; space-store-sync stays green; existing tests untouched.
+Expected: PASS — sync service has 24 tests (10 reconcile + 8 pushOne + 6 pushDelete); space-store-sync 18 tests stays green; existing tests untouched.
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-05-06-spaces-sync-spinout.md
+++ b/docs/superpowers/plans/2026-05-06-spaces-sync-spinout.md
@@ -1,0 +1,2027 @@
+# Spaces Sync Spin-out Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cloud-mirror the `spaces` table to D1 so a fresh signed-in device sees the user's spaces — and so published-artefact ghosts resolve to real spaces instead of `_cloud`.
+
+**Architecture:** Local SQLite remains the immediate write target. Cloud (D1) is the cross-device source of truth. Dirty-row reconciliation, last-write-wins by `updated_at`. Mutations push fire-and-forget; sign-in does a full pull+push reconcile. Tombstones propagate deletes.
+
+**Tech Stack:** Cloudflare D1 + Workers (`oyster-publish`), better-sqlite3, TypeScript, vitest, `@cloudflare/vitest-pool-workers`.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md`
+
+---
+
+## File structure
+
+**New files:**
+- `infra/auth-worker/migrations/0006_synced_spaces.sql` — D1 table + index
+- `infra/oyster-publish/test/spaces-handler.test.ts` — worker endpoint tests
+- `server/src/space-sync-service.ts` — local sync service (`reconcile()`, `pushOne()`)
+- `server/test/space-sync-service.test.ts` — sync service unit tests
+
+**Modified files:**
+- `infra/oyster-publish/src/worker.ts` — three new endpoints (GET/PUT/DELETE `/api/spaces/...`)
+- `infra/oyster-publish/test/fixtures/seed.ts` — extend test schema + helpers
+- `server/src/db.ts` — additive ALTER TABLE for `cloud_synced_at`, `deleted_at`
+- `server/src/space-store.ts` — soft-delete in `delete()`; new methods: `softDelete`, `getDirtyRows`, `markSynced`, `getAllIncludingDeleted`; filter `getAll`/`getById` on `deleted_at IS NULL`
+- `server/src/space-service.ts` — accept `SpaceSyncService` dep; call `pushOne()` after every mutation
+- `server/src/index.ts` — wire `spaceSync`; reconcile on sign-in BEFORE `backfillPublications`; reconcile on boot when signed in
+- `CHANGELOG.md` — Changed entry
+
+---
+
+## Task 1: D1 migration for synced_spaces
+
+**Files:**
+- Create: `infra/auth-worker/migrations/0006_synced_spaces.sql`
+- Modify: `infra/oyster-publish/test/fixtures/seed.ts` (add schema + seed helpers)
+
+- [ ] **Step 1: Write the migration file**
+
+Create `infra/auth-worker/migrations/0006_synced_spaces.sql`:
+
+```sql
+-- 0006_synced_spaces.sql — cross-device mirror of the local spaces table.
+-- Spec: docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
+-- Wedge of #319 (R1). Used by the local server's space-sync-service to
+-- reconcile per-user spaces across devices. Tombstones propagate deletes.
+
+CREATE TABLE IF NOT EXISTS synced_spaces (
+  owner_id        TEXT    NOT NULL,
+  space_id        TEXT    NOT NULL,
+  display_name    TEXT    NOT NULL,
+  color           TEXT,
+  parent_id       TEXT,
+  summary_title   TEXT,
+  summary_content TEXT,
+  updated_at      INTEGER NOT NULL,    -- unix ms; LWW comparison key
+  deleted_at      INTEGER,             -- tombstone; non-NULL means deleted
+  created_at      INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, space_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_synced_spaces_owner_updated
+  ON synced_spaces (owner_id, updated_at DESC);
+```
+
+- [ ] **Step 2: Extend test fixture seed.ts with the new schema + helpers**
+
+Open `infra/oyster-publish/test/fixtures/seed.ts`. Find the `SCHEMA_SQL` constant and append the synced_spaces table at the end of its multi-line string (before the closing backtick):
+
+```sql
+CREATE TABLE synced_spaces (
+  owner_id        TEXT    NOT NULL,
+  space_id        TEXT    NOT NULL,
+  display_name    TEXT    NOT NULL,
+  color           TEXT,
+  parent_id       TEXT,
+  summary_title   TEXT,
+  summary_content TEXT,
+  updated_at      INTEGER NOT NULL,
+  deleted_at      INTEGER,
+  created_at      INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, space_id)
+);
+CREATE INDEX idx_synced_spaces_owner_updated
+  ON synced_spaces (owner_id, updated_at DESC);
+```
+
+Then append two helper functions to the bottom of the file:
+
+```ts
+export async function seedSyncedSpace(opts: {
+  ownerId: string;
+  spaceId: string;
+  displayName?: string;
+  color?: string | null;
+  parentId?: string | null;
+  summaryTitle?: string | null;
+  summaryContent?: string | null;
+  updatedAt?: number;
+  deletedAt?: number | null;
+}): Promise<void> {
+  const now = opts.updatedAt ?? Date.now();
+  await env.DB.prepare(
+    `INSERT INTO synced_spaces
+     (owner_id, space_id, display_name, color, parent_id,
+      summary_title, summary_content, updated_at, deleted_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    opts.ownerId, opts.spaceId,
+    opts.displayName ?? opts.spaceId,
+    opts.color ?? null,
+    opts.parentId ?? null,
+    opts.summaryTitle ?? null,
+    opts.summaryContent ?? null,
+    now,
+    opts.deletedAt ?? null,
+    now,
+  ).run();
+}
+
+export async function readSyncedSpace(
+  ownerId: string, spaceId: string,
+): Promise<Record<string, unknown> | null> {
+  const row = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces
+      WHERE owner_id = ? AND space_id = ?`,
+  ).bind(ownerId, spaceId).first<Record<string, unknown>>();
+  return row ?? null;
+}
+```
+
+- [ ] **Step 3: Apply migration to dev D1 (manual)**
+
+Run from repo root:
+
+```bash
+cd infra/auth-worker && npx wrangler d1 migrations apply oyster-auth --local
+```
+
+Expected: `Migrations executed: 0006_synced_spaces.sql`. (For production, run `--remote` after merge.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/auth-worker/migrations/0006_synced_spaces.sql \
+        infra/oyster-publish/test/fixtures/seed.ts
+git commit -m "feat(spaces-sync): D1 migration + test fixtures for synced_spaces"
+```
+
+---
+
+## Task 2: Worker — GET /api/spaces/mine handler
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts` (add route + handler)
+- Create: `infra/oyster-publish/test/spaces-handler.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `infra/oyster-publish/test/spaces-handler.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, authHeader, seedSyncedSpace, readSyncedSpace } from "./fixtures/seed";
+
+beforeEach(async () => { await applySchema(); });
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function mineRequest(cookie?: string): Request {
+  const headers = new Headers();
+  if (cookie) headers.set("Cookie", cookie);
+  return new Request("https://oyster.to/api/spaces/mine", { method: "GET", headers });
+}
+
+describe("GET /api/spaces/mine", () => {
+  it("returns 401 sign_in_required when cookie missing", async () => {
+    const res = await call(mineRequest());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "sign_in_required" });
+  });
+
+  it("returns empty array when user has no spaces", async () => {
+    const u = await seedUser();
+    const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ spaces: [] });
+  });
+
+  it("returns the user's spaces, including tombstones, ordered by updated_at desc", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", updatedAt: 1000 });
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "home", updatedAt: 3000 });
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "old",  updatedAt: 2000, deletedAt: 2500 });
+
+    const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { spaces: Array<Record<string, unknown>> };
+    expect(json.spaces).toHaveLength(3);
+    expect(json.spaces[0]).toMatchObject({ space_id: "home", deleted_at: null });
+    expect(json.spaces[1]).toMatchObject({ space_id: "old",  deleted_at: 2500 });
+    expect(json.spaces[2]).toMatchObject({ space_id: "work", deleted_at: null });
+  });
+
+  it("scopes results to the calling user (no leak)", async () => {
+    const u1 = await seedUser({ id: "u1", email: "u1@e.com" });
+    const u2 = await seedUser({ id: "u2", email: "u2@e.com" });
+    await seedSyncedSpace({ ownerId: u1.id, spaceId: "u1-space" });
+    await seedSyncedSpace({ ownerId: u2.id, spaceId: "u2-space" });
+
+    const res = await call(mineRequest(authHeader(u1.sessionToken).Cookie));
+    const json = await res.json() as { spaces: Array<{ space_id: string }> };
+    expect(json.spaces.map((s) => s.space_id)).toEqual(["u1-space"]);
+  });
+
+  it("sets cache-control: private, no-store", async () => {
+    const u = await seedUser();
+    const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+});
+
+// Suppress unused-import warning until tasks 3 + 4 land.
+void readSyncedSpace;
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd infra/oyster-publish && npm test -- spaces-handler.test.ts
+```
+
+Expected: FAIL — endpoint returns 404 (route not registered) for the "returns empty array" / "returns the user's spaces" tests.
+
+- [ ] **Step 3: Add route + handler in worker.ts**
+
+In `infra/oyster-publish/src/worker.ts`, inside the `fetch` handler's route table, add the GET route after the existing publish routes (after line 35, before the `/p/` block):
+
+```ts
+    if (url.pathname === "/api/spaces/mine" && req.method === "GET") {
+      return handleSpacesMine(req, env);
+    }
+```
+
+Then add the handler near the other `handlePublish*` handlers (after `handlePublishMine`):
+
+```ts
+async function handleSpacesMine(req: Request, env: Env): Promise<Response> {
+  // Returns this signed-in user's synced spaces — both live rows AND tombstones,
+  // so a peer device that's been offline can apply deletions on next reconcile.
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+
+  type Row = {
+    owner_id: string;
+    space_id: string;
+    display_name: string;
+    color: string | null;
+    parent_id: string | null;
+    summary_title: string | null;
+    summary_content: string | null;
+    updated_at: number;
+    deleted_at: number | null;
+    created_at: number;
+  };
+  const rows = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces
+      WHERE owner_id = ?
+      ORDER BY updated_at DESC`,
+  ).bind(user.id).all<Row>();
+
+  // Per-user data — never cache at the browser, proxy, or edge layer.
+  return jsonOk({ spaces: rows.results ?? [] }, 200, { "cache-control": "private, no-store" });
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd infra/oyster-publish && npm test -- spaces-handler.test.ts
+```
+
+Expected: PASS, all 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/worker.ts infra/oyster-publish/test/spaces-handler.test.ts
+git commit -m "feat(spaces-sync): GET /api/spaces/mine returns user spaces incl. tombstones"
+```
+
+---
+
+## Task 3: Worker — PUT /api/spaces/:id handler
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+- Modify: `infra/oyster-publish/test/spaces-handler.test.ts`
+
+- [ ] **Step 1: Append failing PUT tests**
+
+Append to the same `spaces-handler.test.ts`:
+
+```ts
+function putRequest(spaceId: string, body: object, cookie?: string): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (cookie) headers.set("Cookie", cookie);
+  return new Request(`https://oyster.to/api/spaces/${spaceId}`, {
+    method: "PUT", headers, body: JSON.stringify(body),
+  });
+}
+
+describe("PUT /api/spaces/:id", () => {
+  it("returns 401 when cookie missing", async () => {
+    const res = await call(putRequest("work", { display_name: "Work", updated_at: 1000 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a new row when none exists, returns 200 with the row", async () => {
+    const u = await seedUser();
+    const res = await call(putRequest("work", {
+      display_name: "Work", color: "#6057c4", parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 5000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space: Record<string, unknown> };
+    expect(json.space).toMatchObject({
+      space_id: "work", display_name: "Work", color: "#6057c4",
+      updated_at: 5000, deleted_at: null,
+    });
+
+    const row = await readSyncedSpace(u.id, "work");
+    expect(row).toMatchObject({ display_name: "Work", updated_at: 5000 });
+  });
+
+  it("updates an existing row when incoming updated_at is greater", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", displayName: "Old", updatedAt: 1000 });
+
+    const res = await call(putRequest("work", {
+      display_name: "New", color: null, parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 2000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space: Record<string, unknown> };
+    expect(json.space).toMatchObject({ display_name: "New", updated_at: 2000 });
+  });
+
+  it("rejects stale writes (updated_at <= existing) with 200 returning the existing row (no-op)", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", displayName: "Current", updatedAt: 5000 });
+
+    const res = await call(putRequest("work", {
+      display_name: "Stale", color: null, parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 3000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space: Record<string, unknown> };
+    expect(json.space).toMatchObject({ display_name: "Current", updated_at: 5000 });
+  });
+
+  it("returns 410 gone when PUTting to a tombstoned row", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", updatedAt: 1000, deletedAt: 1500 });
+
+    const res = await call(putRequest("work", {
+      display_name: "Reborn", color: null, parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 2000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(410);
+    expect(await res.json()).toMatchObject({ error: "space_tombstoned" });
+  });
+
+  it("returns 400 invalid_metadata when display_name missing", async () => {
+    const u = await seedUser();
+    const res = await call(putRequest("work", { updated_at: 1000 },
+      authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+
+  it("returns 400 invalid_metadata when updated_at missing or non-numeric", async () => {
+    const u = await seedUser();
+    const res = await call(putRequest("work", { display_name: "Work" },
+      authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd infra/oyster-publish && npm test -- spaces-handler.test.ts
+```
+
+Expected: FAIL on the new PUT block — route returns 404.
+
+- [ ] **Step 3: Add PUT route + handler**
+
+In `worker.ts`, add this route after the GET route from Task 2:
+
+```ts
+    if (url.pathname.startsWith("/api/spaces/") && req.method === "PUT") {
+      const spaceId = url.pathname.slice("/api/spaces/".length);
+      return handleSpacesPut(req, env, spaceId);
+    }
+```
+
+Add the handler near `handleSpacesMine`:
+
+```ts
+async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (!spaceId || spaceId.includes("/")) return jsonError(400, "invalid_space_id");
+
+  let body: {
+    display_name?: unknown;
+    color?: unknown;
+    parent_id?: unknown;
+    summary_title?: unknown;
+    summary_content?: unknown;
+    updated_at?: unknown;
+  };
+  try { body = await req.json() as typeof body; }
+  catch { return jsonError(400, "invalid_metadata"); }
+
+  if (typeof body.display_name !== "string" || body.display_name.length === 0) {
+    return jsonError(400, "invalid_metadata");
+  }
+  if (typeof body.updated_at !== "number" || !Number.isFinite(body.updated_at)) {
+    return jsonError(400, "invalid_metadata");
+  }
+  // Optional fields — null is allowed; unset becomes null.
+  const color           = body.color           === undefined ? null : (body.color           as string | null);
+  const parentId        = body.parent_id       === undefined ? null : (body.parent_id       as string | null);
+  const summaryTitle    = body.summary_title   === undefined ? null : (body.summary_title   as string | null);
+  const summaryContent  = body.summary_content === undefined ? null : (body.summary_content as string | null);
+  const incomingUpdated = body.updated_at;
+
+  type Row = {
+    owner_id: string; space_id: string; display_name: string;
+    color: string | null; parent_id: string | null;
+    summary_title: string | null; summary_content: string | null;
+    updated_at: number; deleted_at: number | null; created_at: number;
+  };
+  const existing = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces WHERE owner_id = ? AND space_id = ?`,
+  ).bind(user.id, spaceId).first<Row>();
+
+  // Resurrection rule — peer pushed an update after this device tombstoned.
+  // 410 tells the peer to apply the tombstone locally and stop dirty-retrying.
+  if (existing && existing.deleted_at !== null) {
+    return jsonError(410, "space_tombstoned");
+  }
+
+  // Last-write-wins: stale writes become no-ops returning the existing row.
+  if (existing && incomingUpdated <= existing.updated_at) {
+    return jsonOk({ space: existing });
+  }
+
+  const now = Date.now();
+  if (existing) {
+    await env.DB.prepare(
+      `UPDATE synced_spaces
+          SET display_name = ?, color = ?, parent_id = ?,
+              summary_title = ?, summary_content = ?, updated_at = ?
+        WHERE owner_id = ? AND space_id = ?`,
+    ).bind(
+      body.display_name, color, parentId,
+      summaryTitle, summaryContent, incomingUpdated,
+      user.id, spaceId,
+    ).run();
+  } else {
+    await env.DB.prepare(
+      `INSERT INTO synced_spaces
+       (owner_id, space_id, display_name, color, parent_id,
+        summary_title, summary_content, updated_at, deleted_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+    ).bind(
+      user.id, spaceId, body.display_name, color, parentId,
+      summaryTitle, summaryContent, incomingUpdated, now,
+    ).run();
+  }
+
+  const row = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces WHERE owner_id = ? AND space_id = ?`,
+  ).bind(user.id, spaceId).first<Row>();
+
+  return jsonOk({ space: row });
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd infra/oyster-publish && npm test -- spaces-handler.test.ts
+```
+
+Expected: PASS, all 12 tests (5 GET + 7 PUT).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/worker.ts infra/oyster-publish/test/spaces-handler.test.ts
+git commit -m "feat(spaces-sync): PUT /api/spaces/:id with LWW + tombstone resurrection rule"
+```
+
+---
+
+## Task 4: Worker — DELETE /api/spaces/:id handler
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts`
+- Modify: `infra/oyster-publish/test/spaces-handler.test.ts`
+
+- [ ] **Step 1: Append failing DELETE tests**
+
+Append to `spaces-handler.test.ts`:
+
+```ts
+function deleteRequest(spaceId: string, cookie?: string): Request {
+  const headers = new Headers();
+  if (cookie) headers.set("Cookie", cookie);
+  return new Request(`https://oyster.to/api/spaces/${spaceId}`, { method: "DELETE", headers });
+}
+
+describe("DELETE /api/spaces/:id", () => {
+  it("returns 401 when cookie missing", async () => {
+    const res = await call(deleteRequest("work"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the row does not exist", async () => {
+    const u = await seedUser();
+    const res = await call(deleteRequest("ghost", authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "space_not_found" });
+  });
+
+  it("sets deleted_at and bumps updated_at on a live row", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", updatedAt: 1000 });
+
+    const res = await call(deleteRequest("work", authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space_id: string; deleted_at: number; updated_at: number };
+    expect(json.space_id).toBe("work");
+    expect(json.deleted_at).toBeGreaterThan(0);
+    expect(json.updated_at).toBeGreaterThan(1000);
+
+    const row = await readSyncedSpace(u.id, "work");
+    expect(row?.deleted_at).toBe(json.deleted_at);
+    expect(row?.updated_at).toBe(json.updated_at);
+  });
+
+  it("is idempotent — re-DELETE returns the existing tombstone", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({
+      ownerId: u.id, spaceId: "work", updatedAt: 1000, deletedAt: 1500,
+    });
+
+    const res = await call(deleteRequest("work", authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space_id: string; deleted_at: number };
+    expect(json.deleted_at).toBe(1500);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd infra/oyster-publish && npm test -- spaces-handler.test.ts
+```
+
+Expected: FAIL on new DELETE block.
+
+- [ ] **Step 3: Add DELETE route + handler**
+
+In `worker.ts`, add this route after the PUT route from Task 3:
+
+```ts
+    if (url.pathname.startsWith("/api/spaces/") && req.method === "DELETE") {
+      const spaceId = url.pathname.slice("/api/spaces/".length);
+      return handleSpacesDelete(req, env, spaceId);
+    }
+```
+
+Add the handler:
+
+```ts
+async function handleSpacesDelete(req: Request, env: Env, spaceId: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (!spaceId || spaceId.includes("/")) return jsonError(400, "invalid_space_id");
+
+  type Row = { deleted_at: number | null; updated_at: number };
+  const existing = await env.DB.prepare(
+    "SELECT deleted_at, updated_at FROM synced_spaces WHERE owner_id = ? AND space_id = ?",
+  ).bind(user.id, spaceId).first<Row>();
+
+  if (!existing) return jsonError(404, "space_not_found");
+
+  // Idempotent: existing tombstone returns as-is.
+  if (existing.deleted_at !== null) {
+    return jsonOk({
+      space_id: spaceId,
+      deleted_at: existing.deleted_at,
+      updated_at: existing.updated_at,
+    });
+  }
+
+  const now = Date.now();
+  await env.DB.prepare(
+    `UPDATE synced_spaces
+        SET deleted_at = ?, updated_at = ?
+      WHERE owner_id = ? AND space_id = ?`,
+  ).bind(now, now, user.id, spaceId).run();
+
+  return jsonOk({ space_id: spaceId, deleted_at: now, updated_at: now });
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd infra/oyster-publish && npm test -- spaces-handler.test.ts
+```
+
+Expected: PASS, all 16 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/worker.ts infra/oyster-publish/test/spaces-handler.test.ts
+git commit -m "feat(spaces-sync): DELETE /api/spaces/:id sets tombstone, idempotent"
+```
+
+---
+
+## Task 5: Local — db.ts adds cloud_synced_at + deleted_at to spaces
+
+**Files:**
+- Modify: `server/src/db.ts`
+
+- [ ] **Step 1: Add ALTER TABLE statements**
+
+In `server/src/db.ts`, find the existing spaces ALTER block (lines 50-52: `ALTER TABLE spaces ADD COLUMN parent_id ...`) and append two new statements to the same array:
+
+```ts
+    "ALTER TABLE spaces ADD COLUMN cloud_synced_at INTEGER",
+    "ALTER TABLE spaces ADD COLUMN deleted_at INTEGER",
+```
+
+The full updated block:
+
+```ts
+  for (const sql of [
+    "ALTER TABLE artifacts ADD COLUMN group_name TEXT",
+    "ALTER TABLE artifacts ADD COLUMN removed_at TEXT",
+    "ALTER TABLE artifacts ADD COLUMN source_origin TEXT NOT NULL DEFAULT 'manual'",
+    "ALTER TABLE artifacts ADD COLUMN source_ref TEXT",
+    "ALTER TABLE spaces ADD COLUMN parent_id TEXT REFERENCES spaces(id)",
+    "ALTER TABLE spaces ADD COLUMN summary_title TEXT",
+    "ALTER TABLE spaces ADD COLUMN summary_content TEXT",
+    "ALTER TABLE spaces ADD COLUMN cloud_synced_at INTEGER",
+    "ALTER TABLE spaces ADD COLUMN deleted_at INTEGER",
+  ]) {
+    try { db.exec(sql); } catch { /* already exists */ }
+  }
+```
+
+- [ ] **Step 2: Verify migration is idempotent**
+
+Run the existing server test suite — many tests construct fresh DBs via `initDb`:
+
+```bash
+cd server && npm test
+```
+
+Expected: PASS (no test broken; the new columns just default NULL on existing rows).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/db.ts
+git commit -m "feat(spaces-sync): add cloud_synced_at + deleted_at to local spaces table"
+```
+
+---
+
+## Task 6: Local — extend SpaceStore with sync methods + soft-delete
+
+**Files:**
+- Modify: `server/src/space-store.ts`
+- Create: `server/test/space-store-sync.test.ts`
+
+- [ ] **Step 1: Write failing tests for the new methods**
+
+Create `server/test/space-store-sync.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { SqliteSpaceStore } from "../src/space-store.js";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE spaces (
+      id                TEXT PRIMARY KEY,
+      display_name      TEXT NOT NULL,
+      color             TEXT,
+      parent_id         TEXT,
+      scan_status       TEXT NOT NULL DEFAULT 'none',
+      scan_error        TEXT,
+      last_scanned_at   TEXT,
+      last_scan_summary TEXT,
+      ai_job_status     TEXT,
+      ai_job_error      TEXT,
+      summary_title     TEXT,
+      summary_content   TEXT,
+      cloud_synced_at   INTEGER,
+      deleted_at        INTEGER,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE space_paths (
+      space_id TEXT NOT NULL, path TEXT NOT NULL, label TEXT,
+      added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (space_id, path)
+    );
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY, space_id TEXT NOT NULL,
+      type TEXT NOT NULL, path TEXT NOT NULL,
+      label TEXT, added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at TEXT
+    );
+  `);
+  return db;
+}
+
+function insertRow(store: SqliteSpaceStore, id: string, opts: Partial<{ displayName: string }> = {}) {
+  store.insert({
+    id, display_name: opts.displayName ?? id, color: null, parent_id: null,
+    scan_status: "none", scan_error: null, last_scanned_at: null,
+    last_scan_summary: null, ai_job_status: null, ai_job_error: null,
+    summary_title: null, summary_content: null,
+  });
+}
+
+describe("SqliteSpaceStore — sync methods + soft-delete", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+  });
+
+  describe("getDirtyRows", () => {
+    it("returns rows where cloud_synced_at IS NULL", () => {
+      insertRow(store, "a");
+      insertRow(store, "b");
+      expect(store.getDirtyRows().map(r => r.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("returns rows where updated_at > cloud_synced_at", () => {
+      insertRow(store, "a");
+      // Mark as synced 1s ago, then bump updated_at to now.
+      db.prepare("UPDATE spaces SET cloud_synced_at = ? WHERE id = 'a'").run(Date.now() - 60_000);
+      db.prepare("UPDATE spaces SET updated_at = datetime('now') WHERE id = 'a'").run();
+      const dirty = store.getDirtyRows();
+      expect(dirty.map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes rows where cloud_synced_at >= updated_at", () => {
+      insertRow(store, "a");
+      // Mark synced AT or AFTER current updated_at — the row is clean.
+      db.prepare("UPDATE spaces SET cloud_synced_at = ? WHERE id = 'a'").run(Date.now() + 60_000);
+      expect(store.getDirtyRows()).toEqual([]);
+    });
+
+    it("excludes tombstoned rows (those go via the delete-push path)", () => {
+      insertRow(store, "a");
+      store.softDelete("a");
+      expect(store.getDirtyRows().map(r => r.id)).toEqual([]);
+    });
+  });
+
+  describe("markSynced", () => {
+    it("sets cloud_synced_at to the given timestamp", () => {
+      insertRow(store, "a");
+      store.markSynced("a", 9999);
+      const row = store.getById("a")!;
+      expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(9999);
+    });
+  });
+
+  describe("softDelete", () => {
+    it("sets deleted_at to now", () => {
+      insertRow(store, "a");
+      const before = Date.now();
+      store.softDelete("a");
+      const row = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'a'")
+        .get() as { deleted_at: number };
+      expect(row.deleted_at).toBeGreaterThanOrEqual(before);
+    });
+
+    it("excludes the soft-deleted row from getAll() and getById()", () => {
+      insertRow(store, "a"); insertRow(store, "b");
+      store.softDelete("a");
+      expect(store.getAll().map(r => r.id)).toEqual(["b"]);
+      expect(store.getById("a")).toBeUndefined();
+    });
+
+    it("is idempotent — re-softDelete leaves deleted_at unchanged", () => {
+      insertRow(store, "a");
+      store.softDelete("a");
+      const first = (db.prepare("SELECT deleted_at FROM spaces WHERE id='a'")
+        .get() as { deleted_at: number }).deleted_at;
+      store.softDelete("a");
+      const second = (db.prepare("SELECT deleted_at FROM spaces WHERE id='a'")
+        .get() as { deleted_at: number }).deleted_at;
+      expect(second).toBe(first);
+    });
+  });
+
+  describe("getAllIncludingDeleted", () => {
+    it("includes tombstoned rows", () => {
+      insertRow(store, "a"); insertRow(store, "b");
+      store.softDelete("a");
+      expect(store.getAllIncludingDeleted().map(r => r.id).sort()).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("delete (hard delete)", () => {
+    it("getAll still excludes hard-deleted rows", () => {
+      insertRow(store, "a");
+      store.delete("a");
+      expect(store.getAll()).toEqual([]);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd server && npm test -- space-store-sync.test.ts
+```
+
+Expected: FAIL — methods `getDirtyRows`, `markSynced`, `softDelete`, `getAllIncludingDeleted` are not defined.
+
+- [ ] **Step 3: Update SpaceStore interface + add methods to SqliteSpaceStore**
+
+In `server/src/space-store.ts`:
+
+a) Update the `SpaceRow` interface to include the two new columns. Find:
+
+```ts
+export interface SpaceRow {
+  id: string;
+  display_name: string;
+  ...
+  updated_at: string;
+}
+```
+
+Add two fields:
+
+```ts
+  cloud_synced_at: number | null;
+  deleted_at: number | null;
+```
+
+b) Update the `SpaceStore` interface (around line 30) — add four new methods after `getSourcesByIds`:
+
+```ts
+  /** Soft-delete a space. Sets deleted_at. Future getAll/getById excludes it.
+   *  Idempotent — re-calling on an already-deleted row is a no-op. */
+  softDelete(id: string): void;
+  /** All rows the local server is dirty against the cloud, by the predicate
+   *  cloud_synced_at IS NULL OR updated_at > cloud_synced_at. Excludes
+   *  tombstoned rows (those push via the DELETE endpoint, not PUT). */
+  getDirtyRows(): SpaceRow[];
+  /** Mark a row as synced through to the cloud at `cloudUpdatedAt` (the
+   *  timestamp the cloud row carries — the LWW comparison key). */
+  markSynced(id: string, cloudUpdatedAt: number): void;
+  /** All rows including tombstones. Sync only — surface always uses getAll. */
+  getAllIncludingDeleted(): SpaceRow[];
+```
+
+c) Replace the `getAll`, `getById`, and `getByDisplayName` prepared statements to filter `deleted_at IS NULL`. Find lines 70-75 and replace:
+
+```ts
+      getAll: db.prepare("SELECT * FROM spaces WHERE deleted_at IS NULL ORDER BY display_name"),
+      getById: db.prepare("SELECT * FROM spaces WHERE id = ? AND deleted_at IS NULL"),
+      getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(TRIM(display_name)) = LOWER(TRIM(?)) AND deleted_at IS NULL ORDER BY updated_at DESC LIMIT 1"),
+```
+
+d) Add the four new method implementations at the end of the class (before the closing `}`):
+
+```ts
+  softDelete(id: string): void {
+    // datetime('now') returns text; the cloud column is unix ms. We use unix
+    // ms here too so dirty/sync timestamps are uniformly comparable across
+    // the cloud row, the local soft-delete, and cloud_synced_at.
+    this.db.prepare(
+      "UPDATE spaces SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL",
+    ).run(Date.now(), id);
+  }
+
+  getDirtyRows(): SpaceRow[] {
+    // updated_at on spaces is the legacy `datetime('now')` text format —
+    // compare via strftime to unix-ms so the predicate works against the
+    // unix-ms cloud_synced_at column. SQLite returns NULL for invalid dates,
+    // which trips the IS NULL branch correctly.
+    return this.db.prepare(`
+      SELECT * FROM spaces
+       WHERE deleted_at IS NULL
+         AND (cloud_synced_at IS NULL
+              OR (CAST(strftime('%s', updated_at) AS INTEGER) * 1000) > cloud_synced_at)
+    `).all() as SpaceRow[];
+  }
+
+  markSynced(id: string, cloudUpdatedAt: number): void {
+    this.db.prepare(
+      "UPDATE spaces SET cloud_synced_at = ? WHERE id = ?",
+    ).run(cloudUpdatedAt, id);
+  }
+
+  getAllIncludingDeleted(): SpaceRow[] {
+    return this.db.prepare("SELECT * FROM spaces ORDER BY display_name").all() as SpaceRow[];
+  }
+```
+
+e) Replace the existing `delete` method to keep hard-delete behaviour (unchanged from current — used only by failed-promotion cleanup in space-service):
+
+The existing `delete` already does cascading hard-delete via space_paths + spaces. Leave it as-is. Soft-delete is a separate path used by `space-service.deleteSpace`.
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd server && npm test -- space-store-sync.test.ts
+```
+
+Expected: PASS, all 11 tests.
+
+- [ ] **Step 5: Run full server test suite to confirm no regressions**
+
+```bash
+cd server && npm test
+```
+
+Expected: PASS. (Existing tests don't touch `deleted_at`, so the filter clauses are a no-op for them.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/space-store.ts server/test/space-store-sync.test.ts
+git commit -m "feat(spaces-sync): SpaceStore soft-delete + dirty-row + markSynced helpers"
+```
+
+---
+
+## Task 7: Local — space-sync-service.ts: reconcile() (TDD)
+
+**Files:**
+- Create: `server/src/space-sync-service.ts`
+- Create: `server/test/space-sync-service.test.ts`
+
+- [ ] **Step 1: Write failing tests for reconcile()**
+
+Create `server/test/space-sync-service.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { SqliteSpaceStore } from "../src/space-store.js";
+import { createSpaceSyncService } from "../src/space-sync-service.js";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE spaces (
+      id                TEXT PRIMARY KEY,
+      display_name      TEXT NOT NULL,
+      color             TEXT,
+      parent_id         TEXT,
+      scan_status       TEXT NOT NULL DEFAULT 'none',
+      scan_error        TEXT,
+      last_scanned_at   TEXT,
+      last_scan_summary TEXT,
+      ai_job_status     TEXT,
+      ai_job_error      TEXT,
+      summary_title     TEXT,
+      summary_content   TEXT,
+      cloud_synced_at   INTEGER,
+      deleted_at        INTEGER,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+  return db;
+}
+
+function insertRow(
+  store: SqliteSpaceStore,
+  id: string,
+  opts: Partial<{ displayName: string; color: string; parentId: string; summaryTitle: string; summaryContent: string }> = {},
+) {
+  store.insert({
+    id,
+    display_name: opts.displayName ?? id,
+    color: opts.color ?? null,
+    parent_id: opts.parentId ?? null,
+    scan_status: "none", scan_error: null, last_scanned_at: null,
+    last_scan_summary: null, ai_job_status: null, ai_job_error: null,
+    summary_title: opts.summaryTitle ?? null,
+    summary_content: opts.summaryContent ?? null,
+  });
+}
+
+describe("createSpaceSyncService — reconcile()", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("returns zeros when no signed-in user", async () => {
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await svc.reconcile();
+    expect(result).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("pulls cloud rows that don't exist locally and inserts them", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "from-cloud", display_name: "From Cloud",
+            color: "#3d8aaa", parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 5000, deleted_at: null, created_at: 5000,
+          }],
+        }), { status: 200 });
+      }
+      // No PUTs expected (no local dirty rows).
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await svc.reconcile();
+    expect(result.pulled).toBe(1);
+    const row = store.getById("from-cloud")!;
+    expect(row.display_name).toBe("From Cloud");
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(5000);
+  });
+
+  it("updates a local row when cloud.updated_at > local.updated_at", async () => {
+    insertRow(store, "work", { displayName: "Old Name" });
+    // Mark synced at an old timestamp; we'll pretend cloud has a newer one.
+    store.markSynced("work", 1000);
+    // Bump local updated_at to be older than cloud's.
+    db.prepare("UPDATE spaces SET updated_at = '1970-01-01 00:00:01' WHERE id = 'work'").run();
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "work", display_name: "New Name",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 9999, deleted_at: null, created_at: 1000,
+          }],
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await svc.reconcile();
+    const row = store.getById("work")!;
+    expect(row.display_name).toBe("New Name");
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(9999);
+  });
+
+  it("soft-deletes a local row when cloud row carries deleted_at", async () => {
+    insertRow(store, "work");
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "work", display_name: "Work",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 9000, deleted_at: 9000, created_at: 1000,
+          }],
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await svc.reconcile();
+    expect(result.tombstoned).toBe(1);
+    expect(store.getById("work")).toBeUndefined(); // filter excludes deleted
+    const raw = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'work'")
+      .get() as { deleted_at: number };
+    expect(raw.deleted_at).toBe(9000);
+  });
+
+  it("pushes dirty rows to PUT /api/spaces/:id and updates cloud_synced_at", async () => {
+    insertRow(store, "work", { displayName: "Work" }); // dirty: cloud_synced_at is NULL
+
+    const puts: Array<{ url: string; body: unknown }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "PUT") {
+        puts.push({ url, body: JSON.parse(init.body as string) });
+        return new Response(JSON.stringify({
+          space: {
+            owner_id: "u1", space_id: "work", display_name: "Work",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 7777, deleted_at: null, created_at: 7777,
+          },
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await svc.reconcile();
+    expect(result.pushed).toBe(1);
+    expect(puts).toHaveLength(1);
+    expect(puts[0]!.body).toMatchObject({ display_name: "Work" });
+
+    const row = store.getById("work")!;
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(7777);
+  });
+
+  it("is idempotent — back-to-back reconciles with no mutations report 0/0/0", async () => {
+    insertRow(store, "work");
+    store.markSynced("work", 5000);
+    db.prepare("UPDATE spaces SET updated_at = '1970-01-01 00:00:01' WHERE id = 'work'").run();
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ spaces: [] }), { status: 200 }));
+
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const first = await svc.reconcile();
+    const second = await svc.reconcile();
+    expect(first).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    expect(second).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+cd server && npm test -- space-sync-service.test.ts
+```
+
+Expected: FAIL — module `space-sync-service.js` does not exist.
+
+- [ ] **Step 3: Implement createSpaceSyncService — reconcile() only**
+
+Create `server/src/space-sync-service.ts`:
+
+```ts
+// space-sync-service.ts — cross-device sync of the local spaces table.
+// Spec: docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
+//
+// Wedge of #319 (R1). Pattern: dirty-row push + full pull on reconcile,
+// fire-and-forget pushOne after each mutation.
+//
+// IMPORTANT: this is the FIRST instance of cross-device row-sync. Before
+// replicating this shape for memory (#318), session metadata, or artefact
+// bytes (R7), evaluate PowerSync / ElectricSQL / Replicache / object-
+// storage-only designs. See project_sync_build_vs_lease memory.
+
+import type Database from "better-sqlite3";
+import type { SpaceStore, SpaceRow } from "./space-store.js";
+
+export interface SyncUser {
+  id: string;
+  email: string;
+  tier: string;
+}
+
+export interface SpaceSyncDeps {
+  db: Database.Database;
+  store: SpaceStore;
+  currentUser: () => SyncUser | null;
+  sessionToken: () => string | null;
+  workerBase: string;
+  fetch: typeof fetch;
+}
+
+export interface SpaceSyncService {
+  /** Pull cloud → local, then push local → cloud. Idempotent. Called on
+   *  sign-in (BEFORE backfillPublications, so the headline _cloud-fallback
+   *  fix is immediate) and on app start when signed in. */
+  reconcile(): Promise<{ pulled: number; pushed: number; tombstoned: number }>;
+
+  /** Fire-and-forget push for one row after a local mutation. Swallows
+   *  network errors with a console.warn; the next reconcile() will retry. */
+  pushOne(spaceId: string): Promise<void>;
+
+  /** Fire-and-forget DELETE for a space the local server just soft-deleted.
+   *  Symmetrical to pushOne. Swallows 404 (already gone) and network errors. */
+  pushDelete(spaceId: string): Promise<void>;
+}
+
+interface CloudSpace {
+  owner_id: string;
+  space_id: string;
+  display_name: string;
+  color: string | null;
+  parent_id: string | null;
+  summary_title: string | null;
+  summary_content: string | null;
+  updated_at: number;
+  deleted_at: number | null;
+  created_at: number;
+}
+
+// Compare local SpaceRow.updated_at (text, sqlite datetime('now') format)
+// against cloud updated_at (unix ms). Returns local as unix ms.
+function localUpdatedAtMs(row: SpaceRow): number {
+  // SpaceRow.updated_at is a sqlite datetime string like "2026-05-06 12:34:56"
+  // (UTC). new Date(...) on that string is UTC-parsed by Node — verified by
+  // the surrounding store. Returns 0 (-> always-stale) if unparseable.
+  const t = Date.parse(row.updated_at + "Z");
+  return Number.isFinite(t) ? t : 0;
+}
+
+export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
+  return {
+    async reconcile() {
+      const user = deps.currentUser();
+      const token = deps.sessionToken();
+      if (!user || !token) return { pulled: 0, pushed: 0, tombstoned: 0 };
+
+      // ── Pull ──
+      let res: Response;
+      try {
+        res = await deps.fetch(`${deps.workerBase}/api/spaces/mine`, {
+          headers: { Cookie: `oyster_session=${token}` },
+        });
+      } catch (err) {
+        console.warn("[spaces] reconcile pull failed:", err);
+        return { pulled: 0, pushed: 0, tombstoned: 0 };
+      }
+      if (!res.ok) {
+        console.warn(`[spaces] reconcile pull non-ok ${res.status}`);
+        return { pulled: 0, pushed: 0, tombstoned: 0 };
+      }
+
+      const body = await res.json().catch(() => null) as { spaces?: CloudSpace[] } | null;
+      const cloudRows = body?.spaces ?? [];
+
+      let pulled = 0;
+      let tombstoned = 0;
+      // Use raw SQL for the upsert path because store.update() filters by
+      // UPDATABLE_COLUMNS and would refuse to set cloud_synced_at via the
+      // public method (we set it directly via markSynced afterwards).
+      const upsertStmt = deps.db.prepare(`
+        INSERT INTO spaces
+          (id, display_name, color, parent_id, summary_title, summary_content,
+           scan_status, cloud_synced_at, updated_at, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'none', ?, datetime('now'), datetime('now'))
+        ON CONFLICT(id) DO UPDATE SET
+          display_name = excluded.display_name,
+          color = excluded.color,
+          parent_id = excluded.parent_id,
+          summary_title = excluded.summary_title,
+          summary_content = excluded.summary_content,
+          cloud_synced_at = excluded.cloud_synced_at,
+          updated_at = datetime('now')
+      `);
+
+      for (const cloud of cloudRows) {
+        if (cloud.deleted_at !== null) {
+          // Tombstone: soft-delete locally if not already.
+          const existing = deps.db.prepare(
+            "SELECT id, deleted_at FROM spaces WHERE id = ?",
+          ).get(cloud.space_id) as { id: string; deleted_at: number | null } | undefined;
+          if (existing && existing.deleted_at === null) {
+            deps.store.softDelete(cloud.space_id);
+            tombstoned++;
+          }
+          continue;
+        }
+
+        const existing = deps.db.prepare(
+          "SELECT updated_at, cloud_synced_at FROM spaces WHERE id = ? AND deleted_at IS NULL",
+        ).get(cloud.space_id) as { updated_at: string; cloud_synced_at: number | null } | undefined;
+
+        if (!existing) {
+          upsertStmt.run(
+            cloud.space_id, cloud.display_name, cloud.color, cloud.parent_id,
+            cloud.summary_title, cloud.summary_content, cloud.updated_at,
+          );
+          pulled++;
+        } else {
+          const localMs = Date.parse(existing.updated_at + "Z");
+          const localComparable = Number.isFinite(localMs) ? localMs : 0;
+          if (cloud.updated_at > localComparable) {
+            upsertStmt.run(
+              cloud.space_id, cloud.display_name, cloud.color, cloud.parent_id,
+              cloud.summary_title, cloud.summary_content, cloud.updated_at,
+            );
+            pulled++;
+          }
+          // else: local is newer or equal; will be pushed below if dirty.
+        }
+      }
+
+      // ── Push ──
+      const dirty = deps.store.getDirtyRows();
+      let pushed = 0;
+      for (const row of dirty) {
+        const ok = await pushRow(deps, row);
+        if (ok) pushed++;
+      }
+
+      return { pulled, pushed, tombstoned };
+    },
+
+    async pushOne(spaceId) {
+      const user = deps.currentUser();
+      const token = deps.sessionToken();
+      if (!user || !token) return;
+      // Read by id including deleted? No — pushOne handles live mutations only.
+      // Soft-deletes are pushed via the DELETE endpoint, separate path.
+      const row = deps.db.prepare(
+        "SELECT * FROM spaces WHERE id = ? AND deleted_at IS NULL",
+      ).get(spaceId) as SpaceRow | undefined;
+      if (!row) return;
+      // Skip if the row is already clean — saves a redundant PUT.
+      const localMs = localUpdatedAtMs(row);
+      const synced = (row as { cloud_synced_at: number | null }).cloud_synced_at;
+      if (synced !== null && synced >= localMs) return;
+      await pushRow(deps, row);
+    },
+
+    async pushDelete(spaceId) {
+      const user = deps.currentUser();
+      const token = deps.sessionToken();
+      if (!user || !token) return;
+      try {
+        const res = await deps.fetch(
+          `${deps.workerBase}/api/spaces/${encodeURIComponent(spaceId)}`,
+          { method: "DELETE", headers: { Cookie: `oyster_session=${token}` } },
+        );
+        // 404 = already gone elsewhere; swallow quietly. Other non-OK gets a warn.
+        if (!res.ok && res.status !== 404) {
+          console.warn(`[spaces] delete ${spaceId} non-ok ${res.status}`);
+        }
+      } catch (err) {
+        console.warn(`[spaces] delete ${spaceId} failed:`, err);
+      }
+    },
+  };
+}
+
+async function pushRow(deps: SpaceSyncDeps, row: SpaceRow): Promise<boolean> {
+  const token = deps.sessionToken();
+  if (!token) return false;
+  const localMs = localUpdatedAtMs(row);
+  let res: Response;
+  try {
+    res = await deps.fetch(`${deps.workerBase}/api/spaces/${encodeURIComponent(row.id)}`, {
+      method: "PUT",
+      headers: {
+        Cookie: `oyster_session=${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        display_name: row.display_name,
+        color: row.color,
+        parent_id: row.parent_id,
+        summary_title: row.summary_title,
+        summary_content: row.summary_content,
+        // Use the local row's updated_at translated to unix ms — the worker
+        // uses this as the LWW comparison key.
+        updated_at: localMs,
+      }),
+    });
+  } catch (err) {
+    console.warn(`[spaces] push ${row.id} failed:`, err);
+    return false;
+  }
+
+  if (res.status === 410) {
+    // Cloud has tombstoned this row. Apply locally and stop dirty-retrying.
+    deps.store.softDelete(row.id);
+    return false;
+  }
+  if (!res.ok) {
+    console.warn(`[spaces] push ${row.id} non-ok ${res.status}`);
+    return false;
+  }
+
+  const body = await res.json().catch(() => null) as { space?: { updated_at?: number } } | null;
+  const cloudUpdated = body?.space?.updated_at ?? localMs;
+  deps.store.markSynced(row.id, cloudUpdated);
+  return true;
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+cd server && npm test -- space-sync-service.test.ts
+```
+
+Expected: PASS, all 6 reconcile tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/space-sync-service.ts server/test/space-sync-service.test.ts
+git commit -m "feat(spaces-sync): SpaceSyncService.reconcile() + pushOne() — pull/push/LWW"
+```
+
+---
+
+## Task 8: Local — pushOne() additional tests + 410 handling
+
+**Files:**
+- Modify: `server/test/space-sync-service.test.ts`
+
+- [ ] **Step 1: Append failing pushOne tests**
+
+Append to `space-sync-service.test.ts`:
+
+```ts
+describe("createSpaceSyncService — pushOne()", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when user is signed out", async () => {
+    insertRow(store, "work");
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row is missing", async () => {
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("ghost");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row is already clean (cloud_synced_at >= updated_at)", async () => {
+    insertRow(store, "work");
+    // Mark synced way in the future — dirtiness check returns false.
+    store.markSynced("work", Date.now() + 60_000);
+
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("PUTs a dirty row and updates cloud_synced_at on 200", async () => {
+    insertRow(store, "work");
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(init?.method).toBe("PUT");
+      return new Response(JSON.stringify({
+        space: {
+          owner_id: "u1", space_id: "work", display_name: "work",
+          color: null, parent_id: null,
+          summary_title: null, summary_content: null,
+          updated_at: 8888, deleted_at: null, created_at: 8888,
+        },
+      }), { status: 200 });
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const row = store.getById("work")!;
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(8888);
+  });
+
+  it("on 410, soft-deletes the local row (deletion wins over stale rename)", async () => {
+    insertRow(store, "work");
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: "space_tombstoned" }), { status: 410 },
+    ));
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(store.getById("work")).toBeUndefined();
+  });
+
+  it("swallows network errors (console.warn, no throw)", async () => {
+    insertRow(store, "work");
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(svc.pushOne("work")).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify pass (the implementation from Task 7 already covers these)**
+
+```bash
+cd server && npm test -- space-sync-service.test.ts
+```
+
+Expected: PASS, all 12 tests (6 reconcile + 6 pushOne).
+
+If any test fails, fix in `space-sync-service.ts` and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/space-sync-service.test.ts
+git commit -m "test(spaces-sync): pushOne() — auth, dirty check, 410 tombstone, network error"
+```
+
+---
+
+## Task 9: Local — wire pushOne into SpaceService mutations
+
+**Files:**
+- Modify: `server/src/space-service.ts`
+- Modify: existing `server/test/` (no new test file required — manual smoke + acceptance test in Task 11 covers the wire)
+
+- [ ] **Step 1: Inject SpaceSyncService into SpaceService**
+
+In `server/src/space-service.ts`, update the imports and constructor:
+
+a) Add import near the top:
+
+```ts
+import type { SpaceSyncService } from "./space-sync-service.js";
+```
+
+b) Update the constructor signature to accept the new dependency (optional so existing call sites keep compiling until Task 10 wires it):
+
+```ts
+  constructor(
+    private spaceStore: SpaceStore,
+    private artifactStore: ArtifactStore,
+    private artifactService: ArtifactService,
+    private sessionStore: SessionStore,
+    private spaceSync?: SpaceSyncService,
+  ) {}
+```
+
+c) Add fire-and-forget push at the end of every mutation method. After each `this.spaceStore.update(...)` / `insert(...)` / soft-delete, append:
+
+In `createSpace` (after `this.spaceStore.insert(...)`, before the `return`):
+
+```ts
+    void this.spaceSync?.pushOne(id);
+```
+
+In `setSummary`, after `this.spaceStore.update(id, ...)`:
+
+```ts
+    void this.spaceSync?.pushOne(id);
+```
+
+In `updateSpace`, after `this.spaceStore.update(id, dbFields)`:
+
+```ts
+    void this.spaceSync?.pushOne(id);
+```
+
+In `deleteSpace`, replace the existing `this.spaceStore.delete(id)` (the very last line of the method) with the soft-delete + cloud push pattern:
+
+```ts
+    // Soft-delete locally; cloud propagates the tombstone via pushDelete.
+    // (pushDelete is fire-and-forget; the next reconcile catches retries.)
+    this.spaceStore.softDelete(id);
+    void this.spaceSync?.pushDelete(id);
+```
+
+> **WHY soft-delete instead of hard-delete here?** Hard-delete loses the row entirely, which means the cloud DELETE isn't retried on offline → online. Soft-delete keeps the local row marked tombstoned (filtered out of getAll/getById, same effect on the surface) and lets pushDelete (or a later reconcile) propagate without re-discovering the deletion.
+
+> **Known limit (acceptable for the wedge):** `scanSpace` updates `scan_status` etc. via `spaceStore.update()`, which bumps `updated_at`. The dirty-row predicate then fires for that row even though no synced field changed, so the next `reconcile()` pushes a no-op PUT. The worker accepts the write (LWW), bumps cloud `updated_at`, and peer devices re-pull — wasteful but not wrong. Acceptable for v1. Follow-up: split scan-status writes into a method that doesn't touch `updated_at`, or filter the dirty predicate by a `synced_dirty_at` column distinct from `updated_at`.
+
+- [ ] **Step 2: Add pushDelete tests to space-sync-service.test.ts**
+
+Append to the `pushOne()` describe block, then a sibling `describe("pushDelete()")`:
+
+```ts
+describe("createSpaceSyncService — pushDelete()", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when user is signed out", async () => {
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETEs the cloud row when signed in", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(init?.method).toBe("DELETE");
+      expect(url).toMatch(/\/api\/spaces\/work$/);
+      return new Response(JSON.stringify({ space_id: "work", deleted_at: 1, updated_at: 1 }), { status: 200 });
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("swallows 404 (row gone elsewhere) without warning loudly", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ error: "space_not_found" }), { status: 404 }));
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(svc.pushDelete("work")).resolves.toBeUndefined();
+  });
+
+  it("swallows network errors (no throw)", async () => {
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => ({ id: "u1", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(svc.pushDelete("work")).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run server tests**
+
+```bash
+cd server && npm test
+```
+
+Expected: PASS — sync service has 16 tests now; space-store-sync stays green; existing tests untouched.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/space-service.ts server/src/space-sync-service.ts server/test/space-sync-service.test.ts
+git commit -m "feat(spaces-sync): wire pushOne/pushDelete into SpaceService mutations"
+```
+
+---
+
+## Task 10: Local — wire reconcile into auth + boot (index.ts)
+
+**Files:**
+- Modify: `server/src/index.ts`
+
+- [ ] **Step 1: Construct SpaceSyncService and pass to SpaceService**
+
+In `server/src/index.ts`:
+
+a) Add import near the top with the other server-src imports:
+
+```ts
+import { createSpaceSyncService } from "./space-sync-service.js";
+```
+
+b) Find the `spaceService` construction (line 267):
+
+```ts
+const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore);
+```
+
+Replace with construction that creates spaceSync first, then injects it:
+
+```ts
+// spaceSync provides cross-device mirror of the spaces table to D1.
+// Constructed before spaceService so the latter can fire pushOne/pushDelete
+// after each mutation. Same auth bridge as publishService.
+const spaceSync = createSpaceSyncService({
+  db,
+  store: spaceStore,
+  currentUser: () => {
+    const u = authService.getState().user;
+    return u ? { id: u.id, email: u.email, tier: u.tier } : null;
+  },
+  sessionToken: () => authService.getState().sessionToken,
+  workerBase: WORKER_BASE,
+  fetch,
+});
+const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
+```
+
+> **WAIT** — `authService` is constructed AFTER `spaceService` in the current order (lines 267 vs 276). Reorder: hoist `authService` construction so spaceSync (which captures it) can be wired immediately. Move the `authService` block (lines 271-284) above `spaceService` (line 267). Reading order should become: spaceStore → artifactService → authService (with persisted-session validation) → spaceSync → spaceService.
+
+Concrete edit: cut the block
+
+```ts
+const authService = new AuthService(CONFIG_DIR);
+authService.onAuthChanged((state) => { ... });
+void authService.validatePersistedSession();
+```
+
+…and paste it just *above* the original `spaceService` line. Then add the `spaceSync` construction immediately after `authService`, then the modified `spaceService` line.
+
+c) Wire reconcile to run BEFORE backfillPublications. Find the existing block (lines 329-338):
+
+```ts
+authService.onAuthChanged(() => {
+  void publishService.backfillPublications().then((r) => logBackfill("auth-backfill", r));
+});
+if (authService.getState().user) {
+  void publishService.backfillPublications().then((r) => logBackfill("startup-backfill", r));
+}
+```
+
+Replace with:
+
+```ts
+async function syncOnAuth(label: string): Promise<void> {
+  // Spaces FIRST — the headline fix is that published-artefact ghosts resolve
+  // to real spaces, not _cloud. Doing publications first defeats that.
+  try {
+    const sr = await spaceSync.reconcile();
+    console.log(`[spaces] ${label}: pulled=${sr.pulled} pushed=${sr.pushed} tombstoned=${sr.tombstoned}`);
+    if (sr.pulled > 0 || sr.tombstoned > 0) {
+      // Notify the surface so any space pills update immediately.
+      broadcastUiEvent({ version: 1, command: "artifact_changed", payload: { id: null } });
+    }
+  } catch (err) {
+    console.warn(`[spaces] ${label} failed:`, err);
+  }
+  // Then publications (existing behaviour).
+  const pr = await publishService.backfillPublications();
+  logBackfill(label, pr);
+}
+
+authService.onAuthChanged(() => { void syncOnAuth("auth"); });
+if (authService.getState().user) {
+  void syncOnAuth("startup");
+}
+```
+
+- [ ] **Step 2: Build server, fix any TypeScript errors**
+
+```bash
+cd server && npm run build
+```
+
+Expected: PASS. If there's a TS error about `SpaceService` constructor arity, double-check Task 9 made `spaceSync` optional in the signature (`spaceSync?: SpaceSyncService`).
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:7337`. Sign in as a Pro user. Watch the server console for:
+
+```
+[spaces] auth: pulled=N pushed=M tombstoned=K
+[publish] auth-backfill: mirrored=... skipped=...
+```
+
+Both should appear, in that order, on every sign-in.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/index.ts
+git commit -m "feat(spaces-sync): wire spaceSync.reconcile() into sign-in (BEFORE publish backfill)"
+```
+
+---
+
+## Task 11: Cross-device manual verification
+
+**Files:** None (manual checklist).
+
+This task replaces an automated end-to-end test. The unit tests across Tasks 2–8 cover the slices; the cross-device flow is best smoke-tested by hand for the wedge.
+
+- [ ] **Step 1: Set up two dev environments pointing at the same Pro account**
+
+Use a primary terminal for "Machine A" and a second `userland` directory for "Machine B":
+
+```bash
+# Terminal 1 — Machine A
+npm run dev   # Vite at 7337, server at 3333, userland at ./userland
+
+# Terminal 2 — Machine B (separate userland)
+USERLAND_DIR=$(mktemp -d) PORT=3334 VITE_PORT=7338 npm run dev
+```
+
+Sign into both with the same Pro Google account. Sign-in flow opens the auth worker; same email both times.
+
+- [ ] **Step 2: Headline fix — published-artefact ghost resolves to real space on Machine B**
+
+On Machine A:
+1. Create a space "Work".
+2. Publish any artefact in space "Work".
+
+On Machine B:
+1. Sign in (or refresh — sign-in fires reconcile + backfill).
+2. The published-artefact ghost in the surface should show space pill **"Work"**, NOT the generic `_cloud` bucket.
+
+Pass criterion: pill colour matches "Work" (per A's palette), and clicking the pill filters to that space.
+
+- [ ] **Step 3: Rename propagates**
+
+On Machine A:
+1. Rename "Work" → "Work Stuff" (right-click pill → rename, or via API).
+
+On Machine B:
+1. Trigger a refresh/sign-in cycle.
+2. Pill should display "Work Stuff".
+
+- [ ] **Step 4: Soft-delete propagates**
+
+On Machine A:
+1. Delete the "Work Stuff" space.
+
+On Machine B:
+1. Refresh.
+2. Pill disappears from the surface; orphaned artefacts move to "home" per existing `deleteSpace` logic.
+
+- [ ] **Step 5: Free user / signed-out — no cloud writes**
+
+Sign out on Machine A. Create a space "Throwaway". Inspect D1 (or check `[spaces]` logs — none should be emitted). The space should NOT appear in `synced_spaces`.
+
+- [ ] **Step 6: Document any failures as follow-up issues, then commit a manual log**
+
+If anything fails the above, file a follow-up issue. Otherwise, no commit needed for this task — it's verification.
+
+---
+
+## Task 12: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add Changed entry under [Unreleased]**
+
+Open `CHANGELOG.md`. Find the `[Unreleased]` section (top of file). If it doesn't have a `### Changed` subsection, add one. Append a single bullet:
+
+```markdown
+### Changed
+- **Spaces now sync across signed-in devices.** Pro users see the same set of spaces — name, hierarchy, summary — on every device they sign into. Published artefacts on a fresh device resolve to their real space instead of a generic "Cloud" bucket.
+```
+
+(Per `feedback_changelog_style`: outcome, not internals. No mention of D1, dirty rows, sync service, etc.)
+
+- [ ] **Step 2: Regenerate the rendered changelog**
+
+```bash
+npm run build:changelog
+```
+
+Expected: refreshes `docs/changelog.html` with the new entry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md docs/changelog.html
+git commit -m "docs(changelog): spaces sync entry"
+```
+
+---
+
+## Final verification
+
+Before opening the PR:
+
+- [ ] `cd server && npm test` — all green.
+- [ ] `cd infra/oyster-publish && npm test` — all green.
+- [ ] `npm run build` from repo root — full build (web + server) succeeds.
+- [ ] Manual cross-device walkthrough (Task 11) all pass.
+- [ ] Branch is `spaces-sync-spinout` (already created during brainstorm).
+- [ ] Spec doc (`docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md`) is on the branch.
+- [ ] Issue #406 referenced in PR title or body.
+
+PR title: `feat(spaces-sync): cloud-mirror the spaces table (closes #406)`.

--- a/docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
+++ b/docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
@@ -1,0 +1,222 @@
+# Spaces sync — spin-out from #319
+
+**Status:** Draft (2026-05-06). Brainstormed in session; awaits implementation plan.
+**Tracks:** new ticket, R1 wedge, milestone 0.8.0. Dovetails with [#319](https://github.com/mattslight/oyster/issues/319).
+
+## Goal
+
+Cloud-mirror the `spaces` table so that on a fresh signed-in device, the user's spaces resolve correctly — pill labels, parent hierarchy, summary content. Resolves the `_cloud` fallback bug at `server/src/artifact-service.ts:220` where a published artefact's mirrored `space_id` can't be matched against any local row.
+
+This is the **A1 wedge** of #319: the smallest piece that closes a real cross-device gap and establishes the architectural pattern for the rest of 0.8.0. Sources, repo paths, and the re-attach UX stay in #319.
+
+## Architectural pattern (wedge scope only)
+
+**This is the first small metadata-sync wedge. It is not yet the general Oyster sync architecture.** Before applying the same pattern to memory (#318), sessions, or artefact bytes (R7), run a dedicated build-vs-lease decision covering PowerSync, ElectricSQL, Replicache, and object-storage-only designs. The wedge is small enough that DIY is faster than a framework evaluation; the *second* resource type asking for the same plumbing is the inflection point where the question becomes load-bearing.
+
+**Three different patterns are likely needed across 0.8.0+ resources** — do not assume one-size-fits-all sync:
+
+| Resource type | Examples | Likely pattern |
+|---|---|---|
+| Metadata rows (small, mutable, structural) | spaces, publication records, settings | DIY row-level sync to D1 (this wedge) — or framework if many of these |
+| Append-only / mergeable records | memories, session events, summaries | event log / append-only cloud store; merge-at-recall; not full row sync |
+| Artefact bytes (large blobs) | HTML, markdown, decks, files | R2 object storage, fetch-on-open, lock-on-edit; do **not** build Dropbox |
+
+The wedge below is pattern (1), scoped to spaces only. Other resource types deserve their own design conversation, not a copy-paste of this shape.
+
+**Oyster is local-first by default, cloud-backed when signed in.** Two forced decisions:
+
+1. **All Pro spaces sync.** On Pro upgrade, every existing local space is promoted to cloud — no per-space cloud-or-not flag. On a new-device sign-in, the user may optionally pick which subset of their cloud spaces to materialise locally; that selective-pull affordance is a future ticket (folds into #319's sign-in UX alongside re-attach). The wedge pulls everything.
+2. **Local SQLite remains the immediate write target. Cloud is the cross-device source of truth.** Dirty-row reconciliation, last-write-wins by `updated_at`.
+
+**Why no `sync_eligibility` flag?** A per-row "this space stays local forever" toggle is a privacy concept; the candidate use cases (privacy, embarrassment, storage cost, compliance) are either fringe or addressed by other levers. The better-shaped affordance is per-device selective subscription at sign-in (Dropbox model), which doesn't need a column on the canonical row — it's a sign-in choice about which cloud rows to materialise on this device.
+
+The "cloud truth principle" memory has been refined accordingly — see `project_cloud_truth_principle.md`. The pre-existing read of "cloud is canonical, local is a cache" was directionally right but wrong about write order. Writes happen locally first; cloud catches up in the background.
+
+## Out of scope
+
+- **Sources / repo paths / re-attach UX** — owned by #319.
+- **Realtime push** (websockets, Durable Objects) — sync is reconcile-on-trigger.
+- **Selective sync at new-device sign-in** — the affordance to pick which cloud spaces to materialise locally on a fresh device. Folds naturally into #319's onboarding flow. The wedge pulls all cloud spaces unconditionally.
+- **Memory sync (#318) and artefact byte sync (R7)** — same pattern, different tables, different specs.
+
+## Data model
+
+### Local SQLite — additive migration
+
+Two new columns on `spaces` (additive `ALTER TABLE ... ADD COLUMN`, idempotent per project convention):
+
+| Column | Type | Default | Purpose |
+|---|---|---|---|
+| `cloud_synced_at` | INTEGER (unix ms) | NULL | Timestamp of the cloud row's `updated_at` from the last successful push. NULL = never synced. |
+| `deleted_at` | INTEGER (unix ms) | NULL | Soft-delete tombstone; needed so deletions can propagate to cloud and out to peers. Replaces hard-delete in `space-store.delete()`. |
+
+**Dirty-row predicate:**
+```sql
+WHERE cloud_synced_at IS NULL OR updated_at > cloud_synced_at
+```
+
+`updated_at` is already maintained by `space-store.update()` (set to `datetime('now')`). For comparison, both sides should be in unix ms; the migration converts the existing TEXT `updated_at` representation or the comparison is done at the application layer. (Project already mixes both formats — pick one consistently in the service.)
+
+When the user is signed out / on free tier, `reconcile()` and `pushOne()` early-return without making network calls — `cloud_synced_at` simply stays NULL on those rows, harmlessly, until first Pro sign-in.
+
+### Cloud D1 — new table in `oyster-publish` worker
+
+The `oyster-publish` worker already owns user-scoped D1 tables, has session auth, and ships with #400's worker shape. Adding spaces here avoids a new worker. New migration: `infra/oyster-publish/migrations/0006_spaces.sql`.
+
+```sql
+CREATE TABLE synced_spaces (
+  owner_id        TEXT NOT NULL,
+  space_id        TEXT NOT NULL,
+  display_name    TEXT NOT NULL,
+  color           TEXT,
+  parent_id       TEXT,
+  summary_title   TEXT,
+  summary_content TEXT,
+  updated_at      INTEGER NOT NULL,
+  deleted_at      INTEGER,                  -- tombstone; row stays after delete
+  created_at      INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, space_id)
+);
+
+CREATE INDEX idx_synced_spaces_owner_updated
+  ON synced_spaces (owner_id, updated_at DESC);
+```
+
+Tombstones (rather than DELETE FROM) are kept so that other devices can apply the deletion on next reconcile. They can be GC'd after, say, 30 days — out of scope for this ticket.
+
+### Fields explicitly NOT in the cloud row
+
+These stay device-local. Pushing them up would corrupt cross-device state.
+
+| Local-only | Why |
+|---|---|
+| `scan_status`, `scan_error`, `last_scanned_at`, `last_scan_summary` | Scanner runs against a local filesystem path; status is per-device. |
+| `ai_job_status`, `ai_job_error` | Per-device job state. |
+| `sources.*`, `space_paths.*` | Filesystem paths are device-specific. Owned by #319. |
+
+`space-store.update()` already filters via `UPDATABLE_COLUMNS`; we do not need to filter on the cloud-write side — only the synced columns are sent.
+
+## Worker endpoints (`infra/oyster-publish/src/worker.ts`)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/spaces/mine` | Returns this user's live + tombstoned `synced_spaces` rows. Optional `?since=<unix_ms>` for incremental pulls (omitting returns all rows). Response: `{spaces: SyncedSpace[]}` where `SyncedSpace` includes `deleted_at` (null or unix ms). |
+| `PUT`  | `/api/spaces/:id` | Upsert one row. Body: `{display_name, color, parent_id, summary_title, summary_content, updated_at}`. Worker COALESCEs missing fields (mirrors PATCH-style of #400). Last-write-wins by `updated_at` — server rejects writes with `updated_at <= existing.updated_at` and returns the existing row (200 with the existing data), so a stale write becomes a no-op rather than an error. **Resurrection rule:** PUT against a tombstoned row (`deleted_at IS NOT NULL`) returns `410 gone` so the client knows to apply the tombstone locally instead. Response: `{space: SyncedSpace}`. |
+| `DELETE` | `/api/spaces/:id` | Sets `deleted_at = now()` and bumps `updated_at = now()` on the cloud row (so peers' next pull picks up the tombstone via the same updated_at gradient). Idempotent — re-DELETE returns the existing tombstone. Response: `{space_id, deleted_at, updated_at}`. |
+
+Auth: session cookie (same as publish endpoints). `owner_id` derived from session, never trusted from request body.
+
+## Server side — new `space-sync-service.ts`
+
+Modelled on `publish-service.ts`. Single file, cohesive surface, called from `auth-service` (sign-in) and `space-service` (mutations).
+
+**Surface:**
+
+```ts
+export interface SpaceSyncService {
+  /** Pull cloud → local, then push local → cloud. Idempotent. Called on sign-in
+   *  (from auth-service after backfillPublications) and on app start when
+   *  signed in. Same shape as backfillPublications. */
+  reconcile(): Promise<{ pulled: number; pushed: number; tombstoned: number }>;
+
+  /** Fire-and-forget push for one row after a local mutation. Awaited only by
+   *  tests; UI does not block. Single-row PUT to /api/spaces/:id. */
+  pushOne(spaceId: string): Promise<void>;
+}
+```
+
+**`reconcile()` algorithm:**
+
+1. If no signed-in user: clear no state, return zeros. (Free / signed-out path is a true no-op — no cloud writes have ever happened, so there's nothing to clear.)
+2. `GET /api/spaces/mine` → list of `{space_id, ...fields, updated_at, deleted_at}`.
+3. For each cloud row:
+   - If `deleted_at` is set: soft-delete locally (set `deleted_at` on local row). Skip down-sync of fields.
+   - Else if no local row: insert. Set `cloud_synced_at = updated_at`.
+   - Else if `cloud.updated_at > local.updated_at`: update local. Set `cloud_synced_at = updated_at`.
+   - Else if `cloud.updated_at < local.updated_at`: local is newer; will be pushed in step 4.
+4. Find dirty local rows (predicate above) and `PUT /api/spaces/:id` for each. On 200, set `cloud_synced_at = response.updated_at`.
+5. Returns counts for logging.
+
+**`pushOne(spaceId)`** — checks the row is dirty + eligible, PUTs it, updates `cloud_synced_at`. Swallows network errors with a `console.warn`; the next `reconcile()` will retry.
+
+**Wiring:**
+
+- `auth-service.ts` on sign-in, run in this order:
+  1. `spaceSync.reconcile()`
+  2. `backfillPublications()`
+  3. render Home
+
+  The headline fix of this ticket is precisely that published-artefact ghosts resolve to real spaces, not `_cloud`. Doing publications first defeats that — the ghost rendering would still fall through to `_cloud` until the *next* sign-in. Spaces first → publications second → render is what makes the fix immediate.
+- `space-service.ts` after every `update()` / `insert()` / `delete()`: call `spaceSync.pushOne()` (fire-and-forget).
+- App start (when already signed in, e.g. server restart): call `reconcile()` then `backfillPublications()`.
+
+## Promotion act (first Pro sign-in)
+
+By construction: the new `cloud_synced_at` column defaults to NULL on existing rows after migration, so every existing local row matches the dirty predicate on the first `reconcile()` and gets pushed up. No special "promote" code path. The migration *is* the promotion mechanism.
+
+## Resolves `_cloud` fallback
+
+Today, `artifact-service.ts:220` does:
+
+```ts
+const spaceId = pub.spaceId && localSpaceIds.has(pub.spaceId) ? pub.spaceId : "_cloud";
+```
+
+After this ticket, on a fresh device, the first `reconcile()` after sign-in populates `localSpaceIds`. Subsequent ghost rendering resolves to the real space. No change to artifact-service is needed for the wedge — the fix happens upstream when the spaces are present.
+
+## Acceptance criteria
+
+**Cross-device ground truth:**
+
+- [ ] Sign in as Pro on Machine A with N existing local spaces. Inspect cloud (D1) — N rows present.
+- [ ] Rename a space on Machine A. Wait. Sign in on Machine B. Space appears with new name.
+- [ ] Create a space on Machine A. Sign in on Machine B. Space appears.
+- [ ] Delete a space on Machine A. Sign in on Machine B. Space is soft-deleted locally (and hidden from UI).
+- [ ] Publish an artefact on Machine A in space "Work". Sign in on Machine B. Published-artefact ghost resolves to "Work" (not `_cloud`). **This is the headline fix.**
+
+**Local-first / offline:**
+
+- [ ] Free user / signed-out: no cloud writes; local spaces work as before.
+- [ ] Pro user offline: local mutations apply instantly. On reconnect + next reconcile, dirty rows push up.
+
+**Idempotence:**
+
+- [ ] Run `reconcile()` twice in a row with no mutations between: second call reports `pulled: 0, pushed: 0`.
+- [ ] Re-running migration on already-migrated DB: no-op (try/catch on ALTER per project convention).
+
+## Edge cases & known limits
+
+- **Concurrent rename, two devices.** Last-write-wins by `updated_at`. The losing device sees the winning name on next `reconcile()` (mutation, sign-in, or app start). Acceptable for spaces — they're not chatty.
+- **Tombstone before peer sync.** Device A deletes space X. Device B is offline, has a pending dirty rename for X. When B comes online, B's `pushOne()` PUTs to the tombstoned cloud row and gets `410 gone`. B's service handler treats `410` as a signal to soft-delete the local row and stop dirty-re-trying. Net behaviour: deletion wins over a stale rename. The next `reconcile()` pull confirms the tombstone idempotently.
+- **Free-tier sign-out after Pro use.** If a user downgrades or signs out, `currentUser()` returns null and `reconcile()` early-returns. Local SQLite continues to work. Cloud rows stay until the user re-signs-in or explicitly clears. (Out of scope to handle downgrade-time tombstoning.)
+- **`parent_id` referential integrity.** Cloud doesn't enforce FK on parent. Possible (rare) state: parent space tombstoned but child still references it. Surface treats orphaned parent_id as null (existing behaviour for missing parents in space-store).
+- **Tombstone GC.** Out of scope; tombstones grow forever in this iteration. Realistic at expected volumes (tens of spaces per user).
+
+## Sequencing / build order
+
+1. Worker migration `0006_spaces.sql` + endpoints in `worker.ts` + helpers in `publish-helpers.ts`. Deploy to dev environment.
+2. Local migration: ALTER TABLE adds the three columns. `db.ts`.
+3. `space-sync-service.ts` with `reconcile()` + `pushOne()`.
+4. Wire into `auth-service` (sign-in) and `space-service` (mutations).
+5. Replace hard-delete in `space-store.delete()` with soft-delete (`deleted_at`); update queries that read live spaces (`getAll`, `getById`, etc.) to filter `WHERE deleted_at IS NULL`.
+6. Tests: unit + cross-device acceptance test (two SQLite instances + worker).
+7. CHANGELOG entry under **Changed**: *"Spaces now sync across signed-in devices for Pro users."* (Per `feedback_changelog_style` — outcome, not internals.)
+
+## Dependencies
+
+- **#400** (R5 hardening) — done. Provides the worker shape this ticket extends.
+- Auth (#295) — done. Session cookie wiring already used by publish.
+- No blockers.
+
+## Hand-off to #319
+
+Once this ticket is in:
+
+- `localSpaceIds` is populated cross-device → `_cloud` fallback resolves naturally.
+- #319 picks up sources / repo paths / re-attach UX as a coherent unit.
+- #319's "tell the user which spaces have a `repo_path` so they can clone or re-attach" verify clause depends on this ticket having shipped — without it, the user wouldn't see their spaces on Machine B at all.
+
+## Sub-spec / unresolved
+
+- **Endpoint placement.** Default plan is to put endpoints in the `oyster-publish` worker. If naming feels wrong long-term, a rename to `oyster-cloud` (single multi-resource worker) can happen out of band — not gating.
+- **Selective per-device sync at new-device sign-in.** A user signing in on a fresh device may want to pick a subset of their cloud spaces to materialise locally (Dropbox-style selective sync). This is sign-in UX, not a property of the canonical row. Folds into #319's onboarding flow. Out of scope for this wedge — wedge pulls everything.

--- a/docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
+++ b/docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
@@ -43,25 +43,38 @@ The "cloud truth principle" memory has been refined accordingly — see `project
 
 ### Local SQLite — additive migration
 
-Two new columns on `spaces` (additive `ALTER TABLE ... ADD COLUMN`, idempotent per project convention):
+Three new columns on `spaces` (additive `ALTER TABLE ... ADD COLUMN`, idempotent per project convention):
 
 | Column | Type | Default | Purpose |
 |---|---|---|---|
+| `sync_dirty_at` | INTEGER (unix ms) | NULL | Timestamp of the last mutation to a *synced* field (display_name, color, parent_id, summary_title, summary_content). NULL = no sync-relevant changes since last push (or never). The dirty-row marker. |
 | `cloud_synced_at` | INTEGER (unix ms) | NULL | Timestamp of the cloud row's `updated_at` from the last successful push. NULL = never synced. |
-| `deleted_at` | INTEGER (unix ms) | NULL | Soft-delete tombstone; needed so deletions can propagate to cloud and out to peers. Replaces hard-delete in `space-store.delete()`. |
+| `deleted_at` | INTEGER (unix ms) | NULL | Soft-delete tombstone; needed so deletions can propagate to cloud and out to peers. Replaces hard-delete in `space-service.deleteSpace()`. |
 
-**Dirty-row predicate:**
+**Why a separate `sync_dirty_at` instead of using `updated_at`?** `spaces.updated_at` is bumped by every `space-store.update()` — including local-only fields like `scan_status` / `last_scanned_at` / `ai_job_status`. Using `updated_at` as the sync marker would push unchanged synced data after every scanner pass, and worse: a local scan could *win* an LWW race against a peer's legitimate rename (newer `updated_at` from a scan → cloud accepts the no-op write → peer's rename is overwritten). `sync_dirty_at` is bumped only by mutations that actually change synced fields.
+
+**Dirty-row predicate (live rows):**
 ```sql
-WHERE cloud_synced_at IS NULL OR updated_at > cloud_synced_at
+WHERE deleted_at IS NULL
+  AND sync_dirty_at IS NOT NULL
+  AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at)
 ```
 
-`updated_at` is already maintained by `space-store.update()` (set to `datetime('now')`). For comparison, both sides should be in unix ms; the migration converts the existing TEXT `updated_at` representation or the comparison is done at the application layer. (Project already mixes both formats — pick one consistently in the service.)
+**Pending-delete predicate (rows to push as DELETE):**
+```sql
+WHERE deleted_at IS NOT NULL
+  AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at)
+```
 
-When the user is signed out / on free tier, `reconcile()` and `pushOne()` early-return without making network calls — `cloud_synced_at` simply stays NULL on those rows, harmlessly, until first Pro sign-in.
+Both predicates and timestamps are unix ms throughout (no `datetime('now')` text comparisons). When the user is signed out / on free tier, `reconcile()`, `pushOne()`, and `pushDelete()` all early-return without making network calls — sync columns stay NULL, harmlessly, until first Pro sign-in.
 
-### Cloud D1 — new table in `oyster-publish` worker
+**Pro entitlement.** Per the requirements doc tier mapping, R1 (empty-machine continuity, which this wedge serves) is a Pro feature. The sync service explicitly checks `user.tier === "pro"` in addition to having a session token. Free / signed-out users do not push or pull.
 
-The `oyster-publish` worker already owns user-scoped D1 tables, has session auth, and ships with #400's worker shape. Adding spaces here avoids a new worker. New migration: `infra/oyster-publish/migrations/0006_spaces.sql`.
+### Cloud D1 — new table on the shared `oyster-auth` D1 database
+
+The `oyster-publish` worker reads/writes the *same* D1 database as `oyster-auth` (binding name `DB`, database name `oyster-auth`, ID `44086805-...`) — that's how publish reads the `users` and `sessions` tables produced by the auth worker, and where `published_artifacts` already lives. Adding spaces to that same DB avoids a second database and lets the existing session-auth flow gate every endpoint identically.
+
+**Migration files for that shared D1 live under `infra/auth-worker/migrations/`.** New migration: `infra/auth-worker/migrations/0006_synced_spaces.sql`. The endpoints are still served by the `oyster-publish` worker (`infra/oyster-publish/src/worker.ts`).
 
 ```sql
 CREATE TABLE synced_spaces (
@@ -100,7 +113,7 @@ These stay device-local. Pushing them up would corrupt cross-device state.
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/spaces/mine` | Returns this user's live + tombstoned `synced_spaces` rows. Optional `?since=<unix_ms>` for incremental pulls (omitting returns all rows). Response: `{spaces: SyncedSpace[]}` where `SyncedSpace` includes `deleted_at` (null or unix ms). |
+| `GET` | `/api/spaces/mine` | Returns this user's live + tombstoned `synced_spaces` rows (full pull). Response: `{spaces: SyncedSpace[]}` where `SyncedSpace` includes `deleted_at` (null or unix ms). Volumes are tens-to-hundreds of rows per user, so full pull is the right shape for the wedge. Incremental `?since` is a future optimisation if the row count materially grows. |
 | `PUT`  | `/api/spaces/:id` | Upsert one row. Body: `{display_name, color, parent_id, summary_title, summary_content, updated_at}`. Worker COALESCEs missing fields (mirrors PATCH-style of #400). Last-write-wins by `updated_at` — server rejects writes with `updated_at <= existing.updated_at` and returns the existing row (200 with the existing data), so a stale write becomes a no-op rather than an error. **Resurrection rule:** PUT against a tombstoned row (`deleted_at IS NOT NULL`) returns `410 gone` so the client knows to apply the tombstone locally instead. Response: `{space: SyncedSpace}`. |
 | `DELETE` | `/api/spaces/:id` | Sets `deleted_at = now()` and bumps `updated_at = now()` on the cloud row (so peers' next pull picks up the tombstone via the same updated_at gradient). Idempotent — re-DELETE returns the existing tombstone. Response: `{space_id, deleted_at, updated_at}`. |
 
@@ -127,17 +140,20 @@ export interface SpaceSyncService {
 
 **`reconcile()` algorithm:**
 
-1. If no signed-in user: clear no state, return zeros. (Free / signed-out path is a true no-op — no cloud writes have ever happened, so there's nothing to clear.)
+1. Pro gate: if no signed-in user, no session token, OR `user.tier !== "pro"`: return zeros (no network calls).
 2. `GET /api/spaces/mine` → list of `{space_id, ...fields, updated_at, deleted_at}`.
 3. For each cloud row:
-   - If `deleted_at` is set: soft-delete locally (set `deleted_at` on local row). Skip down-sync of fields.
-   - Else if no local row: insert. Set `cloud_synced_at = updated_at`.
-   - Else if `cloud.updated_at > local.updated_at`: update local. Set `cloud_synced_at = updated_at`.
-   - Else if `cloud.updated_at < local.updated_at`: local is newer; will be pushed in step 4.
-4. Find dirty local rows (predicate above) and `PUT /api/spaces/:id` for each. On 200, set `cloud_synced_at = response.updated_at`.
-5. Returns counts for logging.
+   - If `deleted_at` is set: soft-delete locally **using `cloud.deleted_at` as the local `deleted_at` timestamp** (not `Date.now()` — preserves cross-device tombstone provenance). Set `cloud_synced_at = cloud.updated_at`. Skip down-sync of fields.
+   - Else if no local row: insert. Set `cloud_synced_at = cloud.updated_at`.
+   - Else if `local.sync_dirty_at IS NULL OR cloud.updated_at > local.sync_dirty_at`: cloud is the winner; update local synced fields, set `cloud_synced_at = cloud.updated_at`. (Don't touch `sync_dirty_at` — leave it where it was; the predicate naturally goes clean because `cloud_synced_at >= sync_dirty_at`.)
+   - Else: local has newer unsynced changes; defer to step 4.
+4. Find dirty local rows (live, dirty predicate above) and `PUT /api/spaces/:id` for each. Wire `updated_at = local.sync_dirty_at`. On 200, set `cloud_synced_at = response.space.updated_at`.
+5. Find pending deletes (deleted-row predicate above) and `DELETE /api/spaces/:id` for each. On 200, set `cloud_synced_at = response.deleted_at`. On 404 (already gone elsewhere), set `cloud_synced_at = local.deleted_at` so the row stops being treated as pending.
+6. Return counts for logging.
 
-**`pushOne(spaceId)`** — checks the row is dirty + eligible, PUTs it, updates `cloud_synced_at`. Swallows network errors with a `console.warn`; the next `reconcile()` will retry.
+**`pushOne(spaceId)`** — Pro gate, checks the row is dirty + live, PUTs it (wire `updated_at = sync_dirty_at`), updates `cloud_synced_at`. Swallows network errors with a `console.warn`; the next `reconcile()` will retry.
+
+**`pushDelete(spaceId)`** — Pro gate, DELETEs the cloud row. On 200, mark synced. On 404, treat the local tombstone as already acknowledged. Network errors swallow; pending-delete sweep in `reconcile()` retries.
 
 **Wiring:**
 
@@ -152,7 +168,12 @@ export interface SpaceSyncService {
 
 ## Promotion act (first Pro sign-in)
 
-By construction: the new `cloud_synced_at` column defaults to NULL on existing rows after migration, so every existing local row matches the dirty predicate on the first `reconcile()` and gets pushed up. No special "promote" code path. The migration *is* the promotion mechanism.
+The migration adds `sync_dirty_at` defaulting to NULL — i.e. existing rows are *not* automatically dirty. We need a one-time backfill so the first `reconcile()` actually pushes existing data up. Two acceptable shapes:
+
+- **Migration-time backfill:** the same `db.ts` block that adds `sync_dirty_at` immediately runs `UPDATE spaces SET sync_dirty_at = strftime('%s','now') * 1000 WHERE sync_dirty_at IS NULL` so every existing row is marked dirty exactly once.
+- **First-Pro-sign-in backfill:** in the sync service, on first invocation when the user is Pro, run the same UPDATE if `cloud_synced_at IS NULL` rows exist that haven't been seen by sync before.
+
+Migration-time is simpler and cheaper — pick that. After the backfill, the dirty predicate fires for every existing row on the next `reconcile()`. The migration *is* the promotion mechanism, plus one line of UPDATE.
 
 ## Resolves `_cloud` fallback
 

--- a/infra/auth-worker/migrations/0006_synced_spaces.sql
+++ b/infra/auth-worker/migrations/0006_synced_spaces.sql
@@ -1,0 +1,22 @@
+-- 0006_synced_spaces.sql — cross-device mirror of the local spaces table.
+-- Spec: docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
+-- Wedge of #319 (R1). Used by the local server's space-sync-service to
+-- reconcile per-user spaces across devices. Tombstones propagate deletes.
+-- Lives in the shared oyster-auth D1 (oyster-publish Worker reads/writes it).
+
+CREATE TABLE IF NOT EXISTS synced_spaces (
+  owner_id        TEXT    NOT NULL,
+  space_id        TEXT    NOT NULL,
+  display_name    TEXT    NOT NULL,
+  color           TEXT,
+  parent_id       TEXT,
+  summary_title   TEXT,
+  summary_content TEXT,
+  updated_at      INTEGER NOT NULL,    -- unix ms; LWW comparison key
+  deleted_at      INTEGER,             -- tombstone; non-NULL means deleted
+  created_at      INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, space_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_synced_spaces_owner_updated
+  ON synced_spaces (owner_id, updated_at DESC);

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -34,6 +34,10 @@ export default {
       return handlePublishPatch(req, env, token);
     }
 
+    if (url.pathname === "/api/spaces/mine" && req.method === "GET") {
+      return handleSpacesMine(req, env);
+    }
+
     if (url.pathname.startsWith("/p/")) {
       // Issue #397: viewer canonical origin is share.oyster.to. Anything that
       // still hits oyster.to/p/* (or www.) gets a 308 to the new origin so
@@ -306,6 +310,36 @@ async function handlePublishMine(req: Request, env: Env): Promise<Response> {
 
   // Per-user data — never cache at the browser, proxy, or edge layer.
   return jsonOk({ publications: rows.results ?? [] }, 200, { "cache-control": "private, no-store" });
+}
+
+async function handleSpacesMine(req: Request, env: Env): Promise<Response> {
+  // Returns this signed-in user's synced spaces — both live rows AND tombstones,
+  // so a peer device that's been offline can apply deletions on next reconcile.
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+
+  type Row = {
+    owner_id: string;
+    space_id: string;
+    display_name: string;
+    color: string | null;
+    parent_id: string | null;
+    summary_title: string | null;
+    summary_content: string | null;
+    updated_at: number;
+    deleted_at: number | null;
+    created_at: number;
+  };
+  const rows = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces
+      WHERE owner_id = ?
+      ORDER BY updated_at DESC`,
+  ).bind(user.id).all<Row>();
+
+  // Per-user data — never cache at the browser, proxy, or edge layer.
+  return jsonOk({ spaces: rows.results ?? [] }, 200, { "cache-control": "private, no-store" });
 }
 
 async function handlePublishPatch(req: Request, env: Env, shareToken: string): Promise<Response> {

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -389,8 +389,9 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
     return jsonError(400, "invalid_metadata");
   }
 
-  // Strict optional-field validation — accept undefined (preserve), null (clear),
-  // or string (set). Anything else is a 400.
+  // Strict optional-field validation — null (clear) or string (set). undefined
+  // is rejected as a strict-required PUT field (full replacement contract);
+  // omitting an optional field returns 400 rather than silently clearing.
   const color          = validateOptional(body.color);
   const parentId       = validateOptional(body.parent_id);
   const summaryTitle   = validateOptional(body.summary_title);

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -368,11 +368,12 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
   try { body = await req.json() as typeof body; }
   catch { return jsonError(400, "invalid_metadata"); }
 
-  if (typeof body.display_name !== "string" || body.display_name.trim().length === 0) {
+  if (typeof body.display_name !== "string") {
     return jsonError(400, "invalid_metadata");
   }
-  if (body.display_name.length > 200) {
-    // Cheap upper bound; protects D1 from pathological inputs.
+  const trimmedName = body.display_name.trim();
+  if (trimmedName.length === 0 || trimmedName.length > 200) {
+    // Empty after trim, or pathologically long. Length check is on visible chars.
     return jsonError(400, "invalid_metadata");
   }
   if (typeof body.updated_at !== "number" || !Number.isFinite(body.updated_at) || body.updated_at < 0) {
@@ -381,15 +382,10 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
 
   // Strict optional-field validation — accept undefined (preserve), null (clear),
   // or string (set). Anything else is a 400.
-  function validateOptional(name: string, v: unknown): { ok: true; value: string | null } | { ok: false } {
-    if (v === undefined || v === null) return { ok: true, value: null };
-    if (typeof v === "string") return { ok: true, value: v };
-    return { ok: false };
-  }
-  const color          = validateOptional("color",          body.color);
-  const parentId       = validateOptional("parent_id",      body.parent_id);
-  const summaryTitle   = validateOptional("summary_title",  body.summary_title);
-  const summaryContent = validateOptional("summary_content", body.summary_content);
+  const color          = validateOptional(body.color);
+  const parentId       = validateOptional(body.parent_id);
+  const summaryTitle   = validateOptional(body.summary_title);
+  const summaryContent = validateOptional(body.summary_content);
   if (!color.ok || !parentId.ok || !summaryTitle.ok || !summaryContent.ok) {
     return jsonError(400, "invalid_metadata");
   }
@@ -426,7 +422,7 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
               summary_title = ?, summary_content = ?, updated_at = ?
         WHERE owner_id = ? AND space_id = ?`,
     ).bind(
-      body.display_name.trim(), color.value, parentId.value,
+      trimmedName, color.value, parentId.value,
       summaryTitle.value, summaryContent.value, incomingUpdated,
       user.id, spaceId,
     ).run();
@@ -437,7 +433,7 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
         summary_title, summary_content, updated_at, deleted_at, created_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
     ).bind(
-      user.id, spaceId, body.display_name.trim(), color.value, parentId.value,
+      user.id, spaceId, trimmedName, color.value, parentId.value,
       summaryTitle.value, summaryContent.value, incomingUpdated, now,
     ).run();
   }
@@ -559,6 +555,16 @@ async function handlePublishDelete(req: Request, env: Env, shareToken: string): 
 }
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
+
+/** Validates a synced-space optional field. Maps both undefined (field absent
+ *  from JSON) and null (explicit clear) to null — appropriate for PUT semantics
+ *  (full replacement). Do NOT reuse for PATCH-style preserve-on-undefined paths
+ *  without rethinking; you'd silently clear fields the caller meant to leave alone. */
+function validateOptional(v: unknown): { ok: true; value: string | null } | { ok: false } {
+  if (v === undefined || v === null) return { ok: true, value: null };
+  if (typeof v === "string") return { ok: true, value: v };
+  return { ok: false };
+}
 
 interface SessionUser {
   id: string;

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -599,12 +599,13 @@ async function handlePublishDelete(req: Request, env: Env, shareToken: string): 
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
-/** Validates a synced-space optional field. Maps both undefined (field absent
- *  from JSON) and null (explicit clear) to null — appropriate for PUT semantics
- *  (full replacement). Do NOT reuse for PATCH-style preserve-on-undefined paths
- *  without rethinking; you'd silently clear fields the caller meant to leave alone. */
+/** Validates a synced-space optional field. PUT is full-replacement: every
+ *  optional field MUST be present in the body (null = clear, string = set).
+ *  Omitting a field returns { ok: false } so the caller gets a 400, not a
+ *  silent clear. The sync service always sends all 5 fields; this strictness
+ *  protects against future partial-PUT clients accidentally clearing data. */
 function validateOptional(v: unknown): { ok: true; value: string | null } | { ok: false } {
-  if (v === undefined || v === null) return { ok: true, value: null };
+  if (v === null) return { ok: true, value: null };
   if (typeof v === "string") return { ok: true, value: v };
   return { ok: false };
 }

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -48,6 +48,15 @@ export default {
       return handleSpacesPut(req, env, spaceId);
     }
 
+    if (url.pathname.startsWith("/api/spaces/") && req.method === "DELETE") {
+      const raw = url.pathname.slice("/api/spaces/".length);
+      if (raw.includes("/")) return new Response("Not Found", { status: 404 });
+      let spaceId: string;
+      try { spaceId = decodeURIComponent(raw); }
+      catch { return jsonError(400, "invalid_space_id"); }
+      return handleSpacesDelete(req, env, spaceId);
+    }
+
     if (url.pathname.startsWith("/p/")) {
       // Issue #397: viewer canonical origin is share.oyster.to. Anything that
       // still hits oyster.to/p/* (or www.) gets a 308 to the new origin so
@@ -445,6 +454,40 @@ async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise
   ).bind(user.id, spaceId).first<Row>();
 
   return jsonOk({ space: row });
+}
+
+async function handleSpacesDelete(req: Request, env: Env, spaceId: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (!spaceId || spaceId.includes("/")) return jsonError(400, "invalid_space_id");
+
+  type Row = { deleted_at: number | null; updated_at: number };
+  const existing = await env.DB.prepare(
+    "SELECT deleted_at, updated_at FROM synced_spaces WHERE owner_id = ? AND space_id = ?",
+  ).bind(user.id, spaceId).first<Row>();
+
+  // 404 means: there's no cloud row to tombstone — the local delete is the
+  // only state that ever existed for this id. Caller treats 404 as "already
+  // gone elsewhere; mark the local tombstone synced and stop retrying."
+  if (!existing) return jsonError(404, "space_not_found");
+
+  // Idempotent: existing tombstone returns as-is.
+  if (existing.deleted_at !== null) {
+    return jsonOk({
+      space_id: spaceId,
+      deleted_at: existing.deleted_at,
+      updated_at: existing.updated_at,
+    });
+  }
+
+  const now = Date.now();
+  await env.DB.prepare(
+    `UPDATE synced_spaces
+        SET deleted_at = ?, updated_at = ?
+      WHERE owner_id = ? AND space_id = ?`,
+  ).bind(now, now, user.id, spaceId).run();
+
+  return jsonOk({ space_id: spaceId, deleted_at: now, updated_at: now });
 }
 
 async function handlePublishPatch(req: Request, env: Env, shareToken: string): Promise<Response> {

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -38,6 +38,16 @@ export default {
       return handleSpacesMine(req, env);
     }
 
+    if (url.pathname.startsWith("/api/spaces/") && req.method === "PUT") {
+      const raw = url.pathname.slice("/api/spaces/".length);
+      // Reject any path with extra segments before decoding (defence in depth).
+      if (raw.includes("/")) return new Response("Not Found", { status: 404 });
+      let spaceId: string;
+      try { spaceId = decodeURIComponent(raw); }
+      catch { return jsonError(400, "invalid_space_id"); }
+      return handleSpacesPut(req, env, spaceId);
+    }
+
     if (url.pathname.startsWith("/p/")) {
       // Issue #397: viewer canonical origin is share.oyster.to. Anything that
       // still hits oyster.to/p/* (or www.) gets a 308 to the new origin so
@@ -340,6 +350,105 @@ async function handleSpacesMine(req: Request, env: Env): Promise<Response> {
 
   // Per-user data — never cache at the browser, proxy, or edge layer.
   return jsonOk({ spaces: rows.results ?? [] }, 200, { "cache-control": "private, no-store" });
+}
+
+async function handleSpacesPut(req: Request, env: Env, spaceId: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (!spaceId || spaceId.includes("/")) return jsonError(400, "invalid_space_id");
+
+  let body: {
+    display_name?: unknown;
+    color?: unknown;
+    parent_id?: unknown;
+    summary_title?: unknown;
+    summary_content?: unknown;
+    updated_at?: unknown;
+  };
+  try { body = await req.json() as typeof body; }
+  catch { return jsonError(400, "invalid_metadata"); }
+
+  if (typeof body.display_name !== "string" || body.display_name.trim().length === 0) {
+    return jsonError(400, "invalid_metadata");
+  }
+  if (body.display_name.length > 200) {
+    // Cheap upper bound; protects D1 from pathological inputs.
+    return jsonError(400, "invalid_metadata");
+  }
+  if (typeof body.updated_at !== "number" || !Number.isFinite(body.updated_at) || body.updated_at < 0) {
+    return jsonError(400, "invalid_metadata");
+  }
+
+  // Strict optional-field validation — accept undefined (preserve), null (clear),
+  // or string (set). Anything else is a 400.
+  function validateOptional(name: string, v: unknown): { ok: true; value: string | null } | { ok: false } {
+    if (v === undefined || v === null) return { ok: true, value: null };
+    if (typeof v === "string") return { ok: true, value: v };
+    return { ok: false };
+  }
+  const color          = validateOptional("color",          body.color);
+  const parentId       = validateOptional("parent_id",      body.parent_id);
+  const summaryTitle   = validateOptional("summary_title",  body.summary_title);
+  const summaryContent = validateOptional("summary_content", body.summary_content);
+  if (!color.ok || !parentId.ok || !summaryTitle.ok || !summaryContent.ok) {
+    return jsonError(400, "invalid_metadata");
+  }
+  const incomingUpdated = body.updated_at;
+
+  type Row = {
+    owner_id: string; space_id: string; display_name: string;
+    color: string | null; parent_id: string | null;
+    summary_title: string | null; summary_content: string | null;
+    updated_at: number; deleted_at: number | null; created_at: number;
+  };
+  const existing = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces WHERE owner_id = ? AND space_id = ?`,
+  ).bind(user.id, spaceId).first<Row>();
+
+  // Resurrection rule — peer pushed an update after this device tombstoned.
+  // 410 tells the peer to apply the tombstone locally and stop dirty-retrying.
+  if (existing && existing.deleted_at !== null) {
+    return jsonError(410, "space_tombstoned");
+  }
+
+  // Last-write-wins: stale writes become no-ops returning the existing row.
+  if (existing && incomingUpdated <= existing.updated_at) {
+    return jsonOk({ space: existing });
+  }
+
+  const now = Date.now();
+  if (existing) {
+    await env.DB.prepare(
+      `UPDATE synced_spaces
+          SET display_name = ?, color = ?, parent_id = ?,
+              summary_title = ?, summary_content = ?, updated_at = ?
+        WHERE owner_id = ? AND space_id = ?`,
+    ).bind(
+      body.display_name.trim(), color.value, parentId.value,
+      summaryTitle.value, summaryContent.value, incomingUpdated,
+      user.id, spaceId,
+    ).run();
+  } else {
+    await env.DB.prepare(
+      `INSERT INTO synced_spaces
+       (owner_id, space_id, display_name, color, parent_id,
+        summary_title, summary_content, updated_at, deleted_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)`,
+    ).bind(
+      user.id, spaceId, body.display_name.trim(), color.value, parentId.value,
+      summaryTitle.value, summaryContent.value, incomingUpdated, now,
+    ).run();
+  }
+
+  const row = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces WHERE owner_id = ? AND space_id = ?`,
+  ).bind(user.id, spaceId).first<Row>();
+
+  return jsonOk({ space: row });
 }
 
 async function handlePublishPatch(req: Request, env: Env, shareToken: string): Promise<Response> {

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -176,7 +176,7 @@ export async function seedSyncedSpace(opts: {
   deletedAt?: number | null;
 }): Promise<void> {
   const now = opts.updatedAt ?? Date.now();
-  const createdAt = opts.createdAt ?? Date.now();
+  const createdAt = opts.createdAt ?? now;
   await env.DB.prepare(
     `INSERT INTO synced_spaces
      (owner_id, space_id, display_name, color, parent_id,

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -7,6 +7,7 @@ const SCHEMA_SQL = `
 -- Mirror of oyster-auth's relevant schema for tests. Keep in sync with:
 --   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
 --   infra/auth-worker/migrations/0003_publish.sql (users.tier, published_artifacts)
+--   infra/auth-worker/migrations/0006_synced_spaces.sql (synced_spaces)
 CREATE TABLE users (
   id            TEXT PRIMARY KEY,
   email         TEXT NOT NULL UNIQUE,
@@ -45,6 +46,21 @@ CREATE INDEX idx_pubart_owner ON published_artifacts(owner_user_id);
 CREATE UNIQUE INDEX idx_pubart_active_per_owner_artifact
   ON published_artifacts(owner_user_id, artifact_id)
   WHERE unpublished_at IS NULL;
+CREATE TABLE synced_spaces (
+  owner_id        TEXT    NOT NULL,
+  space_id        TEXT    NOT NULL,
+  display_name    TEXT    NOT NULL,
+  color           TEXT,
+  parent_id       TEXT,
+  summary_title   TEXT,
+  summary_content TEXT,
+  updated_at      INTEGER NOT NULL,
+  deleted_at      INTEGER,
+  created_at      INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, space_id)
+);
+CREATE INDEX idx_synced_spaces_owner_updated
+  ON synced_spaces (owner_id, updated_at DESC);
 `;
 
 export async function applySchema(): Promise<void> {
@@ -145,4 +161,46 @@ export async function seedActiveOpenWithBody(opts: {
   ).bind(token, opts.ownerUserId, opts.artifactId, kind, r2Key, contentType, sizeBytes, now, now).run();
   await putR2Object(r2Key, opts.body, contentType);
   return { shareToken: token, r2Key };
+}
+
+export async function seedSyncedSpace(opts: {
+  ownerId: string;
+  spaceId: string;
+  displayName?: string;
+  color?: string | null;
+  parentId?: string | null;
+  summaryTitle?: string | null;
+  summaryContent?: string | null;
+  updatedAt?: number;
+  deletedAt?: number | null;
+}): Promise<void> {
+  const now = opts.updatedAt ?? Date.now();
+  await env.DB.prepare(
+    `INSERT INTO synced_spaces
+     (owner_id, space_id, display_name, color, parent_id,
+      summary_title, summary_content, updated_at, deleted_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    opts.ownerId, opts.spaceId,
+    opts.displayName ?? opts.spaceId,
+    opts.color ?? null,
+    opts.parentId ?? null,
+    opts.summaryTitle ?? null,
+    opts.summaryContent ?? null,
+    now,
+    opts.deletedAt ?? null,
+    now,
+  ).run();
+}
+
+export async function readSyncedSpace(
+  ownerId: string, spaceId: string,
+): Promise<Record<string, unknown> | null> {
+  const row = await env.DB.prepare(
+    `SELECT owner_id, space_id, display_name, color, parent_id,
+            summary_title, summary_content, updated_at, deleted_at, created_at
+       FROM synced_spaces
+      WHERE owner_id = ? AND space_id = ?`,
+  ).bind(ownerId, spaceId).first<Record<string, unknown>>();
+  return row ?? null;
 }

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -172,9 +172,11 @@ export async function seedSyncedSpace(opts: {
   summaryTitle?: string | null;
   summaryContent?: string | null;
   updatedAt?: number;
+  createdAt?: number;
   deletedAt?: number | null;
 }): Promise<void> {
   const now = opts.updatedAt ?? Date.now();
+  const createdAt = opts.createdAt ?? Date.now();
   await env.DB.prepare(
     `INSERT INTO synced_spaces
      (owner_id, space_id, display_name, color, parent_id,
@@ -189,7 +191,7 @@ export async function seedSyncedSpace(opts: {
     opts.summaryContent ?? null,
     now,
     opts.deletedAt ?? null,
-    now,
+    createdAt,
   ).run();
 }
 

--- a/infra/oyster-publish/test/spaces-handler.test.ts
+++ b/infra/oyster-publish/test/spaces-handler.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, authHeader, seedSyncedSpace, readSyncedSpace } from "./fixtures/seed";
+
+beforeEach(async () => { await applySchema(); });
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function mineRequest(cookie?: string): Request {
+  const headers = new Headers();
+  if (cookie) headers.set("Cookie", cookie);
+  return new Request("https://oyster.to/api/spaces/mine", { method: "GET", headers });
+}
+
+describe("GET /api/spaces/mine", () => {
+  it("returns 401 sign_in_required when cookie missing", async () => {
+    const res = await call(mineRequest());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: "sign_in_required" });
+  });
+
+  it("returns empty array when user has no spaces", async () => {
+    const u = await seedUser();
+    const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ spaces: [] });
+  });
+
+  it("returns the user's spaces, including tombstones, ordered by updated_at desc", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", updatedAt: 1000 });
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "home", updatedAt: 3000 });
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "old",  updatedAt: 2000, deletedAt: 2500 });
+
+    const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { spaces: Array<Record<string, unknown>> };
+    expect(json.spaces).toHaveLength(3);
+    expect(json.spaces[0]).toMatchObject({ space_id: "home", deleted_at: null });
+    expect(json.spaces[1]).toMatchObject({ space_id: "old",  deleted_at: 2500 });
+    expect(json.spaces[2]).toMatchObject({ space_id: "work", deleted_at: null });
+  });
+
+  it("scopes results to the calling user (no leak)", async () => {
+    const u1 = await seedUser({ id: "u1", email: "u1@e.com" });
+    const u2 = await seedUser({ id: "u2", email: "u2@e.com" });
+    await seedSyncedSpace({ ownerId: u1.id, spaceId: "u1-space" });
+    await seedSyncedSpace({ ownerId: u2.id, spaceId: "u2-space" });
+
+    const res = await call(mineRequest(authHeader(u1.sessionToken).Cookie));
+    const json = await res.json() as { spaces: Array<{ space_id: string }> };
+    expect(json.spaces.map((s) => s.space_id)).toEqual(["u1-space"]);
+  });
+
+  it("sets cache-control: private, no-store", async () => {
+    const u = await seedUser();
+    const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+});
+
+// Suppress unused-import warning until tasks 3 + 4 land.
+void readSyncedSpace;

--- a/infra/oyster-publish/test/spaces-handler.test.ts
+++ b/infra/oyster-publish/test/spaces-handler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../src/worker";
-import { applySchema, seedUser, authHeader, seedSyncedSpace, readSyncedSpace } from "./fixtures/seed";
+import { applySchema, seedUser, authHeader, seedSyncedSpace } from "./fixtures/seed";
 
 beforeEach(async () => { await applySchema(); });
 
@@ -64,6 +64,3 @@ describe("GET /api/spaces/mine", () => {
     expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
 });
-
-// Suppress unused-import warning until tasks 3 + 4 land.
-void readSyncedSpace;

--- a/infra/oyster-publish/test/spaces-handler.test.ts
+++ b/infra/oyster-publish/test/spaces-handler.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import worker from "../src/worker";
-import { applySchema, seedUser, authHeader, seedSyncedSpace } from "./fixtures/seed";
+import { applySchema, seedUser, authHeader, seedSyncedSpace, readSyncedSpace } from "./fixtures/seed";
 
 beforeEach(async () => { await applySchema(); });
 
@@ -62,5 +62,95 @@ describe("GET /api/spaces/mine", () => {
     const u = await seedUser();
     const res = await call(mineRequest(authHeader(u.sessionToken).Cookie));
     expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+});
+
+function putRequest(spaceId: string, body: object, cookie?: string): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (cookie) headers.set("Cookie", cookie);
+  return new Request(`https://oyster.to/api/spaces/${spaceId}`, {
+    method: "PUT", headers, body: JSON.stringify(body),
+  });
+}
+
+describe("PUT /api/spaces/:id", () => {
+  it("returns 401 when cookie missing", async () => {
+    const res = await call(putRequest("work", { display_name: "Work", updated_at: 1000 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a new row when none exists, returns 200 with the row", async () => {
+    const u = await seedUser();
+    const res = await call(putRequest("work", {
+      display_name: "Work", color: "#6057c4", parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 5000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space: Record<string, unknown> };
+    expect(json.space).toMatchObject({
+      space_id: "work", display_name: "Work", color: "#6057c4",
+      updated_at: 5000, deleted_at: null,
+    });
+
+    const row = await readSyncedSpace(u.id, "work");
+    expect(row).toMatchObject({ display_name: "Work", updated_at: 5000 });
+  });
+
+  it("updates an existing row when incoming updated_at is greater", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", displayName: "Old", updatedAt: 1000 });
+
+    const res = await call(putRequest("work", {
+      display_name: "New", color: null, parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 2000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space: Record<string, unknown> };
+    expect(json.space).toMatchObject({ display_name: "New", updated_at: 2000 });
+  });
+
+  it("rejects stale writes (updated_at <= existing) with 200 returning the existing row (no-op)", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", displayName: "Current", updatedAt: 5000 });
+
+    const res = await call(putRequest("work", {
+      display_name: "Stale", color: null, parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 3000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space: Record<string, unknown> };
+    expect(json.space).toMatchObject({ display_name: "Current", updated_at: 5000 });
+  });
+
+  it("returns 410 gone when PUTting to a tombstoned row", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", updatedAt: 1000, deletedAt: 1500 });
+
+    const res = await call(putRequest("work", {
+      display_name: "Reborn", color: null, parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 2000,
+    }, authHeader(u.sessionToken).Cookie));
+
+    expect(res.status).toBe(410);
+    expect(await res.json()).toMatchObject({ error: "space_tombstoned" });
+  });
+
+  it("returns 400 invalid_metadata when display_name missing", async () => {
+    const u = await seedUser();
+    const res = await call(putRequest("work", { updated_at: 1000 },
+      authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
+
+  it("returns 400 invalid_metadata when updated_at missing or non-numeric", async () => {
+    const u = await seedUser();
+    const res = await call(putRequest("work", { display_name: "Work" },
+      authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
   });
 });

--- a/infra/oyster-publish/test/spaces-handler.test.ts
+++ b/infra/oyster-publish/test/spaces-handler.test.ts
@@ -153,6 +153,17 @@ describe("PUT /api/spaces/:id", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
   });
+
+  it("returns 400 invalid_metadata when an optional field is missing entirely (strict-required PUT contract)", async () => {
+    const u = await seedUser();
+    // color is omitted entirely — must 400, not silently clear.
+    const res = await call(putRequest("work", {
+      display_name: "Work", parent_id: null,
+      summary_title: null, summary_content: null, updated_at: 1000,
+    }, authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
+  });
 });
 
 function deleteRequest(spaceId: string, cookie?: string): Request {

--- a/infra/oyster-publish/test/spaces-handler.test.ts
+++ b/infra/oyster-publish/test/spaces-handler.test.ts
@@ -154,3 +154,51 @@ describe("PUT /api/spaces/:id", () => {
     expect(await res.json()).toMatchObject({ error: "invalid_metadata" });
   });
 });
+
+function deleteRequest(spaceId: string, cookie?: string): Request {
+  const headers = new Headers();
+  if (cookie) headers.set("Cookie", cookie);
+  return new Request(`https://oyster.to/api/spaces/${spaceId}`, { method: "DELETE", headers });
+}
+
+describe("DELETE /api/spaces/:id", () => {
+  it("returns 401 when cookie missing", async () => {
+    const res = await call(deleteRequest("work"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the row does not exist", async () => {
+    const u = await seedUser();
+    const res = await call(deleteRequest("ghost", authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "space_not_found" });
+  });
+
+  it("sets deleted_at and bumps updated_at on a live row", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({ ownerId: u.id, spaceId: "work", updatedAt: 1000 });
+
+    const res = await call(deleteRequest("work", authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space_id: string; deleted_at: number; updated_at: number };
+    expect(json.space_id).toBe("work");
+    expect(json.deleted_at).toBeGreaterThan(0);
+    expect(json.updated_at).toBeGreaterThan(1000);
+
+    const row = await readSyncedSpace(u.id, "work");
+    expect(row?.deleted_at).toBe(json.deleted_at);
+    expect(row?.updated_at).toBe(json.updated_at);
+  });
+
+  it("is idempotent — re-DELETE returns the existing tombstone", async () => {
+    const u = await seedUser();
+    await seedSyncedSpace({
+      ownerId: u.id, spaceId: "work", updatedAt: 1000, deletedAt: 1500,
+    });
+
+    const res = await call(deleteRequest("work", authHeader(u.sessionToken).Cookie));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { space_id: string; deleted_at: number };
+    expect(json.deleted_at).toBe(1500);
+  });
+});

--- a/infra/oyster-publish/wrangler.toml
+++ b/infra/oyster-publish/wrangler.toml
@@ -28,6 +28,16 @@ zone_name = "oyster.to"
 pattern = "www.oyster.to/api/publish/*"
 zone_name = "oyster.to"
 
+# Spaces sync endpoints (#406): GET /api/spaces/mine, PUT/DELETE /api/spaces/:id.
+# Same worker, same auth flow as /api/publish/*. Both apex and www.
+[[routes]]
+pattern = "oyster.to/api/spaces/*"
+zone_name = "oyster.to"
+
+[[routes]]
+pattern = "www.oyster.to/api/spaces/*"
+zone_name = "oyster.to"
+
 [[routes]]
 pattern = "oyster.to/p/*"
 zone_name = "oyster.to"

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -57,15 +57,21 @@ export function initDb(userlandDir: string): Database.Database {
     try { db.exec(sql); } catch { /* already exists */ }
   }
 
-  // Promotion backfill: any pre-existing rows (created before sync existed)
-  // need to be pushed up on first Pro sign-in. Mark them dirty exactly once
-  // by setting sync_dirty_at where it's still NULL — a no-op on subsequent
-  // boots since the column will already be populated.
-  // Excludes tombstones: deleted_at IS NULL is the live-row guard.
+  // Promotion backfill: pre-existing local rows (created before sync existed,
+  // or while the user was on the free tier) need to be pushed up on first Pro
+  // sign-in. Mark them dirty exactly once by setting sync_dirty_at where it's
+  // still NULL AND there's no cloud_synced_at yet — i.e. truly never-synced
+  // local rows. This explicitly excludes rows freshly pulled from the cloud
+  // (which have cloud_synced_at set but sync_dirty_at=NULL by design); marking
+  // those dirty would cause a spurious push on next reconcile that could
+  // overwrite a peer's legitimate edit via LWW.
+  // Excludes tombstones via deleted_at IS NULL.
   db.exec(`
     UPDATE spaces
        SET sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000
-     WHERE sync_dirty_at IS NULL AND deleted_at IS NULL
+     WHERE sync_dirty_at IS NULL
+       AND cloud_synced_at IS NULL
+       AND deleted_at IS NULL
   `);
 
   // space_paths — legacy join table. Replaced by `sources` below (#208).

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -50,9 +50,23 @@ export function initDb(userlandDir: string): Database.Database {
     "ALTER TABLE spaces ADD COLUMN parent_id TEXT REFERENCES spaces(id)",
     "ALTER TABLE spaces ADD COLUMN summary_title TEXT",
     "ALTER TABLE spaces ADD COLUMN summary_content TEXT",
+    "ALTER TABLE spaces ADD COLUMN sync_dirty_at INTEGER",
+    "ALTER TABLE spaces ADD COLUMN cloud_synced_at INTEGER",
+    "ALTER TABLE spaces ADD COLUMN deleted_at INTEGER",
   ]) {
     try { db.exec(sql); } catch { /* already exists */ }
   }
+
+  // Promotion backfill: any pre-existing rows (created before sync existed)
+  // need to be pushed up on first Pro sign-in. Mark them dirty exactly once
+  // by setting sync_dirty_at where it's still NULL — a no-op on subsequent
+  // boots since the column will already be populated.
+  // Excludes tombstones: deleted_at IS NULL is the live-row guard.
+  db.exec(`
+    UPDATE spaces
+       SET sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+     WHERE sync_dirty_at IS NULL AND deleted_at IS NULL
+  `);
 
   // space_paths — legacy join table. Replaced by `sources` below (#208).
   // Kept for now so the existing migration block (lines below) can read

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { tryHandleAuthRoute } from "./routes/auth.js";
 import { tryHandlePublishRoute } from "./routes/publish.js";
 import { tryHandlePinRoute } from "./routes/pin.js";
 import { createPublishService, PublishError } from "./publish-service.js";
+import { createSpaceSyncService } from "./space-sync-service.js";
 import { hashPassword } from "./password-hash.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
 import { tryHandleImportRoute } from "./routes/import.js";
@@ -264,7 +265,6 @@ const VIEWER_BASE = process.env.OYSTER_VIEWER_BASE
 // linked-source path for tiles whose `source_id` is non-null.
 const artifactService = new ArtifactService(store, WORKER_BASE, VIEWER_BASE, OYSTER_HOME, spaceStore);
 
-const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore);
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);
 await bootTimeAsync("memoryProvider.init", () => memoryProvider.init());
 
@@ -282,6 +282,23 @@ authService.onAuthChanged((state) => {
   });
 });
 void authService.validatePersistedSession();
+
+// spaceSync provides cross-device mirror of the spaces table to D1.
+// Constructed before spaceService so the latter can fire pushOne/pushDelete
+// after each mutation. Same auth bridge as publishService.
+const spaceSync = createSpaceSyncService({
+  db,
+  store: spaceStore,
+  currentUser: () => {
+    const u = authService.getState().user;
+    return u ? { id: u.id, email: u.email, tier: u.tier } : null;
+  },
+  sessionToken: () => authService.getState().sessionToken,
+  workerBase: WORKER_BASE,
+  fetch,
+});
+
+const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const publishService = createPublishService({
   db,
   readArtifactBytes: async (artifactId) => {
@@ -326,15 +343,30 @@ function logBackfill(label: string, result: { mirrored: number; skipped: number 
 // itself is just a getter on publish-service.
 artifactService.setCloudOnlyPublicationsSource(() => publishService.getCloudOnlyPublications());
 
-authService.onAuthChanged(() => {
-  // Run on every auth transition — including sign-out. backfillPublications
-  // handles the signed-out case by clearing the cloudOnly cache and returning
-  // {0,0}, and logBackfill broadcasts artifact_changed unconditionally so the
-  // surface drops any ghost rows on the spot.
-  void publishService.backfillPublications().then((r) => logBackfill("auth-backfill", r));
-});
+async function syncOnAuth(label: string): Promise<void> {
+  // Spaces FIRST — the headline fix of #406 is that published-artefact
+  // ghosts resolve to real spaces, not _cloud. Doing publications first
+  // defeats that — the ghost render would still fall through to _cloud
+  // until the *next* sign-in. spaces first → publications second → render.
+  try {
+    const sr = await spaceSync.reconcile();
+    console.log(`[spaces] ${label}: pulled=${sr.pulled} pushed=${sr.pushed} tombstoned=${sr.tombstoned}`);
+    if (sr.pulled > 0 || sr.tombstoned > 0) {
+      // Notify the surface so any space pills update immediately.
+      broadcastUiEvent({ version: 1, command: "artifact_changed", payload: { id: null } });
+    }
+  } catch (err) {
+    console.warn(`[spaces] ${label} failed:`, err);
+  }
+  // Then publications (preserves existing behaviour: clears ghost cache on
+  // sign-out, broadcasts artifact_changed unconditionally via logBackfill).
+  const pr = await publishService.backfillPublications();
+  logBackfill(label, pr);
+}
+
+authService.onAuthChanged(() => { void syncOnAuth("auth"); });
 if (authService.getState().user) {
-  void publishService.backfillPublications().then((r) => logBackfill("startup-backfill", r));
+  void syncOnAuth("startup");
 }
 
 // ── Initialize subsystems ──

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -257,6 +257,12 @@ export class SpaceService {
       if (!/^#[0-9a-fA-F]{6}$/.test(fields.color)) throw new Error("color must be a 6-digit hex string");
       dbFields.color = fields.color;
     }
+    if (Object.keys(dbFields).length === 0) {
+      // No fields to update — caller's intent was a no-op (e.g. updateSpace(id, {})
+      // or all fields explicitly undefined). Don't mark dirty or push; doing so
+      // would overwrite a peer's legitimate edit via LWW with no local intent.
+      return rowToSpace(row);
+    }
     this.spaceStore.update(id, dbFields);
     this.spaceStore.markSyncDirty(id);
     void this.spaceSync?.pushOne(id);

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -7,6 +7,7 @@ import type { SpaceStore, SpaceRow, Source } from "./space-store.js";
 import type { ArtifactStore } from "./artifact-store.js";
 import type { ArtifactService } from "./artifact-service.js";
 import type { SessionStore } from "./session-store.js";
+import type { SpaceSyncService } from "./space-sync-service.js";
 import type { Space, ScanResult } from "../../shared/types.js";
 import { slugify, toScanStatus } from "./utils.js";
 
@@ -87,6 +88,7 @@ export class SpaceService {
     private artifactStore: ArtifactStore,
     private artifactService: ArtifactService,
     private sessionStore: SessionStore,
+    private spaceSync?: SpaceSyncService,
   ) {}
 
   createSpace(params: { name: string }): Space {
@@ -103,6 +105,8 @@ export class SpaceService {
       last_scan_summary: null, ai_job_status: null, ai_job_error: null,
       summary_title: null, summary_content: null,
     });
+    this.spaceStore.markSyncDirty(id);
+    void this.spaceSync?.pushOne(id);
 
     return rowToSpace(this.spaceStore.getById(id)!);
   }
@@ -235,6 +239,8 @@ export class SpaceService {
     const row = this.spaceStore.getById(id);
     if (!row) throw new Error(`Space "${id}" not found`);
     this.spaceStore.update(id, { summary_title: title, summary_content: content });
+    this.spaceStore.markSyncDirty(id);
+    void this.spaceSync?.pushOne(id);
     return rowToSpace(this.spaceStore.getById(id)!);
   }
 
@@ -252,6 +258,8 @@ export class SpaceService {
       dbFields.color = fields.color;
     }
     this.spaceStore.update(id, dbFields);
+    this.spaceStore.markSyncDirty(id);
+    void this.spaceSync?.pushOne(id);
     return rowToSpace(this.spaceStore.getById(id)!);
   }
 
@@ -319,7 +327,11 @@ export class SpaceService {
     for (const a of artifacts) {
       this.artifactStore.update(a.id, { space_id: "home", group_name: folderName });
     }
-    this.spaceStore.delete(id);
+    // Soft-delete locally; cloud propagates the tombstone via pushDelete.
+    // (pushDelete is fire-and-forget; the pending-delete sweep in the next
+    // reconcile() retries on failure.)
+    this.spaceStore.softDelete(id);
+    void this.spaceSync?.pushDelete(id);
   }
 
   async scanSpace(spaceId: string): Promise<ScanResult> {

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -34,7 +34,7 @@ export interface SpaceStore {
   getAll(): SpaceRow[];
   getById(id: string): SpaceRow | undefined;
   getByDisplayName(name: string): SpaceRow | undefined;
-  insert(row: Omit<SpaceRow, "created_at" | "updated_at" | "sync_dirty_at" | "cloud_synced_at" | "deleted_at"> & { sync_dirty_at?: number | null; cloud_synced_at?: number | null; deleted_at?: number | null }): void;
+  insert(row: Omit<SpaceRow, "created_at" | "updated_at" | "sync_dirty_at" | "cloud_synced_at" | "deleted_at">): void;
   update(id: string, fields: Partial<Omit<SpaceRow, "id" | "created_at">>): void;
   delete(id: string): void;
   // sources
@@ -105,13 +105,11 @@ export class SqliteSpaceStore implements SpaceStore {
         INSERT INTO spaces (
           id, display_name, color, parent_id, scan_status,
           scan_error, last_scanned_at, last_scan_summary,
-          ai_job_status, ai_job_error, summary_title, summary_content,
-          sync_dirty_at, cloud_synced_at, deleted_at
+          ai_job_status, ai_job_error, summary_title, summary_content
         ) VALUES (
           @id, @display_name, @color, @parent_id, @scan_status,
           @scan_error, @last_scanned_at, @last_scan_summary,
-          @ai_job_status, @ai_job_error, @summary_title, @summary_content,
-          @sync_dirty_at, @cloud_synced_at, @deleted_at
+          @ai_job_status, @ai_job_error, @summary_title, @summary_content
         )
       `),
       addSource: db.prepare(`
@@ -133,11 +131,8 @@ export class SqliteSpaceStore implements SpaceStore {
   getAll(): SpaceRow[] { return this.stmts.getAll.all() as SpaceRow[]; }
   getById(id: string): SpaceRow | undefined { return this.stmts.getById.get(id) as SpaceRow | undefined; }
   getByDisplayName(name: string): SpaceRow | undefined { return this.stmts.getByDisplayName.get(name) as SpaceRow | undefined; }
-  insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void {
-    this.stmts.insert.run({
-      sync_dirty_at: null, cloud_synced_at: null, deleted_at: null,
-      ...row,
-    });
+  insert(row: Omit<SpaceRow, "created_at" | "updated_at" | "sync_dirty_at" | "cloud_synced_at" | "deleted_at">): void {
+    this.stmts.insert.run(row);
   }
   delete(id: string): void {
     // Cascade: sources.space_id ON DELETE CASCADE → sources rows hard-deleted,

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -13,6 +13,9 @@ export interface SpaceRow {
   ai_job_error: string | null;
   summary_title: string | null;
   summary_content: string | null;
+  sync_dirty_at: number | null;
+  cloud_synced_at: number | null;
+  deleted_at: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -31,7 +34,7 @@ export interface SpaceStore {
   getAll(): SpaceRow[];
   getById(id: string): SpaceRow | undefined;
   getByDisplayName(name: string): SpaceRow | undefined;
-  insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void;
+  insert(row: Omit<SpaceRow, "created_at" | "updated_at" | "sync_dirty_at" | "cloud_synced_at" | "deleted_at"> & { sync_dirty_at?: number | null; cloud_synced_at?: number | null; deleted_at?: number | null }): void;
   update(id: string, fields: Partial<Omit<SpaceRow, "id" | "created_at">>): void;
   delete(id: string): void;
   // sources
@@ -44,6 +47,32 @@ export interface SpaceStore {
   getSourcesByIds(sourceIds: string[]): Source[];
   getActiveSourceByPath(path: string): Source | undefined;
   getSoftDeletedSourceByPathForSpace(spaceId: string, path: string): Source | undefined;
+  /** Soft-delete a space. Sets deleted_at to the provided timestamp (or
+   *  Date.now()). Idempotent — re-call on an already-deleted row is a no-op
+   *  (preserves the original deleted_at). When applying a cross-device
+   *  tombstone, pass the cloud's deleted_at to preserve provenance. */
+  softDelete(id: string, deletedAt?: number): void;
+  /** Mark a row as having a sync-relevant change pending push. Bumped only
+   *  by mutations that change synced fields (display_name, color, parent_id,
+   *  summary_title, summary_content). NOT bumped by scanner/local-only
+   *  mutations — so a scanner pass can't stomp a peer's rename via LWW. */
+  markSyncDirty(id: string, dirtyAt?: number): void;
+  /** Live rows with pending pushes. Predicate:
+   *    deleted_at IS NULL
+   *    AND sync_dirty_at IS NOT NULL
+   *    AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at) */
+  getDirtyRows(): SpaceRow[];
+  /** Tombstoned rows whose deletion hasn't been confirmed by the cloud.
+   *  Predicate:
+   *    deleted_at IS NOT NULL
+   *    AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at) */
+  getPendingDeletes(): SpaceRow[];
+  /** Mark a row as synced through to the cloud at `cloudUpdatedAt`. For live
+   *  rows this is the cloud's updated_at; for confirmed deletes, the cloud's
+   *  deleted_at (or 404-acknowledged local deleted_at). */
+  markSynced(id: string, cloudUpdatedAt: number): void;
+  /** All rows including tombstones. Sync only — surface always uses getAll. */
+  getAllIncludingDeleted(): SpaceRow[];
   // Run a closure inside a SAVEPOINT-backed transaction. better-sqlite3
   // rolls back the SQL writes if the closure throws. (JS state mutations
   // inside the closure don't roll back — that's the caller's problem.)
@@ -68,19 +97,21 @@ export class SqliteSpaceStore implements SpaceStore {
 
   constructor(private db: Database.Database) {
     this.stmts = {
-      getAll: db.prepare("SELECT * FROM spaces ORDER BY display_name"),
-      getById: db.prepare("SELECT * FROM spaces WHERE id = ?"),
+      getAll: db.prepare("SELECT * FROM spaces WHERE deleted_at IS NULL ORDER BY display_name"),
+      getById: db.prepare("SELECT * FROM spaces WHERE id = ? AND deleted_at IS NULL"),
       // Case-insensitive + trim-tolerant match; most recently updated wins when displayNames collide
-      getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(TRIM(display_name)) = LOWER(TRIM(?)) ORDER BY updated_at DESC LIMIT 1"),
+      getByDisplayName: db.prepare("SELECT * FROM spaces WHERE LOWER(TRIM(display_name)) = LOWER(TRIM(?)) AND deleted_at IS NULL ORDER BY updated_at DESC LIMIT 1"),
       insert: db.prepare(`
         INSERT INTO spaces (
           id, display_name, color, parent_id, scan_status,
           scan_error, last_scanned_at, last_scan_summary,
-          ai_job_status, ai_job_error, summary_title, summary_content
+          ai_job_status, ai_job_error, summary_title, summary_content,
+          sync_dirty_at, cloud_synced_at, deleted_at
         ) VALUES (
           @id, @display_name, @color, @parent_id, @scan_status,
           @scan_error, @last_scanned_at, @last_scan_summary,
-          @ai_job_status, @ai_job_error, @summary_title, @summary_content
+          @ai_job_status, @ai_job_error, @summary_title, @summary_content,
+          @sync_dirty_at, @cloud_synced_at, @deleted_at
         )
       `),
       addSource: db.prepare(`
@@ -102,7 +133,12 @@ export class SqliteSpaceStore implements SpaceStore {
   getAll(): SpaceRow[] { return this.stmts.getAll.all() as SpaceRow[]; }
   getById(id: string): SpaceRow | undefined { return this.stmts.getById.get(id) as SpaceRow | undefined; }
   getByDisplayName(name: string): SpaceRow | undefined { return this.stmts.getByDisplayName.get(name) as SpaceRow | undefined; }
-  insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void { this.stmts.insert.run(row); }
+  insert(row: Omit<SpaceRow, "created_at" | "updated_at">): void {
+    this.stmts.insert.run({
+      sync_dirty_at: null, cloud_synced_at: null, deleted_at: null,
+      ...row,
+    });
+  }
   delete(id: string): void {
     // Cascade: sources.space_id ON DELETE CASCADE → sources rows hard-deleted,
     // which fires artifacts.source_id ON DELETE SET NULL on their artifacts.
@@ -141,6 +177,51 @@ export class SqliteSpaceStore implements SpaceStore {
       throw new Error("spaceStore.transaction(fn): fn must be synchronous (got a Promise)");
     }
     return result;
+  }
+
+  softDelete(id: string, deletedAt: number = Date.now()): void {
+    // Unix ms throughout so the dirty/pending-delete predicates and the
+    // cloud column are uniformly comparable. The IS NULL guard makes this
+    // idempotent (re-call preserves the original tombstone timestamp).
+    this.db.prepare(
+      "UPDATE spaces SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL",
+    ).run(deletedAt, id);
+  }
+
+  markSyncDirty(id: string, dirtyAt: number = Date.now()): void {
+    // Unconditional set — the caller's timestamp is the right one. (We don't
+    // guard MAX(existing, dirtyAt) because mutations always represent the
+    // user's most recent intent; a stale write would be a bug.)
+    this.db.prepare(
+      "UPDATE spaces SET sync_dirty_at = ? WHERE id = ?",
+    ).run(dirtyAt, id);
+  }
+
+  getDirtyRows(): SpaceRow[] {
+    return this.db.prepare(`
+      SELECT * FROM spaces
+       WHERE deleted_at IS NULL
+         AND sync_dirty_at IS NOT NULL
+         AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at)
+    `).all() as SpaceRow[];
+  }
+
+  getPendingDeletes(): SpaceRow[] {
+    return this.db.prepare(`
+      SELECT * FROM spaces
+       WHERE deleted_at IS NOT NULL
+         AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at)
+    `).all() as SpaceRow[];
+  }
+
+  markSynced(id: string, cloudUpdatedAt: number): void {
+    this.db.prepare(
+      "UPDATE spaces SET cloud_synced_at = ? WHERE id = ?",
+    ).run(cloudUpdatedAt, id);
+  }
+
+  getAllIncludingDeleted(): SpaceRow[] {
+    return this.db.prepare("SELECT * FROM spaces ORDER BY display_name").all() as SpaceRow[];
   }
 
   private static readonly UPDATABLE_COLUMNS = new Set([

--- a/server/src/space-store.ts
+++ b/server/src/space-store.ts
@@ -93,6 +93,12 @@ export class SqliteSpaceStore implements SpaceStore {
     getSourceById: Database.Statement;
     getActiveSourceByPath: Database.Statement;
     getSoftDeletedSourceByPathForSpace: Database.Statement;
+    softDelete: Database.Statement;
+    markSyncDirty: Database.Statement;
+    getDirtyRows: Database.Statement;
+    getPendingDeletes: Database.Statement;
+    markSynced: Database.Statement;
+    getAllIncludingDeleted: Database.Statement;
   };
 
   constructor(private db: Database.Database) {
@@ -125,6 +131,21 @@ export class SqliteSpaceStore implements SpaceStore {
       getSoftDeletedSourceByPathForSpace: db.prepare(
         "SELECT * FROM sources WHERE space_id = ? AND path = ? AND removed_at IS NOT NULL ORDER BY added_at DESC LIMIT 1"
       ),
+      softDelete: db.prepare("UPDATE spaces SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL"),
+      markSyncDirty: db.prepare("UPDATE spaces SET sync_dirty_at = ? WHERE id = ?"),
+      getDirtyRows: db.prepare(`
+        SELECT * FROM spaces
+         WHERE deleted_at IS NULL
+           AND sync_dirty_at IS NOT NULL
+           AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at)
+      `),
+      getPendingDeletes: db.prepare(`
+        SELECT * FROM spaces
+         WHERE deleted_at IS NOT NULL
+           AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at)
+      `),
+      markSynced: db.prepare("UPDATE spaces SET cloud_synced_at = ? WHERE id = ?"),
+      getAllIncludingDeleted: db.prepare("SELECT * FROM spaces ORDER BY display_name"),
     };
   }
 
@@ -178,45 +199,30 @@ export class SqliteSpaceStore implements SpaceStore {
     // Unix ms throughout so the dirty/pending-delete predicates and the
     // cloud column are uniformly comparable. The IS NULL guard makes this
     // idempotent (re-call preserves the original tombstone timestamp).
-    this.db.prepare(
-      "UPDATE spaces SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL",
-    ).run(deletedAt, id);
+    this.stmts.softDelete.run(deletedAt, id);
   }
 
   markSyncDirty(id: string, dirtyAt: number = Date.now()): void {
     // Unconditional set — the caller's timestamp is the right one. (We don't
     // guard MAX(existing, dirtyAt) because mutations always represent the
     // user's most recent intent; a stale write would be a bug.)
-    this.db.prepare(
-      "UPDATE spaces SET sync_dirty_at = ? WHERE id = ?",
-    ).run(dirtyAt, id);
+    this.stmts.markSyncDirty.run(dirtyAt, id);
   }
 
   getDirtyRows(): SpaceRow[] {
-    return this.db.prepare(`
-      SELECT * FROM spaces
-       WHERE deleted_at IS NULL
-         AND sync_dirty_at IS NOT NULL
-         AND (cloud_synced_at IS NULL OR sync_dirty_at > cloud_synced_at)
-    `).all() as SpaceRow[];
+    return this.stmts.getDirtyRows.all() as SpaceRow[];
   }
 
   getPendingDeletes(): SpaceRow[] {
-    return this.db.prepare(`
-      SELECT * FROM spaces
-       WHERE deleted_at IS NOT NULL
-         AND (cloud_synced_at IS NULL OR deleted_at > cloud_synced_at)
-    `).all() as SpaceRow[];
+    return this.stmts.getPendingDeletes.all() as SpaceRow[];
   }
 
   markSynced(id: string, cloudUpdatedAt: number): void {
-    this.db.prepare(
-      "UPDATE spaces SET cloud_synced_at = ? WHERE id = ?",
-    ).run(cloudUpdatedAt, id);
+    this.stmts.markSynced.run(cloudUpdatedAt, id);
   }
 
   getAllIncludingDeleted(): SpaceRow[] {
-    return this.db.prepare("SELECT * FROM spaces ORDER BY display_name").all() as SpaceRow[];
+    return this.stmts.getAllIncludingDeleted.all() as SpaceRow[];
   }
 
   private static readonly UPDATABLE_COLUMNS = new Set([

--- a/server/src/space-sync-service.ts
+++ b/server/src/space-sync-service.ts
@@ -1,0 +1,282 @@
+// space-sync-service.ts — cross-device sync of the local spaces table.
+// Spec: docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md
+//
+// Wedge of #319 (R1). Pattern: dirty-row push + pending-delete sweep + full
+// pull on reconcile, fire-and-forget pushOne/pushDelete after each mutation.
+// Pro-only — sync is gated on user.tier === "pro".
+//
+// IMPORTANT: this is the FIRST instance of cross-device row-sync. Before
+// replicating this shape for memory (#318), session metadata, or artefact
+// bytes (R7), evaluate PowerSync / ElectricSQL / Replicache / object-
+// storage-only designs. See project_sync_build_vs_lease memory.
+
+import type Database from "better-sqlite3";
+import type { SpaceStore, SpaceRow } from "./space-store.js";
+
+export interface SyncUser {
+  id: string;
+  email: string;
+  tier: string;
+}
+
+export interface SpaceSyncDeps {
+  db: Database.Database;
+  store: SpaceStore;
+  currentUser: () => SyncUser | null;
+  sessionToken: () => string | null;
+  workerBase: string;
+  fetch: typeof fetch;
+}
+
+export interface SpaceSyncService {
+  /** Pull cloud → local, then push live dirty rows, then push pending
+   *  deletes. Idempotent. Called on sign-in (BEFORE backfillPublications,
+   *  so the headline _cloud-fallback fix is immediate) and on app start
+   *  when signed in. Pro-only — returns zeros for free / signed-out. */
+  reconcile(): Promise<{ pulled: number; pushed: number; tombstoned: number }>;
+
+  /** Fire-and-forget push for one row after a local mutation. Swallows
+   *  network errors with a console.warn; the next reconcile() retries.
+   *  Pro-only — no-op for free / signed-out. */
+  pushOne(spaceId: string): Promise<void>;
+
+  /** Fire-and-forget DELETE for a space the local server just soft-deleted.
+   *  Marks the local tombstone synced on 200/404. Pro-only. */
+  pushDelete(spaceId: string): Promise<void>;
+}
+
+interface CloudSpace {
+  owner_id: string;
+  space_id: string;
+  display_name: string;
+  color: string | null;
+  parent_id: string | null;
+  summary_title: string | null;
+  summary_content: string | null;
+  updated_at: number;
+  deleted_at: number | null;
+  created_at: number;
+}
+
+interface CloudDeleteResponse {
+  space_id: string;
+  deleted_at: number;
+  updated_at: number;
+}
+
+/** Pro tier check. Spec: R1 (this wedge) is Pro-only per the requirements doc
+ *  tier mapping. Keep in one place so it's easy to change if the gate moves. */
+function isProSession(deps: SpaceSyncDeps): { user: SyncUser; token: string } | null {
+  const user = deps.currentUser();
+  const token = deps.sessionToken();
+  if (!user || !token || user.tier !== "pro") return null;
+  return { user, token };
+}
+
+export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
+  return {
+    async reconcile() {
+      const session = isProSession(deps);
+      if (!session) return { pulled: 0, pushed: 0, tombstoned: 0 };
+
+      // ── Pull ──
+      let res: Response;
+      try {
+        res = await deps.fetch(`${deps.workerBase}/api/spaces/mine`, {
+          headers: { Cookie: `oyster_session=${session.token}` },
+        });
+      } catch (err) {
+        console.warn("[spaces] reconcile pull failed:", err);
+        return { pulled: 0, pushed: 0, tombstoned: 0 };
+      }
+      if (!res.ok) {
+        console.warn(`[spaces] reconcile pull non-ok ${res.status}`);
+        return { pulled: 0, pushed: 0, tombstoned: 0 };
+      }
+
+      const body = await res.json().catch(() => null) as { spaces?: CloudSpace[] } | null;
+      const cloudRows = body?.spaces ?? [];
+
+      let pulled = 0;
+      let tombstoned = 0;
+
+      // Raw SQL for the upsert path because store.update() filters by
+      // UPDATABLE_COLUMNS and we need to set cloud_synced_at directly.
+      // Note: NOT touching sync_dirty_at — leave it whatever it was. The
+      // dirty predicate naturally goes clean because cloud_synced_at >=
+      // sync_dirty_at after this write.
+      const upsertStmt = deps.db.prepare(`
+        INSERT INTO spaces
+          (id, display_name, color, parent_id, summary_title, summary_content,
+           scan_status, cloud_synced_at, updated_at, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'none', ?, datetime('now'), datetime('now'))
+        ON CONFLICT(id) DO UPDATE SET
+          display_name    = excluded.display_name,
+          color           = excluded.color,
+          parent_id       = excluded.parent_id,
+          summary_title   = excluded.summary_title,
+          summary_content = excluded.summary_content,
+          cloud_synced_at = excluded.cloud_synced_at,
+          updated_at      = datetime('now')
+      `);
+
+      for (const cloud of cloudRows) {
+        if (cloud.deleted_at !== null) {
+          // Tombstone application — preserve cloud's deleted_at as local's
+          // deleted_at (cross-device tombstone provenance), and mark synced
+          // so the pending-delete sweep doesn't re-push.
+          const existing = deps.db.prepare(
+            "SELECT id, deleted_at FROM spaces WHERE id = ?",
+          ).get(cloud.space_id) as { id: string; deleted_at: number | null } | undefined;
+          if (existing && existing.deleted_at === null) {
+            deps.store.softDelete(cloud.space_id, cloud.deleted_at);
+            tombstoned++;
+          }
+          // Mark synced unconditionally (also covers the case where local
+          // had its own tombstone and they happen to match).
+          if (existing) deps.store.markSynced(cloud.space_id, cloud.deleted_at);
+          continue;
+        }
+
+        const existing = deps.db.prepare(
+          "SELECT sync_dirty_at, cloud_synced_at FROM spaces WHERE id = ? AND deleted_at IS NULL",
+        ).get(cloud.space_id) as { sync_dirty_at: number | null; cloud_synced_at: number | null } | undefined;
+
+        if (!existing) {
+          upsertStmt.run(
+            cloud.space_id, cloud.display_name, cloud.color, cloud.parent_id,
+            cloud.summary_title, cloud.summary_content, cloud.updated_at,
+          );
+          pulled++;
+        } else {
+          // LWW pull rule: cloud wins iff local has no dirty mark, OR cloud
+          // is newer than local's dirty mark. Otherwise push step takes over.
+          const localDirty = existing.sync_dirty_at;
+          if (localDirty === null || cloud.updated_at > localDirty) {
+            upsertStmt.run(
+              cloud.space_id, cloud.display_name, cloud.color, cloud.parent_id,
+              cloud.summary_title, cloud.summary_content, cloud.updated_at,
+            );
+            pulled++;
+          }
+          // else: local has unsynced changes newer than cloud; push handles it.
+        }
+      }
+
+      // ── Push live dirty rows ──
+      const dirty = deps.store.getDirtyRows();
+      let pushed = 0;
+      for (const row of dirty) {
+        const ok = await pushRow(deps, session.token, row);
+        if (ok) pushed++;
+      }
+
+      // ── Push pending deletes ──
+      const pending = deps.store.getPendingDeletes();
+      for (const row of pending) {
+        await pushRowDelete(deps, session.token, row);
+      }
+
+      return { pulled, pushed, tombstoned };
+    },
+
+    async pushOne(spaceId) {
+      const session = isProSession(deps);
+      if (!session) return;
+      const row = deps.db.prepare(
+        "SELECT * FROM spaces WHERE id = ? AND deleted_at IS NULL",
+      ).get(spaceId) as SpaceRow | undefined;
+      if (!row) return;
+      const dirtyAt = (row as { sync_dirty_at: number | null }).sync_dirty_at;
+      const synced  = (row as { cloud_synced_at: number | null }).cloud_synced_at;
+      // Clean if no dirty mark, or already synced past it.
+      if (dirtyAt === null) return;
+      if (synced !== null && synced >= dirtyAt) return;
+      await pushRow(deps, session.token, row);
+    },
+
+    async pushDelete(spaceId) {
+      const session = isProSession(deps);
+      if (!session) return;
+      // Read the local tombstone row (including deleted) so we know what
+      // deleted_at to use if the worker says 404.
+      const row = deps.db.prepare(
+        "SELECT id, deleted_at, cloud_synced_at FROM spaces WHERE id = ?",
+      ).get(spaceId) as { id: string; deleted_at: number | null; cloud_synced_at: number | null } | undefined;
+      if (!row || row.deleted_at === null) return;
+      await pushRowDelete(deps, session.token, row as unknown as SpaceRow);
+    },
+  };
+}
+
+async function pushRow(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promise<boolean> {
+  const dirtyAt = (row as { sync_dirty_at: number | null }).sync_dirty_at;
+  if (dirtyAt === null) return false;  // shouldn't happen — caller filters
+
+  let res: Response;
+  try {
+    res = await deps.fetch(`${deps.workerBase}/api/spaces/${encodeURIComponent(row.id)}`, {
+      method: "PUT",
+      headers: {
+        Cookie: `oyster_session=${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        display_name:    row.display_name,
+        color:           row.color,
+        parent_id:       row.parent_id,
+        summary_title:   row.summary_title,
+        summary_content: row.summary_content,
+        // Wire LWW key = sync_dirty_at (timestamp of the last sync-relevant
+        // mutation), NOT the row's general-purpose updated_at.
+        updated_at: dirtyAt,
+      }),
+    });
+  } catch (err) {
+    console.warn(`[spaces] push ${row.id} failed:`, err);
+    return false;
+  }
+
+  if (res.status === 410) {
+    // Cloud has tombstoned this row. Apply locally and stop dirty-retrying.
+    deps.store.softDelete(row.id);
+    return false;
+  }
+  if (!res.ok) {
+    console.warn(`[spaces] push ${row.id} non-ok ${res.status}`);
+    return false;
+  }
+
+  const body = await res.json().catch(() => null) as { space?: { updated_at?: number } } | null;
+  const cloudUpdated = body?.space?.updated_at ?? dirtyAt;
+  deps.store.markSynced(row.id, cloudUpdated);
+  return true;
+}
+
+async function pushRowDelete(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promise<void> {
+  const localDeletedAt = (row as { deleted_at: number | null }).deleted_at ?? Date.now();
+  let res: Response;
+  try {
+    res = await deps.fetch(
+      `${deps.workerBase}/api/spaces/${encodeURIComponent(row.id)}`,
+      { method: "DELETE", headers: { Cookie: `oyster_session=${token}` } },
+    );
+  } catch (err) {
+    console.warn(`[spaces] delete ${row.id} failed:`, err);
+    return;
+  }
+
+  if (res.status === 404) {
+    // Cloud has no record — local tombstone is the only state; consider it
+    // acknowledged so the pending-delete sweep stops re-trying.
+    deps.store.markSynced(row.id, localDeletedAt);
+    return;
+  }
+  if (!res.ok) {
+    console.warn(`[spaces] delete ${row.id} non-ok ${res.status}`);
+    return;
+  }
+  const body = await res.json().catch(() => null) as CloudDeleteResponse | null;
+  const cloudDeletedAt = body?.deleted_at ?? localDeletedAt;
+  deps.store.markSynced(row.id, cloudDeletedAt);
+}

--- a/server/src/space-sync-service.ts
+++ b/server/src/space-sync-service.ts
@@ -120,14 +120,19 @@ export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
           updated_at      = datetime('now')
       `);
 
+      const tombstoneCheckStmt = deps.db.prepare(
+        "SELECT id, deleted_at FROM spaces WHERE id = ?",
+      );
+      const liveCheckStmt = deps.db.prepare(
+        "SELECT sync_dirty_at, cloud_synced_at FROM spaces WHERE id = ? AND deleted_at IS NULL",
+      );
+
       for (const cloud of cloudRows) {
         if (cloud.deleted_at !== null) {
           // Tombstone application — preserve cloud's deleted_at as local's
           // deleted_at (cross-device tombstone provenance), and mark synced
           // so the pending-delete sweep doesn't re-push.
-          const existing = deps.db.prepare(
-            "SELECT id, deleted_at FROM spaces WHERE id = ?",
-          ).get(cloud.space_id) as { id: string; deleted_at: number | null } | undefined;
+          const existing = tombstoneCheckStmt.get(cloud.space_id) as { id: string; deleted_at: number | null } | undefined;
           if (existing && existing.deleted_at === null) {
             deps.store.softDelete(cloud.space_id, cloud.deleted_at);
             tombstoned++;
@@ -138,9 +143,7 @@ export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
           continue;
         }
 
-        const existing = deps.db.prepare(
-          "SELECT sync_dirty_at, cloud_synced_at FROM spaces WHERE id = ? AND deleted_at IS NULL",
-        ).get(cloud.space_id) as { sync_dirty_at: number | null; cloud_synced_at: number | null } | undefined;
+        const existing = liveCheckStmt.get(cloud.space_id) as { sync_dirty_at: number | null; cloud_synced_at: number | null } | undefined;
 
         if (!existing) {
           upsertStmt.run(
@@ -187,8 +190,8 @@ export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
         "SELECT * FROM spaces WHERE id = ? AND deleted_at IS NULL",
       ).get(spaceId) as SpaceRow | undefined;
       if (!row) return;
-      const dirtyAt = (row as { sync_dirty_at: number | null }).sync_dirty_at;
-      const synced  = (row as { cloud_synced_at: number | null }).cloud_synced_at;
+      const dirtyAt = row.sync_dirty_at;
+      const synced  = row.cloud_synced_at;
       // Clean if no dirty mark, or already synced past it.
       if (dirtyAt === null) return;
       if (synced !== null && synced >= dirtyAt) return;
@@ -204,13 +207,13 @@ export function createSpaceSyncService(deps: SpaceSyncDeps): SpaceSyncService {
         "SELECT id, deleted_at, cloud_synced_at FROM spaces WHERE id = ?",
       ).get(spaceId) as { id: string; deleted_at: number | null; cloud_synced_at: number | null } | undefined;
       if (!row || row.deleted_at === null) return;
-      await pushRowDelete(deps, session.token, row as unknown as SpaceRow);
+      await pushRowDelete(deps, session.token, row);
     },
   };
 }
 
 async function pushRow(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promise<boolean> {
-  const dirtyAt = (row as { sync_dirty_at: number | null }).sync_dirty_at;
+  const dirtyAt = row.sync_dirty_at;
   if (dirtyAt === null) return false;  // shouldn't happen — caller filters
 
   let res: Response;
@@ -253,8 +256,12 @@ async function pushRow(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promi
   return true;
 }
 
-async function pushRowDelete(deps: SpaceSyncDeps, token: string, row: SpaceRow): Promise<void> {
-  const localDeletedAt = (row as { deleted_at: number | null }).deleted_at ?? Date.now();
+async function pushRowDelete(
+  deps: SpaceSyncDeps,
+  token: string,
+  row: { id: string; deleted_at: number | null },
+): Promise<void> {
+  const localDeletedAt = row.deleted_at ?? Date.now();
   let res: Response;
   try {
     res = await deps.fetch(

--- a/server/test/space-store-sync.test.ts
+++ b/server/test/space-store-sync.test.ts
@@ -45,7 +45,6 @@ function insertRow(store: SqliteSpaceStore, id: string, opts: Partial<{ displayN
     scan_status: "none", scan_error: null, last_scanned_at: null,
     last_scan_summary: null, ai_job_status: null, ai_job_error: null,
     summary_title: null, summary_content: null,
-    sync_dirty_at: null, cloud_synced_at: null, deleted_at: null,
   });
 }
 

--- a/server/test/space-store-sync.test.ts
+++ b/server/test/space-store-sync.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { SqliteSpaceStore } from "../src/space-store.js";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE spaces (
+      id                TEXT PRIMARY KEY,
+      display_name      TEXT NOT NULL,
+      color             TEXT,
+      parent_id         TEXT,
+      scan_status       TEXT NOT NULL DEFAULT 'none',
+      scan_error        TEXT,
+      last_scanned_at   TEXT,
+      last_scan_summary TEXT,
+      ai_job_status     TEXT,
+      ai_job_error      TEXT,
+      summary_title     TEXT,
+      summary_content   TEXT,
+      sync_dirty_at     INTEGER,
+      cloud_synced_at   INTEGER,
+      deleted_at        INTEGER,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE space_paths (
+      space_id TEXT NOT NULL, path TEXT NOT NULL, label TEXT,
+      added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (space_id, path)
+    );
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY, space_id TEXT NOT NULL,
+      type TEXT NOT NULL, path TEXT NOT NULL,
+      label TEXT, added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at TEXT
+    );
+  `);
+  return db;
+}
+
+function insertRow(store: SqliteSpaceStore, id: string, opts: Partial<{ displayName: string }> = {}) {
+  store.insert({
+    id, display_name: opts.displayName ?? id, color: null, parent_id: null,
+    scan_status: "none", scan_error: null, last_scanned_at: null,
+    last_scan_summary: null, ai_job_status: null, ai_job_error: null,
+    summary_title: null, summary_content: null,
+    sync_dirty_at: null, cloud_synced_at: null, deleted_at: null,
+  });
+}
+
+describe("SqliteSpaceStore — sync methods + soft-delete", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+  });
+
+  describe("markSyncDirty", () => {
+    it("sets sync_dirty_at to the given timestamp", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1234);
+      const row = db.prepare("SELECT sync_dirty_at FROM spaces WHERE id='a'")
+        .get() as { sync_dirty_at: number };
+      expect(row.sync_dirty_at).toBe(1234);
+    });
+
+    it("defaults to Date.now() when no timestamp is given", () => {
+      insertRow(store, "a");
+      const before = Date.now();
+      store.markSyncDirty("a");
+      const after = Date.now();
+      const row = db.prepare("SELECT sync_dirty_at FROM spaces WHERE id='a'")
+        .get() as { sync_dirty_at: number };
+      expect(row.sync_dirty_at).toBeGreaterThanOrEqual(before);
+      expect(row.sync_dirty_at).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("getDirtyRows", () => {
+    it("excludes rows where sync_dirty_at IS NULL (no sync-relevant change yet)", () => {
+      insertRow(store, "a");
+      // No markSyncDirty call → row is not dirty per the new predicate.
+      expect(store.getDirtyRows()).toEqual([]);
+    });
+
+    it("returns rows where sync_dirty_at IS NOT NULL AND cloud_synced_at IS NULL", () => {
+      insertRow(store, "a");
+      insertRow(store, "b");
+      store.markSyncDirty("a", 1000);
+      store.markSyncDirty("b", 2000);
+      expect(store.getDirtyRows().map(r => r.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("returns rows where sync_dirty_at > cloud_synced_at", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 5000);
+      store.markSynced("a", 3000);  // synced state from before this dirty mark
+      expect(store.getDirtyRows().map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes rows where cloud_synced_at >= sync_dirty_at", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1000);
+      store.markSynced("a", 1000);
+      expect(store.getDirtyRows()).toEqual([]);
+    });
+
+    it("excludes tombstoned rows (those go via getPendingDeletes)", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1000);
+      store.softDelete("a");
+      expect(store.getDirtyRows().map(r => r.id)).toEqual([]);
+    });
+  });
+
+  describe("getPendingDeletes", () => {
+    it("returns soft-deleted rows whose deleted_at is unsynced", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 5000);
+      const pending = store.getPendingDeletes();
+      expect(pending.map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes soft-deleted rows already synced past their deleted_at", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 5000);
+      store.markSynced("a", 5000);
+      expect(store.getPendingDeletes()).toEqual([]);
+    });
+
+    it("includes soft-deleted rows where cloud_synced_at < deleted_at (peer state stale)", () => {
+      insertRow(store, "a");
+      store.markSynced("a", 1000);
+      store.softDelete("a", 5000);
+      expect(store.getPendingDeletes().map(r => r.id)).toEqual(["a"]);
+    });
+
+    it("excludes live rows", () => {
+      insertRow(store, "a");
+      store.markSyncDirty("a", 1000);
+      expect(store.getPendingDeletes()).toEqual([]);
+    });
+  });
+
+  describe("markSynced", () => {
+    it("sets cloud_synced_at to the given timestamp", () => {
+      insertRow(store, "a");
+      store.markSynced("a", 9999);
+      const row = store.getById("a")!;
+      expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(9999);
+    });
+  });
+
+  describe("softDelete", () => {
+    it("sets deleted_at to now() by default", () => {
+      insertRow(store, "a");
+      const before = Date.now();
+      store.softDelete("a");
+      const row = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'a'")
+        .get() as { deleted_at: number };
+      expect(row.deleted_at).toBeGreaterThanOrEqual(before);
+    });
+
+    it("uses the provided deletedAt timestamp when given (preserves cross-device tombstone provenance)", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 12345);
+      const row = db.prepare("SELECT deleted_at FROM spaces WHERE id = 'a'")
+        .get() as { deleted_at: number };
+      expect(row.deleted_at).toBe(12345);
+    });
+
+    it("excludes the soft-deleted row from getAll() and getById()", () => {
+      insertRow(store, "a"); insertRow(store, "b");
+      store.softDelete("a");
+      expect(store.getAll().map(r => r.id)).toEqual(["b"]);
+      expect(store.getById("a")).toBeUndefined();
+    });
+
+    it("is idempotent — re-softDelete leaves deleted_at unchanged", () => {
+      insertRow(store, "a");
+      store.softDelete("a", 5000);
+      store.softDelete("a", 9999);  // attempts to overwrite
+      const row = db.prepare("SELECT deleted_at FROM spaces WHERE id='a'")
+        .get() as { deleted_at: number };
+      expect(row.deleted_at).toBe(5000);
+    });
+  });
+
+  describe("getAllIncludingDeleted", () => {
+    it("includes tombstoned rows", () => {
+      insertRow(store, "a"); insertRow(store, "b");
+      store.softDelete("a");
+      expect(store.getAllIncludingDeleted().map(r => r.id).sort()).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("delete (hard delete — kept for failed-promotion cleanup)", () => {
+    it("getAll still excludes hard-deleted rows", () => {
+      insertRow(store, "a");
+      store.delete("a");
+      expect(store.getAll()).toEqual([]);
+    });
+  });
+});

--- a/server/test/space-sync-service.test.ts
+++ b/server/test/space-sync-service.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { SqliteSpaceStore } from "../src/space-store.js";
+import { createSpaceSyncService } from "../src/space-sync-service.js";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE spaces (
+      id                TEXT PRIMARY KEY,
+      display_name      TEXT NOT NULL,
+      color             TEXT,
+      parent_id         TEXT,
+      scan_status       TEXT NOT NULL DEFAULT 'none',
+      scan_error        TEXT,
+      last_scanned_at   TEXT,
+      last_scan_summary TEXT,
+      ai_job_status     TEXT,
+      ai_job_error      TEXT,
+      summary_title     TEXT,
+      summary_content   TEXT,
+      sync_dirty_at     INTEGER,
+      cloud_synced_at   INTEGER,
+      deleted_at        INTEGER,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE space_paths (
+      space_id TEXT NOT NULL, path TEXT NOT NULL, label TEXT,
+      added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (space_id, path)
+    );
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY, space_id TEXT NOT NULL,
+      type TEXT NOT NULL, path TEXT NOT NULL,
+      label TEXT, added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at TEXT
+    );
+  `);
+  return db;
+}
+
+function insertRow(
+  store: SqliteSpaceStore,
+  id: string,
+  opts: Partial<{ displayName: string; color: string; parentId: string; summaryTitle: string; summaryContent: string }> = {},
+) {
+  store.insert({
+    id,
+    display_name: opts.displayName ?? id,
+    color: opts.color ?? null,
+    parent_id: opts.parentId ?? null,
+    scan_status: "none", scan_error: null, last_scanned_at: null,
+    last_scan_summary: null, ai_job_status: null, ai_job_error: null,
+    summary_title: opts.summaryTitle ?? null,
+    summary_content: opts.summaryContent ?? null,
+  });
+}
+
+const FREE_USER  = { id: "u1", email: "a@a", tier: "free" };
+const PRO_USER   = { id: "u1", email: "a@a", tier: "pro" };
+
+describe("createSpaceSyncService — reconcile()", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("returns zeros when no signed-in user (no network call)", async () => {
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns zeros for free-tier users (sync is Pro-only — no network call)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => FREE_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("pulls cloud rows that don't exist locally and inserts them", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "from-cloud", display_name: "From Cloud",
+            color: "#3d8aaa", parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 5000, deleted_at: null, created_at: 5000,
+          }],
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result.pulled).toBe(1);
+    const row = store.getById("from-cloud")!;
+    expect(row.display_name).toBe("From Cloud");
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(5000);
+  });
+
+  it("updates a local row when cloud.updated_at > local.sync_dirty_at (cloud wins)", async () => {
+    insertRow(store, "work", { displayName: "Old Name" });
+    store.markSyncDirty("work", 1000);
+    store.markSynced("work", 1000);
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "work", display_name: "New Name",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 9999, deleted_at: null, created_at: 1000,
+          }],
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.reconcile();
+    const row = store.getById("work")!;
+    expect(row.display_name).toBe("New Name");
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(9999);
+  });
+
+  it("does NOT pull when local.sync_dirty_at > cloud.updated_at (local wins, will push)", async () => {
+    insertRow(store, "work", { displayName: "Local Edit" });
+    store.markSyncDirty("work", 9999);
+    store.markSynced("work", 1000);
+
+    const puts: Array<{ url: string; body: any }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "work", display_name: "Stale Cloud",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 5000, deleted_at: null, created_at: 1000,
+          }],
+        }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "PUT") {
+        puts.push({ url, body: JSON.parse(init.body as string) });
+        return new Response(JSON.stringify({
+          space: {
+            owner_id: "u1", space_id: "work", display_name: "Local Edit",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 9999, deleted_at: null, created_at: 1000,
+          },
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result.pulled).toBe(0);
+    expect(result.pushed).toBe(1);
+    expect(puts[0]!.body.updated_at).toBe(9999);   // wire ts = sync_dirty_at
+    expect(store.getById("work")!.display_name).toBe("Local Edit");  // local preserved
+  });
+
+  it("soft-deletes a local row when cloud row carries deleted_at, preserving cloud's deleted_at timestamp", async () => {
+    insertRow(store, "work");
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({
+          spaces: [{
+            owner_id: "u1", space_id: "work", display_name: "Work",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 9000, deleted_at: 9000, created_at: 1000,
+          }],
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result.tombstoned).toBe(1);
+    expect(store.getById("work")).toBeUndefined();
+    const raw = db.prepare("SELECT deleted_at, cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { deleted_at: number; cloud_synced_at: number };
+    expect(raw.deleted_at).toBe(9000);              // cloud's tombstone preserved
+    expect(raw.cloud_synced_at).toBe(9000);         // marked synced
+  });
+
+  it("pushes dirty rows to PUT /api/spaces/:id with sync_dirty_at as wire updated_at", async () => {
+    insertRow(store, "work", { displayName: "Work" });
+    store.markSyncDirty("work", 7000);
+
+    const puts: Array<{ url: string; body: any }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "PUT") {
+        puts.push({ url, body: JSON.parse(init.body as string) });
+        return new Response(JSON.stringify({
+          space: {
+            owner_id: "u1", space_id: "work", display_name: "Work",
+            color: null, parent_id: null,
+            summary_title: null, summary_content: null,
+            updated_at: 7000, deleted_at: null, created_at: 7000,
+          },
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const result = await svc.reconcile();
+    expect(result.pushed).toBe(1);
+    expect(puts[0]!.body.updated_at).toBe(7000);
+    const row = store.getById("work")!;
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(7000);
+  });
+
+  it("pushes pending deletes via DELETE /api/spaces/:id and marks them synced", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 8000);
+
+    const deletes: string[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "DELETE") {
+        deletes.push(url);
+        return new Response(JSON.stringify({
+          space_id: "work", deleted_at: 8000, updated_at: 8000,
+        }), { status: 200 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.reconcile();
+    expect(deletes).toHaveLength(1);
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(8000);
+    // Pending-delete predicate is now false → next reconcile won't re-push.
+    expect(store.getPendingDeletes()).toEqual([]);
+  });
+
+  it("treats DELETE 404 as 'already gone elsewhere' and marks the local tombstone synced", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 8000);
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/api/spaces/mine")) {
+        return new Response(JSON.stringify({ spaces: [] }), { status: 200 });
+      }
+      if (url.includes("/api/spaces/work") && init?.method === "DELETE") {
+        return new Response(JSON.stringify({ error: "space_not_found" }), { status: 404 });
+      }
+      throw new Error("unexpected fetch: " + url);
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.reconcile();
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(8000);  // local deleted_at acknowledged
+    expect(store.getPendingDeletes()).toEqual([]);
+  });
+
+  it("is idempotent — back-to-back reconciles with no mutations report 0/0/0", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 5000);
+    store.markSynced("work", 5000);
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ spaces: [] }), { status: 200 }));
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const first = await svc.reconcile();
+    const second = await svc.reconcile();
+    expect(first).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    expect(second).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+  });
+});

--- a/server/test/space-sync-service.test.ts
+++ b/server/test/space-sync-service.test.ts
@@ -498,3 +498,120 @@ describe("createSpaceSyncService — pushOne()", () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 });
+
+describe("createSpaceSyncService — pushDelete()", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when user is signed out", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for free-tier users (Pro-only)", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => FREE_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row is not soft-deleted (live row)", async () => {
+    insertRow(store, "work");
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETEs the cloud row and marks the local tombstone synced on 200", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 5000);
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(init?.method).toBe("DELETE");
+      expect(url).toMatch(/\/api\/spaces\/work$/);
+      return new Response(JSON.stringify({
+        space_id: "work", deleted_at: 5000, updated_at: 5000,
+      }), { status: 200 });
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushDelete("work");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(5000);
+    expect(store.getPendingDeletes()).toEqual([]);
+  });
+
+  it("on 404 (row never made it to cloud), marks the local tombstone synced anyway", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 5000);
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: "space_not_found" }), { status: 404 },
+    ));
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(svc.pushDelete("work")).resolves.toBeUndefined();
+    const raw = db.prepare("SELECT cloud_synced_at FROM spaces WHERE id = 'work'")
+      .get() as { cloud_synced_at: number };
+    expect(raw.cloud_synced_at).toBe(5000);
+    expect(store.getPendingDeletes()).toEqual([]);
+  });
+
+  it("swallows network errors and leaves the tombstone pending (will retry next reconcile)", async () => {
+    insertRow(store, "work");
+    store.softDelete("work", 5000);
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(svc.pushDelete("work")).resolves.toBeUndefined();
+    // Tombstone remains pending — no cloud_synced_at update on network error.
+    expect(store.getPendingDeletes().map(r => r.id)).toEqual(["work"]);
+  });
+});

--- a/server/test/space-sync-service.test.ts
+++ b/server/test/space-sync-service.test.ts
@@ -350,3 +350,151 @@ describe("createSpaceSyncService — reconcile()", () => {
     expect(second).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
   });
 });
+
+describe("createSpaceSyncService — pushOne()", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when user is signed out", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => null,
+      sessionToken: () => null,
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for free-tier users (Pro-only feature)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => FREE_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row is missing", async () => {
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("ghost");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row has no sync_dirty_at (no sync-relevant change)", async () => {
+    insertRow(store, "work");
+    // No markSyncDirty — row was inserted but not flagged for sync.
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when row is already clean (cloud_synced_at >= sync_dirty_at)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    store.markSynced("work", 1000);
+    const fetchMock = vi.fn();
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("PUTs a dirty row with sync_dirty_at as wire updated_at, updates cloud_synced_at on 200", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 6000);
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(init?.method).toBe("PUT");
+      const body = JSON.parse(init!.body as string) as { updated_at: number };
+      expect(body.updated_at).toBe(6000);
+      return new Response(JSON.stringify({
+        space: {
+          owner_id: "u1", space_id: "work", display_name: "work",
+          color: null, parent_id: null,
+          summary_title: null, summary_content: null,
+          updated_at: 6000, deleted_at: null, created_at: 6000,
+        },
+      }), { status: 200 });
+    });
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const row = store.getById("work")!;
+    expect((row as { cloud_synced_at: number | null }).cloud_synced_at).toBe(6000);
+  });
+
+  it("on 410, soft-deletes the local row (deletion wins over stale rename)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: "space_tombstoned" }), { status: 410 },
+    ));
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await svc.pushOne("work");
+    expect(store.getById("work")).toBeUndefined();
+  });
+
+  it("swallows network errors (console.warn, no throw)", async () => {
+    insertRow(store, "work");
+    store.markSyncDirty("work", 1000);
+    const fetchMock = vi.fn(async () => { throw new Error("offline"); });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const svc = createSpaceSyncService({
+      db, store,
+      currentUser: () => PRO_USER,
+      sessionToken: () => "tok",
+      workerBase: "https://oyster.to",
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(svc.pushOne("work")).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

First metadata-sync wedge for 0.8.0 / R1. Cloud-mirrors the `spaces` table to D1 so a fresh signed-in Pro device sees the user's spaces — and so published-artefact ghosts resolve to their real space instead of falling back to the generic `_cloud` bucket.

Closes #406. Sub-piece of #319 (R1 fresh-machine restore).

- **Worker side** (`oyster-publish`): new `GET /api/spaces/mine`, `PUT /api/spaces/:id` (last-write-wins by `updated_at`, 410 resurrection rule for tombstoned rows), `DELETE /api/spaces/:id` (idempotent tombstone). Migration `0006_synced_spaces.sql` on the shared `oyster-auth` D1.
- **Local server**: additive schema (`sync_dirty_at`, `cloud_synced_at`, `deleted_at` + first-Pro-sign-in promotion backfill); new `SpaceSyncService` (Pro-gated `reconcile` + `pushOne` + `pushDelete`); `SpaceService` mutations call `markSyncDirty` + `pushOne` for synced-field changes; `deleteSpace` switched to soft-delete + `pushDelete`. `scanSpace` deliberately does **not** trigger sync (so scanner activity can't stomp peer renames).
- **Sign-in flow**: `spaceSync.reconcile()` runs **before** `backfillPublications()` so the `_cloud`-fallback fix is immediate, not a cycle behind.

## Architectural caveat

This is a wedge, **not** the general Oyster sync architecture. Spec calls out a build-vs-lease checkpoint (PowerSync / ElectricSQL / Replicache / R2-only) before replicating this DIY shape for memory (#318), session metadata, or artefact bytes (R7). Three patterns are likely needed across resource types — do not assume one-size-fits-all sync.

Anchor docs:
- Spec — `docs/superpowers/specs/2026-05-06-spaces-sync-spinout-design.md`
- Plan — `docs/superpowers/plans/2026-05-06-spaces-sync-spinout.md`

## Forced decisions (from brainstorm)

1. **All Pro spaces sync** — no per-space "stay local" flag; selective per-device pull is a future affordance.
2. **Local SQLite is the immediate write target; cloud is the cross-device source of truth** — dirty-row reconciliation, last-write-wins by `sync_dirty_at`. (Note: `sync_dirty_at`, not `updated_at` — the dedicated column prevents scanner mutations stomping peer renames.)

## Deploy state

- ✅ Remote D1 migration `0006_synced_spaces.sql` applied (also backfilled `d1_migrations` tracker for 0003-0005, which had been previously applied via direct SQL outside wrangler — long-standing meta-state drift now cleaned up).
- ✅ Worker `oyster-publish` deployed (`af6975c6`).
- ⚠️ This branch adds route patterns `oyster.to/api/spaces/*` + `www.oyster.to/api/spaces/*` to `infra/oyster-publish/wrangler.toml` — the deployed worker does not yet route these paths to itself. **Needs a redeploy after merge** before the new endpoints are reachable.

## Test plan

- [x] Unit + integration: 137 server tests + 131 worker tests all pass locally
- [ ] Verify the new route patterns are picked up by `wrangler deploy` after merge
- [ ] Cross-device manual verification (5 flows in the plan):
  - [ ] Sign in as Pro on Machine A with N existing local spaces → cloud has N rows
  - [ ] Rename a space on Machine A → sign in on Machine B → renamed
  - [ ] Create a space on Machine A → sign in on Machine B → appears
  - [ ] Delete a space on Machine A → sign in on Machine B → soft-deleted, pill drops
  - [ ] Publish an artefact on Machine A in space "Work" → sign in on Machine B → ghost resolves to "Work" (not `_cloud`) **— headline fix**
- [ ] Free user / signed-out: no cloud writes; local spaces work as before
- [ ] Pro user offline: local mutations apply instantly; dirty rows push up on reconnect

## Known limits / follow-ups (deferred, all documented in plan)

- Soft-deleted spaces still leave behind `space_paths` and `sources` rows. Direct readers don't filter on `spaces.deleted_at IS NULL`; current code paths reach those tables only after `getById`, which now filters — so the leak is contained. Cascade clean-up is a follow-up.
- `createSpaceFromPath` rollback hard-deletes locally but doesn't undo the inner `createSpace`'s cloud push. Tiny race window; reconcile resolves the orphan.
- Worker `/api/spaces/*` endpoints don't have a server-side Pro tier gate — Pro check is local-server-side only. Tightenable for defence-in-depth.
- Tombstone GC: tombstones grow forever in this iteration. Realistic at expected volumes (tens of spaces per user); GC is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)