### PR TITLE
feat(memory): local event substrate for cross-device sync (#318)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -500,7 +500,14 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   })) return;
 
   // /api/memories
-  if (await tryHandleMemoryRoute(req, res, url, ctx, { memoryProvider, broadcastUiEvent })) return;
+  if (await tryHandleMemoryRoute(req, res, url, ctx, {
+    memoryProvider,
+    broadcastUiEvent,
+    resolveCurrentOwnerId: () => {
+      const u = authService.getState().user;
+      return u?.tier === "pro" ? u.id : null;
+    },
+  })) return;
 
   // /api/auth/* — local glue (whoami / startSignIn / signOut). Real auth
   // (magic-link, OAuth) lives in the Cloudflare Worker.
@@ -523,6 +530,10 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     userlandDir: USERLAND_DIR,
     getNativeSourcePath,
     publishService,
+    resolveCurrentOwnerId: () => {
+      const u = authService.getState().user;
+      return u?.tier === "pro" ? u.id : null;
+    },
   })) return;
 
   // /api/import/* — paste-from-another-AI flow

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -475,6 +475,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   const ctx = makeRouteCtx(req, res);
   const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
 
+  const resolveCurrentOwnerId = (): string | null => {
+    const u = authService.getState().user;
+    return u?.tier === "pro" ? u.id : null;
+  };
+
   // /api/sessions/* — first extracted route bucket. Returns true when
   // handled; falls through if no session route matched.
   if (await tryHandleSessionRoute(req, res, url, ctx, {
@@ -503,10 +508,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   if (await tryHandleMemoryRoute(req, res, url, ctx, {
     memoryProvider,
     broadcastUiEvent,
-    resolveCurrentOwnerId: () => {
-      const u = authService.getState().user;
-      return u?.tier === "pro" ? u.id : null;
-    },
+    resolveCurrentOwnerId,
   })) return;
 
   // /api/auth/* — local glue (whoami / startSignIn / signOut). Real auth
@@ -530,10 +532,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     userlandDir: USERLAND_DIR,
     getNativeSourcePath,
     publishService,
-    resolveCurrentOwnerId: () => {
-      const u = authService.getState().user;
-      return u?.tier === "pro" ? u.id : null;
-    },
+    resolveCurrentOwnerId,
   })) return;
 
   // /api/import/* — paste-from-another-AI flow

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -140,6 +140,12 @@ interface McpDeps {
    * lived MCP connection still reflects the current active session.
    */
   resolveActiveSessionId: () => string | null;
+  /**
+   * Returns the cloud owner id to tag memory events with, or null for
+   * Free / signed-out users (events without an owner stay local-only and
+   * are not pushed to the cloud sync endpoint).
+   */
+  resolveCurrentOwnerId: () => string | null;
 }
 
 function buildContext(userlandDir: string): string {
@@ -803,7 +809,7 @@ export function createMcpServer(deps: McpDeps): McpServer {
   );
 
   // ── Memory tools ──
-  registerMemoryTools(tool, deps.memoryProvider, deps.resolveActiveSessionId);
+  registerMemoryTools(tool, deps.memoryProvider, deps.resolveActiveSessionId, deps.resolveCurrentOwnerId);
 
   // ── Transcript search (R2 verbatim, #311) ──
   // Distinct from `recall` (which searches the memory layer). Returns

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -445,33 +445,53 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
         WHERE e.memory_id IS NULL`,
     ).all() as LegacyRow[];
 
-    for (const r of rows) {
-      // SQLite text timestamps → unix ms
-      const created_ms = Date.parse(r.created_at + "Z") || Date.now();
-      // cloud_owner_id intentionally NULL — backfilled events do not push to
-      // any current Pro account. Pre-existing memories stay local until an
-      // explicit claim flow is shipped (see "Account-switching policy").
-      this.db.prepare(
-        `INSERT OR IGNORE INTO memory_events
-           (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
-         VALUES (?, ?, 'memory_created', ?, NULL, ?, NULL)`,
-      ).run(crypto.randomUUID(), r.id, r.space_id, created_ms);
+    if (rows.length === 0) return;
 
-      this.db.prepare(
-        `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags)
-         VALUES (?, ?, ?)`,
-      ).run(r.id, r.content, r.tags);
+    // Hoist statements once; the loop reuses them inside a single transaction
+    // so N legacy rows produce one fsync, not 3*N.
+    const insertCreatedEvent = this.db.prepare(
+      `INSERT OR IGNORE INTO memory_events
+         (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+       VALUES (?, ?, 'memory_created', ?, NULL, ?, NULL)`,
+    );
+    const insertPayload = this.db.prepare(
+      `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags)
+       VALUES (?, ?, ?)`,
+    );
+    const insertSecondaryEvent = this.db.prepare(
+      `INSERT OR IGNORE INTO memory_events
+         (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+       VALUES (?, ?, ?, NULL, NULL, ?, NULL)`,
+    );
 
-      if (r.superseded_by !== null) {
-        // Map legacy 'forgotten' / 'purged' marker to the appropriate event.
-        const evType = r.superseded_by === "purged" ? "memory_purged" : "memory_forgotten";
-        this.db.prepare(
-          `INSERT OR IGNORE INTO memory_events
-             (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
-           VALUES (?, ?, ?, NULL, NULL, ?, NULL)`,
-        ).run(crypto.randomUUID(), r.id, evType, created_ms + 1);
+    const txn = this.db.transaction(() => {
+      for (const r of rows) {
+        // SQLite text timestamps may be either "YYYY-MM-DD HH:MM:SS" (from
+        // datetime('now')) or "YYYY-MM-DD" (date-only). V8's Date.parse rejects
+        // the space-separated form, so normalise to the ISO `T` separator
+        // before appending the UTC marker. Fall back to now() if still unparseable.
+        const isoText = r.created_at.includes("T") ? r.created_at : r.created_at.replace(" ", "T");
+        const parsed = Date.parse(isoText.endsWith("Z") ? isoText : isoText + "Z");
+        const created_ms = Number.isFinite(parsed) ? parsed : Date.now();
+
+        // cloud_owner_id intentionally NULL — backfilled events do not push to
+        // any current Pro account. Pre-existing memories stay local until an
+        // explicit claim flow is shipped (see "Account-switching policy").
+        // source_session_id is fetched into LegacyRow for completeness but
+        // intentionally not forwarded — the existing `memories` row retains
+        // its original value, and the cloud event log doesn't carry session
+        // attribution.
+        insertCreatedEvent.run(crypto.randomUUID(), r.id, r.space_id, created_ms);
+        insertPayload.run(r.id, r.content, r.tags);
+
+        if (r.superseded_by !== null) {
+          // Map legacy 'forgotten' / 'purged' marker to the appropriate event.
+          const evType = r.superseded_by === "purged" ? "memory_purged" : "memory_forgotten";
+          insertSecondaryEvent.run(crypto.randomUUID(), r.id, evType, created_ms + 1);
+        }
       }
-    }
+    });
+    txn();
   }
 
   writeForgotten(memory_id: string, cloud_owner_id: string | null = null): boolean {

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -215,8 +215,10 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       )
     `);
 
-    // Add purged_at to memories. Recall code filters this column out so
-    // forgotten and purged rows behave identically for FTS5 readers.
+    // `memories.purged_at` is reserved for future use. Today, purge deletes
+    // the memories row outright (see materialiseMemory), so this column is
+    // never set or read by the live code paths. Kept additively to avoid
+    // future migration churn if recall ever wants a soft-purge filter.
     try {
       this.db.exec(`ALTER TABLE memories ADD COLUMN purged_at INTEGER`);
     } catch (err) {
@@ -454,18 +456,19 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
          (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
        VALUES (?, ?, ?, NULL, NULL, ?, NULL)`,
     );
-    const nullPurgedPayload = this.db.prepare(
-      `UPDATE memory_payloads SET content = NULL, tags = '[]', purged_at = ? WHERE memory_id = ?`,
-    );
-
     const txn = this.db.transaction(() => {
       for (const r of rows) {
-        // SQLite text timestamps may be either "YYYY-MM-DD HH:MM:SS" (from
-        // datetime('now')) or "YYYY-MM-DD" (date-only). V8's Date.parse rejects
-        // the space-separated form, so normalise to the ISO `T` separator
-        // before appending the UTC marker. Fall back to now() if still unparseable.
-        const isoText = r.created_at.includes("T") ? r.created_at : r.created_at.replace(" ", "T");
-        const parsed = Date.parse(isoText.endsWith("Z") ? isoText : isoText + "Z");
+        // SQLite text timestamps come in two flavours:
+        //   - "YYYY-MM-DD HH:MM:SS" from datetime('now')
+        //   - "YYYY-MM-DD" if a row was inserted with just the date
+        // V8's Date.parse rejects the space-separated form and the "YYYY-MM-DDZ"
+        // form, so normalise: replace any space with the ISO `T` separator, then
+        // append a midnight time component if the string is date-only, then add
+        // the UTC marker.
+        let isoText = r.created_at.replace(" ", "T");
+        if (!isoText.includes("T")) isoText += "T00:00:00";
+        if (!isoText.endsWith("Z")) isoText += "Z";
+        const parsed = Date.parse(isoText);
         const created_ms = Number.isFinite(parsed) ? parsed : Date.now();
 
         // cloud_owner_id intentionally NULL — backfilled events do not push to
@@ -482,13 +485,13 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
           // Map legacy 'forgotten' / 'purged' marker to the appropriate event.
           const evType = r.superseded_by === "purged" ? "memory_purged" : "memory_forgotten";
           insertSecondaryEvent.run(crypto.randomUUID(), r.id, evType, created_ms + 1);
-          if (evType === "memory_purged") {
-            // Spec Q7: purged content must be nulled in all storage. Backfill
-            // for legacy 'purged' rows must not retain content even though
-            // no real production path writes 'purged' today.
-            nullPurgedPayload.run(Date.now(), r.id);
-          }
         }
+
+        // Apply precedence uniformly. For legacy 'purged' rows this nulls
+        // the payload AND deletes the memories row + its FTS5 entry,
+        // satisfying spec Q7. For legacy 'forgotten' rows it (re)sets
+        // superseded_by. For active rows it's an idempotent upsert.
+        this.materialiseMemory(r.id);
       }
     });
     txn();

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -98,9 +98,7 @@ function rowToMemory(row: MemoryRow): Memory {
 export class SqliteFtsMemoryProvider implements MemoryProvider {
   private db!: Database.Database;
   private stmts!: {
-    insert: Database.Statement;
     findExact: Database.Statement;
-    supersede: Database.Statement;
     listActive: Database.Statement;
     listActiveBySpace: Database.Statement;
     getById: Database.Statement;
@@ -253,17 +251,10 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
 
     // Prepared statements
     this.stmts = {
-      insert: this.db.prepare(
-        `INSERT INTO memories (id, space_id, content, tags, source_session_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
-      ),
       findExact: this.db.prepare(
         `SELECT * FROM memories
          WHERE content = ? AND (space_id = ? OR (space_id IS NULL AND ? IS NULL))
            AND superseded_by IS NULL`,
-      ),
-      supersede: this.db.prepare(
-        `UPDATE memories SET superseded_by = ?, updated_at = datetime('now') WHERE id = ?`,
       ),
       listActive: this.db.prepare(
         `SELECT * FROM memories WHERE superseded_by IS NULL ORDER BY updated_at DESC`,
@@ -463,6 +454,9 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
          (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
        VALUES (?, ?, ?, NULL, NULL, ?, NULL)`,
     );
+    const nullPurgedPayload = this.db.prepare(
+      `UPDATE memory_payloads SET content = NULL, tags = '[]', purged_at = ? WHERE memory_id = ?`,
+    );
 
     const txn = this.db.transaction(() => {
       for (const r of rows) {
@@ -488,6 +482,12 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
           // Map legacy 'forgotten' / 'purged' marker to the appropriate event.
           const evType = r.superseded_by === "purged" ? "memory_purged" : "memory_forgotten";
           insertSecondaryEvent.run(crypto.randomUUID(), r.id, evType, created_ms + 1);
+          if (evType === "memory_purged") {
+            // Spec Q7: purged content must be nulled in all storage. Backfill
+            // for legacy 'purged' rows must not retain content even though
+            // no real production path writes 'purged' today.
+            nullPurgedPayload.run(Date.now(), r.id);
+          }
         }
       }
     });

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -164,6 +164,60 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       CREATE INDEX IF NOT EXISTS memory_recalls_memory ON memory_recalls(memory_id);
     `);
 
+    // ── #318 cloud sync substrate ─────────────────────────────────
+    // Append-only event log. Doubles as outbox via cloud_synced_at IS NULL.
+    // Per-type uniqueness mirrors the cloud constraints (spec Q6) so backfill
+    // and replay are safely idempotent locally too.
+    // cloud_owner_id is captured at write time from auth state; events are
+    // only pushed when cloud_owner_id matches the current Pro user. This is
+    // the single-Pro-account-per-device guard (see "Account-switching policy").
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_events (
+        event_id        TEXT    PRIMARY KEY,
+        memory_id       TEXT    NOT NULL,
+        event_type      TEXT    NOT NULL CHECK (event_type IN ('memory_created','memory_forgotten','memory_purged')),
+        space_id        TEXT,
+        cloud_owner_id  TEXT,
+        created_at      INTEGER NOT NULL,
+        cloud_synced_at INTEGER
+      )
+    `);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS idx_memory_events_memory ON memory_events(memory_id)`);
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_memory_events_pending
+         ON memory_events(cloud_synced_at) WHERE cloud_synced_at IS NULL`,
+    );
+    this.db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_events_created
+         ON memory_events(memory_id) WHERE event_type = 'memory_created'`,
+    );
+    this.db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_events_forgotten
+         ON memory_events(memory_id) WHERE event_type = 'memory_forgotten'`,
+    );
+    this.db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_events_purged
+         ON memory_events(memory_id) WHERE event_type = 'memory_purged'`,
+    );
+
+    // Redactable content store. Purge nulls content + tags and sets purged_at.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_payloads (
+        memory_id  TEXT PRIMARY KEY,
+        content    TEXT,
+        tags       TEXT NOT NULL DEFAULT '[]',
+        purged_at  INTEGER
+      )
+    `);
+
+    // Add purged_at to memories. Recall code filters this column out so
+    // forgotten and purged rows behave identically for FTS5 readers.
+    try {
+      this.db.exec(`ALTER TABLE memories ADD COLUMN purged_at INTEGER`);
+    } catch (err) {
+      if (!(err instanceof Error) || !/duplicate column/i.test(err.message)) throw err;
+    }
+
     // FTS5 virtual table
     this.db.exec(`
       CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -178,7 +178,7 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
         event_type      TEXT    NOT NULL CHECK (event_type IN ('memory_created','memory_forgotten','memory_purged')),
         space_id        TEXT,
         cloud_owner_id  TEXT,
-        created_at      INTEGER NOT NULL,
+        created_at      INTEGER NOT NULL,    -- Unix epoch ms (not ISO string; matches D1 cloud schema for cross-device events)
         cloud_synced_at INTEGER
       )
     `);
@@ -200,7 +200,9 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
          ON memory_events(memory_id) WHERE event_type = 'memory_purged'`,
     );
 
-    // Redactable content store. Purge nulls content + tags and sets purged_at.
+    // Redactable content store. Purge nulls content + tags (tags are
+    // redacted alongside content so no PII can leak via tag text) and
+    // sets purged_at.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS memory_payloads (
         memory_id  TEXT PRIMARY KEY,

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -24,6 +24,7 @@ export interface RememberInput {
   space_id?: string;
   tags?: string[];
   source_session_id?: string | null;
+  cloud_owner_id?: string | null;
 }
 
 export interface RecallInput {
@@ -49,7 +50,11 @@ export interface MemoryProvider {
   recall(input: RecallInput): Promise<Memory[]>;
   /** Marks a memory as forgotten. Returns true if a row was updated, false if
    *  the id doesn't exist — callers can map false → 404. */
-  forget(id: string): Promise<boolean>;
+  forget(id: string, cloud_owner_id?: string | null): Promise<boolean>;
+  /** Server-internal hard-redaction. Writes a purge event and nulls payload
+   *  content. Not exposed via MCP in v1; reserved for "delete forever" UI,
+   *  account deletion, and secret-exposure flows. */
+  purge(id: string, cloud_owner_id?: string | null): Promise<boolean>;
   list(space_id?: string): Promise<Memory[]>;
   /** Synchronous existence check used by the import flow's dedupe — true
    *  when an active memory with this exact (content, space_id) already
@@ -333,7 +338,7 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     const owner_id  = input.cloud_owner_id ?? null;
 
     let inserted = false;
-    let returned_event_id = event_id;
+    let returned_event_id: string = event_id;
 
     const txn = this.db.transaction(() => {
       const info = this.db.prepare(
@@ -466,18 +471,23 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
 
   async remember(input: RememberInput): Promise<Memory> {
     const spaceId = input.space_id ?? null;
-    const tags = JSON.stringify(input.tags ?? []);
-    const sourceSessionId = input.source_session_id ?? null;
 
-    // Conservative dedupe: exact content match in same scope
-    const existing = this.stmts.findExact.get(input.content, spaceId, spaceId) as MemoryRow | undefined;
-    if (existing) {
-      return rowToMemory(existing);
+    // Conservative dedupe: exact content match in same scope. Preserves the
+    // existing surface contract — `remember` returns the existing row instead
+    // of duplicating. Skip for empty content (defensive).
+    if (input.content.length > 0) {
+      const existing = this.stmts.findExact.get(input.content, spaceId, spaceId) as MemoryRow | undefined;
+      if (existing) return rowToMemory(existing);
     }
 
-    const id = crypto.randomUUID();
-    this.stmts.insert.run(id, spaceId, input.content, tags, sourceSessionId);
-    const row = this.stmts.getById.get(id) as MemoryRow;
+    const { memory_id } = this.writeCreated({
+      content: input.content,
+      space_id: spaceId,
+      tags: input.tags,
+      source_session_id: input.source_session_id,
+      cloud_owner_id: input.cloud_owner_id ?? null,
+    });
+    const row = this.stmts.getById.get(memory_id) as MemoryRow;
     return rowToMemory(row);
   }
 
@@ -534,10 +544,20 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     return rows.map((row) => ({ ...rowToMemory(row), recalled_at: row.recalled_at }));
   }
 
-  async forget(id: string): Promise<boolean> {
+  async forget(id: string, cloud_owner_id: string | null = null): Promise<boolean> {
     const row = this.stmts.getById.get(id) as MemoryRow | undefined;
     if (!row) return false;
-    this.stmts.supersede.run("forgotten", id);
+    this.writeForgotten(id, cloud_owner_id);
+    return true;
+  }
+
+  async purge(id: string, cloud_owner_id: string | null = null): Promise<boolean> {
+    const row = this.stmts.getById.get(id) as MemoryRow | undefined;
+    const hasEvent = this.db.prepare(
+      `SELECT 1 FROM memory_events WHERE memory_id = ? LIMIT 1`,
+    ).get(id);
+    if (!row && !hasEvent) return false;
+    this.writePurged(id, cloud_owner_id);
     return true;
   }
 
@@ -587,6 +607,7 @@ export function registerMemoryTools(
   // when we can't attribute (no matching active session, internal-only call,
   // unknown user-agent). Stamps memories at write time and logs recalls.
   resolveActiveSessionId: () => string | null = () => null,
+  resolveCurrentOwnerId: () => string | null = () => null,
 ): void {
   tool(
     "remember",
@@ -601,6 +622,7 @@ export function registerMemoryTools(
       space_id,
       tags,
       source_session_id: resolveActiveSessionId(),
+      cloud_owner_id: resolveCurrentOwnerId(),
     }),
   );
 
@@ -631,7 +653,7 @@ export function registerMemoryTools(
       id: z.string().describe("Memory ID to forget"),
     },
     async ({ id }) => {
-      await provider.forget(id);
+      await provider.forget(id, resolveCurrentOwnerId());
       return `Memory "${id}" forgotten.`;
     },
   );

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -543,11 +543,12 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
 
     // Conservative dedupe: exact content match in same scope. Preserves the
     // existing surface contract — `remember` returns the existing row instead
-    // of duplicating. Skip for empty content (defensive).
-    if (input.content.length > 0) {
-      const existing = this.stmts.findExact.get(input.content, spaceId, spaceId) as MemoryRow | undefined;
-      if (existing) return rowToMemory(existing);
-    }
+    // of duplicating. Applies to empty content too: callers that accidentally
+    // pass "" don't spam empty rows. The HTTP POST route rejects empty
+    // content at its boundary; the MCP tool currently allows it but dedupe
+    // is sufficient defence at this layer.
+    const existing = this.stmts.findExact.get(input.content, spaceId, spaceId) as MemoryRow | undefined;
+    if (existing) return rowToMemory(existing);
 
     const { memory_id } = this.writeCreated({
       content: input.content,

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -425,14 +425,19 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
 
   writeForgotten(memory_id: string, cloud_owner_id: string | null = null): boolean {
     // Idempotent: per-type uniqueness means a second forget event is rejected.
-    const info = this.db.prepare(
-      `INSERT OR IGNORE INTO memory_events
-         (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
-       VALUES (?, ?, 'memory_forgotten', NULL, ?, ?, NULL)`,
-    ).run(crypto.randomUUID(), memory_id, cloud_owner_id, Date.now());
-    if (info.changes === 0) return false;
-    this.materialiseMemory(memory_id);
-    return true;
+    let inserted = false;
+    const txn = this.db.transaction(() => {
+      const info = this.db.prepare(
+        `INSERT OR IGNORE INTO memory_events
+           (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+         VALUES (?, ?, 'memory_forgotten', NULL, ?, ?, NULL)`,
+      ).run(crypto.randomUUID(), memory_id, cloud_owner_id, Date.now());
+      if (info.changes === 0) return;
+      inserted = true;
+      this.materialiseMemory(memory_id);
+    });
+    txn();
+    return inserted;
   }
 
   writePurged(memory_id: string, cloud_owner_id: string | null = null): boolean {
@@ -440,18 +445,23 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     // is a valid sequence — purge dominates regardless of arrival order).
     // Returns false only when a memory_purged event already exists for this
     // memory_id (idempotent).
-    const info = this.db.prepare(
-      `INSERT OR IGNORE INTO memory_events
-         (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
-       VALUES (?, ?, 'memory_purged', NULL, ?, ?, NULL)`,
-    ).run(crypto.randomUUID(), memory_id, cloud_owner_id, Date.now());
-    if (info.changes === 0) return false;
-    // Ensure a payload row exists so the materialisation pass can null its content.
-    this.db.prepare(
-      `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags) VALUES (?, NULL, '[]')`,
-    ).run(memory_id);
-    this.materialiseMemory(memory_id);
-    return true;
+    let inserted = false;
+    const txn = this.db.transaction(() => {
+      const info = this.db.prepare(
+        `INSERT OR IGNORE INTO memory_events
+           (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+         VALUES (?, ?, 'memory_purged', NULL, ?, ?, NULL)`,
+      ).run(crypto.randomUUID(), memory_id, cloud_owner_id, Date.now());
+      if (info.changes === 0) return;
+      inserted = true;
+      // Ensure a payload row exists so the materialisation pass can null its content.
+      this.db.prepare(
+        `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags) VALUES (?, NULL, '[]')`,
+      ).run(memory_id);
+      this.materialiseMemory(memory_id);
+    });
+    txn();
+    return inserted;
   }
 
   async remember(input: RememberInput): Promise<Memory> {

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -377,10 +377,15 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     const created = events.find((e) => e.event_type === "memory_created");
 
     if (has("memory_purged")) {
-      // Purge: nullify payload + remove from recall surface.
+      // Purge: nullify payload + remove from recall surface. Use the purge
+      // event's created_at as the canonical purged_at so re-materialisation
+      // (e.g. cloud-replay in Task 8) is idempotent and the value matches
+      // across devices.
+      const purgeEvent = events.find((e) => e.event_type === "memory_purged");
+      const purgedAt = purgeEvent?.created_at ?? Date.now();
       this.db.prepare(
         `UPDATE memory_payloads SET content = NULL, tags = '[]', purged_at = ? WHERE memory_id = ?`,
-      ).run(Date.now(), memory_id);
+      ).run(purgedAt, memory_id);
       this.db.prepare(`DELETE FROM memories WHERE id = ?`).run(memory_id);
       return;
     }

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -315,6 +315,145 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     return !!(this.stmts.findExact.get(content, sid, sid) as MemoryRow | undefined);
   }
 
+  writeCreated(input: {
+    memory_id?: string;
+    content: string;
+    space_id?: string | null;
+    tags?: string[];
+    source_session_id?: string | null;
+    created_at?: number;
+    cloud_owner_id?: string | null;
+  }): { memory_id: string; event_id: string; inserted: boolean } {
+    const memory_id = input.memory_id ?? crypto.randomUUID();
+    const event_id  = crypto.randomUUID();
+    const space_id  = input.space_id ?? null;
+    const tags      = JSON.stringify(input.tags ?? []);
+    const ssid      = input.source_session_id ?? null;
+    const created_at = input.created_at ?? Date.now();
+    const owner_id  = input.cloud_owner_id ?? null;
+
+    let inserted = false;
+    let returned_event_id = event_id;
+
+    const txn = this.db.transaction(() => {
+      const info = this.db.prepare(
+        `INSERT OR IGNORE INTO memory_events
+           (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+         VALUES (?, ?, 'memory_created', ?, ?, ?, NULL)`,
+      ).run(event_id, memory_id, space_id, owner_id, created_at);
+      inserted = info.changes > 0;
+
+      if (!inserted) {
+        // A memory_created event already exists for this memory_id. Look up
+        // its event_id so the caller can reference the canonical event.
+        const existing = this.db.prepare(
+          `SELECT event_id FROM memory_events WHERE memory_id = ? AND event_type = 'memory_created'`,
+        ).get(memory_id) as { event_id: string } | undefined;
+        if (existing) returned_event_id = existing.event_id;
+      }
+
+      this.db.prepare(
+        `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags)
+         VALUES (?, ?, ?)`,
+      ).run(memory_id, input.content, tags);
+
+      this.materialiseMemory(memory_id, { ssid });
+    });
+    txn();
+    return { memory_id, event_id: returned_event_id, inserted };
+  }
+
+  materialiseMemory(memory_id: string, opts?: { ssid?: string | null }): void {
+    // Pick highest-precedence event for this memory_id.
+    type EvRow = { event_type: string; space_id: string | null; created_at: number };
+    const events = this.db.prepare(
+      `SELECT event_type, space_id, created_at FROM memory_events WHERE memory_id = ?`,
+    ).all(memory_id) as EvRow[];
+    if (events.length === 0) {
+      this.db.prepare(`DELETE FROM memories WHERE id = ?`).run(memory_id);
+      return;
+    }
+    const has = (t: string) => events.some((e) => e.event_type === t);
+    const created = events.find((e) => e.event_type === "memory_created");
+
+    if (has("memory_purged")) {
+      // Purge: nullify payload + remove from recall surface.
+      this.db.prepare(
+        `UPDATE memory_payloads SET content = NULL, tags = '[]', purged_at = ? WHERE memory_id = ?`,
+      ).run(Date.now(), memory_id);
+      this.db.prepare(`DELETE FROM memories WHERE id = ?`).run(memory_id);
+      return;
+    }
+
+    if (!created) {
+      // Forget arrived before create. Nothing to materialise yet.
+      return;
+    }
+
+    const payload = this.db.prepare(
+      `SELECT content, tags FROM memory_payloads WHERE memory_id = ?`,
+    ).get(memory_id) as { content: string | null; tags: string } | undefined;
+    if (!payload || payload.content === null) {
+      // Created event with no payload yet, or payload purged. Nothing to show.
+      this.db.prepare(`DELETE FROM memories WHERE id = ?`).run(memory_id);
+      return;
+    }
+
+    const ssid = opts?.ssid ?? null;
+    const supersededBy = has("memory_forgotten") ? "forgotten" : null;
+
+    // Upsert the recall surface. FTS5 triggers on memories keep the index in sync.
+    this.db.prepare(
+      `INSERT INTO memories (id, space_id, content, tags, source_session_id, superseded_by, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, datetime(?, 'unixepoch'), datetime('now'))
+       ON CONFLICT(id) DO UPDATE SET
+         space_id = excluded.space_id,
+         content = excluded.content,
+         tags = excluded.tags,
+         superseded_by = excluded.superseded_by,
+         updated_at = datetime('now')`,
+    ).run(
+      memory_id,
+      created.space_id,
+      payload.content,
+      payload.tags,
+      ssid,
+      supersededBy,
+      Math.floor(created.created_at / 1000),
+    );
+  }
+
+  writeForgotten(memory_id: string, cloud_owner_id: string | null = null): boolean {
+    // Idempotent: per-type uniqueness means a second forget event is rejected.
+    const info = this.db.prepare(
+      `INSERT OR IGNORE INTO memory_events
+         (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+       VALUES (?, ?, 'memory_forgotten', NULL, ?, ?, NULL)`,
+    ).run(crypto.randomUUID(), memory_id, cloud_owner_id, Date.now());
+    if (info.changes === 0) return false;
+    this.materialiseMemory(memory_id);
+    return true;
+  }
+
+  writePurged(memory_id: string, cloud_owner_id: string | null = null): boolean {
+    // Succeeds even when no memory_created event exists yet (purge-before-create
+    // is a valid sequence — purge dominates regardless of arrival order).
+    // Returns false only when a memory_purged event already exists for this
+    // memory_id (idempotent).
+    const info = this.db.prepare(
+      `INSERT OR IGNORE INTO memory_events
+         (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+       VALUES (?, ?, 'memory_purged', NULL, ?, ?, NULL)`,
+    ).run(crypto.randomUUID(), memory_id, cloud_owner_id, Date.now());
+    if (info.changes === 0) return false;
+    // Ensure a payload row exists so the materialisation pass can null its content.
+    this.db.prepare(
+      `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags) VALUES (?, NULL, '[]')`,
+    ).run(memory_id);
+    this.materialiseMemory(memory_id);
+    return true;
+  }
+
   async remember(input: RememberInput): Promise<Memory> {
     const spaceId = input.space_id ?? null;
     const tags = JSON.stringify(input.tags ?? []);

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -313,6 +313,8 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
         if (recallerId) logRecall.run(row.id, recallerId);
       }
     });
+
+    this.backfillFromLegacy();
   }
 
   findExact(content: string, spaceId?: string): boolean {
@@ -426,6 +428,50 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       supersededBy,
       Math.floor(created.created_at / 1000),
     );
+  }
+
+  /** One-time backfill: for each row in `memories` without a matching
+   *  memory_created event, write events + payload from the legacy state.
+   *  Idempotent because the per-type uniqueness indexes reject duplicates. */
+  private backfillFromLegacy(): void {
+    type LegacyRow = {
+      id: string; space_id: string | null; content: string; tags: string;
+      superseded_by: string | null; created_at: string; source_session_id: string | null;
+    };
+    const rows = this.db.prepare(
+      `SELECT m.id, m.space_id, m.content, m.tags, m.superseded_by, m.created_at, m.source_session_id
+         FROM memories m
+         LEFT JOIN memory_events e ON e.memory_id = m.id AND e.event_type = 'memory_created'
+        WHERE e.memory_id IS NULL`,
+    ).all() as LegacyRow[];
+
+    for (const r of rows) {
+      // SQLite text timestamps → unix ms
+      const created_ms = Date.parse(r.created_at + "Z") || Date.now();
+      // cloud_owner_id intentionally NULL — backfilled events do not push to
+      // any current Pro account. Pre-existing memories stay local until an
+      // explicit claim flow is shipped (see "Account-switching policy").
+      this.db.prepare(
+        `INSERT OR IGNORE INTO memory_events
+           (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+         VALUES (?, ?, 'memory_created', ?, NULL, ?, NULL)`,
+      ).run(crypto.randomUUID(), r.id, r.space_id, created_ms);
+
+      this.db.prepare(
+        `INSERT OR IGNORE INTO memory_payloads (memory_id, content, tags)
+         VALUES (?, ?, ?)`,
+      ).run(r.id, r.content, r.tags);
+
+      if (r.superseded_by !== null) {
+        // Map legacy 'forgotten' / 'purged' marker to the appropriate event.
+        const evType = r.superseded_by === "purged" ? "memory_purged" : "memory_forgotten";
+        this.db.prepare(
+          `INSERT OR IGNORE INTO memory_events
+             (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+           VALUES (?, ?, ?, NULL, NULL, ?, NULL)`,
+        ).run(crypto.randomUUID(), r.id, evType, created_ms + 1);
+      }
+    }
   }
 
   writeForgotten(memory_id: string, cloud_owner_id: string | null = null): boolean {

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -10,6 +10,7 @@ import type { UiCommand } from "../../../shared/types.js";
 export interface MemoryRouteDeps {
   memoryProvider: MemoryProvider;
   broadcastUiEvent: (event: UiCommand) => void;
+  resolveCurrentOwnerId: () => string | null;
 }
 
 export async function tryHandleMemoryRoute(
@@ -39,7 +40,7 @@ export async function tryHandleMemoryRoute(
       return true;
     }
     try {
-      const removed = await memoryProvider.forget(id);
+      const removed = await memoryProvider.forget(id, deps.resolveCurrentOwnerId());
       if (!removed) {
         sendJson({ error: "memory not found" }, 404);
         return true;
@@ -86,7 +87,10 @@ export async function tryHandleMemoryRoute(
       const tags = Array.isArray(body.tags)
         ? body.tags.filter((t): t is string => typeof t === "string" && t.length > 0)
         : undefined;
-      const memory = await memoryProvider.remember({ content, space_id, tags });
+      const memory = await memoryProvider.remember({
+        content, space_id, tags,
+        cloud_owner_id: deps.resolveCurrentOwnerId(),
+      });
       sendJson(memory, 201);
     } catch (err) {
       sendError(err);

--- a/server/src/routes/oauth-mcp.ts
+++ b/server/src/routes/oauth-mcp.ts
@@ -44,6 +44,7 @@ export interface OAuthMcpRouteDeps {
   userlandDir: string;
   getNativeSourcePath: (spaceId: string) => string;
   publishService: import("../publish-service.js").PublishService;
+  resolveCurrentOwnerId: () => string | null;
 }
 
 export async function tryHandleOAuthMcpRoute(
@@ -179,6 +180,7 @@ export async function tryHandleOAuthMcpRoute(
       broadcastUiEvent,
       clientContext: isInternal ? { isInternal: true } : { isInternal: false, userAgent: externalUa ?? "unknown" },
       resolveActiveSessionId,
+      resolveCurrentOwnerId: deps.resolveCurrentOwnerId,
     });
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => { transport.close(); mcpServer.close(); });

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -265,6 +265,21 @@ describe("event write API — writeCreated", () => {
     db.close();
     provider.close();
   });
+
+  it("writeForgotten records cloud_owner_id on the event row", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ev-forget-owner-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const { memory_id } = provider.writeCreated({ content: "owned" });
+    provider.writeForgotten(memory_id, "user-pro-456");
+    const db = new Database(join(tmp, "memory.db"));
+    const row = db.prepare(
+      `SELECT cloud_owner_id FROM memory_events WHERE memory_id = ? AND event_type = 'memory_forgotten'`,
+    ).get(memory_id) as { cloud_owner_id: string | null };
+    expect(row.cloud_owner_id).toBe("user-pro-456");
+    db.close();
+    provider.close();
+  });
 });
 
 describe("event write API — writeForgotten / writePurged / precedence", () => {
@@ -449,6 +464,34 @@ describe("backfill from legacy memories rows", () => {
     // Should match 2026-01-15 10:30:00 UTC ≈ 1768516200000, NOT Date.now()
     const expected = Date.parse("2026-01-15T10:30:00Z");
     expect(ev.created_at).toBe(expected);
+    db2.close();
+    provider2.close();
+  });
+
+  it("nulls payload content for legacy rows with superseded_by = 'purged'", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bf-purged-"));
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    const db1 = new Database(join(tmp, "memory.db"));
+    db1.prepare(
+      `INSERT INTO memories (id, content, tags, superseded_by, created_at, updated_at)
+       VALUES ('legacy-purged', 'AKIA-leak', '["sensitive"]', 'purged', '2026-01-01', '2026-01-01')`,
+    ).run();
+    db1.close();
+    provider1.close();
+
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await provider2.init();
+    const db2 = new Database(join(tmp, "memory.db"));
+    const types = db2.prepare(
+      `SELECT event_type FROM memory_events WHERE memory_id = ? ORDER BY created_at`,
+    ).all("legacy-purged") as Array<{ event_type: string }>;
+    expect(types.map((r) => r.event_type)).toEqual(["memory_created", "memory_purged"]);
+    const pay = db2.prepare(
+      `SELECT content, purged_at FROM memory_payloads WHERE memory_id = ?`,
+    ).get("legacy-purged") as { content: string | null; purged_at: number | null };
+    expect(pay.content).toBeNull();
+    expect(pay.purged_at).not.toBeNull();
     db2.close();
     provider2.close();
   });

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -217,3 +217,89 @@ describe("schema migration — memory_events + memory_payloads", () => {
     provider2.close();
   });
 });
+
+describe("event write API — writeCreated", () => {
+  it("inserts an event, payload, and materialised memories row", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ev-created-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const result = provider.writeCreated({ content: "hello world", tags: ["greeting"] });
+    expect(result.memory_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(result.event_id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const memories = await provider.list();
+    expect(memories).toHaveLength(1);
+    expect(memories[0].content).toBe("hello world");
+    expect(memories[0].tags).toEqual(["greeting"]);
+
+    const recalled = await provider.recall({ query: "hello" });
+    expect(recalled).toHaveLength(1);
+    expect(recalled[0].id).toBe(result.memory_id);
+    provider.close();
+  });
+
+  it("a fresh writeCreated event is pending sync (cloud_synced_at IS NULL)", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ev-pending-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const { event_id } = provider.writeCreated({ content: "pending" });
+    const db = new Database(join(tmp, "memory.db"));
+    const row = db.prepare("SELECT cloud_synced_at FROM memory_events WHERE event_id = ?").get(event_id) as { cloud_synced_at: number | null };
+    expect(row.cloud_synced_at).toBeNull();
+    db.close();
+    provider.close();
+  });
+});
+
+describe("event write API — writeForgotten / writePurged / precedence", () => {
+  async function fresh() {
+    const tmp = mkdtempSync(join(tmpdir(), "ev-prec-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    return provider;
+  }
+
+  it("forget hides the memory from recall but content remains in payload", async () => {
+    const provider = await fresh();
+    const { memory_id } = provider.writeCreated({ content: "secret" });
+    expect(provider.writeForgotten(memory_id)).toBe(true);
+    const found = await provider.recall({ query: "secret" });
+    expect(found).toHaveLength(0);
+    const list = await provider.list();
+    expect(list).toHaveLength(0);
+    provider.close();
+  });
+
+  it("purge nulls payload content and removes from recall", async () => {
+    const provider = await fresh();
+    const { memory_id } = provider.writeCreated({ content: "AKIA-secret-key" });
+    expect(provider.writePurged(memory_id)).toBe(true);
+    const found = await provider.recall({ query: "AKIA" });
+    expect(found).toHaveLength(0);
+    const list = await provider.list();
+    expect(list).toHaveLength(0);
+    provider.close();
+  });
+
+  it("late create after purge does not restore content", async () => {
+    const provider = await fresh();
+    const memory_id = "11111111-1111-1111-1111-111111111111";
+    // Simulate purge-arrives-before-create by writing the purge event first.
+    provider.writePurged(memory_id);
+    // Now writeCreated for the same id.
+    provider.writeCreated({ memory_id, content: "should-not-appear" });
+    const list = await provider.list();
+    expect(list).toHaveLength(0);
+    const found = await provider.recall({ query: "should-not-appear" });
+    expect(found).toHaveLength(0);
+    provider.close();
+  });
+
+  it("forget after create then forget again is a no-op", async () => {
+    const provider = await fresh();
+    const { memory_id } = provider.writeCreated({ content: "hi" });
+    expect(provider.writeForgotten(memory_id)).toBe(true);
+    expect(provider.writeForgotten(memory_id)).toBe(false); // idempotent: returns false on no-op
+    provider.close();
+  });
+});

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -271,18 +271,28 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
   });
 
   it("purge nulls payload content and removes from recall", async () => {
-    const provider = await fresh();
+    const tmp = mkdtempSync(join(tmpdir(), "ev-prec-purge-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
     const { memory_id } = provider.writeCreated({ content: "AKIA-secret-key" });
     expect(provider.writePurged(memory_id)).toBe(true);
     const found = await provider.recall({ query: "AKIA" });
     expect(found).toHaveLength(0);
     const list = await provider.list();
     expect(list).toHaveLength(0);
+    // Payload content must be physically nulled (spec Q7 footgun).
+    const db = new Database(join(tmp, "memory.db"));
+    const row = db.prepare(`SELECT content, purged_at FROM memory_payloads WHERE memory_id = ?`).get(memory_id) as { content: string | null; purged_at: number | null };
+    expect(row.content).toBeNull();
+    expect(row.purged_at).not.toBeNull();
+    db.close();
     provider.close();
   });
 
   it("late create after purge does not restore content", async () => {
-    const provider = await fresh();
+    const tmp = mkdtempSync(join(tmpdir(), "ev-prec-late-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
     const memory_id = "11111111-1111-1111-1111-111111111111";
     // Simulate purge-arrives-before-create by writing the purge event first.
     provider.writePurged(memory_id);
@@ -292,6 +302,11 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
     expect(list).toHaveLength(0);
     const found = await provider.recall({ query: "should-not-appear" });
     expect(found).toHaveLength(0);
+    // The late create's content must NOT have landed in the payload — purge dominates.
+    const db = new Database(join(tmp, "memory.db"));
+    const row = db.prepare(`SELECT content FROM memory_payloads WHERE memory_id = ?`).get(memory_id) as { content: string | null };
+    expect(row.content).toBeNull();
+    db.close();
     provider.close();
   });
 

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -249,6 +249,22 @@ describe("event write API — writeCreated", () => {
     db.close();
     provider.close();
   });
+
+  it("writeCreated records cloud_owner_id on the event row", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ev-owner-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const { event_id } = provider.writeCreated({
+      content: "owner test",
+      cloud_owner_id: "user-pro-123",
+    });
+    const db = new Database(join(tmp, "memory.db"));
+    const row = db.prepare("SELECT cloud_owner_id FROM memory_events WHERE event_id = ?")
+      .get(event_id) as { cloud_owner_id: string | null };
+    expect(row.cloud_owner_id).toBe("user-pro-123");
+    db.close();
+    provider.close();
+  });
 });
 
 describe("event write API — writeForgotten / writePurged / precedence", () => {

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -354,3 +354,77 @@ describe("provider.purge", () => {
     provider.close();
   });
 });
+
+describe("backfill from legacy memories rows", () => {
+  it("creates memory_created events for pre-existing rows on init()", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bf-"));
+    // First boot: write memories the old way (skip writeCreated path) by
+    // simulating a legacy row directly in the DB.
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    const db1 = new Database(join(tmp, "memory.db"));
+    db1.prepare(`DELETE FROM memory_events`).run();
+    db1.prepare(`DELETE FROM memory_payloads`).run();
+    db1.prepare(
+      `INSERT INTO memories (id, content, tags, created_at, updated_at)
+       VALUES ('legacy-1', 'old memory', '["legacy"]', '2026-01-01', '2026-01-01')`,
+    ).run();
+    db1.close();
+    provider1.close();
+
+    // Second boot: backfill should kick in.
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await provider2.init();
+    const db2 = new Database(join(tmp, "memory.db"));
+    const ev = db2.prepare(
+      `SELECT event_type, cloud_synced_at FROM memory_events WHERE memory_id = ?`,
+    ).get("legacy-1") as { event_type: string; cloud_synced_at: number | null } | undefined;
+    expect(ev?.event_type).toBe("memory_created");
+    expect(ev?.cloud_synced_at).toBeNull();
+    const pay = db2.prepare(
+      `SELECT content FROM memory_payloads WHERE memory_id = ?`,
+    ).get("legacy-1") as { content: string } | undefined;
+    expect(pay?.content).toBe("old memory");
+    db2.close();
+    provider2.close();
+  });
+
+  it("re-running init() is idempotent (no duplicate events)", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bf-idem-"));
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    await provider1.remember({ content: "hello" });
+    provider1.close();
+
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await provider2.init();
+    const db = new Database(join(tmp, "memory.db"));
+    const count = db.prepare(`SELECT COUNT(*) as c FROM memory_events`).get() as { c: number };
+    expect(count.c).toBe(1); // one create event from the original remember(), not duplicated
+    db.close();
+    provider2.close();
+  });
+
+  it("emits memory_forgotten for legacy soft-deleted rows", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bf-forgotten-"));
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    const db1 = new Database(join(tmp, "memory.db"));
+    db1.prepare(
+      `INSERT INTO memories (id, content, tags, superseded_by, created_at, updated_at)
+       VALUES ('legacy-2', 'gone', '[]', 'forgotten', '2026-01-01', '2026-01-01')`,
+    ).run();
+    db1.close();
+    provider1.close();
+
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await provider2.init();
+    const db2 = new Database(join(tmp, "memory.db"));
+    const types = db2.prepare(
+      `SELECT event_type FROM memory_events WHERE memory_id = ? ORDER BY created_at`,
+    ).all("legacy-2") as Array<{ event_type: string }>;
+    expect(types.map((r) => r.event_type)).toEqual(["memory_created", "memory_forgotten"]);
+    db2.close();
+    provider2.close();
+  });
+});

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -468,6 +468,30 @@ describe("backfill from legacy memories rows", () => {
     provider2.close();
   });
 
+  it("preserves legacy created_at for date-only legacy timestamps", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bf-ts-dateonly-"));
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    const db1 = new Database(join(tmp, "memory.db"));
+    db1.prepare(
+      `INSERT INTO memories (id, content, tags, created_at, updated_at)
+       VALUES ('legacy-date', 'date-only', '[]', '2026-01-15', '2026-01-15')`,
+    ).run();
+    db1.close();
+    provider1.close();
+
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await provider2.init();
+    const db2 = new Database(join(tmp, "memory.db"));
+    const ev = db2.prepare(
+      `SELECT created_at FROM memory_events WHERE memory_id = ?`,
+    ).get("legacy-date") as { created_at: number };
+    // Should match midnight UTC for 2026-01-15, NOT Date.now()
+    expect(ev.created_at).toBe(Date.parse("2026-01-15T00:00:00Z"));
+    db2.close();
+    provider2.close();
+  });
+
   it("nulls payload content for legacy rows with superseded_by = 'purged'", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "bf-purged-"));
     const provider1 = new SqliteFtsMemoryProvider(tmp);
@@ -492,6 +516,17 @@ describe("backfill from legacy memories rows", () => {
     ).get("legacy-purged") as { content: string | null; purged_at: number | null };
     expect(pay.content).toBeNull();
     expect(pay.purged_at).not.toBeNull();
+
+    // Q7: the legacy memories row and its FTS entry must also be gone —
+    // purge is hard-redaction across all local storage, not just the
+    // payload store.
+    const memRow = db2.prepare(
+      `SELECT id FROM memories WHERE id = ?`,
+    ).get("legacy-purged") as { id: string } | undefined;
+    expect(memRow).toBeUndefined();
+
+    const recalled = await provider2.recall({ query: "AKIA-leak" });
+    expect(recalled).toHaveLength(0);
     db2.close();
     provider2.close();
   });

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -376,6 +376,31 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
     expect(provider.writeForgotten(memory_id)).toBe(false); // idempotent: returns false on no-op
     provider.close();
   });
+
+  it("re-materialise after purge does not bump purged_at (idempotent)", async () => {
+    const t = tmp("idem-purgedat-");
+    const provider = new SqliteFtsMemoryProvider(t);
+    await provider.init();
+    const { memory_id } = provider.writeCreated({ content: "secret" });
+    expect(provider.writePurged(memory_id)).toBe(true);
+
+    // Capture the initial purged_at (set during writePurged → materialiseMemory).
+    const db = new Database(join(t, "memory.db"));
+    const before = db.prepare(
+      `SELECT purged_at FROM memory_payloads WHERE memory_id = ?`,
+    ).get(memory_id) as { purged_at: number };
+    expect(before.purged_at).not.toBeNull();
+
+    // Force a re-materialise. With Date.now() this would bump purged_at.
+    // With the event's created_at as the source, it stays the same.
+    provider.materialiseMemory(memory_id);
+    const after = db.prepare(
+      `SELECT purged_at FROM memory_payloads WHERE memory_id = ?`,
+    ).get(memory_id) as { purged_at: number };
+    expect(after.purged_at).toBe(before.purged_at);
+    db.close();
+    provider.close();
+  });
 });
 
 describe("provider.purge", () => {

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -318,3 +318,23 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
     provider.close();
   });
 });
+
+describe("provider.purge", () => {
+  it("purges existing memory and returns true", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "purge-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const m = await provider.remember({ content: "secret-content" });
+    expect(await provider.purge(m.id)).toBe(true);
+    expect(await provider.recall({ query: "secret-content" })).toHaveLength(0);
+    provider.close();
+  });
+
+  it("returns false when memory does not exist", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "purge-missing-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    expect(await provider.purge("nonexistent")).toBe(false);
+    provider.close();
+  });
+});

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -153,3 +153,68 @@ describe("SqliteFtsMemoryProvider", () => {
     });
   });
 });
+
+import Database from "better-sqlite3";
+
+describe("schema migration — memory_events + memory_payloads", () => {
+  it("creates memory_events with the expected columns", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "mem-events-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const db = new Database(join(tmp, "memory.db"));
+    const cols = db.prepare("PRAGMA table_info(memory_events)").all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual([
+      "cloud_owner_id", "cloud_synced_at", "created_at",
+      "event_id", "event_type", "memory_id", "space_id",
+    ]);
+    db.close();
+    provider.close();
+  });
+
+  it("enforces event_type CHECK constraint", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "mem-check-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const db = new Database(join(tmp, "memory.db"));
+    expect(() => db.prepare(
+      `INSERT INTO memory_events (event_id, memory_id, event_type, created_at)
+       VALUES ('ev-bad', 'm', 'bogus', 0)`,
+    ).run()).toThrow(/CHECK constraint failed/);
+    db.close();
+    provider.close();
+  });
+
+  it("creates memory_payloads with the expected columns", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "mem-payloads-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const db = new Database(join(tmp, "memory.db"));
+    const cols = db.prepare("PRAGMA table_info(memory_payloads)").all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name).sort();
+    expect(names).toEqual(["content", "memory_id", "purged_at", "tags"]);
+    db.close();
+    provider.close();
+  });
+
+  it("adds purged_at to memories", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "mem-purgedat-"));
+    const provider = new SqliteFtsMemoryProvider(tmp);
+    await provider.init();
+    const db = new Database(join(tmp, "memory.db"));
+    const cols = db.prepare("PRAGMA table_info(memories)").all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === "purged_at")).toBe(true);
+    db.close();
+    provider.close();
+  });
+
+  it("re-running init() is idempotent", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "mem-idem-"));
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    provider1.close();
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await expect(provider2.init()).resolves.not.toThrow();
+    provider2.close();
+  });
+});

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -14,6 +14,22 @@ async function makeProvider() {
   return { provider, dir };
 }
 
+// Shared tmpdir tracker for new describe blocks. afterEach below cleans all
+// entries so new tests never leak temp dirs.
+const trackedTmps: string[] = [];
+function tmp(prefix: string): string {
+  const t = mkdtempSync(join(tmpdir(), prefix));
+  trackedTmps.push(t);
+  return t;
+}
+
+afterEach(() => {
+  while (trackedTmps.length > 0) {
+    const t = trackedTmps.pop()!;
+    try { rmSync(t, { recursive: true, force: true }); } catch { /* swallow */ }
+  }
+});
+
 describe("SqliteFtsMemoryProvider", () => {
   let provider: SqliteFtsMemoryProvider;
   let dir: string;
@@ -157,10 +173,10 @@ describe("SqliteFtsMemoryProvider", () => {
 
 describe("schema migration — memory_events + memory_payloads", () => {
   it("creates memory_events with the expected columns", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "mem-events-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("mem-events-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const cols = db.prepare("PRAGMA table_info(memory_events)").all() as Array<{ name: string }>;
     const names = cols.map((c) => c.name).sort();
     expect(names).toEqual([
@@ -172,10 +188,10 @@ describe("schema migration — memory_events + memory_payloads", () => {
   });
 
   it("enforces event_type CHECK constraint", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "mem-check-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("mem-check-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     expect(() => db.prepare(
       `INSERT INTO memory_events (event_id, memory_id, event_type, created_at)
        VALUES ('ev-bad', 'm', 'bogus', 0)`,
@@ -185,10 +201,10 @@ describe("schema migration — memory_events + memory_payloads", () => {
   });
 
   it("creates memory_payloads with the expected columns", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "mem-payloads-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("mem-payloads-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const cols = db.prepare("PRAGMA table_info(memory_payloads)").all() as Array<{ name: string }>;
     const names = cols.map((c) => c.name).sort();
     expect(names).toEqual(["content", "memory_id", "purged_at", "tags"]);
@@ -197,10 +213,10 @@ describe("schema migration — memory_events + memory_payloads", () => {
   });
 
   it("adds purged_at to memories", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "mem-purgedat-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("mem-purgedat-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const cols = db.prepare("PRAGMA table_info(memories)").all() as Array<{ name: string }>;
     expect(cols.some((c) => c.name === "purged_at")).toBe(true);
     db.close();
@@ -208,11 +224,11 @@ describe("schema migration — memory_events + memory_payloads", () => {
   });
 
   it("re-running init() is idempotent", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "mem-idem-"));
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("mem-idem-");
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
     provider1.close();
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await expect(provider2.init()).resolves.not.toThrow();
     provider2.close();
   });
@@ -220,8 +236,8 @@ describe("schema migration — memory_events + memory_payloads", () => {
 
 describe("event write API — writeCreated", () => {
   it("inserts an event, payload, and materialised memories row", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-created-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-created-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const result = provider.writeCreated({ content: "hello world", tags: ["greeting"] });
     expect(result.memory_id).toMatch(/^[0-9a-f-]{36}$/);
@@ -239,11 +255,11 @@ describe("event write API — writeCreated", () => {
   });
 
   it("a fresh writeCreated event is pending sync (cloud_synced_at IS NULL)", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-pending-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-pending-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const { event_id } = provider.writeCreated({ content: "pending" });
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const row = db.prepare("SELECT cloud_synced_at FROM memory_events WHERE event_id = ?").get(event_id) as { cloud_synced_at: number | null };
     expect(row.cloud_synced_at).toBeNull();
     db.close();
@@ -251,14 +267,14 @@ describe("event write API — writeCreated", () => {
   });
 
   it("writeCreated records cloud_owner_id on the event row", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-owner-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-owner-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const { event_id } = provider.writeCreated({
       content: "owner test",
       cloud_owner_id: "user-pro-123",
     });
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const row = db.prepare("SELECT cloud_owner_id FROM memory_events WHERE event_id = ?")
       .get(event_id) as { cloud_owner_id: string | null };
     expect(row.cloud_owner_id).toBe("user-pro-123");
@@ -267,12 +283,12 @@ describe("event write API — writeCreated", () => {
   });
 
   it("writeForgotten records cloud_owner_id on the event row", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-forget-owner-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-forget-owner-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const { memory_id } = provider.writeCreated({ content: "owned" });
     provider.writeForgotten(memory_id, "user-pro-456");
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const row = db.prepare(
       `SELECT cloud_owner_id FROM memory_events WHERE memory_id = ? AND event_type = 'memory_forgotten'`,
     ).get(memory_id) as { cloud_owner_id: string | null };
@@ -280,12 +296,24 @@ describe("event write API — writeCreated", () => {
     db.close();
     provider.close();
   });
+
+  it("remember dedupes empty content within same scope", async () => {
+    const t = tmp("dedupe-empty-");
+    const provider = new SqliteFtsMemoryProvider(t);
+    await provider.init();
+    const m1 = await provider.remember({ content: "" });
+    const m2 = await provider.remember({ content: "" });
+    expect(m1.id).toBe(m2.id);
+    const list = await provider.list();
+    expect(list).toHaveLength(1);
+    provider.close();
+  });
 });
 
 describe("event write API — writeForgotten / writePurged / precedence", () => {
   async function fresh() {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-prec-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-prec-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     return provider;
   }
@@ -302,8 +330,8 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
   });
 
   it("purge nulls payload content and removes from recall", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-prec-purge-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-prec-purge-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const { memory_id } = provider.writeCreated({ content: "AKIA-secret-key" });
     expect(provider.writePurged(memory_id)).toBe(true);
@@ -312,7 +340,7 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
     const list = await provider.list();
     expect(list).toHaveLength(0);
     // Payload content must be physically nulled (spec Q7 footgun).
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const row = db.prepare(`SELECT content, purged_at FROM memory_payloads WHERE memory_id = ?`).get(memory_id) as { content: string | null; purged_at: number | null };
     expect(row.content).toBeNull();
     expect(row.purged_at).not.toBeNull();
@@ -321,8 +349,8 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
   });
 
   it("late create after purge does not restore content", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "ev-prec-late-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("ev-prec-late-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const memory_id = "11111111-1111-1111-1111-111111111111";
     // Simulate purge-arrives-before-create by writing the purge event first.
@@ -334,7 +362,7 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
     const found = await provider.recall({ query: "should-not-appear" });
     expect(found).toHaveLength(0);
     // The late create's content must NOT have landed in the payload — purge dominates.
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const row = db.prepare(`SELECT content FROM memory_payloads WHERE memory_id = ?`).get(memory_id) as { content: string | null };
     expect(row.content).toBeNull();
     db.close();
@@ -352,8 +380,8 @@ describe("event write API — writeForgotten / writePurged / precedence", () => 
 
 describe("provider.purge", () => {
   it("purges existing memory and returns true", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "purge-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("purge-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     const m = await provider.remember({ content: "secret-content" });
     expect(await provider.purge(m.id)).toBe(true);
@@ -362,8 +390,8 @@ describe("provider.purge", () => {
   });
 
   it("returns false when memory does not exist", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "purge-missing-"));
-    const provider = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("purge-missing-");
+    const provider = new SqliteFtsMemoryProvider(t);
     await provider.init();
     expect(await provider.purge("nonexistent")).toBe(false);
     provider.close();
@@ -372,12 +400,12 @@ describe("provider.purge", () => {
 
 describe("backfill from legacy memories rows", () => {
   it("creates memory_created events for pre-existing rows on init()", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "bf-"));
+    const t = tmp("bf-");
     // First boot: write memories the old way (skip writeCreated path) by
     // simulating a legacy row directly in the DB.
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
-    const db1 = new Database(join(tmp, "memory.db"));
+    const db1 = new Database(join(t, "memory.db"));
     db1.prepare(`DELETE FROM memory_events`).run();
     db1.prepare(`DELETE FROM memory_payloads`).run();
     db1.prepare(
@@ -388,9 +416,9 @@ describe("backfill from legacy memories rows", () => {
     provider1.close();
 
     // Second boot: backfill should kick in.
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await provider2.init();
-    const db2 = new Database(join(tmp, "memory.db"));
+    const db2 = new Database(join(t, "memory.db"));
     const ev = db2.prepare(
       `SELECT event_type, cloud_synced_at FROM memory_events WHERE memory_id = ?`,
     ).get("legacy-1") as { event_type: string; cloud_synced_at: number | null } | undefined;
@@ -405,15 +433,15 @@ describe("backfill from legacy memories rows", () => {
   });
 
   it("re-running init() is idempotent (no duplicate events)", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "bf-idem-"));
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("bf-idem-");
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
     await provider1.remember({ content: "hello" });
     provider1.close();
 
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await provider2.init();
-    const db = new Database(join(tmp, "memory.db"));
+    const db = new Database(join(t, "memory.db"));
     const count = db.prepare(`SELECT COUNT(*) as c FROM memory_events`).get() as { c: number };
     expect(count.c).toBe(1); // one create event from the original remember(), not duplicated
     db.close();
@@ -421,10 +449,10 @@ describe("backfill from legacy memories rows", () => {
   });
 
   it("emits memory_forgotten for legacy soft-deleted rows", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "bf-forgotten-"));
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("bf-forgotten-");
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
-    const db1 = new Database(join(tmp, "memory.db"));
+    const db1 = new Database(join(t, "memory.db"));
     db1.prepare(
       `INSERT INTO memories (id, content, tags, superseded_by, created_at, updated_at)
        VALUES ('legacy-2', 'gone', '[]', 'forgotten', '2026-01-01', '2026-01-01')`,
@@ -432,9 +460,9 @@ describe("backfill from legacy memories rows", () => {
     db1.close();
     provider1.close();
 
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await provider2.init();
-    const db2 = new Database(join(tmp, "memory.db"));
+    const db2 = new Database(join(t, "memory.db"));
     const types = db2.prepare(
       `SELECT event_type FROM memory_events WHERE memory_id = ? ORDER BY created_at`,
     ).all("legacy-2") as Array<{ event_type: string }>;
@@ -444,10 +472,10 @@ describe("backfill from legacy memories rows", () => {
   });
 
   it("preserves legacy created_at when parseable", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "bf-ts-"));
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("bf-ts-");
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
-    const db1 = new Database(join(tmp, "memory.db"));
+    const db1 = new Database(join(t, "memory.db"));
     db1.prepare(
       `INSERT INTO memories (id, content, tags, created_at, updated_at)
        VALUES ('legacy-ts', 'has timestamp', '[]', '2026-01-15 10:30:00', '2026-01-15 10:30:00')`,
@@ -455,9 +483,9 @@ describe("backfill from legacy memories rows", () => {
     db1.close();
     provider1.close();
 
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await provider2.init();
-    const db2 = new Database(join(tmp, "memory.db"));
+    const db2 = new Database(join(t, "memory.db"));
     const ev = db2.prepare(
       `SELECT created_at FROM memory_events WHERE memory_id = ?`,
     ).get("legacy-ts") as { created_at: number };
@@ -469,10 +497,10 @@ describe("backfill from legacy memories rows", () => {
   });
 
   it("preserves legacy created_at for date-only legacy timestamps", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "bf-ts-dateonly-"));
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("bf-ts-dateonly-");
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
-    const db1 = new Database(join(tmp, "memory.db"));
+    const db1 = new Database(join(t, "memory.db"));
     db1.prepare(
       `INSERT INTO memories (id, content, tags, created_at, updated_at)
        VALUES ('legacy-date', 'date-only', '[]', '2026-01-15', '2026-01-15')`,
@@ -480,9 +508,9 @@ describe("backfill from legacy memories rows", () => {
     db1.close();
     provider1.close();
 
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await provider2.init();
-    const db2 = new Database(join(tmp, "memory.db"));
+    const db2 = new Database(join(t, "memory.db"));
     const ev = db2.prepare(
       `SELECT created_at FROM memory_events WHERE memory_id = ?`,
     ).get("legacy-date") as { created_at: number };
@@ -493,10 +521,10 @@ describe("backfill from legacy memories rows", () => {
   });
 
   it("nulls payload content for legacy rows with superseded_by = 'purged'", async () => {
-    const tmp = mkdtempSync(join(tmpdir(), "bf-purged-"));
-    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    const t = tmp("bf-purged-");
+    const provider1 = new SqliteFtsMemoryProvider(t);
     await provider1.init();
-    const db1 = new Database(join(tmp, "memory.db"));
+    const db1 = new Database(join(t, "memory.db"));
     db1.prepare(
       `INSERT INTO memories (id, content, tags, superseded_by, created_at, updated_at)
        VALUES ('legacy-purged', 'AKIA-leak', '["sensitive"]', 'purged', '2026-01-01', '2026-01-01')`,
@@ -504,9 +532,9 @@ describe("backfill from legacy memories rows", () => {
     db1.close();
     provider1.close();
 
-    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    const provider2 = new SqliteFtsMemoryProvider(t);
     await provider2.init();
-    const db2 = new Database(join(tmp, "memory.db"));
+    const db2 = new Database(join(t, "memory.db"));
     const types = db2.prepare(
       `SELECT event_type FROM memory_events WHERE memory_id = ? ORDER BY created_at`,
     ).all("legacy-purged") as Array<{ event_type: string }>;

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
 import { SqliteFtsMemoryProvider } from "../src/memory-store.js";
 
 // SqliteFtsMemoryProvider does its own schema/migrations on init().
@@ -153,8 +154,6 @@ describe("SqliteFtsMemoryProvider", () => {
     });
   });
 });
-
-import Database from "better-sqlite3";
 
 describe("schema migration — memory_events + memory_payloads", () => {
   it("creates memory_events with the expected columns", async () => {

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -427,4 +427,29 @@ describe("backfill from legacy memories rows", () => {
     db2.close();
     provider2.close();
   });
+
+  it("preserves legacy created_at when parseable", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "bf-ts-"));
+    const provider1 = new SqliteFtsMemoryProvider(tmp);
+    await provider1.init();
+    const db1 = new Database(join(tmp, "memory.db"));
+    db1.prepare(
+      `INSERT INTO memories (id, content, tags, created_at, updated_at)
+       VALUES ('legacy-ts', 'has timestamp', '[]', '2026-01-15 10:30:00', '2026-01-15 10:30:00')`,
+    ).run();
+    db1.close();
+    provider1.close();
+
+    const provider2 = new SqliteFtsMemoryProvider(tmp);
+    await provider2.init();
+    const db2 = new Database(join(tmp, "memory.db"));
+    const ev = db2.prepare(
+      `SELECT created_at FROM memory_events WHERE memory_id = ?`,
+    ).get("legacy-ts") as { created_at: number };
+    // Should match 2026-01-15 10:30:00 UTC ≈ 1768516200000, NOT Date.now()
+    const expected = Date.parse("2026-01-15T10:30:00Z");
+    expect(ev.created_at).toBe(expected);
+    db2.close();
+    provider2.close();
+  });
 });


### PR DESCRIPTION
## Summary

PR 1 of 2 for issue #318 (cross-device memory sync). **Local-only — no cloud writes yet.** Lays the event-model groundwork that PR 2 will sync across devices.

Implements [Tasks 1–4 of the plan](docs/superpowers/plans/2026-05-08-memory-sync.md) per the [decision spec](docs/superpowers/specs/2026-05-08-memory-sync-design.md):

- **Schema** — `memory_events` (append-only event log, doubles as outbox via `cloud_synced_at IS NULL`) and `memory_payloads` (redactable content store), plus `purged_at` column on `memories`. CHECK constraint on `event_type`; per-type partial unique indexes (`memory_created` / `memory_forgotten` / `memory_purged`) for idempotent replay.
- **Event write API** — `writeCreated`, `writeForgotten`, `writePurged` on `SqliteFtsMemoryProvider`. Each wraps in a transaction. The `materialiseMemory` precedence-resolver re-derives the FTS5 recall surface from events + payloads using **purged > forgotten > created** — the load-bearing invariant from spec Q7.
- **Routed entry points** — existing MCP/HTTP `remember`/`forget` now go through the event API. New internal `provider.purge(id)` method (NOT exposed via MCP, per spec). Every write path threads `cloud_owner_id` from auth state — Pro-only — so events are tagged with the owner at write time.
- **Backfill at boot** — one-time idempotent pass: legacy `memories` rows without matching events get them, with `cloud_owner_id = NULL` so they stay local (account-switching policy). Robust SQLite timestamp parsing handles both space-separated and date-only formats. Legacy `superseded_by = 'purged'` rows have their payload content nulled per spec Q7.

### What's deliberately not here

- Cloud writes / Worker / D1 — all of that lands in PR 2.
- Profile-owner binding (Task 4.4) — prerequisite for PR 2's cloud work, lands there.
- MCP exposure of `purge` — out of scope per spec.

### Implementation notes

- Built via `superpowers:subagent-driven-development` with two-stage review per task (spec compliance + code quality). Final cross-task review caught three carry-over issues; all addressed in `5e4a882`.
- 9 clean commits — 5 `feat`, 3 `refactor`, 1 `test` — each task ships as one or two commits.
- 157/157 tests passing in the full server suite. **39 memory-store tests** (was 19 before this PR — 20 new). TypeScript build clean.
- No dead code: removed `stmts.insert` and `stmts.supersede` made unused by routing through the event API.

## Test plan

- [ ] \`cd server && npm install && npx vitest run\` — full suite green (157 tests)
- [ ] \`cd server && npm run build\` — TypeScript clean
- [ ] \`cd server && npx vitest run test/memory-store.test.ts -t "schema migration"\` — schema layer green
- [ ] \`cd server && npx vitest run test/memory-store.test.ts -t "writeCreated"\` — write API green
- [ ] \`cd server && npx vitest run test/memory-store.test.ts -t "writeForgotten"\` — precedence + late-create-after-purge
- [ ] \`cd server && npx vitest run test/memory-store.test.ts -t "backfill"\` — backfill including legacy purge content nulling
- [ ] Smoke run \`npm run dev\` and verify the existing MCP \`remember\` / \`forget\` flows still behave identically from a user perspective (no behaviour change at the surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)