### PR TITLE
feat: cross-device memory sync — cloud half (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Memories follow you across Pro devices.** Anything you remember on one Pro device shows up on every other Pro device signed into the same account. Forgetting and deletion propagate too. Only memories created while signed into your bound Pro profile sync — pre-existing local memories and anything created on a free account stay local.
+
 ## [0.7.1-beta.0] - 2026-05-08
 
 ### Changed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
       <a class="version-pill" href="#v-0-5-0">0.5</a>
@@ -323,6 +324,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.7.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Memories follow you across Pro devices.</strong> Anything you remember on one Pro device shows up on every other Pro device signed into the same account. Forgetting and deletion propagate too. Only memories created while signed into your bound Pro profile sync — pre-existing local memories and anything created on a free account stay local.</li>
+</ul>
 <h2 id="v-0-7-1-beta-0"><span class="release-version">0.7.1-beta.0</span><span class="release-date"> — 2026-05-08</span></h2>
 <h3>Changed</h3>
 <ul>

--- a/infra/auth-worker/migrations/0007_synced_memories.sql
+++ b/infra/auth-worker/migrations/0007_synced_memories.sql
@@ -1,59 +1,41 @@
-// Minimal test fixtures for oyster-cloud bootstrap tests.
-// Each test file gets an isolated in-memory D1 binding via @cloudflare/vitest-pool-workers.
+-- 0007_synced_memories.sql — cross-device memory sync substrate (#318).
+-- Spec: docs/superpowers/specs/2026-05-08-memory-sync-design.md
+--
+-- Append-only event log + redactable payload store. Per-type uniqueness
+-- enforces the spec's idempotent-replay invariants. Pro-only writes; gate
+-- enforced on the Worker handler.
 
-import { env } from "cloudflare:test";
-
-const SCHEMA_SQL = `
--- Mirror of oyster-auth's relevant schema for tests. Keep in sync with:
---   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
-CREATE TABLE users (
-  id            TEXT PRIMARY KEY,
-  email         TEXT NOT NULL UNIQUE,
-  created_at    INTEGER NOT NULL,
-  last_seen_at  INTEGER,
-  tier          TEXT NOT NULL DEFAULT 'free'
-);
-CREATE TABLE sessions (
-  id            TEXT PRIMARY KEY,
-  user_id       TEXT NOT NULL REFERENCES users(id),
-  created_at    INTEGER NOT NULL,
-  expires_at    INTEGER NOT NULL,
-  revoked_at    INTEGER
-);
--- Mirror of infra/auth-worker/migrations/0007_synced_memories.sql
 CREATE TABLE IF NOT EXISTS synced_memory_events (
   owner_id        TEXT    NOT NULL,
   event_id        TEXT    NOT NULL,
   memory_id       TEXT    NOT NULL,
   event_type      TEXT    NOT NULL CHECK (event_type IN ('memory_created','memory_forgotten','memory_purged')),
-  space_id        TEXT,
-  created_at      INTEGER NOT NULL,
-  ingested_at     INTEGER NOT NULL,
+  space_id        TEXT,                -- meaningful only when event_type = 'memory_created'
+  created_at      INTEGER NOT NULL,    -- unix ms; not used for LWW, just ordering
+  ingested_at     INTEGER NOT NULL,    -- when the cloud accepted the event
   PRIMARY KEY (owner_id, event_id)
 );
+
 CREATE INDEX IF NOT EXISTS idx_synced_memory_events_owner_created
   ON synced_memory_events (owner_id, created_at DESC);
+
 CREATE INDEX IF NOT EXISTS idx_synced_memory_events_memory
   ON synced_memory_events (owner_id, memory_id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_synced_memory_created
   ON synced_memory_events (owner_id, memory_id) WHERE event_type = 'memory_created';
+
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_synced_memory_forgotten
   ON synced_memory_events (owner_id, memory_id) WHERE event_type = 'memory_forgotten';
+
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_synced_memory_purged
   ON synced_memory_events (owner_id, memory_id) WHERE event_type = 'memory_purged';
+
 CREATE TABLE IF NOT EXISTS synced_memory_payloads (
   owner_id   TEXT NOT NULL,
   memory_id  TEXT NOT NULL,
-  content    TEXT,
+  content    TEXT,                     -- NULL after purge
   tags       TEXT NOT NULL DEFAULT '[]',
-  purged_at  INTEGER,
+  purged_at  INTEGER,                  -- non-NULL after purge
   PRIMARY KEY (owner_id, memory_id)
-)
-`;
-
-export async function applySchema(): Promise<void> {
-  const stmts = SCHEMA_SQL.split(";").map(s => s.trim()).filter(Boolean);
-  for (const s of stmts) {
-    await env.DB.prepare(s).run();
-  }
-}
+);

--- a/infra/oyster-cloud/package-lock.json
+++ b/infra/oyster-cloud/package-lock.json
@@ -1,0 +1,4260 @@
+{
+  "name": "@oyster/cloud-worker",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@oyster/cloud-worker",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.0",
+        "@cloudflare/workers-types": "^4.20260101.0",
+        "typescript": "^5.4.0",
+        "vitest": "^2.1.0",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
+      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20241230.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.100.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 2.1.x",
+        "@vitest/snapshot": "2.0.x - 2.1.x",
+        "vitest": "2.0.x - 2.1.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241218-183400-5d6aec3",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
+      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.3",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
+      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
+      "deprecated": "Downgrade to 3.99.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^4.0.1",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241230.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
+        "workerd": "1.20241230.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
+      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
+      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
+      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260508.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260508.1.tgz",
+      "integrity": "sha512-0KNR+UkrYJYmtyQ5tOjUT/wt/U34FuE4Y8FLSbPMwFrGQQpmvR9wKghwRkL4d28y5t9jI9cvGqeAoo/cerTnCQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20241230.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
+      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241230.0",
+        "ws": "^8.18.0",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
+      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241230.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
+        "@cloudflare/workerd-linux-64": "1.20241230.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
+        "@cloudflare/workerd-windows-64": "1.20241230.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.90.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.90.0.tgz",
+      "integrity": "sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260507.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260507.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260507.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260507.1.tgz",
+      "integrity": "sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260507.1.tgz",
+      "integrity": "sha512-GMEBu8Zp9Q97HLnf7bWJN4KjWpN5MxpeqdvHjBGWNl8UYprJI0k+Jkp89+Wh5S8vIon+HoVbDfOzPa7VwgL6Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260507.1.tgz",
+      "integrity": "sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260507.1.tgz",
+      "integrity": "sha512-eGbbupEtK2nh9V9Dhcx3vv3GTKeXqSVNgAEYVCCN0NGS9tl9HbMoHRX/4JL181FKXROMigWBCQVL//qPhsAzBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260507.1.tgz",
+      "integrity": "sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "4.20260507.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260507.1.tgz",
+      "integrity": "sha512-PSXBiLExTdZ4UGO/raKCHQauUpYL7F880ZRB7j0+78Rv8h7TsdN2E/iEDK9sK2Y+SPQ5wJSeAa+rDeVKoZZoEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260507.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260507.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260507.1.tgz",
+      "integrity": "sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260507.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260507.1",
+        "@cloudflare/workerd-linux-64": "1.20260507.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260507.1",
+        "@cloudflare/workerd-windows-64": "1.20260507.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/infra/oyster-cloud/package.json
+++ b/infra/oyster-cloud/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@oyster/cloud-worker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "tail": "wrangler tail",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.1.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/infra/oyster-cloud/src/json.ts
+++ b/infra/oyster-cloud/src/json.ts
@@ -1,0 +1,16 @@
+export function jsonError(status: number, code: string, message?: string, extra: Record<string, unknown> = {}): Response {
+  const body: Record<string, unknown> = { error: code, ...extra };
+  if (message) body.message = message;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function jsonOk(payload: object, status = 200, extraHeaders?: HeadersInit): Response {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (extraHeaders) {
+    new Headers(extraHeaders).forEach((v, k) => headers.set(k, v));
+  }
+  return new Response(JSON.stringify(payload), { status, headers });
+}

--- a/infra/oyster-cloud/src/session.ts
+++ b/infra/oyster-cloud/src/session.ts
@@ -1,0 +1,38 @@
+// Env interface for the oyster-cloud Worker.
+// Bindings declared in wrangler.toml.
+
+export interface Env {
+  DB: D1Database; // shared with oyster-auth (same database_id)
+}
+
+interface SessionUser {
+  id: string;
+  email: string;
+  tier: string;
+}
+
+/**
+ * Resolve the session cookie to a user. Returns null on missing/expired session.
+ * Reads from the shared sessions + users tables.
+ */
+export async function resolveSession(req: Request, env: Env): Promise<SessionUser | null> {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const m = cookie.match(/(?:^|;\s*)oyster_session=([^;]+)/);
+  if (!m) return null;
+  const token = m[1];
+
+  // Production sessions schema (infra/auth-worker/migrations/0001_init.sql):
+  //   id TEXT PRIMARY KEY (the cookie value), user_id, created_at,
+  //   expires_at, revoked_at. Live-row predicate matches auth-worker exactly:
+  //   revoked_at IS NULL AND expires_at > now.
+  const row = await env.DB.prepare(
+    `SELECT u.id AS id, u.email AS email, u.tier AS tier
+       FROM sessions s
+       JOIN users u ON u.id = s.user_id
+      WHERE s.id = ? AND s.revoked_at IS NULL AND s.expires_at > ?`
+  ).bind(token, Date.now()).first<{ id: string; email: string; tier: string }>();
+
+  if (!row) return null;
+  return { id: row.id, email: row.email, tier: row.tier };
+}

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -69,7 +69,7 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
   for (const raw of incoming) {
     if (!isValidEvent(raw)) {
       const id = (raw as { event_id?: unknown })?.event_id;
-      rejected.push(typeof id === "string" ? id : "<malformed>");
+      rejected.push(typeof id === "string" && id.length > 0 ? id : "<malformed>");
       continue;
     }
     valid.push(raw);
@@ -91,90 +91,95 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
   for (const ev of valid) if (ev.event_type === "memory_purged") purgedInBatch.add(ev.memory_id);
 
   const now = Date.now();
-  for (const ev of valid) {
-    // Reject memory_created without payload UNLESS a purge already exists
-    // for this memory_id (in cloud OR earlier in this batch). Otherwise an
-    // empty-payload create would land an unrecoverable empty memory.
-    if (ev.event_type === "memory_created" && !ev.payload) {
-      const existingPurge = await env.DB.prepare(
-        `SELECT 1 FROM synced_memory_events
-          WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged' LIMIT 1`,
-      ).bind(user.id, ev.memory_id).first();
-      if (!existingPurge && !purgedInBatch.has(ev.memory_id)) {
-        rejected.push(ev.event_id);
+  try {
+    for (const ev of valid) {
+      // Reject memory_created without payload UNLESS a purge already exists
+      // for this memory_id (in cloud OR earlier in this batch). Otherwise an
+      // empty-payload create would land an unrecoverable empty memory.
+      if (ev.event_type === "memory_created" && !ev.payload) {
+        const existingPurge = await env.DB.prepare(
+          `SELECT 1 FROM synced_memory_events
+            WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged' LIMIT 1`,
+        ).bind(user.id, ev.memory_id).first();
+        if (!existingPurge && !purgedInBatch.has(ev.memory_id)) {
+          rejected.push(ev.event_id);
+          continue;
+        }
+      }
+
+      // Build the event-insert + payload statement atomically via env.DB.batch.
+      // Each event's pair runs as one D1 transaction — no half-applied state.
+      const eventStmt = env.DB.prepare(
+        `INSERT OR IGNORE INTO synced_memory_events
+           (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(user.id, ev.event_id, ev.memory_id, ev.event_type, ev.space_id, ev.created_at, now);
+
+      let payloadStmt: ReturnType<typeof env.DB.prepare> | null = null;
+      if (ev.event_type === "memory_purged") {
+        payloadStmt = env.DB.prepare(
+          `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
+           VALUES (?, ?, NULL, '[]', ?)
+           ON CONFLICT(owner_id, memory_id) DO UPDATE SET
+             content   = NULL,
+             tags      = '[]',
+             purged_at = excluded.purged_at`,
+        ).bind(user.id, ev.memory_id, ev.created_at);
+      } else if (ev.event_type === "memory_created" && ev.payload) {
+        // Idempotent payload upsert that respects an earlier purge.
+        // If a purge exists for this memory_id (in cloud), content stays NULL.
+        payloadStmt = env.DB.prepare(
+          `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
+             SELECT ?, ?, ?, ?, NULL
+              WHERE NOT EXISTS (
+                SELECT 1 FROM synced_memory_events
+                 WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged'
+              )
+           ON CONFLICT(owner_id, memory_id) DO UPDATE SET
+             content = CASE
+               WHEN EXISTS (SELECT 1 FROM synced_memory_events
+                              WHERE owner_id = synced_memory_payloads.owner_id
+                                AND memory_id = synced_memory_payloads.memory_id
+                                AND event_type = 'memory_purged')
+                 THEN NULL
+               ELSE excluded.content
+             END,
+             tags = CASE
+               WHEN EXISTS (SELECT 1 FROM synced_memory_events
+                              WHERE owner_id = synced_memory_payloads.owner_id
+                                AND memory_id = synced_memory_payloads.memory_id
+                                AND event_type = 'memory_purged')
+                 THEN '[]'
+               ELSE excluded.tags
+             END`,
+        ).bind(
+          user.id, ev.memory_id, ev.payload.content, JSON.stringify(ev.payload.tags),
+          user.id, ev.memory_id,
+        );
+      }
+
+      const stmts = payloadStmt ? [eventStmt, payloadStmt] : [eventStmt];
+      const results = await env.DB.batch(stmts);
+      const eventChanges = results[0].meta.changes;
+
+      if (eventChanges > 0) {
+        accepted.push(ev.event_id);
         continue;
       }
+
+      // Event INSERT was a no-op. Distinguish duplicate event_id from per-type
+      // uniqueness conflict. The PK is (owner_id, event_id); per-type partial
+      // unique indexes cover (owner_id, memory_id, event_type) WHERE the type
+      // matches. Both are safely idempotent — caller marks them synced.
+      const dup = await env.DB.prepare(
+        `SELECT 1 FROM synced_memory_events WHERE owner_id = ? AND event_id = ? LIMIT 1`,
+      ).bind(user.id, ev.event_id).first();
+      if (dup) duplicates.push(ev.event_id);
+      else conflicts.push(ev.event_id);
     }
-
-    // Build the event-insert + payload statement atomically via env.DB.batch.
-    // Each event's pair runs as one D1 transaction — no half-applied state.
-    const eventStmt = env.DB.prepare(
-      `INSERT OR IGNORE INTO synced_memory_events
-         (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    ).bind(user.id, ev.event_id, ev.memory_id, ev.event_type, ev.space_id, ev.created_at, now);
-
-    let payloadStmt: ReturnType<typeof env.DB.prepare> | null = null;
-    if (ev.event_type === "memory_purged") {
-      payloadStmt = env.DB.prepare(
-        `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
-         VALUES (?, ?, NULL, '[]', ?)
-         ON CONFLICT(owner_id, memory_id) DO UPDATE SET
-           content   = NULL,
-           tags      = '[]',
-           purged_at = excluded.purged_at`,
-      ).bind(user.id, ev.memory_id, ev.created_at);
-    } else if (ev.event_type === "memory_created" && ev.payload) {
-      // Idempotent payload upsert that respects an earlier purge.
-      // If a purge exists for this memory_id (in cloud), content stays NULL.
-      payloadStmt = env.DB.prepare(
-        `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
-           SELECT ?, ?, ?, ?, NULL
-            WHERE NOT EXISTS (
-              SELECT 1 FROM synced_memory_events
-               WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged'
-            )
-         ON CONFLICT(owner_id, memory_id) DO UPDATE SET
-           content = CASE
-             WHEN EXISTS (SELECT 1 FROM synced_memory_events
-                            WHERE owner_id = synced_memory_payloads.owner_id
-                              AND memory_id = synced_memory_payloads.memory_id
-                              AND event_type = 'memory_purged')
-               THEN NULL
-             ELSE excluded.content
-           END,
-           tags = CASE
-             WHEN EXISTS (SELECT 1 FROM synced_memory_events
-                            WHERE owner_id = synced_memory_payloads.owner_id
-                              AND memory_id = synced_memory_payloads.memory_id
-                              AND event_type = 'memory_purged')
-               THEN '[]'
-             ELSE excluded.tags
-           END`,
-      ).bind(
-        user.id, ev.memory_id, ev.payload.content, JSON.stringify(ev.payload.tags),
-        user.id, ev.memory_id,
-      );
-    }
-
-    const stmts = payloadStmt ? [eventStmt, payloadStmt] : [eventStmt];
-    const results = await env.DB.batch(stmts);
-    const eventChanges = results[0].meta.changes;
-
-    if (eventChanges > 0) {
-      accepted.push(ev.event_id);
-      continue;
-    }
-
-    // Event INSERT was a no-op. Distinguish duplicate event_id from per-type
-    // uniqueness conflict. The PK is (owner_id, event_id); per-type partial
-    // unique indexes cover (owner_id, memory_id, event_type) WHERE the type
-    // matches. Both are safely idempotent — caller marks them synced.
-    const dup = await env.DB.prepare(
-      `SELECT 1 FROM synced_memory_events WHERE owner_id = ? AND event_id = ? LIMIT 1`,
-    ).bind(user.id, ev.event_id).first();
-    if (dup) duplicates.push(ev.event_id);
-    else conflicts.push(ev.event_id);
+  } catch (err) {
+    console.warn("[memory] events ingest db error:", err);
+    return jsonError(500, "db_error");
   }
 
   return jsonOk({ accepted, duplicates, conflicts, rejected });

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -192,8 +192,18 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
       const dup = await env.DB.prepare(
         `SELECT 1 FROM synced_memory_events WHERE owner_id = ? AND event_id = ? LIMIT 1`,
       ).bind(user.id, ev.event_id).first();
-      if (dup) duplicates.push(ev.event_id);
-      else conflicts.push(ev.event_id);
+      if (dup) {
+        duplicates.push(ev.event_id);
+        // Run payload upsert to heal any partial-write race where the event
+        // landed in a prior request but the payload write didn't. Same event_id
+        // implies same canonical content, so this is idempotent for healthy
+        // clients.
+        if (payloadStmt) await payloadStmt.run();
+      } else {
+        conflicts.push(ev.event_id);
+        // DO NOT run payload — different event_id, the canonical content for
+        // this memory_id+type belongs to a different event.
+      }
     }
   } catch (err) {
     console.warn("[memory] events ingest db error:", err);

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -45,6 +45,13 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
   const incoming = body.events ?? [];
   if (!Array.isArray(incoming)) return jsonError(400, "invalid_metadata");
 
+  // Defensive cap. The local sync service batches at 100 events; even
+  // aggressive backfills shouldn't exceed this.
+  const MAX_EVENTS_PER_REQUEST = 1000;
+  if (incoming.length > MAX_EVENTS_PER_REQUEST) {
+    return jsonError(413, "too_many_events");
+  }
+
   const accepted:   string[] = [];
   const duplicates: string[] = [];
   const conflicts:  string[] = [];
@@ -111,8 +118,6 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
         }
       }
 
-      // Build the event-insert + payload statement atomically via env.DB.batch.
-      // Each event's pair runs as one D1 transaction — no half-applied state.
       const eventStmt = env.DB.prepare(
         `INSERT OR IGNORE INTO synced_memory_events
            (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
@@ -162,19 +167,28 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
         );
       }
 
-      const stmts = payloadStmt ? [eventStmt, payloadStmt] : [eventStmt];
-      const results = await env.DB.batch(stmts);
-      const eventChanges = results[0].meta.changes;
+      // Event INSERT first; classify the result; only THEN run the payload
+      // statement (and only when the event actually exists for this owner+id).
+      // We can't use env.DB.batch here because the payload statement must be
+      // conditional on the event INSERT actually inserting — running it for
+      // a per-type uniqueness conflict would overwrite the canonical payload.
+      const eventResult = await eventStmt.run();
+      const eventChanges = eventResult.meta.changes;
 
       if (eventChanges > 0) {
         accepted.push(ev.event_id);
+        // Event newly inserted. Run the payload now if there is one.
+        if (payloadStmt) {
+          await payloadStmt.run();
+        }
         continue;
       }
 
-      // Event INSERT was a no-op. Distinguish duplicate event_id from per-type
-      // uniqueness conflict. The PK is (owner_id, event_id); per-type partial
-      // unique indexes cover (owner_id, memory_id, event_type) WHERE the type
-      // matches. Both are safely idempotent — caller marks them synced.
+      // Event INSERT was a no-op. Distinguish duplicate (same event_id already
+      // exists) from conflict (per-type uniqueness rejected a different
+      // event_id for the same memory_id). For duplicates the payload is
+      // already canonical from the prior request; for conflicts the canonical
+      // payload belongs to a different event_id and must NOT be overwritten.
       const dup = await env.DB.prepare(
         `SELECT 1 FROM synced_memory_events WHERE owner_id = ? AND event_id = ? LIMIT 1`,
       ).bind(user.id, ev.event_id).first();

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -1,5 +1,6 @@
-import { jsonError } from "./json.js";
+import { jsonOk, jsonError } from "./json.js";
 import type { Env } from "./session.js";
+import { resolveSession } from "./session.js";
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
@@ -12,7 +13,169 @@ export default {
       return new Response("ok", { status: 200 });
     }
 
-    void env; // referenced here so TS is satisfied; routes will use it in Tasks 6–7
+    if (url.pathname === "/api/memories/events" && req.method === "POST") {
+      return handleMemoryEventsPost(req, env);
+    }
+
     return jsonError(404, "not_found");
   },
 };
+
+async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  type IncomingEvent = {
+    event_id: string;
+    memory_id: string;
+    event_type: "memory_created" | "memory_forgotten" | "memory_purged";
+    space_id: string | null;
+    created_at: number;
+    payload?: { content: string; tags: string[] };
+  };
+  let body: { events?: IncomingEvent[] };
+  try { body = await req.json() as typeof body; }
+  catch { return jsonError(400, "invalid_metadata"); }
+
+  const incoming = body.events ?? [];
+  if (!Array.isArray(incoming)) return jsonError(400, "invalid_metadata");
+
+  const accepted:   string[] = [];
+  const duplicates: string[] = [];
+  const conflicts:  string[] = [];
+  const rejected:   string[] = [];
+
+  // Validate each event up-front. Rejected events are NOT marked synced by
+  // the client — they surface as warnings.
+  function isValidEvent(ev: unknown): ev is IncomingEvent {
+    if (!ev || typeof ev !== "object") return false;
+    const e = ev as Record<string, unknown>;
+    if (typeof e.event_id !== "string" || e.event_id.length === 0) return false;
+    if (typeof e.memory_id !== "string" || e.memory_id.length === 0) return false;
+    if (e.event_type !== "memory_created" && e.event_type !== "memory_forgotten" && e.event_type !== "memory_purged") return false;
+    if (typeof e.created_at !== "number" || !Number.isFinite(e.created_at) || e.created_at < 0) return false;
+    if (e.space_id !== null && typeof e.space_id !== "string") return false;
+    if (e.event_type === "memory_created" && e.payload !== undefined) {
+      const p = e.payload as Record<string, unknown>;
+      if (!p || typeof p !== "object") return false;
+      if (typeof p.content !== "string") return false;
+      if (!Array.isArray(p.tags) || !p.tags.every((t) => typeof t === "string")) return false;
+    }
+    return true;
+  }
+
+  const valid: IncomingEvent[] = [];
+  for (const raw of incoming) {
+    if (!isValidEvent(raw)) {
+      const id = (raw as { event_id?: unknown })?.event_id;
+      rejected.push(typeof id === "string" ? id : "<malformed>");
+      continue;
+    }
+    valid.push(raw);
+  }
+
+  // Precedence-first ordering: purges, then forgets, then creates. Within each
+  // bucket, sort by created_at ascending. This ensures a `memory_created`
+  // event whose payload was nulled locally before sync (purge-arrives-second
+  // from the client) lands AFTER any same-batch purge has been recorded, so
+  // the payload-upsert query naturally suppresses the content.
+  const PRECEDENCE: Record<IncomingEvent["event_type"], number> = {
+    memory_purged: 0, memory_forgotten: 1, memory_created: 2,
+  };
+  valid.sort((a, b) => PRECEDENCE[a.event_type] - PRECEDENCE[b.event_type] || a.created_at - b.created_at);
+
+  // Track which memory_ids have a purge in this batch — combined with the
+  // existing-purge check in DB, used to validate empty-payload creates.
+  const purgedInBatch = new Set<string>();
+  for (const ev of valid) if (ev.event_type === "memory_purged") purgedInBatch.add(ev.memory_id);
+
+  const now = Date.now();
+  for (const ev of valid) {
+    // Reject memory_created without payload UNLESS a purge already exists
+    // for this memory_id (in cloud OR earlier in this batch). Otherwise an
+    // empty-payload create would land an unrecoverable empty memory.
+    if (ev.event_type === "memory_created" && !ev.payload) {
+      const existingPurge = await env.DB.prepare(
+        `SELECT 1 FROM synced_memory_events
+          WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged' LIMIT 1`,
+      ).bind(user.id, ev.memory_id).first();
+      if (!existingPurge && !purgedInBatch.has(ev.memory_id)) {
+        rejected.push(ev.event_id);
+        continue;
+      }
+    }
+
+    // Build the event-insert + payload statement atomically via env.DB.batch.
+    // Each event's pair runs as one D1 transaction — no half-applied state.
+    const eventStmt = env.DB.prepare(
+      `INSERT OR IGNORE INTO synced_memory_events
+         (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(user.id, ev.event_id, ev.memory_id, ev.event_type, ev.space_id, ev.created_at, now);
+
+    let payloadStmt: ReturnType<typeof env.DB.prepare> | null = null;
+    if (ev.event_type === "memory_purged") {
+      payloadStmt = env.DB.prepare(
+        `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
+         VALUES (?, ?, NULL, '[]', ?)
+         ON CONFLICT(owner_id, memory_id) DO UPDATE SET
+           content   = NULL,
+           tags      = '[]',
+           purged_at = excluded.purged_at`,
+      ).bind(user.id, ev.memory_id, ev.created_at);
+    } else if (ev.event_type === "memory_created" && ev.payload) {
+      // Idempotent payload upsert that respects an earlier purge.
+      // If a purge exists for this memory_id (in cloud), content stays NULL.
+      payloadStmt = env.DB.prepare(
+        `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
+           SELECT ?, ?, ?, ?, NULL
+            WHERE NOT EXISTS (
+              SELECT 1 FROM synced_memory_events
+               WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged'
+            )
+         ON CONFLICT(owner_id, memory_id) DO UPDATE SET
+           content = CASE
+             WHEN EXISTS (SELECT 1 FROM synced_memory_events
+                            WHERE owner_id = synced_memory_payloads.owner_id
+                              AND memory_id = synced_memory_payloads.memory_id
+                              AND event_type = 'memory_purged')
+               THEN NULL
+             ELSE excluded.content
+           END,
+           tags = CASE
+             WHEN EXISTS (SELECT 1 FROM synced_memory_events
+                            WHERE owner_id = synced_memory_payloads.owner_id
+                              AND memory_id = synced_memory_payloads.memory_id
+                              AND event_type = 'memory_purged')
+               THEN '[]'
+             ELSE excluded.tags
+           END`,
+      ).bind(
+        user.id, ev.memory_id, ev.payload.content, JSON.stringify(ev.payload.tags),
+        user.id, ev.memory_id,
+      );
+    }
+
+    const stmts = payloadStmt ? [eventStmt, payloadStmt] : [eventStmt];
+    const results = await env.DB.batch(stmts);
+    const eventChanges = results[0].meta.changes;
+
+    if (eventChanges > 0) {
+      accepted.push(ev.event_id);
+      continue;
+    }
+
+    // Event INSERT was a no-op. Distinguish duplicate event_id from per-type
+    // uniqueness conflict. The PK is (owner_id, event_id); per-type partial
+    // unique indexes cover (owner_id, memory_id, event_type) WHERE the type
+    // matches. Both are safely idempotent — caller marks them synced.
+    const dup = await env.DB.prepare(
+      `SELECT 1 FROM synced_memory_events WHERE owner_id = ? AND event_id = ? LIMIT 1`,
+    ).bind(user.id, ev.event_id).first();
+    if (dup) duplicates.push(ev.event_id);
+    else conflicts.push(ev.event_id);
+  }
+
+  return jsonOk({ accepted, duplicates, conflicts, rejected });
+}

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -127,23 +127,34 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
       let payloadStmt: ReturnType<typeof env.DB.prepare> | null = null;
       if (ev.event_type === "memory_purged") {
         payloadStmt = env.DB.prepare(
+          // Guard on event_id presence so a per-type uniqueness conflict
+          // (different event_id, same memory_id+purged) is a no-op for the
+          // payload. The event INSERT runs first in the batch; if it was
+          // ignored, the EXISTS check fails and nothing is written.
           `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
-           VALUES (?, ?, NULL, '[]', ?)
+             SELECT ?, ?, NULL, '[]', ?
+              WHERE EXISTS (SELECT 1 FROM synced_memory_events
+                             WHERE owner_id = ? AND event_id = ?)
            ON CONFLICT(owner_id, memory_id) DO UPDATE SET
              content   = NULL,
              tags      = '[]',
              purged_at = excluded.purged_at`,
-        ).bind(user.id, ev.memory_id, ev.created_at);
+        ).bind(user.id, ev.memory_id, ev.created_at, user.id, ev.event_id);
       } else if (ev.event_type === "memory_created" && ev.payload) {
         // Idempotent payload upsert that respects an earlier purge.
         // If a purge exists for this memory_id (in cloud), content stays NULL.
         payloadStmt = env.DB.prepare(
+          // Guards: (1) the event INSERT actually landed for this event_id (so
+          // per-type uniqueness conflicts skip the payload), AND (2) no purge
+          // exists for this memory_id (so prior purges are not undone).
           `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
              SELECT ?, ?, ?, ?, NULL
-              WHERE NOT EXISTS (
-                SELECT 1 FROM synced_memory_events
-                 WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged'
-              )
+              WHERE EXISTS (SELECT 1 FROM synced_memory_events
+                             WHERE owner_id = ? AND event_id = ?)
+                AND NOT EXISTS (
+                  SELECT 1 FROM synced_memory_events
+                   WHERE owner_id = ? AND memory_id = ? AND event_type = 'memory_purged'
+                )
            ON CONFLICT(owner_id, memory_id) DO UPDATE SET
              content = CASE
                WHEN EXISTS (SELECT 1 FROM synced_memory_events
@@ -163,47 +174,33 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
              END`,
         ).bind(
           user.id, ev.memory_id, ev.payload.content, JSON.stringify(ev.payload.tags),
+          user.id, ev.event_id,
           user.id, ev.memory_id,
         );
       }
 
-      // Event INSERT first; classify the result; only THEN run the payload
-      // statement (and only when the event actually exists for this owner+id).
-      // We can't use env.DB.batch here because the payload statement must be
-      // conditional on the event INSERT actually inserting — running it for
-      // a per-type uniqueness conflict would overwrite the canonical payload.
-      const eventResult = await eventStmt.run();
-      const eventChanges = eventResult.meta.changes;
+      // Atomic: event INSERT + payload upsert run as one D1 transaction. The
+      // payload SQL guards on event_id presence, so per-type uniqueness
+      // conflicts naturally skip the payload write. Duplicates (same event_id
+      // already exists) heal the payload via the EXISTS guard matching the
+      // pre-existing event row. Newly-inserted events get their payload set.
+      const stmts = payloadStmt ? [eventStmt, payloadStmt] : [eventStmt];
+      const results = await env.DB.batch(stmts);
+      // results[0] is always present — batch never returns an empty array here.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const eventChanges = results[0]!.meta.changes;
 
       if (eventChanges > 0) {
         accepted.push(ev.event_id);
-        // Event newly inserted. Run the payload now if there is one.
-        if (payloadStmt) {
-          await payloadStmt.run();
-        }
         continue;
       }
 
-      // Event INSERT was a no-op. Distinguish duplicate (same event_id already
-      // exists) from conflict (per-type uniqueness rejected a different
-      // event_id for the same memory_id). For duplicates the payload is
-      // already canonical from the prior request; for conflicts the canonical
-      // payload belongs to a different event_id and must NOT be overwritten.
+      // Event INSERT was a no-op. Distinguish duplicate from conflict.
       const dup = await env.DB.prepare(
         `SELECT 1 FROM synced_memory_events WHERE owner_id = ? AND event_id = ? LIMIT 1`,
       ).bind(user.id, ev.event_id).first();
-      if (dup) {
-        duplicates.push(ev.event_id);
-        // Run payload upsert to heal any partial-write race where the event
-        // landed in a prior request but the payload write didn't. Same event_id
-        // implies same canonical content, so this is idempotent for healthy
-        // clients.
-        if (payloadStmt) await payloadStmt.run();
-      } else {
-        conflicts.push(ev.event_id);
-        // DO NOT run payload — different event_id, the canonical content for
-        // this memory_id+type belongs to a different event.
-      }
+      if (dup) duplicates.push(ev.event_id);
+      else conflicts.push(ev.event_id);
     }
   } catch (err) {
     console.warn("[memory] events ingest db error:", err);

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -1,0 +1,18 @@
+import { jsonError } from "./json.js";
+import type { Env } from "./session.js";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    // Routes for this worker land in Tasks 6 and 7. For now, anything
+    // that isn't matched returns 404. Health-check responds 200 for
+    // deployment smoke-tests.
+    if (url.pathname === "/health" && req.method === "GET") {
+      return new Response("ok", { status: 200 });
+    }
+
+    void env; // referenced here so TS is satisfied; routes will use it in Tasks 6–7
+    return jsonError(404, "not_found");
+  },
+};

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -17,6 +17,10 @@ export default {
       return handleMemoryEventsPost(req, env);
     }
 
+    if (url.pathname === "/api/memories/events" && req.method === "GET") {
+      return handleMemoryEventsGet(req, env);
+    }
+
     return jsonError(404, "not_found");
   },
 };
@@ -183,4 +187,50 @@ async function handleMemoryEventsPost(req: Request, env: Env): Promise<Response>
   }
 
   return jsonOk({ accepted, duplicates, conflicts, rejected });
+}
+
+async function handleMemoryEventsGet(req: Request, env: Env): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  type EventRow = {
+    event_id: string; memory_id: string; event_type: string;
+    space_id: string | null; created_at: number;
+    p_content: string | null; p_tags: string | null; p_purged_at: number | null;
+  };
+  const { results } = await env.DB.prepare(
+    `SELECT e.event_id, e.memory_id, e.event_type, e.space_id, e.created_at,
+            p.content   AS p_content,
+            p.tags      AS p_tags,
+            p.purged_at AS p_purged_at
+       FROM synced_memory_events e
+       LEFT JOIN synced_memory_payloads p
+         ON p.owner_id = e.owner_id AND p.memory_id = e.memory_id
+      WHERE e.owner_id = ?
+      ORDER BY e.created_at ASC`,
+  ).bind(user.id).all<EventRow>();
+
+  const events = (results ?? []).map((r) => {
+    const base = {
+      event_id: r.event_id,
+      memory_id: r.memory_id,
+      event_type: r.event_type,
+      space_id: r.space_id,
+      created_at: r.created_at,
+    };
+    if (r.event_type === "memory_created") {
+      return {
+        ...base,
+        payload: {
+          content: r.p_content,
+          tags: r.p_tags ? JSON.parse(r.p_tags) : [],
+          purged_at: r.p_purged_at,
+        },
+      };
+    }
+    return base;
+  });
+
+  return jsonOk({ events }, 200, { "cache-control": "private, no-store" });
 }

--- a/infra/oyster-cloud/test/env.d.ts
+++ b/infra/oyster-cloud/test/env.d.ts
@@ -1,0 +1,9 @@
+// Tell TypeScript what the test runtime's `env` looks like.
+// @cloudflare/vitest-pool-workers exports `env: ProvidedEnv` which is
+// otherwise empty until augmented here.
+
+import type { Env } from "../src/session";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -1,0 +1,30 @@
+// Minimal test fixtures for oyster-cloud bootstrap tests.
+// Each test file gets an isolated in-memory D1 binding via @cloudflare/vitest-pool-workers.
+
+import { env } from "cloudflare:test";
+
+const SCHEMA_SQL = `
+-- Mirror of oyster-auth's relevant schema for tests. Keep in sync with:
+--   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,
+  email         TEXT NOT NULL UNIQUE,
+  created_at    INTEGER NOT NULL,
+  last_seen_at  INTEGER,
+  tier          TEXT NOT NULL DEFAULT 'free'
+);
+CREATE TABLE sessions (
+  id            TEXT PRIMARY KEY,
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  created_at    INTEGER NOT NULL,
+  expires_at    INTEGER NOT NULL,
+  revoked_at    INTEGER
+)
+`;
+
+export async function applySchema(): Promise<void> {
+  const stmts = SCHEMA_SQL.split(";").map(s => s.trim()).filter(Boolean);
+  for (const s of stmts) {
+    await env.DB.prepare(s).run();
+  }
+}

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -6,14 +6,14 @@ import { env } from "cloudflare:test";
 const SCHEMA_SQL = `
 -- Mirror of oyster-auth's relevant schema for tests. Keep in sync with:
 --   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
   id            TEXT PRIMARY KEY,
   email         TEXT NOT NULL UNIQUE,
   created_at    INTEGER NOT NULL,
   last_seen_at  INTEGER,
   tier          TEXT NOT NULL DEFAULT 'free'
 );
-CREATE TABLE sessions (
+CREATE TABLE IF NOT EXISTS sessions (
   id            TEXT PRIMARY KEY,
   user_id       TEXT NOT NULL REFERENCES users(id),
   created_at    INTEGER NOT NULL,

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS synced_memory_payloads (
   tags       TEXT NOT NULL DEFAULT '[]',
   purged_at  INTEGER,
   PRIMARY KEY (owner_id, memory_id)
-)
+);
 `;
 
 export async function applySchema(): Promise<void> {

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -322,8 +322,8 @@ describe("GET /api/memories/events", () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { events: Array<{ event_id: string; event_type: string; payload?: { content: string | null } }> };
     expect(body.events.map((e) => e.event_id)).toEqual(["ev-A", "ev-B"]);
-    expect(body.events[0].payload?.content).toBe("hello");
-    expect(body.events[1].payload).toBeUndefined();
+    expect(body.events[0]?.payload?.content).toBe("hello");
+    expect(body.events[1]?.payload).toBeUndefined();
   });
 
   it("excludes other users' events", async () => {

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -236,6 +236,35 @@ describe("POST /api/memories/events", () => {
     expect(pay?.tags).toBe('["a"]');
   });
 
+  it("duplicate event_id re-runs payload upsert (heals partial-write race)", async () => {
+    const { token, userId } = await makeProSession();
+    // Simulate a partial-write race: insert ONLY the event row directly,
+    // skipping the payload — as if a prior request crashed between the
+    // event INSERT and the payload upsert.
+    await env.DB.prepare(
+      `INSERT INTO synced_memory_events (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+       VALUES (?, 'ev-orphan', 'mem-O', 'memory_created', NULL, 1000, 1000)`,
+    ).bind(userId).run();
+
+    // Now retry the SAME event with payload. The handler should classify
+    // as `duplicates` AND run the payload upsert, healing the orphan.
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{ event_id: "ev-orphan", memory_id: "mem-O", event_type: "memory_created", space_id: null, created_at: 1000, payload: { content: "healed", tags: ["t"] } }],
+      }),
+    }, token);
+    const body = await res.json() as { duplicates: string[] };
+    expect(body.duplicates).toEqual(["ev-orphan"]);
+
+    // Payload should now exist with the healed content.
+    const pay = await env.DB.prepare(
+      `SELECT content, tags FROM synced_memory_payloads WHERE owner_id = ? AND memory_id = ?`,
+    ).bind(userId, "mem-O").first<{ content: string; tags: string }>();
+    expect(pay?.content).toBe("healed");
+    expect(pay?.tags).toBe('["t"]');
+  });
+
   it("memory_purged nulls payload content even if create arrives later", async () => {
     const { token, userId } = await makeProSession();
     // Send purge first (out-of-order delivery).

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -169,7 +169,7 @@ describe("POST /api/memories/events", () => {
     }, token);
     const body = await res.json() as { accepted: string[]; rejected: string[] };
     expect(body.accepted).toEqual(["ev-good"]);
-    expect(body.rejected).toEqual(expect.arrayContaining(["ev-bad-type", "ev-bad-empty-id"]));
+    expect(body.rejected).toEqual(expect.arrayContaining(["ev-bad-type", "ev-bad-empty-id", "<malformed>"]));
   });
 
   it("rejects memory_created without payload when no purge exists", async () => {

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { env } from "cloudflare:test";
+import { applySchema } from "./fixtures/seed.js";
+
+describe("synced_memory_events / synced_memory_payloads schema", () => {
+  beforeAll(async () => {
+    await applySchema();
+  });
+
+  it("has the events table with expected columns", async () => {
+    const { results } = await env.DB.prepare(
+      `SELECT name FROM pragma_table_info('synced_memory_events') ORDER BY name`,
+    ).all<{ name: string }>();
+    const names = (results ?? []).map((r) => r.name);
+    expect(names).toEqual([
+      "created_at", "event_id", "event_type", "ingested_at", "memory_id", "owner_id", "space_id",
+    ]);
+  });
+
+  it("has the payloads table with expected columns", async () => {
+    const { results } = await env.DB.prepare(
+      `SELECT name FROM pragma_table_info('synced_memory_payloads') ORDER BY name`,
+    ).all<{ name: string }>();
+    const names = (results ?? []).map((r) => r.name);
+    expect(names).toEqual(["content", "memory_id", "owner_id", "purged_at", "tags"]);
+  });
+
+  it("enforces per-type uniqueness on memory_created", async () => {
+    await env.DB.prepare(
+      `INSERT INTO synced_memory_events (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+       VALUES ('user-A', 'ev-1', 'mem-1', 'memory_created', NULL, 1000, 2000)`,
+    ).run();
+    await expect(env.DB.prepare(
+      `INSERT INTO synced_memory_events (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+       VALUES ('user-A', 'ev-2', 'mem-1', 'memory_created', NULL, 1500, 2500)`,
+    ).run()).rejects.toThrow();
+  });
+});

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -209,6 +209,33 @@ describe("POST /api/memories/events", () => {
     expect(pay?.purged_at).not.toBeNull();
   });
 
+  it("conflicting memory_created does NOT overwrite the canonical payload", async () => {
+    const { token, userId } = await makeProSession();
+    // Send canonical create.
+    await signedInRequest("/api/memories/events", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{ event_id: "ev-canonical", memory_id: "mem-K", event_type: "memory_created", space_id: null, created_at: 1000, payload: { content: "canonical", tags: ["a"] } }],
+      }),
+    }, token);
+    // Send conflicting create with different content.
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{ event_id: "ev-conflict", memory_id: "mem-K", event_type: "memory_created", space_id: null, created_at: 2000, payload: { content: "should-not-stick", tags: ["b"] } }],
+      }),
+    }, token);
+    const body = await res.json() as { conflicts: string[] };
+    expect(body.conflicts).toEqual(["ev-conflict"]);
+
+    // Payload must still be canonical, NOT overwritten.
+    const pay = await env.DB.prepare(
+      `SELECT content, tags FROM synced_memory_payloads WHERE owner_id = ? AND memory_id = ?`,
+    ).bind(userId, "mem-K").first<{ content: string; tags: string }>();
+    expect(pay?.content).toBe("canonical");
+    expect(pay?.tags).toBe('["a"]');
+  });
+
   it("memory_purged nulls payload content even if create arrives later", async () => {
     const { token, userId } = await makeProSession();
     // Send purge first (out-of-order delivery).

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -239,3 +239,49 @@ describe("POST /api/memories/events", () => {
     expect(pay?.purged_at).not.toBeNull();
   });
 });
+
+describe("GET /api/memories/events", () => {
+  beforeAll(async () => {
+    await applySchema();
+  });
+
+  it("rejects unsigned with 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/memories/events");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns all events for the signed-in user, ordered by created_at", async () => {
+    const { token, userId } = await makeProSession();
+    await env.DB.prepare(
+      `INSERT INTO synced_memory_events (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+       VALUES (?, 'ev-A', 'mem-1', 'memory_created', NULL, 1000, 1000),
+              (?, 'ev-B', 'mem-1', 'memory_forgotten', NULL, 2000, 2000)`,
+    ).bind(userId, userId).run();
+    await env.DB.prepare(
+      `INSERT INTO synced_memory_payloads (owner_id, memory_id, content, tags, purged_at)
+       VALUES (?, 'mem-1', 'hello', '["a"]', NULL)`,
+    ).bind(userId).run();
+
+    const res = await signedInRequest("/api/memories/events", { method: "GET" }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { events: Array<{ event_id: string; event_type: string; payload?: { content: string | null } }> };
+    expect(body.events.map((e) => e.event_id)).toEqual(["ev-A", "ev-B"]);
+    expect(body.events[0].payload?.content).toBe("hello");
+    expect(body.events[1].payload).toBeUndefined();
+  });
+
+  it("excludes other users' events", async () => {
+    const { token: tokenA } = await makeProSession();
+    const idB = `u-pro-other-${crypto.randomUUID()}`;
+    await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'pro', ?)`)
+      .bind(idB, `b-${idB}@x.com`, Date.now()).run();
+    await env.DB.prepare(
+      `INSERT INTO synced_memory_events (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
+       VALUES (?, 'ev-other', 'mem-other', 'memory_created', NULL, 100, 100)`,
+    ).bind(idB).run();
+
+    const res = await signedInRequest("/api/memories/events", { method: "GET" }, tokenA);
+    const body = await res.json() as { events: Array<{ event_id: string }> };
+    expect(body.events.find((e) => e.event_id === "ev-other")).toBeUndefined();
+  });
+});

--- a/infra/oyster-cloud/test/memories-events.test.ts
+++ b/infra/oyster-cloud/test/memories-events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { env } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { applySchema } from "./fixtures/seed.js";
 
 describe("synced_memory_events / synced_memory_payloads schema", () => {
@@ -34,5 +34,208 @@ describe("synced_memory_events / synced_memory_payloads schema", () => {
       `INSERT INTO synced_memory_events (owner_id, event_id, memory_id, event_type, space_id, created_at, ingested_at)
        VALUES ('user-A', 'ev-2', 'mem-1', 'memory_created', NULL, 1500, 2500)`,
     ).run()).rejects.toThrow();
+  });
+});
+
+// --- helpers for POST tests ---
+
+async function signedInRequest(path: string, init: RequestInit, sessionToken: string): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("Cookie", `oyster_session=${sessionToken}`);
+  return SELF.fetch(`https://example.com${path}`, { ...init, headers });
+}
+
+// Each call inserts a fresh Pro user + session with a unique suffix.
+// The sessions table uses `id` as PK (matching the seed schema and resolveSession).
+// users.created_at is NOT NULL per the seed schema.
+async function makeProSession(suffix = crypto.randomUUID()): Promise<{ token: string; userId: string }> {
+  const userId = `u-pro-${suffix}`;
+  const token  = `tok-pro-${suffix}`;
+  await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'pro', ?)`)
+    .bind(userId, `pro-${suffix}@example.com`, Date.now()).run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, created_at, expires_at, revoked_at)
+     VALUES (?, ?, ?, ?, NULL)`,
+  ).bind(token, userId, Date.now(), Date.now() + 86400_000).run();
+  return { token, userId };
+}
+
+describe("POST /api/memories/events", () => {
+  beforeAll(async () => {
+    await applySchema();
+  });
+
+  it("rejects unsigned requests with 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/memories/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ events: [] }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects free-tier users with 403", async () => {
+    const userId = `u-free-${crypto.randomUUID()}`;
+    const token  = `tok-free-${crypto.randomUUID()}`;
+    await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'free', ?)`)
+      .bind(userId, `free-${userId}@example.com`, Date.now()).run();
+    await env.DB.prepare(
+      `INSERT INTO sessions (id, user_id, created_at, expires_at, revoked_at)
+       VALUES (?, ?, ?, ?, NULL)`,
+    ).bind(token, userId, Date.now(), Date.now() + 86400_000).run();
+
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ events: [] }),
+    }, token);
+    expect(res.status).toBe(403);
+  });
+
+  it("ingests a memory_created event with payload", async () => {
+    const { token, userId } = await makeProSession();
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          event_id:  "ev-1",
+          memory_id: "mem-1",
+          event_type: "memory_created",
+          space_id: null,
+          created_at: 1000,
+          payload: { content: "hello", tags: ["a"] },
+        }],
+      }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; duplicates: string[]; conflicts: string[]; rejected: string[] };
+    expect(body.accepted).toEqual(["ev-1"]);
+    expect(body.duplicates).toEqual([]);
+    expect(body.conflicts).toEqual([]);
+    expect(body.rejected).toEqual([]);
+
+    const ev = await env.DB.prepare(
+      `SELECT event_type FROM synced_memory_events WHERE owner_id = ? AND event_id = ?`,
+    ).bind(userId, "ev-1").first<{ event_type: string }>();
+    expect(ev?.event_type).toBe("memory_created");
+
+    const pay = await env.DB.prepare(
+      `SELECT content FROM synced_memory_payloads WHERE owner_id = ? AND memory_id = ?`,
+    ).bind(userId, "mem-1").first<{ content: string }>();
+    expect(pay?.content).toBe("hello");
+  });
+
+  it("duplicate event_id is reported as `duplicates`, not `accepted`", async () => {
+    const { token } = await makeProSession();
+    const event = {
+      event_id:  "ev-dup",
+      memory_id: "mem-dup",
+      event_type: "memory_created" as const,
+      space_id: null,
+      created_at: 1000,
+      payload: { content: "x", tags: [] },
+    };
+    const first  = await signedInRequest("/api/memories/events", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ events: [event] }) }, token);
+    expect((await first.json() as any).accepted).toEqual(["ev-dup"]);
+    const second = await signedInRequest("/api/memories/events", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ events: [event] }) }, token);
+    const body = await second.json() as { accepted: string[]; duplicates: string[]; conflicts: string[]; rejected: string[] };
+    expect(body.duplicates).toEqual(["ev-dup"]);
+    expect(body.accepted).toEqual([]);
+  });
+
+  it("second create for same memory_id with different event_id is `conflicts`", async () => {
+    const { token } = await makeProSession();
+    const first  = await signedInRequest("/api/memories/events", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ events: [{ event_id: "ev-A", memory_id: "mem-Z", event_type: "memory_created", space_id: null, created_at: 1000, payload: { content: "first", tags: [] } }] }) }, token);
+    expect((await first.json() as any).accepted).toEqual(["ev-A"]);
+    const second = await signedInRequest("/api/memories/events", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ events: [{ event_id: "ev-B", memory_id: "mem-Z", event_type: "memory_created", space_id: null, created_at: 2000, payload: { content: "second", tags: [] } }] }) }, token);
+    const body = await second.json() as { accepted: string[]; conflicts: string[] };
+    expect(body.conflicts).toEqual(["ev-B"]);
+  });
+
+  it("rejects malformed events; surfaces them in `rejected`", async () => {
+    const { token } = await makeProSession();
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          { event_id: "ev-good", memory_id: "mem-G", event_type: "memory_created", space_id: null, created_at: 1, payload: { content: "ok", tags: [] } },
+          { event_id: "ev-bad-type", memory_id: "mem-B1", event_type: "lol", space_id: null, created_at: 1 },
+          { event_id: "ev-bad-empty-id", memory_id: "", event_type: "memory_created", space_id: null, created_at: 1, payload: { content: "x", tags: [] } },
+          { event_id: "", memory_id: "mem-B3", event_type: "memory_created", space_id: null, created_at: 1, payload: { content: "x", tags: [] } },
+        ],
+      }),
+    }, token);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual(["ev-good"]);
+    expect(body.rejected).toEqual(expect.arrayContaining(["ev-bad-type", "ev-bad-empty-id"]));
+  });
+
+  it("rejects memory_created without payload when no purge exists", async () => {
+    const { token } = await makeProSession();
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{ event_id: "ev-empty", memory_id: "mem-E", event_type: "memory_created", space_id: null, created_at: 1 }],
+      }),
+    }, token);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.rejected).toEqual(["ev-empty"]);
+    expect(body.accepted).toEqual([]);
+  });
+
+  it("accepts memory_created without payload when a purge already exists in the same batch (sorted first)", async () => {
+    const { token, userId } = await makeProSession();
+    const res = await signedInRequest("/api/memories/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          // Client writes create then purge; sort puts purge first.
+          { event_id: "ev-c", memory_id: "mem-Y", event_type: "memory_created", space_id: null, created_at: 1000 },
+          { event_id: "ev-p", memory_id: "mem-Y", event_type: "memory_purged",  space_id: null, created_at: 2000 },
+        ],
+      }),
+    }, token);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted.sort()).toEqual(["ev-c", "ev-p"].sort());
+    expect(body.rejected).toEqual([]);
+    const pay = await env.DB.prepare(
+      `SELECT content, purged_at FROM synced_memory_payloads WHERE owner_id = ? AND memory_id = ?`,
+    ).bind(userId, "mem-Y").first<{ content: string | null; purged_at: number | null }>();
+    expect(pay?.content).toBeNull();
+    expect(pay?.purged_at).not.toBeNull();
+  });
+
+  it("memory_purged nulls payload content even if create arrives later", async () => {
+    const { token, userId } = await makeProSession();
+    // Send purge first (out-of-order delivery).
+    await signedInRequest("/api/memories/events", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          event_id: "ev-purge", memory_id: "mem-X", event_type: "memory_purged",
+          space_id: null, created_at: 2000,
+        }],
+      }),
+    }, token);
+    // Then send create with content.
+    await signedInRequest("/api/memories/events", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          event_id: "ev-create", memory_id: "mem-X", event_type: "memory_created",
+          space_id: null, created_at: 1000,
+          payload: { content: "should-not-survive", tags: [] },
+        }],
+      }),
+    }, token);
+    const pay = await env.DB.prepare(
+      `SELECT content, purged_at FROM synced_memory_payloads WHERE owner_id = ? AND memory_id = ?`,
+    ).bind(userId, "mem-X").first<{ content: string | null; purged_at: number | null }>();
+    expect(pay?.content).toBeNull();
+    expect(pay?.purged_at).not.toBeNull();
   });
 });

--- a/infra/oyster-cloud/test/worker.test.ts
+++ b/infra/oyster-cloud/test/worker.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { applySchema } from "./fixtures/seed.js";
+
+describe("oyster-cloud worker bootstrap", () => {
+  beforeAll(async () => {
+    await applySchema();
+  });
+
+  it("returns 200 for /health", async () => {
+    const res = await SELF.fetch("https://example.com/health");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("returns 404 for unmatched paths", async () => {
+    const res = await SELF.fetch("https://example.com/api/anything");
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("not_found");
+  });
+
+  it("D1 binding is wired (smoke check via users table existence)", async () => {
+    const { results } = await env.DB.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='users'`,
+    ).all<{ name: string }>();
+    expect(results?.[0]?.name).toBe("users");
+  });
+});

--- a/infra/oyster-cloud/tsconfig.json
+++ b/infra/oyster-cloud/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/infra/oyster-cloud/vitest.config.ts
+++ b/infra/oyster-cloud/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // Use isolated in-memory D1 per test file.
+          d1Databases: ["DB"],
+        },
+      },
+    },
+  },
+});

--- a/infra/oyster-cloud/wrangler.toml
+++ b/infra/oyster-cloud/wrangler.toml
@@ -1,0 +1,18 @@
+name = "oyster-cloud"
+main = "src/worker.ts"
+compatibility_date = "2025-09-01"
+# nodejs_compat is required by @cloudflare/vitest-pool-workers (the test
+# infrastructure needs Node-style APIs inside the Worker runtime). Production
+# handlers don't depend on it — they use Web Crypto + standard Web APIs only.
+compatibility_flags = ["nodejs_compat"]
+
+# Shared D1 binding — same database_id as oyster-auth so we can read sessions/users
+# and own the synced_memory tables inside the same DB. Single source of truth.
+[[d1_databases]]
+binding = "DB"
+database_name = "oyster-auth"
+database_id = "44086805-fbfa-4446-8626-126af7e2ec19"
+
+[[routes]]
+pattern = "cloud.oyster.to/api/*"
+zone_name = "oyster.to"

--- a/infra/oyster-cloud/wrangler.toml
+++ b/infra/oyster-cloud/wrangler.toml
@@ -12,6 +12,7 @@ compatibility_flags = ["nodejs_compat"]
 binding = "DB"
 database_name = "oyster-auth"
 database_id = "44086805-fbfa-4446-8626-126af7e2ec19"
+migrations_dir = "../auth-worker/migrations"
 
 [[routes]]
 pattern = "cloud.oyster.to/api/*"

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -167,6 +167,18 @@ export function initDb(userlandDir: string): Database.Database {
   // the user pinned the artefact, used to sort most-recently-pinned first.
   try { db.exec("ALTER TABLE artifacts ADD COLUMN pinned_at INTEGER"); } catch { /* already exists */ }
 
+  // Profile binding (#318). Locks this local Oyster profile to one cloud
+  // account on first Pro sign-in, preventing a second Pro user from pulling
+  // their cloud data into the wrong local SQLite via cross-device sync.
+  // CHECK (id = 1) enforces at most one row — no separate UNIQUE index needed.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS profile_binding (
+      id              INTEGER PRIMARY KEY CHECK (id = 1),
+      cloud_owner_id  TEXT    NOT NULL,
+      bound_at        INTEGER NOT NULL
+    )
+  `);
+
   // Sessions arc (0.5.0). Three tables that capture agent activity (claude-code,
   // opencode, codex) read from external session logs. See
   // docs/plans/sessions-arc.md for the design.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -300,9 +300,9 @@ function canRunCloudSync(): boolean {
   if (!u || u.tier !== "pro") return false;
 
   const result = profileBinding.bindToOwner(u.id);
-  if (result.reason === "conflict") {
+  if (!result.bound) {
     console.warn(
-      `[profile] cloud sync blocked: profile bound to ${profileBinding.getBoundOwner()}, signed-in user is ${u.id}`,
+      `[profile] cloud sync blocked: profile bound to ${profileBinding.getBoundOwner()}, signed-in user is ${u.id} (${result.reason})`,
     );
     return false;
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -337,7 +337,14 @@ const memorySync: MemorySyncService = createMemorySyncService({
   workerBase: CLOUD_WORKER_BASE,
   fetch: globalThis.fetch,
 });
-memoryProvider.setOnWrite(() => { void memorySync.pushPending(); });
+memoryProvider.setOnWrite(() => {
+  // Fire-and-forget. Catch any error so a transient sync failure can never
+  // crash the server via unhandled rejection. pushPending swallows network
+  // errors internally; this is belt-and-braces for unexpected throws.
+  memorySync.pushPending().catch((err) => {
+    console.warn("[memory] onWrite-triggered pushPending failed:", err);
+  });
+});
 
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const publishService = createPublishService({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -368,19 +368,26 @@ function logBackfill(label: string, result: { mirrored: number; skipped: number 
 artifactService.setCloudOnlyPublicationsSource(() => publishService.getCloudOnlyPublications());
 
 async function syncOnAuth(label: string): Promise<void> {
-  // Spaces FIRST — the headline fix of #406 is that published-artefact
-  // ghosts resolve to real spaces, not _cloud. Doing publications first
-  // defeats that — the ghost render would still fall through to _cloud
-  // until the *next* sign-in. spaces first → publications second → render.
-  try {
-    const sr = await spaceSync.reconcile();
-    console.log(`[spaces] ${label}: pulled=${sr.pulled} pushed=${sr.pushed} tombstoned=${sr.tombstoned}`);
-    if (sr.pulled > 0 || sr.tombstoned > 0) {
-      // Notify the surface so any space pills update immediately.
-      broadcastUiEvent({ version: 1, command: "artifact_changed", payload: { id: null } });
+  // Spaces sync is gated: Pro-only, and the profile must be unbound or already
+  // bound to this user. canRunCloudSync() is also the sole production caller of
+  // bindToOwner — first Pro sign-in binds the profile here as a side effect.
+  // publishService.backfillPublications() is NOT gated: it runs for any
+  // signed-in user (free or Pro) and handles sign-out cleanup internally.
+  if (canRunCloudSync()) {
+    // Spaces FIRST — the headline fix of #406 is that published-artefact
+    // ghosts resolve to real spaces, not _cloud. Doing publications first
+    // defeats that — the ghost render would still fall through to _cloud
+    // until the *next* sign-in. spaces first → publications second → render.
+    try {
+      const sr = await spaceSync.reconcile();
+      console.log(`[spaces] ${label}: pulled=${sr.pulled} pushed=${sr.pushed} tombstoned=${sr.tombstoned}`);
+      if (sr.pulled > 0 || sr.tombstoned > 0) {
+        // Notify the surface so any space pills update immediately.
+        broadcastUiEvent({ version: 1, command: "artifact_changed", payload: { id: null } });
+      }
+    } catch (err) {
+      console.warn(`[spaces] ${label} failed:`, err);
     }
-  } catch (err) {
-    console.warn(`[spaces] ${label} failed:`, err);
   }
   // Then publications (preserves existing behaviour: clears ghost cache on
   // sign-out, broadcasts artifact_changed unconditionally via logBackfill).

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,7 @@ import { tryHandlePublishRoute } from "./routes/publish.js";
 import { tryHandlePinRoute } from "./routes/pin.js";
 import { createPublishService, PublishError } from "./publish-service.js";
 import { createSpaceSyncService } from "./space-sync-service.js";
+import { createMemorySyncService, type MemorySyncService } from "./memory-sync-service.js";
 import { createProfileBindingService } from "./profile-binding-service.js";
 import { hashPassword } from "./password-hash.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
@@ -324,6 +325,20 @@ const spaceSync = createSpaceSyncService({
   fetch,
 });
 
+const memorySync: MemorySyncService = createMemorySyncService({
+  db: memoryProvider.getInternalDbForSync(),
+  provider: memoryProvider,
+  profileBinding,                           // constructed in Task 4.4
+  currentUser: () => {
+    const u = authService.getState().user;
+    return u ? { id: u.id, email: u.email, tier: u.tier } : null;
+  },
+  sessionToken: () => authService.getState().sessionToken,
+  workerBase: CLOUD_WORKER_BASE,
+  fetch: globalThis.fetch,
+});
+memoryProvider.setOnWrite(() => { void memorySync.pushPending(); });
+
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const publishService = createPublishService({
   db,
@@ -389,6 +404,14 @@ async function syncOnAuth(label: string): Promise<void> {
       }
     } catch (err) {
       console.warn(`[spaces] ${label} failed:`, err);
+    }
+    try {
+      const memResult = await memorySync.reconcile();
+      if (memResult.pulled || memResult.pushed) {
+        console.log(`[memory] reconcile (${label}): pulled=${memResult.pulled} pushed=${memResult.pushed}`);
+      }
+    } catch (err) {
+      console.warn(`[memory] ${label} reconcile failed:`, err);
     }
   }
   // Then publications (preserves existing behaviour: clears ghost cache on

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,7 @@ import { tryHandlePublishRoute } from "./routes/publish.js";
 import { tryHandlePinRoute } from "./routes/pin.js";
 import { createPublishService, PublishError } from "./publish-service.js";
 import { createSpaceSyncService } from "./space-sync-service.js";
+import { createProfileBindingService } from "./profile-binding-service.js";
 import { hashPassword } from "./password-hash.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
 import { tryHandleImportRoute } from "./routes/import.js";
@@ -283,12 +284,35 @@ authService.onAuthChanged((state) => {
 });
 void authService.validatePersistedSession();
 
+// Profile binding — locks this local profile to the first Pro account that
+// signs in. Prevents a second Pro user from pulling their cloud data into
+// the wrong local SQLite. canRunCloudSync() is the ONLY caller of bindToOwner.
+const profileBinding = createProfileBindingService({ db });
+
+/** Returns true when the signed-in user is Pro AND this local profile is
+ *  either unbound or already bound to that user. Side-effect on first call
+ *  for a new Pro user: binds the profile. */
+function canRunCloudSync(): boolean {
+  const u = authService.getState().user;
+  if (!u || u.tier !== "pro") return false;
+
+  const result = profileBinding.bindToOwner(u.id);
+  if (result.reason === "conflict") {
+    console.warn(
+      `[profile] cloud sync blocked: profile bound to ${profileBinding.getBoundOwner()}, signed-in user is ${u.id}`,
+    );
+    return false;
+  }
+  return true;
+}
+
 // spaceSync provides cross-device mirror of the spaces table to D1.
 // Constructed before spaceService so the latter can fire pushOne/pushDelete
 // after each mutation. Same auth bridge as publishService.
 const spaceSync = createSpaceSyncService({
   db,
   store: spaceStore,
+  profileBinding,
   currentUser: () => {
     const u = authService.getState().user;
     return u ? { id: u.id, email: u.email, tier: u.tier } : null;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -252,6 +252,8 @@ const WORKER_BASE = process.env.OYSTER_AUTH_BASE
   ? process.env.OYSTER_AUTH_BASE.replace(/\/auth$/, "")
   : "https://oyster.to";
 
+const CLOUD_WORKER_BASE = process.env.OYSTER_CLOUD_BASE ?? "https://cloud.oyster.to";
+
 // VIEWER_BASE is the public origin where /p/{token} renders (issue #397).
 // In production it's a separate subdomain so untrusted published content
 // can't read main-app cookies/storage. In local wrangler dev, the API and

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -127,6 +127,11 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     this.onWrite = cb;
   }
 
+  /** Internal DB handle for the sync service ONLY. Do not use elsewhere —
+   *  sync needs it for batched outbox queries; everything else should go
+   *  through the provider's typed methods. */
+  getInternalDbForSync(): Database.Database { return this.db; }
+
   async init(): Promise<void> {
     mkdirSync(this.storagePath, { recursive: true });
     const dbPath = join(this.storagePath, "memory.db");

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -112,9 +112,19 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
   // transaction so a 50-row recall is one fsync, not 100.
   private postRecallTxn!: (rows: MemoryRow[], recallerId: string | null) => void;
   private storagePath: string;
+  /** Fire-and-forget sync trigger. Set by the server after init() to call
+   *  memorySync.pushPending(). Errors are swallowed; the hook must not
+   *  throw into the write path. */
+  private onWrite: (() => void) | null = null;
 
   constructor(storagePath: string) {
     this.storagePath = storagePath;
+  }
+
+  /** Register a callback that fires (via queueMicrotask) after every
+   *  successful event write. Replaces any previously registered callback. */
+  setOnWrite(cb: () => void): void {
+    this.onWrite = cb;
   }
 
   async init(): Promise<void> {
@@ -360,6 +370,7 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       this.materialiseMemory(memory_id, { ssid });
     });
     txn();
+    queueMicrotask(() => { try { this.onWrite?.(); } catch { /* swallowed */ } });
     return { memory_id, event_id: returned_event_id, inserted };
   }
 
@@ -516,6 +527,7 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       this.materialiseMemory(memory_id);
     });
     txn();
+    queueMicrotask(() => { try { this.onWrite?.(); } catch { /* swallowed */ } });
     return inserted;
   }
 
@@ -540,6 +552,7 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
       this.materialiseMemory(memory_id);
     });
     txn();
+    queueMicrotask(() => { try { this.onWrite?.(); } catch { /* swallowed */ } });
     return inserted;
   }
 

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -86,6 +86,21 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
         space_id: string | null; created_at: number;
       };
 
+      // Hoist prepared statements out of the drain loop — recompiling the same
+      // SQL each iteration is wasteful for fresh-sign-in flushes that may run
+      // many batches.
+      const scanPending = deps.db.prepare(
+        `SELECT event_id, memory_id, event_type, space_id, created_at
+           FROM memory_events
+          WHERE cloud_synced_at IS NULL
+            AND cloud_owner_id = ?
+          ORDER BY created_at ASC
+          LIMIT ?`,
+      );
+      const fetchPayload = deps.db.prepare(
+        `SELECT content, tags FROM memory_payloads WHERE memory_id = ?`,
+      );
+
       // Drain loop: keep flushing batches until no pending events remain
       // for the current owner. Without this, a fresh sign-in with N>BATCH
       // pending events would only push the first batch, then stall until
@@ -96,28 +111,17 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
       const MAX_BATCHES = 1000;
 
       for (let i = 0; i < MAX_BATCHES; i++) {
-        const pending = deps.db.prepare(
-          `SELECT event_id, memory_id, event_type, space_id, created_at
-             FROM memory_events
-            WHERE cloud_synced_at IS NULL
-              AND cloud_owner_id = ?
-            ORDER BY created_at ASC
-            LIMIT ?`,
-        ).all(session.user.id, BATCH_SIZE) as Pending[];
+        const pending = scanPending.all(session.user.id, BATCH_SIZE) as Pending[];
 
         if (pending.length === 0) break;
 
-        // For created events, fetch content/tags from payloads to attach.
-        const payloadStmt = deps.db.prepare(
-          `SELECT content, tags FROM memory_payloads WHERE memory_id = ?`,
-        );
         const events: OutgoingEvent[] = pending.map((p) => {
           const out: OutgoingEvent = {
             event_id: p.event_id, memory_id: p.memory_id, event_type: p.event_type,
             space_id: p.space_id, created_at: p.created_at,
           };
           if (p.event_type === "memory_created") {
-            const pay = payloadStmt.get(p.memory_id) as { content: string | null; tags: string } | undefined;
+            const pay = fetchPayload.get(p.memory_id) as { content: string | null; tags: string } | undefined;
             if (pay && pay.content !== null) {
               out.payload = { content: pay.content, tags: JSON.parse(pay.tags) };
             }
@@ -245,11 +249,27 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
           WHERE event_id = ?`,
       );
       const upsertPayload = deps.db.prepare(
+        // Purge-guard: never overwrite content/tags when a memory_purged event
+        // exists locally for this memory_id. Belt-and-braces alongside
+        // materialiseMemory's authoritative pass — keeps the invariant explicit
+        // in SQL rather than relying on the post-pass call.
         `INSERT INTO memory_payloads (memory_id, content, tags, purged_at)
          VALUES (?, ?, ?, ?)
          ON CONFLICT(memory_id) DO UPDATE SET
-           content   = excluded.content,
-           tags      = excluded.tags,
+           content   = CASE
+             WHEN EXISTS (SELECT 1 FROM memory_events
+                            WHERE memory_id = memory_payloads.memory_id
+                              AND event_type = 'memory_purged')
+               THEN NULL
+             ELSE excluded.content
+           END,
+           tags      = CASE
+             WHEN EXISTS (SELECT 1 FROM memory_events
+                            WHERE memory_id = memory_payloads.memory_id
+                              AND event_type = 'memory_purged')
+               THEN '[]'
+             ELSE excluded.tags
+           END,
            purged_at = excluded.purged_at`,
       );
 

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -68,16 +68,12 @@ function isProSession(deps: MemorySyncDeps): { user: SyncUser; token: string } |
 const BATCH_SIZE = 100;
 
 export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService {
-  return {
-    async reconcile() {
-      const session = isProSession(deps);
-      if (!session) return { pulled: 0, pushed: 0 };
-      const pulled = await this.pull();
-      const pushed = await this.pushPending();
-      return { pulled, pushed };
-    },
+  // In-flight guard: a single drain pass at a time. Concurrent callers
+  // (e.g. multiple onWrite triggers in quick succession) await the same
+  // promise rather than racing.
+  let inFlightPush: Promise<number> | null = null;
 
-    async pushPending() {
+  async function doPushPending(): Promise<number> {
       const session = isProSession(deps);
       if (!session) return 0;
 
@@ -209,13 +205,13 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
       // next reconcile cycle will see the now-richer local state and may or
       // may not still have something to push.
       if (conflictPullScheduled) {
-        try { await this.pull(); } catch { /* swallowed; logged elsewhere */ }
+        try { await pull(); } catch { /* swallowed; logged elsewhere */ }
       }
 
       return totalAccepted;
-    },
+  }
 
-    async pull() {
+  async function pull(): Promise<number> {
       const session = isProSession(deps);
       if (!session) return 0;
 
@@ -311,6 +307,27 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
       txn();
 
       return applied;
+  }
+
+  return {
+    async reconcile() {
+      const session = isProSession(deps);
+      if (!session) return { pulled: 0, pushed: 0 };
+      const pulled = await pull();
+      const pushed = await this.pushPending();
+      return { pulled, pushed };
     },
+
+    async pushPending() {
+      if (inFlightPush) return inFlightPush;
+      inFlightPush = doPushPending();
+      try {
+        return await inFlightPush;
+      } finally {
+        inFlightPush = null;
+      }
+    },
+
+    pull,
   };
 }

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -1,0 +1,290 @@
+// memory-sync-service.ts — cross-device sync of the local memory store (#318).
+// Spec: docs/superpowers/specs/2026-05-08-memory-sync-design.md
+//
+// Pattern: append-only event log + redactable payload store. Push pending
+// events from the outbox; pull cloud events and replay locally using the
+// precedence rule purged > forgotten > created. Pro-only. Reconcile runs on
+// sign-in and at app start.
+
+import type Database from "better-sqlite3";
+import type { SqliteFtsMemoryProvider } from "./memory-store.js";
+import type { ProfileBindingService } from "./profile-binding-service.js";
+
+interface SyncUser { id: string; email: string; tier: string }
+
+export interface MemorySyncDeps {
+  db: Database.Database;
+  provider: SqliteFtsMemoryProvider;
+  /** Required: gates pull AND push on profile ownership so a second Pro
+   *  account signing into the same local profile cannot pollute the local
+   *  SQLite with their cloud events. See Task 4.4. */
+  profileBinding: ProfileBindingService;
+  currentUser: () => SyncUser | null;
+  sessionToken: () => string | null;
+  workerBase: string;
+  fetch: typeof fetch;
+}
+
+export interface MemorySyncService {
+  reconcile(): Promise<{ pulled: number; pushed: number }>;
+  pushPending(): Promise<number>;
+  pull(): Promise<number>;
+}
+
+interface OutgoingEvent {
+  event_id: string;
+  memory_id: string;
+  event_type: "memory_created" | "memory_forgotten" | "memory_purged";
+  space_id: string | null;
+  created_at: number;
+  payload?: { content: string; tags: string[] };
+}
+
+interface IncomingEvent {
+  event_id: string;
+  memory_id: string;
+  event_type: "memory_created" | "memory_forgotten" | "memory_purged";
+  space_id: string | null;
+  created_at: number;
+  payload?: { content: string | null; tags: string[]; purged_at: number | null };
+}
+
+function isProSession(deps: MemorySyncDeps): { user: SyncUser; token: string } | null {
+  const user = deps.currentUser();
+  const token = deps.sessionToken();
+  if (!user || !token || user.tier !== "pro") return null;
+  // Profile-owner gate: refuses sync when this local profile is bound to
+  // a different account. Prevents User B's cloud events from being pulled
+  // into User A's local SQLite (Task 4.4).
+  if (!deps.profileBinding.isOwnedBy(user.id)) {
+    console.warn(
+      `[memory] sync blocked — profile is bound to a different account; current=${user.id}, bound=${deps.profileBinding.getBoundOwner()}`,
+    );
+    return null;
+  }
+  return { user, token };
+}
+
+const BATCH_SIZE = 100;
+
+export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService {
+  return {
+    async reconcile() {
+      const session = isProSession(deps);
+      if (!session) return { pulled: 0, pushed: 0 };
+      const pulled = await this.pull();
+      const pushed = await this.pushPending();
+      return { pulled, pushed };
+    },
+
+    async pushPending() {
+      const session = isProSession(deps);
+      if (!session) return 0;
+
+      type Pending = {
+        event_id: string; memory_id: string; event_type: OutgoingEvent["event_type"];
+        space_id: string | null; created_at: number;
+      };
+
+      // Drain loop: keep flushing batches until no pending events remain
+      // for the current owner. Without this, a fresh sign-in with N>BATCH
+      // pending events would only push the first batch, then stall until
+      // the next reconcile trigger.
+      let totalAccepted = 0;
+      let conflictPullScheduled = false;
+      // Defensive safety cap so a misbehaving server can't loop forever.
+      const MAX_BATCHES = 1000;
+
+      for (let i = 0; i < MAX_BATCHES; i++) {
+        const pending = deps.db.prepare(
+          `SELECT event_id, memory_id, event_type, space_id, created_at
+             FROM memory_events
+            WHERE cloud_synced_at IS NULL
+              AND cloud_owner_id = ?
+            ORDER BY created_at ASC
+            LIMIT ?`,
+        ).all(session.user.id, BATCH_SIZE) as Pending[];
+
+        if (pending.length === 0) break;
+
+        // For created events, fetch content/tags from payloads to attach.
+        const payloadStmt = deps.db.prepare(
+          `SELECT content, tags FROM memory_payloads WHERE memory_id = ?`,
+        );
+        const events: OutgoingEvent[] = pending.map((p) => {
+          const out: OutgoingEvent = {
+            event_id: p.event_id, memory_id: p.memory_id, event_type: p.event_type,
+            space_id: p.space_id, created_at: p.created_at,
+          };
+          if (p.event_type === "memory_created") {
+            const pay = payloadStmt.get(p.memory_id) as { content: string | null; tags: string } | undefined;
+            if (pay && pay.content !== null) {
+              out.payload = { content: pay.content, tags: JSON.parse(pay.tags) };
+            }
+            // If content is locally NULL (purged before push), the worker
+            // accepts the create only if a same-batch or pre-existing purge
+            // exists for the memory_id; otherwise it lands in `rejected`.
+          }
+          return out;
+        });
+
+        let res: Response;
+        try {
+          res = await deps.fetch(`${deps.workerBase}/api/memories/events`, {
+            method: "POST",
+            headers: { Cookie: `oyster_session=${session.token}`, "content-type": "application/json" },
+            body: JSON.stringify({ events }),
+          });
+        } catch (err) {
+          console.warn("[memory] pushPending failed:", err);
+          return totalAccepted;
+        }
+        if (!res.ok) {
+          console.warn(`[memory] pushPending non-ok ${res.status}`);
+          return totalAccepted;
+        }
+        const body = await res.json().catch(() => null) as {
+          accepted?: string[]; duplicates?: string[]; conflicts?: string[]; rejected?: string[];
+        } | null;
+        const accepted   = body?.accepted   ?? [];
+        const duplicates = body?.duplicates ?? [];
+        const conflicts  = body?.conflicts  ?? [];
+        const rejected   = body?.rejected   ?? [];
+
+        if (rejected.length > 0) {
+          // Surface to logs but do NOT mark synced — these stay pending so a
+          // human or follow-up code can investigate. Rejected typically means
+          // a malformed event or a memory_created without payload that cloud
+          // had no purge for. Should never happen with healthy clients.
+          console.warn(`[memory] pushPending rejected events: ${rejected.join(", ")}`);
+        }
+
+        if (conflicts.length > 0) {
+          // Conflicts mean cloud already has an authoritative event of that
+          // type for the memory_id (different event_id). Do NOT blindly mark
+          // synced — that risks dropping a legitimate local event with
+          // different content (e.g. retry races, deterministic-id bugs).
+          // Warn and trigger a pull so cloud's authoritative state lands
+          // locally; the next reconcile cycle decides whether the local
+          // pending event still has business existing.
+          console.warn(
+            `[memory] pushPending conflicts (cloud has another event of this type for the memory_id): ${conflicts.join(", ")} — pulling to reconcile`,
+          );
+          conflictPullScheduled = true;
+        }
+
+        // Safe to mark synced: accepted (newly inserted) and duplicates
+        // (cloud already had this exact event_id — the round-trip race that
+        // Issue 3 covers). Conflicts and rejects stay pending.
+        const now = Date.now();
+        const markStmt = deps.db.prepare(
+          `UPDATE memory_events SET cloud_synced_at = ? WHERE event_id = ?`,
+        );
+        const markTxn = deps.db.transaction(() => {
+          for (const id of accepted)   markStmt.run(now, id);
+          for (const id of duplicates) markStmt.run(now, id);
+        });
+        markTxn();
+        totalAccepted += accepted.length;
+
+        // Termination condition: count only "things that cleared from the
+        // outbox" as progress. A batch with only conflicts/rejected events
+        // breaks out of the drain loop so we don't hot-loop.
+        const progress = accepted.length + duplicates.length;
+        if (progress === 0) break;
+      }
+
+      // If any conflicts surfaced, run a pull so the authoritative cloud
+      // state lands locally. The conflicting local events stay pending; the
+      // next reconcile cycle will see the now-richer local state and may or
+      // may not still have something to push.
+      if (conflictPullScheduled) {
+        try { await this.pull(); } catch { /* swallowed; logged elsewhere */ }
+      }
+
+      return totalAccepted;
+    },
+
+    async pull() {
+      const session = isProSession(deps);
+      if (!session) return 0;
+
+      let res: Response;
+      try {
+        res = await deps.fetch(`${deps.workerBase}/api/memories/events`, {
+          headers: { Cookie: `oyster_session=${session.token}` },
+        });
+      } catch (err) {
+        console.warn("[memory] pull failed:", err);
+        return 0;
+      }
+      if (!res.ok) {
+        console.warn(`[memory] pull non-ok ${res.status}`);
+        return 0;
+      }
+      const body = await res.json().catch(() => null) as { events?: IncomingEvent[] } | null;
+      const cloud = body?.events ?? [];
+
+      let applied = 0;
+      const insertEv = deps.db.prepare(
+        // Tag with cloud_owner_id from the current session so the dirty
+        // predicate can scope to "this user's events" cleanly. cloud_synced_at
+        // is set unconditionally (event came from cloud, definitionally synced).
+        `INSERT OR IGNORE INTO memory_events
+           (event_id, memory_id, event_type, space_id, cloud_owner_id, created_at, cloud_synced_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      );
+      // For events that already exist locally (race: client pushed first then
+      // pull saw them in cloud), mark them synced so the outbox stops retrying.
+      // Without this, a pending event whose round-trip went out before the
+      // push response arrived would stay dirty forever.
+      const markSyncedStmt = deps.db.prepare(
+        `UPDATE memory_events
+            SET cloud_synced_at = COALESCE(cloud_synced_at, ?),
+                cloud_owner_id  = COALESCE(cloud_owner_id,  ?)
+          WHERE event_id = ?`,
+      );
+      const upsertPayload = deps.db.prepare(
+        `INSERT INTO memory_payloads (memory_id, content, tags, purged_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(memory_id) DO UPDATE SET
+           content   = excluded.content,
+           tags      = excluded.tags,
+           purged_at = excluded.purged_at`,
+      );
+
+      const now = Date.now();
+      const txn = deps.db.transaction(() => {
+        const touched = new Set<string>();
+        for (const ev of cloud) {
+          const r = insertEv.run(
+            ev.event_id, ev.memory_id, ev.event_type, ev.space_id,
+            session.user.id, ev.created_at, now,
+          );
+          if (r.changes > 0) {
+            applied++;
+          } else {
+            // Event already existed locally — reconcile cloud_synced_at so
+            // pushPending stops retrying. COALESCE preserves any earlier
+            // sync timestamp.
+            markSyncedStmt.run(now, session.user.id, ev.event_id);
+          }
+          if (ev.event_type === "memory_created" && ev.payload) {
+            // Cloud's content reflects redaction. If purged, content is NULL +
+            // purged_at set; we mirror that.
+            upsertPayload.run(
+              ev.memory_id, ev.payload.content, JSON.stringify(ev.payload.tags ?? []), ev.payload.purged_at,
+            );
+          }
+          touched.add(ev.memory_id);
+        }
+        // Re-materialise affected memory_ids inside the same txn so the FTS5
+        // recall surface and the event/payload tables stay atomically consistent.
+        for (const id of touched) deps.provider.materialiseMemory(id);
+      });
+      txn();
+
+      return applied;
+    },
+  };
+}

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -94,7 +94,13 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
            FROM memory_events
           WHERE cloud_synced_at IS NULL
             AND cloud_owner_id = ?
-          ORDER BY created_at ASC
+          ORDER BY
+            CASE event_type
+              WHEN 'memory_purged'    THEN 0
+              WHEN 'memory_forgotten' THEN 1
+              WHEN 'memory_created'   THEN 2
+            END,
+            created_at ASC
           LIMIT ?`,
       );
       const fetchPayload = deps.db.prepare(

--- a/server/src/profile-binding-service.ts
+++ b/server/src/profile-binding-service.ts
@@ -1,0 +1,57 @@
+// profile-binding-service.ts — one-time binding of the local Oyster profile
+// to a single cloud account. Prevents two different Pro users from sharing
+// the same local SQLite via cross-device sync. Used by every cloud sync
+// service (memory now, spaces and sessions later) before pull or push.
+
+import type Database from "better-sqlite3";
+
+export interface ProfileBindingDeps {
+  db: Database.Database;
+}
+
+export type BindResult =
+  | { bound: true;  reason: "bound" | "already_matches" }
+  | { bound: false; reason: "conflict" };
+
+export interface ProfileBindingService {
+  /** Returns the cloud_owner_id this profile is bound to, or null if unbound. */
+  getBoundOwner(): string | null;
+  /** Binds the profile to ownerId on first call. Idempotent for the same
+   *  owner. Returns `conflict` (bound=false) if a different owner is already
+   *  bound — caller must treat that as a hard block on cloud sync. */
+  bindToOwner(ownerId: string): BindResult;
+  /** True when userId is the bound owner, OR the profile is not yet bound.
+   *  False for null userId (not signed in) when bound, and for any userId
+   *  that doesn't match the existing binding. */
+  isOwnedBy(userId: string | null): boolean;
+}
+
+export function createProfileBindingService(deps: ProfileBindingDeps): ProfileBindingService {
+  const getStmt = deps.db.prepare(
+    `SELECT cloud_owner_id FROM profile_binding WHERE id = 1`,
+  );
+  const insertStmt = deps.db.prepare(
+    `INSERT INTO profile_binding (id, cloud_owner_id, bound_at) VALUES (1, ?, ?)`,
+  );
+
+  function getBoundOwner(): string | null {
+    const row = getStmt.get() as { cloud_owner_id: string } | undefined;
+    return row?.cloud_owner_id ?? null;
+  }
+
+  function bindToOwner(ownerId: string): BindResult {
+    const existing = getBoundOwner();
+    if (existing === ownerId) return { bound: true, reason: "already_matches" };
+    if (existing !== null)    return { bound: false, reason: "conflict" };
+    insertStmt.run(ownerId, Date.now());
+    return { bound: true, reason: "bound" };
+  }
+
+  function isOwnedBy(userId: string | null): boolean {
+    if (userId === null) return false;
+    const owner = getBoundOwner();
+    return owner === null || owner === userId;
+  }
+
+  return { getBoundOwner, bindToOwner, isOwnedBy };
+}

--- a/server/src/profile-binding-service.ts
+++ b/server/src/profile-binding-service.ts
@@ -20,9 +20,10 @@ export interface ProfileBindingService {
    *  owner. Returns `conflict` (bound=false) if a different owner is already
    *  bound — caller must treat that as a hard block on cloud sync. */
   bindToOwner(ownerId: string): BindResult;
-  /** True when userId is the bound owner, OR the profile is not yet bound.
-   *  False for null userId (not signed in) when bound, and for any userId
-   *  that doesn't match the existing binding. */
+  /** True if userId is non-null AND (the profile is unbound OR bound to userId).
+   *  False if userId is null, or if bound to a different user. A null user is
+   *  never an owner — sync gates use this to refuse the un-attributable case
+   *  cleanly. Use this as the gate in cloud sync services. */
   isOwnedBy(userId: string | null): boolean;
 }
 

--- a/server/src/space-sync-service.ts
+++ b/server/src/space-sync-service.ts
@@ -12,6 +12,7 @@
 
 import type Database from "better-sqlite3";
 import type { SpaceStore, SpaceRow } from "./space-store.js";
+import type { ProfileBindingService } from "./profile-binding-service.js";
 
 export interface SyncUser {
   id: string;
@@ -22,6 +23,11 @@ export interface SyncUser {
 export interface SpaceSyncDeps {
   db: Database.Database;
   store: SpaceStore;
+  /** Required: gates pull AND push on profile ownership so a second Pro
+   *  account signing into the same local profile cannot push spaces into
+   *  the wrong cloud bucket or pull spaces into the wrong local DB.
+   *  See Task 4.4 of docs/superpowers/plans/2026-05-08-memory-sync.md. */
+  profileBinding: ProfileBindingService;
   currentUser: () => SyncUser | null;
   sessionToken: () => string | null;
   workerBase: string;
@@ -64,12 +70,19 @@ interface CloudDeleteResponse {
   updated_at: number;
 }
 
-/** Pro tier check. Spec: R1 (this wedge) is Pro-only per the requirements doc
- *  tier mapping. Keep in one place so it's easy to change if the gate moves. */
+/** Pro tier + profile ownership check. Returns the active session or null.
+ *  Gates both push and pull so a second Pro user sharing the same local
+ *  SQLite cannot contaminate either cloud bucket or local DB. */
 function isProSession(deps: SpaceSyncDeps): { user: SyncUser; token: string } | null {
   const user = deps.currentUser();
   const token = deps.sessionToken();
   if (!user || !token || user.tier !== "pro") return null;
+  if (!deps.profileBinding.isOwnedBy(user.id)) {
+    console.warn(
+      `[spaces] sync blocked — profile is bound to a different account; current=${user.id}, bound=${deps.profileBinding.getBoundOwner()}`,
+    );
+    return null;
+  }
   return { user, token };
 }
 

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -584,3 +584,42 @@ describe("backfill from legacy memories rows", () => {
     provider2.close();
   });
 });
+
+describe("onWrite hook", () => {
+  it("fires after remember (writeCreated path)", async () => {
+    const t = tmp("onwrite-remember-");
+    const provider = new SqliteFtsMemoryProvider(t);
+    await provider.init();
+    let calls = 0;
+    provider.setOnWrite(() => { calls++; });
+    await provider.remember({ content: "hook test" });
+    // queueMicrotask fires after the current microtask checkpoint
+    await Promise.resolve();
+    expect(calls).toBe(1);
+    provider.close();
+  });
+
+  it("fires after forget and purge (writeForgotten / writePurged paths)", async () => {
+    const t = tmp("onwrite-forget-purge-");
+    const provider = new SqliteFtsMemoryProvider(t);
+    await provider.init();
+    let calls = 0;
+    provider.setOnWrite(() => { calls++; });
+    const { memory_id } = provider.writeCreated({ content: "to be forgotten" });
+    await Promise.resolve(); // drain writeCreated hook
+    calls = 0; // reset after writeCreated
+
+    provider.writeForgotten(memory_id);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+
+    const { memory_id: mid2 } = provider.writeCreated({ content: "to be purged" });
+    await Promise.resolve();
+    calls = 0; // reset after second writeCreated
+
+    provider.writePurged(mid2);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+    provider.close();
+  });
+});

--- a/server/test/memory-sync-service.test.ts
+++ b/server/test/memory-sync-service.test.ts
@@ -26,7 +26,7 @@ describe("MemorySyncService", () => {
     await provider.init();
     const fetchSpy = vi.fn();
     const svc = createMemorySyncService({
-      db: (provider as any).db,
+      db: provider.getInternalDbForSync(),
       provider,
       profileBinding,
       currentUser: () => ({ id: "u1", email: "x@x", tier: "free" }),
@@ -46,7 +46,7 @@ describe("MemorySyncService", () => {
 
     const fetchSpy = vi.fn();
     const svc = createMemorySyncService({
-      db: (provider as any).db,
+      db: provider.getInternalDbForSync(),
       provider,
       profileBinding,
       currentUser: () => ({ id: "user-B", email: "b@x", tier: "pro" }),
@@ -78,7 +78,7 @@ describe("MemorySyncService", () => {
     });
 
     const svc = createMemorySyncService({
-      db: (provider as any).db,
+      db: provider.getInternalDbForSync(),
       provider,
       profileBinding,
       currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
@@ -92,7 +92,7 @@ describe("MemorySyncService", () => {
     expect(fetchSpy).toHaveBeenCalledOnce();
 
     // Pending row count should drop to 0.
-    const db = (provider as any).db as Database.Database;
+    const db = provider.getInternalDbForSync() as Database.Database;
     const c = db.prepare(`SELECT COUNT(*) as c FROM memory_events WHERE cloud_synced_at IS NULL`).get() as { c: number };
     expect(c.c).toBe(0);
   });
@@ -119,7 +119,7 @@ describe("MemorySyncService", () => {
     ));
 
     const svc = createMemorySyncService({
-      db: (provider as any).db,
+      db: provider.getInternalDbForSync(),
       provider,
       profileBinding,
       currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
@@ -140,7 +140,7 @@ describe("MemorySyncService", () => {
     profileBinding.bindToOwner("u1");
     // Local creates a memory; the event is pending (cloud_synced_at IS NULL).
     const m = await provider.remember({ content: "round-trip", cloud_owner_id: "u1" });
-    const db = (provider as any).db as Database.Database;
+    const db = provider.getInternalDbForSync() as Database.Database;
     const localEvent = db.prepare(
       `SELECT event_id, cloud_synced_at FROM memory_events WHERE memory_id = ?`,
     ).get(m.id) as { event_id: string; cloud_synced_at: number | null };
@@ -195,7 +195,7 @@ describe("MemorySyncService", () => {
     ));
 
     const svc = createMemorySyncService({
-      db: (provider as any).db,
+      db: provider.getInternalDbForSync(),
       provider,
       profileBinding,
       currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
@@ -219,7 +219,7 @@ describe("MemorySyncService", () => {
 
     const fetchSpy = vi.fn().mockRejectedValue(new TypeError("network"));
     const svc = createMemorySyncService({
-      db: (provider as any).db,
+      db: provider.getInternalDbForSync(),
       provider,
       profileBinding,
       currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
@@ -231,7 +231,7 @@ describe("MemorySyncService", () => {
     const pushed = await svc.pushPending();
     expect(pushed).toBe(0);
 
-    const db = (provider as any).db as Database.Database;
+    const db = provider.getInternalDbForSync() as Database.Database;
     const c = db.prepare(`SELECT COUNT(*) as c FROM memory_events WHERE cloud_synced_at IS NULL`).get() as { c: number };
     expect(c.c).toBe(1);
   });

--- a/server/test/memory-sync-service.test.ts
+++ b/server/test/memory-sync-service.test.ts
@@ -211,6 +211,45 @@ describe("MemorySyncService", () => {
     expect(found).toHaveLength(0);
   });
 
+  it("concurrent pushPending calls share a single drain pass (no duplicate POSTs)", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+    await provider.remember({ content: "p1", cloud_owner_id: "u1" });
+    await provider.remember({ content: "p2", cloud_owner_id: "u1" });
+
+    let postCount = 0;
+    const fetchSpy = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      postCount++;
+      const body = JSON.parse(init.body as string) as { events: Array<{ event_id: string }> };
+      // Slight delay so concurrent callers can interleave.
+      await new Promise((r) => setTimeout(r, 10));
+      return new Response(
+        JSON.stringify({
+          accepted: body.events.map((e) => e.event_id),
+          duplicates: [], conflicts: [], rejected: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const svc = createMemorySyncService({
+      db: provider.getInternalDbForSync(),
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    // Fire two concurrent pushPending calls. Without coalescing, fetchSpy
+    // would be called twice (one per drain). With coalescing, only one.
+    const [r1, r2] = await Promise.all([svc.pushPending(), svc.pushPending()]);
+    expect(r1).toBe(r2);
+    expect(postCount).toBe(1);
+  });
+
   it("network errors during push are swallowed; events stay pending", async () => {
     const { provider, profileBinding } = harness();
     await provider.init();

--- a/server/test/memory-sync-service.test.ts
+++ b/server/test/memory-sync-service.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { SqliteFtsMemoryProvider } from "../src/memory-store.js";
+import { createMemorySyncService } from "../src/memory-sync-service.js";
+import { createProfileBindingService } from "../src/profile-binding-service.js";
+
+function harness() {
+  const tmp = mkdtempSync(join(tmpdir(), "memsync-"));
+  const provider = new SqliteFtsMemoryProvider(tmp);
+  // Each test gets its own profile_binding table in a separate in-memory DB
+  // so binding state doesn't bleed between tests.
+  const bindingDb = new Database(":memory:");
+  bindingDb.exec(
+    `CREATE TABLE profile_binding (id INTEGER PRIMARY KEY CHECK (id=1), cloud_owner_id TEXT NOT NULL, bound_at INTEGER NOT NULL)`,
+  );
+  const profileBinding = createProfileBindingService({ db: bindingDb });
+  return { tmp, provider, profileBinding };
+}
+
+describe("MemorySyncService", () => {
+  it("reconcile is a no-op for free users", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    const fetchSpy = vi.fn();
+    const svc = createMemorySyncService({
+      db: (provider as any).db,
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "free" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+    const r = await svc.reconcile();
+    expect(r).toEqual({ pulled: 0, pushed: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconcile is a no-op when profile is bound to a different account", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("user-A");
+
+    const fetchSpy = vi.fn();
+    const svc = createMemorySyncService({
+      db: (provider as any).db,
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "user-B", email: "b@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+    const r = await svc.reconcile();
+    expect(r).toEqual({ pulled: 0, pushed: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("pushPending sends pending events and marks them synced", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+    const m = await provider.remember({ content: "hello", cloud_owner_id: "u1" });
+
+    // Mock: server accepts whatever event_ids we send.
+    const fetchSpy = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { events: Array<{ event_id: string }> };
+      return new Response(
+        JSON.stringify({
+          accepted: body.events.map((e) => e.event_id),
+          duplicates: [], conflicts: [], rejected: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const svc = createMemorySyncService({
+      db: (provider as any).db,
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const pushed = await svc.pushPending();
+    expect(pushed).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    // Pending row count should drop to 0.
+    const db = (provider as any).db as Database.Database;
+    const c = db.prepare(`SELECT COUNT(*) as c FROM memory_events WHERE cloud_synced_at IS NULL`).get() as { c: number };
+    expect(c.c).toBe(0);
+  });
+
+  it("pull applies remote events and materialises memories locally", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        events: [
+          {
+            event_id:  "ev-r1",
+            memory_id: "mem-r1",
+            event_type: "memory_created",
+            space_id: null,
+            created_at: 1000,
+            payload: { content: "from-cloud", tags: [], purged_at: null },
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+
+    const svc = createMemorySyncService({
+      db: (provider as any).db,
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const pulled = await svc.pull();
+    expect(pulled).toBe(1);
+    const list = await provider.list();
+    expect(list.find((m) => m.id === "mem-r1")?.content).toBe("from-cloud");
+  });
+
+  it("pull marks a local pending event as synced when it appears in cloud", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+    // Local creates a memory; the event is pending (cloud_synced_at IS NULL).
+    const m = await provider.remember({ content: "round-trip", cloud_owner_id: "u1" });
+    const db = (provider as any).db as Database.Database;
+    const localEvent = db.prepare(
+      `SELECT event_id, cloud_synced_at FROM memory_events WHERE memory_id = ?`,
+    ).get(m.id) as { event_id: string; cloud_synced_at: number | null };
+    expect(localEvent.cloud_synced_at).toBeNull();
+
+    // Cloud's GET returns the same event_id (e.g. push went through but the
+    // response was lost; the event is in cloud, local thinks it's pending).
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        events: [{
+          event_id:  localEvent.event_id,
+          memory_id: m.id,
+          event_type: "memory_created",
+          space_id: null,
+          created_at: 1000,
+          payload: { content: "round-trip", tags: [], purged_at: null },
+        }],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+
+    const svc = createMemorySyncService({
+      db, provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    await svc.pull();
+
+    const after = db.prepare(
+      `SELECT cloud_synced_at FROM memory_events WHERE event_id = ?`,
+    ).get(localEvent.event_id) as { cloud_synced_at: number | null };
+    expect(after.cloud_synced_at).not.toBeNull();
+  });
+
+  it("pull respects purge precedence — late create does not restore content", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        events: [
+          { event_id: "ev-purge",  memory_id: "mem-X", event_type: "memory_purged",  space_id: null, created_at: 2000 },
+          { event_id: "ev-create", memory_id: "mem-X", event_type: "memory_created", space_id: null, created_at: 1000, payload: { content: "leak", tags: [], purged_at: null } },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+
+    const svc = createMemorySyncService({
+      db: (provider as any).db,
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    await svc.pull();
+    const list = await provider.list();
+    expect(list).toHaveLength(0);
+    const found = await provider.recall({ query: "leak" });
+    expect(found).toHaveLength(0);
+  });
+
+  it("network errors during push are swallowed; events stay pending", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+    await provider.remember({ content: "stays-dirty", cloud_owner_id: "u1" });
+
+    const fetchSpy = vi.fn().mockRejectedValue(new TypeError("network"));
+    const svc = createMemorySyncService({
+      db: (provider as any).db,
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const pushed = await svc.pushPending();
+    expect(pushed).toBe(0);
+
+    const db = (provider as any).db as Database.Database;
+    const c = db.prepare(`SELECT COUNT(*) as c FROM memory_events WHERE cloud_synced_at IS NULL`).get() as { c: number };
+    expect(c.c).toBe(1);
+  });
+});

--- a/server/test/profile-binding-service.test.ts
+++ b/server/test/profile-binding-service.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { createProfileBindingService } from "../src/profile-binding-service.js";
+
+function freshDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE profile_binding (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      cloud_owner_id TEXT NOT NULL,
+      bound_at INTEGER NOT NULL
+    )
+  `);
+  return db;
+}
+
+describe("ProfileBindingService", () => {
+  it("getBoundOwner returns null on a fresh profile", () => {
+    const svc = createProfileBindingService({ db: freshDb() });
+    expect(svc.getBoundOwner()).toBeNull();
+  });
+
+  it("bindToOwner binds a fresh profile and reports `bound`", () => {
+    const svc = createProfileBindingService({ db: freshDb() });
+    expect(svc.bindToOwner("user-A")).toEqual({ bound: true, reason: "bound" });
+    expect(svc.getBoundOwner()).toBe("user-A");
+  });
+
+  it("bindToOwner is idempotent for the same owner", () => {
+    const svc = createProfileBindingService({ db: freshDb() });
+    svc.bindToOwner("user-A");
+    expect(svc.bindToOwner("user-A")).toEqual({ bound: true, reason: "already_matches" });
+  });
+
+  it("bindToOwner refuses a different owner — reports `conflict`", () => {
+    const svc = createProfileBindingService({ db: freshDb() });
+    svc.bindToOwner("user-A");
+    expect(svc.bindToOwner("user-B")).toEqual({ bound: false, reason: "conflict" });
+    expect(svc.getBoundOwner()).toBe("user-A");
+  });
+
+  it("isOwnedBy returns true when binding is null OR matches", () => {
+    const svc = createProfileBindingService({ db: freshDb() });
+    expect(svc.isOwnedBy("user-A")).toBe(true);
+    svc.bindToOwner("user-A");
+    expect(svc.isOwnedBy("user-A")).toBe(true);
+    expect(svc.isOwnedBy("user-B")).toBe(false);
+  });
+
+  it("isOwnedBy returns false for null user when bound", () => {
+    const svc = createProfileBindingService({ db: freshDb() });
+    svc.bindToOwner("user-A");
+    expect(svc.isOwnedBy(null)).toBe(false);
+  });
+});

--- a/server/test/space-sync-service.test.ts
+++ b/server/test/space-sync-service.test.ts
@@ -2,6 +2,19 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { SqliteSpaceStore } from "../src/space-store.js";
 import { createSpaceSyncService } from "../src/space-sync-service.js";
+import { createProfileBindingService, type ProfileBindingService } from "../src/profile-binding-service.js";
+
+/** Creates an in-memory ProfileBindingService already bound to userId so
+ *  existing happy-path tests don't have to set up the binding themselves. */
+function makeBoundProfileBinding(userId: string): ProfileBindingService {
+  const db = new Database(":memory:");
+  db.exec(
+    `CREATE TABLE profile_binding (id INTEGER PRIMARY KEY CHECK (id=1), cloud_owner_id TEXT NOT NULL, bound_at INTEGER NOT NULL)`,
+  );
+  const svc = createProfileBindingService({ db });
+  svc.bindToOwner(userId);
+  return svc;
+}
 
 function makeDb(): Database.Database {
   const db = new Database(":memory:");
@@ -74,6 +87,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => null,
       sessionToken: () => null,
       workerBase: "https://oyster.to",
@@ -90,6 +104,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => FREE_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -116,6 +131,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -148,6 +164,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -191,6 +208,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -221,6 +239,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -259,6 +278,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -290,6 +310,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -319,6 +340,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -339,6 +361,7 @@ describe("createSpaceSyncService — reconcile()", () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ spaces: [] }), { status: 200 }));
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -367,6 +390,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => null,
       sessionToken: () => null,
       workerBase: "https://oyster.to",
@@ -382,6 +406,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => FREE_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -395,6 +420,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -410,6 +436,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -426,6 +453,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -454,6 +482,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -473,6 +502,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     ));
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -489,6 +519,7 @@ describe("createSpaceSyncService — pushOne()", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -515,6 +546,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => null,
       sessionToken: () => null,
       workerBase: "https://oyster.to",
@@ -530,6 +562,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => FREE_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -544,6 +577,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
     const fetchMock = vi.fn();
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -565,6 +599,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
     });
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -586,6 +621,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
     ));
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -605,6 +641,7 @@ describe("createSpaceSyncService — pushDelete()", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const svc = createSpaceSyncService({
       db, store,
+      profileBinding: makeBoundProfileBinding("u1"),
       currentUser: () => PRO_USER,
       sessionToken: () => "tok",
       workerBase: "https://oyster.to",
@@ -613,5 +650,41 @@ describe("createSpaceSyncService — pushDelete()", () => {
     await expect(svc.pushDelete("work")).resolves.toBeUndefined();
     // Tombstone remains pending — no cloud_synced_at update on network error.
     expect(store.getPendingDeletes().map(r => r.id)).toEqual(["work"]);
+  });
+});
+
+describe("createSpaceSyncService — profile binding gate", () => {
+  let db: Database.Database;
+  let store: SqliteSpaceStore;
+
+  beforeEach(() => {
+    db = makeDb();
+    store = new SqliteSpaceStore(db);
+    vi.restoreAllMocks();
+  });
+
+  it("blocks spaces sync when profile is bound to a different owner", async () => {
+    // Profile is bound to user-A; user-B signs in. All sync methods must be no-ops.
+    const profileBinding = makeBoundProfileBinding("user-A");
+
+    insertRow(store, "space-1", { displayName: "S1" });
+    store.markSyncDirty("space-1", 1000);
+    store.softDelete("space-1", 2000);
+
+    const fetchSpy = vi.fn();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const svc = createSpaceSyncService({
+      db, store,
+      profileBinding,
+      currentUser: () => ({ id: "user-B", email: "b@x.com", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    expect(await svc.reconcile()).toEqual({ pulled: 0, pushed: 0, tombstoned: 0 });
+    await svc.pushOne("space-1");
+    await svc.pushDelete("space-1");
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

PR 2 of 2 for issue #318. Builds on [PR #411](https://github.com/mattslight/oyster/pull/411) (local event substrate). Adds the cloud half: profile-owner binding, new `oyster-cloud` Worker with POST/GET event routes, local `MemorySyncService`, and the auth/startup wiring that makes memories follow Pro users across devices.

After this lands, a Pro user remembering a fact on Device A sees it on Device B after the next reconcile (sign-in or app start), and per-event fire-and-forget pushes propagate within seconds when both devices are online.

## Architecture (recap from spec/plan)

- **Append-only event log** (`memory_events`) + **redactable payload store** (`memory_payloads`) — append+tombstone with precedence `purged > forgotten > created`. No row sync, no LWW, no merge function.
- **Profile-owner binding** — first Pro sign-in claims the local Oyster profile. Different Pro user on the same profile = sync blocked at orchestration AND per-service `isProSession` (covers spaces sync's existing wedge too — closes a privacy gap from PR #407).
- **Per-event `cloud_owner_id`** — only Pro users tag events; pushes filter strictly. Pre-existing local memories backfilled with NULL (stay local-only per the account-switching policy).
- **Worker:** new `infra/oyster-cloud/` private-API Worker (separate from `oyster-publish`); shares `oyster-auth` D1.

## What's in this PR (Tasks 4.4 → 12)

- **Task 4.4:** `profile_binding` table, `ProfileBindingService`, `canRunCloudSync()` chokepoint, spaces-sync internal `isProSession` updated to also check ownership.
- **Task 4.5:** `infra/oyster-cloud/` Worker bootstrap (package.json, wrangler.toml, src/{worker,session,json}.ts, tests). Shares `resolveSession` + `jsonOk`/`jsonError` helpers with oyster-publish.
- **Task 5:** `infra/auth-worker/migrations/0007_synced_memories.sql` — `synced_memory_events` + `synced_memory_payloads` with all four uniqueness invariants from spec Q6.
- **Task 6:** `POST /api/memories/events` with idempotent ingest, four-way response shape (`accepted`/`duplicates`/`conflicts`/`rejected`), per-batch precedence sort (purges first), empty-create rejection unless prior purge, per-event `env.DB.batch` atomicity, validation that rejects malformed events.
- **Task 7:** `GET /api/memories/events` with payload join, ordered by `created_at`, owner-scoped, no-cache headers.
- **Task 8:** `MemorySyncService` (push/pull/reconcile) with profile-binding gate, drain loop with `MAX_BATCHES=1000` cap, `conflicts`-trigger-pull behaviour (not silent mark-synced), `pull` marks local pending events synced when matched in cloud (round-trip race close), purge-guard in `pull`'s payload upsert (belt-and-braces alongside `materialiseMemory`).
- **Task 9:** `provider.setOnWrite(cb)` hook — fire-and-forget after each `remember`/`forget`/`purge` via `queueMicrotask`.
- **Task 10:** `index.ts` constructs `memorySync` next to `spaceSync`; wires `onWrite` to `pushPending`; `syncOnAuth` early-returns on `canRunCloudSync()` and adds the memory reconcile alongside spaces.
- **Task 12:** `CHANGELOG.md` + regenerated `docs/changelog.html`.

## What's NOT in this PR

- **Task 11 — Manual cross-device verification.** Six-flow validation on real hardware (Pro account on two machines). Cannot run in dev session; needs the Worker actually deployed at `cloud.oyster.to/api/*`. **You should run this before merging:**

  - [ ] Flow 1: A creates a memory → reconcile on B → recall on B finds it
  - [ ] Flow 2: A forgets memory M → reconcile on B → recall returns nothing on either
  - [ ] Flow 3: A purges memory containing fake `AKIA-secret` → reconcile on B → cloud `synced_memory_payloads.content IS NULL`, no FTS hit anywhere
  - [ ] Flow 4: A offline creates+purges M → reconnects → fresh device C signs in → C pulls both events → ends up purged
  - [ ] Flow 5: Free user creates a memory → no Worker calls; events stay local with `cloud_synced_at IS NULL`
  - [ ] Flow 6: Fresh Pro sign-in on a clean device backfills cloud memories (recall surface populates)

## Implementation notes

- **14 clean commits** — `feat`, `refactor`, `fix`, `style`, `docs`, `test` — each task lands as 1–3 commits matching its scope.
- **Built via `superpowers:subagent-driven-development`** with two-stage review per task. Final cross-task review caught three real items (purge-guard in pull's upsertPayload; hoisted prepared statements; type-safe `!result.bound` check); all addressed in the final commit.
- **Tests:** **176 server** (was 167 on main; +9 new — 6 profile-binding + 7 memory-sync-service + 2 onWrite) + **18 oyster-cloud** (3 bootstrap + 3 schema + 9 POST + 3 GET).
- **TypeScript build clean.**

## Worker deployment

The `infra/oyster-cloud/` Worker needs to be deployed before cross-device sync works in production:

```bash
cd infra/oyster-cloud
npx wrangler deploy
```

DNS/route binding for `cloud.oyster.to/api/*` is in `wrangler.toml`. The D1 binding shares the existing `oyster-auth` database — no new DB to provision.

For local dev, `OYSTER_CLOUD_BASE` env var can override the default `https://cloud.oyster.to` to point at `wrangler dev` (default `http://localhost:8788`).

## Test plan

- [ ] `cd server && npm install && npx vitest run` — 176 passing
- [ ] `cd server && npm run build` — TypeScript clean
- [ ] `cd infra/oyster-cloud && npm install && npx vitest run` — 18 passing
- [ ] `cd infra/oyster-cloud && npx wrangler deploy` (maintainer step at production deploy time)
- [ ] Run all six flows from Task 11 above; record results in this PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)