### PR TITLE
feat(memory): periodic pull + success logging for cross-device freshness (#318)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -346,6 +346,27 @@ memoryProvider.setOnWrite(() => {
   });
 });
 
+// Periodic pull. Pull-only triggers (auth-changed and app-startup) leave a
+// running server stale until the next reconcile event. A modest 30s tick
+// keeps cross-device memory updates fresh without burning excessive
+// requests. Pro-only via canRunCloudSync (also covers profile-binding
+// conflict). Configurable via OYSTER_SYNC_POLL_MS for ops/testing.
+const MEMORY_POLL_INTERVAL_MS = Math.max(
+  5_000,
+  Number(process.env.OYSTER_SYNC_POLL_MS) || 30_000,
+);
+const memoryPollHandle = setInterval(() => {
+  if (!canRunCloudSync()) return;
+  memorySync.pull().then((applied) => {
+    if (applied > 0) {
+      console.log(`[memory] periodic pull: applied=${applied}`);
+    }
+  }).catch((err) => {
+    console.warn("[memory] periodic pull failed:", err);
+  });
+}, MEMORY_POLL_INTERVAL_MS);
+memoryPollHandle.unref();
+
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const publishService = createPublishService({
   db,

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -193,6 +193,13 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
         markTxn();
         totalAccepted += accepted.length;
 
+        // Success log: only when something actually moved through this batch.
+        // Quiet in steady-state, visible when activity happens.
+        const moved = accepted.length + duplicates.length;
+        if (moved > 0) {
+          console.log(`[memory] pushed: accepted=${accepted.length} duplicates=${duplicates.length}${conflicts.length ? ` conflicts=${conflicts.length}` : ""}${rejected.length ? ` rejected=${rejected.length}` : ""}`);
+        }
+
         // Termination condition: count only "things that cleared from the
         // outbox" as progress. A batch with only conflicts/rejected events
         // breaks out of the drain loop so we don't hot-loop.
@@ -305,6 +312,10 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
         for (const id of touched) deps.provider.materialiseMemory(id);
       });
       txn();
+
+      if (applied > 0) {
+        console.log(`[memory] pulled: applied=${applied}`);
+      }
 
       return applied;
   }


### PR DESCRIPTION
## Summary

Follow-up to PR #412 (`0.8.0-beta.0`). Cross-device testing surfaced a UX gap: pull only fires on auth-changed or app-startup, so a running laptop never sees memories another Pro device created until the user signs out/in or restarts. Same limitation in spaces sync (inherited from PR #407) but more visible for memories.

### Changes

- **Periodic pull.** New `setInterval` in `index.ts` calls `memorySync.pull()` every 30 seconds (configurable via `OYSTER_SYNC_POLL_MS`, 5s floor). Gated on `canRunCloudSync()` — skips for free users, signed-out, and profile-binding conflicts. Errors swallowed with `console.warn`. Timer `.unref()`'d so it doesn't keep Node alive at exit.
- **Success logging.** `MemorySyncService.pushPending` and `pull` now log `[memory] pushed: accepted=N duplicates=N …` and `[memory] pulled: applied=N` respectively, gated on `> 0` so steady-state is silent. Without these, the only way to verify sync was a direct D1 query — which is exactly the diagnostic friction we hit during cross-device testing.

### Why now

User-visible cross-device propagation is the headline feature of `0.8.0`. Real-time SSE-pushed pull is the long-term right answer, but a 30s poll is a 5-line change that makes the feature actually usable. Polling is justifiable at this scale — for a Pro-only userbase, even 1000 devices polling every 30s is ~33 req/sec on a Cloudflare Worker, well within free tier.

## Test plan

- [ ] `cd server && npx vitest run` — 177 passing
- [ ] `cd server && npm run build` — TypeScript clean
- [ ] Manual: `oyster` → wait 30s → check log for periodic pull activity (only logs if applied > 0)
- [ ] Manual: create a memory on Device A, wait <30s on Device B's running session, confirm it appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)