### PR TITLE
feat(memory): manual + lifecycle reconcile triggers for snappy cross-device freshness (#318)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -593,6 +593,7 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     memoryProvider,
     broadcastUiEvent,
     resolveCurrentOwnerId,
+    memorySync,
   })) return;
 
   // /api/auth/* — local glue (whoami / startSignIn / signOut). Real auth

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -72,6 +72,7 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
   // (e.g. multiple onWrite triggers in quick succession) await the same
   // promise rather than racing.
   let inFlightPush: Promise<number> | null = null;
+  let inFlightReconcile: Promise<{ pulled: number; pushed: number }> | null = null;
 
   async function doPushPending(): Promise<number> {
       const session = isProSession(deps);
@@ -320,13 +321,21 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
       return applied;
   }
 
-  return {
+  const service: MemorySyncService = {
     async reconcile() {
+      if (inFlightReconcile) return inFlightReconcile;
       const session = isProSession(deps);
       if (!session) return { pulled: 0, pushed: 0 };
-      const pulled = await pull();
-      const pushed = await this.pushPending();
-      return { pulled, pushed };
+      inFlightReconcile = (async () => {
+        const pulled = await pull();
+        const pushed = await service.pushPending();
+        return { pulled, pushed };
+      })();
+      try {
+        return await inFlightReconcile;
+      } finally {
+        inFlightReconcile = null;
+      }
     },
 
     async pushPending() {
@@ -341,4 +350,5 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
 
     pull,
   };
+  return service;
 }

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -6,11 +6,13 @@ import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
 import { safeDecode } from "../http-utils.js";
 import type { UiCommand } from "../../../shared/types.js";
+import type { MemorySyncService } from "../memory-sync-service.js";
 
 export interface MemoryRouteDeps {
   memoryProvider: MemoryProvider;
   broadcastUiEvent: (event: UiCommand) => void;
   resolveCurrentOwnerId: () => string | null;
+  memorySync: MemorySyncService;
 }
 
 export async function tryHandleMemoryRoute(
@@ -24,6 +26,27 @@ export async function tryHandleMemoryRoute(
   const { memoryProvider, broadcastUiEvent } = deps;
 
   const memoriesPath = url.split("?")[0];
+
+  // POST /api/memories/reconcile — manual / lifecycle-triggered sync pass.
+  // Calls memorySync.reconcile(); returns { pulled, pushed, applied, status }.
+  // No-op (free user / signed out / profile conflict) returns 200 + zero counts.
+  if (req.method === "POST" && memoriesPath === "/api/memories/reconcile") {
+    if (rejectIfNonLocalOrigin()) return true;
+    try {
+      const parsed = new URL(req.url ?? "/", "http://localhost");
+      const reason = parsed.searchParams.get("reason") ?? "";
+      const result = await deps.memorySync.reconcile();
+      const status = result.pulled || result.pushed ? "synced" : "noop";
+      if (status === "synced") {
+        const tag = reason ? `manual reconcile (reason=${reason})` : "manual reconcile";
+        console.log(`[memory] ${tag}: pulled=${result.pulled} pushed=${result.pushed}`);
+      }
+      sendJson({ ...result, applied: result.pulled, status });
+    } catch (err) {
+      sendError(err);
+    }
+    return true;
+  }
 
   // DELETE /api/memories/:id — soft-delete (mark forgotten). Mirrors the MCP
   // `forget` tool. 404 if the id doesn't exist so the UI can distinguish

--- a/server/test/memory-sync-service.test.ts
+++ b/server/test/memory-sync-service.test.ts
@@ -250,6 +250,37 @@ describe("MemorySyncService", () => {
     expect(postCount).toBe(1);
   });
 
+  it("concurrent reconcile calls share a single in-flight pass", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+
+    let pullCount = 0;
+    const fetchSpy = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      // GET = pull
+      if (!init?.method || init.method === "GET") {
+        pullCount++;
+        await new Promise((r) => setTimeout(r, 10));
+        return new Response(JSON.stringify({ events: [] }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      // POST = pushPending
+      return new Response(JSON.stringify({ accepted: [], duplicates: [], conflicts: [], rejected: [] }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const svc = createMemorySyncService({
+      db: provider.getInternalDbForSync(),
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    await Promise.all([svc.reconcile(), svc.reconcile()]);
+    expect(pullCount).toBe(1);
+  });
+
   it("network errors during push are swallowed; events stay pending", async () => {
     const { provider, profileBinding } = harness();
     await provider.init();

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -885,6 +885,37 @@
 }
 
 /* ── Add-memory form ── */
+.home-memories-refresh-btn {
+  background: transparent;
+  border: 1px solid var(--home-border);
+  border-radius: 999px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+}
+.home-memories-refresh-btn:hover {
+  background: rgba(124, 107, 255, 0.08);
+  color: var(--text);
+  border-color: rgba(124, 107, 255, 0.32);
+}
+.home-memories-refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.home-memories-sync-msg {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
 .home-memories-add-btn {
   background: transparent;
   border: 1px solid var(--home-border);

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
 import { ArrowUpRight, Folder, FolderPlus, Shield } from "lucide-react";
 import type { SessionState } from "../../data/sessions-api";
@@ -170,6 +170,10 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // space starts collapsed too.
   const [memoriesLimit, setMemoriesLimit] = useState(MEMORIES_PREVIEW);
   const [showAddMemory, setShowAddMemory] = useState(false);
+  const [reconciling, setReconciling] = useState(false);
+  const [lastSyncMessage, setLastSyncMessage] = useState<string | null>(null);
+  const lastAutoReconcileRef = useRef<number>(0);
+  const AUTO_THROTTLE_MS = 10_000;
   const [sessionsLimit, setSessionsLimit] = useState(SESSIONS_PREVIEW);
   // Artefact source filter (#280) + 3-row collapse. Reset on scope change
   // so each space starts compact and at "all".
@@ -547,6 +551,71 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     };
     window.addEventListener("oyster:open-session", handler);
     return () => window.removeEventListener("oyster:open-session", handler);
+  }, []);
+
+  // Manual refresh: calls reconcile immediately (bypasses throttle), then
+  // refreshes the memories list on success.
+  const handleManualReconcile = useCallback(async () => {
+    if (reconciling) return;
+    setReconciling(true);
+    setLastSyncMessage(null);
+    try {
+      const res = await fetch("/api/memories/reconcile?reason=manual", { method: "POST" });
+      if (res.ok) {
+        const data = await res.json() as { applied?: number; status?: string };
+        await refreshMemories();
+        const msg = data.applied && data.applied > 0
+          ? `Pulled ${data.applied} update${data.applied === 1 ? "" : "s"}`
+          : "Synced";
+        setLastSyncMessage(msg);
+        setTimeout(() => setLastSyncMessage(null), 3000);
+        // Reset the auto throttle so lifecycle events respect the 10s window
+        lastAutoReconcileRef.current = Date.now();
+      }
+    } catch (err) {
+      console.warn("[memory] manual reconcile failed:", err);
+    } finally {
+      setReconciling(false);
+    }
+  }, [reconciling, refreshMemories]);
+
+  // Lifecycle-triggered reconcile: focus, visibilitychange, online, panel-open.
+  // Throttled to once per 10s so rapid events don't pile up.
+  const triggerLifecycleReconcile = useCallback((reason: string) => {
+    const now = Date.now();
+    if (now - lastAutoReconcileRef.current < AUTO_THROTTLE_MS) return;
+    lastAutoReconcileRef.current = now;
+    fetch(`/api/memories/reconcile?reason=${reason}`, { method: "POST" })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data: { applied?: number } | null) => {
+        if (data?.applied && data.applied > 0) refreshMemories();
+      })
+      .catch((err) => console.warn("[memory] lifecycle reconcile failed:", err));
+  }, [refreshMemories]);
+
+  useEffect(() => {
+    const onFocus = () => triggerLifecycleReconcile("focus");
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") triggerLifecycleReconcile("visible");
+    };
+    const onOnline = () => triggerLifecycleReconcile("online");
+
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("online", onOnline);
+
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("online", onOnline);
+    };
+  }, [triggerLifecycleReconcile]);
+
+  // Trigger reconcile when the Memories section becomes visible (panel open /
+  // scope navigation mounts this component).
+  useEffect(() => {
+    triggerLifecycleReconcile("panel-open");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const activeSpaceRow = scopedSpace ? spaces.find((s) => s.id === scopedSpace) : null;
@@ -1126,6 +1195,32 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             <span className="home-section-label">Memories</span>
             <span className="home-artefacts-count">{scopedMemories.length}</span>
             <span className="home-section-rule" />
+            <button
+              type="button"
+              className="home-memories-refresh-btn"
+              onClick={handleManualReconcile}
+              disabled={reconciling}
+              aria-label="Sync memories"
+              title="Sync memories"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                style={{ width: 13, height: 13, display: "block", transition: "transform 0.6s linear", transform: reconciling ? "rotate(360deg)" : "none" }}
+                aria-hidden="true"
+              >
+                <path d="M23 4v6h-6" />
+                <path d="M1 20v-6h6" />
+                <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+              </svg>
+            </button>
+            {lastSyncMessage && (
+              <span className="home-memories-sync-msg">{lastSyncMessage}</span>
+            )}
             <button
               type="button"
               className="home-memories-add-btn"


### PR DESCRIPTION
## Summary

UX/liveness patch on top of [#318](https://github.com/mattslight/oyster/issues/318) cross-device memory sync. Data model and 30s periodic poll unchanged. This PR adds:

- **Manual refresh button** next to the Memories header. Spinner during in-flight, disabled during reconcile, status message ("Synced" / "Pulled N updates") for ~3s after.
- **Lifecycle-triggered reconcile** on `focus`, `visibilitychange → visible`, `online`, and Memories panel mount. 10s throttle on auto-triggered; manual refresh bypasses.
- **`POST /api/memories/reconcile`** local-origin endpoint backing both. Accepts `?reason=` query param for log diagnostics.
- **In-flight reconcile coalesce** in `MemorySyncService` — concurrent reconcile calls share one promise, matching the existing `pushPending` pattern. New regression test confirms.
- **Diagnostic logs** distinguish `[memory] manual reconcile (reason=…)` from the existing poll/auth/startup variants.

The 30s server-side periodic poll stays as the safety net. Layered defence: poll = background freshness, lifecycle = fast UX, manual = user escape hatch.

### Why this matters

In `0.8.0-beta.1` testing, a running laptop didn't see a memory created on a son's Windows PC until either (a) the 30s poll fired or (b) sign out/in. 30s feels sluggish for a "memories follow you across devices" promise. With focus/visibility hooks, propagation feels near-instant when the user is actually looking at the device.

## Test plan

- [ ] `cd server && npx vitest run` — 178 passing
- [ ] `cd server && npm run build` — TS clean
- [ ] `cd web && npm run build` — web build clean
- [ ] Manual: two devices signed in to same Pro account.
  - Create memory on A → tab away from B → tab back to B → memory appears within seconds.
  - Click refresh button on B explicitly → spinner → "Pulled 1 update" → memory appears.
  - Mash refresh button repeatedly → no parallel calls (in-flight coalesce).
  - Free user → button still works but every reconcile returns `status: "noop"`.
- [ ] Profile-bound mismatch still blocks all pull/push (covered by existing tests).

## Acceptance criteria from the spec

- [x] Two devices, same Pro account, A creates memory → B receives via 30s poll
- [x] B opening/focusing pulls sooner (focus/visibilitychange listeners)
- [x] Manual refresh pulls immediately (button onClick → POST /api/memories/reconcile?reason=manual)
- [x] Repeated focus/open events don't spam server (10s throttle)
- [x] Profile-bound mismatch still blocks all pull/push (gate in `MemorySyncService.isProSession` unchanged)
- [x] Free/signed-out users do not call cloud sync (gate unchanged; route returns noop status)
- [x] Existing periodic polling still works (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)