### PR TITLE
feat(cli): show version in banner bottom-right of ASCII logo

### DIFF
--- a/bin/_banner.mjs
+++ b/bin/_banner.mjs
@@ -101,8 +101,12 @@ export function getTips() {
 // `tipIndex` lets the preview script iterate every variant deterministically;
 // production calls omit it and get a random tip.
 // `options.logo` lets the preview script swap the ASCII font.
+// `options.version` (e.g. "0.8.0-beta.2") renders a faint `vX.Y.Z` flush
+// to the bottom-right of the ASCII block — quietly visible without
+// crowding the rest of the banner.
 export function printHeroBox(url, tipIndex, options = {}) {
   const logo = options.logo || DEFAULT_LOGO;
+  const version = options.version;
   const tips = getTips();
   const tip = tipIndex != null
     ? tips[tipIndex]
@@ -147,7 +151,17 @@ export function printHeroBox(url, tipIndex, options = {}) {
     return `${" ".repeat(artLeftPad)}${coloured}`;
   });
 
-  const lines = [``, ...artLines, ...contentLines];
+  // Faint `vX.Y.Z` right-aligned to the ASCII block's right edge — sits
+  // immediately under the logo so it reads as an attached marker rather
+  // than a separate banner row.
+  const versionLines = [];
+  if (version) {
+    const versionText = `v${version}`;
+    const versionLeftPad = Math.max(0, artLeftPad + artLineLen - versionText.length);
+    versionLines.push(`${" ".repeat(versionLeftPad)}${D}${versionText}${R}`);
+  }
+
+  const lines = [``, ...artLines, ...versionLines, ...contentLines];
 
   const hr = "─".repeat(innerWidth);
   const out = [];

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -419,7 +419,8 @@ async function main() {
       if (match) {
         opened = true;
         const url = match[1];
-        printHeroBox(url);
+        const pkg = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8"));
+        printHeroBox(url, undefined, { version: pkg.version });
         try {
           const platform = process.platform;
           if (platform === "darwin") execSync(`open ${url}`);

--- a/scripts/preview-banner.mjs
+++ b/scripts/preview-banner.mjs
@@ -3,7 +3,14 @@
 // full server. Run with `npm run preview:banner` (tip rotation) or
 // `npm run preview:banner -- --fonts` (logo font comparison).
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { printHeroBox, getTips, LOGO_FONTS } from "../bin/_banner.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8"));
+const version = pkg.version;
 
 const url = "http://127.0.0.1:4444";
 const args = process.argv.slice(2);
@@ -12,13 +19,13 @@ if (args[0] === "--fonts" || args[0] === "-f") {
   console.log(`\nComparing ${Object.keys(LOGO_FONTS).length} logo fonts (using tip 1 throughout):\n`);
   for (const name of Object.keys(LOGO_FONTS)) {
     console.log(`--- font: ${name} ---`);
-    printHeroBox(url, 0, { logo: LOGO_FONTS[name] });
+    printHeroBox(url, 0, { logo: LOGO_FONTS[name], version });
   }
 } else {
   const tips = getTips();
   console.log(`\nRendering ${tips.length} tip variants:\n`);
   for (let i = 0; i < tips.length; i++) {
     console.log(`--- variant ${i + 1} of ${tips.length} ---`);
-    printHeroBox(url, i);
+    printHeroBox(url, i, { version });
   }
 }


### PR DESCRIPTION
Renders vX.Y.Z faintly under the bottom-right corner of the Oyster ASCII logo at boot. Quietly useful for confirming which version is running.

3 files changed: bin/_banner.mjs (new options.version), bin/oyster.mjs (passes pkg.version), scripts/preview-banner.mjs (mirrors for npm run preview:banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)