### PR TITLE
fix(memory): broadcast memory_changed SSE on cloud pull and local writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 ### Fixed
 
 - **Memory timestamps now respect your timezone.** "Created" times in the Memories panel previously read as up to several hours off when running outside UTC; they now reflect the actual moment a memory was written.
+- **Memories panel updates live again.** Writing a memory in chat, or having one arrive from another device on the periodic poll, now refreshes the panel automatically — previously only window focus or the manual refresh button surfaced changes.
 
 ## [0.8.0-beta.3] - 2026-05-09
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -329,6 +329,7 @@
 <h3>Fixed</h3>
 <ul>
 <li><strong>Memory timestamps now respect your timezone.</strong> &quot;Created&quot; times in the Memories panel previously read as up to several hours off when running outside UTC; they now reflect the actual moment a memory was written.</li>
+<li><strong>Memories panel updates live again.</strong> Writing a memory in chat, or having one arrive from another device on the periodic poll, now refreshes the panel automatically — previously only window focus or the manual refresh button surfaced changes.</li>
 </ul>
 <h2 id="v-0-8-0-beta-3"><span class="release-version">0.8.0-beta.3</span><span class="release-date"> — 2026-05-09</span></h2>
 <h3>Added</h3>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -596,7 +596,6 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // /api/memories
   if (await tryHandleMemoryRoute(req, res, url, ctx, {
     memoryProvider,
-    broadcastUiEvent,
     resolveCurrentOwnerId,
     memorySync,
   })) return;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -336,6 +336,7 @@ const memorySync: MemorySyncService = createMemorySyncService({
   sessionToken: () => authService.getState().sessionToken,
   workerBase: CLOUD_WORKER_BASE,
   fetch: globalThis.fetch,
+  onApplied: () => broadcastUiEvent({ version: 1, command: "memory_changed", payload: { op: "pull" } }),
 });
 memoryProvider.setOnWrite(() => {
   // Fire-and-forget. Catch any error so a transient sync failure can never
@@ -344,6 +345,10 @@ memoryProvider.setOnWrite(() => {
   memorySync.pushPending().catch((err) => {
     console.warn("[memory] onWrite-triggered pushPending failed:", err);
   });
+  // Notify the UI on every local mutation (remember/forget/purge). The
+  // routes/memories.ts forget-DELETE used to be the only emitter; this
+  // covers MCP-initiated remember and any other provider-level write path.
+  broadcastUiEvent({ version: 1, command: "memory_changed", payload: { op: "write" } });
 });
 
 // Periodic pull. Pull-only triggers (auth-changed and app-startup) leave a

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -23,6 +23,12 @@ export interface MemorySyncDeps {
   sessionToken: () => string | null;
   workerBase: string;
   fetch: typeof fetch;
+  /** Optional: invoked after a successful pull when applied > 0. Used by the
+   *  server entry point to broadcast a `memory_changed` SSE so the UI
+   *  re-fetches its memory list. Cloud-pulled events bypass the local
+   *  `onWrite` hook, so without this the periodic poll lands fresh data
+   *  silently and the panel stays stale until a focus/refresh trigger. */
+  onApplied?: (applied: number) => void;
 }
 
 export interface MemorySyncService {
@@ -316,6 +322,9 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
 
       if (applied > 0) {
         console.log(`[memory] pulled: applied=${applied}`);
+        try { deps.onApplied?.(applied); } catch (err) {
+          console.warn("[memory] onApplied threw:", err);
+        }
       }
 
       return applied;

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -5,12 +5,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
 import { safeDecode } from "../http-utils.js";
-import type { UiCommand } from "../../../shared/types.js";
 import type { MemorySyncService } from "../memory-sync-service.js";
 
 export interface MemoryRouteDeps {
   memoryProvider: MemoryProvider;
-  broadcastUiEvent: (event: UiCommand) => void;
   resolveCurrentOwnerId: () => string | null;
   memorySync: MemorySyncService;
 }
@@ -23,7 +21,7 @@ export async function tryHandleMemoryRoute(
   deps: MemoryRouteDeps,
 ): Promise<boolean> {
   const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
-  const { memoryProvider, broadcastUiEvent } = deps;
+  const { memoryProvider } = deps;
 
   const memoriesPath = url.split("?")[0];
 
@@ -68,7 +66,8 @@ export async function tryHandleMemoryRoute(
         sendJson({ error: "memory not found" }, 404);
         return true;
       }
-      broadcastUiEvent({ version: 1, command: "memory_changed", payload: { id, op: "forget" } });
+      // SSE broadcast is fired via the provider's onWrite hook in index.ts —
+      // no need to emit here too (would cause a duplicate refetch).
       res.statusCode = 204;
       res.end();
     } catch (err) {

--- a/server/test/memory-sync-service.test.ts
+++ b/server/test/memory-sync-service.test.ts
@@ -305,4 +305,68 @@ describe("MemorySyncService", () => {
     const c = db.prepare(`SELECT COUNT(*) as c FROM memory_events WHERE cloud_synced_at IS NULL`).get() as { c: number };
     expect(c.c).toBe(1);
   });
+
+  it("invokes onApplied(applied) when pull lands new events", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        events: [
+          {
+            event_id:  "ev-applied-1",
+            memory_id: "mem-applied-1",
+            event_type: "memory_created",
+            space_id: null,
+            created_at: 1000,
+            payload: { content: "from-cloud", tags: [], purged_at: null },
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+
+    const onApplied = vi.fn();
+    const svc = createMemorySyncService({
+      db: provider.getInternalDbForSync(),
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+      onApplied,
+    });
+
+    await svc.pull();
+    expect(onApplied).toHaveBeenCalledTimes(1);
+    expect(onApplied).toHaveBeenCalledWith(1);
+  });
+
+  it("does not invoke onApplied when pull applies zero events", async () => {
+    const { provider, profileBinding } = harness();
+    await provider.init();
+    profileBinding.bindToOwner("u1");
+
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ events: [] }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+
+    const onApplied = vi.fn();
+    const svc = createMemorySyncService({
+      db: provider.getInternalDbForSync(),
+      provider,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+      onApplied,
+    });
+
+    await svc.pull();
+    expect(onApplied).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- The Memories panel was only refreshing on focus / visibility / online / panel-mount / manual refresh — paths that explicitly call `refreshMemories()` in JS after a reconcile. The 30s server-side periodic pull, MCP-initiated remember/forget, and provider.purge all landed events in the local DB without ever broadcasting `memory_changed` SSE, so the panel sat stale.
- Surfaced during 0.8.0 cross-device UAT — Mac wrote a memory and the dev panel only updated when refocused.
- Adds an `onApplied` callback to `MemorySyncService`, fired after `pull()` when applied > 0, wired in `index.ts` to broadcast `memory_changed`. Extends the existing `onWrite` hook to also broadcast on local mutations.

## Test plan
- [x] Unit tests for `onApplied` (fires on apply > 0, suppressed on apply = 0)
- [x] Full `server` test suite green (180 → 180 still passing on this branch's count)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Manual: dev server, write a memory in chat — panel updates without focus/refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)