### PR TITLE
fix(memory): return created_at as ISO-8601 UTC at the API boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Memory timestamps now respect your timezone.** "Created" times in the Memories panel previously read as up to several hours off when running outside UTC; they now reflect the actual moment a memory was written.
+
 ## [0.8.0-beta.3] - 2026-05-09
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-8-0-beta-3">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
@@ -324,6 +325,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.7.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Memory timestamps now respect your timezone.</strong> &quot;Created&quot; times in the Memories panel previously read as up to several hours off when running outside UTC; they now reflect the actual moment a memory was written.</li>
+</ul>
 <h2 id="v-0-8-0-beta-3"><span class="release-version">0.8.0-beta.3</span><span class="release-date"> — 2026-05-09</span></h2>
 <h3>Added</h3>
 <ul>

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -84,13 +84,24 @@ interface MemoryRow {
   source_session_id: string | null;
 }
 
+// SQLite's datetime('now') yields "YYYY-MM-DD HH:MM:SS" — UTC but without a
+// zone marker. JS Date.parse() on that string is engine-defined and on V8
+// is treated as local time, so a non-UTC client shows a skewed "ago" label.
+// Normalise to canonical ISO-8601 UTC at the API boundary.
+function toIsoUtc(text: string): string {
+  let iso = text.replace(" ", "T");
+  if (!iso.includes("T")) iso += "T00:00:00";
+  if (!iso.endsWith("Z") && !/[+-]\d{2}:\d{2}$/.test(iso)) iso += "Z";
+  return iso;
+}
+
 function rowToMemory(row: MemoryRow): Memory {
   return {
     id: row.id,
     content: row.content,
     space_id: row.space_id,
     tags: JSON.parse(row.tags),
-    created_at: row.created_at,
+    created_at: toIsoUtc(row.created_at),
     source_session_id: row.source_session_id ?? null,
   };
 }

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -678,19 +678,25 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
   }
 
   async importMemories(memories: Memory[]): Promise<void> {
+    // Canonicalise to the SQLite space-form `YYYY-MM-DD HH:MM:SS` so the
+    // column form stays uniform regardless of whether a row was written
+    // organically or imported. Mixed forms break ORDER BY (T > space in
+    // ASCII would push all imports after all organic rows).
     const insertOrIgnore = this.db.prepare(
       `INSERT OR IGNORE INTO memories (id, space_id, content, tags, source_session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+       VALUES (?, ?, ?, ?, ?, datetime(?, 'unixepoch'), datetime('now'))`,
     );
     const tx = this.db.transaction((items: Memory[]) => {
       for (const m of items) {
+        const ms = Date.parse(m.created_at);
+        const seconds = Number.isFinite(ms) ? Math.floor(ms / 1000) : Math.floor(Date.now() / 1000);
         insertOrIgnore.run(
           m.id,
           m.space_id,
           m.content,
           JSON.stringify(m.tags),
           m.source_session_id ?? null,
-          m.created_at,
+          seconds,
         );
       }
     });

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -80,18 +80,48 @@ describe("SqliteFtsMemoryProvider", () => {
       // SQLite's datetime('now') yields "YYYY-MM-DD HH:MM:SS" (UTC, no zone
       // marker). JS Date.parse() of that string is treated as local time —
       // so a Dubai (UTC+4) browser shows a 4-hour skew. The provider must
-      // return an unambiguous form (trailing Z or a +HH:MM offset).
+      // return strict ISO-8601 with a T separator and a Z (or ±HH:MM) marker.
       const before = Date.now();
       const m = await provider.remember({ content: "timestamp-shape" });
       const after = Date.now();
-      // Must end with Z or include an explicit ±HH:MM offset.
-      expect(m.created_at).toMatch(/(Z|[+-]\d{2}:\d{2})$/);
+      // Strict ISO-8601 datetime: YYYY-MM-DDThh:mm:ss[.sss](Z|±HH:MM)
+      expect(m.created_at).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/,
+      );
       // Must round-trip via Date to a moment within the call window
       // (allow 5s slack for slow CI).
       const parsed = Date.parse(m.created_at);
       expect(Number.isNaN(parsed)).toBe(false);
       expect(parsed).toBeGreaterThanOrEqual(before - 5_000);
       expect(parsed).toBeLessThanOrEqual(after + 5_000);
+    });
+
+    it("importMemories canonicalises created_at to the SQLite text form", async () => {
+      // Read-side normalisation alone leaves a seam: exportMemories emits ISO
+      // strings, but importMemories used to insert them verbatim into a column
+      // that organic writes fill with `YYYY-MM-DD HH:MM:SS`. SQLite ORDER BY
+      // is lexicographic, so mixed forms reorder rows incorrectly (T > space
+      // in ASCII, so all imported rows sort after all organic rows regardless
+      // of when they were created). Inserts must canonicalise to keep the DB
+      // column uniform.
+      await provider.importMemories([
+        {
+          id: "imp-iso",
+          content: "imported with iso form",
+          space_id: null,
+          tags: [],
+          created_at: "2026-01-15T10:30:00.000Z",
+          source_session_id: null,
+        },
+      ]);
+      // Inspect the raw DB column directly — must be the SQLite space-form,
+      // not the ISO form passed in.
+      const db = (provider as unknown as { db: Database.Database }).db;
+      const row = db
+        .prepare("SELECT created_at FROM memories WHERE id = 'imp-iso'")
+        .get() as { created_at: string };
+      expect(row.created_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+      expect(Date.parse(row.created_at + "Z")).toBe(Date.parse("2026-01-15T10:30:00.000Z"));
     });
   });
 

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -75,6 +75,24 @@ describe("SqliteFtsMemoryProvider", () => {
       expect(written).toHaveLength(1);
       expect(written[0].id).toBe(m.id);
     });
+
+    it("returns created_at as an unambiguous UTC ISO-8601 string", async () => {
+      // SQLite's datetime('now') yields "YYYY-MM-DD HH:MM:SS" (UTC, no zone
+      // marker). JS Date.parse() of that string is treated as local time —
+      // so a Dubai (UTC+4) browser shows a 4-hour skew. The provider must
+      // return an unambiguous form (trailing Z or a +HH:MM offset).
+      const before = Date.now();
+      const m = await provider.remember({ content: "timestamp-shape" });
+      const after = Date.now();
+      // Must end with Z or include an explicit ±HH:MM offset.
+      expect(m.created_at).toMatch(/(Z|[+-]\d{2}:\d{2})$/);
+      // Must round-trip via Date to a moment within the call window
+      // (allow 5s slack for slow CI).
+      const parsed = Date.parse(m.created_at);
+      expect(Number.isNaN(parsed)).toBe(false);
+      expect(parsed).toBeGreaterThanOrEqual(before - 5_000);
+      expect(parsed).toBeLessThanOrEqual(after + 5_000);
+    });
   });
 
   describe("recall query parsing", () => {


### PR DESCRIPTION
## Summary
- SQLite's `datetime('now')` stores `"YYYY-MM-DD HH:MM:SS"` — UTC but with no zone marker. V8's `Date.parse()` treats that as local time, so a non-UTC client (e.g. a Dubai laptop on UTC+4) renders the "ago" label hours off.
- Surfaced as "4h ago" on a freshly-written memory during 0.8.0 cross-device UAT.
- `rowToMemory` now normalises to `"YYYY-MM-DDTHH:MM:SSZ"` so any client parses the timestamp unambiguously. No schema change.

## Test plan
- [x] Unit test: `created_at` returned as ISO with `Z`, parses to a UTC moment within the call window
- [x] Full `server` test suite green (179 passing)
- [x] `tsc --noEmit` clean
- [x] Manual: dev server in non-UTC tz, write a memory, panel reads "just now"

🤖 Generated with [Claude Code](https://claude.com/claude-code)