### PR TITLE
ci: run server tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Test server
+        run: cd server && npm test
+
       - name: Lint web
         # Non-blocking until the existing lint debt is resolved. Output is
         # visible in PR checks; flip to blocking by removing this flag.


### PR DESCRIPTION
## Summary
- Adds a `Test server` step to `.github/workflows/ci.yml` that runs `cd server && npm test` after build.
- Catches regressions from vitest / runtime bumps that build + lint miss (e.g. yesterday's vitest 2→4 jump in #418 only got validated because I ran tests locally).

## Test plan
- [x] `cd server && npm test` passes locally on main (13 files, 182 tests)
- [ ] CI on this PR turns green