### PR TITLE
docs: post-0.8.0 audit — roadmap, README, gap matrix, memory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ Browser → http://localhost:4444
 
 ## Status
 
-Early v1. Local-first. Single-user. Built for fast iteration.
+Early v1. Local-first. Cross-device for Pro. Built for fast iteration.
 
-- **Now (`0.5.x`)** — Sessions feed (Claude Code), Memories on Home, Project tiles per space, repo onboarding, 19 MCP tools, slash commands.
-- **Next (`0.6.x`)** — Bundles. Multi-file static artefacts; agents push artefacts via MCP.
-- **Then (`0.7.x`)** — Oyster Pro. Auth, cross-device sync, end-to-end encrypted storage, shareable links. ([pricing](https://oyster.to/pricing))
-- **Then (`0.8.x`)** — Multi-agent ingestion. Cursor, Codex, OpenCode session feeds — every agent feeds the same workspace.
+- **Now (`0.8.x`)** — Cross-device memory sync (Pro). Anything you remember on one signed-in device shows up on every other.
+- **Recently shipped** — Sign in with GitHub or magic-link (0.7.0), Publish & share artefacts (0.7.0), Spaces sync across devices (0.7.1), Cloud memory store (0.8.0).
+- **Next (`0.9.x`)** — Fresh-machine restore from cloud, semantic recall, *Pick up here* cross-device session priming, cold-storage transcript backup, multi-agent ingestion (Cursor, Codex, OpenCode).
+- **Later** — Artefact version history, cross-device artefact-byte sync.
 
-See every shipped change in the [changelog](https://oyster.to/changelog).
+See every shipped change in the [changelog](https://oyster.to/changelog). Pro details on the [pricing page](https://oyster.to/pricing).
 
 ## Contributing
 

--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -1,6 +1,6 @@
 # 0.5.0 → Pro: gap matrix
 
-> **Status:** living doc. Originally a 2026-05-01 snapshot; per-requirement sections are updated in place as work lands. Most recent edit: 2026-05-04 — auth (#295/#340) closed, R2 verbatim (#311/#328) and R6 traceable recall (#310) shipped in 0.6.0, R5 schema/backend/viewer (#314/#315/#316) shipped, only R5 Publish UI (#317) outstanding for 0.7.0.
+> **Status:** living doc. Originally a 2026-05-01 snapshot; per-requirement sections are updated in place as work lands. Most recent edit: 2026-05-09 — 0.7.0 (auth + R5 Publish UI #317 + hardening #400) shipped; 0.7.1 (spaces sync wedge #407) shipped; **0.8.0 shipped — R4 cross-device memory live (#318)**. R1 / R2 (cross-device + semantic) / R3 / Pick-up-here punted from 0.8.0 to 0.9.0 alongside R7. See [`roadmap.md`](./roadmap.md) for milestone-level status.
 >
 > **Reads alongside** [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md). The requirements doc is canonical and pins observable user outcomes (R1–R7). This doc tracks where the current implementation stands against those outcomes — what survives, what changes, what's missing entirely. Architecture decisions are made *against* the requirements, evaluated against this matrix.
 
@@ -52,25 +52,25 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 ### R4. Memory that crosses agents
 
-**Current state:** Memory is MCP-accessible and agent-agnostic *by design* — any client connecting to `/mcp/` (now routed via `server/src/routes/oauth-mcp.ts`) gets the same four tools. Mechanically already works on a single machine: Claude Code, Cursor, Codex all share the same `memory.db`. `clientContext` on `McpDeps` (`mcp-server.ts`) distinguishes internal from external for telemetry only — same provider instance.
+**Current state:** **Delivered in 0.8.0** (#318). Cloud memory store backed by `synced_memory_events` + `synced_memory_payloads` in D1, with a write-through outbox in `memory-sync-service.ts`, profile-binding gate so account A's events can't pollute account B's local SQLite, and reconcile triggers on focus/visibility/online/panel-mount/30s-poll. Cross-device propagation verified end-to-end in Task 11. The MCP surface (`remember`/`recall`/`forget`/`list_memories`) is unchanged — what swapped is the implementation behind the local provider.
 
-**Survives:** The architecture (one MCP, one memory store, multiple agents) carries forward. `memories.space_id` already handles global vs space-scoped recall. MCP tool surface is stable.
+**Survives:** The architecture (one MCP, one memory store, multiple agents). `memories.space_id` carries forward unchanged. MCP tool surface stable.
 
-**Changes:** Cross-agent memory today is single-device. Pro entitlement requires cloud-backed memory store. `SqliteFtsMemoryProvider` has no publish/subscribe hook — writes don't fan out. Add an `onChange` hook to the interface, or replace the implementation with a cloud-backed one.
+**Changes:** None outstanding for the core R4 outcome.
 
-**Missing entirely:** Cross-device propagation. Identity tying a corpus to an account.
+**Missing entirely:** Worker hardening (rate limit / quotas / retention / account deletion — tracked in #425). Inspector UI for managing synced memories (#427). These are non-blocking polish.
 
 ---
 
 ### R5. Publish & share artefacts
 
-**Current state:** **Backend, schema, and viewer delivered** (#314/#315/#316). `share_token` / `share_mode` / `share_password_hash` / `published_at` / `share_updated_at` / `unpublished_at` columns on `artifacts`. `publish-service.ts` is the single source of truth, called by both `routes/publish.ts` (HTTP) and `mcp-server.ts` (`publish_artifact` / `unpublish_artifact` MCP tools). Cloud storage = R2 via `infra/oyster-publish` Worker; public viewer at `oyster.to/p/<token>` with three access modes (open / password / sign-in). `owner_id` populated on first publish. **UI affordance still missing** (#317 in flight) — today users publish via MCP tool only.
+**Current state:** **Delivered in 0.7.0** (schema #314, backend #315, viewer #316, UI #317, hardening #400, origin isolation #397). `share_token` / `share_mode` / `share_password_hash` / `published_at` / `share_updated_at` / `unpublished_at` columns on `artifacts`. `publish-service.ts` is the single source of truth, called by both `routes/publish.ts` (HTTP) and `mcp-server.ts` (`publish_artifact` / `unpublish_artifact` MCP tools). Cloud storage = R2 via `infra/oyster-publish` Worker; public viewer at `share.oyster.to/p/<token>` with three access modes (open / password / sign-in). `owner_id` populated on first publish.
 
 **Survives:** Everything that landed survives. R5 cycles back into the matrix only when version-history (R7) introduces published-version pinning.
 
-**Changes:** None remaining for the backend. UI work is the last 0.7.0 gap.
+**Changes:** None outstanding.
 
-**Missing entirely:** UI action surface (modal, mode picker, copy-to-clipboard, tile chip). Tracked as #317.
+**Missing entirely:** Cloud-down reconcile when a remote unpublish is missed (#403). Non-blocking.
 
 ---
 
@@ -82,7 +82,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 **Changes:** None outstanding.
 
-**Missing entirely:** Cross-device provenance — depends on R4 cloud memory store (#318, 0.8.0), so that the source-session pointer remains valid after a memory syncs to another device.
+**Missing entirely:** Cross-device provenance — `source_session_id` is preserved across cloud round-trips (the column travels with the event), but the *target* session a recall was pulled into is local-only. Click-through from a recalled memory to its source session works on the originating device today; surfacing it on a different device requires session metadata to be addressable cross-device, which is 0.9.0 work (#322).
 
 ---
 
@@ -104,8 +104,8 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 
 - ~~**Identity + auth layer**~~ — **shipped** (#295 magic-link, #340 OAuth as primary). Unblocks R1 and R5; rest of Pro hangs off this.
 - ~~**Share/publish CDN or proxy**~~ — **shipped** for R5 (Cloudflare Worker at `infra/oyster-publish` with R2 object storage for artefact bytes). R5 backend complete.
-- **Cloud data store (DB + blob)** — unblocks R1, R3, R4, R7. R5 already uses Cloudflare R2 for published-artefact bytes; a hosted DB for memories/sessions is the next piece.
-- **Sync / push-pull layer** — unblocks R1, R3, R4, R7. Distinct from the storage choice.
+- ~~**Cloud data store (DB)**~~ — **partially shipped**. D1 backs spaces sync (#407, 0.7.1) and memory sync (#318, 0.8.0). Worker at `cloud.oyster.to/api/*` shares the `oyster-auth` D1 with `oyster-publish`. Still needed: cold-storage transcripts (R3, 0.9.0), embeddings (R2 semantic, 0.9.0), artefact bytes (R7).
+- ~~**Sync / push-pull layer**~~ — **partially shipped**. DIY events-table + outbox + worker pattern proven in spaces (0.7.1) and memory (0.8.0). Per `project_sync_build_vs_lease` checkpoint: re-evaluate PowerSync / ElectricSQL / R2-only before extending the DIY pattern to artefact bytes (R7).
 - **Artefact version store** — unblocks R7. Could be an `artifact_versions` SQLite table or `git` per space directory.
 
 **Hard-coded localhost / single-device assumptions** (still true post-refactor):

--- a/docs/plans/0.5.0-gap-matrix.md
+++ b/docs/plans/0.5.0-gap-matrix.md
@@ -105,7 +105,7 @@ What the requirements demand on top is identity, cloud storage, sync, restore, p
 - ~~**Identity + auth layer**~~ — **shipped** (#295 magic-link, #340 OAuth as primary). Unblocks R1 and R5; rest of Pro hangs off this.
 - ~~**Share/publish CDN or proxy**~~ — **shipped** for R5 (Cloudflare Worker at `infra/oyster-publish` with R2 object storage for artefact bytes). R5 backend complete.
 - ~~**Cloud data store (DB)**~~ — **partially shipped**. D1 backs spaces sync (#407, 0.7.1) and memory sync (#318, 0.8.0). Worker at `cloud.oyster.to/api/*` shares the `oyster-auth` D1 with `oyster-publish`. Still needed: cold-storage transcripts (R3, 0.9.0), embeddings (R2 semantic, 0.9.0), artefact bytes (R7).
-- ~~**Sync / push-pull layer**~~ — **partially shipped**. DIY events-table + outbox + worker pattern proven in spaces (0.7.1) and memory (0.8.0). Per `project_sync_build_vs_lease` checkpoint: re-evaluate PowerSync / ElectricSQL / R2-only before extending the DIY pattern to artefact bytes (R7).
+- ~~**Sync / push-pull layer**~~ — **partially shipped**. DIY events-table + outbox + worker pattern proven in spaces (0.7.1) and memory (0.8.0). The DIY shape suits low-volume metadata; before extending it to higher-volume / larger-payload surfaces (artefact bytes for R7, transcripts for R3), re-evaluate turnkey alternatives (PowerSync, ElectricSQL, plain R2) — replicating the pattern by default would cost more than buying it.
 - **Artefact version store** — unblocks R7. Could be an `artifact_versions` SQLite table or `git` per space directory.
 
 **Hard-coded localhost / single-device assumptions** (still true post-refactor):

--- a/docs/plans/agent-memory-api.md
+++ b/docs/plans/agent-memory-api.md
@@ -13,8 +13,9 @@ Agent (Claude Code / Cursor / Codex / …)
    ▼
 Local Oyster server (always running on the user's machine)
    │
-   │  free / today: SqliteFtsMemoryProvider → <userland>/db/memory.db
-   │  Pro (0.8.0+):  CloudMemoryProvider → Cloudflare D1 + Vectorize
+   │  free:         SqliteFtsMemoryProvider → <userland>/db/memory.db (local only)
+   │  Pro (0.8.0+): SqliteFtsMemoryProvider + write-through outbox → Cloudflare D1
+   │                (cross-device + cross-agent; FTS5 today, embeddings deferred to 0.9.0)
    ▼
 Cloud (Pro only)
 ```
@@ -25,15 +26,16 @@ Cloud (Pro only)
 
 - **R4 (memory crosses agents)** — delivered structurally by every connected agent talking to the same MCP. A per-agent integration or per-agent skill would need re-implementing across the matrix of agents.
 - **R2 (conversational recall)** — needs FTS + vector queries that aren't realistic over a flat file scan. The MCP boundary lets us put the index where it has to go without leaking that detail to agents.
-- **R1 (empty-machine continuity)** — Pro turns on without agent reconfiguration. Magic-link sign-in flips the local provider from local-SQLite to cloud-backed; agents see no difference.
+- **R1 (empty-machine continuity)** — Pro turns on without agent reconfiguration. OAuth or magic-link sign-in attaches the local provider to the cloud event log; agents see no difference.
 
-## What 0.8.0 actually changes
+## What 0.8.0 changed
 
 Behind the same MCP tool surface:
 
-1. Magic-link sign-in stores a token in `~/Oyster/config/`.
-2. The local server's `MemoryProvider` becomes a write-through-cache: writes go to cloud + local; reads check local first then cloud; offline writes queue and replay.
-3. Cross-device propagation: another signed-in machine's local server pulls cloud writes and replays into its local DB. Its agents see the same memory store via MCP.
+1. Sign-in (OAuth GitHub primary, magic-link fallback) stores a session in `~/Oyster/config/`.
+2. The local server's memory writes go through a write-through outbox: events land in `synced_memory_events` locally, then push to D1 via `cloud.oyster.to/api/memories/events`. Reads stay against the local SQLite mirror — fast, offline-tolerant.
+3. Cross-device propagation: another signed-in machine's local server pulls cloud events and replays them into its local DB on focus / visibility / online / panel-mount / 30s-poll.
+4. Profile-binding gate ensures account A's events can't pollute a local profile bound to account B.
 
 Same MCP tools, same agent config, same `localhost:4444/mcp/`.
 

--- a/docs/plans/agent-memory-api.md
+++ b/docs/plans/agent-memory-api.md
@@ -32,8 +32,8 @@ Cloud (Pro only)
 
 Behind the same MCP tool surface:
 
-1. Sign-in (OAuth GitHub primary, magic-link fallback) stores a session in `~/Oyster/config/`.
-2. The local server's memory writes go through a write-through outbox: events land in `synced_memory_events` locally, then push to D1 via `cloud.oyster.to/api/memories/events`. Reads stay against the local SQLite mirror — fast, offline-tolerant.
+1. Sign-in (OAuth GitHub primary, magic-link fallback) persists to `~/Oyster/config/auth.json`.
+2. The local server's memory writes go through a write-through outbox: events land locally in `memory_events` + `memory_payloads`, then push to the cloud Worker which ingests into D1's `synced_memory_events` + `synced_memory_payloads`. Reads stay against the local SQLite mirror — fast, offline-tolerant.
 3. Cross-device propagation: another signed-in machine's local server pulls cloud events and replays them into its local DB on focus / visibility / online / panel-mount / 30s-poll.
 4. Profile-binding gate ensures account A's events can't pollute a local profile bound to account B.
 

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -1,4 +1,4 @@
-# Oyster roadmap (2026-05 onwards)
+# Oyster roadmap (2026-05 onwards; last edit 2026-05-09)
 
 > **Status:** canonical. Each milestone is an epic that delivers one or more requirements from [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md). If a ticket isn't on the path to making a requirement true, it doesn't belong on a milestone — it gets deferred or shipped opportunistically.
 >
@@ -25,51 +25,65 @@ Each milestone from here delivers one or more requirements. Polish, refactors, a
 
 **Didn't ship:** anything else. Deferred items remain deferred.
 
-## 0.7.0 — Free account + Publish/Share
+## 0.7.0 — Free account + Publish/Share ✅ shipped
 
-**Delivers:** R5 (publish & share artefacts) + the identity substrate that R1 / R5 / R7 ride on.
+**Delivered:** R5 (publish & share artefacts) + the identity substrate that R1 / R5 / R7 ride on.
 
-**Purpose:** first visible Cloud wedge. Convert the waitlist into a free-account funnel. The pricing page promise of *"Sync · Memory · Publish"* starts being true with **Publish**.
+**Purpose:** first visible Cloud wedge — convert the waitlist into a free-account funnel and start making the pricing-page promise of *"Sync · Memory · Publish"* true.
 
-**Status:** auth + R5 backend + viewer all shipped. Only the Publish UI affordance (#317) remains.
+**Shipped:**
 
-**Ships:**
-
-- ✅ **Auth** — magic-link (#295) shipped first; **OAuth Google + GitHub (#340) replaced it as the primary path**, magic-link demoted to fallback. Account state surfaced in-app. Pattern adapted from `~/Dev/oyster-crm`.
+- ✅ **Auth** — magic-link (#295) shipped first; **OAuth GitHub (#340) replaced it as the primary path**, magic-link demoted to fallback. Account state surfaced in-app.
 - ✅ **R5 schema** (#314) — `share_token`, `share_mode`, `share_password_hash`, `published_at`, `share_updated_at`, `unpublished_at` columns on artefacts.
-- ✅ **R5 backend** (#315) — `publish_artifact` / `unpublish_artifact` MCP tools, `POST /api/artifacts/:id/publish` + unpublish, cloud upload to R2 via `infra/oyster-publish` Worker. Single source of truth in `server/src/publish-service.ts`.
-- ✅ **R5 viewer** (#316) — public viewer at `oyster.to/p/<token>` with three access modes (open, password, sign-in-required). Implemented as a Cloudflare Worker route with markdown rendering.
-- ⏳ **R5 UI** (#317) — Publish action in the artefact UI (modal, mode picker, URL display, copy-to-clipboard). **In flight.**
-- **Entitlement / caps model** — free-tier caps for published-artefact size enforced in the Worker (10 MB ceiling); Pro tier unlocks higher. Folded into the work above.
+- ✅ **R5 backend** (#315) — `publish_artifact` / `unpublish_artifact` MCP tools, `POST /api/artifacts/:id/publish` + unpublish, cloud upload to R2 via `infra/oyster-publish` Worker.
+- ✅ **R5 viewer** (#316) — public viewer at `share.oyster.to/p/<token>` with three access modes (open, password, sign-in-required). Origin-isolated from the main app (#397).
+- ✅ **R5 UI** (#317) — Publish action in the artefact UI (modal, mode picker, URL display, copy-to-clipboard).
+- ✅ **R5 hardening** (#400) — local-mirror backfill, cloud-only ghost rows, password=Pro gating, list-view context menu, cloud-only edit/rename/unpublish.
+- ✅ **Entitlement / caps model** — free-tier caps for published-artefact size enforced in the Worker (10 MB ceiling); Pro tier unlocks higher.
 
-**Won't ship:** sync, durability, cloud memory store, semantic recall, cross-device anything, artefact-byte sync, version history. Those are 0.8.0+. Multi-file bundles also out of scope — single-file artefacts are sufficient for R5; richer Publish lives in 0.9.0+ if it earns its keep.
+## 0.7.1 — Spaces sync wedge ✅ shipped
 
-## 0.8.0 — Pro continuity
+**Delivered:** the first cross-device sync wedge — spaces metadata propagating across signed-in devices. Validated the DIY events-table + outbox + worker shape before extending to memory in 0.8.0.
 
-**Delivers:** R1 (empty-machine continuity) + R3 (durability) + R4 cross-device + R2 cross-device extension.
+**Shipped:**
 
-**Purpose:** solve the empty-machine deadness. *Sign in on a new laptop and your work is there.*
+- ✅ **Spaces sync** (#406, PR #407) — Pro users see the same set of spaces (name, hierarchy, summary) on every device. Published artefacts on a fresh device resolve to their real space instead of a generic "Cloud" bucket.
+- ✅ **Boot banner refresh** — new logo + rotating tip per boot.
+
+## 0.8.0 — Cross-device memory ✅ shipped
+
+**Delivered:** R4 — memories travel with the user, not the device. Cross-agent recall (Claude / Cursor / Codex) works cross-device on the same Pro account.
+
+**Purpose:** make the *"every agent, one shared brain"* tagline true across machines, not just across agents on one machine.
+
+**Shipped:**
+
+- ✅ **R4 cloud memory store** (#318) — `synced_memory_events` + `synced_memory_payloads` in D1, write-through outbox + cloud pull on focus/visibility/online/panel-mount/30s-poll, manual refresh button, profile-binding gate so account A's events don't pollute account B's local SQLite.
+- ✅ **Live panel updates** (#421) — `memory_changed` SSE on cloud pulls and local writes, so the Memories panel re-fetches without focus.
+- ✅ **Timezone-correct timestamps** (#422) — ISO-8601 UTC at the API boundary so non-UTC clients no longer render "ago" times skewed by their offset.
+
+**Punted to 0.9.0** (originally scoped here, moved out for shipping speed):
+
+- **Sync engine, broader** (#296) — beyond memory + spaces, the longer-tail surface. Memory-first stance from `archived/sync-direction.md` holds; transcripts intentionally cold-path.
+- **R1 fresh-machine restore** (#319) — Home (memories + spaces) restores today; the missing piece is artefact-byte restore, which is R7-shaped.
+- **R3 cold-storage transcripts** (#320) — durable backup of `session_events`, lazy-pulled by the inspector on first open per device.
+- **R2 semantic recall** (#321) — embedding-backed recall, cross-device.
+- **Pick up here** (#322) — cross-device session priming with summary + memories + artefact refs.
+
+## 0.9.0 — Pro continuity (deepened) + multi-agent + R7
+
+**Delivers:** the items punted from 0.8.0 (R1 / R2 / R3 / Pick-up-here / broader sync) plus R7 (artefact continuity across devices and across time) and native multi-agent ingestion beyond MCP memory.
+
+**Purpose:** the hardest pieces, after the cloud substrate has soaked. Don't let any of these block earlier milestones.
 
 **Ships:**
 
-- **Sync engine** (#296) — memory-first transport, end-to-end encrypted. Per `archived/sync-direction.md` framing: hot path = memories + spaces + artefact manifests + session metadata + summaries; cold path = transcripts.
-- **R4 cloud memory store** (#318) — memories travel with the user, not the device. Cross-agent recall (Claude / Cursor / Codex) works cross-device.
-- **R1 fresh-machine restore** (#319) — sign-in on a clean device populates Home from cloud, no manual setup.
-- **R3 cold-storage transcripts** (#320) — durable backup of `session_events`, lazy-pulled by the inspector on first open per device. Survives machine loss.
+- **Sync engine, broader** (#296) — extends 0.8.0's memory + spaces sync to the longer tail.
+- **R1 fresh-machine restore** (#319) — sign-in on a clean device populates Home from cloud end-to-end (memories + spaces shipped in 0.8.0; this finishes the artefact + transcript half).
 - **R2 semantic recall** (#321) — embedding-backed recall, replaces / augments the OR-joined FTS for natural-language queries. Cross-device because vectors live in cloud.
+- **R3 cold-storage transcripts** (#320) — durable backup of `session_events`, lazy-pulled by the inspector on first open per device. Survives machine loss.
 - **Pick up here** (#322) — the killer demo. Cross-device session priming with summary + memories + artefact refs. Not a transcript replay — the agent is *primed*, not replayed.
-
-**Won't ship:** artefact-byte sync, version history, diff/revert, cross-device artefact editing. R7 is its own arc.
-
-## 0.9.0 — Artefact continuity + multi-agent depth
-
-**Delivers:** R7 (artefact continuity across devices and across time) + R4 deepening (native multi-agent ingestion beyond MCP memory).
-
-**Purpose:** the hardest pieces, after the Cloud substrate is steady-state. Don't let any of these block 0.6.0 / 0.7.0 / 0.8.0.
-
-**Ships:**
-
-- **R7 across-time** (#323) — `artifact_versions` table (or git-backed), snapshot-on-write, history view, diff between versions, revert. Local-first is acceptable; the across-time axis is independent of cross-device. Ship first to prove the version-store choice.
+- **R7 across-time** (#323) — `artifact_versions` table (or git-backed), snapshot-on-write, history view, diff between versions, revert. Local-first is acceptable; the across-time axis is independent of cross-device.
 - **R7 across-device** (#324) — bidirectional artefact-byte sync with a defined conflict policy (LWW + version history is the leading candidate). The compound R7 scenario from the requirements doc passes end-to-end.
 - **Multi-agent ingestion** (#298) — beyond MCP memory: native session ingestion for Cursor, Codex, OpenCode and beyond. Folds in #177 (closed).
 


### PR DESCRIPTION
## Summary
- Refreshes long-form docs that were stale after today's 0.8.0 release + the milestone reassignments to 0.9.0.
- Roadmap is the load-bearing change: 0.7.0 / 0.7.1 / 0.8.0 marked shipped (with what actually landed); 0.8.0 entry calls out what punted to 0.9.0 (#296/#319/#320/#321/#322); 0.9.0 entry absorbs them alongside R7 + multi-agent.
- README's user-facing Status section was stuck on 0.5.x — now reflects 0.8.0 + Next 0.9.x scope.
- Gap matrix R4 / R5 sections updated to "delivered"; cross-cutting observations note that the cloud data store and sync layer are now partially shipped.
- agent-memory-api drops Vectorize from the Pro provider description (semantic recall is 0.9.0) and refreshes the "what 0.8.0 changes" walkthrough.

Other docs audited and intentionally left alone: requirements/oyster-cloud.md (timeless tier statements), auth.md / auth-oauth.md (canonical for 0.7.0 work, which shipped as described), launch-readiness-2026-04-23.md (explicitly historical), mockups/, research/, archived/, future/.

## Test plan
- [ ] Skim the four files diff-by-diff
- [ ] Confirm version statements match recent commits