### PR TITLE
feat(sessions-sync): cross-device session sync — local + cloud + chunked-delta (#322)

### DIFF
--- a/infra/auth-worker/migrations/0008_synced_sessions.sql
+++ b/infra/auth-worker/migrations/0008_synced_sessions.sql
@@ -1,33 +1,60 @@
 -- 0008_synced_sessions.sql — cross-device session sync substrate (#322).
 -- Spec: PR #431 (eventual-soaring-swan plan).
 --
--- Per-row LWW model. Sessions are append-only by nature (one device produces
--- a session, another resumes it as a fresh session) so we don't need an event
--- log here — just the latest metadata row per session, and the R2 key once
--- the bytes are uploaded. Pro-only writes; gate enforced on the Worker.
+-- Two tables drive the cross-device sync:
+--   1. synced_session_metadata — per-session metadata row, LWW on updated_at,
+--      with bytes_generation incrementing on truncation/reset.
+--   2. synced_session_chunks — append-only manifest of encrypted jsonl chunks
+--      uploaded for the session. Manifest reads filter to current generation.
+-- Pro-only writes; gate enforced on the Worker.
 
 CREATE TABLE IF NOT EXISTS synced_session_metadata (
-  owner_id        TEXT    NOT NULL,
-  session_id      TEXT    NOT NULL,
-  device_id       TEXT,                 -- which device pushed this row
-  agent           TEXT    NOT NULL,
-  title           TEXT,
-  state           TEXT    NOT NULL,
-  cwd             TEXT,
-  model           TEXT,
-  started_at      TEXT    NOT NULL,
-  ended_at        TEXT,
-  last_event_at   TEXT    NOT NULL,
-  jsonl_r2_key    TEXT,                 -- NULL until bytes uploaded
-  updated_at      INTEGER NOT NULL,     -- LWW tiebreaker; unix ms
+  owner_id          TEXT    NOT NULL,
+  session_id        TEXT    NOT NULL,
+  device_id         TEXT,                 -- which device pushed this row
+  agent             TEXT    NOT NULL,
+  title             TEXT,
+  state             TEXT    NOT NULL,
+  cwd               TEXT,
+  model             TEXT,
+  started_at        TEXT    NOT NULL,
+  ended_at          TEXT,
+  last_event_at     TEXT    NOT NULL,
+  bytes_generation  INTEGER NOT NULL DEFAULT 0,  -- bumped on reset; chunks scoped to current gen
+  updated_at        INTEGER NOT NULL,     -- LWW tiebreaker; unix ms
   PRIMARY KEY (owner_id, session_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_updated
   ON synced_session_metadata (owner_id, updated_at DESC);
 
--- The list endpoint orders by last_event_at DESC (user-facing ""most recently
--- active first""), distinct from updated_at (the LWW sync tiebreaker). Without
+-- The list endpoint orders by last_event_at DESC (user-facing "most recently
+-- active first"), distinct from updated_at (the LWW sync tiebreaker). Without
 -- this index a Pro user with hundreds of sessions would force a sort per GET.
 CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_last_event
   ON synced_session_metadata (owner_id, last_event_at DESC);
+
+-- Chunk manifest. Each row is one delta-uploaded encrypted jsonl segment.
+-- PK includes bytes_generation so a reset (which bumps the generation on
+-- the metadata row) cleanly orphans prior-generation rows without DELETE —
+-- manifest reads filter to the current generation. Background GC of
+-- orphaned R2 objects from older generations deferred to v1.1.
+--
+-- plaintext_sha256 is verified by Device B after per-chunk download to
+-- detect bit-rot or transport error. byte_count is denormalised
+-- (end_offset - start_offset) so manifest reads don't recompute.
+CREATE TABLE IF NOT EXISTS synced_session_chunks (
+  owner_id          TEXT    NOT NULL,
+  session_id        TEXT    NOT NULL,
+  bytes_generation  INTEGER NOT NULL,
+  chunk_number      INTEGER NOT NULL,
+  start_offset      INTEGER NOT NULL,    -- plaintext byte offset of first byte in this chunk
+  end_offset        INTEGER NOT NULL,    -- plaintext byte offset just past last byte
+  byte_count        INTEGER NOT NULL,    -- end_offset - start_offset
+  plaintext_sha256  TEXT    NOT NULL,    -- hex digest of plaintext chunk bytes
+  uploaded_at       INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, session_id, bytes_generation, chunk_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_synced_session_chunks_active
+  ON synced_session_chunks (owner_id, session_id, bytes_generation, chunk_number);

--- a/infra/auth-worker/migrations/0008_synced_sessions.sql
+++ b/infra/auth-worker/migrations/0008_synced_sessions.sql
@@ -1,5 +1,5 @@
 -- 0008_synced_sessions.sql — cross-device session sync substrate (#322).
--- Spec: PR #431 (eventual-soaring-swan plan).
+-- Implementation: PR #431.
 --
 -- Two tables drive the cross-device sync:
 --   1. synced_session_metadata — per-session metadata row, LWW on updated_at,

--- a/infra/auth-worker/migrations/0008_synced_sessions.sql
+++ b/infra/auth-worker/migrations/0008_synced_sessions.sql
@@ -1,0 +1,27 @@
+-- 0008_synced_sessions.sql — cross-device session sync substrate (#322).
+-- Spec: PR #431 (eventual-soaring-swan plan).
+--
+-- Per-row LWW model. Sessions are append-only by nature (one device produces
+-- a session, another resumes it as a fresh session) so we don't need an event
+-- log here — just the latest metadata row per session, and the R2 key once
+-- the bytes are uploaded. Pro-only writes; gate enforced on the Worker.
+
+CREATE TABLE IF NOT EXISTS synced_session_metadata (
+  owner_id        TEXT    NOT NULL,
+  session_id      TEXT    NOT NULL,
+  device_id       TEXT,                 -- which device pushed this row
+  agent           TEXT    NOT NULL,
+  title           TEXT,
+  state           TEXT    NOT NULL,
+  cwd             TEXT,
+  model           TEXT,
+  started_at      TEXT    NOT NULL,
+  ended_at        TEXT,
+  last_event_at   TEXT    NOT NULL,
+  jsonl_r2_key    TEXT,                 -- NULL until bytes uploaded
+  updated_at      INTEGER NOT NULL,     -- LWW tiebreaker; unix ms
+  PRIMARY KEY (owner_id, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_updated
+  ON synced_session_metadata (owner_id, updated_at DESC);

--- a/infra/auth-worker/migrations/0008_synced_sessions.sql
+++ b/infra/auth-worker/migrations/0008_synced_sessions.sql
@@ -25,3 +25,9 @@ CREATE TABLE IF NOT EXISTS synced_session_metadata (
 
 CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_updated
   ON synced_session_metadata (owner_id, updated_at DESC);
+
+-- The list endpoint orders by last_event_at DESC (user-facing ""most recently
+-- active first""), distinct from updated_at (the LWW sync tiebreaker). Without
+-- this index a Pro user with hundreds of sessions would force a sort per GET.
+CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_last_event
+  ON synced_session_metadata (owner_id, last_event_at DESC);

--- a/infra/oyster-cloud/src/encryption.ts
+++ b/infra/oyster-cloud/src/encryption.ts
@@ -1,0 +1,55 @@
+// encryption.ts — per-user AES-GCM for session jsonl bytes (#322).
+//
+// HKDF (SHA-256) derives an AES-256 key from a master secret + per-user salt.
+// A leak of one user's derived key cannot decrypt another user's bytes.
+// A leak of the master secret without the user id list still requires
+// re-deriving each user's key separately.
+//
+// Wire format on R2: 12-byte IV || ciphertext+tag. The IV is random per
+// encryption — never reused with the same key (AES-GCM nonce-reuse breaks
+// confidentiality and integrity). 12 bytes is the standard AES-GCM IV size.
+
+const HKDF_INFO = new TextEncoder().encode("oyster-session-bytes-v1");
+const IV_LENGTH = 12;
+
+async function deriveKey(masterSecret: string, userId: string): Promise<CryptoKey> {
+  const ikm = new TextEncoder().encode(masterSecret);
+  const salt = new TextEncoder().encode(userId);
+  const baseKey = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveKey"]);
+  return crypto.subtle.deriveKey(
+    { name: "HKDF", hash: "SHA-256", salt, info: HKDF_INFO },
+    baseKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+export async function encryptForUser(
+  masterSecret: string,
+  userId: string,
+  plaintext: Uint8Array,
+): Promise<Uint8Array> {
+  const key = await deriveKey(masterSecret, userId);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext);
+  const out = new Uint8Array(IV_LENGTH + ciphertext.byteLength);
+  out.set(iv, 0);
+  out.set(new Uint8Array(ciphertext), IV_LENGTH);
+  return out;
+}
+
+export async function decryptForUser(
+  masterSecret: string,
+  userId: string,
+  blob: Uint8Array,
+): Promise<Uint8Array> {
+  if (blob.byteLength < IV_LENGTH + 16 /* AES-GCM tag */) {
+    throw new Error("ciphertext too short");
+  }
+  const key = await deriveKey(masterSecret, userId);
+  const iv = blob.subarray(0, IV_LENGTH);
+  const ciphertext = blob.subarray(IV_LENGTH);
+  const plaintext = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  return new Uint8Array(plaintext);
+}

--- a/infra/oyster-cloud/src/encryption.ts
+++ b/infra/oyster-cloud/src/encryption.ts
@@ -1,9 +1,15 @@
-// encryption.ts — per-user AES-GCM for session jsonl bytes (#322).
+// encryption.ts — per-user AES-GCM for session jsonl chunks (#322).
 //
 // HKDF (SHA-256) derives an AES-256 key from a master secret + per-user salt.
 // A leak of one user's derived key cannot decrypt another user's bytes.
 // A leak of the master secret without the user id list still requires
 // re-deriving each user's key separately.
+//
+// Each chunk's ciphertext is bound to its identifying metadata via AES-GCM's
+// Additional Authenticated Data (AAD). AAD doesn't change ciphertext length
+// but decrypt fails if any AAD field differs from what was bound at encrypt.
+// This makes chunks non-substitutable: a chunk's ciphertext from session A,
+// chunk 3, generation 0 cannot be served as session B / chunk 7 / generation 1.
 //
 // Wire format on R2: 12-byte IV || ciphertext+tag. The IV is random per
 // encryption — never reused with the same key (AES-GCM nonce-reuse breaks
@@ -11,6 +17,35 @@
 
 const HKDF_INFO = new TextEncoder().encode("oyster-session-bytes-v1");
 const IV_LENGTH = 12;
+
+/** Fields bound into a chunk's ciphertext via AES-GCM AAD. Any change to
+ *  any field invalidates the chunk on decrypt. Keep field names + order
+ *  stable forever — they're part of the on-disk format. */
+export interface ChunkAad {
+  owner_id: string;
+  session_id: string;
+  bytes_generation: number;
+  chunk_number: number;
+  start_offset: number;
+  end_offset: number;
+  plaintext_sha256: string;
+}
+
+/** Canonical AAD serialisation. Field order is fixed so encrypt and decrypt
+ *  produce byte-identical inputs to AES-GCM regardless of JSON.stringify
+ *  key-order quirks. */
+function serialiseAad(aad: ChunkAad): Uint8Array {
+  const canonical = JSON.stringify({
+    owner_id: aad.owner_id,
+    session_id: aad.session_id,
+    bytes_generation: aad.bytes_generation,
+    chunk_number: aad.chunk_number,
+    start_offset: aad.start_offset,
+    end_offset: aad.end_offset,
+    plaintext_sha256: aad.plaintext_sha256,
+  });
+  return new TextEncoder().encode(canonical);
+}
 
 async function deriveKey(masterSecret: string, userId: string): Promise<CryptoKey> {
   const ikm = new TextEncoder().encode(masterSecret);
@@ -25,31 +60,53 @@ async function deriveKey(masterSecret: string, userId: string): Promise<CryptoKe
   );
 }
 
-export async function encryptForUser(
+export async function encryptChunk(
   masterSecret: string,
-  userId: string,
+  aad: ChunkAad,
   plaintext: Uint8Array,
 ): Promise<Uint8Array> {
-  const key = await deriveKey(masterSecret, userId);
+  const key = await deriveKey(masterSecret, aad.owner_id);
   const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
-  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, plaintext);
+  const additionalData = serialiseAad(aad);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv, additionalData },
+    key,
+    plaintext,
+  );
   const out = new Uint8Array(IV_LENGTH + ciphertext.byteLength);
   out.set(iv, 0);
   out.set(new Uint8Array(ciphertext), IV_LENGTH);
   return out;
 }
 
-export async function decryptForUser(
+export async function decryptChunk(
   masterSecret: string,
-  userId: string,
+  aad: ChunkAad,
   blob: Uint8Array,
 ): Promise<Uint8Array> {
   if (blob.byteLength < IV_LENGTH + 16 /* AES-GCM tag */) {
     throw new Error("ciphertext too short");
   }
-  const key = await deriveKey(masterSecret, userId);
+  const key = await deriveKey(masterSecret, aad.owner_id);
   const iv = blob.subarray(0, IV_LENGTH);
   const ciphertext = blob.subarray(IV_LENGTH);
-  const plaintext = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  const additionalData = serialiseAad(aad);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv, additionalData },
+    key,
+    ciphertext,
+  );
   return new Uint8Array(plaintext);
+}
+
+/** Hex-encoded SHA-256 of plaintext bytes. Used as the chunk's content hash
+ *  for the manifest, for AAD binding, and for Device B verification. */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(digest);
+  let hex = "";
+  for (let i = 0; i < view.length; i++) {
+    hex += view[i]!.toString(16).padStart(2, "0");
+  }
+  return hex;
 }

--- a/infra/oyster-cloud/src/session.ts
+++ b/infra/oyster-cloud/src/session.ts
@@ -3,6 +3,13 @@
 
 export interface Env {
   DB: D1Database; // shared with oyster-auth (same database_id)
+  // Session bytes (#322): per-user AES-GCM encrypted jsonl objects.
+  SESSIONS_BUCKET: R2Bucket;
+  // HKDF input keying material — provisioned via:
+  //   wrangler secret put SESSIONS_ENCRYPTION_KEY
+  // The actual AES key is derived per-user (salt = user id) so a leak of
+  // one user's derived key never compromises another.
+  SESSIONS_ENCRYPTION_KEY: string;
 }
 
 interface SessionUser {

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -391,9 +391,14 @@ async function handleSessionsMetadataPost(req: Request, env: Env): Promise<Respo
            last_event_at = excluded.last_event_at,
            updated_at    = excluded.updated_at
           WHERE excluded.updated_at > synced_session_metadata.updated_at`,
+      // D1 .bind() throws on undefined; the nullable fields are typed as
+      // `string | null` in IncomingSession but the validator allows them to
+      // be missing entirely. Coerce every nullable to null before binding so
+      // a partial-shape session doesn't fail the whole batch with 500.
       ).bind(
-        user.id, s.id, s.device_id ?? null, s.agent, s.title, s.state, s.cwd, s.model,
-        s.started_at, s.ended_at, s.last_event_at, s.sync_dirty_at,
+        user.id, s.id, s.device_id ?? null, s.agent,
+        s.title ?? null, s.state, s.cwd ?? null, s.model ?? null,
+        s.started_at, s.ended_at ?? null, s.last_event_at, s.sync_dirty_at,
       ).run();
       // changes > 0 means a row was inserted or LWW won an update. changes 0
       // means an older sync_dirty_at lost the LWW race; still acknowledge so
@@ -613,15 +618,22 @@ async function handleSessionsBytesChunkPut(
   // idempotency check above already returned 200 on exact-match retry.
   // A race between two clients pushing the same chunk would hit either
   // the existing-row path or this insert; either way the table is consistent.
-  await env.DB.prepare(
-    `INSERT OR IGNORE INTO synced_session_chunks
-       (owner_id, session_id, bytes_generation, chunk_number,
-        start_offset, end_offset, byte_count, plaintext_sha256, uploaded_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).bind(
-    user.id, sessionId, generation, chunkNumber,
-    startOffset, endOffset, declaredSize, plaintextSha256Header, Date.now(),
-  ).run();
+  // Wrap in try/catch so a transient D1 hiccup surfaces as structured 500
+  // rather than an unhandled exception.
+  try {
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO synced_session_chunks
+         (owner_id, session_id, bytes_generation, chunk_number,
+          start_offset, end_offset, byte_count, plaintext_sha256, uploaded_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      user.id, sessionId, generation, chunkNumber,
+      startOffset, endOffset, declaredSize, plaintextSha256Header, Date.now(),
+    ).run();
+  } catch (err) {
+    console.warn("[sessions] chunk insert db error:", err);
+    return jsonError(500, "db_error");
+  }
 
   return jsonOk({
     ok: true,
@@ -751,11 +763,16 @@ async function handleSessionsBytesReset(
   if (currentGen === null) return jsonError(404, "session_not_found");
 
   const newGen = currentGen + 1;
-  await env.DB.prepare(
-    `UPDATE synced_session_metadata
-        SET bytes_generation = ?
-      WHERE owner_id = ? AND session_id = ?`,
-  ).bind(newGen, user.id, sessionId).run();
+  try {
+    await env.DB.prepare(
+      `UPDATE synced_session_metadata
+          SET bytes_generation = ?
+        WHERE owner_id = ? AND session_id = ?`,
+    ).bind(newGen, user.id, sessionId).run();
+  } catch (err) {
+    console.warn("[sessions] reset db error:", err);
+    return jsonError(500, "db_error");
+  }
 
   // Prior-generation chunk rows are deliberately left in place — the
   // generation filter on manifest / chunk-get makes them effectively

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -1,6 +1,7 @@
 import { jsonOk, jsonError } from "./json.js";
 import type { Env } from "./session.js";
 import { resolveSession } from "./session.js";
+import { encryptForUser, decryptForUser } from "./encryption.js";
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
@@ -19,6 +20,21 @@ export default {
 
     if (url.pathname === "/api/memories/events" && req.method === "GET") {
       return handleMemoryEventsGet(req, env);
+    }
+
+    if (url.pathname === "/api/sessions/metadata" && req.method === "POST") {
+      return handleSessionsMetadataPost(req, env);
+    }
+
+    if (url.pathname === "/api/sessions/metadata" && req.method === "GET") {
+      return handleSessionsMetadataGet(req, env);
+    }
+
+    const bytesMatch = url.pathname.match(/^\/api\/sessions\/bytes\/([^/]+)$/);
+    if (bytesMatch && bytesMatch[1]) {
+      const sessionId = decodeURIComponent(bytesMatch[1]);
+      if (req.method === "PUT") return handleSessionsBytesPut(req, env, sessionId);
+      if (req.method === "GET") return handleSessionsBytesGet(req, env, sessionId);
     }
 
     return jsonError(404, "not_found");
@@ -254,4 +270,211 @@ async function handleMemoryEventsGet(req: Request, env: Env): Promise<Response> 
   });
 
   return jsonOk({ events }, 200, { "cache-control": "private, no-store" });
+}
+
+// ── Session sync (#322) ──────────────────────────────────────────────
+
+interface IncomingSession {
+  id: string;
+  device_id?: string | null;
+  agent: string;
+  title: string | null;
+  state: string;
+  cwd: string | null;
+  model: string | null;
+  started_at: string;
+  ended_at: string | null;
+  last_event_at: string;
+  // Local sync_dirty_at acts as the LWW tiebreaker on the wire — newer
+  // wins on conflicts so a Device-A push during a Device-B-stale window
+  // doesn't get clobbered.
+  sync_dirty_at: number;
+}
+
+function isValidSession(s: unknown): s is IncomingSession {
+  if (!s || typeof s !== "object") return false;
+  const o = s as Record<string, unknown>;
+  if (typeof o.id !== "string" || o.id.length === 0) return false;
+  if (typeof o.agent !== "string" || o.agent.length === 0) return false;
+  if (typeof o.state !== "string" || o.state.length === 0) return false;
+  if (typeof o.started_at !== "string") return false;
+  if (typeof o.last_event_at !== "string") return false;
+  if (typeof o.sync_dirty_at !== "number" || !Number.isFinite(o.sync_dirty_at)) return false;
+  // title / cwd / model / ended_at / device_id are nullable; minimal check.
+  return true;
+}
+
+async function handleSessionsMetadataPost(req: Request, env: Env): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  let body: { sessions?: unknown };
+  try { body = await req.json() as { sessions?: unknown }; }
+  catch { return jsonError(400, "invalid_metadata"); }
+
+  const incoming = body.sessions;
+  if (!Array.isArray(incoming)) return jsonError(400, "invalid_metadata");
+
+  const MAX_SESSIONS_PER_REQUEST = 1000;
+  if (incoming.length > MAX_SESSIONS_PER_REQUEST) {
+    return jsonError(413, "too_many_sessions");
+  }
+
+  const accepted: string[] = [];
+  const rejected: string[] = [];
+
+  try {
+    for (const raw of incoming) {
+      if (!isValidSession(raw)) {
+        const id = (raw as { id?: unknown })?.id;
+        rejected.push(typeof id === "string" && id.length > 0 ? id : "<malformed>");
+        continue;
+      }
+      const s = raw;
+      // LWW: only overwrite an existing row when the incoming sync_dirty_at
+      // is strictly greater than what's stored. New rows always insert.
+      // Using INSERT … ON CONFLICT DO UPDATE WHERE keeps it one statement.
+      const result = await env.DB.prepare(
+        `INSERT INTO synced_session_metadata
+           (owner_id, session_id, device_id, agent, title, state, cwd, model,
+            started_at, ended_at, last_event_at, jsonl_r2_key, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+         ON CONFLICT(owner_id, session_id) DO UPDATE SET
+           device_id     = excluded.device_id,
+           agent         = excluded.agent,
+           title         = excluded.title,
+           state         = excluded.state,
+           cwd           = excluded.cwd,
+           model         = excluded.model,
+           started_at    = excluded.started_at,
+           ended_at      = excluded.ended_at,
+           last_event_at = excluded.last_event_at,
+           updated_at    = excluded.updated_at
+          WHERE excluded.updated_at > synced_session_metadata.updated_at`,
+      ).bind(
+        user.id, s.id, s.device_id ?? null, s.agent, s.title, s.state, s.cwd, s.model,
+        s.started_at, s.ended_at, s.last_event_at, s.sync_dirty_at,
+      ).run();
+      // changes > 0 means a row was inserted or LWW won an update. changes 0
+      // means an older sync_dirty_at lost the LWW race; still acknowledge so
+      // the client clears its dirty flag — cloud has a newer version.
+      accepted.push(s.id);
+      // touch result so the linter is satisfied
+      void result;
+    }
+  } catch (err) {
+    console.warn("[sessions] metadata ingest db error:", err);
+    return jsonError(500, "db_error");
+  }
+
+  return jsonOk({ accepted, rejected });
+}
+
+async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  type Row = {
+    session_id: string; device_id: string | null; agent: string; title: string | null;
+    state: string; cwd: string | null; model: string | null; started_at: string;
+    ended_at: string | null; last_event_at: string; jsonl_r2_key: string | null;
+    updated_at: number;
+  };
+  const { results } = await env.DB.prepare(
+    `SELECT session_id, device_id, agent, title, state, cwd, model, started_at,
+            ended_at, last_event_at, jsonl_r2_key, updated_at
+       FROM synced_session_metadata
+      WHERE owner_id = ?
+      ORDER BY last_event_at DESC`,
+  ).bind(user.id).all<Row>();
+
+  return jsonOk({ sessions: results ?? [] }, 200, { "cache-control": "private, no-store" });
+}
+
+function r2KeyFor(ownerId: string, sessionId: string): string {
+  // No device_id in the key — sessions have a single canonical jsonl per
+  // owner+session. Snapshot updates from the originating device overwrite.
+  return `sessions/${ownerId}/${sessionId}.jsonl`;
+}
+
+async function handleSessionsBytesPut(req: Request, env: Env, sessionId: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  // Confirm the session belongs to the caller before accepting bytes. Without
+  // this check, a Pro user could arbitrarily overwrite any session id in
+  // their own R2 prefix — harmless but wasteful and confusing in audit logs.
+  const owns = await env.DB.prepare(
+    `SELECT 1 FROM synced_session_metadata WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+  ).bind(user.id, sessionId).first();
+  if (!owns) return jsonError(404, "session_not_found");
+
+  const plaintext = new Uint8Array(await req.arrayBuffer());
+  if (plaintext.byteLength === 0) return jsonError(400, "empty_body");
+
+  let ciphertext: Uint8Array;
+  try {
+    ciphertext = await encryptForUser(env.SESSIONS_ENCRYPTION_KEY, user.id, plaintext);
+  } catch (err) {
+    console.warn("[sessions] encrypt failed:", err);
+    return jsonError(500, "encrypt_failed");
+  }
+
+  const key = r2KeyFor(user.id, sessionId);
+  try {
+    await env.SESSIONS_BUCKET.put(key, ciphertext, {
+      httpMetadata: { contentType: "application/octet-stream" },
+      customMetadata: { ownerId: user.id, sessionId, plaintextSize: String(plaintext.byteLength) },
+    });
+  } catch (err) {
+    console.warn("[sessions] R2 put failed:", err);
+    return jsonError(500, "r2_put_failed");
+  }
+
+  // Record the R2 key on the metadata row so cross-device clients know bytes
+  // are available for lazy pull.
+  await env.DB.prepare(
+    `UPDATE synced_session_metadata SET jsonl_r2_key = ?, updated_at = ?
+      WHERE owner_id = ? AND session_id = ?`,
+  ).bind(key, Date.now(), user.id, sessionId).run();
+
+  return jsonOk({ ok: true, key, plaintextSize: plaintext.byteLength, ciphertextSize: ciphertext.byteLength });
+}
+
+async function handleSessionsBytesGet(req: Request, env: Env, sessionId: string): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  // Owner check: refuse if the session isn't in this owner's metadata. Stops
+  // any ""guess another user's session_id"" cross-account read attempt before
+  // we even hit R2.
+  const owns = await env.DB.prepare(
+    `SELECT jsonl_r2_key FROM synced_session_metadata WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+  ).bind(user.id, sessionId).first<{ jsonl_r2_key: string | null }>();
+  if (!owns) return jsonError(404, "session_not_found");
+  if (!owns.jsonl_r2_key) return jsonError(404, "bytes_not_uploaded");
+
+  const obj = await env.SESSIONS_BUCKET.get(owns.jsonl_r2_key);
+  if (!obj) return jsonError(404, "bytes_missing");
+
+  const ciphertext = new Uint8Array(await obj.arrayBuffer());
+  let plaintext: Uint8Array;
+  try {
+    plaintext = await decryptForUser(env.SESSIONS_ENCRYPTION_KEY, user.id, ciphertext);
+  } catch (err) {
+    console.warn("[sessions] decrypt failed:", err);
+    return jsonError(500, "decrypt_failed");
+  }
+
+  return new Response(plaintext, {
+    status: 200,
+    headers: {
+      "content-type": "application/jsonl",
+      "cache-control": "private, no-store",
+    },
+  });
 }

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -305,7 +305,15 @@ function isValidSession(s: unknown): s is IncomingSession {
   if (typeof o.started_at !== "string") return false;
   if (typeof o.last_event_at !== "string") return false;
   if (typeof o.sync_dirty_at !== "number" || !Number.isFinite(o.sync_dirty_at)) return false;
-  // title / cwd / model / ended_at / device_id are nullable; minimal check.
+  if (o.sync_dirty_at < 0) return false;
+  // Nullable fields must be string-or-null. Anything else (number, object,
+  // array) would either crash D1 .bind() with TypeError or silently coerce
+  // to a useless string representation. Each malformed session is rejected
+  // individually so the rest of the batch still lands.
+  for (const key of ["title", "cwd", "model", "ended_at", "device_id"] as const) {
+    const v = o[key];
+    if (v !== null && v !== undefined && typeof v !== "string") return false;
+  }
   return true;
 }
 
@@ -404,6 +412,13 @@ function r2KeyFor(ownerId: string, sessionId: string): string {
   return `sessions/${ownerId}/${sessionId}.jsonl`;
 }
 
+// Hard cap on jsonl uploads. Real Claude Code sessions are typically 1-50 MB;
+// 50 MB covers extreme edge cases without letting an abusive client fill R2
+// or burn worker CPU. Workers' default body limit (100 MB) and CPU budget
+// would catch this anyway, but we want a structured 413 instead of a runtime
+// crash and the limit is small enough to keep encryption fast.
+const MAX_BYTES_UPLOAD = 50 * 1024 * 1024;
+
 async function handleSessionsBytesPut(req: Request, env: Env, sessionId: string): Promise<Response> {
   const user = await resolveSession(req, env);
   if (!user) return jsonError(401, "sign_in_required");
@@ -417,8 +432,20 @@ async function handleSessionsBytesPut(req: Request, env: Env, sessionId: string)
   ).bind(user.id, sessionId).first();
   if (!owns) return jsonError(404, "session_not_found");
 
+  // Fail fast on Content-Length when the client honestly declares it. Saves
+  // reading 50+ MB into memory only to reject. Content-Length can be missing
+  // or lie (chunked transfer, untrusted client) so we re-check after read.
+  const lenHeader = req.headers.get("content-length");
+  if (lenHeader) {
+    const declared = Number(lenHeader);
+    if (Number.isFinite(declared) && declared > MAX_BYTES_UPLOAD) {
+      return jsonError(413, "payload_too_large");
+    }
+  }
+
   const plaintext = new Uint8Array(await req.arrayBuffer());
   if (plaintext.byteLength === 0) return jsonError(400, "empty_body");
+  if (plaintext.byteLength > MAX_BYTES_UPLOAD) return jsonError(413, "payload_too_large");
 
   let ciphertext: Uint8Array;
   try {

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -1,15 +1,20 @@
 import { jsonOk, jsonError } from "./json.js";
 import type { Env } from "./session.js";
 import { resolveSession } from "./session.js";
-import { encryptForUser, decryptForUser } from "./encryption.js";
+import { encryptChunk, decryptChunk, sha256Hex, type ChunkAad } from "./encryption.js";
+
+// Safe decode helper used by all bytes routes. decodeURIComponent throws
+// URIError on malformed percent-encoding (e.g. "%G"); we'd rather a 400 than
+// an unhandled rejection.
+function safeDecode(raw: string): string | null {
+  try { return decodeURIComponent(raw); }
+  catch { return null; }
+}
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
 
-    // Routes for this worker land in Tasks 6 and 7. For now, anything
-    // that isn't matched returns 404. Health-check responds 200 for
-    // deployment smoke-tests.
     if (url.pathname === "/health" && req.method === "GET") {
       return new Response("ok", { status: 200 });
     }
@@ -30,16 +35,35 @@ export default {
       return handleSessionsMetadataGet(req, env);
     }
 
-    const bytesMatch = url.pathname.match(/^\/api\/sessions\/bytes\/([^/]+)$/);
-    if (bytesMatch && bytesMatch[1]) {
-      // decodeURIComponent throws URIError on malformed percent-encoding
-      // (e.g. "%G"). Without this guard, a bad path would surface as an
-      // unhandled rejection instead of a structured 4xx.
-      let sessionId: string;
-      try { sessionId = decodeURIComponent(bytesMatch[1]); }
-      catch { return jsonError(400, "invalid_session_id"); }
-      if (req.method === "PUT") return handleSessionsBytesPut(req, env, sessionId);
-      if (req.method === "GET") return handleSessionsBytesGet(req, env, sessionId);
+    // Session bytes — chunked-delta routes (#322). Four shapes:
+    //   PUT  /api/sessions/bytes/:id/chunk/:n        upload one chunk
+    //   GET  /api/sessions/bytes/:id/manifest        list chunks for current gen
+    //   GET  /api/sessions/bytes/:id/chunk/:n        download one chunk
+    //   POST /api/sessions/bytes/:id/reset           bump generation
+    const chunkMatch = url.pathname.match(/^\/api\/sessions\/bytes\/([^/]+)\/chunk\/(\d+)$/);
+    if (chunkMatch && chunkMatch[1] && chunkMatch[2]) {
+      const sessionId = safeDecode(chunkMatch[1]);
+      const chunkNumber = Number(chunkMatch[2]);
+      if (sessionId === null) return jsonError(400, "invalid_session_id");
+      if (!Number.isInteger(chunkNumber) || chunkNumber < 1) {
+        return jsonError(400, "invalid_chunk_number");
+      }
+      if (req.method === "PUT") return handleSessionsBytesChunkPut(req, env, sessionId, chunkNumber);
+      if (req.method === "GET") return handleSessionsBytesChunkGet(req, env, sessionId, chunkNumber);
+    }
+
+    const manifestMatch = url.pathname.match(/^\/api\/sessions\/bytes\/([^/]+)\/manifest$/);
+    if (manifestMatch && manifestMatch[1] && req.method === "GET") {
+      const sessionId = safeDecode(manifestMatch[1]);
+      if (sessionId === null) return jsonError(400, "invalid_session_id");
+      return handleSessionsBytesManifestGet(req, env, sessionId);
+    }
+
+    const resetMatch = url.pathname.match(/^\/api\/sessions\/bytes\/([^/]+)\/reset$/);
+    if (resetMatch && resetMatch[1] && req.method === "POST") {
+      const sessionId = safeDecode(resetMatch[1]);
+      if (sessionId === null) return jsonError(400, "invalid_session_id");
+      return handleSessionsBytesReset(req, env, sessionId);
     }
 
     return jsonError(404, "not_found");
@@ -348,11 +372,13 @@ async function handleSessionsMetadataPost(req: Request, env: Env): Promise<Respo
       // LWW: only overwrite an existing row when the incoming sync_dirty_at
       // is strictly greater than what's stored. New rows always insert.
       // Using INSERT … ON CONFLICT DO UPDATE WHERE keeps it one statement.
+      // bytes_generation is owned by the chunked-bytes flow and never set
+      // from metadata pushes — left at its existing value (default 0 on insert).
       const result = await env.DB.prepare(
         `INSERT INTO synced_session_metadata
            (owner_id, session_id, device_id, agent, title, state, cwd, model,
-            started_at, ended_at, last_event_at, jsonl_r2_key, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+            started_at, ended_at, last_event_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(owner_id, session_id) DO UPDATE SET
            device_id     = excluded.device_id,
            agent         = excluded.agent,
@@ -389,128 +415,351 @@ async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Respon
   if (!user) return jsonError(401, "sign_in_required");
   if (user.tier !== "pro") return jsonError(403, "pro_required");
 
+  // has_bytes is computed from EXISTS in chunks table at the current
+  // generation. A session may have metadata but no chunks yet (push
+  // hasn't fired) or chunks from older generations only (just reset).
   type Row = {
     session_id: string; device_id: string | null; agent: string; title: string | null;
     state: string; cwd: string | null; model: string | null; started_at: string;
-    ended_at: string | null; last_event_at: string; jsonl_r2_key: string | null;
-    updated_at: number;
+    ended_at: string | null; last_event_at: string;
+    bytes_generation: number; has_bytes: number; updated_at: number;
   };
   const { results } = await env.DB.prepare(
-    `SELECT session_id, device_id, agent, title, state, cwd, model, started_at,
-            ended_at, last_event_at, jsonl_r2_key, updated_at
-       FROM synced_session_metadata
-      WHERE owner_id = ?
-      ORDER BY last_event_at DESC`,
+    `SELECT m.session_id, m.device_id, m.agent, m.title, m.state, m.cwd, m.model,
+            m.started_at, m.ended_at, m.last_event_at, m.bytes_generation, m.updated_at,
+            CASE WHEN EXISTS (
+              SELECT 1 FROM synced_session_chunks c
+               WHERE c.owner_id = m.owner_id
+                 AND c.session_id = m.session_id
+                 AND c.bytes_generation = m.bytes_generation
+            ) THEN 1 ELSE 0 END AS has_bytes
+       FROM synced_session_metadata m
+      WHERE m.owner_id = ?
+      ORDER BY m.last_event_at DESC`,
   ).bind(user.id).all<Row>();
 
-  return jsonOk({ sessions: results ?? [] }, 200, { "cache-control": "private, no-store" });
+  // Normalise has_bytes to boolean for the client.
+  const sessions = (results ?? []).map((r) => ({ ...r, has_bytes: r.has_bytes === 1 }));
+  return jsonOk({ sessions }, 200, { "cache-control": "private, no-store" });
 }
 
-function r2KeyFor(ownerId: string, sessionId: string): string {
-  // No device_id in the key — sessions have a single canonical jsonl per
-  // owner+session. Snapshot updates from the originating device overwrite.
-  return `sessions/${ownerId}/${sessionId}.jsonl`;
+// Per-chunk upload cap. Workers' default body limit is 100 MB; we stay well
+// under that to leave headroom for encryption overhead + HTTP framing. There
+// is no per-session total cap — chunks accumulate as the session grows.
+const MAX_CHUNK_BYTES = 25 * 1024 * 1024;
+
+function chunkR2Key(ownerId: string, sessionId: string, generation: number, chunkNumber: number): string {
+  return `sessions/${ownerId}/${sessionId}/g${generation}/chunk-${chunkNumber}.bin`;
 }
 
-// Hard cap on jsonl uploads. Real Claude Code sessions are typically 1-50 MB;
-// 50 MB covers extreme edge cases without letting an abusive client fill R2
-// or burn worker CPU. Workers' default body limit (100 MB) and CPU budget
-// would catch this anyway, but we want a structured 413 instead of a runtime
-// crash and the limit is small enough to keep encryption fast.
-const MAX_BYTES_UPLOAD = 50 * 1024 * 1024;
+/** Look up the session's current generation. Returns null when the session
+ *  isn't in the caller's metadata (cross-account / never-pushed). */
+async function fetchCurrentGeneration(
+  env: Env,
+  ownerId: string,
+  sessionId: string,
+): Promise<number | null> {
+  const row = await env.DB.prepare(
+    `SELECT bytes_generation FROM synced_session_metadata
+      WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+  ).bind(ownerId, sessionId).first<{ bytes_generation: number }>();
+  return row ? row.bytes_generation : null;
+}
 
-async function handleSessionsBytesPut(req: Request, env: Env, sessionId: string): Promise<Response> {
+async function handleSessionsBytesChunkPut(
+  req: Request,
+  env: Env,
+  sessionId: string,
+  chunkNumber: number,
+): Promise<Response> {
   const user = await resolveSession(req, env);
   if (!user) return jsonError(401, "sign_in_required");
   if (user.tier !== "pro") return jsonError(403, "pro_required");
 
-  // Confirm the session belongs to the caller before accepting bytes. Without
-  // this check, a Pro user could arbitrarily overwrite any session id in
-  // their own R2 prefix — harmless but wasteful and confusing in audit logs.
-  const owns = await env.DB.prepare(
-    `SELECT 1 FROM synced_session_metadata WHERE owner_id = ? AND session_id = ? LIMIT 1`,
-  ).bind(user.id, sessionId).first();
-  if (!owns) return jsonError(404, "session_not_found");
+  const currentGen = await fetchCurrentGeneration(env, user.id, sessionId);
+  if (currentGen === null) return jsonError(404, "session_not_found");
 
-  // Fail fast on Content-Length when the client honestly declares it. Saves
-  // reading 50+ MB into memory only to reject. Content-Length can be missing
-  // or lie (chunked transfer, untrusted client) so we re-check after read.
+  // Headers carry the metadata that gets bound into AAD. Each field must be
+  // a number / string (validated below); the client's pushBytes always sets
+  // these, so any missing header is a client bug or a tampered request.
+  const startOffsetHeader = req.headers.get("x-chunk-start-offset");
+  const endOffsetHeader = req.headers.get("x-chunk-end-offset");
+  const plaintextSha256Header = req.headers.get("x-plaintext-sha256");
+  const generationHeader = req.headers.get("x-bytes-generation");
+
+  if (!startOffsetHeader || !endOffsetHeader || !plaintextSha256Header || !generationHeader) {
+    return jsonError(400, "missing_chunk_headers");
+  }
+
+  const startOffset = Number(startOffsetHeader);
+  const endOffset = Number(endOffsetHeader);
+  const generation = Number(generationHeader);
+
+  if (!Number.isInteger(startOffset) || startOffset < 0) return jsonError(400, "invalid_start_offset");
+  if (!Number.isInteger(endOffset) || endOffset <= startOffset) return jsonError(400, "invalid_end_offset");
+  if (!Number.isInteger(generation) || generation < 0) return jsonError(400, "invalid_generation");
+  if (!/^[0-9a-f]{64}$/.test(plaintextSha256Header)) return jsonError(400, "invalid_sha256");
+
+  // Generation check. Client's local generation must match cloud's current.
+  // Stale-generation PUTs from before a reset are rejected — they'd otherwise
+  // pollute the manifest.
+  if (generation !== currentGen) {
+    return jsonError(409, "stale_generation");
+  }
+
+  // Read body + verify Content-Length against declared end-start. Fail fast
+  // on declared sizes that exceed MAX_CHUNK_BYTES.
+  const declaredSize = endOffset - startOffset;
+  if (declaredSize > MAX_CHUNK_BYTES) return jsonError(413, "chunk_too_large");
+
   const lenHeader = req.headers.get("content-length");
   if (lenHeader) {
     const declared = Number(lenHeader);
-    if (Number.isFinite(declared) && declared > MAX_BYTES_UPLOAD) {
-      return jsonError(413, "payload_too_large");
+    if (Number.isFinite(declared) && declared > MAX_CHUNK_BYTES) {
+      return jsonError(413, "chunk_too_large");
     }
   }
 
   const plaintext = new Uint8Array(await req.arrayBuffer());
   if (plaintext.byteLength === 0) return jsonError(400, "empty_body");
-  if (plaintext.byteLength > MAX_BYTES_UPLOAD) return jsonError(413, "payload_too_large");
+  if (plaintext.byteLength > MAX_CHUNK_BYTES) return jsonError(413, "chunk_too_large");
+  if (plaintext.byteLength !== declaredSize) return jsonError(400, "size_mismatch_with_offsets");
 
+  // Verify the client's declared hash matches the actual body. Mismatch
+  // means corruption in transit or a buggy/tampered client.
+  const computedHash = await sha256Hex(plaintext);
+  if (computedHash !== plaintextSha256Header) {
+    return jsonError(400, "sha256_mismatch");
+  }
+
+  // Idempotency + contiguity checks. Look at any existing row for
+  // (owner, session, generation, chunk_number) and at the prior chunk.
+  const existing = await env.DB.prepare(
+    `SELECT start_offset, end_offset, byte_count, plaintext_sha256
+       FROM synced_session_chunks
+      WHERE owner_id = ? AND session_id = ? AND bytes_generation = ? AND chunk_number = ?
+      LIMIT 1`,
+  ).bind(user.id, sessionId, generation, chunkNumber).first<{
+    start_offset: number; end_offset: number; byte_count: number; plaintext_sha256: string;
+  }>();
+  if (existing) {
+    // Idempotent retry path: all four immutable fields must match.
+    if (
+      existing.start_offset === startOffset &&
+      existing.end_offset === endOffset &&
+      existing.byte_count === declaredSize &&
+      existing.plaintext_sha256 === plaintextSha256Header
+    ) {
+      return jsonOk({ ok: true, idempotent: true, chunk_number: chunkNumber, generation });
+    }
+    return jsonError(409, "chunk_conflict");
+  }
+
+  // Contiguity: this chunk's start_offset must equal the previous chunk's
+  // end_offset (within the same generation). For chunk 1 the previous is
+  // implicit-zero.
+  if (chunkNumber === 1) {
+    if (startOffset !== 0) return jsonError(409, "non_contiguous_start");
+  } else {
+    const prev = await env.DB.prepare(
+      `SELECT end_offset FROM synced_session_chunks
+        WHERE owner_id = ? AND session_id = ? AND bytes_generation = ? AND chunk_number = ?
+        LIMIT 1`,
+    ).bind(user.id, sessionId, generation, chunkNumber - 1).first<{ end_offset: number }>();
+    if (!prev) return jsonError(409, "previous_chunk_missing");
+    if (prev.end_offset !== startOffset) return jsonError(409, "non_contiguous_start");
+  }
+
+  // Encrypt with AAD-binding so the ciphertext can't be replayed as a
+  // different chunk / session / generation.
+  const aad: ChunkAad = {
+    owner_id: user.id,
+    session_id: sessionId,
+    bytes_generation: generation,
+    chunk_number: chunkNumber,
+    start_offset: startOffset,
+    end_offset: endOffset,
+    plaintext_sha256: plaintextSha256Header,
+  };
   let ciphertext: Uint8Array;
   try {
-    ciphertext = await encryptForUser(env.SESSIONS_ENCRYPTION_KEY, user.id, plaintext);
+    ciphertext = await encryptChunk(env.SESSIONS_ENCRYPTION_KEY, aad, plaintext);
   } catch (err) {
-    console.warn("[sessions] encrypt failed:", err);
+    console.warn("[sessions] encryptChunk failed:", err);
     return jsonError(500, "encrypt_failed");
   }
 
-  const key = r2KeyFor(user.id, sessionId);
+  const r2Key = chunkR2Key(user.id, sessionId, generation, chunkNumber);
   try {
-    await env.SESSIONS_BUCKET.put(key, ciphertext, {
+    await env.SESSIONS_BUCKET.put(r2Key, ciphertext, {
       httpMetadata: { contentType: "application/octet-stream" },
-      customMetadata: { ownerId: user.id, sessionId, plaintextSize: String(plaintext.byteLength) },
+      customMetadata: {
+        ownerId: user.id,
+        sessionId,
+        generation: String(generation),
+        chunkNumber: String(chunkNumber),
+        startOffset: String(startOffset),
+        endOffset: String(endOffset),
+        plaintextSha256: plaintextSha256Header,
+        plaintextSize: String(plaintext.byteLength),
+      },
     });
   } catch (err) {
     console.warn("[sessions] R2 put failed:", err);
     return jsonError(500, "r2_put_failed");
   }
 
-  // Record the R2 key on the metadata row so cross-device clients know bytes
-  // are available for lazy pull. Deliberately NOT touching updated_at: that
-  // column is the LWW tiebreaker for metadata pushes (driven by the client's
-  // sync_dirty_at). Bumping it here would be a wallclock value the client
-  // can't beat, causing legitimate later metadata pushes with sync_dirty_at
-  // > the previous metadata but < the bytes-PUT wallclock to be dropped.
+  // Insert the chunk row. INSERT OR IGNORE is safe here because the
+  // idempotency check above already returned 200 on exact-match retry.
+  // A race between two clients pushing the same chunk would hit either
+  // the existing-row path or this insert; either way the table is consistent.
   await env.DB.prepare(
-    `UPDATE synced_session_metadata SET jsonl_r2_key = ?
-      WHERE owner_id = ? AND session_id = ?`,
-  ).bind(key, user.id, sessionId).run();
+    `INSERT OR IGNORE INTO synced_session_chunks
+       (owner_id, session_id, bytes_generation, chunk_number,
+        start_offset, end_offset, byte_count, plaintext_sha256, uploaded_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    user.id, sessionId, generation, chunkNumber,
+    startOffset, endOffset, declaredSize, plaintextSha256Header, Date.now(),
+  ).run();
 
-  return jsonOk({ ok: true, key, plaintextSize: plaintext.byteLength, ciphertextSize: ciphertext.byteLength });
+  return jsonOk({
+    ok: true,
+    chunk_number: chunkNumber,
+    generation,
+    ciphertextSize: ciphertext.byteLength,
+  });
 }
 
-async function handleSessionsBytesGet(req: Request, env: Env, sessionId: string): Promise<Response> {
+async function handleSessionsBytesManifestGet(
+  req: Request,
+  env: Env,
+  sessionId: string,
+): Promise<Response> {
   const user = await resolveSession(req, env);
   if (!user) return jsonError(401, "sign_in_required");
   if (user.tier !== "pro") return jsonError(403, "pro_required");
 
-  // Owner check: refuse if the session isn't in this owner's metadata. Stops
-  // any ""guess another user's session_id"" cross-account read attempt before
-  // we even hit R2.
-  const owns = await env.DB.prepare(
-    `SELECT jsonl_r2_key FROM synced_session_metadata WHERE owner_id = ? AND session_id = ? LIMIT 1`,
-  ).bind(user.id, sessionId).first<{ jsonl_r2_key: string | null }>();
-  if (!owns) return jsonError(404, "session_not_found");
-  if (!owns.jsonl_r2_key) return jsonError(404, "bytes_not_uploaded");
+  const currentGen = await fetchCurrentGeneration(env, user.id, sessionId);
+  if (currentGen === null) return jsonError(404, "session_not_found");
 
-  const obj = await env.SESSIONS_BUCKET.get(owns.jsonl_r2_key);
-  if (!obj) return jsonError(404, "bytes_missing");
+  type Row = {
+    chunk_number: number; start_offset: number; end_offset: number;
+    byte_count: number; plaintext_sha256: string;
+  };
+  const { results } = await env.DB.prepare(
+    `SELECT chunk_number, start_offset, end_offset, byte_count, plaintext_sha256
+       FROM synced_session_chunks
+      WHERE owner_id = ? AND session_id = ? AND bytes_generation = ?
+      ORDER BY chunk_number ASC`,
+  ).bind(user.id, sessionId, currentGen).all<Row>();
+
+  const chunks = results ?? [];
+  const totalSize = chunks.length > 0 ? chunks[chunks.length - 1]!.end_offset : 0;
+  return jsonOk(
+    { bytes_generation: currentGen, total_size: totalSize, chunks },
+    200,
+    { "cache-control": "private, no-store" },
+  );
+}
+
+async function handleSessionsBytesChunkGet(
+  req: Request,
+  env: Env,
+  sessionId: string,
+  chunkNumber: number,
+): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  // Optional ?gen=N selects a specific generation (for diagnostic / future
+  // historical access). Defaults to current.
+  const url = new URL(req.url);
+  const genParam = url.searchParams.get("gen");
+  let generation: number;
+  if (genParam !== null) {
+    generation = Number(genParam);
+    if (!Number.isInteger(generation) || generation < 0) {
+      return jsonError(400, "invalid_generation");
+    }
+  } else {
+    const currentGen = await fetchCurrentGeneration(env, user.id, sessionId);
+    if (currentGen === null) return jsonError(404, "session_not_found");
+    generation = currentGen;
+  }
+
+  const row = await env.DB.prepare(
+    `SELECT start_offset, end_offset, byte_count, plaintext_sha256
+       FROM synced_session_chunks
+      WHERE owner_id = ? AND session_id = ? AND bytes_generation = ? AND chunk_number = ?
+      LIMIT 1`,
+  ).bind(user.id, sessionId, generation, chunkNumber).first<{
+    start_offset: number; end_offset: number; byte_count: number; plaintext_sha256: string;
+  }>();
+  if (!row) return jsonError(404, "chunk_not_found");
+
+  const r2Key = chunkR2Key(user.id, sessionId, generation, chunkNumber);
+  const obj = await env.SESSIONS_BUCKET.get(r2Key);
+  if (!obj) return jsonError(404, "chunk_bytes_missing");
 
   const ciphertext = new Uint8Array(await obj.arrayBuffer());
+  // Reconstruct AAD from the D1 row state (the source of truth). The
+  // R2 customMetadata is diagnostic only — the worker never trusts it
+  // for AAD reconstruction.
+  const aad: ChunkAad = {
+    owner_id: user.id,
+    session_id: sessionId,
+    bytes_generation: generation,
+    chunk_number: chunkNumber,
+    start_offset: row.start_offset,
+    end_offset: row.end_offset,
+    plaintext_sha256: row.plaintext_sha256,
+  };
+
   let plaintext: Uint8Array;
   try {
-    plaintext = await decryptForUser(env.SESSIONS_ENCRYPTION_KEY, user.id, ciphertext);
+    plaintext = await decryptChunk(env.SESSIONS_ENCRYPTION_KEY, aad, ciphertext);
   } catch (err) {
-    console.warn("[sessions] decrypt failed:", err);
+    console.warn("[sessions] decryptChunk failed:", err);
     return jsonError(500, "decrypt_failed");
   }
 
   return new Response(plaintext, {
     status: 200,
     headers: {
-      "content-type": "application/jsonl",
+      "content-type": "application/octet-stream",
       "cache-control": "private, no-store",
+      "x-plaintext-sha256": row.plaintext_sha256,
+      "x-chunk-start-offset": String(row.start_offset),
+      "x-chunk-end-offset": String(row.end_offset),
+      "x-bytes-generation": String(generation),
     },
   });
+}
+
+async function handleSessionsBytesReset(
+  req: Request,
+  env: Env,
+  sessionId: string,
+): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  const currentGen = await fetchCurrentGeneration(env, user.id, sessionId);
+  if (currentGen === null) return jsonError(404, "session_not_found");
+
+  const newGen = currentGen + 1;
+  await env.DB.prepare(
+    `UPDATE synced_session_metadata
+        SET bytes_generation = ?
+      WHERE owner_id = ? AND session_id = ?`,
+  ).bind(newGen, user.id, sessionId).run();
+
+  // Prior-generation chunk rows are deliberately left in place — the
+  // generation filter on manifest / chunk-get makes them effectively
+  // tombstoned. R2 objects for old generations stay until v1.1 GC ships;
+  // they cost a few cents per heavy user, acceptable.
+  return jsonOk({ ok: true, previous_generation: currentGen, current_generation: newGen });
 }

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -32,7 +32,12 @@ export default {
 
     const bytesMatch = url.pathname.match(/^\/api\/sessions\/bytes\/([^/]+)$/);
     if (bytesMatch && bytesMatch[1]) {
-      const sessionId = decodeURIComponent(bytesMatch[1]);
+      // decodeURIComponent throws URIError on malformed percent-encoding
+      // (e.g. "%G"). Without this guard, a bad path would surface as an
+      // unhandled rejection instead of a structured 4xx.
+      let sessionId: string;
+      try { sessionId = decodeURIComponent(bytesMatch[1]); }
+      catch { return jsonError(400, "invalid_session_id"); }
       if (req.method === "PUT") return handleSessionsBytesPut(req, env, sessionId);
       if (req.method === "GET") return handleSessionsBytesGet(req, env, sessionId);
     }
@@ -435,11 +440,15 @@ async function handleSessionsBytesPut(req: Request, env: Env, sessionId: string)
   }
 
   // Record the R2 key on the metadata row so cross-device clients know bytes
-  // are available for lazy pull.
+  // are available for lazy pull. Deliberately NOT touching updated_at: that
+  // column is the LWW tiebreaker for metadata pushes (driven by the client's
+  // sync_dirty_at). Bumping it here would be a wallclock value the client
+  // can't beat, causing legitimate later metadata pushes with sync_dirty_at
+  // > the previous metadata but < the bytes-PUT wallclock to be dropped.
   await env.DB.prepare(
-    `UPDATE synced_session_metadata SET jsonl_r2_key = ?, updated_at = ?
+    `UPDATE synced_session_metadata SET jsonl_r2_key = ?
       WHERE owner_id = ? AND session_id = ?`,
-  ).bind(key, Date.now(), user.id, sessionId).run();
+  ).bind(key, user.id, sessionId).run();
 
   return jsonOk({ ok: true, key, plaintextSize: plaintext.byteLength, ciphertextSize: ciphertext.byteLength });
 }

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -51,25 +51,39 @@ CREATE TABLE IF NOT EXISTS synced_memory_payloads (
 );
 -- Mirror of infra/auth-worker/migrations/0008_synced_sessions.sql
 CREATE TABLE IF NOT EXISTS synced_session_metadata (
-  owner_id        TEXT    NOT NULL,
-  session_id      TEXT    NOT NULL,
-  device_id       TEXT,
-  agent           TEXT    NOT NULL,
-  title           TEXT,
-  state           TEXT    NOT NULL,
-  cwd             TEXT,
-  model           TEXT,
-  started_at      TEXT    NOT NULL,
-  ended_at        TEXT,
-  last_event_at   TEXT    NOT NULL,
-  jsonl_r2_key    TEXT,
-  updated_at      INTEGER NOT NULL,
+  owner_id          TEXT    NOT NULL,
+  session_id        TEXT    NOT NULL,
+  device_id         TEXT,
+  agent             TEXT    NOT NULL,
+  title             TEXT,
+  state             TEXT    NOT NULL,
+  cwd               TEXT,
+  model             TEXT,
+  started_at        TEXT    NOT NULL,
+  ended_at          TEXT,
+  last_event_at     TEXT    NOT NULL,
+  bytes_generation  INTEGER NOT NULL DEFAULT 0,
+  updated_at        INTEGER NOT NULL,
   PRIMARY KEY (owner_id, session_id)
 );
 CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_updated
   ON synced_session_metadata (owner_id, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_last_event
   ON synced_session_metadata (owner_id, last_event_at DESC);
+CREATE TABLE IF NOT EXISTS synced_session_chunks (
+  owner_id          TEXT    NOT NULL,
+  session_id        TEXT    NOT NULL,
+  bytes_generation  INTEGER NOT NULL,
+  chunk_number      INTEGER NOT NULL,
+  start_offset      INTEGER NOT NULL,
+  end_offset        INTEGER NOT NULL,
+  byte_count        INTEGER NOT NULL,
+  plaintext_sha256  TEXT    NOT NULL,
+  uploaded_at       INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, session_id, bytes_generation, chunk_number)
+);
+CREATE INDEX IF NOT EXISTS idx_synced_session_chunks_active
+  ON synced_session_chunks (owner_id, session_id, bytes_generation, chunk_number);
 `;
 
 export async function applySchema(): Promise<void> {

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -49,6 +49,25 @@ CREATE TABLE IF NOT EXISTS synced_memory_payloads (
   purged_at  INTEGER,
   PRIMARY KEY (owner_id, memory_id)
 );
+-- Mirror of infra/auth-worker/migrations/0008_synced_sessions.sql
+CREATE TABLE IF NOT EXISTS synced_session_metadata (
+  owner_id        TEXT    NOT NULL,
+  session_id      TEXT    NOT NULL,
+  device_id       TEXT,
+  agent           TEXT    NOT NULL,
+  title           TEXT,
+  state           TEXT    NOT NULL,
+  cwd             TEXT,
+  model           TEXT,
+  started_at      TEXT    NOT NULL,
+  ended_at        TEXT,
+  last_event_at   TEXT    NOT NULL,
+  jsonl_r2_key    TEXT,
+  updated_at      INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, session_id)
+);
+CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_updated
+  ON synced_session_metadata (owner_id, updated_at DESC);
 `;
 
 export async function applySchema(): Promise<void> {

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -68,6 +68,8 @@ CREATE TABLE IF NOT EXISTS synced_session_metadata (
 );
 CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_updated
   ON synced_session_metadata (owner_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_synced_session_metadata_owner_last_event
+  ON synced_session_metadata (owner_id, last_event_at DESC);
 `;
 
 export async function applySchema(): Promise<void> {

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -144,6 +144,46 @@ describe("POST /api/sessions/metadata", () => {
     ).bind(userId).first<{ n: number }>();
     expect(count?.n).toBe(1);
   });
+
+  it("rejects nullable fields with non-string types instead of crashing D1.bind", async () => {
+    const { token, userId } = await makeProSession();
+    const goodId = `s-${crypto.randomUUID()}`;
+    const badTypeId = `s-${crypto.randomUUID()}`;
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessions: [
+          sampleSession(goodId, 1000),
+          // title is a number — would reach D1.bind() with the lax validation.
+          sampleSession(badTypeId, 1000, { title: 12345 }),
+        ],
+      }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([goodId]);
+    expect(body.rejected).toEqual([badTypeId]);
+    // Only the well-formed session landed.
+    const count = await env.DB.prepare(
+      `SELECT COUNT(*) as n FROM synced_session_metadata WHERE owner_id = ?`,
+    ).bind(userId).first<{ n: number }>();
+    expect(count?.n).toBe(1);
+  });
+
+  it("rejects negative sync_dirty_at", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, -1)] }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([]);
+    expect(body.rejected).toEqual([sid]);
+  });
 });
 
 describe("GET /api/sessions/metadata", () => {
@@ -312,5 +352,47 @@ describe("PUT /api/sessions/bytes/:id + GET round-trip", () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toBe("invalid_session_id");
+  });
+
+  it("rejects oversized PUT bodies with 413", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+
+    // 51 MB payload — over the 50 MB cap.
+    const huge = new Uint8Array(51 * 1024 * 1024);
+    const res = await signedFetch(`/api/sessions/bytes/${sid}`, {
+      method: "PUT",
+      headers: { "content-type": "application/octet-stream" },
+      body: huge,
+    }, token);
+    expect(res.status).toBe(413);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("payload_too_large");
+  });
+
+  it("fast-rejects when Content-Length declares an oversized body", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+
+    // Small body but lying Content-Length header — the fast-path should fire.
+    const res = await signedFetch(`/api/sessions/bytes/${sid}`, {
+      method: "PUT",
+      headers: {
+        "content-type": "application/octet-stream",
+        "content-length": String(60 * 1024 * 1024),
+      },
+      body: new Uint8Array(8),
+    }, token);
+    expect(res.status).toBe(413);
   });
 });

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { env, SELF } from "cloudflare:test";
+import { applySchema } from "./fixtures/seed.js";
+
+async function makeProSession(suffix = crypto.randomUUID()): Promise<{ token: string; userId: string }> {
+  const userId = `u-pro-${suffix}`;
+  const token  = `tok-pro-${suffix}`;
+  await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'pro', ?)`)
+    .bind(userId, `pro-${suffix}@example.com`, Date.now()).run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, created_at, expires_at, revoked_at)
+     VALUES (?, ?, ?, ?, NULL)`,
+  ).bind(token, userId, Date.now(), Date.now() + 86400_000).run();
+  return { token, userId };
+}
+
+async function makeFreeSession(suffix = crypto.randomUUID()): Promise<{ token: string; userId: string }> {
+  const userId = `u-free-${suffix}`;
+  const token  = `tok-free-${suffix}`;
+  await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'free', ?)`)
+    .bind(userId, `free-${suffix}@example.com`, Date.now()).run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, created_at, expires_at, revoked_at)
+     VALUES (?, ?, ?, ?, NULL)`,
+  ).bind(token, userId, Date.now(), Date.now() + 86400_000).run();
+  return { token, userId };
+}
+
+function signedFetch(path: string, init: RequestInit, token: string): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("Cookie", `oyster_session=${token}`);
+  return SELF.fetch(`https://example.com${path}`, { ...init, headers });
+}
+
+function sampleSession(id: string, syncDirtyAt: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    device_id: "dev-mac-01",
+    agent: "claude-code",
+    title: "Test session",
+    state: "done",
+    cwd: "/Users/test/proj",
+    model: "claude-sonnet-4-6",
+    started_at: "2026-05-10T10:00:00Z",
+    ended_at: "2026-05-10T10:30:00Z",
+    last_event_at: "2026-05-10T10:30:00Z",
+    sync_dirty_at: syncDirtyAt,
+    ...overrides,
+  };
+}
+
+describe("POST /api/sessions/metadata", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("rejects unsigned requests with 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [] }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects free-tier users with 403", async () => {
+    const { token } = await makeFreeSession();
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [] }),
+    }, token);
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts a valid session and stores it scoped to owner", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([sid]);
+    expect(body.rejected).toEqual([]);
+
+    const row = await env.DB.prepare(
+      `SELECT owner_id, agent, state, updated_at FROM synced_session_metadata
+        WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first();
+    expect(row).toMatchObject({ owner_id: userId, agent: "claude-code", state: "done", updated_at: 1000 });
+  });
+
+  it("LWW: a newer sync_dirty_at wins; an older one is dropped", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    // First push at t=2000 with title "v1"
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 2000, { title: "v1" })] }),
+    }, token);
+    // Newer push at t=3000 with title "v2" — should win
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 3000, { title: "v2" })] }),
+    }, token);
+    // Older push at t=1000 with title "ancient" — should lose
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000, { title: "ancient" })] }),
+    }, token);
+
+    const row = await env.DB.prepare(
+      `SELECT title, updated_at FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ title: string; updated_at: number }>();
+    expect(row?.title).toBe("v2");
+    expect(row?.updated_at).toBe(3000);
+  });
+
+  it("rejects malformed sessions but still accepts the valid ones in the same batch", async () => {
+    const { token, userId } = await makeProSession();
+    const goodId = `s-${crypto.randomUUID()}`;
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessions: [
+          sampleSession(goodId, 1000),
+          { id: "bad", agent: "claude-code" },  // missing required fields
+          { /* no id */ agent: "claude-code", state: "done", started_at: "x", last_event_at: "y", sync_dirty_at: 1 },
+        ],
+      }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([goodId]);
+    expect(body.rejected).toEqual(["bad", "<malformed>"]);
+
+    const count = await env.DB.prepare(
+      `SELECT COUNT(*) as n FROM synced_session_metadata WHERE owner_id = ?`,
+    ).bind(userId).first<{ n: number }>();
+    expect(count?.n).toBe(1);
+  });
+});
+
+describe("GET /api/sessions/metadata", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("returns only the caller's sessions", async () => {
+    const a = await makeProSession();
+    const b = await makeProSession();
+    const sidA = `s-${crypto.randomUUID()}`;
+    const sidB = `s-${crypto.randomUUID()}`;
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sidA, 1000)] }),
+    }, a.token);
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sidB, 1000)] }),
+    }, b.token);
+
+    const res = await signedFetch("/api/sessions/metadata", { method: "GET" }, a.token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { sessions: Array<{ session_id: string }> };
+    const ids = body.sessions.map((s) => s.session_id);
+    expect(ids).toContain(sidA);
+    expect(ids).not.toContain(sidB);
+  });
+});
+
+describe("PUT /api/sessions/bytes/:id + GET round-trip", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("encrypts on PUT, decrypts on GET, returns identical plaintext", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    // Metadata has to exist first (the PUT does an owner check against it).
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+
+    const plaintext = new TextEncoder().encode(
+      `{"type":"user","content":"hello"}\n{"type":"assistant","content":"hi"}\n`,
+    );
+    const putRes = await signedFetch(`/api/sessions/bytes/${sid}`, {
+      method: "PUT",
+      headers: { "content-type": "application/octet-stream" },
+      body: plaintext,
+    }, token);
+    expect(putRes.status).toBe(200);
+    const putBody = await putRes.json() as { ok: boolean; key: string; plaintextSize: number; ciphertextSize: number };
+    expect(putBody.ok).toBe(true);
+    expect(putBody.plaintextSize).toBe(plaintext.byteLength);
+    // Ciphertext = IV (12) + plaintext + AES-GCM tag (16)
+    expect(putBody.ciphertextSize).toBe(plaintext.byteLength + 12 + 16);
+
+    const getRes = await signedFetch(`/api/sessions/bytes/${sid}`, { method: "GET" }, token);
+    expect(getRes.status).toBe(200);
+    const got = new Uint8Array(await getRes.arrayBuffer());
+    expect(got).toEqual(plaintext);
+  });
+
+  it("R2 object stores ciphertext, not plaintext", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+
+    const plaintext = new TextEncoder().encode("PLAINTEXT_MARKER_DO_NOT_LEAK");
+    await signedFetch(`/api/sessions/bytes/${sid}`, {
+      method: "PUT",
+      headers: { "content-type": "application/octet-stream" },
+      body: plaintext,
+    }, token);
+
+    const obj = await env.SESSIONS_BUCKET.get(`sessions/${userId}/${sid}.jsonl`);
+    expect(obj).not.toBeNull();
+    const stored = new Uint8Array(await obj!.arrayBuffer());
+    const decoded = new TextDecoder().decode(stored);
+    expect(decoded).not.toContain("PLAINTEXT_MARKER_DO_NOT_LEAK");
+  });
+
+  it("returns 404 when uploading to a session that doesn't belong to the caller", async () => {
+    const owner = await makeProSession();
+    const intruder = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    // Owner registers metadata
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, owner.token);
+    // Intruder tries to upload bytes to that session id
+    const res = await signedFetch(`/api/sessions/bytes/${sid}`, {
+      method: "PUT",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("nope"),
+    }, intruder.token);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when GETting bytes that haven't been uploaded", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+
+    const res = await signedFetch(`/api/sessions/bytes/${sid}`, { method: "GET" }, token);
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("bytes_not_uploaded");
+  });
+});

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -49,6 +49,49 @@ function sampleSession(id: string, syncDirtyAt: number, overrides: Record<string
   };
 }
 
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const view = new Uint8Array(digest);
+  let hex = "";
+  for (let i = 0; i < view.length; i++) hex += view[i]!.toString(16).padStart(2, "0");
+  return hex;
+}
+
+async function putChunk(
+  token: string,
+  sessionId: string,
+  chunkNumber: number,
+  bytes: Uint8Array,
+  startOffset: number,
+  generation: number,
+): Promise<{ res: Response; sha: string }> {
+  const sha = await sha256Hex(bytes);
+  const res = await signedFetch(
+    `/api/sessions/bytes/${sessionId}/chunk/${chunkNumber}`,
+    {
+      method: "PUT",
+      headers: {
+        "content-type": "application/octet-stream",
+        "x-chunk-start-offset": String(startOffset),
+        "x-chunk-end-offset": String(startOffset + bytes.byteLength),
+        "x-plaintext-sha256": sha,
+        "x-bytes-generation": String(generation),
+      },
+      body: bytes,
+    },
+    token,
+  );
+  return { res, sha };
+}
+
+async function registerSession(token: string, sid: string) {
+  await signedFetch("/api/sessions/metadata", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+  }, token);
+}
+
 describe("POST /api/sessions/metadata", () => {
   beforeAll(async () => { await applySchema(); });
 
@@ -85,28 +128,28 @@ describe("POST /api/sessions/metadata", () => {
     expect(body.rejected).toEqual([]);
 
     const row = await env.DB.prepare(
-      `SELECT owner_id, agent, state, updated_at FROM synced_session_metadata
-        WHERE owner_id = ? AND session_id = ?`,
+      `SELECT owner_id, agent, state, updated_at, bytes_generation
+         FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
     ).bind(userId, sid).first();
-    expect(row).toMatchObject({ owner_id: userId, agent: "claude-code", state: "done", updated_at: 1000 });
+    expect(row).toMatchObject({
+      owner_id: userId, agent: "claude-code", state: "done",
+      updated_at: 1000, bytes_generation: 0,
+    });
   });
 
   it("LWW: a newer sync_dirty_at wins; an older one is dropped", async () => {
     const { token, userId } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
-    // First push at t=2000 with title "v1"
     await signedFetch("/api/sessions/metadata", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ sessions: [sampleSession(sid, 2000, { title: "v1" })] }),
     }, token);
-    // Newer push at t=3000 with title "v2" — should win
     await signedFetch("/api/sessions/metadata", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ sessions: [sampleSession(sid, 3000, { title: "v2" })] }),
     }, token);
-    // Older push at t=1000 with title "ancient" — should lose
     await signedFetch("/api/sessions/metadata", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -120,7 +163,7 @@ describe("POST /api/sessions/metadata", () => {
     expect(row?.updated_at).toBe(3000);
   });
 
-  it("rejects malformed sessions but still accepts the valid ones in the same batch", async () => {
+  it("rejects malformed sessions but accepts valid ones in the same batch", async () => {
     const { token, userId } = await makeProSession();
     const goodId = `s-${crypto.randomUUID()}`;
     const res = await signedFetch("/api/sessions/metadata", {
@@ -129,8 +172,8 @@ describe("POST /api/sessions/metadata", () => {
       body: JSON.stringify({
         sessions: [
           sampleSession(goodId, 1000),
-          { id: "bad", agent: "claude-code" },  // missing required fields
-          { /* no id */ agent: "claude-code", state: "done", started_at: "x", last_event_at: "y", sync_dirty_at: 1 },
+          { id: "bad", agent: "claude-code" },
+          { agent: "claude-code", state: "done", started_at: "x", last_event_at: "y", sync_dirty_at: 1 },
         ],
       }),
     }, token);
@@ -155,7 +198,6 @@ describe("POST /api/sessions/metadata", () => {
       body: JSON.stringify({
         sessions: [
           sampleSession(goodId, 1000),
-          // title is a number — would reach D1.bind() with the lax validation.
           sampleSession(badTypeId, 1000, { title: 12345 }),
         ],
       }),
@@ -164,7 +206,6 @@ describe("POST /api/sessions/metadata", () => {
     const body = await res.json() as { accepted: string[]; rejected: string[] };
     expect(body.accepted).toEqual([goodId]);
     expect(body.rejected).toEqual([badTypeId]);
-    // Only the well-formed session landed.
     const count = await env.DB.prepare(
       `SELECT COUNT(*) as n FROM synced_session_metadata WHERE owner_id = ?`,
     ).bind(userId).first<{ n: number }>();
@@ -189,210 +230,285 @@ describe("POST /api/sessions/metadata", () => {
 describe("GET /api/sessions/metadata", () => {
   beforeAll(async () => { await applySchema(); });
 
-  it("returns only the caller's sessions", async () => {
+  it("returns only the caller's sessions with has_bytes=false when no chunks", async () => {
     const a = await makeProSession();
     const b = await makeProSession();
     const sidA = `s-${crypto.randomUUID()}`;
     const sidB = `s-${crypto.randomUUID()}`;
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sidA, 1000)] }),
-    }, a.token);
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sidB, 1000)] }),
-    }, b.token);
+    await registerSession(a.token, sidA);
+    await registerSession(b.token, sidB);
 
     const res = await signedFetch("/api/sessions/metadata", { method: "GET" }, a.token);
     expect(res.status).toBe(200);
-    const body = await res.json() as { sessions: Array<{ session_id: string }> };
+    const body = await res.json() as { sessions: Array<{ session_id: string; has_bytes: boolean }> };
     const ids = body.sessions.map((s) => s.session_id);
     expect(ids).toContain(sidA);
     expect(ids).not.toContain(sidB);
+    const ours = body.sessions.find((s) => s.session_id === sidA);
+    expect(ours?.has_bytes).toBe(false);
   });
 });
 
-describe("PUT /api/sessions/bytes/:id + GET round-trip", () => {
+describe("PUT/GET /api/sessions/bytes/:id/chunk/:n (chunked-delta)", () => {
   beforeAll(async () => { await applySchema(); });
 
-  it("encrypts on PUT, decrypts on GET, returns identical plaintext", async () => {
-    const { token } = await makeProSession();
-    const sid = `s-${crypto.randomUUID()}`;
-    // Metadata has to exist first (the PUT does an owner check against it).
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, token);
-
-    const plaintext = new TextEncoder().encode(
-      `{"type":"user","content":"hello"}\n{"type":"assistant","content":"hi"}\n`,
-    );
-    const putRes = await signedFetch(`/api/sessions/bytes/${sid}`, {
-      method: "PUT",
-      headers: { "content-type": "application/octet-stream" },
-      body: plaintext,
-    }, token);
-    expect(putRes.status).toBe(200);
-    const putBody = await putRes.json() as { ok: boolean; key: string; plaintextSize: number; ciphertextSize: number };
-    expect(putBody.ok).toBe(true);
-    expect(putBody.plaintextSize).toBe(plaintext.byteLength);
-    // Ciphertext = IV (12) + plaintext + AES-GCM tag (16)
-    expect(putBody.ciphertextSize).toBe(plaintext.byteLength + 12 + 16);
-
-    const getRes = await signedFetch(`/api/sessions/bytes/${sid}`, { method: "GET" }, token);
-    expect(getRes.status).toBe(200);
-    const got = new Uint8Array(await getRes.arrayBuffer());
-    expect(got).toEqual(plaintext);
-  });
-
-  it("R2 object stores ciphertext, not plaintext", async () => {
+  it("upload chunks 1 + 2 + 3, fetch manifest + each chunk individually, concatenate matches local", async () => {
     const { token, userId } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, token);
+    await registerSession(token, sid);
 
+    const c1 = new TextEncoder().encode("{\"role\":\"user\",\"content\":\"hello\"}\n");
+    const c2 = new TextEncoder().encode("{\"role\":\"assistant\",\"content\":\"hi\"}\n");
+    const c3 = new TextEncoder().encode("{\"role\":\"user\",\"content\":\"bye\"}\n");
+
+    expect((await putChunk(token, sid, 1, c1, 0, 0)).res.status).toBe(200);
+    expect((await putChunk(token, sid, 2, c2, c1.byteLength, 0)).res.status).toBe(200);
+    expect((await putChunk(token, sid, 3, c3, c1.byteLength + c2.byteLength, 0)).res.status).toBe(200);
+
+    // Manifest
+    const manifestRes = await signedFetch(`/api/sessions/bytes/${sid}/manifest`, { method: "GET" }, token);
+    expect(manifestRes.status).toBe(200);
+    const manifest = await manifestRes.json() as {
+      bytes_generation: number;
+      total_size: number;
+      chunks: Array<{ chunk_number: number; start_offset: number; end_offset: number; byte_count: number; plaintext_sha256: string }>;
+    };
+    expect(manifest.bytes_generation).toBe(0);
+    expect(manifest.total_size).toBe(c1.byteLength + c2.byteLength + c3.byteLength);
+    expect(manifest.chunks.map((c) => c.chunk_number)).toEqual([1, 2, 3]);
+
+    // Per-chunk download + concatenate
+    const local = new Uint8Array(manifest.total_size);
+    for (const meta of manifest.chunks) {
+      const r = await signedFetch(`/api/sessions/bytes/${sid}/chunk/${meta.chunk_number}`, { method: "GET" }, token);
+      expect(r.status).toBe(200);
+      const bytes = new Uint8Array(await r.arrayBuffer());
+      expect(bytes.byteLength).toBe(meta.byte_count);
+      expect(await sha256Hex(bytes)).toBe(meta.plaintext_sha256);
+      local.set(bytes, meta.start_offset);
+    }
+
+    const expected = new Uint8Array(c1.byteLength + c2.byteLength + c3.byteLength);
+    expected.set(c1, 0); expected.set(c2, c1.byteLength); expected.set(c3, c1.byteLength + c2.byteLength);
+    expect(local).toEqual(expected);
+
+    // metadata.has_bytes should now be true
+    const listRes = await signedFetch("/api/sessions/metadata", { method: "GET" }, token);
+    const list = await listRes.json() as { sessions: Array<{ session_id: string; has_bytes: boolean }> };
+    expect(list.sessions.find((s) => s.session_id === sid)?.has_bytes).toBe(true);
+    void userId;  // silence unused
+  });
+
+  it("idempotent re-PUT of identical chunk → 200 idempotent:true, no duplicate row", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+
+    const c1 = new TextEncoder().encode("identical bytes");
+    expect((await putChunk(token, sid, 1, c1, 0, 0)).res.status).toBe(200);
+    const second = await putChunk(token, sid, 1, c1, 0, 0);
+    expect(second.res.status).toBe(200);
+    const body = await second.res.json() as { idempotent?: boolean };
+    expect(body.idempotent).toBe(true);
+
+    const count = await env.DB.prepare(
+      `SELECT COUNT(*) as n FROM synced_session_chunks WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ n: number }>();
+    expect(count?.n).toBe(1);
+  });
+
+  it("conflicting re-PUT (same chunk_number, different hash) → 409 chunk_conflict", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+
+    const c1 = new TextEncoder().encode("first content");
+    expect((await putChunk(token, sid, 1, c1, 0, 0)).res.status).toBe(200);
+
+    const c1Alt = new TextEncoder().encode("DIFFERENT content");  // different length + bytes
+    const conflict = await putChunk(token, sid, 1, c1Alt, 0, 0);
+    expect(conflict.res.status).toBe(409);
+    const body = await conflict.res.json() as { error: string };
+    expect(body.error).toBe("chunk_conflict");
+  });
+
+  it("non-contiguous PUT (start_offset doesn't match previous end_offset) → 409 non_contiguous_start", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+
+    const c1 = new TextEncoder().encode("AAAA");
+    expect((await putChunk(token, sid, 1, c1, 0, 0)).res.status).toBe(200);
+
+    // Chunk 2 should start at offset 4, but we say 99.
+    const c2 = new TextEncoder().encode("BBBB");
+    const res = await putChunk(token, sid, 2, c2, 99, 0);
+    expect(res.res.status).toBe(409);
+    const body = await res.res.json() as { error: string };
+    expect(body.error).toBe("non_contiguous_start");
+  });
+
+  it("chunk 1 with non-zero start_offset → 409", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    const bytes = new TextEncoder().encode("XXX");
+    const res = await putChunk(token, sid, 1, bytes, 100, 0);
+    expect(res.res.status).toBe(409);
+    const body = await res.res.json() as { error: string };
+    expect(body.error).toBe("non_contiguous_start");
+  });
+
+  it("wrong-generation PUT → 409 stale_generation", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    const bytes = new TextEncoder().encode("hi");
+    const res = await putChunk(token, sid, 1, bytes, 0, 5 /* wrong gen */);
+    expect(res.res.status).toBe(409);
+    const body = await res.res.json() as { error: string };
+    expect(body.error).toBe("stale_generation");
+  });
+
+  it("sha256 mismatch → 400 sha256_mismatch", async () => {
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    const bytes = new TextEncoder().encode("the truth");
+    const res = await signedFetch(
+      `/api/sessions/bytes/${sid}/chunk/1`,
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/octet-stream",
+          "x-chunk-start-offset": "0",
+          "x-chunk-end-offset": String(bytes.byteLength),
+          "x-plaintext-sha256": "0".repeat(64),  // valid format, wrong digest
+          "x-bytes-generation": "0",
+        },
+        body: bytes,
+      },
+      token,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("sha256_mismatch");
+  });
+
+  it("R2 inspection of any chunk shows ciphertext, never plaintext marker", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
     const plaintext = new TextEncoder().encode("PLAINTEXT_MARKER_DO_NOT_LEAK");
-    await signedFetch(`/api/sessions/bytes/${sid}`, {
-      method: "PUT",
-      headers: { "content-type": "application/octet-stream" },
-      body: plaintext,
-    }, token);
-
-    const obj = await env.SESSIONS_BUCKET.get(`sessions/${userId}/${sid}.jsonl`);
+    expect((await putChunk(token, sid, 1, plaintext, 0, 0)).res.status).toBe(200);
+    const obj = await env.SESSIONS_BUCKET.get(`sessions/${userId}/${sid}/g0/chunk-1.bin`);
     expect(obj).not.toBeNull();
     const stored = new Uint8Array(await obj!.arrayBuffer());
     const decoded = new TextDecoder().decode(stored);
     expect(decoded).not.toContain("PLAINTEXT_MARKER_DO_NOT_LEAK");
   });
 
-  it("returns 404 when uploading to a session that doesn't belong to the caller", async () => {
+  it("cross-account intrusion → 404 session_not_found", async () => {
     const owner = await makeProSession();
     const intruder = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
-    // Owner registers metadata
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, owner.token);
-    // Intruder tries to upload bytes to that session id
-    const res = await signedFetch(`/api/sessions/bytes/${sid}`, {
-      method: "PUT",
-      headers: { "content-type": "application/octet-stream" },
-      body: new TextEncoder().encode("nope"),
-    }, intruder.token);
-    expect(res.status).toBe(404);
+    await registerSession(owner.token, sid);
+    const bytes = new TextEncoder().encode("nope");
+    const res = await putChunk(intruder.token, sid, 1, bytes, 0, 0);
+    expect(res.res.status).toBe(404);
   });
+});
 
-  it("returns 404 when GETting bytes that haven't been uploaded", async () => {
+describe("POST /api/sessions/bytes/:id/reset (generation bump)", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("reset bumps generation, manifest goes empty, stale-gen PUT rejected, new-gen PUT succeeds", async () => {
     const { token } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, token);
+    await registerSession(token, sid);
 
-    const res = await signedFetch(`/api/sessions/bytes/${sid}`, { method: "GET" }, token);
-    expect(res.status).toBe(404);
-    const body = await res.json() as { error: string };
-    expect(body.error).toBe("bytes_not_uploaded");
+    // Upload chunks in gen 0
+    const a = new TextEncoder().encode("aaaa");
+    const b = new TextEncoder().encode("bbbb");
+    expect((await putChunk(token, sid, 1, a, 0, 0)).res.status).toBe(200);
+    expect((await putChunk(token, sid, 2, b, 4, 0)).res.status).toBe(200);
+
+    // Reset
+    const resetRes = await signedFetch(`/api/sessions/bytes/${sid}/reset`, { method: "POST" }, token);
+    expect(resetRes.status).toBe(200);
+    const resetBody = await resetRes.json() as { previous_generation: number; current_generation: number };
+    expect(resetBody.previous_generation).toBe(0);
+    expect(resetBody.current_generation).toBe(1);
+
+    // Manifest filtered to gen 1 is empty
+    const manifestRes = await signedFetch(`/api/sessions/bytes/${sid}/manifest`, { method: "GET" }, token);
+    const manifest = await manifestRes.json() as { bytes_generation: number; chunks: unknown[] };
+    expect(manifest.bytes_generation).toBe(1);
+    expect(manifest.chunks).toEqual([]);
+
+    // Stale-gen PUT (gen 0) rejected
+    const stale = await putChunk(token, sid, 3, new TextEncoder().encode("zzz"), 8, 0);
+    expect(stale.res.status).toBe(409);
+
+    // Fresh upload in gen 1 succeeds, chunk numbering restarts from 1
+    const fresh = new TextEncoder().encode("FRESH");
+    expect((await putChunk(token, sid, 1, fresh, 0, 1)).res.status).toBe(200);
+    const finalManifest = await (await signedFetch(`/api/sessions/bytes/${sid}/manifest`, { method: "GET" }, token)).json() as { chunks: Array<{ chunk_number: number }> };
+    expect(finalManifest.chunks.map((c) => c.chunk_number)).toEqual([1]);
   });
+});
 
-  it("bytes PUT does NOT bump metadata.updated_at — preserves metadata LWW invariant", async () => {
+describe("AAD binding negative test", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("decryption fails when AAD reconstructed from a tampered D1 row", async () => {
     const { token, userId } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
-    // Push metadata at sync_dirty_at=1000 → updated_at=1000
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, token);
-    // PUT bytes — wallclock is much larger than 1000
-    await signedFetch(`/api/sessions/bytes/${sid}`, {
-      method: "PUT",
-      headers: { "content-type": "application/octet-stream" },
-      body: new TextEncoder().encode("payload"),
-    }, token);
-    // updated_at MUST still be 1000. If the bytes-PUT bumped it to wallclock,
-    // a legitimate later metadata push at sync_dirty_at=1500 would be silently
-    // dropped by LWW (1500 < wallclock).
-    const row = await env.DB.prepare(
-      `SELECT updated_at, jsonl_r2_key FROM synced_session_metadata
-        WHERE owner_id = ? AND session_id = ?`,
-    ).bind(userId, sid).first<{ updated_at: number; jsonl_r2_key: string }>();
-    expect(row?.updated_at).toBe(1000);
-    expect(row?.jsonl_r2_key).toBe(`sessions/${userId}/${sid}.jsonl`);
+    await registerSession(token, sid);
 
-    // Confirm the no-skew invariant: a metadata push at sync_dirty_at=1500
-    // wins as expected.
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1500, { title: "after-bytes" })] }),
-    }, token);
-    const after = await env.DB.prepare(
-      `SELECT title, updated_at FROM synced_session_metadata
-        WHERE owner_id = ? AND session_id = ?`,
-    ).bind(userId, sid).first<{ title: string; updated_at: number }>();
-    expect(after?.title).toBe("after-bytes");
-    expect(after?.updated_at).toBe(1500);
+    const a = new TextEncoder().encode("AAA");
+    expect((await putChunk(token, sid, 1, a, 0, 0)).res.status).toBe(200);
+    const b = new TextEncoder().encode("BBB");
+    expect((await putChunk(token, sid, 2, b, 3, 0)).res.status).toBe(200);
+
+    // Tamper: swap chunk 1's plaintext_sha256 in D1 to chunk 2's value.
+    // A GET for chunk 1 will reconstruct AAD with the tampered hash, which
+    // does NOT match what was bound at encrypt — decrypt MUST fail.
+    const chunk2Hash = await sha256Hex(b);
+    await env.DB.prepare(
+      `UPDATE synced_session_chunks SET plaintext_sha256 = ?
+        WHERE owner_id = ? AND session_id = ? AND bytes_generation = 0 AND chunk_number = 1`,
+    ).bind(chunk2Hash, userId, sid).run();
+
+    const res = await signedFetch(`/api/sessions/bytes/${sid}/chunk/1`, { method: "GET" }, token);
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("decrypt_failed");
+  });
+});
+
+describe("GET manifest / chunk error paths", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("manifest 404 when session not in caller's metadata", async () => {
+    const { token } = await makeProSession();
+    const res = await signedFetch(`/api/sessions/bytes/missing-id/manifest`, { method: "GET" }, token);
+    expect(res.status).toBe(404);
   });
 
-  it("returns 400 (not 500) on malformed percent-encoding in the path", async () => {
+  it("chunk GET 404 when chunk doesn't exist", async () => {
     const { token } = await makeProSession();
-    // %G is a malformed percent escape — decodeURIComponent throws URIError.
-    const res = await signedFetch("/api/sessions/bytes/bad%Gid", { method: "GET" }, token);
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    const res = await signedFetch(`/api/sessions/bytes/${sid}/chunk/1`, { method: "GET" }, token);
+    expect(res.status).toBe(404);
+  });
+
+  it("malformed percent-encoding in path → 400 invalid_session_id", async () => {
+    const { token } = await makeProSession();
+    const res = await signedFetch(`/api/sessions/bytes/bad%Gid/manifest`, { method: "GET" }, token);
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toBe("invalid_session_id");
-  });
-
-  it("rejects oversized PUT bodies with 413", async () => {
-    const { token } = await makeProSession();
-    const sid = `s-${crypto.randomUUID()}`;
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, token);
-
-    // 51 MB payload — over the 50 MB cap.
-    const huge = new Uint8Array(51 * 1024 * 1024);
-    const res = await signedFetch(`/api/sessions/bytes/${sid}`, {
-      method: "PUT",
-      headers: { "content-type": "application/octet-stream" },
-      body: huge,
-    }, token);
-    expect(res.status).toBe(413);
-    const body = await res.json() as { error: string };
-    expect(body.error).toBe("payload_too_large");
-  });
-
-  it("fast-rejects when Content-Length declares an oversized body", async () => {
-    const { token } = await makeProSession();
-    const sid = `s-${crypto.randomUUID()}`;
-    await signedFetch("/api/sessions/metadata", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
-    }, token);
-
-    // Small body but lying Content-Length header — the fast-path should fire.
-    const res = await signedFetch(`/api/sessions/bytes/${sid}`, {
-      method: "PUT",
-      headers: {
-        "content-type": "application/octet-stream",
-        "content-length": String(60 * 1024 * 1024),
-      },
-      body: new Uint8Array(8),
-    }, token);
-    expect(res.status).toBe(413);
   });
 });

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -264,4 +264,53 @@ describe("PUT /api/sessions/bytes/:id + GET round-trip", () => {
     const body = await res.json() as { error: string };
     expect(body.error).toBe("bytes_not_uploaded");
   });
+
+  it("bytes PUT does NOT bump metadata.updated_at — preserves metadata LWW invariant", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    // Push metadata at sync_dirty_at=1000 → updated_at=1000
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1000)] }),
+    }, token);
+    // PUT bytes — wallclock is much larger than 1000
+    await signedFetch(`/api/sessions/bytes/${sid}`, {
+      method: "PUT",
+      headers: { "content-type": "application/octet-stream" },
+      body: new TextEncoder().encode("payload"),
+    }, token);
+    // updated_at MUST still be 1000. If the bytes-PUT bumped it to wallclock,
+    // a legitimate later metadata push at sync_dirty_at=1500 would be silently
+    // dropped by LWW (1500 < wallclock).
+    const row = await env.DB.prepare(
+      `SELECT updated_at, jsonl_r2_key FROM synced_session_metadata
+        WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ updated_at: number; jsonl_r2_key: string }>();
+    expect(row?.updated_at).toBe(1000);
+    expect(row?.jsonl_r2_key).toBe(`sessions/${userId}/${sid}.jsonl`);
+
+    // Confirm the no-skew invariant: a metadata push at sync_dirty_at=1500
+    // wins as expected.
+    await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessions: [sampleSession(sid, 1500, { title: "after-bytes" })] }),
+    }, token);
+    const after = await env.DB.prepare(
+      `SELECT title, updated_at FROM synced_session_metadata
+        WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ title: string; updated_at: number }>();
+    expect(after?.title).toBe("after-bytes");
+    expect(after?.updated_at).toBe(1500);
+  });
+
+  it("returns 400 (not 500) on malformed percent-encoding in the path", async () => {
+    const { token } = await makeProSession();
+    // %G is a malformed percent escape — decodeURIComponent throws URIError.
+    const res = await signedFetch("/api/sessions/bytes/bad%Gid", { method: "GET" }, token);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("invalid_session_id");
+  });
 });

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -212,6 +212,36 @@ describe("POST /api/sessions/metadata", () => {
     expect(count?.n).toBe(1);
   });
 
+  it("accepts a session with nullable fields missing entirely (undefined → null at bind)", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessions: [{
+          id: sid,
+          agent: "claude-code",
+          state: "done",
+          started_at: "2026-05-11T10:00:00Z",
+          last_event_at: "2026-05-11T10:30:00Z",
+          sync_dirty_at: 1000,
+          // title, cwd, model, ended_at, device_id all omitted
+        }],
+      }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([sid]);
+    expect(body.rejected).toEqual([]);
+    // The row landed with null for the unspecified columns.
+    const row = await env.DB.prepare(
+      `SELECT title, cwd, model, ended_at, device_id FROM synced_session_metadata
+        WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first();
+    expect(row).toMatchObject({ title: null, cwd: null, model: null, ended_at: null, device_id: null });
+  });
+
   it("rejects negative sync_dirty_at", async () => {
     const { token } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;

--- a/infra/oyster-cloud/vitest.config.ts
+++ b/infra/oyster-cloud/vitest.config.ts
@@ -9,6 +9,13 @@ export default defineWorkersConfig({
         miniflare: {
           // Use isolated in-memory D1 per test file.
           d1Databases: ["DB"],
+          // In-memory R2 bucket for session bytes tests.
+          r2Buckets: ["SESSIONS_BUCKET"],
+          // Encryption key fed in as a binding for tests; in production it's
+          // a wrangler secret.
+          bindings: {
+            SESSIONS_ENCRYPTION_KEY: "test-master-secret-do-not-use-in-prod",
+          },
         },
       },
     },

--- a/infra/oyster-cloud/wrangler.toml
+++ b/infra/oyster-cloud/wrangler.toml
@@ -14,6 +14,13 @@ database_name = "oyster-auth"
 database_id = "44086805-fbfa-4446-8626-126af7e2ec19"
 migrations_dir = "../auth-worker/migrations"
 
+# Session jsonl bytes (#322 Pick-up-here). Each object is a per-user
+# AES-GCM-encrypted Claude Code transcript. Bucket creation:
+#   wrangler r2 bucket create oyster-session-bytes
+[[r2_buckets]]
+binding = "SESSIONS_BUCKET"
+bucket_name = "oyster-session-bytes"
+
 [[routes]]
 pattern = "cloud.oyster.to/api/*"
 zone_name = "oyster.to"

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -383,7 +383,7 @@ export function initDb(userlandDir: string): Database.Database {
     db.exec("ALTER TABLE sessions ADD COLUMN cwd TEXT");
   } catch { /* already exists */ }
 
-  // Cloud session sync (#322). Five columns drive the cross-device sync:
+  // Cloud session sync (#322). Seven columns drive the cross-device sync:
   // - sync_dirty_at: unix-ms of the most recent material change since last
   //   successful push. NULL = clean. Overwritten on every dirty mark, so
   //   bursty updates collapse to the latest. Mirrors spaces.sync_dirty_at.
@@ -394,16 +394,24 @@ export function initDb(userlandDir: string): Database.Database {
   // - cloud_owner_id: which Pro account owns this session. The push gate
   //   only sends events whose cloud_owner_id matches the current Pro user
   //   (account-switching protection, mirrors the memory-events column).
-  // - jsonl_synced_at / jsonl_snapshot_offset: tracks how much of the JSONL
-  //   bytes have been uploaded to R2. NULL means no upload yet. Snapshot
-  //   offset lets the 5-min snapshot timer skip sessions whose disk file
-  //   hasn't grown since the last upload.
+  // - jsonl_synced_at: unix-ms of last successful chunked-bytes push.
+  // - jsonl_snapshot_offset: plaintext-byte offset already uploaded for this
+  //   session in the current bytes_generation. Snapshot timer skips a
+  //   session whose disk file hasn't grown past this. Reset to 0 on
+  //   truncation (which also bumps bytes_generation).
+  // - jsonl_chunk_count: number of chunks uploaded in the current generation.
+  //   Next PUT goes as chunk (jsonl_chunk_count + 1).
+  // - bytes_generation: monotonic per-session counter. Bumped when the local
+  //   jsonl is truncated (rare). Stale in-flight chunks from earlier
+  //   generations are rejected by the worker.
   for (const sql of [
     "ALTER TABLE sessions ADD COLUMN sync_dirty_at INTEGER",
     "ALTER TABLE sessions ADD COLUMN cloud_synced_at INTEGER",
     "ALTER TABLE sessions ADD COLUMN cloud_owner_id TEXT",
     "ALTER TABLE sessions ADD COLUMN jsonl_synced_at INTEGER",
-    "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER",
+    "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE sessions ADD COLUMN jsonl_chunk_count INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE sessions ADD COLUMN bytes_generation INTEGER NOT NULL DEFAULT 0",
   ]) {
     try { db.exec(sql); } catch { /* already exists */ }
   }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -179,6 +179,18 @@ export function initDb(userlandDir: string): Database.Database {
     )
   `);
 
+  // Device identity (#322 session sync). Stable per-device id + label so cloud
+  // metadata can attribute "this session originated on Matthew's MacBook Pro".
+  // Singleton like profile_binding. The id and label are seeded by the server
+  // on first boot if missing (see device-identity-service).
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS device_identity (
+      id         INTEGER PRIMARY KEY CHECK (id = 1),
+      device_id  TEXT    NOT NULL,
+      label      TEXT    NOT NULL
+    )
+  `);
+
   // Sessions arc (0.5.0). Three tables that capture agent activity (claude-code,
   // opencode, codex) read from external session logs. See
   // docs/plans/sessions-arc.md for the design.
@@ -369,6 +381,32 @@ export function initDb(userlandDir: string): Database.Database {
   try {
     db.exec("ALTER TABLE sessions ADD COLUMN cwd TEXT");
   } catch { /* already exists */ }
+
+  // Cloud session sync (#322). Three columns drive the cross-device sync:
+  // - sync_dirty_at: unix-ms when the row was first marked dirty since last
+  //   successful push. NULL = clean. Mirrors spaces.sync_dirty_at.
+  // - cloud_owner_id: which Pro account owns this session. The push gate
+  //   only sends events whose cloud_owner_id matches the current Pro user
+  //   (account-switching protection, mirrors the memory-events column).
+  // - jsonl_synced_at / jsonl_snapshot_offset: tracks how much of the JSONL
+  //   bytes have been uploaded to R2. NULL means no upload yet. Snapshot
+  //   offset lets the 5-min snapshot timer skip sessions whose disk file
+  //   hasn't grown since the last upload.
+  for (const sql of [
+    "ALTER TABLE sessions ADD COLUMN sync_dirty_at INTEGER",
+    "ALTER TABLE sessions ADD COLUMN cloud_synced_at INTEGER",
+    "ALTER TABLE sessions ADD COLUMN cloud_owner_id TEXT",
+    "ALTER TABLE sessions ADD COLUMN jsonl_synced_at INTEGER",
+    "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER",
+  ]) {
+    try { db.exec(sql); } catch { /* already exists */ }
+  }
+  // Index the dirty predicate so the outbox scan stays cheap as the
+  // sessions table grows. Mirror of spaces.sync_dirty_at pattern.
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS sessions_sync_dirty
+       ON sessions(sync_dirty_at) WHERE sync_dirty_at IS NOT NULL`,
+  );
 
   // ── R2 verbatim recall (#311): FTS5 over session_events.text ──
   // Lives after the state-rename rebuild block (which DROPs and rebuilds

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -181,8 +181,9 @@ export function initDb(userlandDir: string): Database.Database {
 
   // Device identity (#322 session sync). Stable per-device id + label so cloud
   // metadata can attribute "this session originated on Matthew's MacBook Pro".
-  // Singleton like profile_binding. The id and label are seeded by the server
-  // on first boot if missing (see device-identity-service).
+  // Singleton like profile_binding. The seeding helper (uuid + os.hostname()
+  // derivation) lands in PR 1b alongside SessionSyncService wiring; this
+  // table is created up-front so the migration sits with the other singletons.
   db.exec(`
     CREATE TABLE IF NOT EXISTS device_identity (
       id         INTEGER PRIMARY KEY CHECK (id = 1),
@@ -382,9 +383,14 @@ export function initDb(userlandDir: string): Database.Database {
     db.exec("ALTER TABLE sessions ADD COLUMN cwd TEXT");
   } catch { /* already exists */ }
 
-  // Cloud session sync (#322). Three columns drive the cross-device sync:
-  // - sync_dirty_at: unix-ms when the row was first marked dirty since last
-  //   successful push. NULL = clean. Mirrors spaces.sync_dirty_at.
+  // Cloud session sync (#322). Five columns drive the cross-device sync:
+  // - sync_dirty_at: unix-ms of the most recent material change since last
+  //   successful push. NULL = clean. Overwritten on every dirty mark, so
+  //   bursty updates collapse to the latest. Mirrors spaces.sync_dirty_at.
+  // - cloud_synced_at: unix-ms of the last successful push acknowledgement.
+  //   The dirty predicate is `sync_dirty_at IS NOT NULL AND
+  //   (cloud_synced_at IS NULL OR cloud_synced_at < sync_dirty_at)`, so a
+  //   dirty bump after a successful push correctly re-pends the row.
   // - cloud_owner_id: which Pro account owns this session. The push gate
   //   only sends events whose cloud_owner_id matches the current Pro user
   //   (account-switching protection, mirrors the memory-events column).

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,6 +34,7 @@ import { tryHandlePinRoute } from "./routes/pin.js";
 import { createPublishService, PublishError } from "./publish-service.js";
 import { createSpaceSyncService } from "./space-sync-service.js";
 import { createMemorySyncService, type MemorySyncService } from "./memory-sync-service.js";
+import { createSessionSyncService, type SessionSyncService } from "./session-sync-service.js";
 import { createProfileBindingService } from "./profile-binding-service.js";
 import { hashPassword } from "./password-hash.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
@@ -351,6 +352,23 @@ memoryProvider.setOnWrite(() => {
   broadcastUiEvent({ version: 1, command: "memory_changed", payload: { op: "write" } });
 });
 
+// Sessions arc — cross-device sync of agent session metadata (#322). The
+// service drains dirty rows from the `sessions` table on push; the watcher
+// hook below marks rows dirty whenever a session row changes. pushBytes
+// (R2 jsonl upload) lives on the same service and lands in PR 1c when the
+// cloud worker route is ready. pull() and remote_sessions land in PR 2.
+const sessionSync: SessionSyncService = createSessionSyncService({
+  db,
+  profileBinding,
+  currentUser: () => {
+    const u = authService.getState().user;
+    return u ? { id: u.id, email: u.email, tier: u.tier } : null;
+  },
+  sessionToken: () => authService.getState().sessionToken,
+  workerBase: CLOUD_WORKER_BASE,
+  fetch: globalThis.fetch,
+});
+
 // Periodic pull. Pull-only triggers (auth-changed and app-startup) leave a
 // running server stale until the next reconcile event. A modest 30s tick
 // keeps cross-device memory updates fresh without burning excessive
@@ -445,6 +463,14 @@ async function syncOnAuth(label: string): Promise<void> {
       }
     } catch (err) {
       console.warn(`[memory] ${label} reconcile failed:`, err);
+    }
+    try {
+      const sesResult = await sessionSync.reconcile();
+      if (sesResult.pulled || sesResult.pushed) {
+        console.log(`[sessions] reconcile (${label}): pulled=${sesResult.pulled} pushed=${sesResult.pushed}`);
+      }
+    } catch (err) {
+      console.warn(`[sessions] ${label} reconcile failed:`, err);
     }
   }
   // Then publications (preserves existing behaviour: clears ghost cache on
@@ -864,8 +890,20 @@ httpServer.listen(port, "127.0.0.1", () => {
     sessionStore,
     spaceStore,
     artifactStore: store,
-    emitSessionChanged: (id) =>
-      broadcastUiEvent({ version: 1, command: "session_changed", payload: { id } }),
+    emitSessionChanged: (id) => {
+      broadcastUiEvent({ version: 1, command: "session_changed", payload: { id } });
+      // Cross-device session sync (#322): every session-row change marks the
+      // row dirty for the current Pro owner, then fires a fire-and-forget
+      // push. The in-flight guard inside SessionSyncService coalesces bursty
+      // updates from active sessions into a single pass.
+      const u = authService.getState().user;
+      if (u && u.tier === "pro") {
+        sessionSync.markDirty(id, u.id);
+        sessionSync.pushPending().catch((err) => {
+          console.warn("[sessions] watcher-triggered pushPending failed:", err);
+        });
+      }
+    },
   });
   claudeCodeWatcher.start().catch((err) => {
     console.warn(`[claude-code-watcher] start failed: ${err instanceof Error ? err.message : err}`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -896,13 +896,18 @@ httpServer.listen(port, "127.0.0.1", () => {
       // row dirty for the current Pro owner, then fires a fire-and-forget
       // push. The in-flight guard inside SessionSyncService coalesces bursty
       // updates from active sessions into a single pass.
-      const u = authService.getState().user;
-      if (u && u.tier === "pro") {
-        sessionSync.markDirty(id, u.id);
-        sessionSync.pushPending().catch((err) => {
-          console.warn("[sessions] watcher-triggered pushPending failed:", err);
-        });
-      }
+      //
+      // canRunCloudSync() (not a bare tier check): when the local profile is
+      // bound to a different account, we MUST NOT call markDirty — it would
+      // overwrite cloud_owner_id to the wrong owner and the rightful bound
+      // owner's later pushPending would no longer find these rows in the
+      // owner-scoped scan.
+      if (!canRunCloudSync()) return;
+      const u = authService.getState().user!;
+      sessionSync.markDirty(id, u.id);
+      sessionSync.pushPending().catch((err) => {
+        console.warn("[sessions] watcher-triggered pushPending failed:", err);
+      });
     },
   });
   claudeCodeWatcher.start().catch((err) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,7 +34,7 @@ import { tryHandlePinRoute } from "./routes/pin.js";
 import { createPublishService, PublishError } from "./publish-service.js";
 import { createSpaceSyncService } from "./space-sync-service.js";
 import { createMemorySyncService, type MemorySyncService } from "./memory-sync-service.js";
-import { createSessionSyncService, type SessionSyncService } from "./session-sync-service.js";
+import { createSessionSyncService, encodeCwd, projectsRoot, type SessionSyncService } from "./session-sync-service.js";
 import { createProfileBindingService } from "./profile-binding-service.js";
 import { hashPassword } from "./password-hash.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
@@ -352,11 +352,12 @@ memoryProvider.setOnWrite(() => {
   broadcastUiEvent({ version: 1, command: "memory_changed", payload: { op: "write" } });
 });
 
-// Sessions arc — cross-device sync of agent session metadata (#322). The
-// service drains dirty rows from the `sessions` table on push; the watcher
-// hook below marks rows dirty whenever a session row changes. pushBytes
-// (R2 jsonl upload) lives on the same service and lands in PR 1c when the
-// cloud worker route is ready. pull() and remote_sessions land in PR 2.
+// Sessions arc — cross-device sync of agent sessions (#322). Two flows on
+// the same service: metadata (markDirty + pushPending → D1) and bytes
+// (pushBytes → chunked-delta uploads to R2 via worker). The watcher hook
+// below marks rows dirty + fires pushBytes on terminal state. The 5-min
+// snapshot timer (further below) drives mid-session bytes uploads.
+// pull() + remote_sessions + resume API land in PR 2.
 const sessionSync: SessionSyncService = createSessionSyncService({
   db,
   profileBinding,
@@ -418,12 +419,10 @@ async function runSessionsSnapshotTick(): Promise<void> {
   ).all(authService.getState().user?.id ?? "") as Candidate[];
   if (candidates.length === 0) return;
 
-  const root = process.env.OYSTER_CLAUDE_PROJECTS_ROOT
-    ?? join(homedir(), ".claude", "projects");
+  const root = projectsRoot();
   for (const cand of candidates) {
     if (!cand.cwd) continue;
-    const encoded = cand.cwd.replace(/[^A-Za-z0-9]/g, "-");
-    const jsonlPath = join(root, encoded, `${cand.id}.jsonl`);
+    const jsonlPath = join(root, encodeCwd(cand.cwd), `${cand.id}.jsonl`);
     let size = 0;
     try {
       const st = statSync(jsonlPath);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -390,6 +390,60 @@ const memoryPollHandle = setInterval(() => {
 }, MEMORY_POLL_INTERVAL_MS);
 memoryPollHandle.unref();
 
+// Session bytes snapshot timer (#322). Every 5 minutes, scan
+// active/waiting sessions whose disk file has grown by >= 1 MB beyond
+// jsonl_snapshot_offset and fire pushBytes for each. The in-flight guard
+// inside SessionSyncService coalesces with any concurrent terminal-hook
+// push. Configurable via OYSTER_SESSIONS_SNAPSHOT_MS for ops/testing.
+const SESSION_SNAPSHOT_INTERVAL_MS = Math.max(
+  30_000,
+  Number(process.env.OYSTER_SESSIONS_SNAPSHOT_MS) || 5 * 60_000,
+);
+const SESSION_SNAPSHOT_DELTA_THRESHOLD = Math.max(
+  64 * 1024,
+  Number(process.env.OYSTER_SESSIONS_SNAPSHOT_DELTA_BYTES) || 1024 * 1024,
+);
+async function runSessionsSnapshotTick(): Promise<void> {
+  if (!canRunCloudSync()) return;
+  // Candidates: active/waiting sessions owned by the current user. We
+  // intentionally don't filter on file size in SQL because the database
+  // doesn't know the current on-disk size — only the offset already uploaded.
+  type Candidate = { id: string; cwd: string | null; jsonl_snapshot_offset: number };
+  const candidates = db.prepare(
+    `SELECT id, cwd, jsonl_snapshot_offset
+       FROM sessions
+      WHERE state IN ('active', 'waiting')
+        AND cwd IS NOT NULL
+        AND cloud_owner_id = ?`,
+  ).all(authService.getState().user?.id ?? "") as Candidate[];
+  if (candidates.length === 0) return;
+
+  const root = process.env.OYSTER_CLAUDE_PROJECTS_ROOT
+    ?? join(homedir(), ".claude", "projects");
+  for (const cand of candidates) {
+    if (!cand.cwd) continue;
+    const encoded = cand.cwd.replace(/[^A-Za-z0-9]/g, "-");
+    const jsonlPath = join(root, encoded, `${cand.id}.jsonl`);
+    let size = 0;
+    try {
+      const st = statSync(jsonlPath);
+      size = st.size;
+    } catch {
+      continue;  // file gone or unreadable; nothing to push
+    }
+    if (size - cand.jsonl_snapshot_offset < SESSION_SNAPSHOT_DELTA_THRESHOLD) continue;
+    sessionSync.pushBytes(cand.id).catch((err) => {
+      console.warn(`[sessions] snapshot pushBytes failed for ${cand.id}:`, err);
+    });
+  }
+}
+const sessionSnapshotHandle = setInterval(() => {
+  runSessionsSnapshotTick().catch((err) => {
+    console.warn("[sessions] snapshot tick failed:", err);
+  });
+}, SESSION_SNAPSHOT_INTERVAL_MS);
+sessionSnapshotHandle.unref();
+
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const publishService = createPublishService({
   db,
@@ -894,8 +948,8 @@ httpServer.listen(port, "127.0.0.1", () => {
       broadcastUiEvent({ version: 1, command: "session_changed", payload: { id } });
       // Cross-device session sync (#322): every session-row change marks the
       // row dirty for the current Pro owner, then fires a fire-and-forget
-      // push. The in-flight guard inside SessionSyncService coalesces bursty
-      // updates from active sessions into a single pass.
+      // metadata push + bytes push on terminal state. The in-flight guards
+      // inside SessionSyncService coalesce bursty updates into single passes.
       //
       // canRunCloudSync() (not a bare tier check): when the local profile is
       // bound to a different account, we MUST NOT call markDirty — it would
@@ -908,6 +962,16 @@ httpServer.listen(port, "127.0.0.1", () => {
       sessionSync.pushPending().catch((err) => {
         console.warn("[sessions] watcher-triggered pushPending failed:", err);
       });
+      // Terminal-state hook: fire one final pushBytes when the session
+      // transitions to done/disconnected so the tail of the jsonl makes it
+      // to cloud even if it's under the snapshot-timer's 1 MB threshold.
+      // sessionStore lookup is a single PK read — cheap.
+      const row = sessionStore.getById(id);
+      if (row && (row.state === "done" || row.state === "disconnected")) {
+        sessionSync.pushBytes(id).catch((err) => {
+          console.warn("[sessions] terminal pushBytes failed:", err);
+        });
+      }
     },
   });
   claudeCodeWatcher.start().catch((err) => {

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -72,8 +72,9 @@ const BATCH_SIZE = 100;
 const MAX_CHUNK_BYTES = 25 * 1024 * 1024;
 
 /** Claude Code's projects root. Read fresh each call so tests can swap the
- *  env var per case without re-importing the module. */
-function projectsRoot(): string {
+ *  env var per case without re-importing the module. Exported so the
+ *  snapshot timer in index.ts uses the same resolution. */
+export function projectsRoot(): string {
   return process.env.OYSTER_CLAUDE_PROJECTS_ROOT ?? join(homedir(), ".claude", "projects");
 }
 
@@ -326,84 +327,95 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       return { uploaded: 0, offsetAfter: offset, generation, resetFired };
     }
 
-    // Read the whole pending region in one shot. We split into chunks in
-    // memory, then PUT each. For the 50 MB-and-up outlier case, the loop
-    // does multiple ~25 MB chunks in one snapshot pass.
-    let pendingBuf: Buffer;
+    // Stream pending bytes one chunk at a time, capped at MAX_CHUNK_BYTES.
+    // A user offline for a while may have a multi-hundred-MB pending region;
+    // we must NOT Buffer.alloc the whole thing or we OOM the server process.
+    //
+    // The read window starts at PROBE_WINDOW (MAX_CHUNK_BYTES + tail slack)
+    // so we can find a newline boundary up to MAX_CHUNK_BYTES back from the
+    // top of the window. If no newline exists in that window, we fall back
+    // to a hard MAX_CHUNK_BYTES slice (per the byte-order reconstruction
+    // contract — JSON-awareness is advisory).
     let fh: import("node:fs/promises").FileHandle | null = null;
+    let uploaded = 0;
+    let pushedBytes = 0;  // plaintext bytes successfully uploaded this call
     try {
       fh = await fs.open(jsonlPath, "r");
-      const length = stat.size - offset;
-      const buf = Buffer.alloc(length);
-      const read = await fh.read(buf, 0, length, offset);
-      pendingBuf = buf.subarray(0, read.bytesRead);
+
+      while (offset + pushedBytes < stat.size) {
+        const cursor = offset + pushedBytes;
+        const remainingTotal = stat.size - cursor;
+        const windowSize = Math.min(remainingTotal, MAX_CHUNK_BYTES);
+        const windowBuf = Buffer.alloc(windowSize);
+        const { bytesRead } = await fh.read(windowBuf, 0, windowSize, cursor);
+        if (bytesRead === 0) break;  // shouldn't happen given the loop guard
+        const window = windowBuf.subarray(0, bytesRead);
+
+        // chooseChunkSize keeps us at-or-under MAX_CHUNK_BYTES and prefers a
+        // newline boundary. For the final chunk it returns the remaining
+        // size (which equals bytesRead, == remainingTotal when ≤ cap).
+        const sliceSize = chooseChunkSize(window, MAX_CHUNK_BYTES);
+        const chunkBytes = window.subarray(0, sliceSize);
+
+        // Copy into a detached ArrayBuffer so the fetch BodyInit type is
+        // happy and the chunk can be released after the PUT regardless of
+        // what runtime fetch does internally.
+        const chunkBody = new ArrayBuffer(sliceSize);
+        new Uint8Array(chunkBody).set(chunkBytes);
+
+        const startOffset = cursor;
+        const endOffset = startOffset + sliceSize;
+        const hash = sha256Hex(new Uint8Array(chunkBody));
+        const nextChunkNumber = chunkCount + 1;
+
+        let res: Response;
+        try {
+          res = await deps.fetch(
+            `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/chunk/${nextChunkNumber}`,
+            {
+              method: "PUT",
+              headers: {
+                Cookie: `oyster_session=${session.token}`,
+                "content-type": "application/octet-stream",
+                "x-chunk-start-offset": String(startOffset),
+                "x-chunk-end-offset": String(endOffset),
+                "x-plaintext-sha256": hash,
+                "x-bytes-generation": String(generation),
+              },
+              body: chunkBody,
+            },
+          );
+        } catch (err) {
+          console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} fetch failed for ${sessionId}:`, err);
+          break;
+        }
+
+        if (res.status === 200) {
+          // Persist after every chunk so a mid-loop crash doesn't re-upload
+          // bytes already in cloud. snapshot_offset advances by exactly
+          // sliceSize plaintext bytes.
+          chunkCount = nextChunkNumber;
+          pushedBytes += sliceSize;
+          advanceBytesState.run(offset + pushedBytes, chunkCount, Date.now(), sessionId);
+          uploaded++;
+          continue;
+        }
+
+        // Per the worker's idempotency contract, an exact-match retry returns
+        // 200 idempotent:true (not 409). So any non-200 here is a real
+        // problem (conflict, stale gen, non-contiguous) — log and abort.
+        // The next reconcile cycle re-derives state from the server's
+        // manifest and recovers.
+        console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} rejected (${res.status}) for ${sessionId}`);
+        break;
+      }
     } catch (err) {
-      console.warn(`[sessions] pushBytes: read failed for ${jsonlPath}:`, err);
-      return { uploaded: 0, offsetAfter: offset, generation, resetFired };
+      console.warn(`[sessions] pushBytes loop failed for ${jsonlPath}:`, err);
     } finally {
       if (fh) await fh.close().catch(() => { /* ignore */ });
     }
 
-    let uploaded = 0;
-    let bufOffset = 0;
-
-    while (bufOffset < pendingBuf.byteLength) {
-      const remaining = pendingBuf.subarray(bufOffset);
-      const sliceSize = chooseChunkSize(remaining, MAX_CHUNK_BYTES);
-      const chunkBytes = remaining.subarray(0, sliceSize);
-      // Node Buffer extends Uint8Array at runtime, but TS's fetch BodyInit
-      // type is picky. Copy into a plain detached ArrayBuffer for the body —
-      // ArrayBuffer IS in BodyInit. The copy is cheap relative to the HTTP
-      // round-trip and avoids cross-realm Uint8Array issues.
-      const chunkBody = new ArrayBuffer(sliceSize);
-      new Uint8Array(chunkBody).set(chunkBytes);
-      const startOffset = offset + bufOffset;
-      const endOffset = startOffset + sliceSize;
-      const hash = sha256Hex(new Uint8Array(chunkBody));
-      const nextChunkNumber = chunkCount + 1;
-
-      let res: Response;
-      try {
-        res = await deps.fetch(
-          `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/chunk/${nextChunkNumber}`,
-          {
-            method: "PUT",
-            headers: {
-              Cookie: `oyster_session=${session.token}`,
-              "content-type": "application/octet-stream",
-              "x-chunk-start-offset": String(startOffset),
-              "x-chunk-end-offset": String(endOffset),
-              "x-plaintext-sha256": hash,
-              "x-bytes-generation": String(generation),
-            },
-            body: chunkBody,
-          },
-        );
-      } catch (err) {
-        console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} fetch failed for ${sessionId}:`, err);
-        break;
-      }
-
-      if (res.status === 200) {
-        // Advance local state and continue the loop. We persist after every
-        // chunk so a mid-loop crash doesn't re-upload bytes already in cloud.
-        chunkCount = nextChunkNumber;
-        bufOffset += sliceSize;
-        advanceBytesState.run(offset + bufOffset, chunkCount, Date.now(), sessionId);
-        uploaded++;
-        continue;
-      }
-
-      // 409 idempotent retry — the worker's idempotency contract guarantees
-      // an exact-match retry returns 200 with idempotent:true, not 409. So
-      // any 409 here is a real conflict (different content / stale gen /
-      // non-contiguous) — log and abort the loop. The next reconcile cycle
-      // will re-derive state from the server's manifest and recover.
-      console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} rejected (${res.status}) for ${sessionId}`);
-      break;
-    }
-
-    return { uploaded, offsetAfter: offset + bufOffset, generation, resetFired };
+    return { uploaded, offsetAfter: offset + pushedBytes, generation, resetFired };
   }
 
   // Capture the service object so methods don't depend on `this` binding —

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -97,10 +97,14 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       LIMIT ?`,
   );
 
+  // Owner-scoped on the WHERE clause: if the server somehow echoes back an id
+  // that belongs to a different cloud_owner_id (account-switch race, server
+  // bug), refuse to mark it synced. Defensive — push is already owner-scoped
+  // on the scan side, but layered checks are cheap.
   const markSyncedStmt = deps.db.prepare(
     `UPDATE sessions
         SET cloud_synced_at = ?
-      WHERE id = ?`,
+      WHERE id = ? AND cloud_owner_id = ?`,
   );
 
   async function doPushPending(): Promise<number> {
@@ -138,7 +142,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       // > cloud_synced_at and the next scan picks it up.
       const now = Date.now();
       const tx = deps.db.transaction(() => {
-        for (const id of accepted) markSyncedStmt.run(now, id);
+        for (const id of accepted) markSyncedStmt.run(now, id, session.user.id);
       });
       tx();
       totalAccepted += accepted.length;
@@ -154,12 +158,15 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     return totalAccepted;
   }
 
-  return {
+  // Capture the service object so methods don't depend on `this` binding —
+  // safe to pass `service.reconcile` directly into a setInterval / event
+  // emitter callback. Mirrors the memory-sync-service shape.
+  const service: SessionSyncService = {
     async reconcile() {
       const session = isProSession(deps);
       if (!session) return { pulled: 0, pushed: 0 };
       // Pull is PR 2 territory; for now reconcile = pushPending.
-      const pushed = await this.pushPending();
+      const pushed = await service.pushPending();
       return { pulled: 0, pushed };
     },
 
@@ -175,4 +182,5 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
 
     markDirty,
   };
+  return service;
 }

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -1,0 +1,178 @@
+// session-sync-service.ts — cross-device sync of agent session metadata (#322).
+//
+// Pattern: row-level dirty tracking on the `sessions` table. The watcher (or
+// any other writer) calls markDirty() when a session row changes; pushPending()
+// drains dirty rows for the current Pro owner up to cloud, marks them synced
+// on the round-trip. Pro-only. Profile-binding gate prevents account A's
+// metadata polluting account B's local SQLite.
+//
+// Mirrors memory-sync-service.ts for the gate / in-flight guard / fetch shape,
+// and spaces' sync_dirty_at + cloud_synced_at columns for the dirty predicate.
+//
+// PR 1 of 3: metadata push only.
+//   PR 2 will add `pull()` + remote_sessions table + lazy bytes pull.
+//   PR 3 will add the UI surface (cross-device cards + Resume on this device).
+// `pushBytes()` and the 5-min snapshot timer also land in a follow-up once
+// the cloud worker route exists.
+
+import type Database from "better-sqlite3";
+import type { ProfileBindingService } from "./profile-binding-service.js";
+
+interface SyncUser { id: string; email: string; tier: string }
+
+export interface SessionSyncDeps {
+  db: Database.Database;
+  /** Required: gates pull AND push on profile ownership so a second Pro
+   *  account signing into the same local profile cannot pollute the local
+   *  SQLite with their cloud sessions. Mirrors memory sync. */
+  profileBinding: ProfileBindingService;
+  currentUser: () => SyncUser | null;
+  sessionToken: () => string | null;
+  workerBase: string;
+  fetch: typeof fetch;
+}
+
+export interface SessionSyncService {
+  reconcile(): Promise<{ pulled: number; pushed: number }>;
+  pushPending(): Promise<number>;
+  /** Mark a session row dirty so the next pushPending() picks it up. The
+   *  watcher should call this on every material session change. */
+  markDirty(sessionId: string, ownerId: string, at?: number): void;
+}
+
+const BATCH_SIZE = 100;
+
+function isProSession(deps: SessionSyncDeps): { user: SyncUser; token: string } | null {
+  const user = deps.currentUser();
+  const token = deps.sessionToken();
+  if (!user || !token || user.tier !== "pro") return null;
+  if (!deps.profileBinding.isOwnedBy(user.id)) {
+    console.warn(
+      `[sessions] sync blocked — profile is bound to a different account; current=${user.id}, bound=${deps.profileBinding.getBoundOwner()}`,
+    );
+    return null;
+  }
+  return { user, token };
+}
+
+interface OutgoingSession {
+  id: string;
+  agent: string;
+  title: string | null;
+  state: string;
+  started_at: string;
+  ended_at: string | null;
+  model: string | null;
+  cwd: string | null;
+  last_event_at: string;
+  sync_dirty_at: number;
+}
+
+export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncService {
+  let inFlightPush: Promise<number> | null = null;
+
+  const markDirtyStmt = deps.db.prepare(
+    `UPDATE sessions
+        SET sync_dirty_at  = ?,
+            cloud_owner_id = ?
+      WHERE id = ?`,
+  );
+
+  function markDirty(sessionId: string, ownerId: string, at = Date.now()): void {
+    markDirtyStmt.run(at, ownerId, sessionId);
+  }
+
+  // Dirty predicate mirrors space-sync: a row is pending when sync_dirty_at
+  // is set AND cloud_synced_at is either NULL or older than the dirty mark.
+  // Restricting to cloud_owner_id = current Pro user is the account-switching
+  // guard (don't push another owner's events; same posture as memory sync).
+  const scanDirty = deps.db.prepare(
+    `SELECT id, agent, title, state, started_at, ended_at, model, cwd,
+            last_event_at, sync_dirty_at
+       FROM sessions
+      WHERE sync_dirty_at IS NOT NULL
+        AND cloud_owner_id = ?
+        AND (cloud_synced_at IS NULL OR cloud_synced_at < sync_dirty_at)
+      ORDER BY sync_dirty_at ASC
+      LIMIT ?`,
+  );
+
+  const markSyncedStmt = deps.db.prepare(
+    `UPDATE sessions
+        SET cloud_synced_at = ?
+      WHERE id = ?`,
+  );
+
+  async function doPushPending(): Promise<number> {
+    const session = isProSession(deps);
+    if (!session) return 0;
+
+    let totalAccepted = 0;
+    const MAX_BATCHES = 1000;  // defensive safety cap
+
+    for (let i = 0; i < MAX_BATCHES; i++) {
+      const pending = scanDirty.all(session.user.id, BATCH_SIZE) as OutgoingSession[];
+      if (pending.length === 0) break;
+
+      let res: Response;
+      try {
+        res = await deps.fetch(`${deps.workerBase}/api/sessions/metadata`, {
+          method: "POST",
+          headers: { Cookie: `oyster_session=${session.token}`, "content-type": "application/json" },
+          body: JSON.stringify({ sessions: pending }),
+        });
+      } catch (err) {
+        console.warn("[sessions] pushPending failed:", err);
+        return totalAccepted;
+      }
+      if (!res.ok) {
+        console.warn(`[sessions] pushPending non-ok ${res.status}`);
+        return totalAccepted;
+      }
+      const body = await res.json().catch(() => null) as { accepted?: string[] } | null;
+      const accepted = body?.accepted ?? [];
+
+      // Mark accepted rows synced. Use Date.now() as cloud_synced_at — any
+      // sync_dirty_at <= this value is considered cleared. If the row was
+      // dirtied AGAIN between scan and ack, the new sync_dirty_at will be
+      // > cloud_synced_at and the next scan picks it up.
+      const now = Date.now();
+      const tx = deps.db.transaction(() => {
+        for (const id of accepted) markSyncedStmt.run(now, id);
+      });
+      tx();
+      totalAccepted += accepted.length;
+
+      if (accepted.length > 0) {
+        console.log(`[sessions] pushed: accepted=${accepted.length}`);
+      }
+      // If nothing was accepted, breaking avoids hot-looping on a server
+      // that returns empty acks.
+      if (accepted.length === 0) break;
+    }
+
+    return totalAccepted;
+  }
+
+  return {
+    async reconcile() {
+      const session = isProSession(deps);
+      if (!session) return { pulled: 0, pushed: 0 };
+      // Pull is PR 2 territory; for now reconcile = pushPending.
+      const pushed = await this.pushPending();
+      return { pulled: 0, pushed };
+    },
+
+    async pushPending() {
+      if (inFlightPush) return inFlightPush;
+      inFlightPush = doPushPending();
+      try {
+        return await inFlightPush;
+      } finally {
+        inFlightPush = null;
+      }
+    },
+
+    markDirty,
+  };
+}

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -1,20 +1,27 @@
-// session-sync-service.ts — cross-device sync of agent session metadata (#322).
+// session-sync-service.ts — cross-device sync of agent sessions (#322).
 //
-// Pattern: row-level dirty tracking on the `sessions` table. The watcher (or
-// any other writer) calls markDirty() when a session row changes; pushPending()
-// drains dirty rows for the current Pro owner up to cloud, marks them synced
-// on the round-trip. Pro-only. Profile-binding gate prevents account A's
-// metadata polluting account B's local SQLite.
+// Two flows on top of the same Pro-tier + profile-binding gate:
+//
+// 1) metadata — row-level dirty tracking on `sessions`. markDirty() flags
+//    a row; pushPending() drains dirty rows for the current owner to D1.
+//
+// 2) bytes — chunked-delta uploads of the jsonl file. pushBytes(sessionId)
+//    reads the new bytes since `jsonl_snapshot_offset`, splits into ≤
+//    MAX_CHUNK_BYTES chunks (advisory newline-boundary), hashes each, PUTs
+//    each as the next chunk in the current generation. Truncation (file
+//    shrank) calls /reset and starts over in the next generation.
 //
 // Mirrors memory-sync-service.ts for the gate / in-flight guard / fetch shape,
 // and spaces' sync_dirty_at + cloud_synced_at columns for the dirty predicate.
 //
-// PR 1 of 3: metadata push only.
-//   PR 2 will add `pull()` + remote_sessions table + lazy bytes pull.
+// Sibling pieces (separate PRs):
+//   PR 2 will add `pull()` + remote_sessions + lazy bytes pull.
 //   PR 3 will add the UI surface (cross-device cards + Resume on this device).
-// `pushBytes()` and the 5-min snapshot timer also land in a follow-up once
-// the cloud worker route exists.
 
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promises as fs } from "node:fs";
 import type Database from "better-sqlite3";
 import type { ProfileBindingService } from "./profile-binding-service.js";
 
@@ -32,15 +39,73 @@ export interface SessionSyncDeps {
   fetch: typeof fetch;
 }
 
+export interface PushBytesResult {
+  /** Number of chunks pushed in this invocation (0 if nothing new). */
+  uploaded: number;
+  /** Final plaintext byte offset (== file size at the moment of upload). */
+  offsetAfter: number;
+  /** Generation chunks were uploaded under. */
+  generation: number;
+  /** Whether a reset happened (file shrank). */
+  resetFired: boolean;
+}
+
 export interface SessionSyncService {
   reconcile(): Promise<{ pulled: number; pushed: number }>;
   pushPending(): Promise<number>;
+  /** Push new jsonl bytes for a session up to cloud as chunked deltas.
+   *  Reads from `~/.claude/projects/<encodeCwd(session.cwd)>/<id>.jsonl`
+   *  starting at `sessions.jsonl_snapshot_offset`. Handles file truncation
+   *  via a generation bump. No-ops cleanly when the file hasn't grown,
+   *  when the session row is missing cwd, or when the gate fails. */
+  pushBytes(sessionId: string): Promise<PushBytesResult>;
   /** Mark a session row dirty so the next pushPending() picks it up. The
    *  watcher should call this on every material session change. */
   markDirty(sessionId: string, ownerId: string, at?: number): void;
 }
 
 const BATCH_SIZE = 100;
+
+/** Per-chunk cap on the wire. Workers' body limit is 100 MB; staying at
+ *  25 MB leaves headroom for encryption overhead. Top-level session size
+ *  is unbounded — chunks accumulate as the file grows. */
+const MAX_CHUNK_BYTES = 25 * 1024 * 1024;
+
+/** Claude Code's projects root. Read fresh each call so tests can swap the
+ *  env var per case without re-importing the module. */
+function projectsRoot(): string {
+  return process.env.OYSTER_CLAUDE_PROJECTS_ROOT ?? join(homedir(), ".claude", "projects");
+}
+
+/** Encode an absolute cwd to Claude Code's projects-subdir convention:
+ *  every non-alphanumeric character → "-". Verified against real Mac
+ *  jsonl paths (e.g. /Users/Matt.Slight/Dev/oyster-os →
+ *  -Users-Matt-Slight-Dev-oyster-os). Generic enough to handle Windows
+ *  separators too (\, :, etc.) without changes. */
+export function encodeCwd(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Find a good split point near the requested size. Prefer the byte just
+ *  after the last "\n" within the window so each chunk ends on a complete
+ *  jsonl event. Falls back to the raw size when no newline exists (e.g. a
+ *  single jsonl line larger than MAX_CHUNK_BYTES). Returned value is in
+ *  [1, maxSize]. */
+function chooseChunkSize(buf: Uint8Array, maxSize: number): number {
+  if (buf.byteLength <= maxSize) return buf.byteLength;
+  // Search backwards from maxSize for a "\n" (0x0A). The split is the
+  // byte AFTER the newline so the chunk includes it.
+  for (let i = maxSize - 1; i >= 0; i--) {
+    if (buf[i] === 0x0a) return i + 1;
+  }
+  // No newline found in the window — split at the cap. Reconstruction is
+  // pure byte-order, so this is still correct.
+  return maxSize;
+}
 
 function isProSession(deps: SessionSyncDeps): { user: SyncUser; token: string } | null {
   const user = deps.currentUser();
@@ -158,6 +223,189 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     return totalAccepted;
   }
 
+  // pushBytes state. A per-session in-flight guard prevents the snapshot
+  // timer firing two parallel pushes for the same session (which would
+  // double-PUT and trigger conflict 409s).
+  const inFlightBytes = new Map<string, Promise<PushBytesResult>>();
+
+  const getBytesState = deps.db.prepare(
+    `SELECT cwd, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation, cloud_owner_id
+       FROM sessions WHERE id = ? LIMIT 1`,
+  );
+  const advanceBytesState = deps.db.prepare(
+    `UPDATE sessions
+        SET jsonl_snapshot_offset = ?,
+            jsonl_chunk_count     = ?,
+            jsonl_synced_at       = ?
+      WHERE id = ?`,
+  );
+  const bumpGeneration = deps.db.prepare(
+    `UPDATE sessions
+        SET bytes_generation       = bytes_generation + 1,
+            jsonl_snapshot_offset  = 0,
+            jsonl_chunk_count      = 0
+      WHERE id = ?`,
+  );
+
+  async function doPushBytes(sessionId: string): Promise<PushBytesResult> {
+    const empty: PushBytesResult = { uploaded: 0, offsetAfter: 0, generation: 0, resetFired: false };
+
+    const session = isProSession(deps);
+    if (!session) return empty;
+
+    const state = getBytesState.get(sessionId) as {
+      cwd: string | null;
+      jsonl_snapshot_offset: number;
+      jsonl_chunk_count: number;
+      bytes_generation: number;
+      cloud_owner_id: string | null;
+    } | undefined;
+    if (!state) {
+      console.warn(`[sessions] pushBytes: no session row for ${sessionId}`);
+      return empty;
+    }
+    if (!state.cwd) {
+      // Orphan session from before sessions.cwd was added, or a session
+      // whose watcher never captured cwd. Nothing to read from disk.
+      console.warn(`[sessions] pushBytes: session ${sessionId} has no cwd, skipping`);
+      return empty;
+    }
+    // Owner check: the watcher hook only marks dirty when canRunCloudSync()
+    // is true, but pushBytes can also be invoked directly. Guard the same
+    // way as markDirty.
+    if (state.cloud_owner_id !== session.user.id) {
+      console.warn(`[sessions] pushBytes: session ${sessionId} owner mismatch, skipping`);
+      return empty;
+    }
+
+    const jsonlPath = join(projectsRoot(), encodeCwd(state.cwd), `${sessionId}.jsonl`);
+    let stat: { size: number };
+    try {
+      const s = await fs.stat(jsonlPath);
+      stat = { size: s.size };
+    } catch (err) {
+      console.warn(`[sessions] pushBytes: cannot stat ${jsonlPath}:`, err);
+      return empty;
+    }
+
+    let offset = state.jsonl_snapshot_offset;
+    let chunkCount = state.jsonl_chunk_count;
+    let generation = state.bytes_generation;
+    let resetFired = false;
+
+    // Truncation handling: if the local file is now smaller than what we
+    // already uploaded, the file was rewritten / rotated. Bump the
+    // generation on cloud, reset local counters, restart from offset 0
+    // in the new generation. Rare in practice.
+    if (stat.size < offset) {
+      try {
+        const resetRes = await deps.fetch(
+          `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/reset`,
+          {
+            method: "POST",
+            headers: { Cookie: `oyster_session=${session.token}` },
+          },
+        );
+        if (!resetRes.ok) {
+          console.warn(`[sessions] pushBytes reset non-ok ${resetRes.status} for ${sessionId}`);
+          return { uploaded: 0, offsetAfter: offset, generation, resetFired: false };
+        }
+      } catch (err) {
+        console.warn(`[sessions] pushBytes reset failed for ${sessionId}:`, err);
+        return { uploaded: 0, offsetAfter: offset, generation, resetFired: false };
+      }
+      bumpGeneration.run(sessionId);
+      offset = 0;
+      chunkCount = 0;
+      generation += 1;
+      resetFired = true;
+    }
+
+    if (stat.size <= offset) {
+      // No new bytes to push (and no truncation either — caught above).
+      return { uploaded: 0, offsetAfter: offset, generation, resetFired };
+    }
+
+    // Read the whole pending region in one shot. We split into chunks in
+    // memory, then PUT each. For the 50 MB-and-up outlier case, the loop
+    // does multiple ~25 MB chunks in one snapshot pass.
+    let pendingBuf: Buffer;
+    let fh: import("node:fs/promises").FileHandle | null = null;
+    try {
+      fh = await fs.open(jsonlPath, "r");
+      const length = stat.size - offset;
+      const buf = Buffer.alloc(length);
+      const read = await fh.read(buf, 0, length, offset);
+      pendingBuf = buf.subarray(0, read.bytesRead);
+    } catch (err) {
+      console.warn(`[sessions] pushBytes: read failed for ${jsonlPath}:`, err);
+      return { uploaded: 0, offsetAfter: offset, generation, resetFired };
+    } finally {
+      if (fh) await fh.close().catch(() => { /* ignore */ });
+    }
+
+    let uploaded = 0;
+    let bufOffset = 0;
+
+    while (bufOffset < pendingBuf.byteLength) {
+      const remaining = pendingBuf.subarray(bufOffset);
+      const sliceSize = chooseChunkSize(remaining, MAX_CHUNK_BYTES);
+      const chunkBytes = remaining.subarray(0, sliceSize);
+      // Node Buffer extends Uint8Array at runtime, but TS's fetch BodyInit
+      // type is picky. Copy into a plain detached ArrayBuffer for the body —
+      // ArrayBuffer IS in BodyInit. The copy is cheap relative to the HTTP
+      // round-trip and avoids cross-realm Uint8Array issues.
+      const chunkBody = new ArrayBuffer(sliceSize);
+      new Uint8Array(chunkBody).set(chunkBytes);
+      const startOffset = offset + bufOffset;
+      const endOffset = startOffset + sliceSize;
+      const hash = sha256Hex(new Uint8Array(chunkBody));
+      const nextChunkNumber = chunkCount + 1;
+
+      let res: Response;
+      try {
+        res = await deps.fetch(
+          `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/chunk/${nextChunkNumber}`,
+          {
+            method: "PUT",
+            headers: {
+              Cookie: `oyster_session=${session.token}`,
+              "content-type": "application/octet-stream",
+              "x-chunk-start-offset": String(startOffset),
+              "x-chunk-end-offset": String(endOffset),
+              "x-plaintext-sha256": hash,
+              "x-bytes-generation": String(generation),
+            },
+            body: chunkBody,
+          },
+        );
+      } catch (err) {
+        console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} fetch failed for ${sessionId}:`, err);
+        break;
+      }
+
+      if (res.status === 200) {
+        // Advance local state and continue the loop. We persist after every
+        // chunk so a mid-loop crash doesn't re-upload bytes already in cloud.
+        chunkCount = nextChunkNumber;
+        bufOffset += sliceSize;
+        advanceBytesState.run(offset + bufOffset, chunkCount, Date.now(), sessionId);
+        uploaded++;
+        continue;
+      }
+
+      // 409 idempotent retry — the worker's idempotency contract guarantees
+      // an exact-match retry returns 200 with idempotent:true, not 409. So
+      // any 409 here is a real conflict (different content / stale gen /
+      // non-contiguous) — log and abort the loop. The next reconcile cycle
+      // will re-derive state from the server's manifest and recover.
+      console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} rejected (${res.status}) for ${sessionId}`);
+      break;
+    }
+
+    return { uploaded, offsetAfter: offset + bufOffset, generation, resetFired };
+  }
+
   // Capture the service object so methods don't depend on `this` binding —
   // safe to pass `service.reconcile` directly into a setInterval / event
   // emitter callback. Mirrors the memory-sync-service shape.
@@ -178,6 +426,16 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       } finally {
         inFlightPush = null;
       }
+    },
+
+    async pushBytes(sessionId: string) {
+      const existing = inFlightBytes.get(sessionId);
+      if (existing) return existing;
+      const promise = doPushBytes(sessionId).finally(() => {
+        inFlightBytes.delete(sessionId);
+      });
+      inFlightBytes.set(sessionId, promise);
+      return promise;
     },
 
     markDirty,

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -84,6 +84,30 @@ describe("SessionSyncService", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("markDirty sets sync_dirty_at + cloud_owner_id so the row becomes pendable", () => {
+    const { db, profileBinding } = harness();
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'))`,
+    ).run();
+    const svc = createSessionSyncService({
+      db,
+      profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: vi.fn(),
+    });
+
+    svc.markDirty("s1", "user-A", 1234);
+
+    const row = db.prepare(
+      "SELECT sync_dirty_at, cloud_owner_id FROM sessions WHERE id='s1'",
+    ).get() as { sync_dirty_at: number; cloud_owner_id: string };
+    expect(row.sync_dirty_at).toBe(1234);
+    expect(row.cloud_owner_id).toBe("user-A");
+  });
+
   it("pushPending sends dirty sessions for the current owner and marks them synced", async () => {
     const { db, profileBinding } = harness();
     profileBinding.bindToOwner("user-A");

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import Database from "better-sqlite3";
+import { createSessionSyncService } from "../src/session-sync-service.js";
+import { createProfileBindingService } from "../src/profile-binding-service.js";
+
+// Minimal DB harness: just the columns SessionSyncService reads from sessions
+// + the profile_binding table the gate checks. Mirrors the
+// memory-sync-service.test.ts harness shape.
+function harness() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE sessions (
+      id              TEXT PRIMARY KEY,
+      space_id        TEXT,
+      agent           TEXT NOT NULL,
+      title           TEXT,
+      state           TEXT NOT NULL,
+      started_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at        TEXT,
+      model           TEXT,
+      last_event_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      last_offset     INTEGER NOT NULL DEFAULT 0,
+      source_id       TEXT,
+      cwd             TEXT,
+      sync_dirty_at   INTEGER,
+      cloud_synced_at INTEGER,
+      cloud_owner_id  TEXT,
+      jsonl_synced_at INTEGER,
+      jsonl_snapshot_offset INTEGER
+    );
+    CREATE TABLE profile_binding (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      cloud_owner_id TEXT NOT NULL,
+      bound_at INTEGER NOT NULL
+    );
+  `);
+  const profileBinding = createProfileBindingService({ db });
+  return { db, profileBinding };
+}
+
+function insertDirtySession(
+  db: Database.Database,
+  id: string,
+  ownerId: string,
+  dirtyAt = Date.now(),
+) {
+  db.prepare(
+    `INSERT INTO sessions (id, agent, state, last_event_at, sync_dirty_at, cloud_owner_id)
+     VALUES (?, 'claude-code', 'done', datetime('now'), ?, ?)`,
+  ).run(id, dirtyAt, ownerId);
+}
+
+describe("SessionSyncService", () => {
+  it("reconcile is a no-op for free users", async () => {
+    const { db, profileBinding } = harness();
+    const fetchSpy = vi.fn();
+    const svc = createSessionSyncService({
+      db,
+      profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "free" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+    const r = await svc.reconcile();
+    expect(r).toEqual({ pulled: 0, pushed: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconcile is a no-op when profile is bound to a different account", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    const fetchSpy = vi.fn();
+    const svc = createSessionSyncService({
+      db,
+      profileBinding,
+      currentUser: () => ({ id: "user-B", email: "b@b", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+    const r = await svc.reconcile();
+    expect(r).toEqual({ pulled: 0, pushed: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("pushPending sends dirty sessions for the current owner and marks them synced", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    insertDirtySession(db, "s1", "user-A", 1000);
+    insertDirtySession(db, "s2", "user-A", 2000);
+    insertDirtySession(db, "s3", "other-user", 3000);  // belongs to another owner
+
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ accepted: ["s1", "s2"] }), { status: 200 }),
+    );
+    const svc = createSessionSyncService({
+      db,
+      profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+
+    const pushed = await svc.pushPending();
+
+    expect(pushed).toBe(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0];
+    expect(call[0]).toBe("https://example.com/api/sessions/metadata");
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.sessions.map((s: { id: string }) => s.id).sort()).toEqual(["s1", "s2"]);
+
+    // s1 + s2 are now synced (cloud_synced_at >= sync_dirty_at)
+    const s1 = db.prepare("SELECT cloud_synced_at, sync_dirty_at FROM sessions WHERE id='s1'")
+      .get() as { cloud_synced_at: number; sync_dirty_at: number };
+    expect(s1.cloud_synced_at).toBeGreaterThanOrEqual(s1.sync_dirty_at);
+    // s3 (other owner) was never sent, never synced
+    const s3 = db.prepare("SELECT cloud_synced_at FROM sessions WHERE id='s3'")
+      .get() as { cloud_synced_at: number | null };
+    expect(s3.cloud_synced_at).toBeNull();
+  });
+});

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -10,23 +10,25 @@ function harness() {
   const db = new Database(":memory:");
   db.exec(`
     CREATE TABLE sessions (
-      id              TEXT PRIMARY KEY,
-      space_id        TEXT,
-      agent           TEXT NOT NULL,
-      title           TEXT,
-      state           TEXT NOT NULL,
-      started_at      TEXT NOT NULL DEFAULT (datetime('now')),
-      ended_at        TEXT,
-      model           TEXT,
-      last_event_at   TEXT NOT NULL DEFAULT (datetime('now')),
-      last_offset     INTEGER NOT NULL DEFAULT 0,
-      source_id       TEXT,
-      cwd             TEXT,
-      sync_dirty_at   INTEGER,
-      cloud_synced_at INTEGER,
-      cloud_owner_id  TEXT,
-      jsonl_synced_at INTEGER,
-      jsonl_snapshot_offset INTEGER
+      id                    TEXT PRIMARY KEY,
+      space_id              TEXT,
+      agent                 TEXT NOT NULL,
+      title                 TEXT,
+      state                 TEXT NOT NULL,
+      started_at            TEXT NOT NULL DEFAULT (datetime('now')),
+      ended_at              TEXT,
+      model                 TEXT,
+      last_event_at         TEXT NOT NULL DEFAULT (datetime('now')),
+      last_offset           INTEGER NOT NULL DEFAULT 0,
+      source_id             TEXT,
+      cwd                   TEXT,
+      sync_dirty_at         INTEGER,
+      cloud_synced_at       INTEGER,
+      cloud_owner_id        TEXT,
+      jsonl_synced_at       INTEGER,
+      jsonl_snapshot_offset INTEGER NOT NULL DEFAULT 0,
+      jsonl_chunk_count     INTEGER NOT NULL DEFAULT 0,
+      bytes_generation      INTEGER NOT NULL DEFAULT 0
     );
     CREATE TABLE profile_binding (
       id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -146,3 +148,266 @@ describe("SessionSyncService", () => {
     expect(s3.cloud_synced_at).toBeNull();
   });
 });
+
+// pushBytes tests use a real on-disk jsonl under a tmp projects root.
+import { mkdtempSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function setupBytesEnv() {
+  const root = mkdtempSync(join(tmpdir(), "oyster-sync-bytes-"));
+  process.env.OYSTER_CLAUDE_PROJECTS_ROOT = root;
+  return root;
+}
+
+describe("SessionSyncService.pushBytes", () => {
+  it("no-op for free user, no fetch fired", async () => {
+    setupBytesEnv();
+    const { db, profileBinding } = harness();
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'done', datetime('now'), '/tmp/x', 'user-A')`,
+    ).run();
+    const fetchSpy = vi.fn();
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "free" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+    const r = await svc.pushBytes("s1");
+    expect(r.uploaded).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-op when session row has no cwd (orphan session)", async () => {
+    setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'done', datetime('now'), NULL, 'user-A')`,
+    ).run();
+    const fetchSpy = vi.fn();
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy,
+    });
+    expect((await svc.pushBytes("s1")).uploaded).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("uploads one chunk for a small file under MAX_CHUNK_BYTES", async () => {
+    const root = setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    const cwd = "/tmp/proj-a";
+    // Mirror encodeCwd: every non-alphanumeric → '-'.
+    const encoded = cwd.replace(/[^A-Za-z0-9]/g, "-");
+    mkdirSync(join(root, encoded), { recursive: true });
+    const jsonl = "{\"role\":\"user\",\"content\":\"hi\"}\n{\"role\":\"assistant\",\"content\":\"hello\"}\n";
+    writeFileSync(join(root, encoded, "s1.jsonl"), jsonl);
+
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'), ?, 'user-A')`,
+    ).run(cwd);
+
+    const calls: Array<{ url: string; chunkNumber: number; gen: number; body: Uint8Array }> = [];
+    const fetchSpy = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const m = u.match(/\/api\/sessions\/bytes\/([^/]+)\/chunk\/(\d+)$/);
+      if (m && init?.method === "PUT") {
+        const body = new Uint8Array(init.body as ArrayBuffer);
+        calls.push({
+          url: u,
+          chunkNumber: Number(m[2]),
+          gen: Number((init.headers as Record<string, string>)["x-bytes-generation"]),
+          body,
+        });
+        return new Response(JSON.stringify({ ok: true, chunk_number: Number(m[2]), generation: 0 }), { status: 200 });
+      }
+      return new Response("not_found", { status: 404 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const r = await svc.pushBytes("s1");
+    expect(r.uploaded).toBe(1);
+    expect(r.offsetAfter).toBe(statSync(join(root, encoded, "s1.jsonl")).size);
+    expect(r.generation).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.chunkNumber).toBe(1);
+    expect(calls[0]!.gen).toBe(0);
+    expect(new TextDecoder().decode(calls[0]!.body)).toBe(jsonl);
+
+    // Local state advanced
+    const row = db.prepare(
+      `SELECT jsonl_snapshot_offset, jsonl_chunk_count, jsonl_synced_at FROM sessions WHERE id='s1'`,
+    ).get() as { jsonl_snapshot_offset: number; jsonl_chunk_count: number; jsonl_synced_at: number };
+    expect(row.jsonl_snapshot_offset).toBe(jsonl.length);
+    expect(row.jsonl_chunk_count).toBe(1);
+    expect(row.jsonl_synced_at).toBeGreaterThan(0);
+  });
+
+  it("idempotent: a second pushBytes with no new bytes is a no-op (no fetch)", async () => {
+    const root = setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    const cwd = "/tmp/proj-b";
+    const encoded = cwd.replace(/[^A-Za-z0-9]/g, "-");
+    mkdirSync(join(root, encoded), { recursive: true });
+    writeFileSync(join(root, encoded, "s1.jsonl"), "hello\n");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'), ?, 'user-A')`,
+    ).run(cwd);
+
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, chunk_number: 1, generation: 0 }), { status: 200 }),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    await svc.pushBytes("s1");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Second call — no new bytes
+    await svc.pushBytes("s1");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);  // unchanged
+  });
+
+  it("appended bytes upload as a new chunk with correct start_offset", async () => {
+    const root = setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    const cwd = "/tmp/proj-c";
+    const encoded = cwd.replace(/[^A-Za-z0-9]/g, "-");
+    mkdirSync(join(root, encoded), { recursive: true });
+    const filePath = join(root, encoded, "s1.jsonl");
+    writeFileSync(filePath, "line-1\n");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'), ?, 'user-A')`,
+    ).run(cwd);
+
+    const calls: Array<{ chunkNumber: number; startOffset: number; bodyText: string }> = [];
+    const fetchSpy = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const m = u.match(/\/chunk\/(\d+)$/);
+      if (m && init?.method === "PUT") {
+        const headers = init.headers as Record<string, string>;
+        const body = new Uint8Array(init.body as ArrayBuffer);
+        calls.push({
+          chunkNumber: Number(m[1]),
+          startOffset: Number(headers["x-chunk-start-offset"]),
+          bodyText: new TextDecoder().decode(body),
+        });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response("not_found", { status: 404 });
+    });
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    await svc.pushBytes("s1");
+    // Append a second line
+    writeFileSync(filePath, "line-1\nline-2\n");
+    await svc.pushBytes("s1");
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.chunkNumber).toBe(1);
+    expect(calls[0]!.startOffset).toBe(0);
+    expect(calls[0]!.bodyText).toBe("line-1\n");
+    expect(calls[1]!.chunkNumber).toBe(2);
+    expect(calls[1]!.startOffset).toBe(7);  // "line-1\n".length
+    expect(calls[1]!.bodyText).toBe("line-2\n");
+  });
+
+  it("truncation: file shrank → calls /reset, bumps generation, restarts chunk numbering", async () => {
+    const root = setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    const cwd = "/tmp/proj-d";
+    const encoded = cwd.replace(/[^A-Za-z0-9]/g, "-");
+    mkdirSync(join(root, encoded), { recursive: true });
+    const filePath = join(root, encoded, "s1.jsonl");
+    writeFileSync(filePath, "old-content-that-will-be-replaced\n");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'), ?, 'user-A')`,
+    ).run(cwd);
+
+    const events: Array<{ kind: "reset" | "chunk"; chunkNumber?: number; gen?: number }> = [];
+    const fetchSpy = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/reset") && init?.method === "POST") {
+        events.push({ kind: "reset" });
+        return new Response(JSON.stringify({ ok: true, previous_generation: 0, current_generation: 1 }), { status: 200 });
+      }
+      const m = u.match(/\/chunk\/(\d+)$/);
+      if (m && init?.method === "PUT") {
+        const headers = init.headers as Record<string, string>;
+        events.push({
+          kind: "chunk",
+          chunkNumber: Number(m[1]),
+          gen: Number(headers["x-bytes-generation"]),
+        });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response("not_found", { status: 404 });
+    });
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    // First push (gen 0, chunk 1)
+    await svc.pushBytes("s1");
+    expect(events).toEqual([{ kind: "chunk", chunkNumber: 1, gen: 0 }]);
+
+    // Now truncate: file shrinks to a smaller size
+    writeFileSync(filePath, "new\n");
+
+    events.length = 0;
+    const r = await svc.pushBytes("s1");
+    expect(r.resetFired).toBe(true);
+    expect(r.generation).toBe(1);
+    // Expect reset call THEN chunk 1 upload in new generation
+    expect(events).toEqual([
+      { kind: "reset" },
+      { kind: "chunk", chunkNumber: 1, gen: 1 },
+    ]);
+
+    // Local state reflects new generation
+    const row = db.prepare(
+      `SELECT bytes_generation, jsonl_chunk_count, jsonl_snapshot_offset FROM sessions WHERE id='s1'`,
+    ).get() as { bytes_generation: number; jsonl_chunk_count: number; jsonl_snapshot_offset: number };
+    expect(row.bytes_generation).toBe(1);
+    expect(row.jsonl_chunk_count).toBe(1);
+    expect(row.jsonl_snapshot_offset).toBe(4);  // "new\n".length
+  });
+});
+

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -84,7 +84,7 @@ describe("SessionSyncService", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("markDirty sets sync_dirty_at + cloud_owner_id so the row becomes pendable", () => {
+  it("markDirty sets sync_dirty_at + cloud_owner_id so the row becomes pending", () => {
     const { db, profileBinding } = harness();
     db.prepare(
       `INSERT INTO sessions (id, agent, state, last_event_at)


### PR DESCRIPTION
## Summary

Cross-device session sync for **Pick-up-here + full conversation backup** (#322). End-to-end after merge + deploy: ending a Claude Code session on Mac propagates the metadata to D1 and the encrypted jsonl bytes (as delta chunks) to R2, ready for PR 2's pull-and-resume on Device B.

Architecture decisions in `~/.claude/plans/eventual-soaring-swan.md`. Spike report (proves cross-device resume works with just placing the jsonl): `/tmp/oyster-spike-report/phase-0-findings.md`.

## What landed (8 commits)

| # | Commit | Scope |
|---|---|---|
| 1 | `8c9b3ff` | Server: schema + `SessionSyncService` skeleton + 3 tests |
| 2 | `50328b2` | Server: wiring (instantiate, watcher hook, reconcile loop) + 1 test |
| 3 | `01fa63f` | Server: Copilot round 1 — `service` const, owner-scoped markSynced, comments |
| 4 | `0cdac5f` | Cloud worker: original metadata + single-PUT bytes routes + 10 tests |
| 5 | `7e6f1e9` | Both: Copilot round 2 — profile-binding gate on watcher hook, LWW-tiebreaker fix on bytes PUT, decodeURIComponent guard |
| 6 | `d0c5a84` | Worker: Copilot round 3 — nullable-field validation, last_event_at index, 50 MB body cap |
| 7 | `51a7bd2` | **Retrofit to v1 architecture: chunked-delta + AAD binding** |

**Tests: 234/234** (192 server + 42 worker).

## v1 architecture (after retrofit in `51a7bd2`)

### Bytes flow — chunked delta, no full re-uploads

- jsonl is append-only by nature → each snapshot uploads ONLY the bytes since `jsonl_snapshot_offset` as a new R2 object.
- Per-chunk cap 25 MB; **no per-session total cap** — chunks accumulate.
- Local push triggers: terminal-state transition (done/disconnected) AND 5-min snapshot timer when delta ≥ 1 MB.
- Truncation handling: file shrank → POST /reset → bumps `bytes_generation` → restart from chunk 1.
- Pull path (Device B, PR 2): GET manifest → GET each chunk individually → write sequentially to disk. Worker never assembles the full jsonl in memory.

### Encryption — per-user key + AAD binding

- HKDF (salt = user_id) derives an AES-256-GCM key per user from a master Worker secret.
- Each chunk encrypted independently with its own random 12-byte IV.
- **AAD binds** `owner_id, session_id, bytes_generation, chunk_number, start_offset, end_offset, plaintext_sha256` into the ciphertext. Decrypt fails if ANY field is tampered. Prevents cross-chunk, cross-session, cross-generation replay.
- R2 sees only ciphertext (negative leak test pins this).

### Idempotency contract

- Retry of exact-match chunk (same offsets + hash) → `200 { idempotent: true }`, no duplicate.
- Same chunk_number, different content → `409 chunk_conflict`.
- Non-contiguous chunk (start_offset != previous end_offset) → `409 non_contiguous_start`.
- Wrong generation → `409 stale_generation`.

## Files

| Area | Files |
|---|---|
| Server schema | `server/src/db.ts` (+7 columns on sessions, dirty-predicate index, `device_identity` singleton) |
| Server service | `server/src/session-sync-service.ts` (markDirty, pushPending, pushBytes, reconcile) |
| Server wiring | `server/src/index.ts` (instantiation, watcher hook with terminal pushBytes, 5-min snapshot timer) |
| Server tests | `server/test/session-sync-service.test.ts` |
| Cloud schema | `infra/auth-worker/migrations/0008_synced_sessions.sql` (`synced_session_metadata` + `synced_session_chunks`) |
| Cloud worker | `infra/oyster-cloud/src/worker.ts` (POST/GET metadata, PUT chunk, GET manifest, GET single chunk, POST reset), `src/encryption.ts` (HKDF + AES-GCM + AAD), `src/session.ts` (Env additions) |
| Cloud config | `infra/oyster-cloud/wrangler.toml` (R2 binding), `vitest.config.ts` (test R2 binding + ENCRYPTION_KEY) |
| Cloud tests | `infra/oyster-cloud/test/sessions-routes.test.ts`, `test/fixtures/seed.ts` |

## Pre-deploy checklist (run before un-drafting)

```bash
wrangler r2 bucket create oyster-session-bytes
wrangler secret put SESSIONS_ENCRYPTION_KEY                  # paste ≥32 byte secret
wrangler d1 execute oyster-auth --file infra/auth-worker/migrations/0008_synced_sessions.sql
wrangler deploy --config infra/oyster-cloud/wrangler.toml
```

## Test plan

- [x] Schema migrations idempotent — existing 14 server test files all green.
- [x] Metadata path: free-user/free-tier 401/403, profile-binding gate, LWW upsert, malformed validation, negative `sync_dirty_at` reject, owner-scoped GET.
- [x] Chunked bytes: PUT chunks 1/2/3 → manifest + per-chunk GET → byte-for-byte reassembly.
- [x] Idempotency: identical retry → 200 idempotent, different content → 409.
- [x] Contiguity: non-contiguous start_offset → 409; chunk 1 with start≠0 → 409.
- [x] Generation: wrong-gen PUT → 409; reset bumps gen, prior-gen tombstoned, fresh gen starts at chunk 1.
- [x] AAD binding negative: tampered D1 plaintext_sha256 → decrypt fails (AAD mismatch).
- [x] Encryption: R2 inspection shows ciphertext, plaintext marker absent.
- [x] Cross-account: chunk PUT against another user's session → 404.
- [x] Local pushBytes: free-user no-op, orphan no-cwd skip, small file 1 chunk, idempotent no-new-bytes no-op, append → next chunk, truncation → reset → new generation.
- [ ] (Post-deploy) End-to-end on Mac: start session, watch metadata + chunks arrive in D1, end session, verify manifest reassembles to local jsonl byte-for-byte.
- [ ] (PR 2) Cross-device: place chunks on Mac, sign in on PC, pull manifest + chunks, reassemble, `claude --resume <id>` works.

## PR sequence

1. **PR 1** ← this one — local + cloud sync infrastructure (chunked-delta, AAD-bound).
2. PR 2 — pull path: `remote_sessions` table + `POST /api/sessions/:id/resume` with sources-based path resolution + folder-picker override + git-remote validation + manifest-driven local reassembly.
3. PR 3 — UI: cross-device session cards + "Resume on this device" button + override flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)