### PR TITLE
docs(changelog): 0.8.1-beta.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+## [0.8.1-beta.0] - 2026-05-11
+
+### Added
+
+- **Conversation backup for Pro users.** Claude Code session transcripts now stream to your Oyster cloud as encrypted delta chunks. Each chunk is sealed with a key derived per user, so transcripts stay private to your account. Cross-device resume — picking up a session on your other machine — comes in a follow-up release.
+
 ## [0.8.0] - 2026-05-09
 
 Memories follow you across Pro devices. Headline changes from the 0.8.0-beta cycle:

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,7 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
-      <a class="version-pill" href="#v-0-8-0">0.8</a>
+      <a class="version-pill" href="#v-0-8-1-beta-0">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
       <a class="version-pill" href="#v-0-5-0">0.5</a>
@@ -324,6 +324,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-0-8-1-beta-0"><span class="release-version">0.8.1-beta.0</span><span class="release-date"> — 2026-05-11</span></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Conversation backup for Pro users.</strong> Claude Code session transcripts now stream to your Oyster cloud as encrypted delta chunks. Each chunk is sealed with a key derived per user, so transcripts stay private to your account. Cross-device resume — picking up a session on your other machine — comes in a follow-up release.</li>
+</ul>
 <h2 id="v-0-8-0"><span class="release-version">0.8.0</span><span class="release-date"> — 2026-05-09</span></h2>
 <p>Memories follow you across Pro devices. Headline changes from the 0.8.0-beta cycle:</p>
 <h3>Added</h3>


### PR DESCRIPTION
Pre-release CHANGELOG entry ahead of \`npm run release:beta\`.

Calls out the encrypted delta-chunk session backup PR #431 ships. Cross-device resume (PR 2 + PR 3) deliberately deferred — beta only shows the push half until pull + UI land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)