### PR TITLE
feat(sessions-sync): pull path + resume API (PR 2 of 3)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -192,6 +192,45 @@ export function initDb(userlandDir: string): Database.Database {
     )
   `);
 
+  // Cross-device session metadata mirror (#322 PR 2). Populated by
+  // SessionSyncService.pull() from the cloud worker's GET
+  // /api/sessions/metadata. Kept in a SEPARATE table from `sessions` so
+  // foreign devices' data never contaminates the local watcher's source
+  // of truth: the watcher writes only to `sessions`; the pull layer
+  // writes only here. The Home / sessions list view merges both for
+  // display via routes/sessions.ts.
+  //
+  // jsonl_local_path is set once a Device-B "Resume on this device"
+  // reassembles the chunks to disk. Subsequent resumes can short-circuit
+  // and just surface the existing local path.
+  //
+  // has_bytes mirrors the cloud manifest's "is there a chunk for this
+  // session in the current generation" — gates whether the Resume button
+  // can even fire (no bytes → only metadata is available, no transcript).
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS remote_sessions (
+      session_id        TEXT    NOT NULL,
+      owner_id          TEXT    NOT NULL,
+      device_id         TEXT,
+      agent             TEXT    NOT NULL,
+      title             TEXT,
+      state             TEXT    NOT NULL,
+      cwd               TEXT,
+      model             TEXT,
+      started_at        TEXT    NOT NULL,
+      ended_at          TEXT,
+      last_event_at     TEXT    NOT NULL,
+      bytes_generation  INTEGER NOT NULL DEFAULT 0,
+      has_bytes         INTEGER NOT NULL DEFAULT 0,
+      cloud_updated_at  INTEGER NOT NULL,
+      fetched_at        INTEGER NOT NULL,
+      jsonl_local_path  TEXT,
+      PRIMARY KEY (owner_id, session_id)
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS remote_sessions_owner_last_event
+             ON remote_sessions(owner_id, last_event_at DESC)`);
+
   // Sessions arc (0.5.0). Three tables that capture agent activity (claude-code,
   // opencode, codex) read from external session logs. See
   // docs/plans/sessions-arc.md for the design.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -651,7 +651,8 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   // /api/sessions/* — first extracted route bucket. Returns true when
   // handled; falls through if no session route matched.
   if (await tryHandleSessionRoute(req, res, url, ctx, {
-    sessionStore, spaceStore, artifactService, memoryProvider,
+    db, sessionStore, spaceStore, artifactService, memoryProvider, sessionSync,
+    currentUserId: () => authService.getState().user?.id ?? null,
   })) return;
 
   // /api/artifacts/*, /api/groups/*, /api/plugins/:id/uninstall.

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -6,18 +6,129 @@
 // behavioural changes, only refactored shape.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
+import { existsSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import type Database from "better-sqlite3";
 import type { SessionStore } from "../session-store.js";
 import type { SqliteSpaceStore } from "../space-store.js";
 import type { ArtifactService } from "../artifact-service.js";
 import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
+import {
+  encodeCwd,
+  projectsRoot,
+  type SessionSyncService,
+} from "../session-sync-service.js";
 
 export interface SessionRouteDeps {
+  db: Database.Database;
   sessionStore: SessionStore;
   spaceStore: SqliteSpaceStore;
   artifactService: ArtifactService;
   memoryProvider: MemoryProvider;
+  sessionSync: SessionSyncService;
+  /** Caller for the current Pro user (for resume gating + path queries). */
+  currentUserId: () => string | null;
+}
+
+// ── Resume helpers (#322 PR 2) ──────────────────────────────────────────
+
+interface SourceCandidate {
+  path: string;
+  label: string | null;
+}
+
+/** Find which local folder(s) match a remote session's space_id. Returns
+ *  exactly one when there's an unambiguous mapping, an empty array when
+ *  this device hasn't attached any source to that space (needs_target),
+ *  or N candidates when multiple sources exist for the space (pick_source). */
+function findResumeCandidates(
+  db: Database.Database,
+  spaceStore: SqliteSpaceStore,
+  sessionId: string,
+  ownerId: string,
+): { spaceId: string | null; candidates: SourceCandidate[]; remoteCwd: string | null } {
+  // Look up the remote session's space_id by joining to the local sessions
+  // table first (if we happen to have ingested it locally too), else fall
+  // back to nothing — remote sessions don't carry space_id today; their
+  // cwd is the only locator we have. We use that to find a matching source
+  // by path-prefix as a best-effort.
+  const remote = db.prepare(
+    `SELECT cwd FROM remote_sessions WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+  ).get(ownerId, sessionId) as { cwd: string | null } | undefined;
+  const remoteCwd = remote?.cwd ?? null;
+
+  // Approach: scan all active local sources. A source is a candidate when
+  // either: (a) its path is a prefix of the remote cwd (the remote session
+  // lived inside a project the user has attached locally — even if at a
+  // different on-disk path), or (b) the basename of its path matches the
+  // basename of the remote cwd (rough but useful for "same project, sister
+  // worktrees" cases). Both checks are advisory — the picker is the
+  // safety net for anything we don't auto-resolve.
+  if (!remoteCwd) {
+    return { spaceId: null, candidates: [], remoteCwd: null };
+  }
+  const remoteBasename = basename(remoteCwd);
+  const allSources = db.prepare(
+    `SELECT id, space_id, path, label FROM sources WHERE removed_at IS NULL`,
+  ).all() as Array<{ id: string; space_id: string; path: string; label: string | null }>;
+  const candidates: SourceCandidate[] = [];
+  for (const src of allSources) {
+    const matchesPrefix = remoteCwd === src.path || remoteCwd.startsWith(`${src.path}/`);
+    const matchesBasename = basename(src.path) === remoteBasename;
+    if (matchesPrefix || matchesBasename) {
+      candidates.push({ path: src.path, label: src.label ?? basename(src.path) });
+    }
+  }
+  // Dedupe by path (sources can legitimately share a basename + prefix overlap).
+  const seen = new Set<string>();
+  const deduped = candidates.filter((c) => seen.has(c.path) ? false : (seen.add(c.path), true));
+  void spaceStore;  // currently unused; reserved for future space-based heuristics
+  return { spaceId: null, candidates: deduped, remoteCwd };
+}
+
+interface ValidationOutcome {
+  ok: boolean;
+  reasons: string[];
+}
+
+/** Validate a user-supplied targetCwd before reassembling into it.
+ *  Hard fail (returns ok:false) only on folder-doesn't-exist. Other
+ *  conditions are advisory and surfaced as reasons so the UI can
+ *  prompt for force:true confirmation. */
+function validateOverrideTarget(targetCwd: string, remoteCwd: string | null): ValidationOutcome {
+  const reasons: string[] = [];
+  if (!existsSync(targetCwd)) {
+    return { ok: false, reasons: ["target_folder_missing"] };
+  }
+  const st = statSync(targetCwd);
+  if (!st.isDirectory()) {
+    return { ok: false, reasons: ["target_not_a_directory"] };
+  }
+  if (!existsSync(join(targetCwd, ".git"))) {
+    reasons.push("not_a_git_repo");
+  }
+  if (remoteCwd) {
+    if (basename(targetCwd).toLowerCase() !== basename(remoteCwd).toLowerCase()) {
+      reasons.push("repo_basename_differs");
+    }
+    // If the target is a git repo AND the session's original cwd was a git
+    // repo, prefer to match remotes. We can only check the LOCAL remote; we
+    // don't store the original. Best we can do is check there IS a remote.
+    if (existsSync(join(targetCwd, ".git"))) {
+      try {
+        execFileSync("git", ["-C", targetCwd, "remote", "get-url", "origin"], {
+          stdio: ["ignore", "pipe", "ignore"],
+          encoding: "utf8",
+        });
+        // origin exists — assume the user knows what they're doing.
+      } catch {
+        reasons.push("no_git_remote_origin");
+      }
+    }
+  }
+  return { ok: reasons.length === 0, reasons };
 }
 
 export async function tryHandleSessionRoute(
@@ -27,8 +138,8 @@ export async function tryHandleSessionRoute(
   ctx: RouteCtx,
   deps: SessionRouteDeps,
 ): Promise<boolean> {
-  const { sendJson, sendError, rejectIfNonLocalOrigin } = ctx;
-  const { sessionStore, spaceStore, artifactService, memoryProvider } = deps;
+  const { sendJson, sendError, rejectIfNonLocalOrigin, readJsonBody } = ctx;
+  const { db, sessionStore, spaceStore, artifactService, memoryProvider, sessionSync, currentUserId } = deps;
 
   // GET /api/sessions — agent sessions captured by the watchers (#251).
   // Read-only for 0.5.0; the home feed renders these. Local-origin only —
@@ -49,8 +160,24 @@ export async function tryHandleSessionRoute(
     for (let i = 0; i < sourceIds.length; i += SOURCE_BATCH) {
       sourceList.push(...spaceStore.getSourcesByIds(sourceIds.slice(i, i + SOURCE_BATCH)));
     }
+    interface MergedSessionPayload {
+      id: string;
+      spaceId: string | null;
+      sourceId: string | null;
+      sourceLabel: string | null;
+      cwd: string | null;
+      agent: string;
+      title: string | null;
+      state: string;
+      startedAt: string;
+      endedAt: string | null;
+      model: string | null;
+      lastEventAt: string;
+      originDeviceId: string | null;
+      jsonlAvailableLocally: boolean;
+    }
     const sourcesById = new Map(sourceList.map((s) => [s.id, s]));
-    sendJson(rows.map((row) => {
+    const localPayload: MergedSessionPayload[] = rows.map((row) => {
       const src = row.source_id ? sourcesById.get(row.source_id) : null;
       const label = src ? (src.label ?? (basename(src.path) || null)) : null;
       return {
@@ -66,8 +193,59 @@ export async function tryHandleSessionRoute(
         endedAt: row.ended_at,
         model: row.model,
         lastEventAt: row.last_event_at,
+        // Local sessions are by definition available on this device.
+        originDeviceId: null,
+        jsonlAvailableLocally: true,
       };
-    }));
+    });
+
+    // Merge cross-device sessions from remote_sessions. Pulled by
+    // SessionSyncService from the cloud's GET /api/sessions/metadata.
+    // We exclude any remote rows whose session_id already exists locally
+    // (the watcher's source of truth for things this device produced).
+    const ownerId = currentUserId();
+    let remotePayload: MergedSessionPayload[] = [];
+    if (ownerId) {
+      const localIds = new Set(rows.map((r) => r.id));
+      type RemoteRow = {
+        session_id: string; device_id: string | null; agent: string; title: string | null;
+        state: string; cwd: string | null; model: string | null; started_at: string;
+        ended_at: string | null; last_event_at: string; has_bytes: number;
+        jsonl_local_path: string | null;
+      };
+      const remoteRows = db.prepare(
+        `SELECT session_id, device_id, agent, title, state, cwd, model, started_at,
+                ended_at, last_event_at, has_bytes, jsonl_local_path
+           FROM remote_sessions
+          WHERE owner_id = ?
+          ORDER BY last_event_at DESC`,
+      ).all(ownerId) as RemoteRow[];
+      remotePayload = remoteRows
+        .filter((r) => !localIds.has(r.session_id))
+        .map((r) => ({
+          id: r.session_id,
+          spaceId: null,
+          sourceId: null,
+          sourceLabel: null,
+          cwd: r.cwd,
+          agent: r.agent,
+          title: r.title,
+          state: r.state,
+          startedAt: r.started_at,
+          endedAt: r.ended_at,
+          model: r.model,
+          lastEventAt: r.last_event_at,
+          originDeviceId: r.device_id,
+          // Available locally only if the user has already reassembled it.
+          jsonlAvailableLocally: r.jsonl_local_path !== null,
+        }));
+    }
+
+    // Combine; sort by lastEventAt DESC to keep the list cohesive.
+    const merged = [...localPayload, ...remotePayload].sort((a, b) =>
+      (b.lastEventAt ?? "").localeCompare(a.lastEventAt ?? ""),
+    );
+    sendJson(merged);
     return true;
   }
 
@@ -303,5 +481,114 @@ export async function tryHandleSessionRoute(
     }
   }
 
+  // POST /api/sessions/:id/resume — pull a cross-device session's encrypted
+  // jsonl chunks from cloud, reassemble + verify locally, return the
+  // `claude --resume <id>` command for the user to run.
+  //
+  // Body: { targetCwd?: string, force?: boolean }
+  //
+  // Without `targetCwd`: auto-resolve via remote_sessions.cwd + local sources.
+  //   - 1 unambiguous candidate → use it
+  //   - 0 candidates → return { status: "needs_target", remoteCwd }
+  //   - N candidates → return { status: "pick_source", candidates: [...] }
+  //
+  // With `targetCwd`: validate (folder exists, git repo, basename match,
+  // remote present). On warnings, return { status: "validation_warning",
+  // reasons: [...] } and require force:true to bypass.
+  //
+  // Local-origin only — placing a jsonl on the user's filesystem.
+  {
+    const m = url.match(/^\/api\/sessions\/([^/]+)\/resume$/);
+    if (m && req.method === "POST") {
+      if (rejectIfNonLocalOrigin()) return true;
+      const sessionId = m[1]!;
+      try {
+        const body = await readJsonBody();
+        const ownerId = currentUserId();
+        if (!ownerId) {
+          sendJson({ error: "sign_in_required" }, 401);
+          return true;
+        }
+
+        // 1. The session must be in remote_sessions and have bytes uploaded.
+        type RemoteRow = { cwd: string | null; has_bytes: number };
+        const remoteRow = db.prepare(
+          `SELECT cwd, has_bytes FROM remote_sessions WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+        ).get(ownerId, sessionId) as RemoteRow | undefined;
+        if (!remoteRow) {
+          sendJson({ error: "session_not_found_in_remote" }, 404);
+          return true;
+        }
+        if (remoteRow.has_bytes !== 1) {
+          sendJson({ error: "bytes_not_available", message: "Cloud has metadata for this session but no chunks yet." }, 409);
+          return true;
+        }
+
+        // 2. Resolve target cwd.
+        let targetCwd: string;
+        const overrideCwd = typeof body.targetCwd === "string" ? body.targetCwd : null;
+        const force = body.force === true;
+
+        if (overrideCwd) {
+          // User-supplied target — validate.
+          const validation = validateOverrideTarget(overrideCwd, remoteRow.cwd);
+          if (!validation.ok) {
+            sendJson({ status: "validation_warning", reasons: validation.reasons }, 200);
+            return true;
+          }
+          if (validation.reasons.length > 0 && !force) {
+            sendJson({ status: "validation_warning", reasons: validation.reasons }, 200);
+            return true;
+          }
+          targetCwd = overrideCwd;
+        } else {
+          // No override — try auto-resolve via local sources.
+          const { candidates, remoteCwd } = findResumeCandidates(db, spaceStore, sessionId, ownerId);
+          if (candidates.length === 0) {
+            sendJson({ status: "needs_target", remoteCwd, suggestedSpaceId: null }, 200);
+            return true;
+          }
+          if (candidates.length > 1) {
+            sendJson({ status: "pick_source", candidates, remoteCwd }, 200);
+            return true;
+          }
+          targetCwd = candidates[0]!.path;
+        }
+
+        // 3. Reassemble chunks into the encoded jsonl path Claude Code expects.
+        const localJsonlPath = join(projectsRoot(), encodeCwd(targetCwd), `${sessionId}.jsonl`);
+        try {
+          await sessionSync.reassembleSessionJsonl(sessionId, localJsonlPath);
+        } catch (err) {
+          sendJson(
+            { error: "reassemble_failed", message: err instanceof Error ? err.message : String(err) },
+            500,
+          );
+          return true;
+        }
+
+        sendJson({
+          status: "ok",
+          sessionId,
+          localCwd: targetCwd,
+          jsonlPath: localJsonlPath,
+          command: `cd ${shellQuote(targetCwd)} && claude --resume ${sessionId}`,
+        });
+        return true;
+      } catch (err) {
+        sendError(err, 500);
+        return true;
+      }
+    }
+  }
+
   return false;
+}
+
+/** Minimal shell-safe quoting for paths surfaced in resume commands. We
+ *  don't need a full shell-parser-grade escape — just wrap in single
+ *  quotes and escape any embedded single quotes. */
+function shellQuote(s: string): string {
+  if (/^[A-Za-z0-9_\-./]+$/.test(s)) return s;  // safe characters, no quotes needed
+  return `'${s.replace(/'/g, "'\\''")}'`;
 }

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -536,9 +536,9 @@ export async function tryHandleSessionRoute(
           // fatal — force:true cannot conjure a folder into existence. All
           // other reasons (.git missing, basename differs, no origin remote)
           // are soft and require explicit force:true to bypass.
-          const hardReasons = validation.reasons.filter((r) =>
-            r === "target_folder_missing" || r === "target_not_a_directory");
-          const softReasons = validation.reasons.filter((r) => !hardReasons.includes(r));
+          const HARD_REASONS = new Set<string>(["target_folder_missing", "target_not_a_directory"]);
+          const hardReasons = validation.reasons.filter((r) => HARD_REASONS.has(r));
+          const softReasons = validation.reasons.filter((r) => !HARD_REASONS.has(r));
           if (hardReasons.length > 0) {
             sendJson({ status: "validation_warning", reasons: validation.reasons }, 200);
             return true;

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -532,11 +532,18 @@ export async function tryHandleSessionRoute(
         if (overrideCwd) {
           // User-supplied target — validate.
           const validation = validateOverrideTarget(overrideCwd, remoteRow.cwd);
-          if (!validation.ok) {
+          // Only "target_folder_missing" / "target_not_a_directory" are truly
+          // fatal — force:true cannot conjure a folder into existence. All
+          // other reasons (.git missing, basename differs, no origin remote)
+          // are soft and require explicit force:true to bypass.
+          const hardReasons = validation.reasons.filter((r) =>
+            r === "target_folder_missing" || r === "target_not_a_directory");
+          const softReasons = validation.reasons.filter((r) => !hardReasons.includes(r));
+          if (hardReasons.length > 0) {
             sendJson({ status: "validation_warning", reasons: validation.reasons }, 200);
             return true;
           }
-          if (validation.reasons.length > 0 && !force) {
+          if (softReasons.length > 0 && !force) {
             sendJson({ status: "validation_warning", reasons: validation.reasons }, 200);
             return true;
           }

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -53,6 +53,12 @@ export interface PushBytesResult {
 export interface SessionSyncService {
   reconcile(): Promise<{ pulled: number; pushed: number }>;
   pushPending(): Promise<number>;
+  /** Pull session metadata from cloud into `remote_sessions`. Idempotent —
+   *  cloud rows are upserted by (owner_id, session_id). Pro-only;
+   *  no-op for free users and when profile-bound to a different account.
+   *  Returns the count of rows newly inserted or whose cloud_updated_at
+   *  advanced. */
+  pull(): Promise<number>;
   /** Push new jsonl bytes for a session up to cloud as chunked deltas.
    *  Reads from `~/.claude/projects/<encodeCwd(session.cwd)>/<id>.jsonl`
    *  starting at `sessions.jsonl_snapshot_offset`. Handles file truncation
@@ -443,6 +449,108 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     return { uploaded, offsetAfter: offset + pushedBytes, generation, resetFired };
   }
 
+  // In-flight guard for pull so concurrent reconcile triggers (focus +
+  // panel-mount + 30s-poll firing in quick succession) coalesce to one
+  // HTTP round-trip. Same shape as pushPending's guard.
+  let inFlightPull: Promise<number> | null = null;
+
+  const upsertRemoteSession = deps.db.prepare(
+    `INSERT INTO remote_sessions
+       (session_id, owner_id, device_id, agent, title, state, cwd, model,
+        started_at, ended_at, last_event_at, bytes_generation, has_bytes,
+        cloud_updated_at, fetched_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(owner_id, session_id) DO UPDATE SET
+       device_id         = excluded.device_id,
+       agent             = excluded.agent,
+       title             = excluded.title,
+       state             = excluded.state,
+       cwd               = excluded.cwd,
+       model             = excluded.model,
+       started_at        = excluded.started_at,
+       ended_at          = excluded.ended_at,
+       last_event_at     = excluded.last_event_at,
+       bytes_generation  = excluded.bytes_generation,
+       has_bytes         = excluded.has_bytes,
+       cloud_updated_at  = excluded.cloud_updated_at,
+       fetched_at        = excluded.fetched_at
+     WHERE excluded.cloud_updated_at > remote_sessions.cloud_updated_at`,
+  );
+
+  async function doPull(): Promise<number> {
+    const session = isProSession(deps);
+    if (!session) return 0;
+
+    let res: Response;
+    try {
+      res = await deps.fetch(`${deps.workerBase}/api/sessions/metadata`, {
+        headers: { Cookie: `oyster_session=${session.token}` },
+      });
+    } catch (err) {
+      console.warn("[sessions] pull failed:", err);
+      return 0;
+    }
+    if (!res.ok) {
+      console.warn(`[sessions] pull non-ok ${res.status}`);
+      return 0;
+    }
+
+    type CloudSession = {
+      session_id: string;
+      device_id: string | null;
+      agent: string;
+      title: string | null;
+      state: string;
+      cwd: string | null;
+      model: string | null;
+      started_at: string;
+      ended_at: string | null;
+      last_event_at: string;
+      bytes_generation: number;
+      has_bytes: boolean;
+      updated_at: number;
+    };
+    const body = await res.json().catch(() => null) as { sessions?: CloudSession[] } | null;
+    const incoming = body?.sessions ?? [];
+    if (incoming.length === 0) return 0;
+
+    // Filter out rows that belong to THIS device — we already have those
+    // in the local `sessions` table via the watcher. remote_sessions is for
+    // OTHER devices' sessions specifically.
+    const myDeviceId = getMyDeviceId();
+    const foreignRows = incoming.filter((s) => s.device_id !== myDeviceId);
+
+    const now = Date.now();
+    let applied = 0;
+    const tx = deps.db.transaction(() => {
+      for (const s of foreignRows) {
+        const info = upsertRemoteSession.run(
+          s.session_id, session.user.id, s.device_id, s.agent, s.title, s.state,
+          s.cwd, s.model, s.started_at, s.ended_at, s.last_event_at,
+          s.bytes_generation, s.has_bytes ? 1 : 0, s.updated_at, now,
+        );
+        if (info.changes > 0) applied++;
+      }
+    });
+    tx();
+
+    if (applied > 0) {
+      console.log(`[sessions] pulled: applied=${applied}`);
+    }
+    return applied;
+  }
+
+  /** Stable per-device id; lazy-initialised on first read. */
+  let cachedDeviceId: string | null = null;
+  function getMyDeviceId(): string | null {
+    if (cachedDeviceId !== null) return cachedDeviceId;
+    const row = deps.db.prepare(
+      `SELECT device_id FROM device_identity WHERE id = 1 LIMIT 1`,
+    ).get() as { device_id: string } | undefined;
+    cachedDeviceId = row?.device_id ?? null;
+    return cachedDeviceId;
+  }
+
   // Capture the service object so methods don't depend on `this` binding —
   // safe to pass `service.reconcile` directly into a setInterval / event
   // emitter callback. Mirrors the memory-sync-service shape.
@@ -450,9 +558,21 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     async reconcile() {
       const session = isProSession(deps);
       if (!session) return { pulled: 0, pushed: 0 };
-      // Pull is PR 2 territory; for now reconcile = pushPending.
+      // Mirror memory-sync: pull first so we have the latest cloud state
+      // visible locally, then push any local-only changes back up.
+      const pulled = await service.pull();
       const pushed = await service.pushPending();
-      return { pulled: 0, pushed };
+      return { pulled, pushed };
+    },
+
+    async pull() {
+      if (inFlightPull) return inFlightPull;
+      inFlightPull = doPull();
+      try {
+        return await inFlightPull;
+      } finally {
+        inFlightPull = null;
+      }
     },
 
     async pushPending() {

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -50,6 +50,17 @@ export interface PushBytesResult {
   resetFired: boolean;
 }
 
+export interface ReassembleResult {
+  /** Number of chunks fetched and concatenated. */
+  chunkCount: number;
+  /** Total plaintext bytes written to disk (== manifest's final end_offset). */
+  totalBytes: number;
+  /** Generation that was reassembled. */
+  generation: number;
+  /** Absolute path the jsonl was written to. */
+  targetPath: string;
+}
+
 export interface SessionSyncService {
   reconcile(): Promise<{ pulled: number; pushed: number }>;
   pushPending(): Promise<number>;
@@ -65,6 +76,13 @@ export interface SessionSyncService {
    *  via a generation bump. No-ops cleanly when the file hasn't grown,
    *  when the session row is missing cwd, or when the gate fails. */
   pushBytes(sessionId: string): Promise<PushBytesResult>;
+  /** Pull a session's encrypted chunks down from cloud, decrypt (in the
+   *  worker, returned plaintext over TLS), verify each chunk's
+   *  plaintext_sha256 against the manifest, and write the assembled
+   *  jsonl to targetPath atomically (writes to .partial then renames).
+   *  Throws on auth failure, manifest GET error, hash mismatch, partial
+   *  fetch, or final-size mismatch. */
+  reassembleSessionJsonl(sessionId: string, targetPath: string): Promise<ReassembleResult>;
   /** Mark a session row dirty so the next pushPending() picks it up. The
    *  watcher should call this on every material session change. */
   markDirty(sessionId: string, ownerId: string, at?: number): void;
@@ -551,6 +569,113 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     return cachedDeviceId;
   }
 
+  const updateRemoteSessionLocalPath = deps.db.prepare(
+    `UPDATE remote_sessions
+        SET jsonl_local_path = ?
+      WHERE owner_id = ? AND session_id = ?`,
+  );
+
+  async function doReassemble(
+    sessionId: string,
+    targetPath: string,
+  ): Promise<ReassembleResult> {
+    const session = isProSession(deps);
+    if (!session) {
+      throw new Error("sessions reassemble: pro-only and profile-binding gate failed");
+    }
+
+    // Fetch manifest.
+    type ManifestChunk = {
+      chunk_number: number;
+      start_offset: number;
+      end_offset: number;
+      byte_count: number;
+      plaintext_sha256: string;
+    };
+    type Manifest = { bytes_generation: number; total_size: number; chunks: ManifestChunk[] };
+
+    let manifest: Manifest;
+    try {
+      const res = await deps.fetch(
+        `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/manifest`,
+        { headers: { Cookie: `oyster_session=${session.token}` } },
+      );
+      if (!res.ok) throw new Error(`manifest non-ok ${res.status}`);
+      manifest = await res.json() as Manifest;
+    } catch (err) {
+      throw new Error(`sessions reassemble: manifest fetch failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    if (!manifest.chunks || manifest.chunks.length === 0) {
+      throw new Error("sessions reassemble: manifest has no chunks (no bytes uploaded yet)");
+    }
+    // Sanity: chunks must be in chunk_number order. The worker promises this
+    // (ORDER BY chunk_number ASC) but verify defensively.
+    for (let i = 1; i < manifest.chunks.length; i++) {
+      if (manifest.chunks[i]!.chunk_number <= manifest.chunks[i - 1]!.chunk_number) {
+        throw new Error("sessions reassemble: manifest chunks not in ascending order");
+      }
+    }
+
+    // Write to a sibling .partial path first; rename on success. This means
+    // a mid-fetch crash leaves a discardable partial file instead of a
+    // half-baked jsonl masquerading as complete.
+    const partialPath = `${targetPath}.partial`;
+    await fs.mkdir(join(targetPath, ".."), { recursive: true }).catch(() => { /* exists */ });
+    const fh = await fs.open(partialPath, "w");
+    let writtenBytes = 0;
+    try {
+      for (const meta of manifest.chunks) {
+        const url = `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/chunk/${meta.chunk_number}`;
+        const r = await deps.fetch(url, { headers: { Cookie: `oyster_session=${session.token}` } });
+        if (!r.ok) {
+          throw new Error(`chunk ${meta.chunk_number} fetch non-ok ${r.status}`);
+        }
+        const buf = new Uint8Array(await r.arrayBuffer());
+        if (buf.byteLength !== meta.byte_count) {
+          throw new Error(`chunk ${meta.chunk_number} size mismatch: expected ${meta.byte_count}, got ${buf.byteLength}`);
+        }
+        const hash = sha256Hex(buf);
+        if (hash !== meta.plaintext_sha256) {
+          throw new Error(`chunk ${meta.chunk_number} hash mismatch: expected ${meta.plaintext_sha256}, got ${hash}`);
+        }
+        await fh.write(buf, 0, buf.byteLength, meta.start_offset);
+        writtenBytes += buf.byteLength;
+      }
+    } catch (err) {
+      await fh.close().catch(() => { /* ignore */ });
+      await fs.unlink(partialPath).catch(() => { /* ignore */ });
+      throw err;
+    }
+    await fh.close();
+
+    // Final-size assertion: writtenBytes must equal the last chunk's end_offset
+    // (== sum of byte_counts == manifest.total_size).
+    const expectedTotal = manifest.chunks[manifest.chunks.length - 1]!.end_offset;
+    if (writtenBytes !== expectedTotal) {
+      await fs.unlink(partialPath).catch(() => { /* ignore */ });
+      throw new Error(`sessions reassemble: total size mismatch (wrote ${writtenBytes}, manifest says ${expectedTotal})`);
+    }
+
+    // Atomic move into place.
+    await fs.rename(partialPath, targetPath);
+
+    // Record the local path in remote_sessions so subsequent UI checks can
+    // surface "already reassembled".
+    updateRemoteSessionLocalPath.run(targetPath, session.user.id, sessionId);
+
+    console.log(
+      `[sessions] reassembled: session=${sessionId.slice(0, 8)} chunks=${manifest.chunks.length} bytes=${writtenBytes} → ${targetPath}`,
+    );
+
+    return {
+      chunkCount: manifest.chunks.length,
+      totalBytes: writtenBytes,
+      generation: manifest.bytes_generation,
+      targetPath,
+    };
+  }
+
   // Capture the service object so methods don't depend on `this` binding —
   // safe to pass `service.reconcile` directly into a setInterval / event
   // emitter callback. Mirrors the memory-sync-service shape.
@@ -594,6 +719,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       inFlightBytes.set(sessionId, promise);
       return promise;
     },
+
+    reassembleSessionJsonl: doReassemble,
 
     markDirty,
   };

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -173,6 +173,175 @@ describe("SessionSyncService", () => {
   });
 });
 
+describe("SessionSyncService.reassembleSessionJsonl", () => {
+  function hash(bytes: Uint8Array): string {
+    // Same algo + format as the service (Node crypto SHA-256 hex).
+    // Use a worker-side equivalent: hash via crypto.subtle on the actual bytes.
+    // For brevity here we just import the runtime's createHash.
+    // (Mirror of sha256Hex in session-sync-service.)
+    // We do this synchronously via require to keep this test file simple.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createHash } = require("node:crypto");
+    return createHash("sha256").update(bytes).digest("hex");
+  }
+
+  function makeFetch(
+    chunks: Uint8Array[],
+    generation = 0,
+    overrides: { manifestStatus?: number; chunkStatus?: number; corruptChunk?: number } = {},
+  ): typeof fetch {
+    return (vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        if (overrides.manifestStatus && overrides.manifestStatus !== 200) {
+          return new Response("err", { status: overrides.manifestStatus });
+        }
+        let off = 0;
+        const manifestChunks = chunks.map((c, i) => {
+          const start = off;
+          off += c.byteLength;
+          return {
+            chunk_number: i + 1,
+            start_offset: start,
+            end_offset: off,
+            byte_count: c.byteLength,
+            plaintext_sha256: hash(c),
+          };
+        });
+        return new Response(JSON.stringify({
+          bytes_generation: generation,
+          total_size: off,
+          chunks: manifestChunks,
+        }), { status: 200 });
+      }
+      const m = u.match(/\/chunk\/(\d+)$/);
+      if (m) {
+        const idx = Number(m[1]) - 1;
+        if (overrides.chunkStatus && overrides.chunkStatus !== 200) {
+          return new Response("err", { status: overrides.chunkStatus });
+        }
+        let bytes = chunks[idx]!;
+        if (overrides.corruptChunk === idx + 1) {
+          // Same-length corruption — exercises the hash check specifically,
+          // not the byte-count check that fires earlier on size mismatch.
+          bytes = new Uint8Array(bytes.byteLength);
+          bytes.fill(0xff);
+        }
+        return new Response(bytes, { status: 200 });
+      }
+      return new Response("not_found", { status: 404 });
+    }) as unknown as typeof fetch);
+  }
+
+  function harnessForReassemble(): { db: Database.Database; profileBinding: ReturnType<typeof createProfileBindingService> } {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    h.db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, 'dev-mac', 'test')`).run();
+    h.db.prepare(`
+      INSERT INTO remote_sessions
+        (session_id, owner_id, device_id, agent, title, state, cwd, model,
+         started_at, ended_at, last_event_at, bytes_generation, has_bytes,
+         cloud_updated_at, fetched_at, jsonl_local_path)
+      VALUES ('s-remote', 'user-A', 'dev-pc', 'claude-code', 't', 'done', '/tmp/x', 'm',
+              '2026-05-11T10:00:00Z', NULL, '2026-05-11T10:30:00Z',
+              0, 1, 1000, ?, NULL)
+    `).run(Date.now());
+    return h;
+  }
+
+  it("happy path: chunks reassemble byte-for-byte and remote_sessions.jsonl_local_path is set", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "reassembled.jsonl");
+    const c1 = new TextEncoder().encode("{\"role\":\"user\",\"content\":\"hi\"}\n");
+    const c2 = new TextEncoder().encode("{\"role\":\"assistant\",\"content\":\"hey\"}\n");
+    const c3 = new TextEncoder().encode("{\"role\":\"user\",\"content\":\"bye\"}\n");
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: makeFetch([c1, c2, c3]),
+    });
+    const r = await svc.reassembleSessionJsonl("s-remote", targetPath);
+
+    expect(r.chunkCount).toBe(3);
+    expect(r.totalBytes).toBe(c1.byteLength + c2.byteLength + c3.byteLength);
+    expect(r.generation).toBe(0);
+
+    const expected = new Uint8Array(r.totalBytes);
+    expected.set(c1, 0);
+    expected.set(c2, c1.byteLength);
+    expected.set(c3, c1.byteLength + c2.byteLength);
+    const got = new Uint8Array(statSync(targetPath).size);
+    // Read back from disk
+    const fs = require("node:fs");
+    fs.readFileSync(targetPath).copy(got);
+    expect(got).toEqual(expected);
+
+    // jsonl_local_path got recorded
+    const row = db.prepare(
+      `SELECT jsonl_local_path FROM remote_sessions WHERE owner_id = ? AND session_id = ?`,
+    ).get("user-A", "s-remote") as { jsonl_local_path: string };
+    expect(row.jsonl_local_path).toBe(targetPath);
+  });
+
+  it("hash mismatch deletes partial + throws + leaves no jsonl on disk", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "reassembled.jsonl");
+    const c1 = new TextEncoder().encode("good\n");
+    const c2 = new TextEncoder().encode("also good\n");
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: makeFetch([c1, c2], 0, { corruptChunk: 2 }),
+    });
+    await expect(svc.reassembleSessionJsonl("s-remote", targetPath)).rejects.toThrow(/hash mismatch/);
+
+    // No file on disk
+    const fs = require("node:fs");
+    expect(fs.existsSync(targetPath)).toBe(false);
+    expect(fs.existsSync(`${targetPath}.partial`)).toBe(false);
+    // jsonl_local_path stayed NULL
+    const row = db.prepare(
+      `SELECT jsonl_local_path FROM remote_sessions WHERE owner_id = ? AND session_id = ?`,
+    ).get("user-A", "s-remote") as { jsonl_local_path: string | null };
+    expect(row.jsonl_local_path).toBeNull();
+  });
+
+  it("free user throws (pro-only)", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "free" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+    await expect(svc.reassembleSessionJsonl("s-remote", "/tmp/x.jsonl"))
+      .rejects.toThrow(/pro-only/);
+  });
+
+  it("empty manifest throws", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: makeFetch([]),
+    });
+    await expect(svc.reassembleSessionJsonl("s-remote", join(root, "out.jsonl")))
+      .rejects.toThrow(/no chunks/);
+  });
+});
+
 describe("SessionSyncService.pull", () => {
   function seedDevice(db: Database.Database, deviceId = "dev-mac"): void {
     db.prepare(

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -35,6 +35,30 @@ function harness() {
       cloud_owner_id TEXT NOT NULL,
       bound_at INTEGER NOT NULL
     );
+    CREATE TABLE device_identity (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      device_id TEXT NOT NULL,
+      label TEXT NOT NULL
+    );
+    CREATE TABLE remote_sessions (
+      session_id        TEXT NOT NULL,
+      owner_id          TEXT NOT NULL,
+      device_id         TEXT,
+      agent             TEXT NOT NULL,
+      title             TEXT,
+      state             TEXT NOT NULL,
+      cwd               TEXT,
+      model             TEXT,
+      started_at        TEXT NOT NULL,
+      ended_at          TEXT,
+      last_event_at     TEXT NOT NULL,
+      bytes_generation  INTEGER NOT NULL DEFAULT 0,
+      has_bytes         INTEGER NOT NULL DEFAULT 0,
+      cloud_updated_at  INTEGER NOT NULL,
+      fetched_at        INTEGER NOT NULL,
+      jsonl_local_path  TEXT,
+      PRIMARY KEY (owner_id, session_id)
+    );
   `);
   const profileBinding = createProfileBindingService({ db });
   return { db, profileBinding };
@@ -146,6 +170,142 @@ describe("SessionSyncService", () => {
     const s3 = db.prepare("SELECT cloud_synced_at FROM sessions WHERE id='s3'")
       .get() as { cloud_synced_at: number | null };
     expect(s3.cloud_synced_at).toBeNull();
+  });
+});
+
+describe("SessionSyncService.pull", () => {
+  function seedDevice(db: Database.Database, deviceId = "dev-mac"): void {
+    db.prepare(
+      `INSERT INTO device_identity (id, device_id, label) VALUES (1, ?, 'test')`,
+    ).run(deviceId);
+  }
+
+  function cloudPayload(sessions: Array<{
+    session_id: string;
+    device_id: string | null;
+    has_bytes?: boolean;
+    bytes_generation?: number;
+    updated_at?: number;
+    title?: string;
+    state?: string;
+  }>) {
+    return new Response(JSON.stringify({
+      sessions: sessions.map((s) => ({
+        session_id: s.session_id,
+        device_id: s.device_id,
+        agent: "claude-code",
+        title: s.title ?? "remote session",
+        state: s.state ?? "done",
+        cwd: "/tmp/x",
+        model: "claude-sonnet-4-6",
+        started_at: "2026-05-11T10:00:00Z",
+        ended_at: null,
+        last_event_at: "2026-05-11T10:30:00Z",
+        bytes_generation: s.bytes_generation ?? 0,
+        has_bytes: s.has_bytes ?? false,
+        updated_at: s.updated_at ?? 1000,
+      })),
+    }), { status: 200 });
+  }
+
+  it("no-op for free users", async () => {
+    const { db, profileBinding } = harness();
+    seedDevice(db);
+    const fetchSpy = vi.fn(async () => cloudPayload([]));
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "u1", email: "x@x", tier: "free" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    expect(await svc.pull()).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("upserts foreign-device sessions and skips this device", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    const fetchSpy = vi.fn(async () =>
+      cloudPayload([
+        { session_id: "s-mine", device_id: "dev-mac", has_bytes: true },
+        { session_id: "s-other", device_id: "dev-pc", has_bytes: true },
+        { session_id: "s-orphan", device_id: null, has_bytes: false },
+      ]),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const applied = await svc.pull();
+    // s-mine filtered out (own device); s-other + s-orphan upserted
+    expect(applied).toBe(2);
+    const rows = db.prepare(
+      `SELECT session_id, has_bytes FROM remote_sessions WHERE owner_id = ? ORDER BY session_id`,
+    ).all("user-A") as Array<{ session_id: string; has_bytes: number }>;
+    expect(rows.map((r) => r.session_id)).toEqual(["s-orphan", "s-other"]);
+    expect(rows.find((r) => r.session_id === "s-other")?.has_bytes).toBe(1);
+    expect(rows.find((r) => r.session_id === "s-orphan")?.has_bytes).toBe(0);
+  });
+
+  it("LWW: older cloud_updated_at does not overwrite newer local copy", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    let payload = cloudPayload([
+      { session_id: "s-other", device_id: "dev-pc", title: "v2", updated_at: 5000 },
+    ]);
+    const fetchSpy = vi.fn(async () => payload);
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pull();
+    // Now serve an OLDER updated_at — should NOT overwrite.
+    payload = cloudPayload([
+      { session_id: "s-other", device_id: "dev-pc", title: "v1-ancient", updated_at: 1000 },
+    ]);
+    await svc.pull();
+    const row = db.prepare(
+      `SELECT title FROM remote_sessions WHERE owner_id = ? AND session_id = ?`,
+    ).get("user-A", "s-other") as { title: string };
+    expect(row.title).toBe("v2");
+  });
+
+  it("reconcile calls pull and pushPending", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db);
+    insertDirtySession(db, "s-dirty", "user-A", 1000);
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/api/sessions/metadata") && !u.includes("?")) {
+        // Could be GET (pull) or POST (push). Either way, return a valid shape.
+        return new Response(JSON.stringify({ sessions: [], accepted: ["s-dirty"], rejected: [] }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const r = await svc.reconcile();
+    expect(r.pulled).toBe(0);
+    expect(r.pushed).toBe(1);
+    // Both verbs were used
+    const methods = fetchSpy.mock.calls.map((c) => (c[1] as RequestInit | undefined)?.method ?? "GET");
+    expect(methods).toContain("GET");
+    expect(methods).toContain("POST");
   });
 });
 

--- a/server/test/sessions-resume-route.test.ts
+++ b/server/test/sessions-resume-route.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { tryHandleSessionRoute } from "../src/routes/sessions.js";
+
+// Fake req/res/ctx mirrors the shape in pin-route.test.ts.
+function fakeCtx(body: unknown = {}) {
+  const captured: { status?: number; json?: unknown } = {};
+  const ctx = {
+    sendJson: (j: unknown, s = 200) => { captured.json = j; captured.status = s; },
+    sendError: (err: unknown, s = 500) => {
+      captured.json = { error: err instanceof Error ? err.message : String(err) };
+      captured.status = s;
+    },
+    rejectIfNonLocalOrigin: () => false,
+    readJsonBody: async () => body as Record<string, unknown>,
+  };
+  return { ctx, captured };
+}
+
+// Build the minimum schema the route reads from. remote_sessions is the
+// star; sources is needed for candidate resolution; sessions is needed by
+// the existing GET /api/sessions logic (irrelevant for resume but the
+// shared route handler touches it).
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE remote_sessions (
+      session_id TEXT NOT NULL, owner_id TEXT NOT NULL, device_id TEXT,
+      agent TEXT NOT NULL, title TEXT, state TEXT NOT NULL, cwd TEXT,
+      model TEXT, started_at TEXT NOT NULL, ended_at TEXT,
+      last_event_at TEXT NOT NULL, bytes_generation INTEGER NOT NULL DEFAULT 0,
+      has_bytes INTEGER NOT NULL DEFAULT 0, cloud_updated_at INTEGER NOT NULL,
+      fetched_at INTEGER NOT NULL, jsonl_local_path TEXT,
+      PRIMARY KEY (owner_id, session_id)
+    );
+    CREATE TABLE sources (
+      id TEXT PRIMARY KEY, space_id TEXT NOT NULL, type TEXT NOT NULL,
+      path TEXT NOT NULL, label TEXT,
+      added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      removed_at TEXT
+    );
+  `);
+  return db;
+}
+
+function insertRemote(
+  db: Database.Database,
+  opts: { sessionId: string; ownerId: string; cwd: string | null; hasBytes: boolean; deviceId?: string },
+) {
+  db.prepare(
+    `INSERT INTO remote_sessions
+       (session_id, owner_id, device_id, agent, title, state, cwd, model,
+        started_at, ended_at, last_event_at, bytes_generation, has_bytes,
+        cloud_updated_at, fetched_at, jsonl_local_path)
+     VALUES (?, ?, ?, 'claude-code', 't', 'done', ?, 'm',
+             '2026-05-11T10:00:00Z', NULL, '2026-05-11T10:30:00Z',
+             0, ?, 1000, ?, NULL)`,
+  ).run(opts.sessionId, opts.ownerId, opts.deviceId ?? "dev-pc", opts.cwd, opts.hasBytes ? 1 : 0, Date.now());
+}
+
+function insertSource(db: Database.Database, id: string, path: string, spaceId = "space-1") {
+  db.prepare(
+    `INSERT INTO sources (id, space_id, type, path, label) VALUES (?, ?, 'local_folder', ?, NULL)`,
+  ).run(id, spaceId, path);
+}
+
+function stubSessionSync(behaviour: "success" | "throw" = "success") {
+  return {
+    reassembleSessionJsonl: vi.fn(async (sessionId: string, targetPath: string) => {
+      if (behaviour === "throw") throw new Error("simulated reassembly failure");
+      return { chunkCount: 1, totalBytes: 42, generation: 0, targetPath };
+    }),
+    // Unused but interface requires them.
+    reconcile: vi.fn(),
+    pushPending: vi.fn(),
+    pull: vi.fn(),
+    pushBytes: vi.fn(),
+    markDirty: vi.fn(),
+  };
+}
+
+const baseDeps = (db: Database.Database, opts: {
+  ownerId?: string | null;
+  sessionSync?: ReturnType<typeof stubSessionSync>;
+}) => ({
+  db,
+  sessionStore: { getAll: () => [] } as any,
+  spaceStore: { getSourcesByIds: () => [] } as any,
+  artifactService: {} as any,
+  memoryProvider: {} as any,
+  sessionSync: opts.sessionSync ?? stubSessionSync(),
+  currentUserId: () => opts.ownerId ?? null,
+});
+
+describe("POST /api/sessions/:id/resume", () => {
+  let db: Database.Database;
+  let projectsRootDir: string;
+
+  beforeEach(() => {
+    db = makeDb();
+    projectsRootDir = mkdtempSync(join(tmpdir(), "oyster-resume-route-"));
+    process.env.OYSTER_CLAUDE_PROJECTS_ROOT = projectsRootDir;
+  });
+
+  it("401 sign_in_required when no Pro user", async () => {
+    insertRemote(db, { sessionId: "s1", ownerId: "user-A", cwd: "/tmp/x", hasBytes: true });
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    const handled = await tryHandleSessionRoute(req, {} as any, "/api/sessions/s1/resume",
+      ctx as any, baseDeps(db, { ownerId: null }));
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(401);
+    expect(captured.json).toEqual({ error: "sign_in_required" });
+  });
+
+  it("404 when session not in remote_sessions", async () => {
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    const handled = await tryHandleSessionRoute(req, {} as any, "/api/sessions/unknown/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A" }));
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(404);
+    expect(captured.json).toMatchObject({ error: "session_not_found_in_remote" });
+  });
+
+  it("409 bytes_not_available when has_bytes = 0", async () => {
+    insertRemote(db, { sessionId: "s1", ownerId: "user-A", cwd: "/tmp/x", hasBytes: false });
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    const handled = await tryHandleSessionRoute(req, {} as any, "/api/sessions/s1/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A" }));
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(409);
+    expect(captured.json).toMatchObject({ error: "bytes_not_available" });
+  });
+
+  it("needs_target when no local source matches the remote cwd", async () => {
+    insertRemote(db, { sessionId: "s1", ownerId: "user-A", cwd: "/Users/somebody-else/proj", hasBytes: true });
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/s1/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A" }));
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({
+      status: "needs_target",
+      remoteCwd: "/Users/somebody-else/proj",
+    });
+  });
+
+  it("pick_source when multiple sources match", async () => {
+    insertRemote(db, { sessionId: "s1", ownerId: "user-A", cwd: "/orig/proj", hasBytes: true });
+    insertSource(db, "src-1", "/local/a/proj");
+    insertSource(db, "src-2", "/local/b/proj");
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/s1/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A" }));
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({ status: "pick_source" });
+    const body = captured.json as { status: string; candidates: Array<{ path: string }> };
+    expect(body.candidates.map((c) => c.path).sort()).toEqual(["/local/a/proj", "/local/b/proj"]);
+  });
+
+  it("happy path: auto-resolve via single matching source, calls reassemble, returns command", async () => {
+    // Set up: source whose basename matches the remote cwd's basename.
+    const localProj = join(projectsRootDir, "..", "auto-resolve-proj");
+    mkdirSync(localProj, { recursive: true });
+    // Remote cwd ends in "auto-resolve-proj" too → basename match wins.
+    insertRemote(db, { sessionId: "abc-123", ownerId: "user-A", cwd: "/orig/auto-resolve-proj", hasBytes: true });
+    insertSource(db, "src-1", localProj);
+
+    const sync = stubSessionSync("success");
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/abc-123/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A", sessionSync: sync }));
+
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({
+      status: "ok",
+      sessionId: "abc-123",
+      localCwd: localProj,
+    });
+    expect(sync.reassembleSessionJsonl).toHaveBeenCalledOnce();
+    const command = (captured.json as { command: string }).command;
+    expect(command).toContain("claude --resume abc-123");
+    expect(command).toContain(localProj);
+  });
+
+  it("validation_warning when targetCwd is missing on disk", async () => {
+    insertRemote(db, { sessionId: "s1", ownerId: "user-A", cwd: "/orig/proj", hasBytes: true });
+    const { ctx, captured } = fakeCtx({ targetCwd: "/no/such/folder" });
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/s1/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A" }));
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({
+      status: "validation_warning",
+      reasons: ["target_folder_missing"],
+    });
+  });
+
+  it("validation_warning surfaces non-fatal reasons when targetCwd is not a git repo (without force)", async () => {
+    const realDir = mkdtempSync(join(tmpdir(), "oyster-route-nonrepo-"));
+    // realDir exists, basename is unlikely to match, no .git → multiple warnings
+    insertRemote(db, { sessionId: "s1", ownerId: "user-A", cwd: "/orig/proj-different", hasBytes: true });
+    const { ctx, captured } = fakeCtx({ targetCwd: realDir });
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/s1/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A" }));
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({ status: "validation_warning" });
+    const reasons = (captured.json as { reasons: string[] }).reasons;
+    expect(reasons).toContain("not_a_git_repo");
+  });
+
+  it("force:true bypasses validation_warning and proceeds with reassembly", async () => {
+    const realDir = mkdtempSync(join(tmpdir(), "oyster-route-force-"));
+    insertRemote(db, { sessionId: "abc-123", ownerId: "user-A", cwd: "/orig/proj", hasBytes: true });
+    const sync = stubSessionSync("success");
+    const { ctx, captured } = fakeCtx({ targetCwd: realDir, force: true });
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/abc-123/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A", sessionSync: sync }));
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({ status: "ok", localCwd: realDir });
+    expect(sync.reassembleSessionJsonl).toHaveBeenCalledOnce();
+  });
+
+  it("500 reassemble_failed when the service throws", async () => {
+    // Use auto-resolve with a single matching source so we get past validation
+    // to the actual reassemble call.
+    const realDir = mkdtempSync(join(tmpdir(), "oyster-route-throws-"));
+    insertRemote(db, { sessionId: "abc-123", ownerId: "user-A", cwd: realDir, hasBytes: true });
+    insertSource(db, "src-1", realDir);
+    const sync = stubSessionSync("throw");
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/abc-123/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A", sessionSync: sync }));
+    expect(captured.status).toBe(500);
+    expect(captured.json).toMatchObject({
+      error: "reassemble_failed",
+      message: "simulated reassembly failure",
+    });
+  });
+});
+
+describe("GET /api/sessions merges local + remote", () => {
+  it("returns merged list with originDeviceId + jsonlAvailableLocally", async () => {
+    const db = makeDb();
+    insertRemote(db, { sessionId: "remote-1", ownerId: "user-A", cwd: "/orig/proj", hasBytes: true, deviceId: "dev-pc" });
+    const sessionStore = {
+      getAll: () => [{
+        id: "local-1", space_id: "space-1", source_id: null, cwd: "/Users/me/local",
+        agent: "claude-code", title: "local", state: "done",
+        started_at: "2026-05-11T09:00:00Z", ended_at: null, model: "m",
+        last_event_at: "2026-05-11T09:30:00Z",
+      }],
+    } as any;
+    const spaceStore = { getSourcesByIds: () => [] } as any;
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions",
+      ctx as any, {
+        db, sessionStore, spaceStore,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+
+    const list = captured.json as Array<{ id: string; originDeviceId: string | null; jsonlAvailableLocally: boolean }>;
+    expect(list.length).toBe(2);
+    const local = list.find((s) => s.id === "local-1");
+    const remote = list.find((s) => s.id === "remote-1");
+    expect(local?.originDeviceId).toBeNull();
+    expect(local?.jsonlAvailableLocally).toBe(true);
+    expect(remote?.originDeviceId).toBe("dev-pc");
+    expect(remote?.jsonlAvailableLocally).toBe(false);  // jsonl_local_path is NULL
+  });
+
+  it("filters remote rows whose session_id collides with a local session", async () => {
+    const db = makeDb();
+    // Same session_id exists in both local and remote — local wins.
+    insertRemote(db, { sessionId: "dup", ownerId: "user-A", cwd: "/orig/proj", hasBytes: true, deviceId: "dev-pc" });
+    const sessionStore = {
+      getAll: () => [{
+        id: "dup", space_id: null, source_id: null, cwd: "/Users/me/local",
+        agent: "claude-code", title: "local-version", state: "done",
+        started_at: "2026-05-11T09:00:00Z", ended_at: null, model: "m",
+        last_event_at: "2026-05-11T09:30:00Z",
+      }],
+    } as any;
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions",
+      ctx as any, {
+        db, sessionStore, spaceStore: { getSourcesByIds: () => [] } as any,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+    const list = captured.json as Array<{ id: string; title: string; originDeviceId: string | null }>;
+    expect(list).toHaveLength(1);
+    expect(list[0]!.title).toBe("local-version");
+    expect(list[0]!.originDeviceId).toBeNull();
+  });
+});
+
+// Touch `existsSync` so the import isn't flagged as unused on linter passes
+// that don't see it via downstream calls. The test sometimes needs to assert
+// on file absence separately.
+void existsSync;
+void writeFileSync;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -107,7 +107,21 @@ export interface Session {
   endedAt: string | null;
   model: string | null;
   lastEventAt: string;
+  /** Pick-up-here cross-device fields (#322). Both null/false for local
+   *  sessions discovered by this device's watcher; populated for remote
+   *  sessions pulled from the cloud manifest. */
+  originDeviceId?: string | null;
+  /** True for local sessions; true for remote sessions whose jsonl has
+   *  already been reassembled to disk on this device; false otherwise. */
+  jsonlAvailableLocally?: boolean;
 }
+
+/** POST /api/sessions/:id/resume response shapes. */
+export type SessionResumeResponse =
+  | { status: "ok"; sessionId: string; localCwd: string; jsonlPath: string; command: string }
+  | { status: "needs_target"; remoteCwd: string | null; suggestedSpaceId: string | null }
+  | { status: "pick_source"; candidates: Array<{ path: string; label: string | null }>; remoteCwd: string | null }
+  | { status: "validation_warning"; reasons: string[] };
 
 export type SessionEventRole =
   | "user"


### PR DESCRIPTION
## Summary

Pulls a cross-device session's encrypted jsonl chunks down, decrypts (worker-side) + verifies (client-side), reassembles to disk at Claude Code's expected encoded path, and surfaces \`cd <localCwd> && claude --resume <id>\` for the user to run. End-to-end *Pick-up-here* push-and-pull, minus the UI (PR 3).

Stacks on PR #431 (merged). Worker side is unchanged — PR 1 already shipped \`GET /api/sessions/bytes/:id/manifest\` + \`GET /api/sessions/bytes/:id/chunk/:n\`, which is what reassembly here consumes.

## Two commits

| | Scope |
|---|---|
| \`4013956\` | Schema: \`remote_sessions\` table. SessionSyncService gains \`pull()\` + reconcile-order pull-then-push. + 4 vitest cases. |
| \`ee87bda\` | \`reassembleSessionJsonl()\` on the service. \`POST /api/sessions/:id/resume\` route. \`GET /api/sessions\` merges local + remote. Session type extended. + 4 vitest cases. |

**Tests: 200/200 server-side.** Worker tests unchanged (43/43).

## What's wired end-to-end after merge

Once a Pro user signs in on Device B with a build that includes this PR:

1. \`SessionSyncService.pull()\` fires on the existing reconcile triggers (auth, focus, panel-mount, 30s poll). Cloud's GET \`/api/sessions/metadata\` filters down to foreign-device rows and lands them in local \`remote_sessions\`.
2. Home (or any \`GET /api/sessions\` caller) sees the merged list: local + cross-device. Each row carries \`originDeviceId\` + \`jsonlAvailableLocally\`.
3. User clicks "Resume on this device" (PR 3 UI) or curls the API directly:
   - \`POST /api/sessions/<id>/resume\` without body → auto-resolve via local sources whose path is a prefix of the remote cwd OR whose basename matches.
   - 0 matches → \`{ status: "needs_target", remoteCwd }\` — UI prompts for a folder.
   - 1 match → reassemble + return command.
   - N matches → \`{ status: "pick_source", candidates: [...] }\` — UI shows a selector.
4. With \`targetCwd\` supplied (folder picker / override): validate (folder exists hard; \`.git\` + remote + basename match are warnings). Warnings require \`force: true\` to bypass.
5. Reassembly: GET manifest, GET each chunk, verify SHA-256 + byte count per chunk, write atomically (.partial → rename). Mid-fetch crash leaves a discardable partial, never a corrupted jsonl.

## API contract — \`POST /api/sessions/:id/resume\`

\`\`\`ts
type SessionResumeResponse =
  | { status: "ok"; sessionId; localCwd; jsonlPath; command }
  | { status: "needs_target"; remoteCwd; suggestedSpaceId }
  | { status: "pick_source"; candidates: [{ path; label }]; remoteCwd }
  | { status: "validation_warning"; reasons: string[] }
\`\`\`

Errors: \`401 sign_in_required\`, \`404 session_not_found_in_remote\`, \`409 bytes_not_available\`, \`500 reassemble_failed\`.

## What's still TODO

- [ ] **Route-level tests** for \`POST /api/sessions/:id/resume\` happy-path + all status branches (auto-resolve, picker, validation warning, force-override). Service-level reassembly + pull are covered.
- [ ] **PR 3** — UI: cross-device session card chip + Resume button + folder picker on \`needs_target\` + "Use this folder for this space" link that inserts a new \`sources\` row.

## Plan reference

Architectural decisions documented in \`~/.claude/plans/eventual-soaring-swan.md\` (local). Key bits this PR implements:

- Pull path = local-server-orchestrated per-chunk fetch (Worker never assembles whole jsonl in memory).
- Per-chunk hash verification on Device B.
- Path resolution via \`sources\` rows (per-device, NOT synced) — not \`spaces.local_path\` (doesn't exist).
- Override is one-shot by default. Persisting the override as a new \`sources\` row is a separate explicit action (PR 3 link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)