### PR TITLE
fix(auto-approver): switch upstream subscription to /global/event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chat replies stream again, and the boot console is quiet.** A recent AI-engine update silently broke the live event stream, which made assistant replies fail to render and flooded the terminal with reconnect messages. Both are working again.
+
 ## [0.8.1-beta.2] - 2026-05-11
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-8-1-beta-2">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
@@ -324,6 +325,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.7.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Chat replies stream again, and the boot console is quiet.</strong> A recent AI-engine update silently broke the live event stream, which made assistant replies fail to render and flooded the terminal with reconnect messages. Both are working again.</li>
+</ul>
 <h2 id="v-0-8-1-beta-2"><span class="release-version">0.8.1-beta.2</span><span class="release-date"> — 2026-05-11</span></h2>
 <h3>Added</h3>
 <ul>

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -162,7 +162,8 @@ function logDisconnect(reason: "disconnected" | "failed to connect") {
   const suffix = suppressedDisconnects > 0
     ? ` (+${suppressedDisconnects} suppressed)`
     : "";
-  console.log(`[auto-approver] ${reason}${suffix}, reconnecting in 3s...`);
+  const seconds = Math.round(RECONNECT_DELAY_MS / 1000);
+  console.log(`[auto-approver] ${reason}${suffix}, reconnecting in ${seconds}s...`);
   lastDisconnectLogAt = now;
   suppressedDisconnects = 0;
 }

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -138,6 +138,34 @@ export function isShuttingDown() {
 // ── Auto-approve permission requests from opencode ──
 // In the PoC, we trust all tool use. This listens to the SSE stream
 // and auto-approves any permission.asked events.
+//
+// We subscribe to /global/event rather than /event: in opencode 1.14.41+
+// (the Effect HttpApi backend that replaced Hono) /event closes the
+// stream within ~40ms of server.connected when the workspace event bus
+// is empty, because the merged events+heartbeat stream uses
+// haltStrategy:"left" and the bus terminates immediately. /global/event
+// stays open and emits the same event types (plus extras we ignore),
+// wrapped in { payload, directory, project, workspace }.
+
+const RECONNECT_DELAY_MS = 3000;
+const DISCONNECT_LOG_INTERVAL_MS = 30_000;
+
+let lastDisconnectLogAt = 0;
+let suppressedDisconnects = 0;
+
+function logDisconnect(reason: "disconnected" | "failed to connect") {
+  const now = Date.now();
+  if (now - lastDisconnectLogAt < DISCONNECT_LOG_INTERVAL_MS) {
+    suppressedDisconnects++;
+    return;
+  }
+  const suffix = suppressedDisconnects > 0
+    ? ` (+${suppressedDisconnects} suppressed)`
+    : "";
+  console.log(`[auto-approver] ${reason}${suffix}, reconnecting in 3s...`);
+  lastDisconnectLogAt = now;
+  suppressedDisconnects = 0;
+}
 
 export function startAutoApprover(
   getPort: () => number,
@@ -147,18 +175,18 @@ export function startAutoApprover(
     const opencodePort = getPort();
     if (!opencodePort) {
       // Port not resolved yet, retry
-      setTimeout(connect, 3000);
+      setTimeout(connect, RECONNECT_DELAY_MS);
       return;
     }
     const controller = new AbortController();
     try {
-      const res = await fetch(`http://127.0.0.1:${opencodePort}/event`, {
+      const res = await fetch(`http://127.0.0.1:${opencodePort}/global/event`, {
         headers: { Accept: "text/event-stream" },
         signal: controller.signal,
       });
       if (!res.ok || !res.body) {
-        console.log("[auto-approver] failed to connect, retrying in 3s...");
-        setTimeout(connect, 3000);
+        logDisconnect("failed to connect");
+        setTimeout(connect, RECONNECT_DELAY_MS);
         return;
       }
 
@@ -171,17 +199,7 @@ export function startAutoApprover(
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
-            const text = decoder.decode(value, { stream: true });
-
-            // Fan out the raw SSE bytes to any connected browser clients
-            // before we parse them for our own reactive behaviour below.
-            // This replaces the previous per-client proxySSE — a single
-            // upstream subscription avoids multiplying opencode load by
-            // the number of open tabs, and gives us a place to inject
-            // server-originated synthetic events.
-            broadcastRaw(text);
-
-            buffer += text;
+            buffer += decoder.decode(value, { stream: true });
 
             // Parse SSE lines
             const lines = buffer.split("\n");
@@ -190,7 +208,22 @@ export function startAutoApprover(
             for (const line of lines) {
               if (!line.startsWith("data: ")) continue;
               try {
-                const event = JSON.parse(line.slice(6));
+                const wrapper = JSON.parse(line.slice(6));
+                // /global/event wraps every event in { payload, directory, project, workspace }.
+                // Unwrap so downstream consumers (the browser EventSource at
+                // /api/chat/events, and the permission/file checks below) see
+                // the same { type, properties } shape /event used to emit.
+                const event = wrapper && typeof wrapper === "object" && "payload" in wrapper
+                  ? wrapper.payload
+                  : wrapper;
+                if (!event || typeof event !== "object") continue;
+
+                // Fan out the unwrapped event to any connected browser clients.
+                // A single upstream subscription avoids multiplying opencode load
+                // by the number of open tabs and gives us a place to inject
+                // server-originated synthetic events.
+                broadcastRaw(`data: ${JSON.stringify(event)}\n\n`);
+
                 if (event.type === "permission.asked") {
                   const requestId = event.properties.id;
                   console.log(`[auto-approver] approving ${requestId}: ${event.properties.permission}`);
@@ -215,17 +248,17 @@ export function startAutoApprover(
       pump().finally(() => {
         controller.abort();
         if (!shuttingDown) {
-          console.log("[auto-approver] disconnected, reconnecting in 3s...");
-          setTimeout(connect, 3000);
+          logDisconnect("disconnected");
+          setTimeout(connect, RECONNECT_DELAY_MS);
         }
       });
     } catch {
-      if (!shuttingDown) setTimeout(connect, 3000);
+      if (!shuttingDown) setTimeout(connect, RECONNECT_DELAY_MS);
     }
   }
 
   // Give opencode serve a moment to start before connecting
-  setTimeout(connect, 3000);
+  setTimeout(connect, RECONNECT_DELAY_MS);
 }
 
 // ── Proxy helpers for opencode API ──


### PR DESCRIPTION
## Summary

- **Root cause.** In `opencode-ai` 1.14.41+ (the Effect HttpApi backend that replaced Hono — sst/opencode#25667), `/event` closes the SSE stream within ~40ms of `server.connected` when the workspace event bus is empty. The handler at `packages/opencode/src/server/routes/instance/httpapi/event.ts` uses `Stream.merge(heartbeat, { haltStrategy: "left" })`, so the merge halts as soon as the bus stream completes. PR #417 (2026-05-09) bumped us from 1.14.31 → 1.14.41, picking up the regression.
- **Impact.** The auto-approver's `pump()` reads `server.connected`, the stream closes, `.finally()` logs `[auto-approver] disconnected, reconnecting in 3s...`, repeat — that's the flood in #435. Worse, the auto-approver never sees `permission.asked` (closed before one fires), and the same fanout feeds the browser's `/api/chat/events`, so chat token streaming was silently broken too.
- **Fix.** Subscribe to `/global/event` instead — same event types in a `{ payload, directory, project, workspace }` envelope, with a 10s heartbeat that keeps the connection alive. Unwrap the envelope server-side so the existing browser EventSource and local permission/file checks see the same `{ type, properties }` shape `/event` used to emit. Throttle the disconnect/failed-connect log to at most one line per 30s with a `(+N suppressed)` count for defense-in-depth.

## Verification

- [x] `tsc --noEmit` clean
- [x] Standalone mirror of the new pump logic, run against the live OpenCode on the installed `0.8.1-beta.1`, received `server.connected` and a `server.heartbeat` at 10s in the unwrapped shape — no premature DONE.
- [ ] Smoke test from a fresh boot: confirm chat replies stream and the boot console no longer floods.
- [ ] Trigger a tool that would request permission and confirm auto-approve still fires.

## Test plan

- [ ] `cd ~/Dev/oyster-os.worktrees/fix-auto-approver-sse && npm run dev`, watch the console for ≥60s after boot — no flood, single concise disconnect line at most every 30s if reconnects happen at all.
- [ ] Open the surface, send a chat message, verify assistant tokens stream in.
- [ ] Run a chat that triggers a tool call (e.g. file edit), confirm `[auto-approver] approving …: …` log fires.

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)