### PR TITLE
fix(sessions-sync): device_id capture + periodic pull + backfill

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { readFileSync, existsSync, mkdirSync, statSync, copyFileSync, readdirSync, cpSync, writeFileSync, rmSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
+import { randomUUID } from "node:crypto";
 import { basename, extname, join, dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -293,6 +294,38 @@ void authService.validatePersistedSession();
 // the wrong local SQLite. canRunCloudSync() is the ONLY caller of bindToOwner.
 const profileBinding = createProfileBindingService({ db });
 
+// Device identity (#322 PR 2 hotfix). Seed the singleton on first boot so
+// every session pushed to cloud carries which device it originated on.
+// The device_id is a fresh uuid; the label is os.hostname() (e.g.
+// "Matthews-MacBook-Pro.local") for human-readable display in PR 3's
+// "Resumed from MacBook" chip. Stored in oyster.db so it survives
+// app restarts and npm uninstall/install of oyster-os (npm doesn't touch
+// the userland data dir). A factory-reset (deleting ~/Oyster/db/) creates
+// a new device_id, which is the correct behaviour — that's effectively a
+// new device.
+//
+// Backfill: if this is the FIRST seed (INSERT OR IGNORE actually inserted),
+// mark every locally-known session with a cloud_owner_id as dirty so the
+// next pushPending uploads them all with device_id attached. This is the
+// one-shot migration that fills in device_id for sessions already in cloud
+// from before this hotfix landed. The cost is one extra full push per
+// existing user; subsequent boots short-circuit (INSERT OR IGNORE = no-op).
+{
+  const deviceSeed = db.prepare(
+    `INSERT OR IGNORE INTO device_identity (id, device_id, label) VALUES (1, ?, ?)`,
+  ).run(randomUUID(), hostname());
+  if (deviceSeed.changes > 0) {
+    const backfill = db.prepare(
+      `UPDATE sessions SET sync_dirty_at = ? WHERE cloud_owner_id IS NOT NULL`,
+    ).run(Date.now());
+    if (backfill.changes > 0) {
+      console.log(`[sessions] device_identity seeded; marked ${backfill.changes} sessions dirty for device_id backfill`);
+    } else {
+      console.log("[sessions] device_identity seeded (no prior sessions to backfill)");
+    }
+  }
+}
+
 /** Returns true when the signed-in user is Pro AND this local profile is
  *  either unbound or already bound to that user. Side-effect on first call
  *  for a new Pro user: binds the profile. */
@@ -387,6 +420,17 @@ const memoryPollHandle = setInterval(() => {
     }
   }).catch((err) => {
     console.warn("[memory] periodic pull failed:", err);
+  });
+  // Cross-device session metadata pull on the same tick (#322 PR 2 hotfix).
+  // Without this, a running Oyster on Device B never sees sessions Device A
+  // pushed after Device B's last sign-in / app-start. Memory had this loop
+  // since 0.8.0; sessions need parity.
+  sessionSync.pull().then((applied) => {
+    if (applied > 0) {
+      console.log(`[sessions] periodic pull: applied=${applied}`);
+    }
+  }).catch((err) => {
+    console.warn("[sessions] periodic pull failed:", err);
   });
 }, MEMORY_POLL_INTERVAL_MS);
 memoryPollHandle.unref();

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -156,6 +156,10 @@ interface OutgoingSession {
   cwd: string | null;
   last_event_at: string;
   sync_dirty_at: number;
+  /** Stable per-device id from the local device_identity singleton.
+   *  Attached at push time so cloud knows which device produced each
+   *  session — drives the "from MacBook" chip on Device B in PR 3. */
+  device_id: string | null;
 }
 
 export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncService {
@@ -204,16 +208,30 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     let totalAccepted = 0;
     const MAX_BATCHES = 1000;  // defensive safety cap
 
+    // Cache device_id once per drain — it doesn't change during a server
+    // lifetime. NULL is tolerated (cloud upsert accepts NULL) but warns so
+    // a missing device_identity seed is visible.
+    const myDeviceId = getMyDeviceId();
+    if (!myDeviceId) {
+      console.warn("[sessions] pushPending: device_identity not seeded; pushing without device_id");
+    }
+
     for (let i = 0; i < MAX_BATCHES; i++) {
       const pending = scanDirty.all(session.user.id, BATCH_SIZE) as OutgoingSession[];
       if (pending.length === 0) break;
+
+      // Stamp every row with this device's id at push time. Rows in the
+      // local `sessions` table don't carry a device_id column — they're
+      // implicitly produced by this device because the watcher only sees
+      // its own filesystem.
+      const stamped = pending.map((s) => ({ ...s, device_id: myDeviceId }));
 
       let res: Response;
       try {
         res = await deps.fetch(`${deps.workerBase}/api/sessions/metadata`, {
           method: "POST",
           headers: { Cookie: `oyster_session=${session.token}`, "content-type": "application/json" },
-          body: JSON.stringify({ sessions: pending }),
+          body: JSON.stringify({ sessions: stamped }),
         });
       } catch (err) {
         console.warn("[sessions] pushPending failed:", err);

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -134,6 +134,54 @@ describe("SessionSyncService", () => {
     expect(row.cloud_owner_id).toBe("user-A");
   });
 
+  it("pushPending stamps device_id from device_identity onto every payload row", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, ?, ?)`)
+      .run("my-mac-uuid", "MacBook-Pro");
+    insertDirtySession(db, "s1", "user-A", 1000);
+
+    let capturedBody: string | null = null;
+    const fetchSpy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({ accepted: ["s1"] }), { status: 200 });
+    });
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pushPending();
+    const body = JSON.parse(capturedBody ?? "{}") as { sessions: Array<{ id: string; device_id: string | null }> };
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0]!.device_id).toBe("my-mac-uuid");
+  });
+
+  it("pushPending tolerates missing device_identity (device_id null in payload)", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    // device_identity intentionally NOT seeded
+    insertDirtySession(db, "s1", "user-A", 1000);
+
+    let capturedBody: string | null = null;
+    const fetchSpy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({ accepted: ["s1"] }), { status: 200 });
+    });
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pushPending();
+    const body = JSON.parse(capturedBody ?? "{}") as { sessions: Array<{ device_id: string | null }> };
+    expect(body.sessions[0]!.device_id).toBeNull();
+  });
+
   it("pushPending sends dirty sessions for the current owner and marks them synced", async () => {
     const { db, profileBinding } = harness();
     profileBinding.bindToOwner("user-A");


### PR DESCRIPTION
## Three real gaps in PR #437

Surfaced during 0.8.1-beta.2 dogfood. All in one commit because they share the same one-shot-on-first-seed concern.

| Gap | Why it matters |
|---|---|
| \`device_id\` never captured on push | Cloud has 72 of my sessions with \`device_id IS NULL\` — we can't tell which Mac/PC pushed any of them. Once Device B exists, "from MacBook" chip would be empty for every row. |
| \`device_identity\` singleton never seeded | getMyDeviceId() returns null. Even after fix #1 the local source-of-truth was empty. |
| No periodic pull for sessions | Memory has a 30s loop; sessions only pulled on sign-in / app-start. Device B going stale until restart. |

## Fixes

- **Seed device_identity on boot.** Fresh uuid + \`os.hostname()\` label. INSERT OR IGNORE keeps it idempotent.
- **Backfill on first seed.** If the seed actually inserted (changes > 0), mark every owned session dirty so the next pushPending uploads them all with device_id attached. Cloud LWW upserts the new value. One-shot per device.
- **Stamp device_id at push time.** OutgoingSession gains the field; doPushPending caches \`getMyDeviceId()\` once per drain and adds it to every payload row.
- **Periodic session pull.** \`sessionSync.pull()\` joins the existing memoryPollHandle tick so cross-device session updates surface within 30s on Device B.

## Persistence

\`device_identity\` lives in \`~/Oyster/db/oyster.db\`. Survives app restarts and \`npm uninstall/install\` (npm doesn't touch user data). A user wiping \`~/Oyster/db/\` creates a new device_id — correct behaviour because that's effectively a new device.

## Tests

2 new vitest cases (214 total):
- \`pushPending\` stamps device_id from device_identity when seeded.
- \`pushPending\` tolerates missing device_identity (device_id null in payload, warned but not crashed).

Server build (strict tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)