### PR TITLE
fix(changelog): derive Unreleased compare URL from doc, drop stale footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -575,7 +575,6 @@ Agents (Claude Code, OpenCode, Cursor, etc.) can manage the Oyster surface via M
 - Surface with Aurora WebGL animated background.
 - Typed artifact icons, chat bar, window system with viewer.
 
-[Unreleased]: https://github.com/mattslight/oyster/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/mattslight/oyster/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mattslight/oyster/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mattslight/oyster/compare/v0.5.0-beta.2...v0.5.0

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -92,9 +92,10 @@ const rendered = rawRendered.replace(
     const id = `v-${slug(version)}`;
     const versionSpan = `<span class="release-version">${escapeHtml(version)}</span>`;
     // For Unreleased, always use the synthesized compare URL — ignore any
-    // stale footer reference. For released versions, marked never emits a
-    // reference link (no footer defs), so linkedHref is null and we render
-    // a plain span.
+    // stale footer reference. For released versions, honour the footer def
+    // when one exists (older releases up to 0.7.0 still have them and
+    // render as compare links); newer releases have no footer def, so
+    // linkedHref is null and we render a plain span.
     const resolvedHref =
       version === "Unreleased"
         ? unreleasedCompareUrl

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -63,18 +63,44 @@ const slug = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g
 // We post-process both the raw-bracket form and the link-rendered form.
 const releases = [];
 
-// Single pass: marked renders `[Unreleased]` as a reference-link (because of the
-// compare-link footer defining it) and `[0.0.x]` as plain brackets (no matching
-// definition). Match both forms in one regex so releases stay in document order.
+const REPO_URL = "https://github.com/mattslight/oyster";
+const H2_VERSION_RE =
+  /<h2[^>]*>(?:<a[^>]*href="([^"]*)"[^>]*>([^<]+)<\/a>|\[([^\]]+)\])(?:\s*-\s*([^<]+?))?<\/h2>/g;
+
+// Derive Unreleased's compare base from the doc, not from a hand-edited footer
+// reference in CHANGELOG.md. The footer used to point at `v0.7.0...HEAD` and
+// drifted across every release since (#440). Walk h2s in document order
+// (newest first) and pick the first non-Unreleased version as the compare base.
+let unreleasedCompareUrl = null;
+for (const m of rawRendered.matchAll(H2_VERSION_RE)) {
+  const v = m[2] || m[3];
+  if (v && v !== "Unreleased") {
+    unreleasedCompareUrl = `${REPO_URL}/compare/v${v}...HEAD`;
+    break;
+  }
+}
+
+// Single pass: marked may render `[Unreleased]` as a reference-link (if the
+// footer compare-link definition exists) and `[0.0.x]` as plain brackets.
+// Match both forms in one regex so releases stay in document order.
 // The `<h2[^>]*>` tolerates any attributes marked may emit in future versions.
 // Captured values (version, rest, href) are escaped before interpolation.
 const rendered = rawRendered.replace(
-  /<h2[^>]*>(?:<a[^>]*href="([^"]*)"[^>]*>([^<]+)<\/a>|\[([^\]]+)\])(?:\s*-\s*([^<]+?))?<\/h2>/g,
+  H2_VERSION_RE,
   (_, linkedHref, linkedVersion, bracketVersion, rest) => {
     const version = linkedVersion || bracketVersion;
     const id = `v-${slug(version)}`;
     const versionSpan = `<span class="release-version">${escapeHtml(version)}</span>`;
-    const resolvedHref = linkedHref ? safeHref(linkedHref) : null;
+    // For Unreleased, always use the synthesized compare URL — ignore any
+    // stale footer reference. For released versions, marked never emits a
+    // reference link (no footer defs), so linkedHref is null and we render
+    // a plain span.
+    const resolvedHref =
+      version === "Unreleased"
+        ? unreleasedCompareUrl
+        : linkedHref
+          ? safeHref(linkedHref)
+          : null;
     const relAttr = resolvedHref && /^https?:/i.test(resolvedHref) ? ' rel="noopener noreferrer"' : "";
     const versionHtml = resolvedHref
       ? `<a class="release-version-link" href="${escapeHtml(resolvedHref)}"${relAttr}>${versionSpan}</a>`


### PR DESCRIPTION
## Summary

- **Root cause.** The `[Unreleased]` heading on docs/changelog.html linked to `v0.7.0...HEAD`. The `[Unreleased]: ...` footer reference in CHANGELOG.md was hand-maintained, and every release since 0.7.0 (six tags: 0.8.0, 0.8.0-beta.0/1/2/3, 0.8.1-beta.0/1/2) silently failed to bump it. Surfaced when Copilot reviewed #439 — that PR was the first to put non-empty content under `[Unreleased]` since the drift started, so the generator stopped suppressing the heading and exposed the stale link.
- **Fix.** Make `scripts/build-changelog.mjs` synthesize Unreleased's compare URL from doc data — walk the rendered h2 list in document order and use the first non-Unreleased version as the compare base. Remove the `[Unreleased]: ...` footer reference from CHANGELOG.md so there's no longer a parallel source of truth that can drift.
- **Result.** Unreleased now correctly points at `compare/v0.8.1-beta.2...HEAD` and bumps automatically on every future release. No version-lifecycle hook needed.

## Out of scope (related but separate)

Released-version headings on docs/changelog.html are linkable only when a footer ref exists for them. The same drift pattern has left 0.8.0 onwards without compare links — those `[X.Y.Z]: ...` footer refs were never added when the versions were tagged. Same root cause (hand-maintained refs); fix would be to synthesize compare URLs for released versions too, walking pairwise through the h2 list. Happy to do that in a follow-up if you want; left alone here to keep #440's scope tight.

## Verification

- [x] `npm run build:changelog` regenerates docs/changelog.html cleanly.
- [x] Unreleased heading now renders as `<a href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.2...HEAD">` — confirmed in docs/changelog.html L328.
- [x] Empty-Unreleased path still works: when `[Unreleased]` has no content, the existing `emptyUnreleasedRe` strips the whole heading, so no stale link can render.
- [x] Released versions (0.7.0 and earlier with footer refs) still render with their existing compare links unchanged.

## Test plan

- [ ] Skim docs/changelog.html — Unreleased pill present, click navigates to the right anchor.
- [ ] On next \`npm run release\`, confirm the regenerated docs/changelog.html shows Unreleased linking to the just-tagged version (no manual intervention needed).

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)