### PR TITLE
fix(sessions-sync): self-mirror cleanup in pull() + startup DELETE

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -326,6 +326,28 @@ const profileBinding = createProfileBindingService({ db });
   }
 }
 
+// Self-mirror cleanup (#322 PR 2 hotfix follow-up). Removes any
+// remote_sessions rows that are actually local — either device_id matches
+// this device, or session_id appears in the local `sessions` table. These
+// ghosts arose during the device_id backfill: pull ran before push, cloud
+// rows still had NULL device_id, so the old filter (device_id !== mine)
+// failed to recognise them as self. Harmless thanks to the GET
+// /api/sessions session_id de-dup, but better to remove the dead state so
+// remote_sessions stays a faithful "other devices only" mirror.
+//
+// Idempotent — runs on every boot. The cost is O(remote_rows + local_rows)
+// once at startup; negligible at typical scales.
+{
+  const cleaned = db.prepare(
+    `DELETE FROM remote_sessions
+      WHERE device_id = (SELECT device_id FROM device_identity WHERE id = 1)
+         OR session_id IN (SELECT id FROM sessions)`,
+  ).run();
+  if (cleaned.changes > 0) {
+    console.log(`[sessions] self-mirror cleanup: removed ${cleaned.changes} ghost remote_sessions rows`);
+  }
+}
+
 /** Returns true when the signed-in user is Pro AND this local profile is
  *  either unbound or already bound to that user. Side-effect on first call
  *  for a new Pro user: binds the profile. */

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -550,11 +550,24 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     const incoming = body?.sessions ?? [];
     if (incoming.length === 0) return 0;
 
-    // Filter out rows that belong to THIS device — we already have those
-    // in the local `sessions` table via the watcher. remote_sessions is for
-    // OTHER devices' sessions specifically.
+    // Filter out anything that's really a local session in disguise.
+    // Two guards:
+    //   1. device_id matches ours (cloud explicitly tagged this row as ours).
+    //   2. session_id collides with a row in the local `sessions` table
+    //      (the watcher's source-of-truth for sessions produced here —
+    //      catches the legacy case where cloud rows have NULL device_id
+    //      from before the device_id capture fix).
+    // Either guard is sufficient. Without (2), NULL-device_id rows that
+    // are actually our own session would have leaked into remote_sessions
+    // and then back into Home's merged list as ghost "from another device"
+    // entries.
     const myDeviceId = getMyDeviceId();
-    const foreignRows = incoming.filter((s) => s.device_id !== myDeviceId);
+    const localIds = new Set(
+      (deps.db.prepare(`SELECT id FROM sessions`).all() as Array<{ id: string }>).map((r) => r.id),
+    );
+    const foreignRows = incoming.filter((s) =>
+      s.device_id !== myDeviceId && !localIds.has(s.session_id),
+    );
 
     const now = Date.now();
     let applied = 0;

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -469,6 +469,39 @@ describe("SessionSyncService.pull", () => {
     expect(rows.find((r) => r.session_id === "s-orphan")?.has_bytes).toBe(0);
   });
 
+  it("skips remote rows whose session_id already exists locally (legacy NULL device_id)", async () => {
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    // Simulate the post-backfill state: local sessions table has a row for
+    // "s-mine-legacy", and cloud has the same id but with NULL device_id
+    // (pre-fix data). Without the local-id filter, this would round-trip
+    // into remote_sessions as a ghost foreign row.
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cloud_owner_id, sync_dirty_at)
+       VALUES ('s-mine-legacy', 'claude-code', 'done', datetime('now'), 'user-A', 1000)`,
+    ).run();
+    const fetchSpy = vi.fn(async () =>
+      cloudPayload([
+        { session_id: "s-mine-legacy", device_id: null, has_bytes: true },
+        { session_id: "s-other-pc", device_id: "dev-pc", has_bytes: true },
+      ]),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const applied = await svc.pull();
+    expect(applied).toBe(1);  // only s-other-pc
+    const rows = db.prepare(
+      `SELECT session_id FROM remote_sessions WHERE owner_id = ?`,
+    ).all("user-A") as Array<{ session_id: string }>;
+    expect(rows.map((r) => r.session_id)).toEqual(["s-other-pc"]);
+  });
+
   it("LWW: older cloud_updated_at does not overwrite newer local copy", async () => {
     const { db, profileBinding } = harness();
     profileBinding.bindToOwner("user-A");


### PR DESCRIPTION
## Why

Surfaced during 0.8.1-beta.3 dogfood (#441): after the device_id backfill landed, the very first reconcile ran pull-before-push, so cloud rows were still \`NULL\`-device_id when pull's filter (\`device_id !== mine\`) inspected them. Result: **67 of the user's own sessions self-mirrored into local \`remote_sessions\`**, where they'd later (if anything else iterated remote_sessions raw) be misread as "from another device."

Currently invisible to the UI thanks to the session_id de-dup in \`GET /api/sessions\`, but better defence-in-depth.

## What changes

- **\`pull()\` adds a second filter**: skip rows whose \`session_id\` already exists in the local \`sessions\` table. Catches NULL-device_id legacy data cleanly.
- **\`index.ts\` adds a startup cleanup**: \`DELETE FROM remote_sessions WHERE device_id = (my device) OR session_id IN (SELECT id FROM sessions)\`. Idempotent, runs every boot, cheap (single query).

## Tests

215/215 (1 new). New case: pull with a cloud row that has NULL \`device_id\` AND a local session of the same id — must be filtered, not upserted into remote_sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)