### PR TITLE
feat(sessions-sync): active-writer + catch-up resume + divergence

### DIFF
--- a/infra/auth-worker/migrations/0009_active_device.sql
+++ b/infra/auth-worker/migrations/0009_active_device.sql
@@ -1,0 +1,24 @@
+-- 0009_active_device.sql — active-writer tracking for cross-device sessions (#322).
+--
+-- A session belongs to one "active writer" device at a time. When a device
+-- resumes a session that another device was last working on, ownership
+-- atomically transfers to the resuming device. This drives the
+-- "Session is now active on Windows" UI signal and keeps the chunk chain
+-- linear (no parallel branches).
+--
+-- Pattern A from the design discussion: one session_id, one timeline.
+-- Forks only happen when a user explicitly chooses to keep divergent
+-- local edits as a new session — that flow doesn't touch this column.
+
+ALTER TABLE synced_session_metadata
+  ADD COLUMN active_device_id TEXT;
+
+-- Backfill: for sessions already in cloud at the time of this migration,
+-- the most recent writer is the only writer we know about. Use device_id
+-- (which 0008 already populates and 0.8.1-beta.3 backfilled). After this
+-- migration, every subsequent chunk PUT bumps active_device_id to the
+-- pushing device.
+UPDATE synced_session_metadata
+   SET active_device_id = device_id
+ WHERE active_device_id IS NULL
+   AND device_id IS NOT NULL;

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -494,9 +494,18 @@ async function handleSessionsBytesChunkPut(
   const plaintextSha256Header = req.headers.get("x-plaintext-sha256");
   const generationHeader = req.headers.get("x-bytes-generation");
   // x-bytes-device-id is optional for backwards-compat with clients pre-PR-2.x.
-  // When present, the worker bumps synced_session_metadata.active_device_id
-  // on every accepted chunk so any reader can tell who's currently writing.
-  const deviceIdHeader = req.headers.get("x-bytes-device-id");
+  // When present and well-formed, the worker bumps synced_session_metadata
+  // .active_device_id on every accepted chunk so any reader can tell who's
+  // currently writing. Clients generate it via crypto.randomUUID() (canonical
+  // lowercase UUID), so we enforce that shape — anything else is silently
+  // ignored to keep this back-compat (a malformed header doesn't fail the
+  // chunk write, it just doesn't bump the column).
+  const rawDeviceIdHeader = req.headers.get("x-bytes-device-id");
+  const deviceIdHeader =
+    rawDeviceIdHeader &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(rawDeviceIdHeader)
+      ? rawDeviceIdHeader
+      : null;
 
   if (!startOffsetHeader || !endOffsetHeader || !plaintextSha256Header || !generationHeader) {
     return jsonError(400, "missing_chunk_headers");

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -427,11 +427,13 @@ async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Respon
     session_id: string; device_id: string | null; agent: string; title: string | null;
     state: string; cwd: string | null; model: string | null; started_at: string;
     ended_at: string | null; last_event_at: string;
-    bytes_generation: number; has_bytes: number; updated_at: number;
+    bytes_generation: number; active_device_id: string | null;
+    has_bytes: number; updated_at: number;
   };
   const { results } = await env.DB.prepare(
     `SELECT m.session_id, m.device_id, m.agent, m.title, m.state, m.cwd, m.model,
-            m.started_at, m.ended_at, m.last_event_at, m.bytes_generation, m.updated_at,
+            m.started_at, m.ended_at, m.last_event_at, m.bytes_generation,
+            m.active_device_id, m.updated_at,
             CASE WHEN EXISTS (
               SELECT 1 FROM synced_session_chunks c
                WHERE c.owner_id = m.owner_id
@@ -491,6 +493,10 @@ async function handleSessionsBytesChunkPut(
   const endOffsetHeader = req.headers.get("x-chunk-end-offset");
   const plaintextSha256Header = req.headers.get("x-plaintext-sha256");
   const generationHeader = req.headers.get("x-bytes-generation");
+  // x-bytes-device-id is optional for backwards-compat with clients pre-PR-2.x.
+  // When present, the worker bumps synced_session_metadata.active_device_id
+  // on every accepted chunk so any reader can tell who's currently writing.
+  const deviceIdHeader = req.headers.get("x-bytes-device-id");
 
   if (!startOffsetHeader || !endOffsetHeader || !plaintextSha256Header || !generationHeader) {
     return jsonError(400, "missing_chunk_headers");
@@ -635,6 +641,25 @@ async function handleSessionsBytesChunkPut(
     return jsonError(500, "db_error");
   }
 
+  // Bump active_device_id to whoever just wrote (#322 Pattern A). The
+  // contiguity check above already enforces "you must be caught up to
+  // write" — by the time we get here, this device is genuinely the
+  // current writer. Header is optional for backwards-compat (pre-PR-2.x
+  // clients won't send it); when absent we leave the column alone.
+  if (deviceIdHeader) {
+    try {
+      await env.DB.prepare(
+        `UPDATE synced_session_metadata
+            SET active_device_id = ?
+          WHERE owner_id = ? AND session_id = ?`,
+      ).bind(deviceIdHeader, user.id, sessionId).run();
+    } catch (err) {
+      // Non-fatal — the chunk landed; the active_device_id bump is
+      // informational. Log and continue.
+      console.warn("[sessions] active_device_id update failed:", err);
+    }
+  }
+
   return jsonOk({
     ok: true,
     chunk_number: chunkNumber,
@@ -652,8 +677,13 @@ async function handleSessionsBytesManifestGet(
   if (!user) return jsonError(401, "sign_in_required");
   if (user.tier !== "pro") return jsonError(403, "pro_required");
 
-  const currentGen = await fetchCurrentGeneration(env, user.id, sessionId);
-  if (currentGen === null) return jsonError(404, "session_not_found");
+  const meta = await env.DB.prepare(
+    `SELECT bytes_generation, active_device_id
+       FROM synced_session_metadata
+      WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+  ).bind(user.id, sessionId).first<{ bytes_generation: number; active_device_id: string | null }>();
+  if (!meta) return jsonError(404, "session_not_found");
+  const currentGen = meta.bytes_generation;
 
   type Row = {
     chunk_number: number; start_offset: number; end_offset: number;
@@ -669,7 +699,16 @@ async function handleSessionsBytesManifestGet(
   const chunks = results ?? [];
   const totalSize = chunks.length > 0 ? chunks[chunks.length - 1]!.end_offset : 0;
   return jsonOk(
-    { bytes_generation: currentGen, total_size: totalSize, chunks },
+    {
+      bytes_generation: currentGen,
+      total_size: totalSize,
+      // active_device_id is the device that most recently wrote a chunk. NULL
+      // for sessions that pre-date the active_device tracking. Used by the
+      // client to surface "Session is active on <device>" and to decide
+      // whether resume should claim ownership.
+      active_device_id: meta.active_device_id,
+      chunks,
+    },
     200,
     { "cache-control": "private, no-store" },
   );

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS synced_session_metadata (
   ended_at          TEXT,
   last_event_at     TEXT    NOT NULL,
   bytes_generation  INTEGER NOT NULL DEFAULT 0,
+  active_device_id  TEXT,
   updated_at        INTEGER NOT NULL,
   PRIMARY KEY (owner_id, session_id)
 );

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -454,35 +454,59 @@ describe("active_device_id tracking + manifest exposure (#322 Pattern A)", () =>
   it("chunk PUT with x-bytes-device-id sets active_device_id; manifest GET returns it", async () => {
     const { token, userId } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
+    const macDeviceId = crypto.randomUUID();
     await registerSession(token, sid);
     const bytes = new TextEncoder().encode("from device A\n");
-    expect((await putChunk(token, sid, 1, bytes, 0, 0, "dev-mac-uuid")).res.status).toBe(200);
+    expect((await putChunk(token, sid, 1, bytes, 0, 0, macDeviceId)).res.status).toBe(200);
 
     // Manifest exposes the active_device_id.
     const manifestRes = await signedFetch(`/api/sessions/bytes/${sid}/manifest`, { method: "GET" }, token);
     const manifest = await manifestRes.json() as { active_device_id: string | null };
-    expect(manifest.active_device_id).toBe("dev-mac-uuid");
+    expect(manifest.active_device_id).toBe(macDeviceId);
 
     // Underlying D1 row confirms persistence.
     const row = await env.DB.prepare(
       `SELECT active_device_id FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
     ).bind(userId, sid).first<{ active_device_id: string }>();
-    expect(row?.active_device_id).toBe("dev-mac-uuid");
+    expect(row?.active_device_id).toBe(macDeviceId);
   });
 
   it("hand-off: a chunk PUT from a different device flips active_device_id", async () => {
     const { token, userId } = await makeProSession();
     const sid = `s-${crypto.randomUUID()}`;
+    const macDeviceId = crypto.randomUUID();
+    const winDeviceId = crypto.randomUUID();
     await registerSession(token, sid);
     const c1 = new TextEncoder().encode("first\n");
     const c2 = new TextEncoder().encode("second from Windows\n");
-    expect((await putChunk(token, sid, 1, c1, 0, 0, "dev-mac-uuid")).res.status).toBe(200);
-    expect((await putChunk(token, sid, 2, c2, c1.byteLength, 0, "dev-windows-uuid")).res.status).toBe(200);
+    expect((await putChunk(token, sid, 1, c1, 0, 0, macDeviceId)).res.status).toBe(200);
+    expect((await putChunk(token, sid, 2, c2, c1.byteLength, 0, winDeviceId)).res.status).toBe(200);
 
     const row = await env.DB.prepare(
       `SELECT active_device_id FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
     ).bind(userId, sid).first<{ active_device_id: string }>();
-    expect(row?.active_device_id).toBe("dev-windows-uuid");
+    expect(row?.active_device_id).toBe(winDeviceId);
+  });
+
+  it("malformed x-bytes-device-id is silently ignored (chunk still lands, column not touched)", async () => {
+    // Validation defends D1 from arbitrary garbage in active_device_id, but a
+    // malformed header is back-compat-friendly: the chunk PUT still succeeds,
+    // the column just isn't bumped. Defence-in-depth, not a hard reject.
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    const goodDeviceId = crypto.randomUUID();
+    await registerSession(token, sid);
+    // Seed a valid active_device_id first.
+    const c1 = new TextEncoder().encode("first\n");
+    expect((await putChunk(token, sid, 1, c1, 0, 0, goodDeviceId)).res.status).toBe(200);
+    // Now PUT chunk 2 with garbage in the header.
+    const c2 = new TextEncoder().encode("second\n");
+    expect((await putChunk(token, sid, 2, c2, c1.byteLength, 0, "not-a-uuid; DROP TABLE")).res.status).toBe(200);
+    // active_device_id remains the original well-formed value.
+    const row = await env.DB.prepare(
+      `SELECT active_device_id FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ active_device_id: string }>();
+    expect(row?.active_device_id).toBe(goodDeviceId);
   });
 
   it("chunk PUT without x-bytes-device-id leaves active_device_id unchanged (back-compat)", async () => {

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -64,21 +64,20 @@ async function putChunk(
   bytes: Uint8Array,
   startOffset: number,
   generation: number,
+  deviceId?: string,
 ): Promise<{ res: Response; sha: string }> {
   const sha = await sha256Hex(bytes);
+  const headers: Record<string, string> = {
+    "content-type": "application/octet-stream",
+    "x-chunk-start-offset": String(startOffset),
+    "x-chunk-end-offset": String(startOffset + bytes.byteLength),
+    "x-plaintext-sha256": sha,
+    "x-bytes-generation": String(generation),
+  };
+  if (deviceId) headers["x-bytes-device-id"] = deviceId;
   const res = await signedFetch(
     `/api/sessions/bytes/${sessionId}/chunk/${chunkNumber}`,
-    {
-      method: "PUT",
-      headers: {
-        "content-type": "application/octet-stream",
-        "x-chunk-start-offset": String(startOffset),
-        "x-chunk-end-offset": String(startOffset + bytes.byteLength),
-        "x-plaintext-sha256": sha,
-        "x-bytes-generation": String(generation),
-      },
-      body: bytes,
-    },
+    { method: "PUT", headers, body: bytes },
     token,
   );
   return { res, sha };
@@ -446,6 +445,61 @@ describe("PUT/GET /api/sessions/bytes/:id/chunk/:n (chunked-delta)", () => {
     const bytes = new TextEncoder().encode("nope");
     const res = await putChunk(intruder.token, sid, 1, bytes, 0, 0);
     expect(res.res.status).toBe(404);
+  });
+});
+
+describe("active_device_id tracking + manifest exposure (#322 Pattern A)", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("chunk PUT with x-bytes-device-id sets active_device_id; manifest GET returns it", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    const bytes = new TextEncoder().encode("from device A\n");
+    expect((await putChunk(token, sid, 1, bytes, 0, 0, "dev-mac-uuid")).res.status).toBe(200);
+
+    // Manifest exposes the active_device_id.
+    const manifestRes = await signedFetch(`/api/sessions/bytes/${sid}/manifest`, { method: "GET" }, token);
+    const manifest = await manifestRes.json() as { active_device_id: string | null };
+    expect(manifest.active_device_id).toBe("dev-mac-uuid");
+
+    // Underlying D1 row confirms persistence.
+    const row = await env.DB.prepare(
+      `SELECT active_device_id FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ active_device_id: string }>();
+    expect(row?.active_device_id).toBe("dev-mac-uuid");
+  });
+
+  it("hand-off: a chunk PUT from a different device flips active_device_id", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    const c1 = new TextEncoder().encode("first\n");
+    const c2 = new TextEncoder().encode("second from Windows\n");
+    expect((await putChunk(token, sid, 1, c1, 0, 0, "dev-mac-uuid")).res.status).toBe(200);
+    expect((await putChunk(token, sid, 2, c2, c1.byteLength, 0, "dev-windows-uuid")).res.status).toBe(200);
+
+    const row = await env.DB.prepare(
+      `SELECT active_device_id FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ active_device_id: string }>();
+    expect(row?.active_device_id).toBe("dev-windows-uuid");
+  });
+
+  it("chunk PUT without x-bytes-device-id leaves active_device_id unchanged (back-compat)", async () => {
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    // Seed an existing active_device_id (as the migration's backfill would have).
+    await env.DB.prepare(
+      `UPDATE synced_session_metadata SET active_device_id = 'pre-existing-device' WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).run();
+    const bytes = new TextEncoder().encode("from a back-compat client\n");
+    // No deviceId argument → header omitted.
+    expect((await putChunk(token, sid, 1, bytes, 0, 0)).res.status).toBe(200);
+    const row = await env.DB.prepare(
+      `SELECT active_device_id FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ active_device_id: string }>();
+    expect(row?.active_device_id).toBe("pre-existing-device");
   });
 });
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -228,6 +228,11 @@ export function initDb(userlandDir: string): Database.Database {
       PRIMARY KEY (owner_id, session_id)
     )
   `);
+  // Additive: active_device_id added in PR 2.x (active-writer tracking).
+  // Idempotent ALTER for installs that already have remote_sessions.
+  try {
+    db.exec(`ALTER TABLE remote_sessions ADD COLUMN active_device_id TEXT`);
+  } catch { /* already exists */ }
   db.exec(`CREATE INDEX IF NOT EXISTS remote_sessions_owner_last_event
              ON remote_sessions(owner_id, last_event_at DESC)`);
 

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -175,6 +175,8 @@ export async function tryHandleSessionRoute(
       lastEventAt: string;
       originDeviceId: string | null;
       jsonlAvailableLocally: boolean;
+      hasBytes: boolean;
+      activeDeviceId: string | null;
     }
     const sourcesById = new Map(sourceList.map((s) => [s.id, s]));
     const localPayload: MergedSessionPayload[] = rows.map((row) => {
@@ -196,6 +198,13 @@ export async function tryHandleSessionRoute(
         // Local sessions are by definition available on this device.
         originDeviceId: null,
         jsonlAvailableLocally: true,
+        // We don't track "is there a cloud chunk for this local session" here
+        // — that requires a cloud round-trip. For the UI, the
+        // jsonlAvailableLocally flag is the right gate. hasBytes mirrors that
+        // (the file is on disk, so there are bytes to read).
+        hasBytes: true,
+        // Local sessions are always actively written by this device.
+        activeDeviceId: null,
       };
     });
 
@@ -211,11 +220,11 @@ export async function tryHandleSessionRoute(
         session_id: string; device_id: string | null; agent: string; title: string | null;
         state: string; cwd: string | null; model: string | null; started_at: string;
         ended_at: string | null; last_event_at: string; has_bytes: number;
-        jsonl_local_path: string | null;
+        active_device_id: string | null; jsonl_local_path: string | null;
       };
       const remoteRows = db.prepare(
         `SELECT session_id, device_id, agent, title, state, cwd, model, started_at,
-                ended_at, last_event_at, has_bytes, jsonl_local_path
+                ended_at, last_event_at, has_bytes, active_device_id, jsonl_local_path
            FROM remote_sessions
           WHERE owner_id = ?
           ORDER BY last_event_at DESC`,
@@ -238,6 +247,8 @@ export async function tryHandleSessionRoute(
           originDeviceId: r.device_id,
           // Available locally only if the user has already reassembled it.
           jsonlAvailableLocally: r.jsonl_local_path !== null,
+          hasBytes: r.has_bytes === 1,
+          activeDeviceId: r.active_device_id,
         }));
     }
 
@@ -563,12 +574,26 @@ export async function tryHandleSessionRoute(
         }
 
         // 3. Reassemble chunks into the encoded jsonl path Claude Code expects.
+        // Three outcomes from the service:
+        //   - success: jsonl is on disk at localJsonlPath (or already was).
+        //   - throw "local_diverged": this device has unsynced edits past
+        //     cloud's chunk chain. Return 409 with a structured status so
+        //     the UI can surface "Local edits won't sync — fork or discard?".
+        //   - any other throw: 500 reassemble_failed.
         const localJsonlPath = join(projectsRoot(), encodeCwd(targetCwd), `${sessionId}.jsonl`);
         try {
           await sessionSync.reassembleSessionJsonl(sessionId, localJsonlPath);
         } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (message.includes("local_diverged")) {
+            sendJson(
+              { status: "local_diverged", localJsonlPath, message },
+              409,
+            );
+            return true;
+          }
           sendJson(
-            { error: "reassemble_failed", message: err instanceof Error ? err.message : String(err) },
+            { error: "reassemble_failed", message },
             500,
           );
           return true;

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -17,6 +17,7 @@ import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
 import {
   encodeCwd,
+  LocalDivergedError,
   projectsRoot,
   type SessionSyncService,
 } from "../session-sync-service.js";
@@ -576,7 +577,7 @@ export async function tryHandleSessionRoute(
         // 3. Reassemble chunks into the encoded jsonl path Claude Code expects.
         // Three outcomes from the service:
         //   - success: jsonl is on disk at localJsonlPath (or already was).
-        //   - throw "local_diverged": this device has unsynced edits past
+        //   - throw LocalDivergedError: this device has unsynced edits past
         //     cloud's chunk chain. Return 409 with a structured status so
         //     the UI can surface "Local edits won't sync — fork or discard?".
         //   - any other throw: 500 reassemble_failed.
@@ -585,7 +586,7 @@ export async function tryHandleSessionRoute(
           await sessionSync.reassembleSessionJsonl(sessionId, localJsonlPath);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          if (message.includes("local_diverged")) {
+          if (err instanceof LocalDivergedError) {
             sendJson(
               { status: "local_diverged", localJsonlPath, message },
               409,

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -427,20 +427,23 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
 
         let res: Response;
         try {
+          const headers: Record<string, string> = {
+            Cookie: `oyster_session=${session.token}`,
+            "content-type": "application/octet-stream",
+            "x-chunk-start-offset": String(startOffset),
+            "x-chunk-end-offset": String(endOffset),
+            "x-plaintext-sha256": hash,
+            "x-bytes-generation": String(generation),
+          };
+          // Stamp the writing device on every chunk so cloud can track who's
+          // active. Worker uses this to bump synced_session_metadata.
+          // active_device_id, which other devices read to render "Active on
+          // <device>" in their session list.
+          const myDeviceId = getMyDeviceId();
+          if (myDeviceId) headers["x-bytes-device-id"] = myDeviceId;
           res = await deps.fetch(
             `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/chunk/${nextChunkNumber}`,
-            {
-              method: "PUT",
-              headers: {
-                Cookie: `oyster_session=${session.token}`,
-                "content-type": "application/octet-stream",
-                "x-chunk-start-offset": String(startOffset),
-                "x-chunk-end-offset": String(endOffset),
-                "x-plaintext-sha256": hash,
-                "x-bytes-generation": String(generation),
-              },
-              body: chunkBody,
-            },
+            { method: "PUT", headers, body: chunkBody },
           );
         } catch (err) {
           console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} fetch failed for ${sessionId}:`, err);
@@ -460,10 +463,23 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
 
         // Per the worker's idempotency contract, an exact-match retry returns
         // 200 idempotent:true (not 409). So any non-200 here is a real
-        // problem (conflict, stale gen, non-contiguous) — log and abort.
-        // The next reconcile cycle re-derives state from the server's
-        // manifest and recovers.
-        console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} rejected (${res.status}) for ${sessionId}`);
+        // problem — most commonly a 409 because another device is now the
+        // active writer (Pattern A hand-off scenario): cloud already has
+        // chunk_number N+1 from them with different bytes, so this device's
+        // contiguous-offset push fails.
+        const body = await res.json().catch(() => null) as { error?: string } | null;
+        const reason = body?.error ?? `http_${res.status}`;
+        if (reason === "non_contiguous_start" || reason === "chunk_conflict" || reason === "stale_generation") {
+          // The user-facing framing for these all collapses to "this session
+          // was continued on another device or has divergent local edits."
+          // PR 3 surfaces this as a banner; for now a clear log is the only
+          // signal.
+          console.warn(
+            `[sessions] session=${sessionId.slice(0, 8)} chunk ${nextChunkNumber} rejected: ${reason} — session likely continued on another device or local jsonl has divergent edits. Next reconcile will refresh state.`,
+          );
+        } else {
+          console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} rejected (${res.status} ${reason}) for ${sessionId}`);
+        }
         break;
       }
     } catch (err) {
@@ -494,8 +510,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     `INSERT INTO remote_sessions
        (session_id, owner_id, device_id, agent, title, state, cwd, model,
         started_at, ended_at, last_event_at, bytes_generation, has_bytes,
-        cloud_updated_at, fetched_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        active_device_id, cloud_updated_at, fetched_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(owner_id, session_id) DO UPDATE SET
        device_id         = excluded.device_id,
        agent             = excluded.agent,
@@ -508,6 +524,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
        last_event_at     = excluded.last_event_at,
        bytes_generation  = excluded.bytes_generation,
        has_bytes         = excluded.has_bytes,
+       active_device_id  = excluded.active_device_id,
        cloud_updated_at  = excluded.cloud_updated_at,
        fetched_at        = excluded.fetched_at
      WHERE excluded.cloud_updated_at > remote_sessions.cloud_updated_at`,
@@ -544,6 +561,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       last_event_at: string;
       bytes_generation: number;
       has_bytes: boolean;
+      active_device_id: string | null;
       updated_at: number;
     };
     const body = await res.json().catch(() => null) as { sessions?: CloudSession[] } | null;
@@ -576,7 +594,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
         const info = upsertRemoteSession.run(
           s.session_id, session.user.id, s.device_id, s.agent, s.title, s.state,
           s.cwd, s.model, s.started_at, s.ended_at, s.last_event_at,
-          s.bytes_generation, s.has_bytes ? 1 : 0, s.updated_at, now,
+          s.bytes_generation, s.has_bytes ? 1 : 0, s.active_device_id ?? null,
+          s.updated_at, now,
         );
         if (info.changes > 0) applied++;
       }
@@ -623,7 +642,12 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       byte_count: number;
       plaintext_sha256: string;
     };
-    type Manifest = { bytes_generation: number; total_size: number; chunks: ManifestChunk[] };
+    type Manifest = {
+      bytes_generation: number;
+      total_size: number;
+      active_device_id: string | null;
+      chunks: ManifestChunk[];
+    };
 
     let manifest: Manifest;
     try {
@@ -648,15 +672,74 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       }
     }
 
-    // Write to a sibling .partial path first; rename on success. This means
-    // a mid-fetch crash leaves a discardable partial file instead of a
-    // half-baked jsonl masquerading as complete.
-    const partialPath = `${targetPath}.partial`;
-    await fs.mkdir(join(targetPath, ".."), { recursive: true }).catch(() => { /* exists */ });
-    const fh = await fs.open(partialPath, "w");
-    let writtenBytes = 0;
+    const expectedTotal = manifest.chunks[manifest.chunks.length - 1]!.end_offset;
+
+    // Probe the local file. Three states matter (Pattern A from the design):
+    //   1. No local file (or empty) → full fresh reassemble.
+    //   2. Local size == cloud total → no-op, session is already in sync.
+    //   3. Local size < cloud total AND aligns with a chunk boundary → catch up,
+    //      append the missing tail chunks.
+    //   4. Local size > cloud total → "local_diverged": this device has unsynced
+    //      edits past the cloud chunk chain. Block and surface conflict.
+    //   5. Local size doesn't match any chunk boundary → also divergent (mid-
+    //      chunk position from a prior crash or hand-edit).
+    let localSize = 0;
     try {
-      for (const meta of manifest.chunks) {
+      localSize = (await fs.stat(targetPath)).size;
+    } catch {
+      // No local file — fall through to full reassemble (localSize stays 0).
+    }
+
+    if (localSize === expectedTotal) {
+      // Already up-to-date — nothing to fetch. Just record the path.
+      updateRemoteSessionLocalPath.run(targetPath, session.user.id, sessionId);
+      console.log(
+        `[sessions] reassemble: session=${sessionId.slice(0, 8)} already up-to-date (${localSize} bytes)`,
+      );
+      return {
+        chunkCount: manifest.chunks.length,
+        totalBytes: localSize,
+        generation: manifest.bytes_generation,
+        targetPath,
+      };
+    }
+
+    if (localSize > expectedTotal) {
+      throw new Error(
+        `local_diverged: local jsonl is ${localSize} bytes but cloud chain is ${expectedTotal}. ` +
+        `This device has local-only edits past the cloud chunk chain. ` +
+        `Resolve by discarding local or forking to a new session.`,
+      );
+    }
+
+    // Find the first chunk we still need to fetch.
+    let firstIdx = 0;
+    if (localSize > 0) {
+      firstIdx = manifest.chunks.findIndex((c) => c.start_offset === localSize);
+      if (firstIdx < 0) {
+        throw new Error(
+          `local_diverged: local jsonl is ${localSize} bytes but no manifest chunk starts at that offset. ` +
+          `File is mid-chunk or contains bytes not present in any chunk.`,
+        );
+      }
+    }
+
+    // Two write strategies based on whether this is a fresh reassemble or a
+    // catch-up append:
+    //   - Fresh (firstIdx === 0): write to a .partial sibling then rename on
+    //     success, so a mid-fetch crash leaves a discardable artefact rather
+    //     than a half-baked jsonl masquerading as complete.
+    //   - Catch-up (firstIdx > 0): open the existing file in r+ mode, write
+    //     new chunks at their declared offsets. On failure, truncate back to
+    //     localSize so the file isn't left in a divergent state.
+    const isFresh = firstIdx === 0;
+    const writePath = isFresh ? `${targetPath}.partial` : targetPath;
+    await fs.mkdir(join(targetPath, ".."), { recursive: true }).catch(() => { /* exists */ });
+    const fh = await fs.open(writePath, isFresh ? "w" : "r+");
+    let writtenBytes = isFresh ? 0 : localSize;
+    try {
+      for (let i = firstIdx; i < manifest.chunks.length; i++) {
+        const meta = manifest.chunks[i]!;
         const url = `${deps.workerBase}/api/sessions/bytes/${encodeURIComponent(sessionId)}/chunk/${meta.chunk_number}`;
         const r = await deps.fetch(url, { headers: { Cookie: `oyster_session=${session.token}` } });
         if (!r.ok) {
@@ -675,32 +758,44 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       }
     } catch (err) {
       await fh.close().catch(() => { /* ignore */ });
-      await fs.unlink(partialPath).catch(() => { /* ignore */ });
+      if (isFresh) {
+        await fs.unlink(writePath).catch(() => { /* ignore */ });
+      } else {
+        // Best-effort rollback to the size we trusted at entry. Next call
+        // restarts the catch-up cleanly.
+        await fs.truncate(targetPath, localSize).catch(() => { /* ignore */ });
+      }
       throw err;
     }
     await fh.close();
 
-    // Final-size assertion: writtenBytes must equal the last chunk's end_offset
-    // (== sum of byte_counts == manifest.total_size).
-    const expectedTotal = manifest.chunks[manifest.chunks.length - 1]!.end_offset;
     if (writtenBytes !== expectedTotal) {
-      await fs.unlink(partialPath).catch(() => { /* ignore */ });
+      if (isFresh) {
+        await fs.unlink(writePath).catch(() => { /* ignore */ });
+      } else {
+        await fs.truncate(targetPath, localSize).catch(() => { /* ignore */ });
+      }
       throw new Error(`sessions reassemble: total size mismatch (wrote ${writtenBytes}, manifest says ${expectedTotal})`);
     }
 
-    // Atomic move into place.
-    await fs.rename(partialPath, targetPath);
+    if (isFresh) {
+      await fs.rename(writePath, targetPath);
+    }
 
-    // Record the local path in remote_sessions so subsequent UI checks can
-    // surface "already reassembled".
     updateRemoteSessionLocalPath.run(targetPath, session.user.id, sessionId);
 
-    console.log(
-      `[sessions] reassembled: session=${sessionId.slice(0, 8)} chunks=${manifest.chunks.length} bytes=${writtenBytes} → ${targetPath}`,
-    );
+    if (isFresh) {
+      console.log(
+        `[sessions] reassembled: session=${sessionId.slice(0, 8)} chunks=${manifest.chunks.length} bytes=${writtenBytes} → ${targetPath}`,
+      );
+    } else {
+      console.log(
+        `[sessions] reassembled (catch-up): session=${sessionId.slice(0, 8)} appended=${manifest.chunks.length - firstIdx} chunks new_bytes=${writtenBytes - localSize} total=${writtenBytes} → ${targetPath}`,
+      );
+    }
 
     return {
-      chunkCount: manifest.chunks.length,
+      chunkCount: manifest.chunks.length - firstIdx,
       totalBytes: writtenBytes,
       generation: manifest.bytes_generation,
       targetPath,

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -20,7 +20,7 @@
 
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { promises as fs } from "node:fs";
 import type Database from "better-sqlite3";
 import type { ProfileBindingService } from "./profile-binding-service.js";
@@ -51,7 +51,8 @@ export interface PushBytesResult {
 }
 
 export interface ReassembleResult {
-  /** Number of chunks fetched and concatenated. */
+  /** Number of chunks fetched and concatenated in this call. 0 on the no-op
+   *  branch (local already in sync), partial count on catch-up. */
   chunkCount: number;
   /** Total plaintext bytes written to disk (== manifest's final end_offset). */
   totalBytes: number;
@@ -59,6 +60,19 @@ export interface ReassembleResult {
   generation: number;
   /** Absolute path the jsonl was written to. */
   targetPath: string;
+}
+
+/** Thrown by reassembleSessionJsonl when the local jsonl can't be reconciled
+ *  with the cloud chunk chain (extra bytes past the chain, or mid-chunk
+ *  position from a prior crash). Callers should surface this as a 409 with a
+ *  structured `local_diverged` status so the UI can offer fork/discard.
+ *  Dedicated class so callers branch on `instanceof` instead of string-
+ *  matching the message. */
+export class LocalDivergedError extends Error {
+  readonly name = "LocalDivergedError";
+  constructor(message: string) {
+    super(message);
+  }
 }
 
 export interface SessionSyncService {
@@ -697,7 +711,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
         `[sessions] reassemble: session=${sessionId.slice(0, 8)} already up-to-date (${localSize} bytes)`,
       );
       return {
-        chunkCount: manifest.chunks.length,
+        chunkCount: 0,
         totalBytes: localSize,
         generation: manifest.bytes_generation,
         targetPath,
@@ -705,8 +719,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     }
 
     if (localSize > expectedTotal) {
-      throw new Error(
-        `local_diverged: local jsonl is ${localSize} bytes but cloud chain is ${expectedTotal}. ` +
+      throw new LocalDivergedError(
+        `local jsonl is ${localSize} bytes but cloud chain is ${expectedTotal}. ` +
         `This device has local-only edits past the cloud chunk chain. ` +
         `Resolve by discarding local or forking to a new session.`,
       );
@@ -717,8 +731,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     if (localSize > 0) {
       firstIdx = manifest.chunks.findIndex((c) => c.start_offset === localSize);
       if (firstIdx < 0) {
-        throw new Error(
-          `local_diverged: local jsonl is ${localSize} bytes but no manifest chunk starts at that offset. ` +
+        throw new LocalDivergedError(
+          `local jsonl is ${localSize} bytes but no manifest chunk starts at that offset. ` +
           `File is mid-chunk or contains bytes not present in any chunk.`,
         );
       }
@@ -734,7 +748,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     //     localSize so the file isn't left in a divergent state.
     const isFresh = firstIdx === 0;
     const writePath = isFresh ? `${targetPath}.partial` : targetPath;
-    await fs.mkdir(join(targetPath, ".."), { recursive: true }).catch(() => { /* exists */ });
+    await fs.mkdir(dirname(targetPath), { recursive: true }).catch(() => { /* exists */ });
     const fh = await fs.open(writePath, isFresh ? "w" : "r+");
     let writtenBytes = isFresh ? 0 : localSize;
     try {

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import Database from "better-sqlite3";
-import { createSessionSyncService } from "../src/session-sync-service.js";
+import { createSessionSyncService, LocalDivergedError } from "../src/session-sync-service.js";
 import { createProfileBindingService } from "../src/profile-binding-service.js";
 
 // Minimal DB harness: just the columns SessionSyncService reads from sessions
@@ -402,6 +402,8 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
     });
     const r = await svc.reassembleSessionJsonl("s-remote", targetPath);
     expect(r.totalBytes).toBe(c1.byteLength + c2.byteLength);
+    // No chunks fetched ⇒ chunkCount reports 0 (per ReassembleResult contract).
+    expect(r.chunkCount).toBe(0);
     expect(chunkFetches).toBe(0);
     // remote_sessions.jsonl_local_path is set even for no-op
     const row = db.prepare(
@@ -498,7 +500,7 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
       fetch: fetchSpy as unknown as typeof fetch,
     });
     await expect(svc.reassembleSessionJsonl("s-remote", targetPath))
-      .rejects.toThrow(/local_diverged/);
+      .rejects.toBeInstanceOf(LocalDivergedError);
     // Local file untouched
     const fs2 = require("node:fs");
     const after = fs2.readFileSync(targetPath) as Buffer;
@@ -539,7 +541,7 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
       fetch: fetchSpy as unknown as typeof fetch,
     });
     await expect(svc.reassembleSessionJsonl("s-remote", targetPath))
-      .rejects.toThrow(/local_diverged/);
+      .rejects.toBeInstanceOf(LocalDivergedError);
   });
 
   it("free user throws (pro-only)", async () => {

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -54,6 +54,7 @@ function harness() {
       last_event_at     TEXT NOT NULL,
       bytes_generation  INTEGER NOT NULL DEFAULT 0,
       has_bytes         INTEGER NOT NULL DEFAULT 0,
+      active_device_id  TEXT,
       cloud_updated_at  INTEGER NOT NULL,
       fetched_at        INTEGER NOT NULL,
       jsonl_local_path  TEXT,
@@ -360,6 +361,185 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
       `SELECT jsonl_local_path FROM remote_sessions WHERE owner_id = ? AND session_id = ?`,
     ).get("user-A", "s-remote") as { jsonl_local_path: string | null };
     expect(row.jsonl_local_path).toBeNull();
+  });
+
+  it("catch-up: existing local file equal to cloud total is a no-op (no chunk fetches)", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "already-synced.jsonl");
+    const c1 = new TextEncoder().encode("event one\n");
+    const c2 = new TextEncoder().encode("event two\n");
+
+    // Pre-populate the local file with the exact contents the manifest will
+    // describe. Catch-up should detect local == cloud and skip fetches.
+    const fs = require("node:fs");
+    fs.writeFileSync(targetPath, Buffer.concat([c1, c2]));
+
+    let chunkFetches = 0;
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 0,
+          total_size: c1.byteLength + c2.byteLength,
+          active_device_id: "dev-mac",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: c1.byteLength, byte_count: c1.byteLength, plaintext_sha256: hash(c1) },
+            { chunk_number: 2, start_offset: c1.byteLength, end_offset: c1.byteLength + c2.byteLength, byte_count: c2.byteLength, plaintext_sha256: hash(c2) },
+          ],
+        }), { status: 200 });
+      }
+      if (u.includes("/chunk/")) chunkFetches++;
+      return new Response("should not fetch", { status: 500 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const r = await svc.reassembleSessionJsonl("s-remote", targetPath);
+    expect(r.totalBytes).toBe(c1.byteLength + c2.byteLength);
+    expect(chunkFetches).toBe(0);
+    // remote_sessions.jsonl_local_path is set even for no-op
+    const row = db.prepare(
+      `SELECT jsonl_local_path FROM remote_sessions WHERE owner_id = ? AND session_id = ?`,
+    ).get("user-A", "s-remote") as { jsonl_local_path: string };
+    expect(row.jsonl_local_path).toBe(targetPath);
+  });
+
+  it("catch-up: local at chunk-1 boundary fetches only the missing tail (chunk 2+)", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "behind.jsonl");
+    const c1 = new TextEncoder().encode("first\n");
+    const c2 = new TextEncoder().encode("second\n");
+    const c3 = new TextEncoder().encode("third\n");
+
+    // Local has chunks 1 only.
+    const fs = require("node:fs");
+    fs.writeFileSync(targetPath, c1);
+
+    const chunkFetches: number[] = [];
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 0,
+          total_size: c1.byteLength + c2.byteLength + c3.byteLength,
+          active_device_id: "dev-pc",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: c1.byteLength, byte_count: c1.byteLength, plaintext_sha256: hash(c1) },
+            { chunk_number: 2, start_offset: c1.byteLength, end_offset: c1.byteLength + c2.byteLength, byte_count: c2.byteLength, plaintext_sha256: hash(c2) },
+            { chunk_number: 3, start_offset: c1.byteLength + c2.byteLength, end_offset: c1.byteLength + c2.byteLength + c3.byteLength, byte_count: c3.byteLength, plaintext_sha256: hash(c3) },
+          ],
+        }), { status: 200 });
+      }
+      const m = u.match(/\/chunk\/(\d+)$/);
+      if (m) {
+        const n = Number(m[1]);
+        chunkFetches.push(n);
+        const bytes = n === 2 ? c2 : n === 3 ? c3 : c1;
+        return new Response(bytes, { status: 200 });
+      }
+      return new Response("not_found", { status: 404 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    const r = await svc.reassembleSessionJsonl("s-remote", targetPath);
+    // Only chunks 2 + 3 fetched; chunk 1 reused from local.
+    expect(chunkFetches.sort()).toEqual([2, 3]);
+    expect(r.chunkCount).toBe(2);
+    expect(r.totalBytes).toBe(c1.byteLength + c2.byteLength + c3.byteLength);
+
+    const fs2 = require("node:fs");
+    const reassembled = fs2.readFileSync(targetPath) as Buffer;
+    expect(reassembled.equals(Buffer.concat([c1, c2, c3]))).toBe(true);
+  });
+
+  it("divergence: local jsonl larger than cloud total throws local_diverged", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "divergent.jsonl");
+    const c1 = new TextEncoder().encode("first\n");
+    const local = new TextEncoder().encode("first\nlocal-only-edits-not-in-cloud\n");
+
+    const fs = require("node:fs");
+    fs.writeFileSync(targetPath, local);
+
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 0,
+          total_size: c1.byteLength,
+          active_device_id: "dev-pc",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: c1.byteLength, byte_count: c1.byteLength, plaintext_sha256: hash(c1) },
+          ],
+        }), { status: 200 });
+      }
+      return new Response("should not fetch", { status: 500 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await expect(svc.reassembleSessionJsonl("s-remote", targetPath))
+      .rejects.toThrow(/local_diverged/);
+    // Local file untouched
+    const fs2 = require("node:fs");
+    const after = fs2.readFileSync(targetPath) as Buffer;
+    expect(after.equals(local)).toBe(true);
+  });
+
+  it("divergence: local jsonl mid-chunk (no matching boundary) throws local_diverged", async () => {
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "mid-chunk.jsonl");
+    const c1 = new TextEncoder().encode("aaaaa");  // 5 bytes
+    const c2 = new TextEncoder().encode("bbbbb");  // 5 bytes
+    // Local has 7 bytes — doesn't match either boundary (0, 5, 10).
+    const fs = require("node:fs");
+    fs.writeFileSync(targetPath, new TextEncoder().encode("aaaaabb"));
+
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 0,
+          total_size: 10,
+          active_device_id: "dev-pc",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: 5, byte_count: 5, plaintext_sha256: hash(c1) },
+            { chunk_number: 2, start_offset: 5, end_offset: 10, byte_count: 5, plaintext_sha256: hash(c2) },
+          ],
+        }), { status: 200 });
+      }
+      return new Response("should not fetch", { status: 500 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await expect(svc.reassembleSessionJsonl("s-remote", targetPath))
+      .rejects.toThrow(/local_diverged/);
   });
 
   it("free user throws (pro-only)", async () => {

--- a/server/test/sessions-resume-route.test.ts
+++ b/server/test/sessions-resume-route.test.ts
@@ -32,7 +32,8 @@ function makeDb(): Database.Database {
       agent TEXT NOT NULL, title TEXT, state TEXT NOT NULL, cwd TEXT,
       model TEXT, started_at TEXT NOT NULL, ended_at TEXT,
       last_event_at TEXT NOT NULL, bytes_generation INTEGER NOT NULL DEFAULT 0,
-      has_bytes INTEGER NOT NULL DEFAULT 0, cloud_updated_at INTEGER NOT NULL,
+      has_bytes INTEGER NOT NULL DEFAULT 0, active_device_id TEXT,
+      cloud_updated_at INTEGER NOT NULL,
       fetched_at INTEGER NOT NULL, jsonl_local_path TEXT,
       PRIMARY KEY (owner_id, session_id)
     );

--- a/server/test/sessions-resume-route.test.ts
+++ b/server/test/sessions-resume-route.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { tryHandleSessionRoute } from "../src/routes/sessions.js";
+import { LocalDivergedError } from "../src/session-sync-service.js";
 
 // Fake req/res/ctx mirrors the shape in pin-route.test.ts.
 function fakeCtx(body: unknown = {}) {
@@ -68,10 +69,13 @@ function insertSource(db: Database.Database, id: string, path: string, spaceId =
   ).run(id, spaceId, path);
 }
 
-function stubSessionSync(behaviour: "success" | "throw" = "success") {
+function stubSessionSync(behaviour: "success" | "throw" | "diverged" = "success") {
   return {
     reassembleSessionJsonl: vi.fn(async (sessionId: string, targetPath: string) => {
       if (behaviour === "throw") throw new Error("simulated reassembly failure");
+      if (behaviour === "diverged") {
+        throw new LocalDivergedError("local jsonl is 99 bytes but cloud chain is 42");
+      }
       return { chunkCount: 1, totalBytes: 42, generation: 0, targetPath };
     }),
     // Unused but interface requires them.
@@ -247,6 +251,26 @@ describe("POST /api/sessions/:id/resume", () => {
       error: "reassemble_failed",
       message: "simulated reassembly failure",
     });
+  });
+
+  it("409 local_diverged when the service throws LocalDivergedError", async () => {
+    // Same setup as the generic 500 test, but the stub throws the dedicated
+    // class so the route branches into the structured response shape rather
+    // than the catch-all 500. Verifies instanceof-based dispatch.
+    const realDir = mkdtempSync(join(tmpdir(), "oyster-route-diverged-"));
+    insertRemote(db, { sessionId: "div-1", ownerId: "user-A", cwd: realDir, hasBytes: true });
+    insertSource(db, "src-1", realDir);
+    const sync = stubSessionSync("diverged");
+    const { ctx, captured } = fakeCtx({});
+    const req = { method: "POST" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/div-1/resume",
+      ctx as any, baseDeps(db, { ownerId: "user-A", sessionSync: sync }));
+    expect(captured.status).toBe(409);
+    expect(captured.json).toMatchObject({
+      status: "local_diverged",
+      message: expect.stringContaining("local jsonl is 99 bytes"),
+    });
+    expect((captured.json as { localJsonlPath: string }).localJsonlPath).toMatch(/div-1\.jsonl$/);
   });
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -114,6 +114,15 @@ export interface Session {
   /** True for local sessions; true for remote sessions whose jsonl has
    *  already been reassembled to disk on this device; false otherwise. */
   jsonlAvailableLocally?: boolean;
+  /** True when cloud has at least one chunk for this session at the current
+   *  generation. False for sessions that have only metadata in cloud (chunks
+   *  not yet uploaded, or never had any). The UI greys out "Resume on this
+   *  device" when this is false on a remote row. */
+  hasBytes?: boolean;
+  /** The device that most recently wrote a chunk for this session. Drives
+   *  "Active on <device>" chip in the UI. Null for sessions that pre-date
+   *  active-writer tracking. */
+  activeDeviceId?: string | null;
 }
 
 /** POST /api/sessions/:id/resume response shapes. */
@@ -121,7 +130,11 @@ export type SessionResumeResponse =
   | { status: "ok"; sessionId: string; localCwd: string; jsonlPath: string; command: string }
   | { status: "needs_target"; remoteCwd: string | null; suggestedSpaceId: string | null }
   | { status: "pick_source"; candidates: Array<{ path: string; label: string | null }>; remoteCwd: string | null }
-  | { status: "validation_warning"; reasons: string[] };
+  | { status: "validation_warning"; reasons: string[] }
+  /** Local jsonl has bytes past cloud's chunk chain — either real divergent
+   *  edits or a mid-chunk file from a prior crash. UI must offer "discard
+   *  local" or "fork as new session" to resolve. */
+  | { status: "local_diverged"; localJsonlPath: string; message: string };
 
 export type SessionEventRole =
   | "user"


### PR DESCRIPTION
## Why

User design call: Pattern A (one session_id follows you across devices) with real "cloud-head awareness" — resume should catch up to cloud rather than replace, and divergence should surface as a structured conflict rather than silently losing the loser's bytes.

Closes the design gap from the previous dogfood: after a Mac→Windows hand-off and a continuation on Windows, if Mac were to also keep typing on the same session_id, its push would silently 409 and Mac's new bytes would never reach cloud. This PR turns that into a clear, surfaceable signal.

## What changes

### Cloud

- **Migration 0009** adds \`synced_session_metadata.active_device_id\`. Backfills from \`device_id\` for the 72 existing rows.
- **Chunk PUT** accepts new \`x-bytes-device-id\` header. Bumps \`active_device_id\` on every accepted chunk (no change if header omitted — back-compat).
- **Manifest GET** + **Metadata GET** surface \`active_device_id\`.

### Server (\`session-sync-service.ts\`)

- **\`pushBytes\`** stamps \`x-bytes-device-id\` on every chunk PUT.
- **\`reassembleSessionJsonl\`** is now catch-up aware:
  - local == cloud → no-op (no chunk fetches)
  - local < cloud AND aligns with a chunk boundary → append tail
  - local > cloud OR mid-chunk → throw \`local_diverged\`
  - On catch-up failure: truncate back to entry size (re-entrant)
- 409 from push classifies the reason and emits a clear log line about session moved / divergent edits.

### Server (\`routes/sessions.ts\`)

- POST \`/resume\` returns structured \`{ status: "local_diverged", localJsonlPath, message }\` (409) for the divergent case.
- GET \`/api/sessions\` adds \`hasBytes\` + \`activeDeviceId\` per row (PR 3 will use these to enable/disable Resume + render "Active on <device>" chip).

### Types

- \`Session\` gains \`hasBytes\` + \`activeDeviceId\`.
- \`SessionResumeResponse\` gains the \`local_diverged\` variant.

## Tests

**265 total** (219 server + 46 worker, +7 new).

Worker:
- chunk PUT with device_id header sets active_device_id
- hand-off (different device on chunk 2) flips it
- chunk PUT without header leaves it unchanged (back-compat)

Server reassemble:
- local == cloud: no-op, zero chunk fetches
- local at chunk-1 boundary: fetches only chunks 2+, file ends up correct
- local > cloud: throws \`local_diverged\`, file untouched
- local mid-chunk (no boundary match): throws \`local_diverged\`

## Pre-deploy checklist (cloud)

\`\`\`bash
npx wrangler d1 execute oyster-auth --remote \\
  --file infra/auth-worker/migrations/0009_active_device.sql
npx wrangler deploy --config infra/oyster-cloud/wrangler.toml
\`\`\`

The backfill runs as part of the migration — every existing session's \`active_device_id\` is set to its previous \`device_id\`. From the next chunk push on, cloud tracks ownership live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)