### PR TITLE
fix(watcher): resolve session cwd from jsonl path, not events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Resumed cross-device sessions sync their continuations back to the cloud.** After resuming another device's session locally, the watcher was capturing the origin device's working directory and the session would silently fail to push its new turns. The watcher now reads the working directory from the file's actual on-disk location, so a session resumed on Mac continues backing up cleanly — and a third device can pick it up from where Mac left it.
+
 ## [0.8.1-beta.5] - 2026-05-12
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,6 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-8-1-beta-5">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
@@ -324,6 +325,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Resumed cross-device sessions sync their continuations back to the cloud.</strong> After resuming another device&#39;s session locally, the watcher was capturing the origin device&#39;s working directory and the session would silently fail to push its new turns. The watcher now reads the working directory from the file&#39;s actual on-disk location, so a session resumed on Mac continues backing up cleanly — and a third device can pick it up from where Mac left it.</li>
+</ul>
 <h2 id="v-0-8-1-beta-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.4...v0.8.1-beta.5" rel="noopener noreferrer"><span class="release-version">0.8.1-beta.5</span></a><span class="release-date"> — 2026-05-12</span></h2>
 <h3>Added</h3>
 <ul>

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import chokidar, { type FSWatcher } from "chokidar";
 import type { ArtifactStore } from "../artifact-store.js";
 import type { SpaceStore } from "../space-store.js";
@@ -11,6 +11,7 @@ import type {
   SessionState,
   SessionStore,
 } from "../session-store.js";
+import { encodeCwd } from "../session-sync-service.js";
 import { activeClaudeCwdCounts } from "./claude-process-probe.js";
 
 // claude-code session log watcher (Sprint 2 of the 0.5.0 sessions arc).
@@ -425,7 +426,11 @@ export class ClaudeCodeWatcher {
     const sessionIdFromName = filenameToSessionId(filePath);
     if (!sessionIdFromName) return null;
 
-    let cwd: string | null = null;
+    // Collect every ev.cwd we see (head + tail). After scanning, run them
+    // through pickJsonlCwd which picks the latest cwd whose encoding matches
+    // this file's actual on-disk parent directory. That lets cross-device
+    // resumes ignore the origin device's cwd embedded in early events.
+    const cwdCandidates: string[] = [];
     let startedAt: string | null = null;
     let model: string | null = null;
     let customTitle: string | null = null;
@@ -439,7 +444,7 @@ export class ClaudeCodeWatcher {
       const ev = safeParse(line);
       if (!ev) continue;
 
-      if (cwd === null && typeof ev.cwd === "string") cwd = ev.cwd;
+      if (typeof ev.cwd === "string") cwdCandidates.push(ev.cwd);
       if (startedAt === null && typeof ev.timestamp === "string") startedAt = ev.timestamp;
       if (model === null && ev.type === "assistant" && ev.message?.model) {
         model = String(ev.message.model);
@@ -459,6 +464,7 @@ export class ClaudeCodeWatcher {
 
     // Pass 2 — tail: take the LAST customTitle / agentName so user renames
     // override the auto-generated slug-style ones written near the start.
+    // Also picks up post-resume cwd updates that landed past the head window.
     // Skip the first line of the tail buffer since reads at an arbitrary
     // byte offset usually start mid-line.
     if (tail) {
@@ -468,6 +474,7 @@ export class ClaudeCodeWatcher {
         if (!line) continue;
         const ev = safeParse(line);
         if (!ev) continue;
+        if (typeof ev.cwd === "string") cwdCandidates.push(ev.cwd);
         if (ev.type === "custom-title" && typeof ev.customTitle === "string") {
           const t = ev.customTitle.trim().slice(0, TITLE_MAX);
           if (t) customTitle = t;
@@ -479,6 +486,7 @@ export class ClaudeCodeWatcher {
       }
     }
 
+    const cwd = pickJsonlCwd(filePath, cwdCandidates);
     return { sessionId: sessionIdFromName, cwd, startedAt, model, customTitle, agentName, userMessageTitle, slug };
   }
 
@@ -582,6 +590,12 @@ export class ClaudeCodeWatcher {
     let latestTimestamp: string | null = null;
     let sessionEnsured = false;
     let titleChanged = false;
+    // Encoded form of the file's parent dir — used to validate any cwd
+    // we'd otherwise pull from events. After cross-device resume, early
+    // events still carry the origin device's cwd; only later events from
+    // the local device match this encoding. Hoisted out of the loop since
+    // it's the same for every line.
+    const parentDir = basename(dirname(filePath));
 
     for (const line of lines) {
       if (!line) continue;
@@ -594,7 +608,12 @@ export class ClaudeCodeWatcher {
         // on a `custom-title` event that may be later in the file. We track
         // four title sources and keep upgrading whenever a higher-priority
         // one shows up (custom > agent-name > user message > slug).
-        if (!tracker.cwd && typeof ev.cwd === "string") tracker.cwd = ev.cwd;
+        // Cwd update: always accept a new ev.cwd if its encoding matches
+        // this file's parent dir. Lets a resumed session correct an earlier
+        // (origin-device) cwd captured at boot/onFileAppeared time.
+        if (typeof ev.cwd === "string" && encodeCwd(ev.cwd) === parentDir && ev.cwd !== tracker.cwd) {
+          tracker.cwd = ev.cwd;
+        }
         if (!tracker.startedAt && typeof ev.timestamp === "string") {
           tracker.startedAt = ev.timestamp;
         }
@@ -817,6 +836,33 @@ export function filenameToSessionId(filePath: string): string {
   // Filename is `<uuid>.jsonl`. The UUID is the session id.
   const base = basename(filePath);
   return base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
+}
+
+/** Resolve the local cwd for a jsonl from the candidate cwds embedded in
+ *  its events, validated against the file's actual parent-dir encoding.
+ *
+ *  Why: cross-device resume copies a jsonl whose early events still carry
+ *  the origin device's cwd (e.g. Windows "C:\\Users\\matth"). Naively
+ *  taking the first ev.cwd poisons the local sessions row with the origin
+ *  cwd, and pushBytes then computes a non-existent local path. Instead
+ *  we trust the on-disk path: only accept candidates whose encoding
+ *  matches the file's parent-dir name, and prefer the latest match so
+ *  cwd-changes mid-session (legitimate within one device) still win.
+ *  Returns null when nothing matches — caller falls back to the existing
+ *  "no cwd, skip" branch in pushBytes / source resolution. */
+export function pickJsonlCwd(
+  filePath: string,
+  candidates: Array<string | null | undefined>,
+): string | null {
+  const parent = basename(dirname(filePath));
+  // dirname("abc.jsonl") returns "." so basename(".") === "." — reject that.
+  if (!parent || parent === "." || parent === "/") return null;
+  let chosen: string | null = null;
+  for (const c of candidates) {
+    if (typeof c !== "string" || c.length === 0) continue;
+    if (encodeCwd(c) === parent) chosen = c;
+  }
+  return chosen;
 }
 
 function safeParse(line: string): Record<string, any> | null {

--- a/server/test/watchers-cwd.test.ts
+++ b/server/test/watchers-cwd.test.ts
@@ -1,0 +1,58 @@
+// pickJsonlCwd unit tests — recovers the local cwd for a jsonl file by
+// matching the file's parent-dir encoding against candidate cwds from the
+// events inside. Critical for cross-device resume: after Device B resumes
+// a Device A session, the jsonl's early events have Device A's cwd, but the
+// file lives at Device B's encoded path on disk. Old behaviour (take the
+// first ev.cwd) poisoned the sessions row with the origin device's cwd
+// and broke pushBytes forever after.
+import { describe, it, expect } from "vitest";
+import { pickJsonlCwd } from "../src/watchers/claude-code.js";
+
+describe("pickJsonlCwd", () => {
+  it("returns null when no candidates", () => {
+    const path = "/Users/me/.claude/projects/-Users-me-proj/abc.jsonl";
+    expect(pickJsonlCwd(path, [])).toBeNull();
+  });
+
+  it("returns null when no candidate encodes to the dir name", () => {
+    // File is in `-Users-me-proj` but candidates are all foreign cwds.
+    const path = "/Users/me/.claude/projects/-Users-me-proj/abc.jsonl";
+    const candidates = ["C:\\Users\\matth", "/home/foo"];
+    expect(pickJsonlCwd(path, candidates)).toBeNull();
+  });
+
+  it("returns the only matching candidate", () => {
+    const path = "/Users/me/.claude/projects/-Users-me-proj/abc.jsonl";
+    expect(pickJsonlCwd(path, ["/Users/me/proj"])).toBe("/Users/me/proj");
+  });
+
+  it("returns the LAST matching candidate (so user-renames / cwd-changes win over stale early events)", () => {
+    const path = "/Users/me/.claude/projects/-Users-me-proj/abc.jsonl";
+    // Two events with the same effective cwd — could happen if a session
+    // touches a sibling working tree mid-session. We take the later one.
+    const candidates = ["/Users/me/proj", "/Users/me/proj"];
+    expect(pickJsonlCwd(path, candidates)).toBe("/Users/me/proj");
+  });
+
+  it("ignores foreign-device cwds and returns the local one (resume scenario)", () => {
+    // Mac-resumed Windows session: file lives at Mac encoded path, jsonl
+    // head has Windows cwd, Mac events appended later have Mac cwd.
+    const path = "/Users/Matthew.Slight/.claude/projects/-Users-Matthew-Slight-Dev-oyster-os/abc.jsonl";
+    const candidates = [
+      "C:\\Users\\matth",                        // Windows-origin, won't encode to the Mac dir
+      "C:\\Users\\matth",
+      "/Users/Matthew.Slight/Dev/oyster-os",     // Mac event appended post-resume — matches
+    ];
+    expect(pickJsonlCwd(path, candidates)).toBe("/Users/Matthew.Slight/Dev/oyster-os");
+  });
+
+  it("skips null / undefined entries", () => {
+    const path = "/Users/me/.claude/projects/-Users-me-proj/abc.jsonl";
+    expect(pickJsonlCwd(path, [null, undefined, "/Users/me/proj", null])).toBe("/Users/me/proj");
+  });
+
+  it("handles paths with no parent dir gracefully", () => {
+    // Defensive — should never happen in practice but the helper shouldn't crash.
+    expect(pickJsonlCwd("abc.jsonl", ["/Users/me/proj"])).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

After resuming a cross-device session locally (e.g. resuming a Windows session on Mac), the watcher captured the **origin device's** cwd — \"C:\\Users\\matth\" — and locked it in. \`pushBytes\` then looked for the jsonl under that encoded Windows path on disk, hit ENOENT, and the resuming device's continuations never made it back to the cloud.

Dogfooded live in oyster-os@0.8.1-beta.5:
\`\`\`
[sessions] pushBytes: cannot stat /Users/Matthew.Slight/.claude/projects/C--Users-matth/c90da198-...jsonl: ENOENT
\`\`\`

So bidirectional cross-device handoff was silently broken: Mac could resume Windows sessions and read them, but anything Mac added afterward never synced — Windows could never see Mac's continuation.

## The fix

The jsonl's location on disk is the authoritative source of truth for the local cwd. The watcher now:

1. Collects every \`ev.cwd\` candidate from head + tail.
2. Picks the **latest** candidate whose \`encodeCwd()\` matches the file's actual parent directory.
3. In the live update path, accepts incoming \`ev.cwd\` only when it matches the file's parent dir AND differs from the current tracker cwd (so stale rows self-heal as soon as a new turn lands locally).

Foreign-device cwds simply don't encode-match and are ignored. No schema change, no migration — existing poisoned rows self-heal on next boot.

## Test plan

- [x] 7 new unit tests for the pure \`pickJsonlCwd\` helper (no-candidates, no-match, single-match, last-match-wins, resume scenario, null-skipping, defensive no-parent-dir)
- [x] All 227 server tests pass (was 220)
- [x] tsc strict clean
- [ ] Manual: ship as 0.8.1-beta.6, reinstall, run the resume scenario from beta.5's verification — \`pushBytes\` should no longer ENOENT after resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)