### PR TITLE
fix(sessions): store jsonl_path on sessions, use in pushBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
-- **Resumed cross-device sessions sync their continuations back to the cloud.** After resuming another device's session locally, the watcher was capturing the origin device's working directory and the session would silently fail to push its new turns. The watcher now reads the working directory from the file's actual on-disk location, so a session resumed on Mac continues backing up cleanly — and a third device can pick it up from where Mac left it.
+- **Resumed cross-device sessions sync their continuations back to the cloud.** After resuming another device's session locally, the original fix in beta.6 wasn't enough: Claude Code preserves the origin device's working directory in every event it writes, even on the resuming device, so the watcher had no event-side signal to recover from. Oyster now tracks each session's actual on-disk transcript path directly, bypassing the working-directory mismatch entirely. A Mac-resumed Windows session now backs up cleanly, and a third device can pick it up from where Mac left it. Existing poisoned rows self-heal on the next boot.
 
 ## [0.8.1-beta.5] - 2026-05-12
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -328,7 +328,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Fixed</h3>
 <ul>
-<li><strong>Resumed cross-device sessions sync their continuations back to the cloud.</strong> After resuming another device&#39;s session locally, the watcher was capturing the origin device&#39;s working directory and the session would silently fail to push its new turns. The watcher now reads the working directory from the file&#39;s actual on-disk location, so a session resumed on Mac continues backing up cleanly — and a third device can pick it up from where Mac left it.</li>
+<li><strong>Resumed cross-device sessions sync their continuations back to the cloud.</strong> After resuming another device&#39;s session locally, the original fix in beta.6 wasn&#39;t enough: Claude Code preserves the origin device&#39;s working directory in every event it writes, even on the resuming device, so the watcher had no event-side signal to recover from. Oyster now tracks each session&#39;s actual on-disk transcript path directly, bypassing the working-directory mismatch entirely. A Mac-resumed Windows session now backs up cleanly, and a third device can pick it up from where Mac left it. Existing poisoned rows self-heal on the next boot.</li>
 </ul>
 <h2 id="v-0-8-1-beta-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.4...v0.8.1-beta.5" rel="noopener noreferrer"><span class="release-version">0.8.1-beta.5</span></a><span class="release-date"> — 2026-05-12</span></h2>
 <h3>Added</h3>

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -456,6 +456,13 @@ export function initDb(userlandDir: string): Database.Database {
     "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE sessions ADD COLUMN jsonl_chunk_count INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE sessions ADD COLUMN bytes_generation INTEGER NOT NULL DEFAULT 0",
+    // Absolute on-disk path to the session's jsonl file. The watcher knows
+    // this directly (it's the chokidar event path); pushBytes used to
+    // recompute it as `projectsRoot()/encodeCwd(cwd)/<id>.jsonl`, which
+    // breaks for cross-device resumed sessions where the events still carry
+    // the origin device's cwd (e.g. "C:\\Users\\matth" on a Mac-resumed
+    // Windows session). Storing the real path is the only ground truth.
+    "ALTER TABLE sessions ADD COLUMN jsonl_path TEXT",
   ]) {
     try { db.exec(sql); } catch { /* already exists */ }
   }

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -23,6 +23,10 @@ export interface SessionRow {
   space_id: string | null;
   source_id: string | null;
   cwd: string | null;
+  /** Absolute on-disk path to the jsonl. NULL on rows that pre-date this
+   *  column (back-compat) — pushBytes falls back to computing from cwd in
+   *  that case. */
+  jsonl_path: string | null;
   agent: SessionAgent;
   title: string | null;
   state: SessionState;
@@ -71,6 +75,12 @@ export interface InsertSession {
   space_id: string | null;
   source_id?: string | null;
   cwd?: string | null;
+  /** Absolute path to the jsonl file on disk. The watcher knows this from
+   *  its chokidar events; passing it on every upsert lets pushBytes locate
+   *  the file directly instead of recomputing it from cwd. Required for
+   *  cross-device resumed sessions where the events carry the origin
+   *  device's cwd, not the actual local file location. */
+  jsonl_path?: string | null;
   agent: SessionAgent;
   title?: string | null;
   state: SessionState;
@@ -170,9 +180,9 @@ export class SqliteSessionStore implements SessionStore {
         LIMIT 1
       `),
       insertSession: db.prepare(`
-        INSERT INTO sessions (id, space_id, source_id, cwd, agent, title, state, started_at, model, last_event_at)
+        INSERT INTO sessions (id, space_id, source_id, cwd, jsonl_path, agent, title, state, started_at, model, last_event_at)
         VALUES (
-          @id, @space_id, @source_id, @cwd, @agent, @title, @state,
+          @id, @space_id, @source_id, @cwd, @jsonl_path, @agent, @title, @state,
           COALESCE(@started_at, datetime('now')),
           @model,
           COALESCE(@last_event_at, datetime('now'))
@@ -189,9 +199,9 @@ export class SqliteSessionStore implements SessionStore {
       // reconcileExistingFile), so the overwrite here keeps the column
       // shape consistent across rows.
       upsertSession: db.prepare(`
-        INSERT INTO sessions (id, space_id, source_id, cwd, agent, title, state, started_at, model, last_event_at)
+        INSERT INTO sessions (id, space_id, source_id, cwd, jsonl_path, agent, title, state, started_at, model, last_event_at)
         VALUES (
-          @id, @space_id, @source_id, @cwd, @agent, @title, @state,
+          @id, @space_id, @source_id, @cwd, @jsonl_path, @agent, @title, @state,
           COALESCE(@started_at, datetime('now')),
           @model,
           COALESCE(@last_event_at, datetime('now'))
@@ -200,6 +210,11 @@ export class SqliteSessionStore implements SessionStore {
           space_id      = excluded.space_id,
           source_id     = excluded.source_id,
           cwd           = COALESCE(excluded.cwd, sessions.cwd),
+          -- jsonl_path: prefer the new value when the watcher knows where
+          -- the file is. The watcher always passes the real path on every
+          -- upsert, so this overwrite is what fixes cross-device rows
+          -- whose cwd field was poisoned with the origin device's path.
+          jsonl_path    = COALESCE(excluded.jsonl_path, sessions.jsonl_path),
           title         = excluded.title,
           state         = excluded.state,
           model         = excluded.model,
@@ -276,6 +291,7 @@ export class SqliteSessionStore implements SessionStore {
       last_event_at: null,
       source_id: null,
       cwd: null,
+      jsonl_path: null,
       ...row,
     });
   }
@@ -288,6 +304,7 @@ export class SqliteSessionStore implements SessionStore {
       last_event_at: null,
       source_id: null,
       cwd: null,
+      jsonl_path: null,
       ...row,
     });
   }

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -286,7 +286,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
   const inFlightBytes = new Map<string, Promise<PushBytesResult>>();
 
   const getBytesState = deps.db.prepare(
-    `SELECT cwd, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation, cloud_owner_id
+    `SELECT cwd, jsonl_path, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation, cloud_owner_id
        FROM sessions WHERE id = ? LIMIT 1`,
   );
   const advanceBytesState = deps.db.prepare(
@@ -327,6 +327,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
 
     const state = getBytesState.get(sessionId) as {
       cwd: string | null;
+      jsonl_path: string | null;
       jsonl_snapshot_offset: number;
       jsonl_chunk_count: number;
       bytes_generation: number;
@@ -334,12 +335,6 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     } | undefined;
     if (!state) {
       console.warn(`[sessions] pushBytes: no session row for ${sessionId}`);
-      return empty;
-    }
-    if (!state.cwd) {
-      // Orphan session from before sessions.cwd was added, or a session
-      // whose watcher never captured cwd. Nothing to read from disk.
-      console.warn(`[sessions] pushBytes: session ${sessionId} has no cwd, skipping`);
       return empty;
     }
     // Owner check: the watcher hook only marks dirty when canRunCloudSync()
@@ -350,7 +345,20 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       return empty;
     }
 
-    const jsonlPath = join(projectsRoot(), encodeCwd(state.cwd), `${sessionId}.jsonl`);
+    // Prefer the watcher-recorded path. Cross-device resumed sessions have
+    // events that still carry the origin device's cwd (e.g. "C:\\Users\\matth"
+    // on a Mac-resumed Windows session), so encoding sessions.cwd back into
+    // a local path doesn't work. The watcher stores the real on-disk path
+    // on every upsert. Fall back to the encoded-cwd computation for rows
+    // that pre-date the jsonl_path column.
+    const jsonlPath = state.jsonl_path
+      ?? (state.cwd ? join(projectsRoot(), encodeCwd(state.cwd), `${sessionId}.jsonl`) : null);
+    if (!jsonlPath) {
+      // Orphan session from before sessions.cwd / jsonl_path columns; the
+      // watcher never captured a location. Nothing to read.
+      console.warn(`[sessions] pushBytes: session ${sessionId} has no jsonl_path or cwd, skipping`);
+      return empty;
+    }
     let stat: { size: number };
     try {
       const s = await fs.stat(jsonlPath);

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -263,6 +263,10 @@ export class ClaudeCodeWatcher {
       space_id: resolved.spaceId,
       source_id: resolved.sourceId,
       cwd: meta.cwd,
+      // Ground truth for pushBytes: the actual on-disk path. Required
+      // for cross-device resumed sessions whose events still carry the
+      // origin device's cwd. See db.ts on the jsonl_path column.
+      jsonl_path: filePath,
       agent: "claude-code",
       title: effectiveTitle(meta),
       state,
@@ -652,6 +656,7 @@ export class ClaudeCodeWatcher {
           space_id: resolved.spaceId,
           source_id: resolved.sourceId,
           cwd: tracker.cwd,
+          jsonl_path: filePath,
           agent: "claude-code",
           title: effectiveTitle(tracker),
           state: "active",

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -28,7 +28,8 @@ function harness() {
       jsonl_synced_at       INTEGER,
       jsonl_snapshot_offset INTEGER NOT NULL DEFAULT 0,
       jsonl_chunk_count     INTEGER NOT NULL DEFAULT 0,
-      bytes_generation      INTEGER NOT NULL DEFAULT 0
+      bytes_generation      INTEGER NOT NULL DEFAULT 0,
+      jsonl_path            TEXT
     );
     CREATE TABLE profile_binding (
       id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -791,6 +792,85 @@ describe("SessionSyncService.pushBytes", () => {
     });
     expect((await svc.pushBytes("s1")).uploaded).toBe(0);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses jsonl_path even when cwd is a foreign path (cross-device resume case)", async () => {
+    // Regression test for 0.8.1-beta.6 dogfooding bug: after Mac resumed a
+    // Windows session, every event in the jsonl still carried
+    // cwd: "C:\\Users\\matth", so the watcher couldn't recover the Mac cwd
+    // from events. The fix is to store the actual on-disk jsonl path and
+    // have pushBytes use it directly, ignoring sessions.cwd for file lookup.
+    const root = setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    // The file lives at the local Mac-encoded path...
+    const realLocalDir = "-Users-me-Dev-oyster";
+    mkdirSync(join(root, realLocalDir), { recursive: true });
+    const jsonl = "{\"role\":\"user\",\"text\":\"hello from mac\"}\n";
+    const realJsonlPath = join(root, realLocalDir, "s1.jsonl");
+    writeFileSync(realJsonlPath, jsonl);
+    // ...but sessions.cwd holds the origin (Windows) cwd. encodeCwd of that
+    // would compute `/tmp/.../C--Users-matth/s1.jsonl`, which does not exist.
+    // The new jsonl_path column is the truth.
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, jsonl_path, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'),
+               'C:\\Users\\matth', ?, 'user-A')`,
+    ).run(realJsonlPath);
+
+    const calls: Array<{ url: string; chunkNumber: number; body: Uint8Array }> = [];
+    const fetchSpy = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const m = u.match(/\/api\/sessions\/bytes\/([^/]+)\/chunk\/(\d+)$/);
+      if (m && init?.method === "PUT") {
+        const body = new Uint8Array(init.body as ArrayBuffer);
+        calls.push({ url: u, chunkNumber: Number(m[2]), body });
+        return new Response(JSON.stringify({ ok: true, chunk_number: 1, generation: 0 }), { status: 200 });
+      }
+      return new Response("not_found", { status: 404 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+
+    const r = await svc.pushBytes("s1");
+    expect(r.uploaded).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(new TextDecoder().decode(calls[0]!.body)).toBe(jsonl);
+  });
+
+  it("falls back to cwd-encoded path when jsonl_path is NULL (back-compat)", async () => {
+    // Rows that pre-date the jsonl_path column (or that the watcher hasn't
+    // re-touched yet) still resolve via the legacy `projectsRoot()/
+    // encodeCwd(cwd)/<id>.jsonl` computation.
+    const root = setupBytesEnv();
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    const cwd = "/tmp/proj-legacy";
+    const encoded = cwd.replace(/[^A-Za-z0-9]/g, "-");
+    mkdirSync(join(root, encoded), { recursive: true });
+    writeFileSync(join(root, encoded, "s1.jsonl"), "legacy\n");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, cwd, jsonl_path, cloud_owner_id)
+       VALUES ('s1', 'claude-code', 'active', datetime('now'), ?, NULL, 'user-A')`,
+    ).run(cwd);
+
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, chunk_number: 1, generation: 0 }), { status: 200 }),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    expect((await svc.pushBytes("s1")).uploaded).toBe(1);
   });
 
   it("uploads one chunk for a small file under MAX_CHUNK_BYTES", async () => {


### PR DESCRIPTION
## Why beta.6 wasn't enough

beta.6 fixed the watcher to "pick the latest ev.cwd whose encoding matches the file's parent dir." On paper, correct. In practice, dogfooding revealed:

\`\`\`
=== cwd values in jsonl (first 5 and last 5 events with cwd) ===
"cwd":"C:\\\\Users\\\\matth"
"cwd":"C:\\\\Users\\\\matth"
...
"cwd":"C:\\\\Users\\\\matth"
"cwd":"C:\\\\Users\\\\matth"
\`\`\`

**Every** event carries the origin device's cwd, including the turns the resuming device appended. Claude Code preserves the original session's cwd field across resume. So no event ever encode-matches the local parent dir, \`pickJsonlCwd\` returns null, the COALESCE upsert keeps the previously-cached Windows cwd, and \`pushBytes\` still hits ENOENT.

## The real fix

The event stream is not a reliable signal for the file's local location. The watcher already knows the actual path from chokidar. Store it directly.

- \`ALTER TABLE sessions ADD COLUMN jsonl_path TEXT\` (additive, idempotent).
- Watcher writes \`filePath\` on every \`upsertSession\` — both the boot-scan path and the first-event-from-new-file path. Existing poisoned rows self-heal on next boot.
- \`pushBytes\` prefers \`state.jsonl_path\`; falls back to the legacy \`projectsRoot()/encodeCwd(cwd)/<id>.jsonl\` computation for rows that pre-date the column.

The beta.6 \`pickJsonlCwd\` helper still ships — it does no harm and correctly handles the single-device case, plus it'll start working as soon as Claude Code ever decides to write a fresh \`cwd\` field on resumed sessions.

## Test plan

- [x] New test: cross-device case (sessions.cwd = "C:\\\\Users\\\\matth", jsonl_path = real Mac path → push succeeds).
- [x] New test: back-compat case (jsonl_path NULL, cwd set → legacy computation still works).
- [x] All 229 server tests pass (was 227).
- [x] tsc strict clean.
- [ ] Manual: ship as 0.8.1-beta.7, reinstall, verify \`pushBytes\` succeeds for the resumed c90da198 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)