### PR TITLE
fix(sessions): seed bookkeeping at reassemble so continuations push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
-- **Resumed cross-device sessions sync their continuations back to the cloud.** After resuming another device's session locally, the original fix in beta.6 wasn't enough: Claude Code preserves the origin device's working directory in every event it writes, even on the resuming device, so the watcher had no event-side signal to recover from. Oyster now tracks each session's actual on-disk transcript path directly, bypassing the working-directory mismatch entirely. A Mac-resumed Windows session now backs up cleanly, and a third device can pick it up from where Mac left it. Existing poisoned rows self-heal on the next boot.
+- **Cross-device session continuations sync back to the cloud.** Resuming another device's session locally — then continuing the conversation — now correctly uploads the new turns. Previously the resuming device wrote new content but couldn't sync it (the cloud's existing chunks blocked re-upload of the same byte range), so the second device could read the original transcript but never push its own additions back. Future resumes from a third device will see the full conversation including everything added on the resuming device.
 
 ## [0.8.1-beta.5] - 2026-05-12
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -328,7 +328,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Fixed</h3>
 <ul>
-<li><strong>Resumed cross-device sessions sync their continuations back to the cloud.</strong> After resuming another device&#39;s session locally, the original fix in beta.6 wasn&#39;t enough: Claude Code preserves the origin device&#39;s working directory in every event it writes, even on the resuming device, so the watcher had no event-side signal to recover from. Oyster now tracks each session&#39;s actual on-disk transcript path directly, bypassing the working-directory mismatch entirely. A Mac-resumed Windows session now backs up cleanly, and a third device can pick it up from where Mac left it. Existing poisoned rows self-heal on the next boot.</li>
+<li><strong>Cross-device session continuations sync back to the cloud.</strong> Resuming another device&#39;s session locally — then continuing the conversation — now correctly uploads the new turns. Previously the resuming device wrote new content but couldn&#39;t sync it (the cloud&#39;s existing chunks blocked re-upload of the same byte range), so the second device could read the original transcript but never push its own additions back. Future resumes from a third device will see the full conversation including everything added on the resuming device.</li>
 </ul>
 <h2 id="v-0-8-1-beta-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.4...v0.8.1-beta.5" rel="noopener noreferrer"><span class="release-version">0.8.1-beta.5</span></a><span class="release-date"> — 2026-05-12</span></h2>
 <h3>Added</h3>

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -660,15 +660,30 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
   // INSERT path covers the case where the file is reassembled before the
   // user runs `claude --resume` (no watcher upsert has fired yet).
   // UPDATE path covers the inverse race + heals existing 0/0/0 rows on
-  // re-resume. ISO timestamps to match the watcher's column shape.
+  // re-resume.
+  //
+  // Carefully chosen columns:
+  //  - last_event_at on INSERT comes from remote_sessions (cloud truth).
+  //    The watcher's upsert uses MAX(...) so a NOW value would ratchet
+  //    last_event_at forward and prevent the watcher from later setting
+  //    the real transcript timestamp.
+  //  - cloud_synced_at is left alone — it's the *metadata* push-ack
+  //    timestamp and is part of the dirty predicate; touching it could
+  //    falsely mark a dirty row as synced. Bytes-side ack lives in
+  //    jsonl_synced_at instead.
+  const getRemoteLastEventAt = deps.db.prepare(
+    `SELECT last_event_at FROM remote_sessions
+       WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+  );
   const seedSessionBytesStateAtReassemble = deps.db.prepare(
     `INSERT INTO sessions
        (id, agent, state, started_at, last_event_at,
         cwd, jsonl_path,
         jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation,
-        cloud_owner_id, cloud_synced_at)
+        cloud_owner_id, jsonl_synced_at)
      VALUES
-       (@id, 'claude-code', 'waiting', @now_iso, @now_iso,
+       (@id, 'claude-code', 'waiting', @now_iso,
+        COALESCE(@last_event_at_iso, @now_iso),
         NULL, @jsonl_path,
         @offset, @chunk_count, @generation,
         @owner_id, @now_ms)
@@ -678,7 +693,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
        jsonl_chunk_count     = excluded.jsonl_chunk_count,
        bytes_generation      = excluded.bytes_generation,
        cloud_owner_id        = excluded.cloud_owner_id,
-       cloud_synced_at       = excluded.cloud_synced_at`,
+       jsonl_synced_at       = excluded.jsonl_synced_at`,
   );
 
   function seedReassembledBookkeeping(
@@ -689,6 +704,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     expectedTotal: number,
   ): void {
     const now = Date.now();
+    const remoteRow = getRemoteLastEventAt.get(ownerId, sessionId) as
+      { last_event_at: string | null } | undefined;
     seedSessionBytesStateAtReassemble.run({
       id: sessionId,
       jsonl_path: targetPath,
@@ -698,6 +715,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       owner_id: ownerId,
       now_iso: new Date(now).toISOString(),
       now_ms: now,
+      last_event_at_iso: remoteRow?.last_event_at ?? null,
     });
   }
 

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -647,6 +647,60 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       WHERE owner_id = ? AND session_id = ?`,
   );
 
+  // Seed the local sessions bookkeeping to match cloud's chain at the
+  // moment of reassemble. Without this, the watcher's later upsert
+  // creates a row with jsonl_snapshot_offset = 0 and pushBytes tries to
+  // re-upload chunk 1 from byte 0 — which the worker rejects as
+  // chunk_conflict because cloud already has chunk 1 with different bytes.
+  //
+  // With the seed, the row tells the truth: "cloud has this much of me
+  // already; push only what's past expectedTotal." Subsequent Mac turns
+  // become chunk N+1, the chain stays linear (Pattern A).
+  //
+  // INSERT path covers the case where the file is reassembled before the
+  // user runs `claude --resume` (no watcher upsert has fired yet).
+  // UPDATE path covers the inverse race + heals existing 0/0/0 rows on
+  // re-resume. ISO timestamps to match the watcher's column shape.
+  const seedSessionBytesStateAtReassemble = deps.db.prepare(
+    `INSERT INTO sessions
+       (id, agent, state, started_at, last_event_at,
+        cwd, jsonl_path,
+        jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation,
+        cloud_owner_id, cloud_synced_at)
+     VALUES
+       (@id, 'claude-code', 'waiting', @now_iso, @now_iso,
+        NULL, @jsonl_path,
+        @offset, @chunk_count, @generation,
+        @owner_id, @now_ms)
+     ON CONFLICT(id) DO UPDATE SET
+       jsonl_path            = excluded.jsonl_path,
+       jsonl_snapshot_offset = excluded.jsonl_snapshot_offset,
+       jsonl_chunk_count     = excluded.jsonl_chunk_count,
+       bytes_generation      = excluded.bytes_generation,
+       cloud_owner_id        = excluded.cloud_owner_id,
+       cloud_synced_at       = excluded.cloud_synced_at`,
+  );
+
+  function seedReassembledBookkeeping(
+    sessionId: string,
+    ownerId: string,
+    targetPath: string,
+    manifest: { bytes_generation: number; chunks: Array<{ chunk_number: number }> },
+    expectedTotal: number,
+  ): void {
+    const now = Date.now();
+    seedSessionBytesStateAtReassemble.run({
+      id: sessionId,
+      jsonl_path: targetPath,
+      offset: expectedTotal,
+      chunk_count: manifest.chunks.length,
+      generation: manifest.bytes_generation,
+      owner_id: ownerId,
+      now_iso: new Date(now).toISOString(),
+      now_ms: now,
+    });
+  }
+
   async function doReassemble(
     sessionId: string,
     targetPath: string,
@@ -715,6 +769,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     if (localSize === expectedTotal) {
       // Already up-to-date — nothing to fetch. Just record the path.
       updateRemoteSessionLocalPath.run(targetPath, session.user.id, sessionId);
+      seedReassembledBookkeeping(sessionId, session.user.id, targetPath, manifest, expectedTotal);
       console.log(
         `[sessions] reassemble: session=${sessionId.slice(0, 8)} already up-to-date (${localSize} bytes)`,
       );
@@ -805,6 +860,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     }
 
     updateRemoteSessionLocalPath.run(targetPath, session.user.id, sessionId);
+    seedReassembledBookkeeping(sessionId, session.user.id, targetPath, manifest, writtenBytes);
 
     if (isFresh) {
       console.log(

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -545,6 +545,112 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
       .rejects.toBeInstanceOf(LocalDivergedError);
   });
 
+  it("seeds local sessions bookkeeping on successful fresh reassemble", async () => {
+    // Without this seed, a subsequent claude --resume appends new bytes,
+    // the watcher creates a sessions row with jsonl_snapshot_offset = 0,
+    // and pushBytes tries to re-upload chunk 1 → cloud returns 409
+    // chunk_conflict because the chain already has chunk 1 from the origin
+    // device. The seed makes pushBytes start at expectedTotal so the next
+    // push goes as chunk N+1 and the chain stays linear (Pattern A).
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "fresh.jsonl");
+    const c1 = new TextEncoder().encode("only-chunk\n");
+
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 3,
+          total_size: c1.byteLength,
+          active_device_id: "dev-origin",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: c1.byteLength, byte_count: c1.byteLength, plaintext_sha256: hash(c1) },
+          ],
+        }), { status: 200 });
+      }
+      if (u.includes("/chunk/")) return new Response(c1, { status: 200 });
+      return new Response("not_found", { status: 404 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.reassembleSessionJsonl("s-remote", targetPath);
+
+    const row = db.prepare(
+      `SELECT jsonl_path, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation, cloud_owner_id
+         FROM sessions WHERE id = 's-remote'`,
+    ).get() as {
+      jsonl_path: string;
+      jsonl_snapshot_offset: number;
+      jsonl_chunk_count: number;
+      bytes_generation: number;
+      cloud_owner_id: string;
+    };
+    expect(row.jsonl_path).toBe(targetPath);
+    expect(row.jsonl_snapshot_offset).toBe(c1.byteLength);
+    expect(row.jsonl_chunk_count).toBe(1);
+    expect(row.bytes_generation).toBe(3);
+    expect(row.cloud_owner_id).toBe("user-A");
+  });
+
+  it("re-seeds bookkeeping on no-op reassemble (heals existing 0/0/0 rows)", async () => {
+    // For the user who hit this bug in beta.7: sessions.jsonl_path correct
+    // but snapshot_offset/chunk_count/generation all 0 because the original
+    // reassemble didn't seed. Calling reassemble again on a fully-synced
+    // local file should re-seed the bookkeeping (the no-op exit path
+    // also seeds).
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "already-synced-seed.jsonl");
+    const c1 = new TextEncoder().encode("one\n");
+    const c2 = new TextEncoder().encode("two\n");
+    const fs = require("node:fs");
+    fs.writeFileSync(targetPath, Buffer.concat([c1, c2]));
+
+    // Pre-existing row simulating the beta.7 bug state.
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at, jsonl_path, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation, cloud_owner_id)
+       VALUES ('s-remote', 'claude-code', 'active', datetime('now'), ?, 0, 0, 0, 'user-A')`,
+    ).run(targetPath);
+
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 0,
+          total_size: c1.byteLength + c2.byteLength,
+          active_device_id: "dev-mac",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: c1.byteLength, byte_count: c1.byteLength, plaintext_sha256: hash(c1) },
+            { chunk_number: 2, start_offset: c1.byteLength, end_offset: c1.byteLength + c2.byteLength, byte_count: c2.byteLength, plaintext_sha256: hash(c2) },
+          ],
+        }), { status: 200 });
+      }
+      return new Response("should not fetch", { status: 500 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.reassembleSessionJsonl("s-remote", targetPath);
+
+    const row = db.prepare(
+      `SELECT jsonl_snapshot_offset, jsonl_chunk_count FROM sessions WHERE id = 's-remote'`,
+    ).get() as { jsonl_snapshot_offset: number; jsonl_chunk_count: number };
+    expect(row.jsonl_snapshot_offset).toBe(c1.byteLength + c2.byteLength);
+    expect(row.jsonl_chunk_count).toBe(2);
+  });
+
   it("free user throws (pro-only)", async () => {
     const { db, profileBinding } = harnessForReassemble();
     const svc = createSessionSyncService({

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -583,7 +583,8 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
     await svc.reassembleSessionJsonl("s-remote", targetPath);
 
     const row = db.prepare(
-      `SELECT jsonl_path, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation, cloud_owner_id
+      `SELECT jsonl_path, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation,
+              cloud_owner_id, last_event_at, jsonl_synced_at, cloud_synced_at
          FROM sessions WHERE id = 's-remote'`,
     ).get() as {
       jsonl_path: string;
@@ -591,12 +592,78 @@ describe("SessionSyncService.reassembleSessionJsonl", () => {
       jsonl_chunk_count: number;
       bytes_generation: number;
       cloud_owner_id: string;
+      last_event_at: string;
+      jsonl_synced_at: number | null;
+      cloud_synced_at: number | null;
     };
     expect(row.jsonl_path).toBe(targetPath);
     expect(row.jsonl_snapshot_offset).toBe(c1.byteLength);
     expect(row.jsonl_chunk_count).toBe(1);
     expect(row.bytes_generation).toBe(3);
     expect(row.cloud_owner_id).toBe("user-A");
+    // last_event_at must come from remote_sessions (cloud truth), not NOW —
+    // otherwise the watcher's MAX(...) upsert ratchets the column forward
+    // and the home feed shows the wrong timestamp until a new event lands.
+    // Harness seeds remote_sessions with '2026-05-11T10:30:00Z'.
+    expect(row.last_event_at).toBe("2026-05-11T10:30:00Z");
+    // Bytes-side ack lives in jsonl_synced_at. cloud_synced_at is for the
+    // metadata push ack; touching it here would corrupt the dirty predicate.
+    expect(row.jsonl_synced_at).toBeGreaterThan(0);
+    expect(row.cloud_synced_at).toBeNull();
+  });
+
+  it("seed does not clobber a dirty row's cloud_synced_at (metadata push ack stays intact)", async () => {
+    // Regression: an earlier draft of the seed wrote cloud_synced_at,
+    // which is the *metadata* push-ack timestamp used by the dirty
+    // predicate. Writing it here can falsely mark a dirty row as synced
+    // and lose a pending metadata push. Seed must touch only jsonl_synced_at.
+    const { db, profileBinding } = harnessForReassemble();
+    const root = setupBytesEnv();
+    const targetPath = join(root, "dirty.jsonl");
+    const c1 = new TextEncoder().encode("x\n");
+    const fs = require("node:fs");
+    fs.writeFileSync(targetPath, c1);
+
+    // Pre-existing dirty row: sync_dirty_at > cloud_synced_at = predicate "dirty"
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, last_event_at,
+                             jsonl_path, jsonl_snapshot_offset, jsonl_chunk_count, bytes_generation,
+                             cloud_owner_id, sync_dirty_at, cloud_synced_at)
+       VALUES ('s-remote', 'claude-code', 'active', datetime('now'),
+               ?, 0, 0, 0,
+               'user-A', 2000, 1000)`,
+    ).run(targetPath);
+
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/manifest")) {
+        return new Response(JSON.stringify({
+          bytes_generation: 0,
+          total_size: c1.byteLength,
+          active_device_id: "dev-mac",
+          chunks: [
+            { chunk_number: 1, start_offset: 0, end_offset: c1.byteLength, byte_count: c1.byteLength, plaintext_sha256: hash(c1) },
+          ],
+        }), { status: 200 });
+      }
+      return new Response("should not fetch", { status: 500 });
+    });
+
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.reassembleSessionJsonl("s-remote", targetPath);
+
+    const row = db.prepare(
+      `SELECT sync_dirty_at, cloud_synced_at FROM sessions WHERE id = 's-remote'`,
+    ).get() as { sync_dirty_at: number; cloud_synced_at: number };
+    // Untouched: row is still dirty by the predicate (sync_dirty_at > cloud_synced_at).
+    expect(row.sync_dirty_at).toBe(2000);
+    expect(row.cloud_synced_at).toBe(1000);
   });
 
   it("re-seeds bookkeeping on no-op reassemble (heals existing 0/0/0 rows)", async () => {


### PR DESCRIPTION
## The dogfood bug after beta.7

beta.7 fixed pushBytes to find the right file. That exposed a coordination bug:

\`\`\`
[sessions] session=c90da198 chunk 1 rejected: chunk_conflict — session
likely continued on another device or local jsonl has divergent edits.
Next reconcile will refresh state.
\`\`\`

State at the time of the conflict:

| | Value |
|---|---|
| Local \`jsonl_snapshot_offset\` | 0 |
| Local \`jsonl_chunk_count\` | 0 |
| File on disk | 48,552 bytes |
| Cloud chain | 48,345 bytes (1 chunk) |

When \`reassembleSessionJsonl\` writes the cross-device transcript locally, it doesn't tell the bookkeeping that those bytes are already in cloud. The watcher then creates a sessions row with snapshot_offset = 0 / chunk_count = 0. When the user appends new turns and pushBytes wakes up, it tries to re-upload chunk 1 starting at byte 0 — cloud's chain already has chunk 1 with different bytes → 409.

So the resuming device's continuations never reached cloud. The "third-device pickup" half of Pattern A was broken.

## The fix

At successful reassemble (no-op, catch-up, and fresh paths), upsert the sessions row with bookkeeping that matches cloud's chain:

\`\`\`
jsonl_snapshot_offset = expectedTotal (last chunk's end_offset)
jsonl_chunk_count     = manifest.chunks.length
bytes_generation      = manifest.bytes_generation
jsonl_path            = targetPath
cloud_owner_id        = current Pro user
cloud_synced_at       = now
\`\`\`

Next push computes \`delta = file_size − expectedTotal\` and uploads as chunk N+1 in the same generation. Chain stays linear; \`active_device_id\` flips to whoever just wrote.

The UPSERT's UPDATE clause also heals existing rows hit by the beta.7 bug: re-calling \`/api/sessions/:id/resume\` on a fully-synced local file (no-op exit path) now correctly re-seats the bookkeeping.

## Test plan

- [x] New test: fresh reassemble seeds snapshot_offset/chunk_count/generation/cloud_owner_id correctly
- [x] New test: re-seed on no-op reassemble heals existing 0/0/0 rows
- [x] All 231 server tests pass (was 229)
- [x] tsc strict clean
- [ ] Manual: ship as 0.8.1-beta.8, the user's c90da198 row will need a manual SQL patch to apply the seed retroactively (or they call /resume on it again — but that hits local_diverged because local is 207 bytes past cloud; for now a SQL UPDATE will fix it cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)