### PR TITLE
feat(sessions): cross-device session chip + Resume on this device UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **Cross-device session continuations sync back to the cloud.** Resuming another device's session locally — then continuing the conversation — now correctly uploads the new turns. Previously the resuming device wrote new content but couldn't sync it (the cloud's existing chunks blocked re-upload of the same byte range), so the second device could read the original transcript but never push its own additions back. Future resumes from a third device will see the full conversation including everything added on the resuming device.
+- **Cross-device sessions in Home, with a one-click resume.** Sessions backed up on another device now appear in Home with an `↗ MacBookPro` chip (or "Other device" if the origin's label hasn't synced yet) on both the grid and list views. Click into one and you'll see a new **Resume on this device** button — it walks you through reassembling the transcript locally and gives you a copyable command to continue the conversation. Sessions whose transcript bytes haven't synced from the origin device yet show the button as disabled with an explanation.
 
 ## [0.8.1-beta.5] - 2026-05-12
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -326,9 +326,9 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
-<h3>Fixed</h3>
+<h3>Added</h3>
 <ul>
-<li><strong>Cross-device session continuations sync back to the cloud.</strong> Resuming another device&#39;s session locally — then continuing the conversation — now correctly uploads the new turns. Previously the resuming device wrote new content but couldn&#39;t sync it (the cloud&#39;s existing chunks blocked re-upload of the same byte range), so the second device could read the original transcript but never push its own additions back. Future resumes from a third device will see the full conversation including everything added on the resuming device.</li>
+<li><strong>Cross-device sessions in Home, with a one-click resume.</strong> Sessions backed up on another device now appear in Home with an <code>↗ MacBookPro</code> chip (or &quot;Other device&quot; if the origin&#39;s label hasn&#39;t synced yet) on both the grid and list views. Click into one and you&#39;ll see a new <strong>Resume on this device</strong> button — it walks you through reassembling the transcript locally and gives you a copyable command to continue the conversation. Sessions whose transcript bytes haven&#39;t synced from the origin device yet show the button as disabled with an explanation.</li>
 </ul>
 <h2 id="v-0-8-1-beta-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.4...v0.8.1-beta.5" rel="noopener noreferrer"><span class="release-version">0.8.1-beta.5</span></a><span class="release-date"> — 2026-05-12</span></h2>
 <h3>Added</h3>

--- a/infra/auth-worker/migrations/0010_device_label.sql
+++ b/infra/auth-worker/migrations/0010_device_label.sql
@@ -1,0 +1,13 @@
+-- 0010_device_label.sql — human-readable origin device label for cross-device UI (#322).
+--
+-- We've had `device_id` (an opaque UUID) since 0008 and `active_device_id`
+-- since 0009. Neither is readable. The cross-device session card in the UI
+-- needs something like "↗ MacBookPro" — that comes from this column.
+--
+-- Sourced from each device's local `device_identity.label` (hostname() at
+-- install time today; user-renameable in a future release). Backfill is
+-- left NULL: old metadata rows pre-date label sync, the UI falls back to
+-- "Other device" until those sessions get re-pushed by their origin.
+
+ALTER TABLE synced_session_metadata
+  ADD COLUMN device_label TEXT;

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -306,6 +306,11 @@ async function handleMemoryEventsGet(req: Request, env: Env): Promise<Response> 
 interface IncomingSession {
   id: string;
   device_id?: string | null;
+  /** Human-readable origin device label (e.g. "MacBookPro"). Drives the
+   *  cross-device chip in the UI. Sourced from device_identity.label on
+   *  the pushing device. Capped at 64 chars to bound a malicious or buggy
+   *  client's UX footprint. */
+  device_label?: string | null;
   agent: string;
   title: string | null;
   state: string;
@@ -319,6 +324,11 @@ interface IncomingSession {
   // doesn't get clobbered.
   sync_dirty_at: number;
 }
+
+/** Max length of an accepted device_label. Hostnames are RFC-bounded to 253
+ *  but realistic labels are far shorter; cap at 64 to stop a buggy or
+ *  malicious client from filling the UI chip with arbitrary text. */
+const DEVICE_LABEL_MAX = 64;
 
 function isValidSession(s: unknown): s is IncomingSession {
   if (!s || typeof s !== "object") return false;
@@ -334,9 +344,16 @@ function isValidSession(s: unknown): s is IncomingSession {
   // array) would either crash D1 .bind() with TypeError or silently coerce
   // to a useless string representation. Each malformed session is rejected
   // individually so the rest of the batch still lands.
-  for (const key of ["title", "cwd", "model", "ended_at", "device_id"] as const) {
+  for (const key of ["title", "cwd", "model", "ended_at", "device_id", "device_label"] as const) {
     const v = o[key];
     if (v !== null && v !== undefined && typeof v !== "string") return false;
+  }
+  // device_label length cap — over-long values are silently truncated to
+  // null rather than rejecting the whole session push. The pushing client
+  // shouldn't send a 1KB label, but if it does we'd rather lose the chip
+  // than lose the session.
+  if (typeof o.device_label === "string" && o.device_label.length > DEVICE_LABEL_MAX) {
+    o.device_label = null;
   }
   return true;
 }
@@ -376,11 +393,12 @@ async function handleSessionsMetadataPost(req: Request, env: Env): Promise<Respo
       // from metadata pushes — left at its existing value (default 0 on insert).
       const result = await env.DB.prepare(
         `INSERT INTO synced_session_metadata
-           (owner_id, session_id, device_id, agent, title, state, cwd, model,
+           (owner_id, session_id, device_id, device_label, agent, title, state, cwd, model,
             started_at, ended_at, last_event_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(owner_id, session_id) DO UPDATE SET
            device_id     = excluded.device_id,
+           device_label  = COALESCE(excluded.device_label, synced_session_metadata.device_label),
            agent         = excluded.agent,
            title         = excluded.title,
            state         = excluded.state,
@@ -396,7 +414,7 @@ async function handleSessionsMetadataPost(req: Request, env: Env): Promise<Respo
       // be missing entirely. Coerce every nullable to null before binding so
       // a partial-shape session doesn't fail the whole batch with 500.
       ).bind(
-        user.id, s.id, s.device_id ?? null, s.agent,
+        user.id, s.id, s.device_id ?? null, s.device_label ?? null, s.agent,
         s.title ?? null, s.state, s.cwd ?? null, s.model ?? null,
         s.started_at, s.ended_at ?? null, s.last_event_at, s.sync_dirty_at,
       ).run();
@@ -424,16 +442,17 @@ async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Respon
   // generation. A session may have metadata but no chunks yet (push
   // hasn't fired) or chunks from older generations only (just reset).
   type Row = {
-    session_id: string; device_id: string | null; agent: string; title: string | null;
+    session_id: string; device_id: string | null; device_label: string | null;
+    agent: string; title: string | null;
     state: string; cwd: string | null; model: string | null; started_at: string;
     ended_at: string | null; last_event_at: string;
     bytes_generation: number; active_device_id: string | null;
     has_bytes: number; updated_at: number;
   };
   const { results } = await env.DB.prepare(
-    `SELECT m.session_id, m.device_id, m.agent, m.title, m.state, m.cwd, m.model,
-            m.started_at, m.ended_at, m.last_event_at, m.bytes_generation,
-            m.active_device_id, m.updated_at,
+    `SELECT m.session_id, m.device_id, m.device_label, m.agent, m.title, m.state,
+            m.cwd, m.model, m.started_at, m.ended_at, m.last_event_at,
+            m.bytes_generation, m.active_device_id, m.updated_at,
             CASE WHEN EXISTS (
               SELECT 1 FROM synced_session_chunks c
                WHERE c.owner_id = m.owner_id

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS synced_session_metadata (
   owner_id          TEXT    NOT NULL,
   session_id        TEXT    NOT NULL,
   device_id         TEXT,
+  device_label      TEXT,
   agent             TEXT    NOT NULL,
   title             TEXT,
   state             TEXT    NOT NULL,

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -254,6 +254,54 @@ describe("POST /api/sessions/metadata", () => {
     expect(body.accepted).toEqual([]);
     expect(body.rejected).toEqual([sid]);
   });
+
+  it("persists device_label and returns it from GET", async () => {
+    // Verifies the device_label column added in migration 0010 round-trips:
+    // worker accepts it on POST, stores it in synced_session_metadata, and
+    // returns it on GET so receiving devices can render "From MacBookPro".
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    const post = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessions: [sampleSession(sid, 1000, { device_label: "MacBookPro" })],
+      }),
+    }, token);
+    expect(post.status).toBe(200);
+    // Stored.
+    const row = await env.DB.prepare(
+      `SELECT device_label FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ device_label: string }>();
+    expect(row?.device_label).toBe("MacBookPro");
+    // Returned in GET.
+    const get = await signedFetch("/api/sessions/metadata", { method: "GET" }, token);
+    const body = await get.json() as { sessions: Array<{ session_id: string; device_label: string | null }> };
+    expect(body.sessions.find((s) => s.session_id === sid)?.device_label).toBe("MacBookPro");
+  });
+
+  it("rejects an over-long device_label by nulling it (keeps the session push valid)", async () => {
+    // Defence-in-depth — a buggy or malicious client should not be able to
+    // stuff a 1KB label into the chip. Cap is 64 chars; over-long values
+    // are silently nulled rather than rejecting the whole push.
+    const { token, userId } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    const tooLong = "X".repeat(200);
+    const res = await signedFetch("/api/sessions/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessions: [sampleSession(sid, 1000, { device_label: tooLong })],
+      }),
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([sid]);   // session still accepted
+    const row = await env.DB.prepare(
+      `SELECT device_label FROM synced_session_metadata WHERE owner_id = ? AND session_id = ?`,
+    ).bind(userId, sid).first<{ device_label: string | null }>();
+    expect(row?.device_label).toBeNull();
+  });
 });
 
 describe("GET /api/sessions/metadata", () => {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -233,6 +233,13 @@ export function initDb(userlandDir: string): Database.Database {
   try {
     db.exec(`ALTER TABLE remote_sessions ADD COLUMN active_device_id TEXT`);
   } catch { /* already exists */ }
+  // Additive: device_label added for the cross-device session chip (PR 3.1).
+  // Human-readable name pulled from each device's device_identity.label
+  // (hostname() at install). Null on rows pushed before this column existed —
+  // UI falls back to "Other device" then.
+  try {
+    db.exec(`ALTER TABLE remote_sessions ADD COLUMN device_label TEXT`);
+  } catch { /* already exists */ }
   db.exec(`CREATE INDEX IF NOT EXISTS remote_sessions_owner_last_event
              ON remote_sessions(owner_id, last_event_at DESC)`);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { tryHandleMemoryRoute } from "./routes/memories.js";
 import { tryHandleAuthRoute } from "./routes/auth.js";
 import { tryHandlePublishRoute } from "./routes/publish.js";
 import { tryHandlePinRoute } from "./routes/pin.js";
+import { tryHandleDeviceRoute } from "./routes/device.js";
 import { createPublishService, PublishError } from "./publish-service.js";
 import { createSpaceSyncService } from "./space-sync-service.js";
 import { createMemorySyncService, type MemorySyncService } from "./memory-sync-service.js";
@@ -755,6 +756,9 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
 
   // /api/artifacts/:id/pin — pin / unpin an artefact (#387).
   if (await tryHandlePinRoute(req, res, url, ctx, { artifactService, broadcastUiEvent })) return;
+
+  // /api/device/identity — local device UUID + label for the cross-device UI chip.
+  if (await tryHandleDeviceRoute(req, res, url, ctx, { db })) return;
 
   // /oauth/*, /.well-known/oauth-*, /mcp/*, /api/mcp/status
   // Pass the actually-bound `port`, not PREFERRED_PORT — findPort() may

--- a/server/src/routes/device.ts
+++ b/server/src/routes/device.ts
@@ -1,0 +1,54 @@
+// /api/device/* route bucket.
+//
+// Tiny route module — currently exposes only the local device identity
+// (id + human-readable label) so the web UI can decide which sessions
+// originated on THIS device vs. another one. Sourced from the
+// device_identity singleton seeded at install time.
+//
+// Returns true when handled; caller falls through to other routes on false.
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type Database from "better-sqlite3";
+import type { RouteCtx } from "../http-utils.js";
+
+export interface DeviceRouteDeps {
+  db: Database.Database;
+}
+
+export interface DeviceIdentityResponse {
+  /** Stable UUID assigned to this machine on first install. Used to
+   *  distinguish local from remote sessions, never user-facing. */
+  deviceId: string;
+  /** Human-readable label, defaults to the machine's hostname at install
+   *  time. UI renders this in the cross-device session chip. */
+  label: string;
+}
+
+export async function tryHandleDeviceRoute(
+  req: IncomingMessage,
+  _res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: DeviceRouteDeps,
+): Promise<boolean> {
+  if (req.method !== "GET" || url !== "/api/device/identity") return false;
+
+  const { db } = deps;
+  const { sendJson } = ctx;
+
+  const row = db.prepare(
+    `SELECT device_id, label FROM device_identity WHERE id = 1 LIMIT 1`,
+  ).get() as { device_id: string; label: string } | undefined;
+
+  // The row is seeded at server boot in index.ts (INSERT OR IGNORE), so a
+  // missing row would mean a pre-seed race against this endpoint or a
+  // corrupted DB. Surface as 503 so the client can retry rather than
+  // silently rendering with no device identity.
+  if (!row) {
+    sendJson({ error: "device_identity_not_ready" }, 503);
+    return true;
+  }
+  const payload: DeviceIdentityResponse = { deviceId: row.device_id, label: row.label };
+  sendJson(payload, 200);
+  return true;
+}

--- a/server/src/routes/device.ts
+++ b/server/src/routes/device.ts
@@ -33,6 +33,13 @@ export async function tryHandleDeviceRoute(
 ): Promise<boolean> {
   if (req.method !== "GET" || url !== "/api/device/identity") return false;
 
+  // The local server permits CORS broadly so the in-browser UI can hit it;
+  // gate this endpoint to localhost-origin requests since deviceId is a
+  // stable per-machine UUID (fingerprinting / leak risk if cross-origin
+  // pages could read it). Mirrors the gate other /api routes use for
+  // device-sensitive surfaces.
+  if (ctx.rejectIfNonLocalOrigin()) return true;
+
   const { db } = deps;
   const { sendJson } = ctx;
 

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -175,6 +175,7 @@ export async function tryHandleSessionRoute(
       model: string | null;
       lastEventAt: string;
       originDeviceId: string | null;
+      originDeviceLabel: string | null;
       jsonlAvailableLocally: boolean;
       hasBytes: boolean;
       activeDeviceId: string | null;
@@ -198,6 +199,7 @@ export async function tryHandleSessionRoute(
         lastEventAt: row.last_event_at,
         // Local sessions are by definition available on this device.
         originDeviceId: null,
+        originDeviceLabel: null,
         jsonlAvailableLocally: true,
         // We don't track "is there a cloud chunk for this local session" here
         // — that requires a cloud round-trip. For the UI, the
@@ -218,14 +220,16 @@ export async function tryHandleSessionRoute(
     if (ownerId) {
       const localIds = new Set(rows.map((r) => r.id));
       type RemoteRow = {
-        session_id: string; device_id: string | null; agent: string; title: string | null;
+        session_id: string; device_id: string | null; device_label: string | null;
+        agent: string; title: string | null;
         state: string; cwd: string | null; model: string | null; started_at: string;
         ended_at: string | null; last_event_at: string; has_bytes: number;
         active_device_id: string | null; jsonl_local_path: string | null;
       };
       const remoteRows = db.prepare(
-        `SELECT session_id, device_id, agent, title, state, cwd, model, started_at,
-                ended_at, last_event_at, has_bytes, active_device_id, jsonl_local_path
+        `SELECT session_id, device_id, device_label, agent, title, state, cwd, model,
+                started_at, ended_at, last_event_at, has_bytes, active_device_id,
+                jsonl_local_path
            FROM remote_sessions
           WHERE owner_id = ?
           ORDER BY last_event_at DESC`,
@@ -246,6 +250,7 @@ export async function tryHandleSessionRoute(
           model: r.model,
           lastEventAt: r.last_event_at,
           originDeviceId: r.device_id,
+          originDeviceLabel: r.device_label,
           // Available locally only if the user has already reassembled it.
           jsonlAvailableLocally: r.jsonl_local_path !== null,
           hasBytes: r.has_bytes === 1,

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -645,20 +645,24 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     return applied;
   }
 
-  /** Stable per-device identity; lazy-initialised on first read. Both
-   *  fields are written once at install and don't change at runtime, so
-   *  one cache survives the process. */
-  let cachedDeviceIdentity: { device_id: string | null; label: string | null } | null = null;
+  /** Stable per-device identity; lazy-initialised on first successful
+   *  read. We cache ONLY on success — a missing device_identity row
+   *  means the install seed hasn't run yet (test setup, repair flows,
+   *  or first-boot ordering), and we want subsequent calls to retry
+   *  rather than locking in a null forever. Once seeded, the row never
+   *  changes for the process lifetime, so one cache is enough. */
+  let cachedDeviceIdentity: { device_id: string; label: string } | null = null;
   function loadDeviceIdentity(): { device_id: string | null; label: string | null } {
     if (cachedDeviceIdentity !== null) return cachedDeviceIdentity;
     const row = deps.db.prepare(
       `SELECT device_id, label FROM device_identity WHERE id = 1 LIMIT 1`,
     ).get() as { device_id: string; label: string } | undefined;
-    cachedDeviceIdentity = {
-      device_id: row?.device_id ?? null,
-      label: row?.label ?? null,
-    };
-    return cachedDeviceIdentity;
+    if (row) {
+      cachedDeviceIdentity = row;
+      return row;
+    }
+    // Don't cache the null result — next caller retries.
+    return { device_id: null, label: null };
   }
   function getMyDeviceId(): string | null { return loadDeviceIdentity().device_id; }
   function getMyDeviceLabel(): string | null { return loadDeviceIdentity().label; }

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -174,6 +174,10 @@ interface OutgoingSession {
    *  Attached at push time so cloud knows which device produced each
    *  session — drives the "from MacBook" chip on Device B in PR 3. */
   device_id: string | null;
+  /** Human-readable device label from device_identity.label. Sent
+   *  alongside device_id so Device B's UI can render "From MacBookPro"
+   *  rather than a UUID prefix. Capped at 64 chars worker-side. */
+  device_label: string | null;
 }
 
 export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncService {
@@ -222,10 +226,11 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     let totalAccepted = 0;
     const MAX_BATCHES = 1000;  // defensive safety cap
 
-    // Cache device_id once per drain — it doesn't change during a server
-    // lifetime. NULL is tolerated (cloud upsert accepts NULL) but warns so
-    // a missing device_identity seed is visible.
+    // Cache device id + label once per drain — neither changes during a
+    // server lifetime. NULL is tolerated (cloud upsert accepts both) but a
+    // missing device_identity seed warns so it's visible.
     const myDeviceId = getMyDeviceId();
+    const myDeviceLabel = getMyDeviceLabel();
     if (!myDeviceId) {
       console.warn("[sessions] pushPending: device_identity not seeded; pushing without device_id");
     }
@@ -234,11 +239,15 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       const pending = scanDirty.all(session.user.id, BATCH_SIZE) as OutgoingSession[];
       if (pending.length === 0) break;
 
-      // Stamp every row with this device's id at push time. Rows in the
-      // local `sessions` table don't carry a device_id column — they're
+      // Stamp every row with this device's id + label at push time. Rows in
+      // the local `sessions` table don't carry these columns — they're
       // implicitly produced by this device because the watcher only sees
       // its own filesystem.
-      const stamped = pending.map((s) => ({ ...s, device_id: myDeviceId }));
+      const stamped = pending.map((s) => ({
+        ...s,
+        device_id: myDeviceId,
+        device_label: myDeviceLabel,
+      }));
 
       let res: Response;
       try {
@@ -530,12 +539,16 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
 
   const upsertRemoteSession = deps.db.prepare(
     `INSERT INTO remote_sessions
-       (session_id, owner_id, device_id, agent, title, state, cwd, model,
+       (session_id, owner_id, device_id, device_label, agent, title, state, cwd, model,
         started_at, ended_at, last_event_at, bytes_generation, has_bytes,
         active_device_id, cloud_updated_at, fetched_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(owner_id, session_id) DO UPDATE SET
        device_id         = excluded.device_id,
+       -- Preserve a known label if cloud sends NULL (legacy row, or
+       -- transient race where a partial-shape session arrived). Only a
+       -- non-null cloud value replaces what we have.
+       device_label      = COALESCE(excluded.device_label, remote_sessions.device_label),
        agent             = excluded.agent,
        title             = excluded.title,
        state             = excluded.state,
@@ -573,6 +586,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     type CloudSession = {
       session_id: string;
       device_id: string | null;
+      device_label: string | null;
       agent: string;
       title: string | null;
       state: string;
@@ -614,8 +628,9 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     const tx = deps.db.transaction(() => {
       for (const s of foreignRows) {
         const info = upsertRemoteSession.run(
-          s.session_id, session.user.id, s.device_id, s.agent, s.title, s.state,
-          s.cwd, s.model, s.started_at, s.ended_at, s.last_event_at,
+          s.session_id, session.user.id, s.device_id, s.device_label ?? null,
+          s.agent, s.title, s.state, s.cwd, s.model,
+          s.started_at, s.ended_at, s.last_event_at,
           s.bytes_generation, s.has_bytes ? 1 : 0, s.active_device_id ?? null,
           s.updated_at, now,
         );
@@ -630,16 +645,23 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
     return applied;
   }
 
-  /** Stable per-device id; lazy-initialised on first read. */
-  let cachedDeviceId: string | null = null;
-  function getMyDeviceId(): string | null {
-    if (cachedDeviceId !== null) return cachedDeviceId;
+  /** Stable per-device identity; lazy-initialised on first read. Both
+   *  fields are written once at install and don't change at runtime, so
+   *  one cache survives the process. */
+  let cachedDeviceIdentity: { device_id: string | null; label: string | null } | null = null;
+  function loadDeviceIdentity(): { device_id: string | null; label: string | null } {
+    if (cachedDeviceIdentity !== null) return cachedDeviceIdentity;
     const row = deps.db.prepare(
-      `SELECT device_id FROM device_identity WHERE id = 1 LIMIT 1`,
-    ).get() as { device_id: string } | undefined;
-    cachedDeviceId = row?.device_id ?? null;
-    return cachedDeviceId;
+      `SELECT device_id, label FROM device_identity WHERE id = 1 LIMIT 1`,
+    ).get() as { device_id: string; label: string } | undefined;
+    cachedDeviceIdentity = {
+      device_id: row?.device_id ?? null,
+      label: row?.label ?? null,
+    };
+    return cachedDeviceIdentity;
   }
+  function getMyDeviceId(): string | null { return loadDeviceIdentity().device_id; }
+  function getMyDeviceLabel(): string | null { return loadDeviceIdentity().label; }
 
   const updateRemoteSessionLocalPath = deps.db.prepare(
     `UPDATE remote_sessions

--- a/server/test/device-route.test.ts
+++ b/server/test/device-route.test.ts
@@ -1,0 +1,73 @@
+// GET /api/device/identity — surfaces the local device_identity singleton
+// to the web UI so it can distinguish local from remote sessions and
+// render the cross-device chip.
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { tryHandleDeviceRoute } from "../src/routes/device.js";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE device_identity (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      device_id TEXT NOT NULL,
+      label TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+function fakeCtx() {
+  const captured: { status?: number; json?: unknown } = {};
+  const ctx = {
+    sendJson: (j: unknown, s = 200) => { captured.json = j; captured.status = s; },
+    sendError: (err: unknown, s = 500) => {
+      captured.json = { error: err instanceof Error ? err.message : String(err) };
+      captured.status = s;
+    },
+    rejectIfNonLocalOrigin: () => false,
+    readJsonBody: async () => ({}),
+  };
+  return { ctx, captured };
+}
+
+describe("GET /api/device/identity", () => {
+  it("returns the seeded device id + label", async () => {
+    const db = makeDb();
+    db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, ?, ?)`)
+      .run("dev-mac-uuid", "MacBookPro");
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    const handled = await tryHandleDeviceRoute(req, {} as any, "/api/device/identity", ctx as any, { db });
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.json).toEqual({ deviceId: "dev-mac-uuid", label: "MacBookPro" });
+  });
+
+  it("503 when device_identity row not seeded", async () => {
+    const db = makeDb();
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    const handled = await tryHandleDeviceRoute(req, {} as any, "/api/device/identity", ctx as any, { db });
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(503);
+    expect(captured.json).toMatchObject({ error: "device_identity_not_ready" });
+  });
+
+  it("passes through (returns false) on non-matching URL", async () => {
+    const db = makeDb();
+    const { ctx } = fakeCtx();
+    const req = { method: "GET" } as any;
+    const handled = await tryHandleDeviceRoute(req, {} as any, "/api/something-else", ctx as any, { db });
+    expect(handled).toBe(false);
+  });
+
+  it("passes through (returns false) on POST", async () => {
+    const db = makeDb();
+    db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, 'x', 'y')`).run();
+    const { ctx } = fakeCtx();
+    const req = { method: "POST" } as any;
+    const handled = await tryHandleDeviceRoute(req, {} as any, "/api/device/identity", ctx as any, { db });
+    expect(handled).toBe(false);
+  });
+});

--- a/server/test/device-route.test.ts
+++ b/server/test/device-route.test.ts
@@ -17,7 +17,7 @@ function makeDb(): Database.Database {
   return db;
 }
 
-function fakeCtx() {
+function fakeCtx(opts: { foreignOrigin?: boolean } = {}) {
   const captured: { status?: number; json?: unknown } = {};
   const ctx = {
     sendJson: (j: unknown, s = 200) => { captured.json = j; captured.status = s; },
@@ -25,7 +25,14 @@ function fakeCtx() {
       captured.json = { error: err instanceof Error ? err.message : String(err) };
       captured.status = s;
     },
-    rejectIfNonLocalOrigin: () => false,
+    rejectIfNonLocalOrigin: () => {
+      if (opts.foreignOrigin) {
+        captured.json = { error: "Forbidden origin" };
+        captured.status = 403;
+        return true;
+      }
+      return false;
+    },
     readJsonBody: async () => ({}),
   };
   return { ctx, captured };
@@ -69,5 +76,17 @@ describe("GET /api/device/identity", () => {
     const req = { method: "POST" } as any;
     const handled = await tryHandleDeviceRoute(req, {} as any, "/api/device/identity", ctx as any, { db });
     expect(handled).toBe(false);
+  });
+
+  it("returns 403 when origin is non-local (deviceId is a fingerprintable per-machine UUID)", async () => {
+    const db = makeDb();
+    db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, 'x', 'y')`).run();
+    const { ctx, captured } = fakeCtx({ foreignOrigin: true });
+    const req = { method: "GET" } as any;
+    const handled = await tryHandleDeviceRoute(req, {} as any, "/api/device/identity", ctx as any, { db });
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(403);
+    // The identity row is NEVER read in this path.
+    expect(captured.json).toMatchObject({ error: "Forbidden origin" });
   });
 });

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -45,6 +45,7 @@ function harness() {
       session_id        TEXT NOT NULL,
       owner_id          TEXT NOT NULL,
       device_id         TEXT,
+      device_label      TEXT,
       agent             TEXT NOT NULL,
       title             TEXT,
       state             TEXT NOT NULL,
@@ -136,7 +137,7 @@ describe("SessionSyncService", () => {
     expect(row.cloud_owner_id).toBe("user-A");
   });
 
-  it("pushPending stamps device_id from device_identity onto every payload row", async () => {
+  it("pushPending stamps device_id and device_label from device_identity onto every payload row", async () => {
     const { db, profileBinding } = harness();
     profileBinding.bindToOwner("user-A");
     db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, ?, ?)`)
@@ -156,9 +157,14 @@ describe("SessionSyncService", () => {
       fetch: fetchSpy as unknown as typeof fetch,
     });
     await svc.pushPending();
-    const body = JSON.parse(capturedBody ?? "{}") as { sessions: Array<{ id: string; device_id: string | null }> };
+    const body = JSON.parse(capturedBody ?? "{}") as {
+      sessions: Array<{ id: string; device_id: string | null; device_label: string | null }>
+    };
     expect(body.sessions).toHaveLength(1);
     expect(body.sessions[0]!.device_id).toBe("my-mac-uuid");
+    // device_label rides alongside so Device B can render "From MacBook-Pro"
+    // without needing a separate hostname-lookup round-trip.
+    expect(body.sessions[0]!.device_label).toBe("MacBook-Pro");
   });
 
   it("pushPending tolerates missing device_identity (device_id null in payload)", async () => {
@@ -756,6 +762,7 @@ describe("SessionSyncService.pull", () => {
   function cloudPayload(sessions: Array<{
     session_id: string;
     device_id: string | null;
+    device_label?: string | null;
     has_bytes?: boolean;
     bytes_generation?: number;
     updated_at?: number;
@@ -766,6 +773,7 @@ describe("SessionSyncService.pull", () => {
       sessions: sessions.map((s) => ({
         session_id: s.session_id,
         device_id: s.device_id,
+        device_label: s.device_label ?? null,
         agent: "claude-code",
         title: s.title ?? "remote session",
         state: s.state ?? "done",
@@ -823,6 +831,67 @@ describe("SessionSyncService.pull", () => {
     expect(rows.map((r) => r.session_id)).toEqual(["s-orphan", "s-other"]);
     expect(rows.find((r) => r.session_id === "s-other")?.has_bytes).toBe(1);
     expect(rows.find((r) => r.session_id === "s-orphan")?.has_bytes).toBe(0);
+  });
+
+  it("populates remote_sessions.device_label from the cloud payload", async () => {
+    // The cross-device session chip in the UI renders this label rather than
+    // the opaque device_id UUID, so it has to flow through the pull path.
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    const fetchSpy = vi.fn(async () =>
+      cloudPayload([
+        { session_id: "s-from-windows", device_id: "dev-pc", device_label: "DESKTOP-WIN", has_bytes: true },
+        { session_id: "s-legacy", device_id: "dev-pc", device_label: null, has_bytes: true },
+      ]),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pull();
+    const rows = db.prepare(
+      `SELECT session_id, device_label FROM remote_sessions WHERE owner_id = ? ORDER BY session_id`,
+    ).all("user-A") as Array<{ session_id: string; device_label: string | null }>;
+    expect(rows.find((r) => r.session_id === "s-from-windows")?.device_label).toBe("DESKTOP-WIN");
+    expect(rows.find((r) => r.session_id === "s-legacy")?.device_label).toBeNull();
+  });
+
+  it("preserves an existing device_label when cloud later sends NULL (COALESCE)", async () => {
+    // A subsequent pull where the origin device is offline or pushed a
+    // partial-shape session must not erase the known label. The upsert's
+    // COALESCE(excluded.device_label, ...) protects against that.
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    let phase: "labelled" | "null" = "labelled";
+    const fetchSpy = vi.fn(async () => {
+      if (phase === "labelled") {
+        return cloudPayload([
+          { session_id: "s1", device_id: "dev-pc", device_label: "DESKTOP-WIN", updated_at: 1000 },
+        ]);
+      }
+      return cloudPayload([
+        { session_id: "s1", device_id: "dev-pc", device_label: null, updated_at: 2000 },
+      ]);
+    });
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pull();
+    phase = "null";
+    await svc.pull();
+    const row = db.prepare(
+      `SELECT device_label FROM remote_sessions WHERE session_id = 's1'`,
+    ).get() as { device_label: string | null };
+    expect(row.device_label).toBe("DESKTOP-WIN");
   });
 
   it("skips remote rows whose session_id already exists locally (legacy NULL device_id)", async () => {

--- a/server/test/sessions-resume-route.test.ts
+++ b/server/test/sessions-resume-route.test.ts
@@ -30,6 +30,7 @@ function makeDb(): Database.Database {
   db.exec(`
     CREATE TABLE remote_sessions (
       session_id TEXT NOT NULL, owner_id TEXT NOT NULL, device_id TEXT,
+      device_label TEXT,
       agent TEXT NOT NULL, title TEXT, state TEXT NOT NULL, cwd TEXT,
       model TEXT, started_at TEXT NOT NULL, ended_at TEXT,
       last_event_at TEXT NOT NULL, bytes_generation INTEGER NOT NULL DEFAULT 0,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -111,6 +111,10 @@ export interface Session {
    *  sessions discovered by this device's watcher; populated for remote
    *  sessions pulled from the cloud manifest. */
   originDeviceId?: string | null;
+  /** Human-readable origin device label (e.g. "MacBookPro"). Pulled from
+   *  the origin device's device_identity.label. Null on rows pushed before
+   *  this column existed — UI falls back to "Other device". */
+  originDeviceLabel?: string | null;
   /** True for local sessions; true for remote sessions whose jsonl has
    *  already been reassembled to disk on this device; false otherwise. */
   jsonlAvailableLocally?: boolean;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -439,6 +439,41 @@
   white-space: nowrap;
 }
 
+/* Cross-device chip — same chrome as the space chip but with a distinct
+ * tint so it reads as "origin device" not "space membership". Lives in
+ * the same top-left slot on tiles; inline-block on rows. */
+.home-remote-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  padding: 3px 8px;
+  border-radius: 7px;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: #8fb6ff;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Row variant — same colour treatment but flows inline next to the title
+ * rather than absolute-positioned over a thumb. Slight size bump so it
+ * doesn't get lost mid-line. */
+.home-row-title .home-remote-chip {
+  position: static;
+  margin-right: 8px;
+  vertical-align: baseline;
+  font-size: 10px;
+}
+
 /* ── Status indicator on the thumb ── */
 .home-status {
   position: absolute;

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -1,15 +1,19 @@
 // Session row (table-view list item). Extracted from Home/index.tsx.
 import type { Session } from "../../data/sessions-api";
 import type { Space } from "../../../../shared/types";
-import { AGENT_PIP_CLASS, formatRelative, spaceLabelFor } from "./utils";
+import {
+  AGENT_PIP_CLASS, formatRelative, originDeviceChipFor, spaceLabelFor,
+} from "./utils";
 
 interface SessionRowProps {
   session: Session;
   spaces: Space[];
+  /** Local device id; drives the cross-device chip. See SessionTile. */
+  myDeviceId: string | null;
   onOpen?: (id: string) => void;
 }
 
-export function SessionRow({ session, spaces, onOpen }: SessionRowProps) {
+export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
   const rel = formatRelative(session.lastEventAt) ?? "—";
   const time = session.state === "waiting" ? `waiting ${rel}`
@@ -21,6 +25,7 @@ export function SessionRow({ session, spaces, onOpen }: SessionRowProps) {
   // the user can identify where the session was running.
   const cwdBasename = session.cwd ? session.cwd.split(/[\\/]/).filter(Boolean).pop() ?? null : null;
   const projectLabel = session.sourceLabel ?? spaceLabel ?? cwdBasename ?? "—";
+  const remoteChip = originDeviceChipFor(session, myDeviceId);
   return (
     <div
       className="home-row"
@@ -33,7 +38,14 @@ export function SessionRow({ session, spaces, onOpen }: SessionRowProps) {
     >
       <span className={`home-row-status ${session.state}`} />
       <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
-      <span className="home-row-title" title={title}>{title}</span>
+      <span className="home-row-title" title={title}>
+        {remoteChip && (
+          <span className="home-remote-chip" title={remoteChip.titleTooltip}>
+            <span aria-hidden="true">↗</span> {remoteChip.label}
+          </span>
+        )}
+        {title}
+      </span>
       <span className={`home-row-agent ${AGENT_PIP_CLASS[session.agent]}`}>
         <span className="home-agent-pip" />
         {session.agent}

--- a/web/src/components/Home/SessionTile.tsx
+++ b/web/src/components/Home/SessionTile.tsx
@@ -1,18 +1,26 @@
 // Session tile (icons-view card). Extracted from Home/index.tsx.
 import type { Session } from "../../data/sessions-api";
 import type { Space } from "../../../../shared/types";
-import { AGENT_CLASS, AGENT_LETTERS, metaForSession, spaceLabelFor } from "./utils";
+import {
+  AGENT_CLASS, AGENT_LETTERS,
+  metaForSession, originDeviceChipFor, spaceLabelFor,
+} from "./utils";
 
 interface SessionTileProps {
   session: Session;
   spaces: Space[];
   showSpaceChip: boolean;
+  /** Local device id, when known. Drives the cross-device chip. Null
+   *  during the brief window before useMyDeviceId resolves — chip is
+   *  suppressed during that window. */
+  myDeviceId: string | null;
   onOpen?: (id: string) => void;
 }
 
-export function SessionTile({ session, spaces, showSpaceChip, onOpen }: SessionTileProps) {
+export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, onOpen }: SessionTileProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
   const title = session.title ?? "(no title yet)";
+  const remoteChip = originDeviceChipFor(session, myDeviceId);
   return (
     <div
       className="home-tile"
@@ -24,8 +32,16 @@ export function SessionTile({ session, spaces, showSpaceChip, onOpen }: SessionT
       tabIndex={onOpen ? 0 : undefined}
     >
       <div className={`home-thumb ${AGENT_CLASS[session.agent]}`}>
-        {showSpaceChip && spaceLabel && (
-          <span className="home-space-chip">{spaceLabel}</span>
+        {remoteChip ? (
+          // Cross-device chip wins over the space chip when both would apply —
+          // origin is a stronger signal than space membership for these cards.
+          <span className="home-remote-chip" title={remoteChip.titleTooltip}>
+            <span aria-hidden="true">↗</span> {remoteChip.label}
+          </span>
+        ) : (
+          showSpaceChip && spaceLabel && (
+            <span className="home-space-chip">{spaceLabel}</span>
+          )
         )}
         <span className="home-agent-mark">{AGENT_LETTERS[session.agent]}</span>
         <span className={`home-status ${session.state}`} />

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -6,6 +6,7 @@ import type { Artifact, Space } from "../../../../shared/types";
 import { useSessions } from "../../hooks/useSessions";
 import { useMemories } from "../../hooks/useMemories";
 import { useAuthSignedIn } from "../../hooks/useAuthSignedIn";
+import { useMyDeviceId } from "../../hooks/useMyDeviceId";
 import { useSpaceSources } from "../../hooks/useSpaceSources";
 import { parseTimestamp } from "../../utils/parseTimestamp";
 import { Desktop } from "../Desktop";
@@ -128,6 +129,8 @@ const FILTER_LABELS: Record<StateFilter, string> = {
 export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange }: Props) {
   const { sessions, error, loading } = useSessions();
   const signedIn = useAuthSignedIn();
+  const myDevice = useMyDeviceId();
+  const myDeviceId = myDevice?.deviceId ?? null;
   const [signingIn, setSigningIn] = useState(false);
   const {
     memories,
@@ -1015,6 +1018,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       session={session}
                       spaces={spaces}
                       showSpaceChip={isMetaView}
+                      myDeviceId={myDeviceId}
                       onOpen={(id) => setActivePanel({ kind: "session", id })}
                     />
                   ))}
@@ -1027,6 +1031,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                         key={session.id}
                         session={session}
                         spaces={spaces}
+                        myDeviceId={myDeviceId}
                         onOpen={(id) => setActivePanel({ kind: "session", id })}
                       />
                     ))}

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -62,6 +62,27 @@ export function spaceLabelFor(spaceId: string | null, spaces: Space[]): string |
   return spaces.find((s) => s.id === spaceId)?.displayName ?? spaceId;
 }
 
+/** Decide whether to show the cross-device chip on a session card and what
+ *  to put in it. Returns null for local sessions and during the brief
+ *  window before useMyDeviceId resolves (we render conservatively rather
+ *  than flashing chips on local sessions). */
+export function originDeviceChipFor(
+  session: Session,
+  myDeviceId: string | null,
+): { label: string; titleTooltip: string } | null {
+  const origin = session.originDeviceId;
+  if (!origin) return null;             // local session, no chip
+  if (!myDeviceId) return null;          // identity still loading
+  if (origin === myDeviceId) return null; // own session, no chip
+  // Prefer the human label pushed by the origin device; fall back to a
+  // generic "Other device" rather than exposing the UUID prefix in the UI.
+  const label = session.originDeviceLabel ?? "Other device";
+  // Tooltip carries the UUID for diagnostic copy-paste, never user-facing
+  // text. Truncated to first 8 chars to match the prior debug format.
+  const titleTooltip = `From ${label} (device ${origin.slice(0, 8)})`;
+  return { label, titleTooltip };
+}
+
 export function metaForSession(session: Session): string {
   const rel = formatRelative(session.lastEventAt) ?? "—";
   if (session.state === "waiting") return `${session.agent} · waiting ${rel}`;

--- a/web/src/components/InspectorPanel.css
+++ b/web/src/components/InspectorPanel.css
@@ -206,6 +206,25 @@
   margin: 6px 0;
   padding-left: 18px;
 }
+.resume-warning input {
+  display: block;
+  width: 100%;
+  margin: 6px 0;
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.resume-warning-actions { display: flex; flex-direction: column; gap: 6px; }
+.resume-warning-actions details { font-size: 12px; }
+.resume-warning-actions summary {
+  cursor: pointer;
+  color: var(--text-dim);
+  padding: 4px 0;
+}
 .resume-pick li { margin: 4px 0; display: flex; gap: 8px; align-items: center; }
 .resume-diverged .resume-tech {
   font-size: 11px;

--- a/web/src/components/InspectorPanel.css
+++ b/web/src/components/InspectorPanel.css
@@ -105,6 +105,120 @@
   font-size: 11px;
 }
 
+/* Resume-on-this-device affordance + dialog (#322 PR 3.1) */
+.inspector-resume {
+  margin: 12px 28px 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.inspector-resume button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(143, 182, 255, 0.4);
+  background: rgba(143, 182, 255, 0.08);
+  color: #cfdcff;
+  font-size: 12px;
+  cursor: pointer;
+}
+.inspector-resume button:hover:not(:disabled) {
+  background: rgba(143, 182, 255, 0.15);
+}
+.inspector-resume button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.inspector-resume-hint {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.resume-dialog {
+  margin: 12px 28px 16px;
+  padding: 14px 16px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(143, 182, 255, 0.2);
+  font-size: 13px;
+}
+.resume-dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.resume-dialog-header h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+.resume-dialog-header .close {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+}
+.resume-dialog p { margin: 6px 0; }
+.resume-dialog code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  word-break: break-all;
+}
+.resume-command {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.resume-command code {
+  flex: 1;
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.3);
+}
+.resume-command button,
+.resume-panel button {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(143, 182, 255, 0.4);
+  background: rgba(143, 182, 255, 0.1);
+  color: #cfdcff;
+  font-size: 12px;
+  cursor: pointer;
+}
+.resume-needs-target input {
+  display: block;
+  width: 100%;
+  margin: 8px 0;
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.resume-warning ul, .resume-pick ul {
+  margin: 6px 0;
+  padding-left: 18px;
+}
+.resume-pick li { margin: 4px 0; display: flex; gap: 8px; align-items: center; }
+.resume-diverged .resume-tech {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.resume-error {
+  color: #f87171;
+}
+.resume-loading {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
 .inspector-tabs {
   display: flex;
   gap: 0;

--- a/web/src/components/SessionInspector/Header.tsx
+++ b/web/src/components/SessionInspector/Header.tsx
@@ -1,6 +1,9 @@
 // Header — extracted from SessionInspector for navigability.
+import { useState } from "react";
 import type { Session, SessionState } from "../../data/sessions-api";
+import { useMyDeviceId } from "../../hooks/useMyDeviceId";
 import { SessionActions } from "./SessionActions";
+import { ResumeDialog } from "./ResumeDialog";
 import { formatTs } from "./utils";
 
 const PIP_CLASS: Record<SessionState, string> = {
@@ -18,6 +21,19 @@ const STATE_LABEL: Record<SessionState, string> = {
 };
 
 export function Header({ session, onClose }: { session: Session; onClose: () => void }) {
+  const myDevice = useMyDeviceId();
+  const myDeviceId = myDevice?.deviceId ?? null;
+  // Show the Resume affordance only on remote sessions. A null myDeviceId
+  // (identity still loading) suppresses the button — once it lands the
+  // header re-renders and the button appears. hasBytes gates whether the
+  // button is enabled vs. disabled.
+  const isRemote = session.originDeviceId !== null
+    && session.originDeviceId !== undefined
+    && session.originDeviceId !== myDeviceId
+    && myDeviceId !== null;
+  const canResume = isRemote && session.hasBytes === true;
+  const [resumeOpen, setResumeOpen] = useState(false);
+
   return (
     <header className="inspector-header">
       <div className="inspector-meta">
@@ -35,6 +51,26 @@ export function Header({ session, onClose }: { session: Session; onClose: () => 
         {session.model ? ` · ${session.model}` : ""}
       </div>
       <SessionActions session={session} />
+
+      {isRemote && (
+        <div className="inspector-resume">
+          <button
+            type="button"
+            disabled={!canResume}
+            onClick={() => setResumeOpen(true)}
+            title={canResume ? undefined : "Transcript bytes haven't synced from the origin device yet."}
+          >
+            Resume on this device
+          </button>
+          {!canResume && (
+            <span className="inspector-resume-hint">Waiting for transcript to sync from origin device…</span>
+          )}
+        </div>
+      )}
+
+      {resumeOpen && (
+        <ResumeDialog session={session} onClose={() => setResumeOpen(false)} />
+      )}
     </header>
   );
 }

--- a/web/src/components/SessionInspector/ResumeDialog.tsx
+++ b/web/src/components/SessionInspector/ResumeDialog.tsx
@@ -1,0 +1,255 @@
+// Inline dialog rendered below SessionInspector's Header when the user
+// clicks "Resume on this device" on a remote session. It steps through the
+// server's four response shapes and surfaces the right next action.
+//
+// State machine:
+//   idle          — initial; show nothing (parent decides whether to mount)
+//   loading       — POST in flight; show a small spinner-ish message
+//   ok            — show copyable `cd <path> && claude --resume <id>` command
+//   needs_target  — show a text input prefilled with remoteCwd (if known) +
+//                   "Resume here" button → re-POST with { targetCwd }
+//   validation    — show reasons + "Use this folder anyway" → re-POST with
+//                   { targetCwd, force: true }
+//   diverged      — surface the conflict; resolution actions are 3.2 work
+//   error         — generic failure (network, 5xx)
+//
+// Folder picker is text-input-only in 3.1 — native picker is 3.2.
+
+import { useEffect, useState } from "react";
+import type { Session } from "../../data/sessions-api";
+import { resumeSession, type SessionResumeResponse } from "../../data/sessions-api";
+
+interface ResumeDialogProps {
+  session: Session;
+  onClose: () => void;
+}
+
+interface DialogState {
+  // The response we're currently rendering. Null on first paint.
+  response: SessionResumeResponse | null;
+  /** Path the user typed into the override input. Persisted across
+   *  re-POSTs so a validation_warning rejection doesn't lose their input. */
+  draftCwd: string;
+  /** Network/5xx error message. Cleared on the next attempt. */
+  error: string | null;
+  /** True between submit and response. */
+  loading: boolean;
+}
+
+export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
+  const [state, setState] = useState<DialogState>({
+    response: null,
+    draftCwd: "",
+    error: null,
+    loading: true,
+  });
+
+  // Kick off the initial auto-resolve POST when the dialog mounts.
+  // Session id is stable for the dialog's lifetime so this fires once.
+  useEffect(() => {
+    runResume({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session.id]);
+
+  async function runResume(opts: { targetCwd?: string; force?: boolean }): Promise<void> {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const response = await resumeSession(session.id, opts);
+      setState((s) => ({
+        ...s,
+        response,
+        // Carry forward the override path so the input doesn't clear on
+        // re-renders. needs_target also seeds it from remoteCwd below.
+        draftCwd: opts.targetCwd ?? s.draftCwd,
+        loading: false,
+      }));
+    } catch (err) {
+      setState((s) => ({
+        ...s,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }
+
+  function copyCommand(command: string): void {
+    void navigator.clipboard.writeText(command);
+  }
+
+  return (
+    <div className="resume-dialog" role="region" aria-label="Resume session on this device">
+      <div className="resume-dialog-header">
+        <h3>Resume on this device</h3>
+        <button type="button" className="close" onClick={onClose} aria-label="Close">✕</button>
+      </div>
+
+      {state.loading && <div className="resume-loading">Working…</div>}
+
+      {state.error && (
+        <div className="resume-error">
+          <p>Something went wrong: {state.error}</p>
+          <button type="button" onClick={() => runResume({})}>Retry</button>
+        </div>
+      )}
+
+      {!state.loading && state.response?.status === "ok" && (
+        <OkPanel response={state.response} onCopy={copyCommand} />
+      )}
+
+      {!state.loading && state.response?.status === "needs_target" && (
+        <NeedsTargetPanel
+          response={state.response}
+          draftCwd={state.draftCwd}
+          onDraftChange={(v) => setState((s) => ({ ...s, draftCwd: v }))}
+          onSubmit={(cwd) => runResume({ targetCwd: cwd })}
+        />
+      )}
+
+      {!state.loading && state.response?.status === "validation_warning" && (
+        <ValidationPanel
+          response={state.response}
+          draftCwd={state.draftCwd}
+          onSubmit={(cwd) => runResume({ targetCwd: cwd, force: true })}
+        />
+      )}
+
+      {!state.loading && state.response?.status === "local_diverged" && (
+        <DivergedPanel response={state.response} />
+      )}
+
+      {!state.loading && state.response?.status === "pick_source" && (
+        <PickSourcePanel
+          response={state.response}
+          onChoose={(path) => runResume({ targetCwd: path })}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Panels ──
+
+function OkPanel({
+  response, onCopy,
+}: {
+  response: Extract<SessionResumeResponse, { status: "ok" }>;
+  onCopy: (cmd: string) => void;
+}) {
+  return (
+    <div className="resume-panel resume-ok">
+      <p>Transcript ready at <code>{response.jsonlPath}</code>.</p>
+      <p>Run this in a terminal to continue the session:</p>
+      <div className="resume-command">
+        <code>{response.command}</code>
+        <button type="button" onClick={() => onCopy(response.command)}>Copy command</button>
+      </div>
+    </div>
+  );
+}
+
+function NeedsTargetPanel({
+  response, draftCwd, onDraftChange, onSubmit,
+}: {
+  response: Extract<SessionResumeResponse, { status: "needs_target" }>;
+  draftCwd: string;
+  onDraftChange: (v: string) => void;
+  onSubmit: (cwd: string) => void;
+}) {
+  // Prefill the input with the origin cwd as a hint. The user almost
+  // always wants something different (it's a foreign-device path), but
+  // it's a useful starting point and they can edit. If they've already
+  // typed something, preserve that.
+  const value = draftCwd || response.remoteCwd || "";
+  return (
+    <div className="resume-panel resume-needs-target">
+      <p>No local folder is registered for this session.</p>
+      <p>Paste the path to the folder where you'd like to continue:</p>
+      <input
+        type="text"
+        value={value}
+        placeholder="/path/to/project"
+        onChange={(e) => onDraftChange(e.target.value)}
+        spellCheck={false}
+        autoFocus
+      />
+      <button
+        type="button"
+        disabled={!value.trim()}
+        onClick={() => onSubmit(value.trim())}
+      >
+        Resume here
+      </button>
+    </div>
+  );
+}
+
+function ValidationPanel({
+  response, draftCwd, onSubmit,
+}: {
+  response: Extract<SessionResumeResponse, { status: "validation_warning" }>;
+  draftCwd: string;
+  onSubmit: (cwd: string) => void;
+}) {
+  return (
+    <div className="resume-panel resume-warning">
+      <p>This folder doesn't quite match the original session:</p>
+      <ul>
+        {response.reasons.map((r) => (
+          <li key={r}>{humanReason(r)}</li>
+        ))}
+      </ul>
+      <p>You can resume here anyway — earlier turns will reference paths that don't exist on this machine, but Claude Code will continue from the conversation context.</p>
+      <button type="button" onClick={() => onSubmit(draftCwd.trim())}>Use this folder anyway</button>
+    </div>
+  );
+}
+
+function DivergedPanel({
+  response,
+}: {
+  response: Extract<SessionResumeResponse, { status: "local_diverged" }>;
+}) {
+  return (
+    <div className="resume-panel resume-diverged">
+      <p>This device has local-only edits past what's in the cloud.</p>
+      <p className="resume-tech">
+        Local transcript at <code>{response.localJsonlPath}</code> diverges from the cloud chain.
+      </p>
+      <p>Resolution (keep local as a fork, or discard local and pull cloud) is coming in the next release.</p>
+    </div>
+  );
+}
+
+function PickSourcePanel({
+  response, onChoose,
+}: {
+  response: Extract<SessionResumeResponse, { status: "pick_source" }>;
+  onChoose: (path: string) => void;
+}) {
+  return (
+    <div className="resume-panel resume-pick">
+      <p>Multiple folders are linked to this session's space. Pick one:</p>
+      <ul>
+        {response.candidates.map((c) => (
+          <li key={c.path}>
+            <button type="button" onClick={() => onChoose(c.path)}>
+              {c.label ?? c.path}
+            </button>
+            <code>{c.path}</code>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// Map raw reason codes the route returns to human-readable text.
+function humanReason(code: string): string {
+  switch (code) {
+    case "folder_missing": return "Folder doesn't exist";
+    case "not_git_repo":   return "Folder isn't a git repository";
+    case "remote_mismatch": return "Git remote doesn't match the original";
+    case "repo_basename_differs": return "Folder name differs from the original";
+    default: return code;
+  }
+}

--- a/web/src/components/SessionInspector/ResumeDialog.tsx
+++ b/web/src/components/SessionInspector/ResumeDialog.tsx
@@ -1,17 +1,19 @@
 // Inline dialog rendered below SessionInspector's Header when the user
 // clicks "Resume on this device" on a remote session. It steps through the
-// server's four response shapes and surfaces the right next action.
+// server's five SessionResumeResponse shapes and surfaces the right next
+// action.
 //
 // State machine:
-//   idle          — initial; show nothing (parent decides whether to mount)
 //   loading       — POST in flight; show a small spinner-ish message
 //   ok            — show copyable `cd <path> && claude --resume <id>` command
 //   needs_target  — show a text input prefilled with remoteCwd (if known) +
 //                   "Resume here" button → re-POST with { targetCwd }
-//   validation    — show reasons + "Use this folder anyway" → re-POST with
-//                   { targetCwd, force: true }
-//   diverged      — surface the conflict; resolution actions are 3.2 work
-//   error         — generic failure (network, 5xx)
+//   pick_source   — multiple sources match this session's space; user
+//                   chooses one → re-POST with that targetCwd
+//   validation_   — show reasons + "Use this folder anyway" → re-POST with
+//     warning       { targetCwd, force: true }
+//   local_diverged— surface the conflict; resolution actions are 3.2 work
+//   error         — generic failure (network, 5xx, 409 bytes_not_available)
 //
 // Folder picker is text-input-only in 3.1 — native picker is 3.2.
 
@@ -43,6 +45,7 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
     error: null,
     loading: true,
   });
+  const [copied, setCopied] = useState(false);
 
   // Kick off the initial auto-resolve POST when the dialog mounts.
   // Session id is stable for the dialog's lifetime so this fires once.
@@ -72,8 +75,21 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
     }
   }
 
+  // Match the existing SessionActions copy pattern: feature-detect the
+  // async clipboard API, fall back to alert() when blocked (insecure
+  // origin, permissions), and never produce an unhandled rejection.
   function copyCommand(command: string): void {
-    void navigator.clipboard.writeText(command);
+    if (!navigator.clipboard) {
+      alert(`Copy failed — resume command:\n${command}`);
+      return;
+    }
+    navigator.clipboard.writeText(command).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      },
+      () => alert(`Copy failed — resume command:\n${command}`),
+    );
   }
 
   return (
@@ -93,7 +109,7 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
       )}
 
       {!state.loading && state.response?.status === "ok" && (
-        <OkPanel response={state.response} onCopy={copyCommand} />
+        <OkPanel response={state.response} copied={copied} onCopy={copyCommand} />
       )}
 
       {!state.loading && state.response?.status === "needs_target" && (
@@ -130,9 +146,10 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
 // ── Panels ──
 
 function OkPanel({
-  response, onCopy,
+  response, copied, onCopy,
 }: {
   response: Extract<SessionResumeResponse, { status: "ok" }>;
+  copied: boolean;
   onCopy: (cmd: string) => void;
 }) {
   return (
@@ -141,7 +158,9 @@ function OkPanel({
       <p>Run this in a terminal to continue the session:</p>
       <div className="resume-command">
         <code>{response.command}</code>
-        <button type="button" onClick={() => onCopy(response.command)}>Copy command</button>
+        <button type="button" onClick={() => onCopy(response.command)}>
+          {copied ? "Copied" : "Copy command"}
+        </button>
       </div>
     </div>
   );

--- a/web/src/components/SessionInspector/ResumeDialog.tsx
+++ b/web/src/components/SessionInspector/ResumeDialog.tsx
@@ -125,7 +125,9 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
         <ValidationPanel
           response={state.response}
           draftCwd={state.draftCwd}
-          onSubmit={(cwd) => runResume({ targetCwd: cwd, force: true })}
+          onDraftChange={(v) => setState((s) => ({ ...s, draftCwd: v }))}
+          onForce={(cwd) => runResume({ targetCwd: cwd, force: true })}
+          onRetry={(cwd) => runResume({ targetCwd: cwd })}
         />
       )}
 
@@ -203,12 +205,21 @@ function NeedsTargetPanel({
 }
 
 function ValidationPanel({
-  response, draftCwd, onSubmit,
+  response, draftCwd, onDraftChange, onForce, onRetry,
 }: {
   response: Extract<SessionResumeResponse, { status: "validation_warning" }>;
   draftCwd: string;
-  onSubmit: (cwd: string) => void;
+  onDraftChange: (v: string) => void;
+  /** Re-POST with force:true to bypass soft reasons. */
+  onForce: (cwd: string) => void;
+  /** Re-POST without force, after the user edited the path. */
+  onRetry: (cwd: string) => void;
 }) {
+  // Split the reasons. Hard ones (target_folder_missing, target_not_a_directory)
+  // can't be bypassed — the server returns validation_warning again on a force
+  // attempt. Show an editable input + "Try this folder" instead of the
+  // misleading force button so the user doesn't get trapped in a loop.
+  const hasHardReason = response.reasons.some(isHardReason);
   return (
     <div className="resume-panel resume-warning">
       <p>This folder doesn't quite match the original session:</p>
@@ -217,8 +228,51 @@ function ValidationPanel({
           <li key={r}>{humanReason(r)}</li>
         ))}
       </ul>
-      <p>You can resume here anyway — earlier turns will reference paths that don't exist on this machine, but Claude Code will continue from the conversation context.</p>
-      <button type="button" onClick={() => onSubmit(draftCwd.trim())}>Use this folder anyway</button>
+
+      {hasHardReason ? (
+        <>
+          <p>The folder needs to exist before Oyster can reassemble the transcript into it. Edit the path and try again:</p>
+          <input
+            type="text"
+            value={draftCwd}
+            placeholder="/path/to/project"
+            onChange={(e) => onDraftChange(e.target.value)}
+            spellCheck={false}
+            autoFocus
+          />
+          <button
+            type="button"
+            disabled={!draftCwd.trim()}
+            onClick={() => onRetry(draftCwd.trim())}
+          >
+            Try this folder
+          </button>
+        </>
+      ) : (
+        <>
+          <p>You can resume here anyway — earlier turns will reference paths that don't exist on this machine, but Claude Code will continue from the conversation context.</p>
+          <div className="resume-warning-actions">
+            <button type="button" onClick={() => onForce(draftCwd.trim())}>Use this folder anyway</button>
+            <details>
+              <summary>Or pick a different folder</summary>
+              <input
+                type="text"
+                value={draftCwd}
+                placeholder="/path/to/project"
+                onChange={(e) => onDraftChange(e.target.value)}
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                disabled={!draftCwd.trim()}
+                onClick={() => onRetry(draftCwd.trim())}
+              >
+                Try this folder instead
+              </button>
+            </details>
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -262,13 +316,25 @@ function PickSourcePanel({
   );
 }
 
-// Map raw reason codes the route returns to human-readable text.
+// Reason codes used by validateOverrideTarget() in server/src/routes/sessions.ts.
+// HARD reasons can't be bypassed with force:true (the server returns
+// validation_warning again — force can't conjure a folder into existence);
+// SOFT reasons are advisory and force:true accepts them.
+const HARD_REASONS = new Set(["target_folder_missing", "target_not_a_directory"]);
+
+function isHardReason(code: string): boolean {
+  return HARD_REASONS.has(code);
+}
+
+// Map raw reason codes from the resume route to human-readable text.
+// Keep in sync with server/src/routes/sessions.ts:validateOverrideTarget.
 function humanReason(code: string): string {
   switch (code) {
-    case "folder_missing": return "Folder doesn't exist";
-    case "not_git_repo":   return "Folder isn't a git repository";
-    case "remote_mismatch": return "Git remote doesn't match the original";
-    case "repo_basename_differs": return "Folder name differs from the original";
+    case "target_folder_missing": return "Folder doesn't exist on this machine";
+    case "target_not_a_directory": return "That path isn't a folder";
+    case "not_a_git_repo": return "Folder isn't a git repository";
+    case "no_git_remote_origin": return "Folder has no `origin` remote configured";
+    case "repo_basename_differs": return "Folder name differs from the original session";
     default: return code;
   }
 }

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -137,3 +137,29 @@ export class SessionNotFoundError extends Error {
     this.name = "SessionNotFoundError";
   }
 }
+
+/** Re-exported shape so callers can type-check the dialog. The server side
+ *  is shared/types.ts → SessionResumeResponse. */
+export type { SessionResumeResponse } from "../../../shared/types";
+import type { SessionResumeResponse } from "../../../shared/types";
+
+/** POST /api/sessions/:id/resume. Returns one of five tagged shapes — see
+ *  SessionResumeResponse for the contract. The dialog renders different UI
+ *  per `status` value. Network or 5xx errors bubble as thrown ApiError. */
+export async function resumeSession(
+  sessionId: string,
+  opts: { targetCwd?: string; force?: boolean } = {},
+): Promise<SessionResumeResponse> {
+  const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/resume`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(opts),
+  });
+  // 200 (ok / needs_target / pick_source) and 409 (validation_warning /
+  // local_diverged / bytes_not_available) all return JSON bodies the dialog
+  // routes on. Anything else is an exception.
+  if (!res.ok && res.status !== 409) {
+    throw new ApiError(`Resume failed: ${res.status}`, res.status);
+  }
+  return (await res.json()) as SessionResumeResponse;
+}

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -143,9 +143,17 @@ export class SessionNotFoundError extends Error {
 export type { SessionResumeResponse } from "../../../shared/types";
 import type { SessionResumeResponse } from "../../../shared/types";
 
-/** POST /api/sessions/:id/resume. Returns one of five tagged shapes — see
- *  SessionResumeResponse for the contract. The dialog renders different UI
- *  per `status` value. Network or 5xx errors bubble as thrown ApiError. */
+/** POST /api/sessions/:id/resume. The route returns one of two shapes:
+ *
+ *  - 200 with a tagged `SessionResumeResponse` body (status: ok |
+ *    needs_target | pick_source | validation_warning).
+ *  - 409 with EITHER `{ status: "local_diverged", ... }` (a real
+ *    response variant we want to surface) OR `{ error, message }` for
+ *    pre-flight errors like bytes_not_available. We re-throw the latter
+ *    as ApiError so the dialog doesn't render a blank state on a
+ *    `status`-less body.
+ *
+ *  Anything else (network failure, 5xx) throws ApiError. */
 export async function resumeSession(
   sessionId: string,
   opts: { targetCwd?: string; force?: boolean } = {},
@@ -155,11 +163,22 @@ export async function resumeSession(
     headers: { "content-type": "application/json" },
     body: JSON.stringify(opts),
   });
-  // 200 (ok / needs_target / pick_source) and 409 (validation_warning /
-  // local_diverged / bytes_not_available) all return JSON bodies the dialog
-  // routes on. Anything else is an exception.
-  if (!res.ok && res.status !== 409) {
-    throw new ApiError(`Resume failed: ${res.status}`, res.status);
+  if (res.ok) {
+    return (await res.json()) as SessionResumeResponse;
   }
-  return (await res.json()) as SessionResumeResponse;
+  if (res.status === 409) {
+    const body = await res.json().catch(() => null) as
+      | { status?: string; error?: string; message?: string }
+      | null;
+    // Only `local_diverged` is a real response variant on 409. Anything
+    // else (bytes_not_available, session_not_found_in_remote, etc.) is an
+    // operational error — surface as ApiError so callers can react
+    // distinctly rather than silently falling off the discriminated union.
+    if (body && body.status === "local_diverged") {
+      return body as SessionResumeResponse;
+    }
+    const message = body?.message ?? body?.error ?? "Conflict";
+    throw new ApiError(message, 409);
+  }
+  throw new ApiError(`Resume failed: ${res.status}`, res.status);
 }

--- a/web/src/hooks/useMyDeviceId.ts
+++ b/web/src/hooks/useMyDeviceId.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+// One-shot fetch of the local device identity. Used to distinguish "local"
+// (this device produced it) from "remote" (another device produced it,
+// pulled cross-device). The identity is stable across the server lifetime,
+// so a single fetch per page load is enough — no SSE refresh needed.
+
+export interface DeviceIdentity {
+  deviceId: string;
+  label: string;
+}
+
+/** Returns the local device id + label, or null while loading / on error.
+ *  Callers gate cross-device UI affordances on a non-null value:
+ *  during the brief window before the fetch returns, sessions are
+ *  rendered as if all-local (no chip, no Resume button). That's a
+ *  conservative default — better than flashing chips on local sessions. */
+export function useMyDeviceId(): DeviceIdentity | null {
+  const [identity, setIdentity] = useState<DeviceIdentity | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/device/identity")
+      .then(async (res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        return (await res.json()) as DeviceIdentity;
+      })
+      .then((body) => {
+        if (!cancelled) setIdentity(body);
+      })
+      .catch(() => {
+        // Leave identity at null — UI degrades gracefully (no remote chip,
+        // no Resume button). A 503 means device_identity isn't seeded yet
+        // (race on first boot); other failures are network glitches.
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return identity;
+}

--- a/web/src/hooks/useMyDeviceId.ts
+++ b/web/src/hooks/useMyDeviceId.ts
@@ -3,11 +3,39 @@ import { useEffect, useState } from "react";
 // One-shot fetch of the local device identity. Used to distinguish "local"
 // (this device produced it) from "remote" (another device produced it,
 // pulled cross-device). The identity is stable across the server lifetime,
-// so a single fetch per page load is enough — no SSE refresh needed.
+// so a single fetch per page load is enough — the module-level promise
+// cache below ensures every consumer of this hook shares one request.
 
 export interface DeviceIdentity {
   deviceId: string;
   label: string;
+}
+
+// Shared in-flight promise so concurrent mounts (Home + SessionInspector
+// header etc.) reuse the same fetch rather than each firing its own. Reset
+// only on a hard 5xx — a 200 stays cached for the page lifetime, a 503
+// (device_identity not seeded yet) clears so the next caller can retry.
+let pending: Promise<DeviceIdentity | null> | null = null;
+
+async function fetchIdentity(): Promise<DeviceIdentity | null> {
+  try {
+    const res = await fetch("/api/device/identity");
+    if (!res.ok) {
+      // 503 = not seeded yet, retry on next hook mount. Other failures also
+      // retryable — leave the cache empty so a subsequent hook re-fires.
+      pending = null;
+      return null;
+    }
+    return (await res.json()) as DeviceIdentity;
+  } catch {
+    pending = null;
+    return null;
+  }
+}
+
+function loadIdentity(): Promise<DeviceIdentity | null> {
+  if (pending === null) pending = fetchIdentity();
+  return pending;
 }
 
 /** Returns the local device id + label, or null while loading / on error.
@@ -20,21 +48,18 @@ export function useMyDeviceId(): DeviceIdentity | null {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/api/device/identity")
-      .then(async (res) => {
-        if (!res.ok) throw new Error(String(res.status));
-        return (await res.json()) as DeviceIdentity;
-      })
-      .then((body) => {
-        if (!cancelled) setIdentity(body);
-      })
-      .catch(() => {
-        // Leave identity at null — UI degrades gracefully (no remote chip,
-        // no Resume button). A 503 means device_identity isn't seeded yet
-        // (race on first boot); other failures are network glitches.
-      });
+    loadIdentity().then((body) => {
+      if (!cancelled && body) setIdentity(body);
+    });
     return () => { cancelled = true; };
   }, []);
 
   return identity;
+}
+
+/** Test-only: reset the module-level cache. Not exported through the
+ *  package surface but available to vitest if we ever add web tests for
+ *  this hook. */
+export function __resetDeviceIdentityCacheForTests(): void {
+  pending = null;
 }

--- a/web/src/hooks/useMyDeviceId.ts
+++ b/web/src/hooks/useMyDeviceId.ts
@@ -12,9 +12,16 @@ export interface DeviceIdentity {
 }
 
 // Shared in-flight promise so concurrent mounts (Home + SessionInspector
-// header etc.) reuse the same fetch rather than each firing its own. Reset
-// only on a hard 5xx — a 200 stays cached for the page lifetime, a 503
-// (device_identity not seeded yet) clears so the next caller can retry.
+// header etc.) reuse the same fetch rather than each firing its own.
+// Cache strategy:
+//   - 200 → stays cached for the page lifetime (identity never changes)
+//   - any non-2xx (503 not-seeded, 4xx forbidden, 5xx) → cache cleared so
+//     the next hook mount retries
+//   - thrown error (network, abort) → cache cleared, retry on next mount
+// The "retry on any failure" stance is intentional: a 503 is the
+// not-seeded race, but a 403 from the rejectIfNonLocalOrigin guard would
+// also benefit from a retry once the request comes from an expected
+// origin (e.g. after dev/prod URL swap).
 let pending: Promise<DeviceIdentity | null> | null = null;
 
 async function fetchIdentity(): Promise<DeviceIdentity | null> {


### PR DESCRIPTION
## Summary

PR 3.1 — thin-slice UI for the cross-device sessions backend that's been working since beta.8. Exposes remote sessions on Home and adds a Resume affordance in the inspector.

## What you'll see in the UI

- **Cross-device chip** on Home grid + list. Reads `↗ MacBookPro` when the origin device has synced its label; falls back to `↗ Other device` for legacy rows. Raw UUID prefix never appears in the chip itself — it's diagnostic tooltip-only.
- **"Resume on this device" button** in the session inspector, visible only when the session originated on another device. Disabled with explainer when transcript bytes haven't synced from the origin yet (\`hasBytes: false\`).
- **Inline dialog** that handles all four \`POST /api/sessions/:id/resume\` response shapes:
  - \`ok\` → copyable \`cd <path> && claude --resume <id>\` command + Copy button
  - \`needs_target\` → text input prefilled with the origin device's cwd as a hint
  - \`validation_warning\` → reasons listed (folder doesn't exist, not a git repo, basename differs…) with "Use this folder anyway"
  - \`local_diverged\` → conflict surfaced, "resolution coming in next release"
  - \`pick_source\` (bonus) → list of registered sources to choose between

## What's deferred to 3.2

- Native OS folder picker (today: text input)
- "Use this folder for this space from now on" source persistence
- Fork / discard actions for \`local_diverged\`
- Active-writer flip UI ("Now active on Mac")

## Backend changes

Additive throughout — no breaking changes:

- **Migration 0010**: \`synced_session_metadata.device_label TEXT\` (cloud D1)
- **Worker**: accepts \`device_label\` on metadata POST (capped at 64 chars; over-long values nulled rather than rejecting the session); returns it on GET. \`COALESCE(excluded.device_label, ...)\` preserves a known label when cloud sends NULL.
- **Local**: \`remote_sessions.device_label\` column. \`SessionSyncService\` stamps push payloads with \`device_identity.label\` and stores incoming labels via pull.
- **New route**: \`GET /api/device/identity\` → \`{ deviceId, label }\`. Lets the web know which sessions are local without leaking the UUID.
- **/api/sessions**: exposes \`originDeviceLabel\` on remote rows.
- **shared/types.ts**: \`Session.originDeviceLabel\`.

## Test plan

- [x] New: \`GET /api/device/identity\` route — 4 cases (200 ok, 503 not seeded, pass-through on wrong URL/method)
- [x] New: \`pushPending\` stamps both \`device_id\` and \`device_label\` from device_identity onto every payload row
- [x] New: pull populates \`remote_sessions.device_label\` from the cloud payload
- [x] New: pull preserves an existing label when cloud sends NULL (COALESCE)
- [x] New: worker POST persists \`device_label\`, GET returns it
- [x] New: worker rejects an over-long \`device_label\` by nulling it (keeps the session push valid)
- [x] Existing harness schemas updated to include \`device_label\`
- [x] 238 server tests pass (was 232)
- [x] 49 worker tests pass (was 47)
- [x] \`tsc --noEmit\` clean for server, worker, and web
- [x] \`npm run build\` clean (web + server bundles)

## Deploy checklist (post-merge)

1. \`wrangler d1 execute oyster-auth --remote --file infra/auth-worker/migrations/0010_device_label.sql\`
2. \`wrangler deploy --config infra/oyster-cloud/wrangler.toml\`
3. \`npm run release:beta\` → cuts 0.8.1-beta.9

## Manual smoke test after upgrading

- Remote session row in Home shows `↗ MacBookPro` chip (after Windows pushes one more session metadata update, since label sync starts now)
- Click into a remote session → "Resume on this device" appears
- Click Resume → modal walks through the same flow we've been doing via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)