### PR TITLE
fix(sessions): cross-device click opens inspector + clearer chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- **Cross-device sessions in Home, with a one-click resume.** Sessions backed up on another device now appear in Home with an `↗ MacBookPro` chip (or "Other device" if the origin's label hasn't synced yet) on both the grid and list views. Click into one and you'll see a new **Resume on this device** button — it walks you through reassembling the transcript locally and gives you a copyable command to continue the conversation. Sessions whose transcript bytes haven't synced from the origin device yet show the button as disabled with an explanation.
+- **Clicking a cross-device session opens its inspector instead of erroring.** Previously the inspector failed with "Session no longer available" for any session that originated on another device, because the session-detail lookup only checked locally-discovered sessions. The lookup now falls back to the cross-device cache, and the inspector renders a friendly "Resume to view transcript" notice while the transcript hasn't been reassembled locally yet. The chip's tooltip also explains why a session shows "Other device" (its origin hasn't pushed its label yet).
 
 ## [0.8.1-beta.5] - 2026-05-12
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -326,9 +326,9 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
-<h3>Added</h3>
+<h3>Fixed</h3>
 <ul>
-<li><strong>Cross-device sessions in Home, with a one-click resume.</strong> Sessions backed up on another device now appear in Home with an <code>↗ MacBookPro</code> chip (or &quot;Other device&quot; if the origin&#39;s label hasn&#39;t synced yet) on both the grid and list views. Click into one and you&#39;ll see a new <strong>Resume on this device</strong> button — it walks you through reassembling the transcript locally and gives you a copyable command to continue the conversation. Sessions whose transcript bytes haven&#39;t synced from the origin device yet show the button as disabled with an explanation.</li>
+<li><strong>Clicking a cross-device session opens its inspector instead of erroring.</strong> Previously the inspector failed with &quot;Session no longer available&quot; for any session that originated on another device, because the session-detail lookup only checked locally-discovered sessions. The lookup now falls back to the cross-device cache, and the inspector renders a friendly &quot;Resume to view transcript&quot; notice while the transcript hasn&#39;t been reassembled locally yet. The chip&#39;s tooltip also explains why a session shows &quot;Other device&quot; (its origin hasn&#39;t pushed its label yet).</li>
 </ul>
 <h2 id="v-0-8-1-beta-5"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.4...v0.8.1-beta.5" rel="noopener noreferrer"><span class="release-version">0.8.1-beta.5</span></a><span class="release-date"> — 2026-05-12</span></h2>
 <h3>Added</h3>

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -307,33 +307,88 @@ export async function tryHandleSessionRoute(
     }
   }
 
-  // GET /api/sessions/:id — single session row (or 404)
+  // GET /api/sessions/:id — single session row (or 404). Checks the local
+  // sessions table first; falls back to remote_sessions so clicking a
+  // cross-device row from Home opens its inspector with the same shape
+  // (plus originDeviceId/Label/hasBytes for the Resume affordance).
+  // Without the fallback every remote click returns 404 → "session no
+  // longer available", which is wrong: the row IS in our DB, just in the
+  // remote_sessions table.
   {
     const m = url.match(/^\/api\/sessions\/([^/]+)$/);
     if (m && req.method === "GET") {
       if (rejectIfNonLocalOrigin()) return true;
-      const row = sessionStore.getById(m[1]);
-      if (!row) {
-        res.writeHead(404, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "session not found" }));
+      const id = m[1]!;
+      const row = sessionStore.getById(id);
+      if (row) {
+        const src = row.source_id ? spaceStore.getSourceById(row.source_id) : undefined;
+        const sourceLabel = src ? (src.label ?? (basename(src.path) || null)) : null;
+        sendJson({
+          id: row.id,
+          spaceId: row.space_id,
+          sourceId: row.source_id ?? null,
+          sourceLabel,
+          cwd: row.cwd,
+          agent: row.agent,
+          title: row.title,
+          state: row.state,
+          startedAt: row.started_at,
+          endedAt: row.ended_at,
+          model: row.model,
+          lastEventAt: row.last_event_at,
+          // Local sessions are by definition local — null/true.
+          originDeviceId: null,
+          originDeviceLabel: null,
+          jsonlAvailableLocally: true,
+          hasBytes: true,
+          activeDeviceId: null,
+        });
         return true;
       }
-      const src = row.source_id ? spaceStore.getSourceById(row.source_id) : undefined;
-      const sourceLabel = src ? (src.label ?? (basename(src.path) || null)) : null;
-      sendJson({
-        id: row.id,
-        spaceId: row.space_id,
-        sourceId: row.source_id ?? null,
-        sourceLabel,
-        cwd: row.cwd,
-        agent: row.agent,
-        title: row.title,
-        state: row.state,
-        startedAt: row.started_at,
-        endedAt: row.ended_at,
-        model: row.model,
-        lastEventAt: row.last_event_at,
-      });
+
+      const ownerId = currentUserId();
+      if (ownerId) {
+        type RemoteRow = {
+          device_id: string | null; device_label: string | null;
+          agent: string; title: string | null; state: string;
+          cwd: string | null; model: string | null; started_at: string;
+          ended_at: string | null; last_event_at: string;
+          has_bytes: number; active_device_id: string | null;
+          jsonl_local_path: string | null;
+        };
+        const remoteRow = db.prepare(
+          `SELECT device_id, device_label, agent, title, state, cwd, model,
+                  started_at, ended_at, last_event_at, has_bytes,
+                  active_device_id, jsonl_local_path
+             FROM remote_sessions
+            WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+        ).get(ownerId, id) as RemoteRow | undefined;
+        if (remoteRow) {
+          sendJson({
+            id,
+            spaceId: null,
+            sourceId: null,
+            sourceLabel: null,
+            cwd: remoteRow.cwd,
+            agent: remoteRow.agent,
+            title: remoteRow.title,
+            state: remoteRow.state,
+            startedAt: remoteRow.started_at,
+            endedAt: remoteRow.ended_at,
+            model: remoteRow.model,
+            lastEventAt: remoteRow.last_event_at,
+            originDeviceId: remoteRow.device_id,
+            originDeviceLabel: remoteRow.device_label,
+            jsonlAvailableLocally: remoteRow.jsonl_local_path !== null,
+            hasBytes: remoteRow.has_bytes === 1,
+            activeDeviceId: remoteRow.active_device_id,
+          });
+          return true;
+        }
+      }
+
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "session not found" }));
       return true;
     }
   }

--- a/server/test/sessions-resume-route.test.ts
+++ b/server/test/sessions-resume-route.test.ts
@@ -336,6 +336,105 @@ describe("GET /api/sessions merges local + remote", () => {
   });
 });
 
+describe("GET /api/sessions/:id falls back to remote_sessions", () => {
+  // Regression: PR 3.1 surfaced cross-device sessions in the list view, but
+  // the singular GET only checked local sessions. Clicking a remote session
+  // returned 404 → the inspector closed with "Session no longer available".
+  it("returns a remote row when no local session matches the id", async () => {
+    const db = makeDb();
+    insertRemote(db, {
+      sessionId: "remote-only-1",
+      ownerId: "user-A",
+      cwd: "C:\\Users\\matth",
+      hasBytes: true,
+      deviceId: "dev-pc",
+    });
+    // Set device_label to verify it flows back through the route.
+    db.prepare(
+      `UPDATE remote_sessions SET device_label = 'WIN-DESKTOP' WHERE session_id = 'remote-only-1'`,
+    ).run();
+    const sessionStore = { getById: () => undefined } as any;
+    const spaceStore = { getSourceById: () => undefined } as any;
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    const handled = await tryHandleSessionRoute(req, {} as any, "/api/sessions/remote-only-1",
+      ctx as any, {
+        db, sessionStore, spaceStore,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({
+      id: "remote-only-1",
+      originDeviceId: "dev-pc",
+      originDeviceLabel: "WIN-DESKTOP",
+      hasBytes: true,
+      jsonlAvailableLocally: false,
+    });
+  });
+
+  it("still 404s when the id is in neither table", async () => {
+    const db = makeDb();
+    const sessionStore = { getById: () => undefined } as any;
+    const spaceStore = { getSourceById: () => undefined } as any;
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    // Need a fake res that captures status — the route writes 404 directly
+    // via res.writeHead/end rather than ctx.sendJson, so add a minimal stub.
+    const res = {
+      writeHead: (s: number) => { captured.status = s; return res; },
+      end: (body: string) => { captured.json = JSON.parse(body); },
+    } as any;
+    await tryHandleSessionRoute(req, res, "/api/sessions/unknown-id",
+      ctx as any, {
+        db, sessionStore, spaceStore,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+    expect(captured.status).toBe(404);
+    expect(captured.json).toEqual({ error: "session not found" });
+  });
+
+  it("returns a local row when one exists (preferred over remote)", async () => {
+    const db = makeDb();
+    insertRemote(db, {
+      sessionId: "dup-id",
+      ownerId: "user-A",
+      cwd: "C:\\elsewhere",
+      hasBytes: true,
+      deviceId: "dev-pc",
+    });
+    const localRow = {
+      id: "dup-id", space_id: "space-1", source_id: null, cwd: "/Users/me/local",
+      agent: "claude-code", title: "local title", state: "active",
+      started_at: "2026-05-11T09:00:00Z", ended_at: null, model: "m",
+      last_event_at: "2026-05-11T09:30:00Z",
+    };
+    const sessionStore = { getById: (id: string) => id === "dup-id" ? localRow : undefined } as any;
+    const spaceStore = { getSourceById: () => undefined } as any;
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions/dup-id",
+      ctx as any, {
+        db, sessionStore, spaceStore,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+    expect(captured.status).toBe(200);
+    expect(captured.json).toMatchObject({
+      id: "dup-id",
+      title: "local title",
+      // Local row → null/true; not the cross-device shape.
+      originDeviceId: null,
+      jsonlAvailableLocally: true,
+    });
+  });
+});
+
 // Touch `existsSync` so the import isn't flagged as unused on linter passes
 // that don't see it via downstream calls. The test sometimes needs to assert
 // on file absence separately.

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -74,13 +74,20 @@ export function originDeviceChipFor(
   if (!origin) return null;             // local session, no chip
   if (!myDeviceId) return null;          // identity still loading
   if (origin === myDeviceId) return null; // own session, no chip
-  // Prefer the human label pushed by the origin device; fall back to a
-  // generic "Other device" rather than exposing the UUID prefix in the UI.
-  const label = session.originDeviceLabel ?? "Other device";
-  // Tooltip carries the UUID for diagnostic copy-paste, never user-facing
-  // text. Truncated to first 8 chars to match the prior debug format.
-  const titleTooltip = `From ${label} (device ${origin.slice(0, 8)})`;
-  return { label, titleTooltip };
+  // Prefer the human label pushed by the origin device. If null, the
+  // session was pushed before device_label sync existed and won't get a
+  // name until that device sends another update. Make the chip text and
+  // tooltip explain why rather than leaving the user wondering.
+  if (session.originDeviceLabel) {
+    return {
+      label: session.originDeviceLabel,
+      titleTooltip: `From ${session.originDeviceLabel} (device ${origin.slice(0, 8)})`,
+    };
+  }
+  return {
+    label: "Other device",
+    titleTooltip: `From another device — its label hasn't synced yet (device ${origin.slice(0, 8)})`,
+  };
 }
 
 export function metaForSession(session: Session): string {

--- a/web/src/components/SessionInspector/index.tsx
+++ b/web/src/components/SessionInspector/index.tsx
@@ -259,34 +259,55 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
     );
   }
 
+  // A remote session whose jsonl hasn't been reassembled yet has no local
+  // transcript to show. Render a "reassemble to view" notice instead of
+  // an empty transcript body; the Header above already exposes the Resume
+  // affordance. Once the user resumes, the watcher ingests the jsonl and
+  // the events tab becomes the right surface.
+  const isRemoteUnsynced =
+    !!session.originDeviceId && session.jsonlAvailableLocally === false;
+
   return (
     <>
       <Header session={session} onClose={onClose} />
       <Banner session={session} />
-      <Tabs
-        tab={tab}
-        setTab={setTab}
-        eventsCount={events?.length ?? 0}
-        hasMoreOlder={hasMoreOlder}
-        artefactsCount={artefacts ? new Set(artefacts.map((a) => a.artifact.id)).size : 0}
-        memoryCount={memory ? memory.written.length + memory.pulled.length : 0}
-      />
-      <TranscriptBody
-        tab={tab}
-        events={events}
-        artefacts={artefacts}
-        memory={memory}
-        memoryError={memoryError}
-        focusEventId={focusEventId}
-        initialSearchQuery={initialSearchQuery}
-        onSwitchTo={onSwitchTo}
-        onOpenArtefact={onOpenArtefact}
-        sessionId={sessionId}
-        agent={session.agent}
-        hasMoreOlder={hasMoreOlder}
-        loadingOlder={loadingOlder}
-        onLoadOlder={() => loadOlderRef.current()}
-      />
+      {isRemoteUnsynced ? (
+        <div className="inspector-empty" style={{ padding: "32px 28px", lineHeight: 1.6 }}>
+          <p style={{ margin: "0 0 8px" }}>
+            <strong>Transcript isn't on this device yet.</strong>
+          </p>
+          <p style={{ margin: 0, color: "var(--text-dim)" }}>
+            This session was started on another device. Use <em>Resume on this device</em> above to reassemble the transcript locally — once it lands, the conversation will show up here.
+          </p>
+        </div>
+      ) : (
+        <>
+          <Tabs
+            tab={tab}
+            setTab={setTab}
+            eventsCount={events?.length ?? 0}
+            hasMoreOlder={hasMoreOlder}
+            artefactsCount={artefacts ? new Set(artefacts.map((a) => a.artifact.id)).size : 0}
+            memoryCount={memory ? memory.written.length + memory.pulled.length : 0}
+          />
+          <TranscriptBody
+            tab={tab}
+            events={events}
+            artefacts={artefacts}
+            memory={memory}
+            memoryError={memoryError}
+            focusEventId={focusEventId}
+            initialSearchQuery={initialSearchQuery}
+            onSwitchTo={onSwitchTo}
+            onOpenArtefact={onOpenArtefact}
+            sessionId={sessionId}
+            agent={session.agent}
+            hasMoreOlder={hasMoreOlder}
+            loadingOlder={loadingOlder}
+            onLoadOlder={() => loadOlderRef.current()}
+          />
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Dogfooded on beta.9

Two regressions surfaced clicking those `↗ Other device` rows:

> "I see two sessions with Other device but what does that mean? I click on both of these and it says session no longer available"

## What's fixed

1. **Click no longer 404s.** `GET /api/sessions/:id` only checked the local \`sessions\` table; remote rows live in \`remote_sessions\`. Now falls back, returning the same shape plus the cross-device fields the Resume affordance needs.

2. **Empty inspector for unsynced remote.** SessionInspector tried to render a TranscriptBody for a remote session whose jsonl hadn't been reassembled. Added a placeholder ("Transcript isn't on this device yet — Use Resume on this device above to reassemble"). Normal Tabs + TranscriptBody render once the transcript is local.

3. **"Other device" tooltip explains why.** Was circular ("From Other device"). Now reads "From another device — its label hasn't synced yet (device 9be64def)". Sessions whose origin device has pushed under beta.9+ retain the friendly "From MacBookPro" wording.

## Test plan

- [x] New tests on the singular GET — remote-only id resolves; hard 404 still 404s; local-id wins over a same-id remote row
- [x] 242 server tests pass (was 239, +3)
- [x] tsc + full build clean
- [ ] Manual: ship as 0.8.1-beta.10, click the previously-broken `matth (no title yet)` rows and confirm the inspector opens with the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)