### PR TITLE
feat(sessions): filter ghosts, backfill labels, active-writer chip (PR 3.2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Active-writer signal on cross-device sessions.** When a session has been handed off — you resume a Mac session on Windows, or vice-versa — Home now shows a `Now active on MacBookPro` chip alongside the origin chip. It updates live as devices push new turns, so the demo "I picked this up over here" handoff is visible at a glance.
+
+### Changed
+
+- **Empty cross-device sessions hidden from Home.** Aborted `claude` invocations (where the user opened a transcript but never had a real conversation) used to clutter the list as "(no title yet)" entries. Those are filtered out now. Sessions with real content always show, regardless of title. (Heuristic-based for the moment; the durable fix lands in a follow-up.)
+- **Device labels backfill automatically on upgrade.** Devices that backed up sessions before the label-sync change won't have a friendly name in cloud yet. On first boot of this release each device marks its own sessions for re-push, so the labels show up everywhere within a few minutes — no manual action required.
+
 ### Fixed
 
 - **Clicking a cross-device session opens its inspector instead of erroring.** Previously the inspector failed with "Session no longer available" for any session that originated on another device, because the session-detail lookup only checked locally-discovered sessions. The lookup now falls back to the cross-device cache, and the inspector renders a friendly "Resume to view transcript" notice while the transcript hasn't been reassembled locally yet. The chip's tooltip also explains why a session shows "Other device" (its origin hasn't pushed its label yet).

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -326,6 +326,15 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Active-writer signal on cross-device sessions.</strong> When a session has been handed off — you resume a Mac session on Windows, or vice-versa — Home now shows a <code>Now active on MacBookPro</code> chip alongside the origin chip. It updates live as devices push new turns, so the demo &quot;I picked this up over here&quot; handoff is visible at a glance.</li>
+</ul>
+<h3>Changed</h3>
+<ul>
+<li><strong>Empty cross-device sessions hidden from Home.</strong> Aborted <code>claude</code> invocations (where the user opened a transcript but never had a real conversation) used to clutter the list as &quot;(no title yet)&quot; entries. Those are filtered out now. Sessions with real content always show, regardless of title. (Heuristic-based for the moment; the durable fix lands in a follow-up.)</li>
+<li><strong>Device labels backfill automatically on upgrade.</strong> Devices that backed up sessions before the label-sync change won&#39;t have a friendly name in cloud yet. On first boot of this release each device marks its own sessions for re-push, so the labels show up everywhere within a few minutes — no manual action required.</li>
+</ul>
 <h3>Fixed</h3>
 <ul>
 <li><strong>Clicking a cross-device session opens its inspector instead of erroring.</strong> Previously the inspector failed with &quot;Session no longer available&quot; for any session that originated on another device, because the session-detail lookup only checked locally-discovered sessions. The lookup now falls back to the cross-device cache, and the inspector renders a friendly &quot;Resume to view transcript&quot; notice while the transcript hasn&#39;t been reassembled locally yet. The chip&#39;s tooltip also explains why a session shows &quot;Other device&quot; (its origin hasn&#39;t pushed its label yet).</li>

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -447,8 +447,14 @@ async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Respon
     state: string; cwd: string | null; model: string | null; started_at: string;
     ended_at: string | null; last_event_at: string;
     bytes_generation: number; active_device_id: string | null;
-    has_bytes: number; updated_at: number;
+    has_bytes: number; total_bytes: number; updated_at: number;
   };
+  // total_bytes: cheap sum across chunks of the current generation. Drives
+  // the "is this a real session or a ghost?" filter on Device B — a session
+  // whose only cloud content is the system permission-mode + file-history-
+  // snapshot + a couple of `<command-name>/exit</command-name>` events
+  // typically lands under ~2 KB. NULL counted as 0 via COALESCE so the
+  // wire shape is always a number.
   const { results } = await env.DB.prepare(
     `SELECT m.session_id, m.device_id, m.device_label, m.agent, m.title, m.state,
             m.cwd, m.model, m.started_at, m.ended_at, m.last_event_at,
@@ -458,7 +464,13 @@ async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Respon
                WHERE c.owner_id = m.owner_id
                  AND c.session_id = m.session_id
                  AND c.bytes_generation = m.bytes_generation
-            ) THEN 1 ELSE 0 END AS has_bytes
+            ) THEN 1 ELSE 0 END AS has_bytes,
+            COALESCE((
+              SELECT SUM(c.byte_count) FROM synced_session_chunks c
+               WHERE c.owner_id = m.owner_id
+                 AND c.session_id = m.session_id
+                 AND c.bytes_generation = m.bytes_generation
+            ), 0) AS total_bytes
        FROM synced_session_metadata m
       WHERE m.owner_id = ?
       ORDER BY m.last_event_at DESC`,

--- a/infra/oyster-cloud/test/sessions-routes.test.ts
+++ b/infra/oyster-cloud/test/sessions-routes.test.ts
@@ -324,6 +324,26 @@ describe("GET /api/sessions/metadata", () => {
     const ours = body.sessions.find((s) => s.session_id === sidA);
     expect(ours?.has_bytes).toBe(false);
   });
+
+  it("returns total_bytes summed from chunks of the current generation", async () => {
+    // Drives the empty-session filter on Device B — sessions with title NULL
+    // and total_bytes < 4KB look like aborted `claude` runs.
+    const { token } = await makeProSession();
+    const sid = `s-${crypto.randomUUID()}`;
+    await registerSession(token, sid);
+    // No chunks yet → total_bytes = 0.
+    const before = await signedFetch("/api/sessions/metadata", { method: "GET" }, token);
+    const beforeBody = await before.json() as { sessions: Array<{ session_id: string; total_bytes: number }> };
+    expect(beforeBody.sessions.find((s) => s.session_id === sid)?.total_bytes).toBe(0);
+    // Upload two chunks; total_bytes should sum.
+    const c1 = new TextEncoder().encode("hello\n");
+    const c2 = new TextEncoder().encode("world!\n");
+    expect((await putChunk(token, sid, 1, c1, 0, 0)).res.status).toBe(200);
+    expect((await putChunk(token, sid, 2, c2, c1.byteLength, 0)).res.status).toBe(200);
+    const after = await signedFetch("/api/sessions/metadata", { method: "GET" }, token);
+    const afterBody = await after.json() as { sessions: Array<{ session_id: string; total_bytes: number }> };
+    expect(afterBody.sessions.find((s) => s.session_id === sid)?.total_bytes).toBe(c1.byteLength + c2.byteLength);
+  });
 });
 
 describe("PUT/GET /api/sessions/bytes/:id/chunk/:n (chunked-delta)", () => {

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -240,6 +240,28 @@ export function initDb(userlandDir: string): Database.Database {
   try {
     db.exec(`ALTER TABLE remote_sessions ADD COLUMN device_label TEXT`);
   } catch { /* already exists */ }
+  // Additive: total_bytes (PR 3.2a) — denormalised sum of chunk byte_count
+  // across the current generation. Drives the empty-session filter on Home
+  // so cross-device "ghost" sessions (title NULL, ended_at NULL, only a
+  // handful of system events) stop crowding the list. NULL on rows pulled
+  // before this column existed — those rows stay visible until the next
+  // pull, then populate.
+  try {
+    db.exec(`ALTER TABLE remote_sessions ADD COLUMN total_bytes INTEGER`);
+  } catch { /* already exists */ }
+
+  // Tiny key→value table for one-shot migrations and feature flags. The
+  // existing INSERT-OR-IGNORE-on-device_identity pattern only fires once
+  // per install (first boot ever); for migrations gated on a specific
+  // version of Oyster being installed, we need a separate flag. Each
+  // flag's existence in this table means "this one-shot has already run."
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS app_state (
+      key        TEXT PRIMARY KEY,
+      value      TEXT NOT NULL,
+      applied_at INTEGER NOT NULL
+    )
+  `);
   db.exec(`CREATE INDEX IF NOT EXISTS remote_sessions_owner_last_event
              ON remote_sessions(owner_id, last_event_at DESC)`);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -327,6 +327,29 @@ const profileBinding = createProfileBindingService({ db });
   }
 }
 
+// One-shot device_label backfill (PR 3.2a). The metadata-sync path stamps
+// device_label on every outgoing push, but that only happens for sessions
+// the push code actually drains — i.e. those whose sync_dirty_at is set.
+// Sessions pushed before beta.9 have a NULL label in cloud and will stay
+// that way until something else makes them dirty. Bump sync_dirty_at on
+// all owned sessions exactly once so the next reconcile re-stamps every
+// row with this device's label. Guarded via app_state so it runs once per
+// install, not on every boot.
+{
+  const flag = db.prepare(
+    `INSERT OR IGNORE INTO app_state (key, value, applied_at)
+     VALUES ('device_label_backfill_done', '1', ?)`,
+  ).run(Date.now());
+  if (flag.changes > 0) {
+    const bumped = db.prepare(
+      `UPDATE sessions SET sync_dirty_at = ? WHERE cloud_owner_id IS NOT NULL`,
+    ).run(Date.now());
+    if (bumped.changes > 0) {
+      console.log(`[sessions] device_label backfill: marked ${bumped.changes} sessions dirty for re-push`);
+    }
+  }
+}
+
 // Self-mirror cleanup (#322 PR 2 hotfix follow-up). Removes any
 // remote_sessions rows that are actually local — either device_id matches
 // this device, or session_id appears in the local `sessions` table. These

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -98,6 +98,38 @@ interface ValidationOutcome {
  *  Hard fail (returns ok:false) only on folder-doesn't-exist. Other
  *  conditions are advisory and surfaced as reasons so the UI can
  *  prompt for force:true confirmation. */
+/** Read the local device identity row (seeded at boot). Returns NULLs when
+ *  the row isn't present — callers degrade gracefully (no active chip). */
+function readMyDeviceIdentity(db: Database.Database): {
+  myDeviceId: string | null;
+  myDeviceLabel: string | null;
+} {
+  const row = db.prepare(
+    `SELECT device_id, label FROM device_identity WHERE id = 1 LIMIT 1`,
+  ).get() as { device_id: string; label: string } | undefined;
+  return {
+    myDeviceId: row?.device_id ?? null,
+    myDeviceLabel: row?.label ?? null,
+  };
+}
+
+/** Resolves `activeDeviceLabel` for a session row given this device's
+ *  identity. Two known sources for a label: device_identity (when active is
+ *  us) and remote_sessions.device_label (when active is the origin device).
+ *  Anything else — a third device we haven't seen yet — falls back to null
+ *  rather than guessing. Used by both the merge route and the singular GET. */
+function makeActiveLabelResolver(
+  myDeviceId: string | null,
+  myDeviceLabel: string | null,
+): (activeId: string | null, originId: string | null, originLabel: string | null) => string | null {
+  return (activeId, originId, originLabel) => {
+    if (!activeId) return null;
+    if (myDeviceId && activeId === myDeviceId) return myDeviceLabel;
+    if (originId && activeId === originId) return originLabel;
+    return null;
+  };
+}
+
 function validateOverrideTarget(targetCwd: string, remoteCwd: string | null): ValidationOutcome {
   const reasons: string[] = [];
   if (!existsSync(targetCwd)) {
@@ -179,7 +211,19 @@ export async function tryHandleSessionRoute(
       jsonlAvailableLocally: boolean;
       hasBytes: boolean;
       activeDeviceId: string | null;
+      /** Human-readable label of whichever device most recently wrote a
+       *  chunk for this session. Resolved server-side from one of:
+       *  - this device's device_identity.label (when active is us)
+       *  - remote_sessions.device_label (when active is the origin device)
+       *  - null (when active is some third device we don't yet know about).
+       *  Drives the "Now active on Mac" chip in the UI. */
+      activeDeviceLabel: string | null;
     }
+    // Cache the current device identity once — used to resolve "active is us"
+    // for both local and remote payload entries. NULL when device_identity
+    // hasn't been seeded yet; the chip silently skips in that case.
+    const { myDeviceId, myDeviceLabel } = readMyDeviceIdentity(db);
+    const resolveActiveLabel = makeActiveLabelResolver(myDeviceId, myDeviceLabel);
     const sourcesById = new Map(sourceList.map((s) => [s.id, s]));
     const localPayload: MergedSessionPayload[] = rows.map((row) => {
       const src = row.source_id ? sourcesById.get(row.source_id) : null;
@@ -208,6 +252,7 @@ export async function tryHandleSessionRoute(
         hasBytes: true,
         // Local sessions are always actively written by this device.
         activeDeviceId: null,
+        activeDeviceLabel: null,
       };
     });
 
@@ -224,18 +269,39 @@ export async function tryHandleSessionRoute(
         agent: string; title: string | null;
         state: string; cwd: string | null; model: string | null; started_at: string;
         ended_at: string | null; last_event_at: string; has_bytes: number;
+        total_bytes: number | null;
         active_device_id: string | null; jsonl_local_path: string | null;
       };
       const remoteRows = db.prepare(
         `SELECT session_id, device_id, device_label, agent, title, state, cwd, model,
-                started_at, ended_at, last_event_at, has_bytes, active_device_id,
-                jsonl_local_path
+                started_at, ended_at, last_event_at, has_bytes, total_bytes,
+                active_device_id, jsonl_local_path
            FROM remote_sessions
           WHERE owner_id = ?
           ORDER BY last_event_at DESC`,
       ).all(ownerId) as RemoteRow[];
+      // Ghost-session filter (PR 3.2a temporary heuristic): hide remote
+      // sessions that look like aborted `claude` invocations — title NULL,
+      // never properly ended, and the chunk chain is smaller than the
+      // typical "permission-mode + file-history + a couple of
+      // <command-name>/exit</command-name> events" overhead (~2 KB observed,
+      // 4 KB cap for headroom). Rows whose total_bytes is NULL (pre-3.2a
+      // pulls, or rows pushed before the column existed) are exempt — we'd
+      // rather keep them visible than risk hiding real sessions until the
+      // next pull populates the column.
+      //
+      // Durable fix [[durable-fix-deferred-to-3.2.x]]: add
+      // real_user_message_count + assistant_message_count to metadata and
+      // filter where both are 0. Tracks content, not size.
+      const GHOST_BYTE_THRESHOLD = 4096;
+      const isGhostSession = (r: RemoteRow): boolean =>
+        r.title === null
+        && r.ended_at === null
+        && r.total_bytes !== null
+        && r.total_bytes < GHOST_BYTE_THRESHOLD;
       remotePayload = remoteRows
         .filter((r) => !localIds.has(r.session_id))
+        .filter((r) => !isGhostSession(r))
         .map((r) => ({
           id: r.session_id,
           spaceId: null,
@@ -255,6 +321,7 @@ export async function tryHandleSessionRoute(
           jsonlAvailableLocally: r.jsonl_local_path !== null,
           hasBytes: r.has_bytes === 1,
           activeDeviceId: r.active_device_id,
+          activeDeviceLabel: resolveActiveLabel(r.active_device_id, r.device_id, r.device_label),
         }));
     }
 
@@ -342,6 +409,7 @@ export async function tryHandleSessionRoute(
           jsonlAvailableLocally: true,
           hasBytes: true,
           activeDeviceId: null,
+          activeDeviceLabel: null,
         });
         return true;
       }
@@ -364,6 +432,8 @@ export async function tryHandleSessionRoute(
             WHERE owner_id = ? AND session_id = ? LIMIT 1`,
         ).get(ownerId, id) as RemoteRow | undefined;
         if (remoteRow) {
+          const { myDeviceId, myDeviceLabel } = readMyDeviceIdentity(db);
+          const resolve = makeActiveLabelResolver(myDeviceId, myDeviceLabel);
           sendJson({
             id,
             spaceId: null,
@@ -382,6 +452,9 @@ export async function tryHandleSessionRoute(
             jsonlAvailableLocally: remoteRow.jsonl_local_path !== null,
             hasBytes: remoteRow.has_bytes === 1,
             activeDeviceId: remoteRow.active_device_id,
+            activeDeviceLabel: resolve(
+              remoteRow.active_device_id, remoteRow.device_id, remoteRow.device_label,
+            ),
           });
           return true;
         }

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -559,7 +559,10 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
        last_event_at     = excluded.last_event_at,
        bytes_generation  = excluded.bytes_generation,
        has_bytes         = excluded.has_bytes,
-       total_bytes       = excluded.total_bytes,
+       -- Preserve a known total_bytes if cloud sends NULL (mid-rollout
+       -- where the worker hasn't been updated yet, or a partial-shape
+       -- response). Only a non-null cloud value replaces what we have.
+       total_bytes       = COALESCE(excluded.total_bytes, remote_sessions.total_bytes),
        active_device_id  = excluded.active_device_id,
        cloud_updated_at  = excluded.cloud_updated_at,
        fetched_at        = excluded.fetched_at
@@ -633,7 +636,14 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
           s.session_id, session.user.id, s.device_id, s.device_label ?? null,
           s.agent, s.title, s.state, s.cwd, s.model,
           s.started_at, s.ended_at, s.last_event_at,
-          s.bytes_generation, s.has_bytes ? 1 : 0, s.total_bytes ?? 0,
+          // total_bytes is NULL when the cloud worker hasn't been upgraded
+          // to the version that returns it. Preserve NULL on the wire so
+          // the upsert can decide whether to overwrite an existing known
+          // value (see COALESCE in upsertRemoteSession). Coercing to 0
+          // would defeat the "NULL = unknown, leave row visible" exemption
+          // in the ghost-session filter and could hide real sessions
+          // during a server-ahead-of-worker rollout window.
+          s.bytes_generation, s.has_bytes ? 1 : 0, s.total_bytes ?? null,
           s.active_device_id ?? null,
           s.updated_at, now,
         );

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -540,9 +540,9 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
   const upsertRemoteSession = deps.db.prepare(
     `INSERT INTO remote_sessions
        (session_id, owner_id, device_id, device_label, agent, title, state, cwd, model,
-        started_at, ended_at, last_event_at, bytes_generation, has_bytes,
+        started_at, ended_at, last_event_at, bytes_generation, has_bytes, total_bytes,
         active_device_id, cloud_updated_at, fetched_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(owner_id, session_id) DO UPDATE SET
        device_id         = excluded.device_id,
        -- Preserve a known label if cloud sends NULL (legacy row, or
@@ -559,6 +559,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
        last_event_at     = excluded.last_event_at,
        bytes_generation  = excluded.bytes_generation,
        has_bytes         = excluded.has_bytes,
+       total_bytes       = excluded.total_bytes,
        active_device_id  = excluded.active_device_id,
        cloud_updated_at  = excluded.cloud_updated_at,
        fetched_at        = excluded.fetched_at
@@ -597,6 +598,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       last_event_at: string;
       bytes_generation: number;
       has_bytes: boolean;
+      total_bytes: number;
       active_device_id: string | null;
       updated_at: number;
     };
@@ -631,7 +633,8 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
           s.session_id, session.user.id, s.device_id, s.device_label ?? null,
           s.agent, s.title, s.state, s.cwd, s.model,
           s.started_at, s.ended_at, s.last_event_at,
-          s.bytes_generation, s.has_bytes ? 1 : 0, s.active_device_id ?? null,
+          s.bytes_generation, s.has_bytes ? 1 : 0, s.total_bytes ?? 0,
+          s.active_device_id ?? null,
           s.updated_at, now,
         );
         if (info.changes > 0) applied++;

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -861,6 +861,70 @@ describe("SessionSyncService.pull", () => {
     expect(rows.find((r) => r.session_id === "s-legacy")?.device_label).toBeNull();
   });
 
+  it("pull persists NULL total_bytes (not 0) when cloud omits the field (mid-rollout)", async () => {
+    // The cloud worker may briefly serve an older shape that doesn't
+    // include total_bytes (server-ahead-of-worker deploy window). The
+    // local store must record NULL — defaulting to 0 would defeat the
+    // "NULL is exempt" ghost-session filter and could silently hide
+    // real sessions until the worker deploy catches up.
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    // cloudPayload() doesn't accept total_bytes; the field is omitted in
+    // the JSON, which mirrors the pre-3.2a worker response shape.
+    const fetchSpy = vi.fn(async () =>
+      cloudPayload([{ session_id: "s-no-total", device_id: "dev-pc", has_bytes: true }]),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pull();
+    const row = db.prepare(
+      `SELECT total_bytes FROM remote_sessions WHERE session_id = 's-no-total'`,
+    ).get() as { total_bytes: number | null };
+    expect(row.total_bytes).toBeNull();
+  });
+
+  it("preserves an existing total_bytes when cloud later sends NULL (COALESCE)", async () => {
+    // Same defensive logic as device_label: a later pull from a downgraded
+    // worker shouldn't wipe a known total_bytes value with NULL.
+    const { db, profileBinding } = harness();
+    profileBinding.bindToOwner("user-A");
+    seedDevice(db, "dev-mac");
+    // First pull stores a known total_bytes by going through the upsert
+    // with an explicit value. cloudPayload doesn't include the field, so
+    // bypass it for the seed insert.
+    db.prepare(
+      `INSERT INTO remote_sessions
+         (session_id, owner_id, device_id, agent, title, state, cwd, model,
+          started_at, ended_at, last_event_at, bytes_generation, has_bytes, total_bytes,
+          cloud_updated_at, fetched_at)
+       VALUES ('s-keeps-total', 'user-A', 'dev-pc', 'claude-code', 't', 'done',
+               '/tmp/x', 'm', '2026-05-11T10:00:00Z', NULL,
+               '2026-05-11T10:30:00Z', 0, 1, 12345, 500, ?)`,
+    ).run(Date.now());
+    // Now pull a fresher version from cloud that omits total_bytes.
+    const fetchSpy = vi.fn(async () =>
+      cloudPayload([{ session_id: "s-keeps-total", device_id: "dev-pc", has_bytes: true, updated_at: 2000 }]),
+    );
+    const svc = createSessionSyncService({
+      db, profileBinding,
+      currentUser: () => ({ id: "user-A", email: "a@a", tier: "pro" }),
+      sessionToken: () => "tok",
+      workerBase: "https://example.com",
+      fetch: fetchSpy as unknown as typeof fetch,
+    });
+    await svc.pull();
+    const row = db.prepare(
+      `SELECT total_bytes FROM remote_sessions WHERE session_id = 's-keeps-total'`,
+    ).get() as { total_bytes: number | null };
+    expect(row.total_bytes).toBe(12345);
+  });
+
   it("preserves an existing device_label when cloud later sends NULL (COALESCE)", async () => {
     // A subsequent pull where the origin device is offline or pushed a
     // partial-shape session must not erase the known label. The upsert's

--- a/server/test/session-sync-service.test.ts
+++ b/server/test/session-sync-service.test.ts
@@ -56,6 +56,7 @@ function harness() {
       last_event_at     TEXT NOT NULL,
       bytes_generation  INTEGER NOT NULL DEFAULT 0,
       has_bytes         INTEGER NOT NULL DEFAULT 0,
+      total_bytes       INTEGER,
       active_device_id  TEXT,
       cloud_updated_at  INTEGER NOT NULL,
       fetched_at        INTEGER NOT NULL,

--- a/server/test/sessions-resume-route.test.ts
+++ b/server/test/sessions-resume-route.test.ts
@@ -34,10 +34,16 @@ function makeDb(): Database.Database {
       agent TEXT NOT NULL, title TEXT, state TEXT NOT NULL, cwd TEXT,
       model TEXT, started_at TEXT NOT NULL, ended_at TEXT,
       last_event_at TEXT NOT NULL, bytes_generation INTEGER NOT NULL DEFAULT 0,
-      has_bytes INTEGER NOT NULL DEFAULT 0, active_device_id TEXT,
+      has_bytes INTEGER NOT NULL DEFAULT 0, total_bytes INTEGER,
+      active_device_id TEXT,
       cloud_updated_at INTEGER NOT NULL,
       fetched_at INTEGER NOT NULL, jsonl_local_path TEXT,
       PRIMARY KEY (owner_id, session_id)
+    );
+    CREATE TABLE device_identity (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      device_id TEXT NOT NULL,
+      label TEXT NOT NULL
     );
     CREATE TABLE sources (
       id TEXT PRIMARY KEY, space_id TEXT NOT NULL, type TEXT NOT NULL,
@@ -51,17 +57,40 @@ function makeDb(): Database.Database {
 
 function insertRemote(
   db: Database.Database,
-  opts: { sessionId: string; ownerId: string; cwd: string | null; hasBytes: boolean; deviceId?: string },
+  opts: {
+    sessionId: string;
+    ownerId: string;
+    cwd: string | null;
+    hasBytes: boolean;
+    deviceId?: string;
+    /** Override title (default 't') — pass null to test the ghost-session filter. */
+    title?: string | null;
+    /** Override ended_at (default null) — set to test "ended cleanly" exemption. */
+    endedAt?: string | null;
+    /** Override total_bytes — drives the ghost-session filter. */
+    totalBytes?: number | null;
+    /** Override active_device_id — drives the active-writer chip. */
+    activeDeviceId?: string | null;
+  },
 ) {
   db.prepare(
     `INSERT INTO remote_sessions
        (session_id, owner_id, device_id, agent, title, state, cwd, model,
-        started_at, ended_at, last_event_at, bytes_generation, has_bytes,
-        cloud_updated_at, fetched_at, jsonl_local_path)
-     VALUES (?, ?, ?, 'claude-code', 't', 'done', ?, 'm',
-             '2026-05-11T10:00:00Z', NULL, '2026-05-11T10:30:00Z',
-             0, ?, 1000, ?, NULL)`,
-  ).run(opts.sessionId, opts.ownerId, opts.deviceId ?? "dev-pc", opts.cwd, opts.hasBytes ? 1 : 0, Date.now());
+        started_at, ended_at, last_event_at, bytes_generation, has_bytes, total_bytes,
+        active_device_id, cloud_updated_at, fetched_at, jsonl_local_path)
+     VALUES (?, ?, ?, 'claude-code', ?, 'done', ?, 'm',
+             '2026-05-11T10:00:00Z', ?, '2026-05-11T10:30:00Z',
+             0, ?, ?, ?, 1000, ?, NULL)`,
+  ).run(
+    opts.sessionId, opts.ownerId, opts.deviceId ?? "dev-pc",
+    opts.title === undefined ? "t" : opts.title,
+    opts.cwd,
+    opts.endedAt === undefined ? null : opts.endedAt,
+    opts.hasBytes ? 1 : 0,
+    opts.totalBytes === undefined ? null : opts.totalBytes,
+    opts.activeDeviceId === undefined ? null : opts.activeDeviceId,
+    Date.now(),
+  );
 }
 
 function insertSource(db: Database.Database, id: string, path: string, spaceId = "space-1") {
@@ -333,6 +362,93 @@ describe("GET /api/sessions merges local + remote", () => {
     expect(list).toHaveLength(1);
     expect(list[0]!.title).toBe("local-version");
     expect(list[0]!.originDeviceId).toBeNull();
+  });
+
+  it("hides ghost remote sessions (title null + ended_at null + tiny byte count)", async () => {
+    // The dogfood `matth (no title yet)` rows: aborted `claude` invocations
+    // that left only permission/file-history/exit events in the jsonl. Hide
+    // them so Home doesn't fill up with non-content.
+    const db = makeDb();
+    insertRemote(db, {
+      sessionId: "ghost-1", ownerId: "user-A", cwd: "C:\\Users\\matth",
+      hasBytes: true, title: null, endedAt: null, totalBytes: 1853,
+    });
+    insertRemote(db, {
+      sessionId: "real-titled", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, title: "real conversation", endedAt: null, totalBytes: 1500,
+    });
+    insertRemote(db, {
+      sessionId: "ended-untitled", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, title: null, endedAt: "2026-05-10T12:00:00Z", totalBytes: 100,
+    });
+    insertRemote(db, {
+      sessionId: "big-untitled", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, title: null, endedAt: null, totalBytes: 50_000,
+    });
+    insertRemote(db, {
+      sessionId: "legacy-no-bytecount", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, title: null, endedAt: null, totalBytes: null,
+    });
+    const sessionStore = { getAll: () => [] } as any;
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions",
+      ctx as any, {
+        db, sessionStore, spaceStore: { getSourcesByIds: () => [] } as any,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+    const ids = (captured.json as Array<{ id: string }>).map((s) => s.id).sort();
+    // ghost-1 hidden; everything else surfaced for one reason or another.
+    expect(ids).toEqual(["big-untitled", "ended-untitled", "legacy-no-bytecount", "real-titled"]);
+  });
+
+  it("computes activeDeviceLabel from local device_identity and origin", async () => {
+    // Three scenarios in one go:
+    //   - active is us → resolves to our local device_identity.label
+    //   - active equals origin → resolves to remote_sessions.device_label
+    //   - active is a third unknown device → null (we don't make one up)
+    const db = makeDb();
+    db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, 'dev-mac', 'MacBookPro')`).run();
+
+    // Origin Windows, active = Mac (us). UI should render "Now active here".
+    insertRemote(db, {
+      sessionId: "s-handed-to-me", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, deviceId: "dev-windows", activeDeviceId: "dev-mac",
+    });
+    db.prepare(`UPDATE remote_sessions SET device_label = 'WIN-DESKTOP' WHERE session_id = 's-handed-to-me'`).run();
+
+    // Origin Windows, active = Windows (steady state). resolveActiveLabel
+    // returns origin's label, but the UI helper hides this case (no handoff).
+    insertRemote(db, {
+      sessionId: "s-still-on-origin", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, deviceId: "dev-windows", activeDeviceId: "dev-windows",
+    });
+    db.prepare(`UPDATE remote_sessions SET device_label = 'WIN-DESKTOP' WHERE session_id = 's-still-on-origin'`).run();
+
+    // Origin Windows, active = third Linux device we've never seen.
+    insertRemote(db, {
+      sessionId: "s-unknown-active", ownerId: "user-A", cwd: "C:\\proj",
+      hasBytes: true, deviceId: "dev-windows", activeDeviceId: "dev-linux",
+    });
+
+    const { ctx, captured } = fakeCtx();
+    const req = { method: "GET" } as any;
+    await tryHandleSessionRoute(req, {} as any, "/api/sessions",
+      ctx as any, {
+        db, sessionStore: { getAll: () => [] } as any,
+        spaceStore: { getSourcesByIds: () => [] } as any,
+        artifactService: {} as any, memoryProvider: {} as any,
+        sessionSync: stubSessionSync(),
+        currentUserId: () => "user-A",
+      });
+    const byId = new Map(
+      (captured.json as Array<{ id: string; activeDeviceLabel: string | null }>).map((s) => [s.id, s.activeDeviceLabel]),
+    );
+    expect(byId.get("s-handed-to-me")).toBe("MacBookPro");
+    expect(byId.get("s-still-on-origin")).toBe("WIN-DESKTOP");
+    expect(byId.get("s-unknown-active")).toBeNull();
   });
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -127,6 +127,11 @@ export interface Session {
    *  "Active on <device>" chip in the UI. Null for sessions that pre-date
    *  active-writer tracking. */
   activeDeviceId?: string | null;
+  /** Resolved human-readable label for `activeDeviceId`. The server
+   *  matches the active id against the local device_identity and against
+   *  remote_sessions.device_label and returns whichever matches; null when
+   *  active is some third device we don't yet have a label for. */
+  activeDeviceLabel?: string | null;
 }
 
 /** POST /api/sessions/:id/resume response shapes. */

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -474,6 +474,36 @@
   font-size: 10px;
 }
 
+/* Active-writer chip — orange/amber so it reads as "live activity" and
+ * doesn't collide visually with the blue cross-device origin chip.
+ * Top-right corner on tiles, inline after the origin chip on rows. */
+.home-active-chip {
+  display: inline-flex;
+  align-items: center;
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  padding: 3px 8px;
+  border-radius: 7px;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  color: #fbbf24;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.home-row-title .home-active-chip {
+  position: static;
+  margin-right: 8px;
+  vertical-align: baseline;
+  font-size: 10px;
+}
+
 /* ── Status indicator on the thumb ── */
 .home-status {
   position: absolute;

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -2,7 +2,8 @@
 import type { Session } from "../../data/sessions-api";
 import type { Space } from "../../../../shared/types";
 import {
-  AGENT_PIP_CLASS, formatRelative, originDeviceChipFor, spaceLabelFor,
+  AGENT_PIP_CLASS, activeWriterChipFor, formatRelative,
+  originDeviceChipFor, spaceLabelFor,
 } from "./utils";
 
 interface SessionRowProps {
@@ -26,6 +27,7 @@ export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowPr
   const cwdBasename = session.cwd ? session.cwd.split(/[\\/]/).filter(Boolean).pop() ?? null : null;
   const projectLabel = session.sourceLabel ?? spaceLabel ?? cwdBasename ?? "—";
   const remoteChip = originDeviceChipFor(session, myDeviceId);
+  const activeChip = activeWriterChipFor(session, myDeviceId);
   return (
     <div
       className="home-row"
@@ -42,6 +44,11 @@ export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowPr
         {remoteChip && (
           <span className="home-remote-chip" title={remoteChip.titleTooltip}>
             <span aria-hidden="true">↗</span> {remoteChip.label}
+          </span>
+        )}
+        {activeChip && (
+          <span className="home-active-chip" title={activeChip.titleTooltip}>
+            {activeChip.label}
           </span>
         )}
         {title}

--- a/web/src/components/Home/SessionTile.tsx
+++ b/web/src/components/Home/SessionTile.tsx
@@ -3,7 +3,7 @@ import type { Session } from "../../data/sessions-api";
 import type { Space } from "../../../../shared/types";
 import {
   AGENT_CLASS, AGENT_LETTERS,
-  metaForSession, originDeviceChipFor, spaceLabelFor,
+  activeWriterChipFor, metaForSession, originDeviceChipFor, spaceLabelFor,
 } from "./utils";
 
 interface SessionTileProps {
@@ -21,6 +21,7 @@ export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, onOpen
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
   const title = session.title ?? "(no title yet)";
   const remoteChip = originDeviceChipFor(session, myDeviceId);
+  const activeChip = activeWriterChipFor(session, myDeviceId);
   return (
     <div
       className="home-tile"
@@ -42,6 +43,14 @@ export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, onOpen
           showSpaceChip && spaceLabel && (
             <span className="home-space-chip">{spaceLabel}</span>
           )
+        )}
+        {activeChip && (
+          // Active-writer chip in the opposite corner so it doesn't clash with
+          // origin/space. Visible whenever there's been a hand-off, including
+          // back to this device.
+          <span className="home-active-chip" title={activeChip.titleTooltip}>
+            {activeChip.label}
+          </span>
         )}
         <span className="home-agent-mark">{AGENT_LETTERS[session.agent]}</span>
         <span className={`home-status ${session.state}`} />

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -90,6 +90,29 @@ export function originDeviceChipFor(
   };
 }
 
+/** Decide whether to show the active-writer chip on a session card. The
+ *  "Now active on X" signal fires when the most recent push to this
+ *  session came from a device OTHER than the origin — i.e. a handoff has
+ *  happened. Returns null when origin and active are the same (steady
+ *  state, no signal needed), when the active device label is unknown, or
+ *  when there's no active device yet (legacy rows pre-active-writer). */
+export function activeWriterChipFor(
+  session: Session,
+  myDeviceId: string | null,
+): { label: string; titleTooltip: string } | null {
+  const active = session.activeDeviceId;
+  if (!active) return null;
+  const origin = session.originDeviceId;
+  if (origin && active === origin) return null;  // no handoff
+  const isMe = myDeviceId && active === myDeviceId;
+  const label = session.activeDeviceLabel ?? (isMe ? "this device" : null);
+  if (!label) return null;  // active is a third unknown device
+  return {
+    label: isMe ? "Now active here" : `Now active on ${label}`,
+    titleTooltip: `Most recent chunk pushed by ${label} (device ${active.slice(0, 8)})`,
+  };
+}
+
 export function metaForSession(session: Session): string {
   const rel = formatRelative(session.lastEventAt) ?? "—";
   if (session.state === "waiting") return `${session.agent} · waiting ${rel}`;

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -104,7 +104,7 @@ export function activeWriterChipFor(
   if (!active) return null;
   const origin = session.originDeviceId;
   if (origin && active === origin) return null;  // no handoff
-  const isMe = myDeviceId && active === myDeviceId;
+  const isMe: boolean = myDeviceId !== null && active === myDeviceId;
   const label = session.activeDeviceLabel ?? (isMe ? "this device" : null);
   if (!label) return null;  // active is a third unknown device
   return {


### PR DESCRIPTION
## Summary

Three improvements to the cross-device Home, based on dogfooding beta.10.

### 1. Filter ghost remote sessions from Home

Aborted \`claude\` invocations leave a transcript in cloud with only system events (permission-mode, file-history-snapshot, a couple of \`<command-name>/exit</command-name>\` lines). They show up as useless "(no title yet)" rows.

- Worker \`/api/sessions/metadata\` GET computes \`total_bytes\` (SUM byte_count for current generation)
- Local \`remote_sessions.total_bytes\` column, populated via pull
- \`/api/sessions\` merge hides rows where \`title IS NULL AND ended_at IS NULL AND total_bytes < 4096\`
- Pre-3.2a rows with NULL total_bytes are exempt (won't hide real sessions until next pull)

Temporary heuristic per the review feedback. Durable fix queued: add \`real_user_message_count\` + \`assistant_message_count\` to metadata, filter where both are 0.

### 2. Device label backfill

Sessions pushed before beta.9 have NULL \`device_label\` in cloud. New \`app_state\` table tracks one-shot migrations gated on Oyster version. On first boot of this release, bump \`sync_dirty_at\` on every locally-owned session → next reconcile re-pushes with the device's label → cloud rows pick up the label → other devices see the friendly name on their next pull. No wrangler script needed.

### 3. Active-writer chip

When \`activeDeviceId !== originDeviceId\` (i.e. a hand-off happened), Home shows \`Now active on MacBookPro\` in amber. Server resolves \`activeDeviceLabel\` from \`device_identity\` (when active is us) or \`remote_sessions.device_label\` (when active is origin). Third unknown devices fall back to null rather than guessing.

## Test plan

- [x] Worker: \`total_bytes\` returned in metadata GET (+1 case)
- [x] Server: ghost filter with 5 row variants (hidden + 4 exempt cases)
- [x] Server: \`activeDeviceLabel\` resolved across 3 scenarios (active=me, active=origin, active=unknown-third-device)
- [x] 244 server tests pass (was 242)
- [x] 50 worker tests pass (was 49)
- [x] tsc + \`npm run build\` clean

## Deploy chain post-merge

No D1 migration in this PR (the worker change uses the existing \`synced_session_chunks\` table via a SUM subquery; no schema change). Cloud deploy is just the worker rebuild.

1. \`wrangler deploy --config infra/oyster-cloud/wrangler.toml\`
2. \`npm run release:beta\` → 0.8.1-beta.11

## Manual smoke test after upgrading

- The 3 \`matth (no title yet)\` rows disappear from Home (filtered)
- The 5 remaining Windows sessions show \`↗ DESKTOP-XYZ\` (Windows hostname) after Windows boots beta.11 once and the next reconcile completes
- After Mac resumes a Windows session and pushes a chunk: the row shows \`Now active here\` (amber) on Mac and \`Now active on MacBookPro\` on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)