### PR TITLE
perf(sessions): debounce metadata pushPending to coalesce per-event pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Empty cross-device sessions hidden from Home.** Aborted `claude` invocations (where the user opened a transcript but never had a real conversation) used to clutter the list as "(no title yet)" entries. Those are filtered out now. Sessions with real content always show, regardless of title. (Heuristic-based for the moment; the durable fix lands in a follow-up.)
 - **Device labels backfill automatically on upgrade.** Devices that backed up sessions before the label-sync change won't have a friendly name in cloud yet. On first boot of this release each device marks its own sessions for re-push, so the labels show up everywhere within a few minutes — no manual action required.
+- **Session metadata sync is quieter under load.** During a busy conversation, every new turn was sending its own one-row push to the cloud — dozens of HTTP round-trips per minute, all with a single session in the payload. Pushes are now coalesced: one round-trip after a ~1-second quiet window, and at most one every ~5 seconds during sustained activity. No data is lost. Transcript bytes still push on terminal state immediately.
 
 ### Fixed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -334,6 +334,7 @@
 <ul>
 <li><strong>Empty cross-device sessions hidden from Home.</strong> Aborted <code>claude</code> invocations (where the user opened a transcript but never had a real conversation) used to clutter the list as &quot;(no title yet)&quot; entries. Those are filtered out now. Sessions with real content always show, regardless of title. (Heuristic-based for the moment; the durable fix lands in a follow-up.)</li>
 <li><strong>Device labels backfill automatically on upgrade.</strong> Devices that backed up sessions before the label-sync change won&#39;t have a friendly name in cloud yet. On first boot of this release each device marks its own sessions for re-push, so the labels show up everywhere within a few minutes — no manual action required.</li>
+<li><strong>Session metadata sync is quieter under load.</strong> During a busy conversation, every new turn was sending its own one-row push to the cloud — dozens of HTTP round-trips per minute, all with a single session in the payload. Pushes are now coalesced: one round-trip after a ~1-second quiet window, and at most one every ~5 seconds during sustained activity. No data is lost. Transcript bytes still push on terminal state immediately.</li>
 </ul>
 <h3>Fixed</h3>
 <ul>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1033,6 +1033,33 @@ httpServer.listen(port, "127.0.0.1", () => {
   // Sessions arc — start the claude-code log watcher (#251). Failures
   // (missing ~/.claude/projects, permission denied) shouldn't block the
   // server; the watcher logs and stays dormant.
+
+  // Debounce window for metadata push. The watcher fires emitSessionChanged
+  // on every jsonl event (assistant turn, tool call, etc.) — during a busy
+  // conversation that's many events per minute. Without debouncing, each
+  // event triggers its own pushPending → its own HTTP round-trip with one
+  // session in the payload (`[sessions] pushed: accepted=1` spam in logs).
+  //
+  // markDirty stays synchronous so durability is intact: any unpushed
+  // session_id keeps its sync_dirty_at marker and is drained by the next
+  // push or the next startup reconcile.
+  //
+  // 1 s is the trade-off: long enough to coalesce a steady event stream
+  // into one push, short enough that cross-device visibility on a quiet
+  // session still feels live. Terminal-state pushBytes is unaffected —
+  // it fires immediately so a session ending lands its last bytes ASAP.
+  const SESSION_PUSH_DEBOUNCE_MS = 1000;
+  let sessionPushTimer: NodeJS.Timeout | null = null;
+  function schedulePushPending(): void {
+    if (sessionPushTimer) clearTimeout(sessionPushTimer);
+    sessionPushTimer = setTimeout(() => {
+      sessionPushTimer = null;
+      sessionSync.pushPending().catch((err) => {
+        console.warn("[sessions] watcher-triggered pushPending failed:", err);
+      });
+    }, SESSION_PUSH_DEBOUNCE_MS);
+  }
+
   const claudeCodeWatcher = new ClaudeCodeWatcher({
     sessionStore,
     spaceStore,
@@ -1040,9 +1067,9 @@ httpServer.listen(port, "127.0.0.1", () => {
     emitSessionChanged: (id) => {
       broadcastUiEvent({ version: 1, command: "session_changed", payload: { id } });
       // Cross-device session sync (#322): every session-row change marks the
-      // row dirty for the current Pro owner, then fires a fire-and-forget
-      // metadata push + bytes push on terminal state. The in-flight guards
-      // inside SessionSyncService coalesce bursty updates into single passes.
+      // row dirty for the current Pro owner, then schedules a debounced
+      // metadata push. Bytes push on terminal state stays immediate so the
+      // last chunk lands ASAP.
       //
       // canRunCloudSync() (not a bare tier check): when the local profile is
       // bound to a different account, we MUST NOT call markDirty — it would
@@ -1052,9 +1079,7 @@ httpServer.listen(port, "127.0.0.1", () => {
       if (!canRunCloudSync()) return;
       const u = authService.getState().user!;
       sessionSync.markDirty(id, u.id);
-      sessionSync.pushPending().catch((err) => {
-        console.warn("[sessions] watcher-triggered pushPending failed:", err);
-      });
+      schedulePushPending();
       // Terminal-state hook: fire one final pushBytes when the session
       // transitions to done/disconnected so the tail of the jsonl makes it
       // to cloud even if it's under the snapshot-timer's 1 MB threshold.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1034,30 +1034,50 @@ httpServer.listen(port, "127.0.0.1", () => {
   // (missing ~/.claude/projects, permission denied) shouldn't block the
   // server; the watcher logs and stays dormant.
 
-  // Debounce window for metadata push. The watcher fires emitSessionChanged
-  // on every jsonl event (assistant turn, tool call, etc.) — during a busy
-  // conversation that's many events per minute. Without debouncing, each
-  // event triggers its own pushPending → its own HTTP round-trip with one
-  // session in the payload (`[sessions] pushed: accepted=1` spam in logs).
+  // Debounce-with-max-wait for metadata push. The watcher fires
+  // emitSessionChanged on every jsonl event (assistant turn, tool call,
+  // etc.) — during a busy conversation that's many events per minute.
+  // Without coalescing, each event triggers its own pushPending → its own
+  // HTTP round-trip with one session in the payload
+  // (`[sessions] pushed: accepted=1` spam in logs).
   //
   // markDirty stays synchronous so durability is intact: any unpushed
   // session_id keeps its sync_dirty_at marker and is drained by the next
   // push or the next startup reconcile.
   //
-  // 1 s is the trade-off: long enough to coalesce a steady event stream
-  // into one push, short enough that cross-device visibility on a quiet
-  // session still feels live. Terminal-state pushBytes is unaffected —
-  // it fires immediately so a session ending lands its last bytes ASAP.
+  // Two timing knobs:
+  // - DEBOUNCE_MS (1 s): how long after the LAST event we wait before
+  //   firing. Coalesces a quick burst of events into a single push at the
+  //   tail of the burst.
+  // - MAX_WAIT_MS (5 s): hard cap on how long the first-event-in-burst
+  //   waits, no matter how many further events arrive. Without this, a
+  //   pure debounce can defer pushes arbitrarily during continuous
+  //   activity — bad for cross-device visibility during long sessions.
+  //
+  // Terminal-state pushBytes is unaffected — it fires immediately so a
+  // session ending lands its last bytes ASAP.
   const SESSION_PUSH_DEBOUNCE_MS = 1000;
+  const SESSION_PUSH_MAX_WAIT_MS = 5000;
   let sessionPushTimer: NodeJS.Timeout | null = null;
+  let sessionPushFirstScheduledAt: number | null = null;
   function schedulePushPending(): void {
+    const now = Date.now();
+    if (sessionPushFirstScheduledAt === null) {
+      sessionPushFirstScheduledAt = now;
+    }
+    // Cap the actual sleep so the first-scheduled event fires within
+    // MAX_WAIT_MS even if events keep arriving. Math.max(0, ...) handles
+    // the "already past the cap" case (next-tick fire).
+    const elapsed = now - sessionPushFirstScheduledAt;
+    const delay = Math.max(0, Math.min(SESSION_PUSH_DEBOUNCE_MS, SESSION_PUSH_MAX_WAIT_MS - elapsed));
     if (sessionPushTimer) clearTimeout(sessionPushTimer);
     sessionPushTimer = setTimeout(() => {
       sessionPushTimer = null;
+      sessionPushFirstScheduledAt = null;
       sessionSync.pushPending().catch((err) => {
         console.warn("[sessions] watcher-triggered pushPending failed:", err);
       });
-    }, SESSION_PUSH_DEBOUNCE_MS);
+    }, delay);
   }
 
   const claudeCodeWatcher = new ClaudeCodeWatcher({


### PR DESCRIPTION
## The noise

During a busy conversation, the server log fills with:

\`\`\`
[sessions] pushed: accepted=1
[sessions] pushed: accepted=1
[sessions] pushed: accepted=1
... (×100+)
\`\`\`

The watcher fires \`emitSessionChanged\` on every jsonl event — assistant turn, tool call, user input. Each event called \`sessionSync.pushPending()\` directly, and the in-flight guard only dedupes *concurrent* calls. A push completes in ~50 ms, the next event arrives 100 ms later, a new push fires with one newly-dirty row.

Wasteful but harmless: data is durable because \`sync_dirty_at\` is set synchronously and survives a crash.

## The fix

Replace the direct call with a 1 s debounced timer. \`markDirty\` stays synchronous (durability intact). A steady stream of events collapses to one push at the tail of the stream rather than N pushes during it.

\`\`\`ts
function schedulePushPending(): void {
  if (sessionPushTimer) clearTimeout(sessionPushTimer);
  sessionPushTimer = setTimeout(() => {
    sessionPushTimer = null;
    sessionSync.pushPending().catch(...);
  }, 1000);
}
\`\`\`

Terminal-state \`pushBytes\` is unchanged — a session ending still lands its final chunk immediately, not after a debounce window.

## Test plan

- [x] 242 server tests pass
- [x] tsc + build clean
- [ ] Manual after merge: run a session, confirm logs show \`accepted=N\` (N>1) rather than dozens of \`accepted=1\` lines

## Independent of PR #455

This PR branches off main, doesn't depend on #455. Order of merge doesn't matter — either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)