### PR TITLE
fix(sync): quieter logs when offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Quieter terminal logs when offline.** When wifi goes out, sync used to log a 30-line stack trace every ~30 seconds for each background pull (memory + sessions). Now the first failure prints a single line — `cloud unreachable (ENOTFOUND)` — subsequent identical failures are suppressed, and a heartbeat appears roughly every 15 minutes if you're still offline. When wifi comes back, a single `back online` line confirms it. Real bugs (non-network errors) still surface their full trace.
+
 ### Added
 
 - **Active-writer signal on cross-device sessions.** When a session has been handed off — you resume a Mac session on Windows, or vice-versa — Home now shows a `Now active on MacBookPro` chip alongside the origin chip. It updates live as devices push new turns, so the demo "I picked this up over here" handoff is visible at a glance.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -326,6 +326,10 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>Quieter terminal logs when offline.</strong> When wifi goes out, sync used to log a 30-line stack trace every ~30 seconds for each background pull (memory + sessions). Now the first failure prints a single line — <code>cloud unreachable (ENOTFOUND)</code> — subsequent identical failures are suppressed, and a heartbeat appears roughly every 15 minutes if you&#39;re still offline. When wifi comes back, a single <code>back online</code> line confirms it. Real bugs (non-network errors) still surface their full trace.</li>
+</ul>
 <h3>Added</h3>
 <ul>
 <li><strong>Active-writer signal on cross-device sessions.</strong> When a session has been handed off — you resume a Mac session on Windows, or vice-versa — Home now shows a <code>Now active on MacBookPro</code> chip alongside the origin chip. It updates live as devices push new turns, so the demo &quot;I picked this up over here&quot; handoff is visible at a glance.</li>

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -9,6 +9,7 @@
 import type Database from "better-sqlite3";
 import type { SqliteFtsMemoryProvider } from "./memory-store.js";
 import type { ProfileBindingService } from "./profile-binding-service.js";
+import { createOfflineLogger } from "./sync-log.js";
 
 interface SyncUser { id: string; email: string; tier: string }
 
@@ -78,6 +79,10 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
   // (e.g. multiple onWrite triggers in quick succession) await the same
   // promise rather than racing.
   let inFlightPush: Promise<number> | null = null;
+  // Offline-aware loggers so a wifi-off laptop doesn't spam the terminal
+  // with full stack traces every reconcile cycle. One per call-site.
+  const pushLog = createOfflineLogger("[memory] pushPending");
+  const pullLog = createOfflineLogger("[memory] pull");
   let inFlightReconcile: Promise<{ pulled: number; pushed: number }> | null = null;
 
   async function doPushPending(): Promise<number> {
@@ -149,13 +154,14 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
             body: JSON.stringify({ events }),
           });
         } catch (err) {
-          console.warn("[memory] pushPending failed:", err);
+          pushLog.failure(err);
           return totalAccepted;
         }
         if (!res.ok) {
           console.warn(`[memory] pushPending non-ok ${res.status}`);
           return totalAccepted;
         }
+        pushLog.success();
         const body = await res.json().catch(() => null) as {
           accepted?: string[]; duplicates?: string[]; conflicts?: string[]; rejected?: string[];
         } | null;
@@ -235,13 +241,14 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
           headers: { Cookie: `oyster_session=${session.token}` },
         });
       } catch (err) {
-        console.warn("[memory] pull failed:", err);
+        pullLog.failure(err);
         return 0;
       }
       if (!res.ok) {
         console.warn(`[memory] pull non-ok ${res.status}`);
         return 0;
       }
+      pullLog.success();
       const body = await res.json().catch(() => null) as { events?: IncomingEvent[] } | null;
       const cloud = body?.events ?? [];
 

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -24,6 +24,7 @@ import { join, dirname } from "node:path";
 import { promises as fs } from "node:fs";
 import type Database from "better-sqlite3";
 import type { ProfileBindingService } from "./profile-binding-service.js";
+import { createOfflineLogger } from "./sync-log.js";
 
 interface SyncUser { id: string; email: string; tier: string }
 
@@ -182,6 +183,12 @@ interface OutgoingSession {
 
 export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncService {
   let inFlightPush: Promise<number> | null = null;
+  // Offline-aware loggers so a wifi-off laptop doesn't spam the terminal
+  // with full stack traces every reconcile cycle. One per call-site so
+  // pull, push and bytes-push each track their own streak.
+  const pushLog = createOfflineLogger("[sessions] pushPending");
+  const pullLog = createOfflineLogger("[sessions] pull");
+  const pushBytesLog = createOfflineLogger("[sessions] pushBytes");
 
   const markDirtyStmt = deps.db.prepare(
     `UPDATE sessions
@@ -257,13 +264,14 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
           body: JSON.stringify({ sessions: stamped }),
         });
       } catch (err) {
-        console.warn("[sessions] pushPending failed:", err);
+        pushLog.failure(err);
         return totalAccepted;
       }
       if (!res.ok) {
         console.warn(`[sessions] pushPending non-ok ${res.status}`);
         return totalAccepted;
       }
+      pushLog.success();
       const body = await res.json().catch(() => null) as { accepted?: string[] } | null;
       const accepted = body?.accepted ?? [];
 
@@ -477,7 +485,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
             { method: "PUT", headers, body: chunkBody },
           );
         } catch (err) {
-          console.warn(`[sessions] pushBytes chunk ${nextChunkNumber} fetch failed for ${sessionId}:`, err);
+          pushBytesLog.failure(err);
           break;
         }
 
@@ -489,6 +497,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
           pushedBytes += sliceSize;
           advanceBytesState.run(offset + pushedBytes, chunkCount, Date.now(), sessionId);
           uploaded++;
+          pushBytesLog.success();
           continue;
         }
 
@@ -579,13 +588,14 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
         headers: { Cookie: `oyster_session=${session.token}` },
       });
     } catch (err) {
-      console.warn("[sessions] pull failed:", err);
+      pullLog.failure(err);
       return 0;
     }
     if (!res.ok) {
       console.warn(`[sessions] pull non-ok ${res.status}`);
       return 0;
     }
+    pullLog.success();
 
     type CloudSession = {
       session_id: string;

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -485,7 +485,7 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
             { method: "PUT", headers, body: chunkBody },
           );
         } catch (err) {
-          pushBytesLog.failure(err);
+          pushBytesLog.failure(err, `session=${sessionId.slice(0, 8)} chunk=${nextChunkNumber}`);
           break;
         }
 

--- a/server/src/sync-log.ts
+++ b/server/src/sync-log.ts
@@ -35,7 +35,9 @@ const NETWORK_ERR_CODES = new Set([
  *  through to the full message (callers can still console.warn with the
  *  raw err object for a stack trace on real bugs). */
 export function formatSyncError(err: unknown): string {
-  if (!err) return "unknown error";
+  // Treat ONLY null/undefined as "missing" — `0`, `false`, `""` are valid
+  // throwables that should fall through to String(err) ("0", "false", "").
+  if (err == null) return "unknown error";
   const e = err as {
     code?: string;
     message?: string;
@@ -62,9 +64,12 @@ export interface OfflineLogger {
   /** Call on a sync failure. Logs the first occurrence with a concise
    *  summary, suppresses subsequent ones, prints a "still offline,
    *  attempt N" heartbeat every `heartbeatEvery` failures. Non-offline
-   *  errors are always logged (with `withStack`'s full err so debug
-   *  context isn't lost). */
-  failure(err: unknown): void;
+   *  errors are always logged in full so debug context isn't lost.
+   *  Pass `context` (e.g. `session=c90da198 chunk=2`) to disambiguate
+   *  per-resource call sites in the first-occurrence and non-offline
+   *  log lines. Heartbeats stay generic since by then context may
+   *  belong to several different resources. */
+  failure(err: unknown, context?: string): void;
   /** Call after a successful round-trip. Prints "back online" if this
    *  follows a failure streak; otherwise no-op. Resets the counter. */
   success(): void;
@@ -73,7 +78,9 @@ export interface OfflineLogger {
 interface OfflineLoggerOptions {
   /** Log a heartbeat every N consecutive failures. Defaults to 30 —
    *  with a ~30 s reconcile cadence, that's roughly one line per
-   *  15 minutes of continuous offline. */
+   *  15 minutes of continuous offline. Clamped to a positive integer;
+   *  invalid values (0, negative, NaN) fall back to the default rather
+   *  than silently suppressing heartbeats forever. */
   heartbeatEvery?: number;
 }
 
@@ -84,20 +91,27 @@ export function createOfflineLogger(
   prefix: string,
   options: OfflineLoggerOptions = {},
 ): OfflineLogger {
-  const heartbeatEvery = options.heartbeatEvery ?? 30;
+  const requested = options.heartbeatEvery;
+  // Accept any positive finite number; round to integer for the modulo.
+  // 0 / negative / NaN / undefined fall back to the 30-step default.
+  const heartbeatEvery =
+    typeof requested === "number" && Number.isFinite(requested) && requested >= 1
+      ? Math.floor(requested)
+      : 30;
   let consecutive = 0;
   return {
-    failure(err: unknown): void {
+    failure(err: unknown, context?: string): void {
+      const ctxSuffix = context ? ` ${context}` : "";
       if (!isOfflineLikeError(err)) {
         // Real error — log full so a stack/details survive. Don't touch
         // the consecutive counter so a transient cloud-side bug in the
         // middle of an offline streak doesn't reset our offline tracking.
-        console.warn(`${prefix} failed:`, err);
+        console.warn(`${prefix}${ctxSuffix} failed:`, err);
         return;
       }
       consecutive++;
       if (consecutive === 1) {
-        console.warn(`${prefix} ${formatSyncError(err)} (further offline retries suppressed)`);
+        console.warn(`${prefix}${ctxSuffix} ${formatSyncError(err)} (further offline retries suppressed)`);
       } else if (consecutive % heartbeatEvery === 0) {
         console.warn(`${prefix} still offline (${consecutive} attempts) — ${formatSyncError(err)}`);
       }

--- a/server/src/sync-log.ts
+++ b/server/src/sync-log.ts
@@ -1,0 +1,112 @@
+// Shared helpers for sync error logging. Two purposes:
+//
+//   1. Format known transient network errors as a one-line summary
+//      (`cloud unreachable (ENOTFOUND)`) instead of a 30-line stack trace.
+//      A laptop that loses wifi triggers a DNS failure every reconcile
+//      cycle; the raw error spammed the terminal.
+//
+//   2. Dedupe repeated failures with createOfflineLogger: log once on
+//      first failure, suppress identical follow-ups, log every Nth as a
+//      heartbeat so the user can see "still offline, attempt 30", and log
+//      "back online" the first time a success follows a failure streak.
+//
+// Used by session-sync-service and memory-sync-service for their pull /
+// push error handlers. Push paths that involve chunk uploads (sessions
+// pushBytes) get their own logger so a long upload stream of network
+// errors collapses to a single line instead of one per chunk attempt.
+
+/** Codes Node + undici raise when the cloud is unreachable for the obvious
+ *  reasons: DNS down (wifi off), TCP can't connect, peer reset, timeout.
+ *  Distinguished from non-network errors (4xx/5xx responses, malformed
+ *  JSON, code bugs) which we still want to surface with a real trace. */
+const NETWORK_ERR_CODES = new Set([
+  "ENOTFOUND",            // DNS resolution failed (wifi off, captive portal)
+  "EAI_AGAIN",            // DNS temporary failure
+  "ECONNREFUSED",         // peer rejected
+  "ECONNRESET",           // peer dropped mid-stream
+  "ENETUNREACH",          // no route to network
+  "ETIMEDOUT",            // socket timeout
+  "UND_ERR_CONNECT_TIMEOUT", // undici-specific: TCP connect timeout
+  "UND_ERR_SOCKET",       // undici-specific: socket error
+]);
+
+/** Format an error for logging. For known transient network errors,
+ *  return a concise one-liner naming the code. For everything else, fall
+ *  through to the full message (callers can still console.warn with the
+ *  raw err object for a stack trace on real bugs). */
+export function formatSyncError(err: unknown): string {
+  if (!err) return "unknown error";
+  const e = err as {
+    code?: string;
+    message?: string;
+    cause?: { code?: string; message?: string };
+  };
+  const code = e.cause?.code ?? e.code;
+  if (code && NETWORK_ERR_CODES.has(code)) {
+    return `cloud unreachable (${code})`;
+  }
+  if (e.cause?.message && e.message) {
+    return `${e.message}: ${e.cause.message}`;
+  }
+  return e.message ?? String(err);
+}
+
+/** Return true when the error is a known transient network failure. */
+export function isOfflineLikeError(err: unknown): boolean {
+  const e = err as { code?: string; cause?: { code?: string } } | null;
+  const code = e?.cause?.code ?? e?.code;
+  return !!code && NETWORK_ERR_CODES.has(code);
+}
+
+export interface OfflineLogger {
+  /** Call on a sync failure. Logs the first occurrence with a concise
+   *  summary, suppresses subsequent ones, prints a "still offline,
+   *  attempt N" heartbeat every `heartbeatEvery` failures. Non-offline
+   *  errors are always logged (with `withStack`'s full err so debug
+   *  context isn't lost). */
+  failure(err: unknown): void;
+  /** Call after a successful round-trip. Prints "back online" if this
+   *  follows a failure streak; otherwise no-op. Resets the counter. */
+  success(): void;
+}
+
+interface OfflineLoggerOptions {
+  /** Log a heartbeat every N consecutive failures. Defaults to 30 —
+   *  with a ~30 s reconcile cadence, that's roughly one line per
+   *  15 minutes of continuous offline. */
+  heartbeatEvery?: number;
+}
+
+/** Create a dedupe-aware logger for a single sync operation. Holds a
+ *  consecutive-failures counter in closure; one logger per call-site so
+ *  pull and push (and bytes-push and reassemble) all track independently. */
+export function createOfflineLogger(
+  prefix: string,
+  options: OfflineLoggerOptions = {},
+): OfflineLogger {
+  const heartbeatEvery = options.heartbeatEvery ?? 30;
+  let consecutive = 0;
+  return {
+    failure(err: unknown): void {
+      if (!isOfflineLikeError(err)) {
+        // Real error — log full so a stack/details survive. Don't touch
+        // the consecutive counter so a transient cloud-side bug in the
+        // middle of an offline streak doesn't reset our offline tracking.
+        console.warn(`${prefix} failed:`, err);
+        return;
+      }
+      consecutive++;
+      if (consecutive === 1) {
+        console.warn(`${prefix} ${formatSyncError(err)} (further offline retries suppressed)`);
+      } else if (consecutive % heartbeatEvery === 0) {
+        console.warn(`${prefix} still offline (${consecutive} attempts) — ${formatSyncError(err)}`);
+      }
+    },
+    success(): void {
+      if (consecutive > 0) {
+        console.warn(`${prefix} back online (after ${consecutive} failed attempt${consecutive === 1 ? "" : "s"})`);
+      }
+      consecutive = 0;
+    },
+  };
+}

--- a/server/test/sync-log.test.ts
+++ b/server/test/sync-log.test.ts
@@ -1,0 +1,126 @@
+// Unit tests for the offline-log helpers. The user dogfooding behaviour:
+// "[memory] pull failed: TypeError: fetch failed ... ENOTFOUND cloud.oyster.to"
+// repeated every ~30s for hours after wifi disconnected.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createOfflineLogger,
+  formatSyncError,
+  isOfflineLikeError,
+} from "../src/sync-log.js";
+
+describe("formatSyncError", () => {
+  it("recognises ENOTFOUND (wifi off → DNS failure)", () => {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code: "ENOTFOUND" };
+    expect(formatSyncError(err)).toBe("cloud unreachable (ENOTFOUND)");
+  });
+
+  it("recognises undici connect-timeout (intermittent wifi)", () => {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code: "UND_ERR_CONNECT_TIMEOUT" };
+    expect(formatSyncError(err)).toBe("cloud unreachable (UND_ERR_CONNECT_TIMEOUT)");
+  });
+
+  it("falls through to the err.message + cause.message for non-network errors", () => {
+    const err = new Error("worker barfed");
+    (err as { cause?: unknown }).cause = { code: "SOMETHING_ELSE", message: "details" };
+    expect(formatSyncError(err)).toBe("worker barfed: details");
+  });
+
+  it("falls through to err.message when no cause", () => {
+    expect(formatSyncError(new Error("plain"))).toBe("plain");
+  });
+
+  it("handles non-Error throwables", () => {
+    expect(formatSyncError("just a string")).toBe("just a string");
+    expect(formatSyncError(null)).toBe("unknown error");
+  });
+
+  it("respects top-level code (no cause)", () => {
+    const err = new Error("connect timeout");
+    (err as { code?: unknown }).code = "UND_ERR_CONNECT_TIMEOUT";
+    expect(formatSyncError(err)).toBe("cloud unreachable (UND_ERR_CONNECT_TIMEOUT)");
+  });
+});
+
+describe("isOfflineLikeError", () => {
+  it("true for ENOTFOUND nested in cause", () => {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code: "ENOTFOUND" };
+    expect(isOfflineLikeError(err)).toBe(true);
+  });
+  it("false for other error codes", () => {
+    const err = new Error("oops");
+    (err as { code?: unknown }).code = "SOMETHING_ELSE";
+    expect(isOfflineLikeError(err)).toBe(false);
+  });
+  it("false on bare Error with no code", () => {
+    expect(isOfflineLikeError(new Error("nope"))).toBe(false);
+  });
+});
+
+describe("createOfflineLogger", () => {
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  function offlineErr(code = "ENOTFOUND"): unknown {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code };
+    return err;
+  }
+
+  it("logs once on first failure, suppresses identical follow-ups", () => {
+    const log = createOfflineLogger("[test]", { heartbeatEvery: 30 });
+    log.failure(offlineErr());
+    log.failure(offlineErr());
+    log.failure(offlineErr());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain("cloud unreachable (ENOTFOUND)");
+    expect(warnSpy.mock.calls[0]![0]).toContain("further offline retries suppressed");
+  });
+
+  it("logs a heartbeat every Nth failure", () => {
+    const log = createOfflineLogger("[test]", { heartbeatEvery: 5 });
+    for (let i = 0; i < 12; i++) log.failure(offlineErr());
+    // Calls: #1 (first), #5 (heartbeat), #10 (heartbeat) = 3 total.
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    expect(warnSpy.mock.calls[1]![0]).toContain("still offline (5 attempts)");
+    expect(warnSpy.mock.calls[2]![0]).toContain("still offline (10 attempts)");
+  });
+
+  it("logs 'back online' on first success after failures, then no-ops", () => {
+    const log = createOfflineLogger("[test]", { heartbeatEvery: 30 });
+    log.failure(offlineErr());
+    log.failure(offlineErr());
+    warnSpy.mockClear();
+    log.success();
+    log.success(); // second success: no extra log
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain("back online (after 2 failed attempts)");
+  });
+
+  it("singular 'attempt' wording when streak is exactly 1", () => {
+    const log = createOfflineLogger("[test]");
+    log.failure(offlineErr());
+    warnSpy.mockClear();
+    log.success();
+    expect(warnSpy.mock.calls[0]![0]).toContain("back online (after 1 failed attempt)");
+  });
+
+  it("non-offline errors are logged in full and don't perturb the counter", () => {
+    const log = createOfflineLogger("[test]", { heartbeatEvery: 5 });
+    log.failure(offlineErr());      // streak=1, logged
+    log.failure(new Error("real bug")); // not offline → logged in full
+    log.failure(offlineErr());      // streak=2, suppressed
+    log.failure(offlineErr());      // streak=3, suppressed
+    log.failure(offlineErr());      // streak=4, suppressed
+    log.failure(offlineErr());      // streak=5, heartbeat
+    // first offline + non-offline + heartbeat = 3 lines
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    expect(warnSpy.mock.calls[0]![0]).toContain("cloud unreachable");
+    expect(warnSpy.mock.calls[1]![0]).toBe("[test] failed:");
+    expect(warnSpy.mock.calls[2]![0]).toContain("still offline (5 attempts)");
+  });
+});

--- a/server/test/sync-log.test.ts
+++ b/server/test/sync-log.test.ts
@@ -1,12 +1,23 @@
 // Unit tests for the offline-log helpers. The user dogfooding behaviour:
 // "[memory] pull failed: TypeError: fetch failed ... ENOTFOUND cloud.oyster.to"
 // repeated every ~30s for hours after wifi disconnected.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
   createOfflineLogger,
   formatSyncError,
   isOfflineLikeError,
 } from "../src/sync-log.js";
+
+describe("formatSyncError edge cases", () => {
+  it("treats only null/undefined as 'unknown error'; falsy primitives stringify normally", () => {
+    expect(formatSyncError(null)).toBe("unknown error");
+    expect(formatSyncError(undefined)).toBe("unknown error");
+    // throw 0 / throw false / throw "" are unusual but legal — preserve them.
+    expect(formatSyncError(0)).toBe("0");
+    expect(formatSyncError(false)).toBe("false");
+    expect(formatSyncError("")).toBe("");
+  });
+});
 
 describe("formatSyncError", () => {
   it("recognises ENOTFOUND (wifi off → DNS failure)", () => {
@@ -63,6 +74,11 @@ describe("createOfflineLogger", () => {
   const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   afterEach(() => {
     warnSpy.mockClear();
+  });
+  // Restore so a global spy doesn't leak into other test files and silently
+  // suppress their logs.
+  afterAll(() => {
+    warnSpy.mockRestore();
   });
 
   function offlineErr(code = "ENOTFOUND"): unknown {
@@ -122,5 +138,39 @@ describe("createOfflineLogger", () => {
     expect(warnSpy.mock.calls[0]![0]).toContain("cloud unreachable");
     expect(warnSpy.mock.calls[1]![0]).toBe("[test] failed:");
     expect(warnSpy.mock.calls[2]![0]).toContain("still offline (5 attempts)");
+  });
+
+  it("context arg disambiguates the first-occurrence line and non-offline errors", () => {
+    const log = createOfflineLogger("[test]");
+    log.failure(offlineErr(), "session=abc12345 chunk=2");
+    log.failure(new Error("real bug"), "session=abc12345 chunk=3");
+    // First occurrence includes context.
+    expect(warnSpy.mock.calls[0]![0]).toContain("session=abc12345 chunk=2");
+    expect(warnSpy.mock.calls[0]![0]).toContain("cloud unreachable");
+    // Non-offline error log also includes context.
+    expect(warnSpy.mock.calls[1]![0]).toContain("session=abc12345 chunk=3");
+    expect(warnSpy.mock.calls[1]![0]).toContain("failed:");
+  });
+
+  it("context is omitted from the heartbeat line (would be misleading across multiple resources)", () => {
+    const log = createOfflineLogger("[test]", { heartbeatEvery: 3 });
+    log.failure(offlineErr(), "session=aaa");
+    log.failure(offlineErr(), "session=bbb");
+    log.failure(offlineErr(), "session=ccc"); // heartbeat
+    expect(warnSpy.mock.calls[1]![0]).toContain("still offline (3 attempts)");
+    expect(warnSpy.mock.calls[1]![0]).not.toContain("session=");
+  });
+
+  it("invalid heartbeatEvery values (0, negative, NaN, Infinity) fall back to the default", () => {
+    // Without the clamp, modulo 0 is NaN (never true) → heartbeats silenced
+    // forever. Each of these should still produce a heartbeat at default 30.
+    for (const bad of [0, -5, NaN, Infinity]) {
+      warnSpy.mockClear();
+      const log = createOfflineLogger("[test]", { heartbeatEvery: bad });
+      for (let i = 0; i < 30; i++) log.failure(offlineErr());
+      // 1 first-failure log + 1 heartbeat at 30 = 2 calls
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy.mock.calls[1]![0]).toContain("still offline (30 attempts)");
+    }
   });
 });


### PR DESCRIPTION
## The noise

Came back to a laptop after wifi was off overnight and found ~30 lines × N retries of:

\`\`\`
[memory] pull failed: TypeError: fetch failed
    at node:internal/deps/undici/undici:13510:13
    ...
    [cause]: Error: getaddrinfo ENOTFOUND cloud.oyster.to
\`\`\`

Behaviour was correct (caught, no crash, retry every ~30 s) but the terminal was overwhelmed.

## The fix

New \`server/src/sync-log.ts\`:

- **\`formatSyncError(err)\`** — recognises ENOTFOUND, EAI_AGAIN, ECONNREFUSED, ECONNRESET, ENETUNREACH, ETIMEDOUT, UND_ERR_CONNECT_TIMEOUT, UND_ERR_SOCKET and returns \`cloud unreachable (CODE)\`. Non-network errors fall through to the original message.
- **\`createOfflineLogger(prefix)\`** — dedupe wrapper:
  - First failure → one concise line + "further offline retries suppressed"
  - Subsequent identical failures → silent
  - Heartbeat every 30 (default) → \`still offline (N attempts)\`
  - First success after streak → \`back online (after N failed attempts)\`
  - Non-network errors → always logged in full, counter untouched (preserves debug)

Wired into \`memory-sync-service\` (push + pull) and \`session-sync-service\` (push + pull + pushBytes). One logger per call-site.

## Before / after

**Before** (30+ minutes offline = N × 30 lines):
\`\`\`
[memory] pull failed: TypeError: fetch failed at node:internal/deps/undici/...
    ... 28 more lines ...
[sessions] pull failed: TypeError: fetch failed at node:internal/deps/undici/...
    ... 28 more lines ...
[memory] pull failed: TypeError: fetch failed at node:internal/deps/undici/...
    ...
\`\`\`

**After** (same period):
\`\`\`
[memory] pull cloud unreachable (ENOTFOUND) (further offline retries suppressed)
[sessions] pull cloud unreachable (ENOTFOUND) (further offline retries suppressed)
[memory] pull still offline (30 attempts) — cloud unreachable (ENOTFOUND)
[sessions] pull still offline (30 attempts) — cloud unreachable (ENOTFOUND)
... eventually ...
[memory] pull back online (after 47 failed attempts)
[sessions] pull back online (after 47 failed attempts)
\`\`\`

## Test plan

- [x] 14 new unit tests for \`formatSyncError\` / \`isOfflineLikeError\` / \`createOfflineLogger\` covering classification, dedupe, heartbeat cadence, recovery, singular/plural wording, and the "non-offline error preserves the counter" edge case
- [x] 260 server tests pass (was 246, +14)
- [x] tsc + \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)