### PR TITLE
chore(sync): suppress single-row push success logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **No more `accepted=1` log noise during a live conversation.** Single-row metadata pushes — which are the steady-state shape during normal conversation pacing — are now silent. Multi-row pushes (boot drains, bursty tool-call sequences) and any pushes with conflicts or rejected events still log so you can see real activity.
 - **Quieter terminal logs when offline.** When wifi goes out, sync used to log a 30-line stack trace every ~30 seconds for each background pull (memory + sessions). Now the first failure prints a single line — `cloud unreachable (ENOTFOUND)` — subsequent identical failures are suppressed, and a heartbeat appears roughly every 15 minutes if you're still offline. When wifi comes back, a single `back online` line confirms it. Real bugs (non-network errors) still surface their full trace.
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -328,6 +328,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/mattslight/oyster/compare/v0.8.1-beta.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Changed</h3>
 <ul>
+<li><strong>No more <code>accepted=1</code> log noise during a live conversation.</strong> Single-row metadata pushes — which are the steady-state shape during normal conversation pacing — are now silent. Multi-row pushes (boot drains, bursty tool-call sequences) and any pushes with conflicts or rejected events still log so you can see real activity.</li>
 <li><strong>Quieter terminal logs when offline.</strong> When wifi goes out, sync used to log a 30-line stack trace every ~30 seconds for each background pull (memory + sessions). Now the first failure prints a single line — <code>cloud unreachable (ENOTFOUND)</code> — subsequent identical failures are suppressed, and a heartbeat appears roughly every 15 minutes if you&#39;re still offline. When wifi comes back, a single <code>back online</code> line confirms it. Real bugs (non-network errors) still surface their full trace.</li>
 </ul>
 <h3>Added</h3>

--- a/server/src/memory-sync-service.ts
+++ b/server/src/memory-sync-service.ts
@@ -206,10 +206,13 @@ export function createMemorySyncService(deps: MemorySyncDeps): MemorySyncService
         markTxn();
         totalAccepted += accepted.length;
 
-        // Success log: only when something actually moved through this batch.
-        // Quiet in steady-state, visible when activity happens.
+        // Success log: only when more than one row moved (boot drains,
+        // bursts) — single-row pushes are routine background noise during
+        // a live session. Always log when there are conflicts/rejects
+        // since those need attention regardless of count.
         const moved = accepted.length + duplicates.length;
-        if (moved > 0) {
+        const noteworthy = conflicts.length > 0 || rejected.length > 0;
+        if (moved > 1 || noteworthy) {
           console.log(`[memory] pushed: accepted=${accepted.length} duplicates=${duplicates.length}${conflicts.length ? ` conflicts=${conflicts.length}` : ""}${rejected.length ? ` rejected=${rejected.length}` : ""}`);
         }
 

--- a/server/src/session-sync-service.ts
+++ b/server/src/session-sync-service.ts
@@ -286,7 +286,13 @@ export function createSessionSyncService(deps: SessionSyncDeps): SessionSyncServ
       tx();
       totalAccepted += accepted.length;
 
-      if (accepted.length > 0) {
+      // Log only multi-row pushes. Single-row pushes are the steady-state
+      // shape during a live conversation (one event lands, debounce fires
+      // ~1 s later with the dirty row, push succeeds) — a useful sign data
+      // is flowing during dev, but routine background noise in production.
+      // Boot drains and bursty tool-call sequences still log under
+      // BATCH_SIZE batching.
+      if (accepted.length > 1) {
         console.log(`[sessions] pushed: accepted=${accepted.length}`);
       }
       // If nothing was accepted, breaking avoids hot-looping on a server


### PR DESCRIPTION
## Summary

After beta.12, post-boot still had `[sessions] pushed: accepted=1` lines streaming during normal use. beta.11's debounce only coalesces events arriving within ~1 s of each other; Claude Code's natural pacing (1–10 s gaps between events) means each event typically lands on its own push.

Single-row pushes are routine background noise. Suppress the log for \`accepted ≤ 1\`. Multi-row pushes still log (boot drains, bursts). Memory push also still logs on conflicts/rejected regardless of count.

## Test plan

- [x] 264 server tests pass
- [x] tsc + build clean
- [ ] Manual after merge: live session no longer prints `accepted=1` stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)