### PR TITLE
Layer 2 rewrite: 'sits on top of your agents'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **Mission control for the AI era.**
 
-Oyster keeps your AI work with you. It captures what your AI wrote and made, syncs it across your devices, and lets you publish any of it as a link. It does not run your AI. It does not tie you to one — bring whichever agent you use (Claude Code today; Cursor / Codex / OpenCode as they connect over MCP).
+Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time (Claude Code today; Cursor / Codex / OpenCode as their watchers ship over MCP).
 
 Users install with `npm install -g oyster-os`, run `oyster`, and get a visual surface at `http://localhost:4444` where their agent's sessions, files, memories, and artefacts live.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **Mission control for the AI era.**
 
-Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time (Claude Code today; Cursor / Codex / OpenCode as their watchers ship over MCP).
+Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time (Claude Code today; Cursor / Codex / OpenCode watchers next — issue #298).
 
 Users install with `npm install -g oyster-os`, run `oyster`, and get a visual surface at `http://localhost:4444` where their agent's sessions, files, memories, and artefacts live.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # 🦪 Mission control for the AI era.
 
-Oyster keeps your AI work with you. Sync it, remember it, publish it, and bring whichever agent you use. It does not run your AI. It does not tie you to one.
+Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.
 
 ```bash
 # 1. Install

--- a/docs/index.html
+++ b/docs/index.html
@@ -459,7 +459,7 @@
   <div class="hero">
     <h1>Mission control for the AI era.</h1>
     <p class="subtitle">
-      Oyster keeps your AI work with you. Sync it, remember it, publish it, and bring whichever agent you use. It does not run your AI. It does not tie you to one.
+      Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.
     </p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -152,12 +152,12 @@ function buildContext(userlandDir: string): string {
   return `
 # Oyster
 
-Oyster is the workspace your AI agent works in. It captures what your AI wrote
-and made, syncs it across the user's devices, and lets them publish any of it
-as a link. **It does not run the user's AI. It does not tie them to one.**
-The user brings whichever agent they use — Claude Code, Cursor, Codex,
-OpenCode, or any other MCP-aware agent (including you, whichever agent you are).
-Oyster watches the work and keeps it.
+Oyster sits on top of the user's agents and keeps track of their AI work
+wherever they are. Sync, memory and publish all baked in. The user brings
+whichever agents they prefer — Claude Code, Cursor, Codex, OpenCode, or any
+other MCP-aware agent (including you, whichever agent you are) — and swaps
+out at any time. **Oyster does not run the user's AI; it keeps the work
+their agents make.**
 
 It is NOT a chat interface or a file browser — it is a workspace surface where
 artifacts (interactive documents, apps, diagrams, etc.) live alongside the

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -153,11 +153,12 @@ function buildContext(userlandDir: string): string {
 # Oyster
 
 Oyster sits on top of the user's agents and keeps track of their AI work
-wherever they are. Sync, memory and publish all baked in. The user brings
-whichever agents they prefer — Claude Code, Cursor, Codex, OpenCode, or any
-other MCP-aware agent (including you, whichever agent you are) — and swaps
-out at any time. **Oyster does not run the user's AI; it keeps the work
-their agents make.**
+wherever they are. It syncs that work across the user's devices, remembers
+it across sessions, and lets them publish any of it as a link — all three
+baked in. The user brings whichever agents they prefer — Claude Code,
+Cursor, Codex, OpenCode, or any other MCP-aware agent (including you,
+whichever agent you are) — and swaps out at any time. **Oyster does not
+run the user's AI; it keeps the work their agents make.**
 
 It is NOT a chat interface or a file browser — it is a workspace surface where
 artifacts (interactive documents, apps, diagrams, etc.) live alongside the


### PR DESCRIPTION
## Summary

Sharper Layer 2 (descriptive paragraph) wording, replacing the version that landed in #463. New text:

> **Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.**

## Why

Three concrete improvements over what #463 shipped:

1. **"sits on top of your agents"** is sharper than the abstract *"keeps your AI work with you."* It makes the umbrella position concrete — Oyster is *above* the agents.
2. **"Sync, memory and publish all baked in"** mirrors the pricing-page triad verbatim. Hero, sub-deck and pricing now all use the same three nouns. Zero copy debt across surfaces.
3. **"swap out at any time"** lands the agent-freedom claim with active-verb energy, replacing the previous passive *"does not tie you to one."*

## What changed about the negations

The previous Layer 2 ended with two explicit negations: *"It does not run your AI. It does not tie you to one."* The new wording drops both from customer-facing copy:

- *"sits on top of your agents"* + *"keeps track of your AI work"* implicitly disambiguates against the chat-app reading (which is what the *"does not run your AI"* line was there to kill). With Layer 1 (*"Mission control for the AI era"*) already category-claiming Oyster as a *layer*, the chat-app risk is lower.
- *"swap out at any time"* covers the agent-freedom claim that *"does not tie you to one"* used to carry — more confident, less defensive.

The negation **is preserved** (slightly tightened) in `server/src/mcp-server.ts`'s MCP context string, where the explicit framing still helps connecting agents (Claude Code / Cursor) understand their role.

## Surfaces touched

- `README.md` sub-deck paragraph
- `docs/index.html` hero subtitle (line ~462)
- `CLAUDE.md` opening paragraph
- `server/src/mcp-server.ts` MCP context (third-person variant for agent-facing instructions)

4 files, +9/-9 lines. No code paths changed.

## Test plan

- [ ] README renders correctly on this PR page
- [ ] `open docs/index.html` — hero subtitle reads consistently with the h1
- [ ] Ask a connected agent *"what is Oyster?"* — answer reflects Layer 2's *"sits on top of"* framing
- [ ] Diff vs #463 is exactly the four edits described above; no other changes

## Out of scope

- The Layer 1 hero (*"Mission control for the AI era."*) — unchanged
- The Layer 3 one-liner (`package.json` description, GitHub About blurb) — unchanged
- The pricing-page Pro-tier strap (orphaned from new hero) — tracked separately as #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)