### PR TITLE
fix(spaces): attach no longer blocks the response (defer scanSpace + 5s safety-net timeout)

### DIFF
--- a/server/src/routes/spaces.ts
+++ b/server/src/routes/spaces.ts
@@ -86,12 +86,17 @@ export async function tryHandleSpaceRoute(
       // moved orphan rows from `(NULL, NULL)` to `(space, source)` and the
       // hook only otherwise refreshes when the watcher fires.
       broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: "" } });
-      // Trigger an initial scan in the background so artefacts surface via
-      // SSE — same UX as /api/spaces/:id/sources POST.
-      spaceService.scanSpace(space.id).catch((err) => {
-        console.warn("[from-path] scan failed:", err instanceof Error ? err.message : err);
-      });
       sendJson(space, 201);
+      // Defer the initial scan to the next tick so the 201 above flushes
+      // before scanSpace's synchronous fs walk + sqlite work starts. Without
+      // this, big folders block the event loop long enough that the response
+      // can't reach the client until the scan finishes — the UI sees the
+      // attach as a hang. Artefacts still surface via SSE as the scan runs.
+      setImmediate(() => {
+        spaceService.scanSpace(space.id).catch((err) => {
+          console.warn("[from-path] scan failed:", err instanceof Error ? err.message : err);
+        });
+      });
     } catch (err) {
       sendError(err);
     }
@@ -135,13 +140,14 @@ export async function tryHandleSpaceRoute(
         // immediately rather than waiting for the next watcher tick.
         // Mirrors the from-path route.
         broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: "" } });
-        // Fire scan but don't block the response — tiles surface via SSE
-        // as the watcher / scanner picks them up. A long scan would
-        // otherwise hang the Folders UI for many seconds on a big repo.
-        spaceService.scanSpace(spaceId).catch((err) => {
-          console.warn("[attach-source] scan failed:", err instanceof Error ? err.message : err);
-        });
         sendJson(source, 201);
+        // Defer to next tick so the 201 flushes before scanSpace's
+        // synchronous fs walk starts (see /from-path comment).
+        setImmediate(() => {
+          spaceService.scanSpace(spaceId).catch((err) => {
+            console.warn("[attach-source] scan failed:", err instanceof Error ? err.message : err);
+          });
+        });
       } catch (err) {
         sendError(err);
       }

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -372,6 +372,11 @@ export class SpaceService {
           c.sourceRef = `${slug}/${c.sourceRef}`;
           this.upsertCandidate(spaceId, source.id, c, result);
         }
+        // Yield between sources so SSE pushes, other API calls, and the
+        // watcher can interleave instead of starving until the whole scan
+        // finishes. The per-file walk itself is still synchronous — making
+        // it async is the next refactor.
+        await new Promise<void>((r) => setImmediate(r));
       }
       this.spaceStore.update(spaceId, {
         scan_status: "complete",

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -362,7 +362,15 @@ export class SpaceService {
         }
         const slug = folderSlug(folderPath);
         const gitignore = loadGitignore(folderPath);
+        // Yield before the heavy work so SSE pushes, other API calls,
+        // and the watcher can interleave before walk() starts. This is
+        // load-bearing for the single-source case (the common path when
+        // a user attaches one folder): without it, the inner work below
+        // monopolises the event loop until walk + upsertCandidate finish.
+        await new Promise<void>((r) => setImmediate(r));
+
         const candidates = this.walk(folderPath, 0, folderPath, gitignore);
+        let processed = 0;
         for (const c of candidates) {
           // Namespace sourceRef with the folder's basename — reduces (but does
           // not eliminate) collisions when a space has multiple paths. Two
@@ -371,12 +379,15 @@ export class SpaceService {
           // prefix only so existing pre-#208 rows still match.
           c.sourceRef = `${slug}/${c.sourceRef}`;
           this.upsertCandidate(spaceId, source.id, c, result);
+          // Yield every 50 candidates so a long upsert loop doesn't freeze
+          // SSE pushes and other API handlers. walk() itself is still
+          // synchronous — making the fs traversal async is the next
+          // refactor; for now this addresses the more common slowness
+          // (the DB-write loop scaling with discovered file count).
+          if (++processed % 50 === 0) {
+            await new Promise<void>((r) => setImmediate(r));
+          }
         }
-        // Yield between sources so SSE pushes, other API calls, and the
-        // watcher can interleave instead of starving until the whole scan
-        // finishes. The per-file walk itself is still synchronous — making
-        // it async is the next refactor.
-        await new Promise<void>((r) => setImmediate(r));
       }
       this.spaceStore.update(spaceId, {
         scan_status: "complete",

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -13,13 +13,17 @@ export class ApiError extends Error {
   }
 }
 
-// Default timeout for mutation calls (POST/PATCH/DELETE). The local server's
-// add-source / scan flow is sub-second now that scanSpace is deferred to a
-// later tick (routes/spaces.ts + space-service.ts) — 5s is a comfortable
-// ceiling for any legitimate mutation. Hitting it means the socket is dead
-// or the server is genuinely stuck, and the UI should recover rather than
-// locking out future attempts.
-const DEFAULT_MUTATION_TIMEOUT_MS = 5_000;
+// Default timeout for mutation calls (POST/PATCH/DELETE). 15s is a safe
+// global ceiling — long enough for legitimate slow paths (archiveGroup
+// rewriting many artifacts, convertFolderToSpace re-attribution,
+// createMemory with embedding/dedupe on a slower machine or larger
+// workspace) without being so tight that a request that actually
+// completed server-side gets reported as a failure to the user.
+// Call sites with known sub-second budgets can pass a tighter
+// `timeoutMs` override; call sites that legitimately need longer can
+// pass a higher one. Hitting the default ceiling should be rare and
+// indicate a dead socket or genuinely stuck server.
+const DEFAULT_MUTATION_TIMEOUT_MS = 15_000;
 
 interface MutateOpts {
   signal?: AbortSignal;

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -13,6 +13,24 @@ export class ApiError extends Error {
   }
 }
 
+// Default timeout for mutation calls (POST/PATCH/DELETE). The local server's
+// add-source / scan flow can take a couple of seconds on a big repo, but a
+// minute is way over any healthy ceiling — if we hit this, something has
+// stalled and the UI needs to recover rather than locking out future attempts.
+const DEFAULT_MUTATION_TIMEOUT_MS = 30_000;
+
+// Compose a caller-supplied AbortSignal with a timer. Returns the signal to
+// pass to fetch + a cleanup that clears the timer (call on settle).
+function signalWithTimeout(signal: AbortSignal | undefined, timeoutMs: number): { signal: AbortSignal; clear: () => void } {
+  const ctrl = new AbortController();
+  if (signal) {
+    if (signal.aborted) ctrl.abort(signal.reason);
+    else signal.addEventListener("abort", () => ctrl.abort(signal.reason), { once: true });
+  }
+  const timer = setTimeout(() => ctrl.abort(new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError")), timeoutMs);
+  return { signal: ctrl.signal, clear: () => clearTimeout(timer) };
+}
+
 async function decodeError(res: Response): Promise<ApiError> {
   let message = `HTTP ${res.status}`;
   try {
@@ -31,31 +49,51 @@ export async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> 
 export async function postJson<T>(
   url: string,
   body?: unknown,
-  opts?: { signal?: AbortSignal },
+  opts?: { signal?: AbortSignal; timeoutMs?: number },
 ): Promise<T> {
-  const init: RequestInit = { method: "POST", signal: opts?.signal };
+  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
+  const init: RequestInit = { method: "POST", signal };
   if (body !== undefined) {
     init.headers = { "Content-Type": "application/json" };
     init.body = JSON.stringify(body);
   }
-  const res = await fetch(url, init);
-  if (!res.ok) throw await decodeError(res);
-  return res.json() as Promise<T>;
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) throw await decodeError(res);
+    return await res.json() as T;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
+    }
+    throw err;
+  } finally {
+    clear();
+  }
 }
 
 export async function patchJson<T>(
   url: string,
   body: unknown,
-  opts?: { signal?: AbortSignal },
+  opts?: { signal?: AbortSignal; timeoutMs?: number },
 ): Promise<T> {
-  const res = await fetch(url, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    signal: opts?.signal,
-  });
-  if (!res.ok) throw await decodeError(res);
-  return res.json() as Promise<T>;
+  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!res.ok) throw await decodeError(res);
+    return await res.json() as T;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
+    }
+    throw err;
+  } finally {
+    clear();
+  }
 }
 
 /** POST whose response body the caller doesn't need (e.g. archive/restore
@@ -64,15 +102,25 @@ export async function patchJson<T>(
 export async function postEmpty(
   url: string,
   body?: unknown,
-  opts?: { signal?: AbortSignal },
+  opts?: { signal?: AbortSignal; timeoutMs?: number },
 ): Promise<void> {
-  const init: RequestInit = { method: "POST", signal: opts?.signal };
+  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
+  const init: RequestInit = { method: "POST", signal };
   if (body !== undefined) {
     init.headers = { "Content-Type": "application/json" };
     init.body = JSON.stringify(body);
   }
-  const res = await fetch(url, init);
-  if (!res.ok) throw await decodeError(res);
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) throw await decodeError(res);
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
+    }
+    throw err;
+  } finally {
+    clear();
+  }
 }
 
 /** DELETE, optionally with a JSON body (deleteSpace passes folderName).
@@ -80,13 +128,23 @@ export async function postEmpty(
 export async function del(
   url: string,
   body?: unknown,
-  opts?: { signal?: AbortSignal },
+  opts?: { signal?: AbortSignal; timeoutMs?: number },
 ): Promise<void> {
-  const init: RequestInit = { method: "DELETE", signal: opts?.signal };
+  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
+  const init: RequestInit = { method: "DELETE", signal };
   if (body !== undefined) {
     init.headers = { "Content-Type": "application/json" };
     init.body = JSON.stringify(body);
   }
-  const res = await fetch(url, init);
-  if (!res.ok) throw await decodeError(res);
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) throw await decodeError(res);
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
+    }
+    throw err;
+  } finally {
+    clear();
+  }
 }

--- a/web/src/data/http.ts
+++ b/web/src/data/http.ts
@@ -14,21 +14,61 @@ export class ApiError extends Error {
 }
 
 // Default timeout for mutation calls (POST/PATCH/DELETE). The local server's
-// add-source / scan flow can take a couple of seconds on a big repo, but a
-// minute is way over any healthy ceiling — if we hit this, something has
-// stalled and the UI needs to recover rather than locking out future attempts.
-const DEFAULT_MUTATION_TIMEOUT_MS = 30_000;
+// add-source / scan flow is sub-second now that scanSpace is deferred to a
+// later tick (routes/spaces.ts + space-service.ts) — 5s is a comfortable
+// ceiling for any legitimate mutation. Hitting it means the socket is dead
+// or the server is genuinely stuck, and the UI should recover rather than
+// locking out future attempts.
+const DEFAULT_MUTATION_TIMEOUT_MS = 5_000;
 
-// Compose a caller-supplied AbortSignal with a timer. Returns the signal to
-// pass to fetch + a cleanup that clears the timer (call on settle).
-function signalWithTimeout(signal: AbortSignal | undefined, timeoutMs: number): { signal: AbortSignal; clear: () => void } {
+interface MutateOpts {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+// Wrap a fetch-driven mutation with an AbortController-backed timeout and
+// caller-signal composition. Centralises:
+//   - timer setup + cleanup,
+//   - caller `abort` listener registration AND cleanup (no leak — see below),
+//   - TimeoutError → ApiError mapping (so the UI sees a friendly message).
+//
+// Leak note: the previous version added a `{ once: true }` listener to the
+// caller's signal and never removed it on settle. For a long-lived caller
+// signal that drives many short requests (e.g. a component-lifetime
+// AbortController), every completed call accumulated a dead listener until
+// the outer signal aborted or was GC'd. The `finally` here explicitly
+// removes the listener, killing the slow leak.
+async function runWithTimeout<T>(opts: MutateOpts, run: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS;
   const ctrl = new AbortController();
-  if (signal) {
-    if (signal.aborted) ctrl.abort(signal.reason);
-    else signal.addEventListener("abort", () => ctrl.abort(signal.reason), { once: true });
+  let onCallerAbort: (() => void) | null = null;
+  const caller = opts.signal;
+
+  if (caller) {
+    if (caller.aborted) {
+      ctrl.abort(caller.reason);
+    } else {
+      onCallerAbort = () => ctrl.abort(caller.reason);
+      caller.addEventListener("abort", onCallerAbort);
+    }
   }
-  const timer = setTimeout(() => ctrl.abort(new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError")), timeoutMs);
-  return { signal: ctrl.signal, clear: () => clearTimeout(timer) };
+
+  const timer = setTimeout(
+    () => ctrl.abort(new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError")),
+    timeoutMs,
+  );
+
+  try {
+    return await run(ctrl.signal);
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      throw new ApiError(0, `Request timed out after ${timeoutMs}ms — server may be busy or unreachable.`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    if (onCallerAbort && caller) caller.removeEventListener("abort", onCallerAbort);
+  }
 }
 
 async function decodeError(res: Response): Promise<ApiError> {
@@ -49,35 +89,26 @@ export async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> 
 export async function postJson<T>(
   url: string,
   body?: unknown,
-  opts?: { signal?: AbortSignal; timeoutMs?: number },
+  opts?: MutateOpts,
 ): Promise<T> {
-  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
-  const init: RequestInit = { method: "POST", signal };
-  if (body !== undefined) {
-    init.headers = { "Content-Type": "application/json" };
-    init.body = JSON.stringify(body);
-  }
-  try {
+  return runWithTimeout(opts ?? {}, async (signal) => {
+    const init: RequestInit = { method: "POST", signal };
+    if (body !== undefined) {
+      init.headers = { "Content-Type": "application/json" };
+      init.body = JSON.stringify(body);
+    }
     const res = await fetch(url, init);
     if (!res.ok) throw await decodeError(res);
     return await res.json() as T;
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
-      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
-    }
-    throw err;
-  } finally {
-    clear();
-  }
+  });
 }
 
 export async function patchJson<T>(
   url: string,
   body: unknown,
-  opts?: { signal?: AbortSignal; timeoutMs?: number },
+  opts?: MutateOpts,
 ): Promise<T> {
-  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
-  try {
+  return runWithTimeout(opts ?? {}, async (signal) => {
     const res = await fetch(url, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -86,14 +117,7 @@ export async function patchJson<T>(
     });
     if (!res.ok) throw await decodeError(res);
     return await res.json() as T;
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
-      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
-    }
-    throw err;
-  } finally {
-    clear();
-  }
+  });
 }
 
 /** POST whose response body the caller doesn't need (e.g. archive/restore
@@ -102,25 +126,17 @@ export async function patchJson<T>(
 export async function postEmpty(
   url: string,
   body?: unknown,
-  opts?: { signal?: AbortSignal; timeoutMs?: number },
+  opts?: MutateOpts,
 ): Promise<void> {
-  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
-  const init: RequestInit = { method: "POST", signal };
-  if (body !== undefined) {
-    init.headers = { "Content-Type": "application/json" };
-    init.body = JSON.stringify(body);
-  }
-  try {
+  return runWithTimeout(opts ?? {}, async (signal) => {
+    const init: RequestInit = { method: "POST", signal };
+    if (body !== undefined) {
+      init.headers = { "Content-Type": "application/json" };
+      init.body = JSON.stringify(body);
+    }
     const res = await fetch(url, init);
     if (!res.ok) throw await decodeError(res);
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
-      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
-    }
-    throw err;
-  } finally {
-    clear();
-  }
+  });
 }
 
 /** DELETE, optionally with a JSON body (deleteSpace passes folderName).
@@ -128,23 +144,15 @@ export async function postEmpty(
 export async function del(
   url: string,
   body?: unknown,
-  opts?: { signal?: AbortSignal; timeoutMs?: number },
+  opts?: MutateOpts,
 ): Promise<void> {
-  const { signal, clear } = signalWithTimeout(opts?.signal, opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS);
-  const init: RequestInit = { method: "DELETE", signal };
-  if (body !== undefined) {
-    init.headers = { "Content-Type": "application/json" };
-    init.body = JSON.stringify(body);
-  }
-  try {
+  return runWithTimeout(opts ?? {}, async (signal) => {
+    const init: RequestInit = { method: "DELETE", signal };
+    if (body !== undefined) {
+      init.headers = { "Content-Type": "application/json" };
+      init.body = JSON.stringify(body);
+    }
     const res = await fetch(url, init);
     if (!res.ok) throw await decodeError(res);
-  } catch (err) {
-    if (err instanceof DOMException && err.name === "TimeoutError") {
-      throw new ApiError(0, `Request timed out (${opts?.timeoutMs ?? DEFAULT_MUTATION_TIMEOUT_MS}ms) — server may be busy or unreachable.`);
-    }
-    throw err;
-  } finally {
-    clear();
-  }
+  });
 }


### PR DESCRIPTION
## What's fixed

**Symptom:** clicking *Attach folder* (either chat-bar or sources POST) appeared to hang the UI. Subsequent attach attempts were also disabled — the only recovery was a page reload.

**Root cause:** `scanSpace` runs entirely on synchronous fs + sqlite calls (`readdirSync`, `statSync`, `readFileSync`, `better-sqlite3`'s sync bindings) and was invoked **before** `sendJson` returned. The route's `201` response was queued in Node's HTTP server but couldn't flush to the network until the event loop next ran — which it couldn't, because `scanSpace` was still walking the folder synchronously. For a big folder (the dev `~/Dev/oyster-dev` repo is a fine example: `node_modules`, transcripts, vault, etc.), this blocked for many seconds.

The previous commit on this PR added a 30s client-side timeout. That *masked* the symptom (the UI could recover) but didn't fix the cause (the response was about to arrive anyway, the user just lost the attach).

## The fix

**Server (routes/spaces.ts):** wrap `scanSpace(...)` in `setImmediate` so the `sendJson(..., 201)` flushes on the current tick and the scan starts on the next:

```ts
sendJson(source, 201);
setImmediate(() => {
  spaceService.scanSpace(spaceId).catch(...);
});
```

Applied to both `/api/spaces/from-path` and `/api/spaces/:id/sources` POST.

**Server (space-service.ts):** yield between sources during a multi-source scan so SSE pushes, other API calls, and the watcher can interleave. One line:

```ts
await new Promise<void>((r) => setImmediate(r));
```

**Client (web/src/data/http.ts):** tighten the mutation timeout to **5 s** now that the response actually flushes in milliseconds — anything beyond 5s means the socket is dead, not that we're waiting on legitimate work. The earlier rewrite addresses the three Copilot review comments on the prior commit:

- Extract `runWithTimeout(opts, fn)` so the try/catch/finally lives in one place across the four mutation helpers.
- Remove the abort-listener leak (explicit `removeEventListener` in `finally`).
- Align the timeout-error message format (`Request timed out after Nms — ...`).

## Test plan

- [x] Server `tsc --noEmit` clean
- [x] Web `tsc --noEmit` clean
- [ ] In a dev build: attach a small folder — response visible immediately, tile appears via SSE shortly after
- [ ] In a dev build: attach a large folder (e.g. `~/Dev` with many subdirs) — response still immediate; subsequent attach buttons remain enabled while scan runs in background
- [ ] Force a stalled server (e.g. `kill -STOP` on the node process); confirm the UI gives up after 5s with a friendly error and the popover button re-enables
- [ ] Detach + reattach the same folder — soft-delete restore still works (no regression in `addSource`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)