### PR TITLE
positioning: Layer 1 → "Mission control for your agents."; Layer 2 rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 ## What Oyster Is
 
-**Mission control for the AI era.**
+**Mission control for your agents.**
 
-Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time (Claude Code today; Cursor / Codex / OpenCode watchers next — issue #298).
+Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime.
 
 Users install with `npm install -g oyster-os`, run `oyster`, and get a visual surface at `http://localhost:4444` where their agent's sessions, files, memories, and artefacts live.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="docs/hero-banner.png" alt="Oyster — Mission control for the AI era." /></p>
+<p align="center"><img src="docs/hero-banner.png" alt="Oyster — Mission control for your agents." /></p>
 
 [![Release](https://img.shields.io/github/v/release/mattslight/oyster?color=7c6bff)](https://github.com/mattslight/oyster/releases)
 [![npm](https://img.shields.io/npm/v/oyster-os?color=7c6bff)](https://www.npmjs.com/package/oyster-os)
@@ -8,9 +8,9 @@
 
 ---
 
-# 🦪 Mission control for the AI era.
+# 🦪 Mission control for your agents.
 
-Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.
+Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime.
 
 ```bash
 # 1. Install

--- a/bin/_banner.mjs
+++ b/bin/_banner.mjs
@@ -89,7 +89,7 @@ function twoToneAscii(line, fill, shadow, reset) {
 // to the top line so a new user always sees what to give their AI.
 export function getTips() {
   return [
-    `Mission control for the AI era.`,
+    `Mission control for your agents.`,
     `Bring whichever agent you use — Oyster doesn't run it, doesn't tie you to one.`,
     `Ask "what did we decide about pricing?" — Oyster finds it across every session.`,
     `Right-click any artefact → publish a public oyster.to/p/ link.`,

--- a/bin/oyster.mjs
+++ b/bin/oyster.mjs
@@ -66,7 +66,7 @@ if (cmd && !cmd.startsWith("-")) {
 
 function printHelp() {
   console.log(`
-  🦪 Oyster — Mission control for the AI era.
+  🦪 Oyster — Mission control for your agents.
 
   Usage:
     oyster                            Start the server (default)
@@ -378,7 +378,7 @@ async function main() {
   // Check auth — if none, run login inline
   if (!hasEnvKey && !hasAuth()) {
     console.log("\n  🦪 Welcome to Oyster");
-    console.log("  Mission control for the AI era.\n");
+    console.log("  Mission control for your agents.\n");
     console.log("  First, let's connect an AI provider.\n");
 
     const ok = await runLogin(opencodeBin);

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,26 +3,26 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Oyster — Mission control for the AI era.</title>
+  <title>Oyster — Mission control for your agents.</title>
   <meta name="description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Oyster">
-  <meta property="og:title" content="Oyster — Mission control for the AI era.">
+  <meta property="og:title" content="Oyster — Mission control for your agents.">
   <meta property="og:description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
   <meta property="og:url" content="https://oyster.to/">
   <meta property="og:image" content="https://oyster.to/social-preview.jpg">
   <meta property="og:image:width" content="1280">
   <meta property="og:image:height" content="640">
-  <meta property="og:image:alt" content="Oyster — Mission control for the AI era.">
+  <meta property="og:image:alt" content="Oyster — Mission control for your agents.">
 
   <!-- Twitter / X card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Oyster — Mission control for the AI era.">
+  <meta name="twitter:title" content="Oyster — Mission control for your agents.">
   <meta name="twitter:description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
   <meta name="twitter:image" content="https://oyster.to/social-preview.jpg">
-  <meta name="twitter:image:alt" content="Oyster — Mission control for the AI era.">
+  <meta name="twitter:image:alt" content="Oyster — Mission control for your agents.">
 
   <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/hero-mock.css">
@@ -457,9 +457,9 @@
 
   <!-- Hero -->
   <div class="hero">
-    <h1>Mission control for the AI era.</h1>
+    <h1>Mission control for your agents.</h1>
     <p class="subtitle">
-      Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.
+      Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime.
     </p>
     <div class="cta-row">
       <a href="#install" class="cta cta-primary">Get started</a>

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -5,7 +5,7 @@
 > **Anchor docs:**
 > - [`docs/requirements/oyster-cloud.md`](../requirements/oyster-cloud.md) — pinned user outcomes (R1–R7).
 > - [`docs/research/yellow-pen-audit.md`](../research/yellow-pen-audit.md) — code-grounded audit of Sprint-2 vestiges still shipping (12 pens, internal + external). Informs Sprint 6 / 0.10.0.
-> - [`docs/research/category-map-2026-05.html`](../research/category-map-2026-05.html) — ~20-product landscape analysis; positions Oyster honestly in the workspace-for-agents category. Informs the *"Mission control for the AI era"* framing.
+> - [`docs/research/category-map-2026-05.html`](../research/category-map-2026-05.html) — ~20-product landscape analysis; positions Oyster honestly in the workspace-for-agents category. Informs the *"Mission control for your agents"* framing.
 > - [`docs/plans/archived/0.5.0-gap-matrix.md`](./archived/0.5.0-gap-matrix.md) — historical snapshot of where 0.5.0 stood against R1–R7 (0.7.0 + 0.8.0 have since shipped).
 
 ## Positioning
@@ -14,13 +14,13 @@ The three layers of customer-facing copy. **All three are canonical** — these 
 
 ### Layer 1 — Hero line (10 words)
 
-> **Mission control for the AI era.**
+> **Mission control for your agents.**
 
 Goes wherever there is **one short prominent piece of copy**: README hero, `oyster.to` `<h1>` and `<title>`, CLI welcome banner, social-preview card hero text, GitHub repo "About" panel.
 
 ### Layer 2 — Descriptive paragraph (3 short sentences)
 
-> **Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.**
+> **Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime.**
 
 Goes in **sub-decks and longer descriptions**: README sub-deck under the hero, `oyster.to` hero subtitle, `CLAUDE.md` opening paragraph, `server/src/mcp-server.ts` MCP context (third-person variant), install-screen / first-run wizard.
 
@@ -36,13 +36,14 @@ Goes wherever a **single descriptive sentence with no commas-of-list** is needed
 
 ### Internal shorthand (do not put in customer-facing copy)
 
-The positioning emerged from a **cassette-deck analogy** — Oyster is the deck; the agents are the cassettes. Any deck, any cassette, swap freely. The cross-agent freedom is the unique value: every direct competitor today fills in *one slice below* Oyster (memory only, or session-management only, or generative UI only). The umbrella position is empty. *Mission control for the AI era* claims it. The analogy is shorthand for strategic conversations; public copy stays direct.
+The positioning emerged from a **cassette-deck analogy** — Oyster is the deck; the agents are the cassettes. Any deck, any cassette, swap freely. The cross-agent freedom is the unique value: every direct competitor today fills in *one slice below* Oyster (memory only, or session-management only, or generative UI only). The umbrella position is empty. *Mission control for your agents* claims it. The analogy is shorthand for strategic conversations; public copy stays direct.
 
 ### Decision history
 
 - 2026-05-14 — Layer 1 settled on *"Mission control for the AI era."* (PR #463 → #469).
 - 2026-05-14 — Layer 2 v1 *"Oyster keeps your AI work with you…"* superseded by v2 *"Oyster sits on top of your agents…"* (PR #469). v2 trades the explicit *"does not run your AI"* negation for the implicit *"sits on top of"* framing; the explicit negation is preserved in the MCP context where agent clients still benefit from it.
 - 2026-05-14 — Pre-rebrand "Oyster OS" naming dropped from public copy. Repo migrated to `github.com/oyster-to/oyster`. NPM rename to `@oyster-to/oyster` tracked in #464 for 1.0.0.
+- 2026-05-14 (revision) — Layer 1 retightened to *"Mission control for your agents."* — drops industry-era framing in favour of the agents the user actually has on their machine. Layer 2 rewritten to *"Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime."* — flips the spine from *what Oyster IS to your agents* to *what Oyster DOES for you*, and explicitly names organised + synced + share + memory + publishing (previously *"all three baked in"*). MCP context retains the explicit *"does not run your AI"* negation.
 
 ## The spine
 
@@ -131,7 +132,7 @@ Each milestone from here delivers one or more requirements. Polish, refactors, a
 
 **Why it's on the roadmap:** doesn't deliver an R directly, but covered by the decision principle's *"reduce the cost of serving one"* clause. Cutting the chat bar + bundled OpenCode makes **R4** (memory crossing agents) structurally honest — the surface no longer contradicts *"bring whichever agent."* Collapsing artefact kinds reduces **R7**'s sync surface area. Dropping the icon generator + zombie-horde removes ongoing cost (fal.ai bills, boot-time `~/Oyster/apps/` syncs) that serves no R.
 
-**Purpose:** make the *"Mission control for the AI era"* pitch honest at first install. The bundled OpenCode + in-app chat bar contradicts *"Bring whichever agents you prefer"*. Several other Sprint-2 surfaces (Ultra Hardcore PTY, AI-fixes-crashed-artefact, fal.ai icon generator, `local_process` runtime, `builtins/zombie-horde/`) describe an alternate "AI app workshop" product that no longer fits the framing.
+**Purpose:** make the *"Mission control for your agents"* pitch honest at first install. The bundled OpenCode + in-app chat bar contradicts *"Use whichever agents you prefer"*. Several other Sprint-2 surfaces (Ultra Hardcore PTY, AI-fixes-crashed-artefact, fal.ai icon generator, `local_process` runtime, `builtins/zombie-horde/`) describe an alternate "AI app workshop" product that no longer fits the framing.
 
 **Ships:**
 

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -18,7 +18,7 @@ The three layers of customer-facing copy. **All three are canonical** — these 
 
 Goes wherever there is **one short prominent piece of copy**: README hero, `oyster.to` `<h1>` and `<title>`, CLI welcome banner, social-preview card hero text, GitHub repo "About" panel.
 
-### Layer 2 — Descriptive paragraph (3 short sentences)
+### Layer 2 — Descriptive paragraph (2 short sentences)
 
 > **Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime.**
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -152,13 +152,12 @@ function buildContext(userlandDir: string): string {
   return `
 # Oyster
 
-Oyster sits on top of the user's agents and keeps track of their AI work
-wherever they are. It syncs that work across the user's devices, remembers
-it across sessions, and lets them publish any of it as a link — all three
-baked in. The user brings whichever agents they prefer — Claude Code,
-Cursor, Codex, OpenCode, or any other MCP-aware agent (including you,
-whichever agent you are) — and swaps out at any time. **Oyster does not
-run the user's AI; it keeps the work their agents make.**
+Oyster keeps the user's AI work organised, synced and ready to share across
+devices, with memory and publishing built in. The user brings whichever
+agents they prefer — Claude Code, Cursor, Codex, OpenCode, or any other
+MCP-aware agent (including you, whichever agent you are) — and switches
+anytime. **Oyster does not run the user's AI; it keeps the work their
+agents make.**
 
 It is NOT a chat interface or a file browser — it is a workspace surface where
 artifacts (interactive documents, apps, diagrams, etc.) live alongside the

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -156,8 +156,8 @@ Oyster keeps the user's AI work organised, synced and ready to share across
 devices, with memory and publishing built in. The user brings whichever
 agents they prefer — Claude Code, Cursor, Codex, OpenCode, or any other
 MCP-aware agent (including you, whichever agent you are) — and switches
-anytime. **Oyster does not run the user's AI; it keeps the work their
-agents make.**
+anytime. **Oyster does not run the user's AI;
+it keeps the work their agents make.**
 
 It is NOT a chat interface or a file browser — it is a workspace surface where
 artifacts (interactive documents, apps, diagrams, etc.) live alongside the


### PR DESCRIPTION
## Summary

Retightens **Layer 1** and rewrites **Layer 2**; Layer 3 unchanged. Canonical source updated at [`docs/plans/roadmap.md`](https://github.com/oyster-to/oyster/blob/positioning/layer-1-2-revision/docs/plans/roadmap.md); every active customer-facing surface follows.

- **Layer 1:** *Mission control for the AI era.* → ***Mission control for your agents.***
  Drops the industry-era framing in favour of the agents the user actually has on their machine. Same five-word cadence, sharper and more concrete.

- **Layer 2:** *Oyster sits on top of your agents and keeps track of your AI work wherever you are. Sync, memory and publish all baked in. Bring whichever agents you prefer and swap out at any time.* → ***Oyster keeps your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer and switch anytime.***
  Flips the spine from *what Oyster IS to your agents* → *what Oyster DOES for you*. Explicitly names organised + synced + share + memory + publishing (previously *"all three baked in"*). Agent-freedom claim still lands as the second sentence.

## Surfaces touched

| File | What changed |
|---|---|
| `README.md` | h1 + sub-deck + image alt |
| `docs/index.html` | h1, hero subtitle, `<title>`, and the four **title-shape** meta tags (`og:title`, `og:image:alt`, `twitter:title`, `twitter:image:alt`) — all carrying Layer 1. The three **description-shape** meta tags (`meta name="description"`, `og:description`, `twitter:description`) carry **Layer 3** by design per the roadmap framework (§11–35) — *not* changed in this PR. |
| `CLAUDE.md` | Opening L1 + L2; parenthetical *"(Claude Code today; Cursor / Codex / OpenCode watchers next — issue #298)"* dropped — redundant with *"switch anytime"* and dates the doc |
| `bin/oyster.mjs` | CLI help text + welcome message |
| `bin/_banner.mjs` | Tip rotator |
| `server/src/mcp-server.ts` | L2 sentence swap; explicit *"Oyster does not run the user's AI"* negation deliberately preserved (per `roadmap.md:44`, MCP context is where that negation has its highest leverage) |
| `docs/plans/roadmap.md` | Canonical L1/L2 quote blocks, Layer 2 sentence-count label (3 → 2), Sprint 0.10.0 Purpose section, anchor-doc footnote, decision-history entry appended; prior 2026-05-14 entries kept as audit trail |

## Layer hierarchy (recap)

| Layer | Length | Surfaces |
|---|---|---|
| L1 | ~5 words | Hero / title / banner |
| L2 | 2 short sentences | Sub-deck / hero subtitle / MCP context / CLAUDE.md opening |
| L3 | ~12 words, one descriptive sentence | `package.json:description`, **meta description fields**, GitHub About, npm card, social bios, awesome-list entries |

## Out of scope (left as historical record)

These reference the old L1 as a snapshot of what shipped at the time — **not edited**:

- `CHANGELOG.md` / `docs/changelog.html` — release note for the prior positioning change
- `docs/research/yellow-pen-audit.md` — analysis of pen #11 resolution
- `docs/plans/archived/oyster-os-design.md` — archived doc

## Image assets — follow-up

`docs/hero-banner.png` and `docs/social-preview.jpg` still visually carry the old L1 text and need regeneration. Their `alt=` attributes are updated in this PR; the images themselves are a separate task so this PR isn't blocked on design work.

## Off-repo (manual after merge)

- GitHub repo "About" blurb → new L1
- GitHub social preview card (re-upload regenerated image)
- Twitter / X, Discord, Reddit bios if they carry the old L1

## Review thread responses

- **`docs/index.html` description tags** — see "Surfaces touched" above: description-shape fields carry Layer 3 by design, intentionally unchanged in this PR.
- **`roadmap.md:21`** — fixed in [8a6d5d3](../commit/8a6d5d3) (3 short sentences → 2).
- **`mcp-server.ts:159–160`** — fixed in [8a6d5d3](../commit/8a6d5d3) (line break shifted to the semicolon).

## Test plan

- [x] `grep -rn "Mission control for the AI era"` across active surfaces — clean (only historical hits remain)
- [x] `grep -rn "sits on top of"` / `"swap out at any time"` — only in roadmap audit trail
- [x] `cd server && ./node_modules/.bin/tsc --noEmit` — clean
- [ ] Render `docs/index.html` locally and confirm hero h1 + subtitle + OG/Twitter previews
- [ ] Boot the CLI on a built copy and confirm the banner + tip rotator surface the new L1
- [ ] Reconnect a Claude Code session to the local MCP, ask *"what is Oyster?"* — confirm the new L2 phrasing + the *"does not run your AI"* negation both come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)