### PR TITLE
fix(cli): banner adapts to narrow terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Boot banner stays readable on narrow terminals.** When the terminal isn't wide enough for the boxed banner, Oyster now drops the box and stacks the URLs on separate lines instead of letting the rails wrap and shred the layout.
+
 ## [0.8.2-beta.0] - 2026-05-14
 
 ### Added

--- a/bin/_banner.mjs
+++ b/bin/_banner.mjs
@@ -106,6 +106,8 @@ export function getTips() {
 // `options.version` (e.g. "0.8.0-beta.2") renders a faint `vX.Y.Z` flush
 // to the bottom-right of the ASCII block — quietly visible without
 // crowding the rest of the banner.
+// `options.columns` lets the preview script simulate terminal widths;
+// production reads `process.stdout.columns` instead.
 export function printHeroBox(url, tipIndex, options = {}) {
   const logo = options.logo || DEFAULT_LOGO;
   const version = options.version;
@@ -129,6 +131,15 @@ export function printHeroBox(url, tipIndex, options = {}) {
   const allTipsMaxVis = Math.max(...tips.map((t) => stripAnsi(t).length));
   const maxVis = Math.max(stripAnsi(topLine).length, artLineLen, allTipsMaxVis);
   const innerWidth = maxVis + 4; // 2 cells breathing room on each side
+
+  // Total render width is `innerWidth + 4`: 2 leading cells, `╭`, the rule,
+  // and `╮`. If the terminal is narrower the box rails wrap and the banner
+  // collapses into stacked `│` columns — fall back to a no-box layout.
+  const cols = options.columns ?? process.stdout.columns ?? 80;
+  if (cols < innerWidth + 4) {
+    printCompactBanner(url, tip, { version, logo: options.logo }, cols);
+    return;
+  }
 
   // Tip is centred (no anchor emoji) so it reads as a quiet inscription
   // rather than a third equal-weight item under the actionable top line.
@@ -174,5 +185,48 @@ export function printHeroBox(url, tipIndex, options = {}) {
     out.push(`  ${M}│${R}  ${line}${" ".repeat(rightPad)}${M}│${R}`);
   }
   out.push(`  ${M}╰${hr}╯${R}\n`);
+  console.log(out.join("\n"));
+}
+
+// Narrow-terminal fallback: no box rails (they wrap and shred the layout),
+// the smallest logo that fits, URLs stacked one-per-line so they don't
+// wrap mid-string. Keeps the same colour vocabulary as the boxed form.
+function printCompactBanner(url, tip, options, cols) {
+  const version = options.version;
+  const requested = options.logo || DEFAULT_LOGO;
+  const requestedWidth = Math.max(...requested.map((l) => l.length));
+  // Try the caller's logo first, then `small` as a fallback, else plain text.
+  // The `+ 4` accounts for 2 leading cells and a couple of cells of right
+  // breathing room so the logo isn't flush against the terminal edge.
+  const logo = requestedWidth + 4 <= cols
+    ? requested
+    : LOGO_FONTS.small[0].length + 4 <= cols
+      ? LOGO_FONTS.small
+      : null;
+
+  const out = [``];
+  if (logo) {
+    const lw = Math.max(...logo.map((l) => l.length));
+    const padded = logo.map((l) => l + " ".repeat(lw - l.length));
+    const hasShadow = padded.some((l) => l.includes("█"));
+    for (const line of padded) {
+      const coloured = hasShadow ? twoToneAscii(line, M, MD, R) : `${M}${line}${R}`;
+      out.push(`  ${coloured}`);
+    }
+    if (version) {
+      const vText = `v${version}`;
+      const pad = Math.max(0, lw - vText.length);
+      out.push(`  ${" ".repeat(pad)}${D}${vText}${R}`);
+    }
+  } else {
+    out.push(`  ${M}Oyster${R}${version ? `  ${D}v${version}${R}` : ""}`);
+  }
+  out.push(``);
+  out.push(`  👉  Open: ${C}${url}${R}`);
+  out.push(`  🤖  MCP server: ${C}${url}/mcp/${R}`);
+  out.push(`      ${D}(give this to your AI)${R}`);
+  out.push(``);
+  out.push(`  ${T}${tip}${R}`);
+  out.push(``);
   console.log(out.join("\n"));
 }

--- a/scripts/preview-banner.mjs
+++ b/scripts/preview-banner.mjs
@@ -21,6 +21,13 @@ if (args[0] === "--fonts" || args[0] === "-f") {
     console.log(`--- font: ${name} ---`);
     printHeroBox(url, 0, { logo: LOGO_FONTS[name], version });
   }
+} else if (args[0] === "--narrow" || args[0] === "-n") {
+  const widths = [120, 100, 80, 60, 40];
+  console.log(`\nRendering banner at ${widths.length} simulated terminal widths:\n`);
+  for (const cols of widths) {
+    console.log(`--- cols = ${cols} ---`);
+    printHeroBox(url, 1, { version, columns: cols });
+  }
 } else {
   const tips = getTips();
   console.log(`\nRendering ${tips.length} tip variants:\n`);


### PR DESCRIPTION
## Summary

- Boot banner currently builds a fixed-width box sized to the widest line (~108 cells). On narrower terminals the rails wrap and the layout collapses into stacked `│` columns (screenshot in chat).
- `printHeroBox` now reads `process.stdout.columns` and falls back to a no-box layout when the box won't fit: full logo if it still fits, `small` logo otherwise, URLs stacked one-per-line so they don't wrap mid-string.
- Adds `npm run preview:banner -- --narrow` to render the banner at simulated widths (120 / 100 / 80 / 60 / 40) without resizing the terminal.
- Targeted for 0.8.3-beta.0 — CHANGELOG entry added under Unreleased.

## Test plan

- [ ] `npm run preview:banner -- --narrow` — confirm box at 120, no-box ANSI Shadow at 100/80/60, small logo at 40
- [ ] Narrow a real terminal to ~80 cols and run `npm run preview:banner` (no flag) — confirms `process.stdout.columns` path
- [ ] `npm run build && node bin/oyster.mjs` in a narrow terminal — end-to-end CLI boot path

🤖 Generated with [Claude Code](https://claude.com/claude-code)