### PR TITLE
fix(home): dedupe orphan-folder tiles when Windows separators differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Windows: same folder no longer shows as two orphan tiles.** A folder you've run sessions in on Windows used to appear twice in *Everything else.* — once as `C:/Users/...` and once as `C:\Users\...` — depending on whether the session was a local one or pulled back from another device. They now collapse into a single tile.
 - **Home's table view now matches the icon view for published artefacts.** Cloud-only published rows previously hid the artefact's real space behind a literal *"Cloud"* label and showed no published-status chip. The table now shows the underlying space (e.g. *tokinvest*) and renders the same *On cloud* / *Published* chip next to the title that the icon view shows below it — both views speak the same visual language.
 - **Sessions no longer get stuck pointing at a detached folder.** Previously, removing a folder left sessions silently linked to a deleted source; they now correctly fall back to the space vault.
 

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -379,14 +379,20 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     }>();
     for (const s of sessions) {
       if (s.spaceId !== null || !s.cwd) continue;
-      let entry = map.get(s.cwd);
+      // Group separator-equivalent Windows paths under one tile: local
+      // sessions write forward-slashed cwds while remote_sessions can hold
+      // the raw backslash form pushed from the origin device, so the same
+      // folder would otherwise render twice. Drive letter is lowercased
+      // because Windows treats the volume case-insensitively.
+      const key = s.cwd.replace(/\\/g, "/").replace(/^([A-Za-z]):/, (_, d: string) => d.toLowerCase() + ":");
+      let entry = map.get(key);
       if (!entry) {
         entry = {
           cwd: s.cwd,
           counts: { active: 0, waiting: 0, disconnected: 0, done: 0 },
           lastEventAt: 0,
         };
-        map.set(s.cwd, entry);
+        map.set(key, entry);
       }
       entry.counts[s.state]++;
       const t = parseTimestamp(s.lastEventAt);


### PR DESCRIPTION
## Summary

- A folder with both `C:/Users/matth` (local sessions, forward-slashed) and `C:\Users\matth` (raw cwd pulled back from `remote_sessions`) was rendering as two orphan tiles in *Everything else.*
- Grouping reducer in `web/src/components/Home/index.tsx` now keys by a separator-normalised form (forward-slash + lowercased drive letter), collapsing equivalent Windows paths into one tile.
- Display label uses whichever raw cwd arrived first. No storage change, no migration.

## Test plan

- [ ] On Windows with both local and cloud-pulled sessions for the same folder, Home shows one tile not two.
- [ ] Mac/Linux orphans are unchanged (the key normalisation is a no-op for forward-slash-only paths).
- [ ] The `~` collapse on `homeRelative()` still works (different cwd, different tile — correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)