### PR TITLE
chore: commit .oyster/id for the Oyster source repo itself

### DIFF
--- a/.oyster/id
+++ b/.oyster/id
@@ -1,0 +1,1 @@
+49b0f26b-593e-4a62-bcd1-f2defdfcedf1


### PR DESCRIPTION
The `.oyster/id` feature (#491) auto-wrote this UUID into the repo on boot of an Oyster 0.8.3+ build. Committing it pins the cross-machine identity for the `oyster-to/oyster` project so any contributor's Oyster recognises the repo on first clone.

Dogfooding the feature on the feature's own source. UUID: `49b0f26b-593e-4a62-bcd1-f2defdfcedf1`.