### PR TITLE
docs(plans): preserve 0.10.0 surgery implementation plan

### DIFF
--- a/docs/plans/2026-05-14-0.10.0-surgery.md
+++ b/docs/plans/2026-05-14-0.10.0-surgery.md
@@ -1,0 +1,1366 @@
+# 0.10.0 Surgery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the Sprint-2 vestiges that still ship inside the Sprint-5 product — chat bar, bundled OpenCode, Ultra Hardcore terminal, AI fix-error, fal.ai icon generator, `local_process` runtime, `builtins/zombie-horde/`, and the 7→3 artefact-kind collapse — so the *"Mission control for the AI era"* / *"Bring whichever agents you prefer"* pitch becomes true on first install.
+
+**Architecture:** Strict-order surgery driven by the load-bearing keystone (Task 1). Removing the chat bar + bundled OpenCode kills the only caller of five other Sprint-2 surfaces; trying to delete them first means untangling things that are about to disappear anyway. Tasks 2–7 can then proceed largely independently. Task 8 replaces the deleted first-run login flow. Task 9 is a small follow-up tracked separately in #467.
+
+**Tech Stack:** TypeScript 6.x (server), React 19 + Vite 7 (web), Node 25, `better-sqlite3`, opencode-ai (subprocess — being removed). Server tests use vitest (installed but currently no test files). Web has no test runner. The project's existing verification model is grep + boot-clean + manual click-through, not automated tests; this plan honours that.
+
+---
+
+## How to use this plan
+
+### Read in this order before starting
+1. `CLAUDE.md` — Behavioral Guidelines: surgical changes, simplicity, goal-driven verification
+2. `docs/plans/roadmap.md` — 0.10.0 section + R-alignment + Layer 1/2/3 positioning
+3. `docs/research/yellow-pen-audit.md` — file:line evidence and ranked moves table
+4. Issue #465 — handover comment posted 2026-05-14 with the actionable cut list
+5. Issue #470 — preserve `pty-manager.ts` as a private module (Task 2 constraint)
+
+### Verification convention (read this — it deviates from default TDD)
+
+**Oyster has no automated UI tests and the server has zero `*.test.ts` files today** (vitest is installed in `server/`, never used). This is a *surgery* plan — most tasks are deletions. Writing tests for code we're about to delete is wasted work. Instead, each task uses three verification gates:
+
+1. **Grep gate** — a `grep` that returns specific output before the cut and zero matches (or the new shape) after. This is the *failing test that becomes a passing test*. Run before, capture output, run after, confirm difference.
+2. **Boot-clean gate** — `npm run dev` starts both Vite (7337) and the server (3333) without printing the deleted module's identifying log lines, no uncaught errors, no `MODULE_NOT_FOUND`, no `Cannot find module`.
+3. **Manual click-through gate** — open `http://localhost:7337` in a fresh incognito window (so localStorage starts empty) and confirm the deleted surface is gone and remaining surfaces still work.
+
+For **new code only** (the command bar in Task 1, the first-run wizard in Task 8), we add minimal vitest unit tests where the logic is non-trivial. The plan calls those out explicitly.
+
+### Branching & worktrees (project convention)
+
+- **Worktree location:** `~/Dev/oyster.worktrees/<branch-name>/` (matches existing `oyster.worktrees/` siblings)
+- **Branch names:** `chore/cut-chatbar-opencode`, `chore/cut-hardcore-pty-trigger`, `chore/cut-fix-error`, `chore/cut-icon-generator`, `chore/cut-local-process`, `chore/cut-zombie-horde`, `chore/collapse-artefact-kinds`, `feat/first-run-mcp-wizard`, `chore/pricing-strap-decision`
+- **One PR per task** (the project uses squash-merge — check `git log --oneline` and you'll see `feat:` / `fix:` / `chore:` / `docs:` prefixes; mirror that)
+- **Never** commit to `main` directly; never `--no-verify`
+- **CHANGELOG.md** — add an `[Unreleased]` entry for every user-visible cut. Style is Keep a Changelog. See `CHANGELOG.md:5-25` for the current `[Unreleased]` block; mirror the bold lead-in + 1–2 sentence outcome focus. Drop file paths, MCP tool names, route names, implementation details.
+
+### Strict order — why the keystone is first
+
+Per yellow-pen-audit.md's Morita-test section, the chat bar is the load-bearing surface:
+- The icon generator has no caller without `create_artifact` flowing through chat
+- `handleFixError` has nothing to spawn into without a chat session
+- The Ultra Hardcore terminal modal trigger lives inside the chat bar (`ChatBar.tsx:632`)
+- `opencode providers login` on first run only exists to authenticate the chat engine
+- `local_process` runtime was driven from chat-bar slash commands
+
+Doing Tasks 2–6 before Task 1 means untangling code that Task 1 deletes wholesale. **Land Task 1 first, merge it, then dispatch 2–7 in parallel.**
+
+### Tracking on #465
+
+After the keystone (Task 1) merges, convert each of Tasks 2–9 into either a sub-issue or a checklist item on #465. Recommended: a single checklist on #465 with one item per task plus a link to the PR. Sub-issues are heavier than this work warrants.
+
+---
+
+## Task sequencing
+
+```
+Task 1 (keystone) ───┬──> Task 2 (Ultra Hardcore trigger)
+                     ├──> Task 3 (handleFixError)
+                     ├──> Task 4 (icon-generator) ──> Task 5 (local_process + process-manager)
+                     ├──> Task 6 (zombie-horde + re-audit builtins)
+                     ├──> Task 7 (collapse artefact kinds)
+                     ├──> Task 8 (first-run MCP wizard) — replaces deleted login flow
+                     └──> Task 9 (pricing strap — tracked separately as #467)
+```
+
+Tasks 2, 3, 4, 6, 7, 9 can proceed in parallel after Task 1 merges. Task 5 depends on Task 4 (process-manager owns `updateGeneratedArtifact`, which icon-generator is the primary consumer of). Task 8 depends on Task 1 (it replaces the login flow Task 1 removes).
+
+---
+
+## Acceptance for closing #465
+
+These are the gates from the handover comment, made concrete with the commands you'll run:
+
+- [ ] `grep -rn "opencode" server/src bin/ | grep -v "// historical"` returns zero matches
+- [ ] `grep -rn "ChatBar\|opencode-manager\|opencode-events\|opencode-orphan-sweep\|icon-generator\|process-manager\|fal\.ai\|handleFixError\|hardcore-gate" web/src/ server/src/ shared/` returns only intentional historical references (changelog / archived docs)
+- [ ] `~/Oyster/apps/zombie-horde/` does not exist after a fresh boot from `npm run dev`
+- [ ] No artefact-creation flow reaches `fal.subscribe` or `https://api.openai.com/v1/chat/completions`
+- [ ] First-run UX works with **no AI provider configured** — server boots, browser opens, OnboardingDock + wizard guide the user to connect their own agent via MCP
+- [ ] `npm run build` succeeds and `npm run dev` boots cleanly (no `Cannot find module`, no `MODULE_NOT_FOUND`, no uncaught exceptions in the first 10 s of logs)
+- [ ] `server/src/pty-manager.ts` still exists as a private module (no import from any user-facing entry point) — preserved per #470
+- [ ] `CHANGELOG.md` `[Unreleased]` has a `### Changed` entry covering the user-visible cuts (chat bar replaced by command bar, terminal removed, etc.) — one bullet per coherent user-visible outcome, not one per task
+
+When all eight gates pass, post the gate outputs as a comment on #465 and close.
+
+---
+
+## Task 1: Cut the chat bar + bundled OpenCode (KEYSTONE)
+
+> **This is the load-bearing task.** Land and merge before any other task. ~480 lines of subprocess supervision removed; replaced with a command bar that keeps `/s` `/o` `/p` `/u` slash commands but routes natural-language input to the user's connected MCP agent rather than running its own.
+
+**Branch:** `chore/cut-chatbar-opencode`
+**Worktree:** `~/Dev/oyster.worktrees/chore-cut-chatbar-opencode/`
+
+**Files:**
+- Delete: `server/src/opencode-manager.ts` (304 lines)
+- Delete: `server/src/opencode-events.ts` (63 lines)
+- Delete: `server/src/opencode-orphan-sweep.ts` (115 lines)
+- Delete: `web/src/components/ChatBar.tsx` (734 lines — replace with new `CommandBar.tsx`)
+- Delete: `web/src/data/chat-api.ts` (151 lines)
+- Delete: `web/src/hooks/useChatSession.ts` (146 lines)
+- Delete: `web/src/hooks/useChatEvents.ts` (278 lines)
+- Delete: `.opencode/agents/oyster.md` (the bundled agent definition)
+- Delete: `.opencode/config.toml` (the bundled agent config)
+- Delete: `opencode.json` (project-root config used by spawned OpenCode)
+- Create: `web/src/components/CommandBar.tsx` — replaces ChatBar; slash commands only, no LLM
+- Modify: `web/src/App.tsx` — swap `<ChatBar>` mount for `<CommandBar>`, drop `handleFixError` (Task 3 will delete it; Task 1 just stops importing chat-api), strip `aiError` state and `ai-error-banner` (was chat-only)
+- Modify: `server/src/index.ts` — remove all opencode imports + chat proxy routes (lines 25, 56-64, 685-686, 849-911, 976-1014, 1031, 1123-1133); remove `tryHandleStaticRoute` no longer (route still serves docs etc.)
+- Modify: `bin/oyster.mjs` — remove `runLogin` call (lines 367-390 around the auth-check block); keep the welcome banner; never spawn `opencode providers login`
+- Modify: `package.json` — remove `opencode-ai` from `dependencies`; remove `.opencode/` and `opencode.json` from `files`
+- Modify: `server/package.json` — remove `opencode-ai` from `dependencies`
+- Modify: `CHANGELOG.md` — add `[Unreleased] ### Changed` entry
+- Modify: `CLAUDE.md` — drop the Architecture block's `"Chat proxy → OpenCode"` line and the `OpenCode` paragraph at `:30`
+
+**Verification commands you will run:**
+- Grep gate (before): `grep -rn "opencode\|ChatBar\|opencode-manager" server/src web/src bin/ 2>/dev/null | wc -l` → expect a number well above 100
+- Grep gate (after): same command → expect zero matches outside `CHANGELOG.md`, `docs/`, and archived files
+- Boot gate: `npm run build && npm run dev` — server logs `Oyster server listening on http://127.0.0.1:3333` and Vite logs its port; no `MODULE_NOT_FOUND`; no `spawn ENOENT` for opencode; no `[opencode-` log lines anywhere
+- Click-through gate: open `http://localhost:7337` in fresh incognito; the input bar at the bottom is the new command bar; typing `#home`, `/s`, `/o` `<artifact>` all work; typing natural language *does not* call the AI (no streaming, no thinking indicator); the spotlight (Cmd+K) still opens
+
+---
+
+- [ ] **Step 1.0: Create worktree from main**
+
+```bash
+cd ~/Dev/oyster
+git fetch origin
+git worktree add -b chore/cut-chatbar-opencode ~/Dev/oyster.worktrees/chore-cut-chatbar-opencode origin/main
+cd ~/Dev/oyster.worktrees/chore-cut-chatbar-opencode
+cd web && npm install && cd ../server && npm install && cd ..
+```
+
+Expected: clean worktree on a fresh branch tracking origin/main. `npm install` succeeds in both `web/` and `server/`.
+
+- [ ] **Step 1.1: Snapshot the "before" grep**
+
+Run and save output to a scratch file (not committed):
+
+```bash
+{
+  echo "=== opencode in server/src ==="
+  grep -rn "opencode" server/src/ 2>/dev/null
+  echo
+  echo "=== opencode in bin/ ==="
+  grep -rn "opencode" bin/ 2>/dev/null
+  echo
+  echo "=== ChatBar references in web/src ==="
+  grep -rn "ChatBar" web/src/ 2>/dev/null
+  echo
+  echo "=== chat-api references in web/src ==="
+  grep -rn "chat-api\|chat/session\|chat/events" web/src/ 2>/dev/null
+} | tee /tmp/before-task1.txt
+```
+
+Expected: hundreds of lines. This becomes the "failing test" — when the after-grep is empty, the task is done.
+
+- [ ] **Step 1.2: Delete the OpenCode server-side modules**
+
+```bash
+git rm server/src/opencode-manager.ts server/src/opencode-events.ts server/src/opencode-orphan-sweep.ts
+```
+
+Expected: three files removed. `tsc -b` will now fail in `server/` because `server/src/index.ts` still imports from them. That's expected — Step 1.3 fixes it.
+
+- [ ] **Step 1.3: Strip the OpenCode wiring from `server/src/index.ts`**
+
+In `server/src/index.ts`, make these surgical edits (line numbers reference current `main`):
+
+1. Remove the imports at lines 56–64:
+   ```ts
+   // DELETE these lines:
+   import {
+     spawnOpenCodeServe,
+     getOpenCodePort,
+     markShuttingDown,
+     killOpenCode,
+     startAutoApprover,
+     proxyToOpenCode,
+   } from "./opencode-manager.js";
+   import { attachChatEventClient } from "./opencode-events.js";
+   import { sweepOrphanOpenCodeProcesses } from "./opencode-orphan-sweep.js";
+   ```
+
+2. The shutdown handlers at lines 685–686 currently call `markShuttingDown()` and `killOpenCode()`. After deletion, they become:
+   ```ts
+   process.on("SIGTERM", () => { db.close(); memoryProvider.close(); clearDevPortFile(); process.exit(0); });
+   process.on("SIGINT", () => { db.close(); memoryProvider.close(); clearDevPortFile(); process.exit(0); });
+   ```
+   Also remove the `markShuttingDown()` + `killOpenCode()` calls in the `uncaughtException` and `unhandledRejection` handlers at lines 687–701.
+
+3. Delete the entire chat-proxy block at lines 849–911 (from `// ── OpenCode chat API proxy ──` through the end of the `questionMatch` handler). The block to delete:
+   ```ts
+   // ── OpenCode chat API proxy ──
+
+   if (req.method === "OPTIONS" && url.startsWith("/api/chat/")) { ... }
+   if (url === "/api/chat/events" || url.startsWith("/api/chat/events?")) { ... }
+   if (url === "/api/chat/doc") { ... }
+   if (url === "/api/chat/session" && req.method === "POST") { ... }
+   if (url === "/api/chat/session" && req.method === "GET") { ... }
+   const msgMatch = url.match(/^\/api\/chat\/session\/([^/]+)\/message$/);
+   if (msgMatch && (req.method === "POST" || req.method === "GET")) { ... }
+   const sessionMatch = url.match(/^\/api\/chat\/session\/([^/]+)$/);
+   if (sessionMatch && req.method === "GET") { ... }
+   const abortMatch = url.match(/^\/api\/chat\/session\/([^/]+)\/abort$/);
+   if (abortMatch && req.method === "POST") { ... }
+   if (url === "/api/chat/permission" && req.method === "GET") { ... }
+   const questionMatch = url.match(/^\/api\/chat\/question\/([^/]+)\/reply$/);
+   if (questionMatch && req.method === "POST") { ... }
+   ```
+
+4. Delete the OpenCode config write block at lines 976–1014 (from `// Write OpenCode config with the actual port ...` through `writeFileSync(join(USERLAND_DIR, "opencode.json"), ...)`). The `bootMark("opencode config written, about to listen")` line at 1014 goes too.
+
+5. Delete the `spawnOpenCodeServe(...)` call in the listen callback (line 1031).
+
+6. Delete the `setImmediate` orphan-sweep block at lines 1123–1133.
+
+7. Remove the now-unused `OPENCODE_PORT`, `OPENCODE_BIN`, `SHELL`, `SHELL_ARGS`, and `findOpenCodeBin` declarations at lines 76, 91–113. Keep `WORKSPACE` (still used by `attachWebSocket`'s `cwd` — Task 2 deals with the terminal). Keep `cleanEnv` (still used elsewhere).
+
+8. The bootstrap `.opencode` syncs at lines 188–197 — delete them:
+   ```ts
+   // DELETE:
+   mkdirSync(`${OYSTER_HOME}/.opencode/agents`, { recursive: true });
+   syncIfNewer(
+     `${PROJECT_ROOT}/.opencode/agents/oyster.md`,
+     `${OYSTER_HOME}/.opencode/agents/oyster.md`,
+   );
+   syncIfNewer(
+     `${PROJECT_ROOT}/.opencode/config.toml`,
+     `${OYSTER_HOME}/.opencode/config.toml`,
+   );
+   ```
+
+9. Delete the `OPENAI_API_KEY` strip at lines 247 (`delete cleanEnv["OPENAI_API_KEY"];`) — the cleanEnv was specifically to avoid leaking to opencode subprocess; we now have no subprocess. Keep `cleanEnv` itself for the PTY (Task 2 may decouple it).
+
+After these edits, `npx tsc --noEmit -p server` should pass.
+
+- [ ] **Step 1.4: Verify server typechecks**
+
+```bash
+cd server && npx tsc --noEmit && cd ..
+```
+
+Expected: zero errors. If you get errors mentioning `opencode`, `getOpenCodePort`, `proxyToOpenCode`, `markShuttingDown`, `killOpenCode`, `attachChatEventClient`, or `sweepOrphanOpenCodeProcesses` — you missed a callsite. Re-grep `server/src/index.ts` for the name and remove it.
+
+- [ ] **Step 1.5: Delete the .opencode + opencode.json bundles**
+
+```bash
+git rm -r .opencode/ opencode.json
+```
+
+Expected: directory and file removed. These were used by the spawned OpenCode subprocess to find its agent definition and MCP endpoint — both gone now.
+
+- [ ] **Step 1.6: Remove `opencode-ai` from package manifests**
+
+In `package.json` (project root), in the `dependencies` block, delete the line:
+```json
+"opencode-ai": "^1.14.41",
+```
+
+In the `files` array, delete `".opencode/"` and `"opencode.json"`:
+```json
+"files": [
+  "bin/",
+  "server/dist/",
+  "builtins/"
+],
+```
+
+In `server/package.json`, in the `dependencies` block, delete:
+```json
+"opencode-ai": "^1.14.41",
+```
+
+Then refresh the lockfiles:
+```bash
+npm install --package-lock-only
+cd server && npm install --package-lock-only && cd ..
+```
+
+Expected: `package-lock.json` files lose every `opencode-ai`-related entry. The `optionalDependencies` block (`@lydell/node-pty`) stays — that's for Task 2.
+
+- [ ] **Step 1.7: Strip the OpenCode auth-check from `bin/oyster.mjs`**
+
+In `bin/oyster.mjs`, delete the entire `// ── Find bundled OpenCode binary ──` block (lines 318–340) and the `// ── Check OpenCode auth ──` block (lines 342–363). Delete the `main()` body's auth-check stanza (lines 369–390):
+
+```js
+// DELETE:
+const opencodeBin = findOpenCodeBin();
+...
+// Skip auth check if any provider API key is in env
+const hasEnvKey = env.ANTHROPIC_API_KEY || env.OPENAI_API_KEY || env.GOOGLE_API_KEY || env.GEMINI_API_KEY;
+
+// Check auth — if none, run login inline
+if (!hasEnvKey && !hasAuth()) {
+  console.log("\n  🦪 Welcome to Oyster");
+  console.log("  Mission control for the AI era.\n");
+  console.log("  First, let's connect an AI provider.\n");
+
+  const ok = await runLogin(opencodeBin);
+  if (!ok || !hasAuth(opencodeBin)) {
+    console.log("\n  No provider configured. Run `oyster` again to retry.\n");
+    process.exit(1);
+  }
+  console.log("\n  Provider connected. Starting Oyster...\n");
+}
+```
+
+Replace with:
+
+```js
+// First-run hint. The OnboardingDock + first-run wizard in the web UI
+// guide the user through connecting their own agent over MCP; no AI
+// provider needs to be configured for the server to run.
+```
+
+Also remove the `runLogin` function definition (lines 355–363) entirely.
+
+The OYSTER_INSTALLED / OYSTER_WORKSPACE lines (392–396) stay. The serverEntry + spawn (398–442) stay.
+
+- [ ] **Step 1.8: Delete the chat-api + chat hooks + ChatBar**
+
+```bash
+git rm web/src/data/chat-api.ts web/src/hooks/useChatSession.ts web/src/hooks/useChatEvents.ts web/src/components/ChatBar.tsx
+```
+
+Expected: four files removed. `tsc` in `web/` now fails — `App.tsx` imports from `chat-api` (line 25) and `ChatBar` (line 4). Step 1.9 fixes it.
+
+- [ ] **Step 1.9: Strip chat-api imports from `web/src/App.tsx`**
+
+In `web/src/App.tsx`:
+
+1. Delete the imports at lines 4 and 25:
+   ```tsx
+   // DELETE:
+   import { ChatBar } from "./components/ChatBar";
+   import { createSession, sendMessage } from "./data/chat-api";
+   ```
+
+2. Delete `aiError` state (line 119) and the `connection-banner ai-error-banner` JSX at lines 433–437. The chat session was the only thing setting `aiError`; with chat gone, the banner has no producer.
+
+3. Delete `handleFixError` (lines 402–422) — Task 3 was going to delete it; doing it here makes `App.tsx` typecheck. Also remove the `onFixError={handleFixError}` prop on `<ViewerWindow>` at line 511. (The `ViewerWindow` props will be cleaned up in Task 3; for now the prop just becomes `undefined`-defaulted.)
+
+4. Delete the `setAiError` reference passed to `<ChatBar>` (line 614) — irrelevant because the whole `<ChatBar>` mount goes in Step 1.10.
+
+After this step, `App.tsx` typechecks but has no command bar. Step 1.10 adds it.
+
+- [ ] **Step 1.10: Create the new `CommandBar.tsx`**
+
+The replacement keeps every slash command from the old ChatBar but drops everything that spoke to OpenCode. Natural-language input does NOT call any AI — the user's connected MCP agent (Claude Code / Cursor / etc.) is the AI; Oyster is the surface.
+
+Write `web/src/components/CommandBar.tsx`:
+
+```tsx
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import type { Space } from "../../../shared/types";
+import type { Artifact } from "../data/artifacts-api";
+
+const SLASH_COMMANDS = [
+  { cmd: "/s", args: "<prefix>", desc: "Switch space", example: "/s bf → blunderfixer" },
+  { cmd: "/o", args: "<search>", desc: "Open artifact", example: "/o competitor analysis" },
+  { cmd: "/p", args: "<artefact>", desc: "Publish artifact", example: "/p competitor analysis" },
+  { cmd: "/u", args: "<artefact>", desc: "Unpublish artifact", example: "/u competitor analysis" },
+  { cmd: "#", args: "<space>", desc: "Quick switch", example: "#bf · #all · #archived" },
+];
+
+interface Props {
+  spaces?: Space[];
+  activeSpace?: string;
+  onSpaceChange?: (space: string) => void;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  artifacts?: Artifact[];
+  onArtifactOpen?: (artifact: Artifact) => void;
+  onArtifactPublish?: (artifact: Artifact) => void;
+  onArtifactUnpublish?: (artifact: Artifact) => void;
+  isHero?: boolean;
+  isFirstRun?: boolean;
+}
+
+export function CommandBar({
+  spaces = [],
+  activeSpace,
+  onSpaceChange,
+  inputRef: externalInputRef,
+  artifacts = [],
+  onArtifactOpen,
+  onArtifactPublish,
+  onArtifactUnpublish,
+  isHero: isHeroProp,
+  isFirstRun,
+}: Props) {
+  const [input, setInput] = useState("");
+  const [slashIndex, setSlashIndex] = useState(0);
+  const localInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef || localInputRef;
+  const isHero = !!isHeroProp;
+
+  const subseq = useCallback((query: string, target: string) => {
+    let qi = 0;
+    for (let ti = 0; ti < target.length && qi < query.length; ti++) {
+      if (target[ti] === query[qi]) qi++;
+    }
+    return qi === query.length;
+  }, []);
+
+  const scoreArtifacts = useCallback((query: string) => {
+    const tokens = query.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return [];
+    return artifacts.map(a => {
+      let score = 0;
+      const label = a.label.toLowerCase();
+      const id = a.id.toLowerCase();
+      const space = a.spaceId.toLowerCase();
+      for (const t of tokens) {
+        if (label.includes(t)) score += 5;
+        else if (subseq(t, label)) score += 3;
+        if (id.includes(t)) score += 4;
+        if (space.startsWith(t) || subseq(t, space)) score += 10;
+      }
+      if (a.spaceId === activeSpace) score += 3;
+      return { a, score };
+    }).filter(x => x.score > 0).sort((a, b) => b.score - a.score);
+  }, [artifacts, activeSpace, subseq]);
+
+  const publishableArtifacts = useMemo(
+    () => artifacts.filter((a) => !a.builtin && !a.plugin && a.status !== "generating"),
+    [artifacts],
+  );
+
+  const livePublications = useMemo(
+    () => artifacts.filter((a) => a.publication != null && a.publication.unpublishedAt == null),
+    [artifacts],
+  );
+
+  // slashItems and slashOpen — port the same logic from ChatBar.tsx:160-254.
+  // No changes to slash-completion behaviour; only the "after Enter on
+  // free-text input" branch differs (we no longer call the AI).
+  // [PORT BLOCK A — see Step 1.10b below for the literal code]
+
+  const handleEnter = useCallback(() => {
+    const content = input.trim();
+    if (!content) return;
+
+    // #space — instant switch, no AI
+    if (content.startsWith("#") && onSpaceChange) {
+      setInput("");
+      const q = content.slice(1).toLowerCase();
+      if (q === "." || q === "0") { onSpaceChange("home"); return; }
+      const positional = q.match(/^(\d+)$/);
+      if (positional) {
+        const idx = parseInt(positional[1], 10);
+        const userSpaces = spaces.filter(s => s.id !== "home");
+        if (idx >= 1 && idx <= userSpaces.length) { onSpaceChange(userSpaces[idx - 1].id); return; }
+      }
+      if (q === "all") { onSpaceChange("home"); return; }
+      if (q === "archived") { onSpaceChange("__archived__"); return; }
+      const match = spaces.find(s => s.id === q)
+        || spaces.find(s => s.id.startsWith(q))
+        || spaces.find(s => s.displayName.toLowerCase().startsWith(q))
+        || spaces.find(s => subseq(q, s.id))
+        || spaces.find(s => subseq(q, s.displayName.toLowerCase()));
+      if (match) onSpaceChange(match.id);
+      return;
+    }
+
+    // /command — instant, no AI. Port the /s /o /p /u handlers from
+    // ChatBar.tsx:341-409 verbatim (they don't call chat-api, only
+    // dispatch local actions). [PORT BLOCK B]
+
+    // Plain text — route to user's connected MCP agent. In v1 of the
+    // command bar this is a no-op with a hint: the user's own agent
+    // (Claude Code / Cursor / etc.) is where they type to Oyster. The
+    // command bar's job is local actions only.
+    //
+    // Future improvement: if we detect a connected MCP client (e.g.
+    // there's an active `mcp_client_connected` SSE event recently), we
+    // could ship the prompt to it via a new MCP tool. Out of scope for
+    // 0.10.0 surgery — keep the bar pure-local until users ask.
+    setInput("");
+    // Optional: show a one-time hint that "Oyster doesn't run an AI —
+    // type into your connected agent instead." Drive via localStorage so
+    // it appears once.
+  }, [input, spaces, onSpaceChange, subseq, /* + scoreArtifacts deps */]);
+
+  // [Render JSX — port from ChatBar.tsx:478-732 BUT drop:
+  //   - The terminal-shell icon at :630-643 (Task 2 will remove the
+  //     `onOpenTerminal` prop wiring entirely; for Task 1 just stop
+  //     rendering the .chatbar-oyster span)
+  //   - The hero tagline's "Set up Oyster" CTA at :491-509 (it dispatched
+  //     handleSend("Set up Oyster"); Task 8's first-run wizard replaces
+  //     this CTA's purpose. For Task 1, render only the dim "Welcome to
+  //     your surface." line.)
+  //   - All `messages.length > 0` JSX at :527-602 (chat panel — gone)
+  //   - The streaming spinner at :644-646 (no streaming)
+  // ]
+  return (
+    <div className={`chatbar-wrapper ${isHero ? "chatbar-hero" : ""}`}>
+      {/* Hero — first-run only renders a static welcome; chat-driven
+          onboarding moves to Task 8's wizard */}
+      {isHero && isFirstRun && (
+        <div className="chatbar-hero-tagline">
+          <span className="tagline-bright">Welcome to your surface.</span>
+        </div>
+      )}
+      <div className="chatbar-bar">
+        {/* slash autocomplete dropdown — port ChatBar.tsx:607-628 verbatim */}
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleEnter();
+            // port slash-autocomplete navigation from ChatBar.tsx:663-702
+          }}
+          placeholder="Type / for commands · # for spaces"
+          className="chatbar-input"
+        />
+        <button
+          className="chatbar-send"
+          onClick={() => handleEnter()}
+          disabled={!input.trim()}
+          aria-label="Run command"
+        >
+          ↑
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+The skeleton above is intentionally schematic in two places marked `[PORT BLOCK A]` and `[PORT BLOCK B]` — see Step 1.10b for the literal blocks to paste in. Keeping the JSX of the slash-autocomplete dropdown identical to the old ChatBar means existing CSS (`.slash-autocomplete`, `.slash-autocomplete-item`, etc. in `App.css`) keeps working untouched.
+
+- [ ] **Step 1.10b: Port the slash-completion blocks verbatim from old ChatBar**
+
+The slash-completion logic at `ChatBar.tsx:160-254` (the `slashItems` memo) and `ChatBar.tsx:341-409` (the `/s` `/o` `/p` `/u` handlers) is local-only — it never touches `chat-api`. Copy both blocks verbatim into `CommandBar.tsx`. The only adjustments:
+
+- `setMessages(prev => [...prev, { role: "assistant", content: "No space matching..." }])` calls at `ChatBar.tsx:335`, `:361`, `:370`, `:384`, `:398` need to be removed (no messages state); replace with `console.warn("[command-bar] no space matching:", q)` or a one-line non-blocking toast. The graceful path is: if there's no match, the input stays as-is and the user sees the dropdown shrink to nothing. Don't introduce a toast library just for this — silent no-match is fine; the dropdown already provides the affordance.
+- `setExpanded(true)` calls similarly drop; there's no expanded state.
+- Remove `pushSessionUrl`, `resetTracking`, `streaming`, `sessionId`, `pendingPromptRef` — all chat-session-coupled.
+
+Run `npx tsc --noEmit -p web` after the port. Expected: zero errors.
+
+- [ ] **Step 1.11: Swap `<ChatBar>` for `<CommandBar>` in `App.tsx`**
+
+In `web/src/App.tsx`:
+
+1. Add the import (where the ChatBar import was):
+   ```tsx
+   import { CommandBar } from "./components/CommandBar";
+   ```
+
+2. Replace the `<ChatBar ... />` mount at lines 602–615 with:
+   ```tsx
+   <CommandBar
+     isHero={isHero}
+     spaces={spaces}
+     activeSpace={activeSpace}
+     onSpaceChange={handleSpaceChange}
+     inputRef={chatInputRef}
+     artifacts={artifacts}
+     onArtifactOpen={handleArtifactClick}
+     onArtifactPublish={handleArtifactPublish}
+     onArtifactUnpublish={handleArtifactUnpublish}
+     isFirstRun={isFirstRun}
+   />
+   ```
+
+Note: `onOpenTerminal={handleOpenTerminal}` is gone. The terminal modal (`showHardcoreGate` state + JSX at `App.tsx:543-566`) is now unreachable; Task 2 will delete it. For Task 1, leave it in — it's dead code that Task 2 cleans up, and keeping the deletion scope tight aids review.
+
+- [ ] **Step 1.12: Boot test**
+
+```bash
+cd ~/Dev/oyster.worktrees/chore-cut-chatbar-opencode
+npm run build
+```
+
+Expected: `npm run build` succeeds. If it fails, the error message will tell you exactly which file still imports a deleted module — fix and re-run.
+
+```bash
+npm run dev
+```
+
+Expected log output within 5 seconds:
+- `Oyster server listening on http://127.0.0.1:3333` (server is up)
+- Vite logs its port (typically 7337)
+- **No** `[opencode-serve]`, `[opencode-sweep]`, or `[auto-approver]` lines anywhere
+- **No** `spawn ENOENT` or `Cannot find module` errors
+- **No** uncaught exception logs
+
+Leave it running for Step 1.13.
+
+- [ ] **Step 1.13: Click-through gate**
+
+In a fresh incognito window, open `http://localhost:7337`:
+
+1. The bottom input is the command bar (smaller; no terminal-shell icon)
+2. Type `/s` — autocomplete dropdown appears showing your spaces
+3. Type `/s home` then Enter — switches to home space
+4. Type `#archived` — switches to archived view
+5. Type `/o ` — autocomplete shows artifacts
+6. Cmd+K opens spotlight; Escape closes it
+7. Click any artifact — opens its viewer
+8. Right-click an artifact → Publish — the publish modal opens
+9. Click somewhere blank, then type a plain-text message and hit Enter — input clears; nothing else happens; no thinking spinner; no network request to `/api/chat/*` in DevTools Network tab
+
+Expected: all of the above work. The chat panel does not appear because there's no streaming. The "Set up Oyster" CTA does not appear on the hero (Task 8 will add the proper wizard).
+
+If any check fails, debug before proceeding — the keystone has to be solid before Tasks 2–7 dispatch.
+
+- [ ] **Step 1.14: Trim CLAUDE.md**
+
+In `CLAUDE.md`, in the Architecture block (around line 17–32):
+
+1. Delete the `Chat proxy → OpenCode (spawned internally) → LLM` line in the ASCII diagram
+2. Delete the entire `**OpenCode** — AI engine, spawned as a subprocess...` paragraph (around line 30)
+3. Tighten the surrounding sentence to: `**Oyster Server** (port 4444 when installed, 3333 in dev) — HTTP API, artifact/space registry (SQLite), MCP tool surface, static web serving. In the installed package, this is the only user-facing port; in dev, Vite serves the UI at 7337 and proxies to the server.`
+
+This keeps CLAUDE.md aligned with the new reality. Future sessions reading this won't be misled into looking for an opencode subprocess.
+
+- [ ] **Step 1.15: CHANGELOG entry**
+
+In `CHANGELOG.md`, under the existing `## [Unreleased]` block, add to `### Changed`:
+
+```markdown
+- **Oyster no longer bundles an AI agent.** The in-app chat surface is replaced by a command bar that runs `/` and `#` shortcuts locally — switch spaces, open or publish an artefact, no LLM round-trip. Bring whichever agent you prefer: connect Claude Code, Cursor, or any MCP client at `http://localhost:4444/mcp/`. The first-run flow no longer asks you to log in to a bundled provider.
+```
+
+Keep the existing positioning bullet (the first one in `[Unreleased]`); this is a separate user-visible outcome.
+
+- [ ] **Step 1.16: Commit**
+
+```bash
+git add -A
+git status   # eyeball it; should be exactly the files this task touched
+git commit -m "$(cat <<'EOF'
+chore: cut chat bar + bundled OpenCode (#465 keystone)
+
+Removes the in-app chat surface, the spawned OpenCode subprocess,
+and the first-run `opencode providers login` flow. Replaces ChatBar
+with a CommandBar that keeps /s /o /p /u + # space switching but no
+longer runs an LLM — the user's own connected MCP agent is the AI.
+
+Deleted:
+- server/src/opencode-manager.ts, opencode-events.ts,
+  opencode-orphan-sweep.ts (~480 lines)
+- web/src/components/ChatBar.tsx, data/chat-api.ts,
+  hooks/useChatSession.ts, hooks/useChatEvents.ts
+- .opencode/, opencode.json
+- opencode-ai dep from root + server package.json
+- bin/oyster.mjs's runLogin / hasAuth / findOpenCodeBin
+
+Added:
+- web/src/components/CommandBar.tsx — local-only slash commands
+
+The Ultra Hardcore terminal modal at App.tsx:543-566 is now dead
+code (no caller); Task 2 (chore/cut-hardcore-pty-trigger) removes
+it. The first-run wizard that replaces the deleted login flow lands
+in Task 8 (feat/first-run-mcp-wizard).
+
+Closes the keystone of #465.
+EOF
+)"
+```
+
+- [ ] **Step 1.17: Push and open PR**
+
+```bash
+git push -u origin chore/cut-chatbar-opencode
+gh pr create --title "chore: cut chat bar + bundled OpenCode (#465 keystone)" --body "$(cat <<'EOF'
+## Summary
+
+Keystone of #465 — removes ~480 lines of OpenCode subprocess supervision and the in-app chat surface that contradicted *"Bring whichever agents you prefer"*. The chat bar is replaced by a command bar that keeps slash + hash commands but no longer runs an LLM.
+
+Five of the seven yellow pens in `docs/research/yellow-pen-audit.md` lose their primary caller with this change. Tasks 2–7 in #465 can now proceed in parallel; the orphaned code they target is dead.
+
+## Test plan
+
+- [ ] `grep -rn "opencode" server/src bin/` returns zero hits (other than CHANGELOG and archived docs)
+- [ ] `npm run build` succeeds
+- [ ] `npm run dev` boots cleanly with no `[opencode-*]` log lines
+- [ ] Fresh incognito click-through: `/s`, `/o`, `/p`, `/u`, `#archived`, Cmd+K spotlight, artefact publish all work
+- [ ] Plain-text input does NOT call any AI (no `/api/chat/*` requests in DevTools)
+- [ ] First-run UX boots without an AI provider configured (the OnboardingDock still mentions "connect your AI" — Task 8 polishes this)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 1.18: Stop. Wait for review and merge.**
+
+This is the keystone. Tasks 2–7 should not dispatch until this is merged to `main`. Once merged, fetch & rebase any in-flight branches against the new `main`.
+
+---
+
+## Task 2: Cut the Ultra Hardcore terminal trigger (preserve pty-manager)
+
+> **Constraint from #470:** `server/src/pty-manager.ts` survives as a private module — only delete user-facing entry points. The PTY mux is reused post-1.0.0 for peek-and-attach.
+
+**Branch:** `chore/cut-hardcore-pty-trigger`
+**Worktree:** `~/Dev/oyster.worktrees/chore-cut-hardcore-pty-trigger/`
+
+**Files:**
+- Delete: `web/src/components/TerminalWindow.tsx` (137 lines)
+- Modify: `web/src/App.tsx` — drop the `showHardcoreGate` state, the `handleOpenTerminal` + `confirmHardcore` functions, the `<TerminalWindow>` mount, the `.hardcore-gate-overlay` JSX, the `TerminalWindow` import, the windows-reducer terminal handling
+- Modify: `web/src/stores/windows.ts` — drop the `OPEN_TERMINAL` action and `terminal` window type (verify before deleting that nothing else dispatches it)
+- Modify: `server/src/index.ts` — keep `attachWebSocket` import + call (`pty-manager.ts` stays), but drop the now-unused `WORKSPACE` / `SHELL` / `SHELL_ARGS` derivations that fed `attachWebSocket`'s spawn params. **Or** call `attachWebSocket(httpServer)` without spawn params so the PTY only spawns on demand if anything ever reconnects (it won't, but the module stays mountable).
+- Modify: `CHANGELOG.md` — `[Unreleased] ### Removed`
+
+**Verification:**
+- Grep gate: `grep -rn "TerminalWindow\|hardcore\|OPEN_TERMINAL\|Game on\|talking directly to the engine" web/src/` → zero matches after
+- Boot gate: `npm run dev` succeeds; the WebSocket server still attaches (pty-manager log line `[pty] loaded @lydell/node-pty` still appears) but nothing in the UI triggers a connection
+- Click-through gate: no terminal-shell icon visible anywhere; no Ultra Hardcore modal can be summoned
+- Static check: `server/src/pty-manager.ts` still exists; `attachWebSocket` is still imported and called in `server/src/index.ts`
+
+- [ ] **Step 2.1: Create worktree**
+
+```bash
+cd ~/Dev/oyster
+git fetch origin
+git worktree add -b chore/cut-hardcore-pty-trigger ~/Dev/oyster.worktrees/chore-cut-hardcore-pty-trigger origin/main
+cd ~/Dev/oyster.worktrees/chore-cut-hardcore-pty-trigger
+cd web && npm install && cd ..
+```
+
+- [ ] **Step 2.2: Strip Ultra Hardcore from `web/src/App.tsx`**
+
+In `web/src/App.tsx`:
+
+1. Delete the import at line 7: `import { TerminalWindow } from "./components/TerminalWindow";`
+2. Delete `showHardcoreGate` state at line 103: `const [showHardcoreGate, setShowHardcoreGate] = useState(false);`
+3. Delete the `terminalWindow` selector at line 319: `const terminalWindow = windows.find((w) => w.type === "terminal");`
+4. Delete `handleOpenTerminal` + `confirmHardcore` (lines 364–377)
+5. Delete the `{terminalWindow && (<TerminalWindow ... />)}` block at lines 531–540
+6. Delete the entire `{showHardcoreGate && (<div className="hardcore-gate-overlay">...)}` block at lines 543–566
+
+After these edits, `App.tsx` has no terminal references.
+
+- [ ] **Step 2.3: Delete `TerminalWindow.tsx`**
+
+```bash
+git rm web/src/components/TerminalWindow.tsx
+```
+
+- [ ] **Step 2.4: Trim the windows reducer**
+
+Read `web/src/stores/windows.ts` and remove the `OPEN_TERMINAL` action handler and the `terminal` window type if they exist (the dispatch at App.tsx:370 was the only caller).
+
+Verification: `grep -rn "OPEN_TERMINAL\|type: \"terminal\"" web/src/` → zero matches.
+
+- [ ] **Step 2.5: Make `attachWebSocket` mount-only**
+
+In `server/src/index.ts`:
+
+1. The call at line 1017 currently is:
+   ```ts
+   attachWebSocket(httpServer, { shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: cleanEnv });
+   ```
+
+2. Change to:
+   ```ts
+   // PTY mux stays mounted as a private module per #470 — preserved for
+   // post-1.0.0 peek-and-attach. No user-facing trigger remains; the WS
+   // server will accept connections but no one in the UI opens them.
+   attachWebSocket(httpServer);
+   ```
+
+3. Remove the now-unused `WORKSPACE`, `SHELL`, `SHELL_ARGS` declarations at lines 113–115 (after Task 1, `SHELL` was already cleaned up; double-check). The `cleanEnv` variable may now be entirely unused — if so, remove it too.
+
+`pty-manager.ts`'s `attachWebSocket` signature already has optional `spawnParams` (see `pty-manager.ts:73-76`), so calling it without spawn params is supported — `spawnSession` just never gets called.
+
+- [ ] **Step 2.6: Boot & verify**
+
+```bash
+npm run build && npm run dev
+```
+
+Expected: clean boot. The `[pty] loaded @lydell/node-pty` line should still appear (the module loads), but no terminal modal can be opened.
+
+Click-through:
+- Open the app — no terminal-shell glyph next to the command bar
+- Try every keyboard shortcut — none summon a terminal
+- DevTools Network → no WebSocket connection initiates
+
+- [ ] **Step 2.7: CHANGELOG**
+
+```markdown
+- **Ultra Hardcore terminal removed.** The in-app shell ("talking directly to the engine") was a Sprint-2 power-user feature that didn't fit the current workspace-companion framing. Use your OS terminal instead. The underlying PTY mux is preserved for a future peek-and-attach view.
+```
+
+Under `### Removed` (add the section if it doesn't exist in `[Unreleased]`).
+
+- [ ] **Step 2.8: Commit + PR**
+
+```bash
+git add -A
+git commit -m "chore: cut Ultra Hardcore terminal trigger (#465)
+
+Removes the in-app shell modal and TerminalWindow. The PTY mux at
+server/src/pty-manager.ts is preserved per #470 — mounted as a
+private module, no user-facing entry point."
+git push -u origin chore/cut-hardcore-pty-trigger
+gh pr create --title "chore: cut Ultra Hardcore terminal trigger (#465)" --body "..."
+```
+
+---
+
+## Task 3: Cut handleFixError flow
+
+> **Note:** Task 1's Step 1.9 already removed `handleFixError` from `App.tsx` so the keystone could typecheck. Task 3's scope is the rest — the `onFixError` prop in `ViewerWindow.tsx` and the error-handling UI inside the viewer that surfaces the "Fix with AI" button.
+
+**Branch:** `chore/cut-fix-error`
+**Worktree:** `~/Dev/oyster.worktrees/chore-cut-fix-error/`
+
+**Files:**
+- Modify: `web/src/components/ViewerWindow.tsx` — drop `onFixError` prop, the `error` state, the "Fix with AI" button, the iframe error capture (lines 25, 113, 250, 354, 362, 472, plus the supporting state)
+- Modify: `CHANGELOG.md` — `[Unreleased] ### Removed`
+
+**Verification:**
+- Grep gate: `grep -rn "onFixError\|handleFixError\|Fix with AI\|resolve-path" web/src/ server/src/` → zero matches outside changelog/archives
+- Click-through gate: open an artefact that crashes in its iframe — the viewer surfaces the error to the user but does not offer to AI-fix it
+- Server route `/api/resolve-path` may also be deletable — grep first; if only `handleFixError` called it, delete from `server/src/routes/static.ts` (line 806 imports tryHandleStaticRoute which handles `/api/resolve-path`); search for `resolve-path` in `server/src/routes/static.ts`
+
+- [ ] **Step 3.1: Create worktree, read ViewerWindow.tsx**
+
+```bash
+cd ~/Dev/oyster
+git fetch origin
+git worktree add -b chore/cut-fix-error ~/Dev/oyster.worktrees/chore-cut-fix-error origin/main
+cd ~/Dev/oyster.worktrees/chore-cut-fix-error
+cd web && npm install && cd ..
+```
+
+Read `web/src/components/ViewerWindow.tsx` in full first to understand the error-capture flow.
+
+- [ ] **Step 3.2: Strip the AI-fix surface**
+
+In `web/src/components/ViewerWindow.tsx`:
+
+1. Remove the `onFixError?: ...` prop type (line 25)
+2. Remove `onFixError` from the destructured props (line 113)
+3. Remove the `if (!onFixError || !error) return;` guard (line 250) and the surrounding handler
+4. Remove the `const sessionId = await onFixError({ ... })` block (line 354) and any state that fed it
+5. Remove the `Fix with AI` button JSX (around line 472)
+6. Keep any error-display UI that just shows the user what crashed — only the AI-handoff goes
+
+Save the file. Run `npx tsc --noEmit -p web` — expect a couple of "unused" warnings if you missed a state variable; tidy them up.
+
+- [ ] **Step 3.3: Check `/api/resolve-path`**
+
+```bash
+grep -rn "resolve-path" web/src/ server/src/
+```
+
+If the only remaining caller was `handleFixError` (which Task 1 deleted), delete the `/api/resolve-path` handler too. Search in `server/src/routes/static.ts` for `resolve-path` and remove the route block. Then re-run the grep — expect zero matches outside of route-table docs.
+
+- [ ] **Step 3.4: Build, boot, verify**
+
+```bash
+npm run build && npm run dev
+```
+
+Open the app, open any artefact that would have surfaced a crash (e.g. a built-in HTML app). The error UI (if any) shows just the error message — no "Fix with AI" button.
+
+- [ ] **Step 3.5: CHANGELOG + commit + PR**
+
+```markdown
+- **No more AI-fix-the-crashed-artefact flow.** The viewer no longer hands stack traces to a bundled agent — Oyster doesn't generate apps, so it shouldn't be debugging them either. Use your connected agent if you need to fix something.
+```
+
+Commit: `chore: cut handleFixError and the AI-fix viewer flow (#465)`
+
+---
+
+## Task 4: Cut the fal.ai icon generator
+
+**Branch:** `chore/cut-icon-generator`
+**Worktree:** `~/Dev/oyster.worktrees/chore-cut-icon-generator/`
+
+**Files:**
+- Delete: `server/src/icon-generator.ts` (263 lines)
+- Modify: `server/src/artifact-detector.ts` — remove `IconGenerator` import (line 7) and parameter (lines 116, 170, 250, 336); remove `iconGenerator.enqueue(...)` and `forceEnqueue(...)` calls (lines 166, 212, 266, 325, 370); update function signatures to drop the parameter
+- Modify: `server/src/mcp-server.ts` — remove `IconGenerator` import (line 8), the `iconGenerator: IconGenerator;` field on deps (line 124), the `deps.iconGenerator.forceEnqueue(...)` call at line 812
+- Modify: `server/src/index.ts` — remove `IconGenerator` import (line 25), the `new IconGenerator(updateGeneratedArtifact)` construction (line 632), pass-throughs to `scanExistingArtifacts` / `startGenerationTimer` / `handleFileEdited` / `tryHandleArtifactRoute` / `tryHandleOAuthMcpRoute` (lines 648, 658, 662, 677, 683, 750, 792). All four call-sites: drop the `iconGenerator` arg
+- Modify: `package.json` + `server/package.json` — remove `@fal-ai/client` from `dependencies`
+- Modify: `server/src/routes/artifacts.ts` (probably) — wherever `iconGenerator` is passed through, remove
+- Modify: `shared/types.ts` — `IconStatus` type may still be referenced from existing `Artifact.iconStatus` field; decide whether to keep `icon?: string` on existing rows as a legacy field (yes — there are persisted rows) but drop new generation. The field stays; only the generator goes.
+- Modify: `CHANGELOG.md` — `### Removed`
+
+**Verification:**
+- Grep gate: `grep -rn "IconGenerator\|icon-generator\|fal\.ai\|fal-ai/flux\|FAL_KEY" server/src/ shared/ package.json server/package.json` → zero matches
+- `grep -rn "fal\\.subscribe\|@fal-ai" server/src/` → zero matches
+- Boot gate: `npm run build && npm run dev` succeeds; no `[icon-generator]` log lines
+- Functional gate: create a new artefact via MCP (`create_artifact`) — the artefact appears in the surface with whatever fallback icon the UI uses for `iconStatus: undefined`. No fal.ai bill incurred.
+
+- [ ] **Step 4.1: Worktree + dependency scan**
+
+```bash
+cd ~/Dev/oyster
+git worktree add -b chore/cut-icon-generator ~/Dev/oyster.worktrees/chore-cut-icon-generator origin/main
+cd ~/Dev/oyster.worktrees/chore-cut-icon-generator
+grep -rn "IconGenerator\|iconGenerator\|icon-generator\|@fal-ai\|fal\.subscribe\|FAL_KEY" server/src/ shared/ web/src/ package.json server/package.json > /tmp/before-task4.txt
+wc -l /tmp/before-task4.txt
+```
+
+Save the before-grep so you can verify completeness later.
+
+- [ ] **Step 4.2: Delete `icon-generator.ts`**
+
+```bash
+git rm server/src/icon-generator.ts
+```
+
+This breaks the build. Steps 4.3–4.6 fix each callsite.
+
+- [ ] **Step 4.3: Strip `artifact-detector.ts`**
+
+In `server/src/artifact-detector.ts`:
+
+1. Delete the import at line 7: `import { IconGenerator } from "./icon-generator.js";`
+2. Change function signatures that take `iconGenerator: IconGenerator` to no longer take it (lines 116, 170, 250, 336). Track each parameter through to its callsite.
+3. Delete `iconGenerator.enqueue(...)` calls (lines 166, 325, 370) and `registerArtifactFromManifest(manifest, artifactDir, iconGenerator, true)` calls — drop the `iconGenerator` arg from the latter (lines 212, 266).
+
+- [ ] **Step 4.4: Strip `mcp-server.ts`**
+
+In `server/src/mcp-server.ts`:
+
+1. Delete the import at line 8
+2. Delete `iconGenerator: IconGenerator;` from the deps type (line 124)
+3. Delete the `force_regenerate_icon` MCP tool entirely (the block containing `deps.iconGenerator.forceEnqueue(...)` at line 812). Grep to find the tool definition's start (`server.tool("force_regenerate_icon", ...)` or similar) and end (the closing of the tool handler).
+
+- [ ] **Step 4.5: Strip `server/src/index.ts`**
+
+1. Delete `import { IconGenerator } from "./icon-generator.js";` at line 25
+2. Delete `const iconGenerator = new IconGenerator(updateGeneratedArtifact);` at line 632
+3. Update the bootMark string at line 639 to drop `iconGenerator`
+4. Drop the `iconGenerator` argument from every call:
+   - `scanExistingArtifacts(APPS_DIR, iconGenerator)` at line 648 → `scanExistingArtifacts(APPS_DIR)`
+   - Same for line 658 (`scanExistingArtifacts(spaceDir, iconGenerator, { manifestOnly: true })`) → `scanExistingArtifacts(spaceDir, { manifestOnly: true })`
+   - Same for line 662 (`scanExistingArtifacts(ARTIFACTS_DIR, iconGenerator)`)
+   - `startGenerationTimer(iconGenerator, ...)` at line 677 → reconsider: this function probably exists primarily to handle icon-gen status transitions. Check `artifact-detector.ts` for its definition; if its only job was driving icon-gen, delete the call here AND the function definition. If it has other side-effects, drop the iconGenerator arg.
+   - `handleFileEdited(file, ARTIFACTS_DIR, iconGenerator)` at line 683 → likewise
+   - In `tryHandleArtifactRoute({ ..., iconGenerator, ... })` at line 750 → drop the field. Then update `server/src/routes/artifacts.ts` deps signature.
+   - In `tryHandleOAuthMcpRoute({ ..., iconGenerator, ... })` at line 792 → drop the field. Then update `server/src/routes/oauth-mcp.ts` and `server/src/mcp-server.ts` deps signature consistently.
+
+- [ ] **Step 4.6: Strip from route files**
+
+```bash
+grep -rn "iconGenerator" server/src/routes/ server/src/mcp-server.ts
+```
+
+For each match, drop the field from the deps interface and any pass-through.
+
+- [ ] **Step 4.7: Drop `@fal-ai/client`**
+
+In `package.json` (root), delete `"@fal-ai/client": "^1.10.1",` from `dependencies`.
+In `server/package.json`, same.
+
+```bash
+npm install --package-lock-only
+cd server && npm install --package-lock-only && cd ..
+```
+
+- [ ] **Step 4.8: Typecheck + boot**
+
+```bash
+cd server && npx tsc --noEmit && cd ..
+npm run build
+npm run dev
+```
+
+Expected: all green, server boots, no `[icon-generator]` log lines.
+
+Re-run the before-grep:
+```bash
+grep -rn "IconGenerator\|iconGenerator\|icon-generator\|@fal-ai\|fal\.subscribe\|FAL_KEY" server/src/ shared/ web/src/ package.json server/package.json
+```
+Expected: zero matches (or only matches in CHANGELOG / docs).
+
+- [ ] **Step 4.9: Functional check — create artefact via MCP**
+
+With the dev server running, point a connected MCP client (Claude Code is easiest) at `http://localhost:3333/mcp/`. Call `create_artifact` with any args. The artefact should appear in the Oyster surface with a fallback icon (whatever `ArtifactIcon` renders for `iconStatus: undefined`). No fal.ai call attempted.
+
+- [ ] **Step 4.10: CHANGELOG + commit + PR**
+
+```markdown
+- **No more AI-generated icons.** Artefacts no longer trigger a fal.ai Flux image generation on creation. The fal.ai dependency and `FAL_KEY` are removed; existing icons stay in place. New artefacts use the built-in fallback glyph.
+```
+
+Branch: `chore/cut-icon-generator`. Commit + push + PR.
+
+---
+
+## Task 5: Cut local_process runtime + process-manager.ts lifecycle bits
+
+> **Order constraint:** must come after Task 4. `process-manager.ts` exports `updateGeneratedArtifact` which the icon generator consumed. After Task 4 lands, the registry's only remaining consumer is `artifact-detector.ts` (for the `getGeneratedArtifactEntries` reconcile loop in `server/src/index.ts:670`). We split: keep the in-memory registry (move it to `artifact-detector.ts` or a tiny new `artifact-registry.ts`), delete the lifecycle/port-management bits, delete the `/api/apps/:name/start|stop` route handlers.
+
+**Branch:** `chore/cut-local-process`
+**Worktree:** `~/Dev/oyster.worktrees/chore-cut-local-process/`
+
+**Files:**
+- Modify or delete: `server/src/process-manager.ts` (169 lines) — split into:
+  - Move the registry (`generatedArtifacts` Map, `registerGeneratedArtifact`, `updateGeneratedArtifact`, `getGeneratedArtifactEntries`, lines 21–54) into a new `server/src/artifact-registry.ts` (or fold into `artifact-detector.ts` if it has natural affinity)
+  - Delete the rest: `startApp`, `stopApp`, `isPortOpen`, `isHttpReady`, `waitForReady`, `tryConnect`, `procs` Map, `starting` Set, cleanup handler
+- Delete the file `server/src/process-manager.ts` after the move
+- Modify: `server/src/index.ts` — change imports at lines 7–15 from `./process-manager.js` to `./artifact-registry.js` (just the registry symbols + the `ArtifactKind` re-export); remove `startApp, stopApp, isPortOpen, waitForReady` imports; in the `tryHandleStaticRoute` deps at lines 818, drop `startApp, stopApp, isPortOpen, waitForReady` from what's passed (the routes will be deleted in static.ts)
+- Modify: `server/src/routes/static.ts` — delete the `/api/apps/:name/start|stop` handlers (lines around 188 per the grep); drop `startApp`, `stopApp`, `isPortOpen`, `waitForReady` from the deps interface
+- Modify: `web/src/App.tsx` — delete the `if (artifact.runtimeKind === "local_process")` branch at lines 337–354 of the original (which started apps via `startAppApi`); delete the `import { startApp as startAppApi, stopApp as stopAppApi } from "./data/artifacts-api"` (line 18) — only `runtimeKind === "redirect"` and static-viewer branches remain
+- Modify: `web/src/App.tsx` — delete `handleArtifactStop` (around line 379) and the `onArtifactStop` props propagation
+- Modify: `web/src/data/artifacts-api.ts` — delete `startApp` and `stopApp` functions (lines 12 onwards)
+- Modify: `web/src/components/ArtifactIcon.tsx` — drop the `isManagedApp = artifact.runtimeKind === "local_process"` status indicators (line 90–91)
+- Modify: `web/src/components/Desktop.tsx` (probably) — drop any local_process-specific UI
+- Modify: `server/src/space-service.ts:537` — `runtimeKind = "local_process";` assignment — replace with `runtimeKind = "static";` or drop the branch entirely depending on what the surrounding code does
+- Modify: `server/src/artifact-service.ts:254, 654` — same handling
+- Modify: `CHANGELOG.md`
+
+**Verification:**
+- Grep gate: `grep -rn "local_process\|startApp\|stopApp\|process-manager\|isPortOpen\|waitForReady" server/src web/src shared/` → zero matches outside the registry move-source and CHANGELOG
+- Boot gate: server starts, no `/api/apps/*` routes resolve (curl returns 404)
+- Click-through gate: artefacts with manifest type `app` still appear and open in the viewer; no "Start" or "Stop" UI; managed apps (none should exist on a fresh install after Task 6's zombie-horde cut) don't appear in the surface
+
+- [ ] **Step 5.1–5.N: Detailed steps follow the same shape as Tasks 1 and 4.**
+
+Sub-steps in order:
+1. Worktree (`chore/cut-local-process`)
+2. Snapshot before-grep
+3. Create `server/src/artifact-registry.ts` with the registry symbols copied from `process-manager.ts:21-54`
+4. Update every importer of `./process-manager.js` to import from `./artifact-registry.js` (mainly `server/src/index.ts` at lines 7–15)
+5. Delete `server/src/process-manager.ts`
+6. Update `server/src/routes/static.ts` — drop the start/stop handlers + the deps fields
+7. Update `server/src/index.ts:818` to remove `startApp, stopApp, isPortOpen, waitForReady` from the static-route deps
+8. Update `web/src/App.tsx` to drop the local_process branch and `handleArtifactStop`
+9. Update `web/src/data/artifacts-api.ts` to delete `startApp` / `stopApp` client functions
+10. Update `web/src/components/ArtifactIcon.tsx` to drop the managed-app status indicators
+11. Audit `web/src/components/Desktop.tsx`, `GroupPopup.tsx` for any remaining `onArtifactStop` or `runtimeKind === "local_process"` references and remove
+12. Audit `server/src/space-service.ts:537`, `artifact-service.ts:254, 654` for `runtimeKind === "local_process"` branches — these are server-side runtime classification; treat all surviving artefact kinds as static for surface purposes
+13. Typecheck both projects (`server` + `web`)
+14. Boot + click-through
+15. CHANGELOG: `- **No more in-app dev-server runtime.** The "Start" / "Stop" buttons on app artefacts are gone, along with the local_process runtime. Run your own dev servers; Oyster surfaces the static output, it doesn't manage processes.`
+16. Commit + PR
+
+Detailed step bodies for the more delicate edits:
+
+**Sub-step 5.3 (artifact-registry.ts) full content:**
+
+```ts
+// In-memory registry of generated artefacts discovered during boot or via
+// the watcher. Used by the reconcile loop in server/src/index.ts to flush
+// new artefacts into the DB once they appear on disk. Lifted out of
+// process-manager.ts during the 0.10.0 surgery so the lifecycle/port-
+// management bits could be deleted while the registry survived.
+
+import { existsSync } from "node:fs";
+import type { Artifact } from "../../shared/types.js";
+
+export type { Artifact, ArtifactKind, ArtifactStatus, IconStatus } from "../../shared/types.js";
+
+type GeneratedEntry = Artifact & { filePath?: string; builtin?: boolean; plugin?: boolean };
+
+const generatedArtifacts = new Map<string, GeneratedEntry>();
+
+export function registerGeneratedArtifact(
+  artifact: Artifact,
+  filePath?: string,
+  builtin = false,
+  plugin = false,
+): void {
+  generatedArtifacts.set(artifact.id, { ...artifact, filePath, builtin, plugin });
+}
+
+export function updateGeneratedArtifact(id: string, fields: Partial<Artifact>, filePath?: string): void {
+  const existing = generatedArtifacts.get(id);
+  if (existing) {
+    Object.assign(existing, fields);
+    if (filePath !== undefined) existing.filePath = filePath;
+  }
+}
+
+export function getGeneratedArtifactEntries(onRemove?: (id: string, filePath: string) => void): GeneratedEntry[] {
+  for (const [id, entry] of generatedArtifacts) {
+    if (entry.filePath && !existsSync(entry.filePath)) {
+      console.log(`[artifact-cleanup] removed stale artifact: ${entry.label} (${entry.filePath})`);
+      generatedArtifacts.delete(id);
+      onRemove?.(id, entry.filePath);
+    }
+  }
+  return Array.from(generatedArtifacts.values());
+}
+```
+
+After Task 4 lands, `updateGeneratedArtifact` may have zero callers (icon-generator was the primary one). Check after Task 4 has merged: if `grep -rn "updateGeneratedArtifact" server/src/` is empty, delete the export entirely. If something else (e.g. artifact-detector status transitions) calls it, keep.
+
+---
+
+## Task 6: Delete builtins/zombie-horde + re-audit other builtins
+
+**Branch:** `chore/cut-zombie-horde`
+**Worktree:** `~/Dev/oyster.worktrees/chore-cut-zombie-horde/`
+
+**Files:**
+- Delete: `builtins/zombie-horde/` (entire directory)
+- Modify: `CHANGELOG.md`
+- Re-audit (separate decision in this PR's description, then act on the decisions):
+  - `builtins/where-are-my-files/` — likely keeps (orients users in Finder)
+  - `builtins/quick-start/` — likely keeps (first-run welcome)
+  - `builtins/connect-your-ai/` — likely keeps, but check if it duplicates Task 8's wizard; if so, delete
+  - `builtins/the-worlds-your-oyster/` — re-evaluate against R1–R7; likely cut (poetic but not R-aligned)
+  - `builtins/import-from-ai/` — likely keeps (R5-adjacent — paste-from-another-AI flow)
+
+**Verification:**
+- Grep gate: `grep -rn "zombie-horde\|--acid\|--ember\|zombie" builtins/ server/src/ web/src/` → zero matches
+- Filesystem check on fresh install: in a *new* userland (`rm -rf userland/apps/ && npm run dev`), `ls userland/apps/` lists only the surviving builtins. **No zombie-horde.**
+- Boot gate: no errors during the `bootstrap` step (`[bootstrap] installed built-in: ...` lines should be 4–5, not 6)
+
+- [ ] **Step 6.1: Worktree**
+
+```bash
+cd ~/Dev/oyster
+git worktree add -b chore/cut-zombie-horde ~/Dev/oyster.worktrees/chore-cut-zombie-horde origin/main
+cd ~/Dev/oyster.worktrees/chore-cut-zombie-horde
+```
+
+- [ ] **Step 6.2: Delete the directory**
+
+```bash
+git rm -r builtins/zombie-horde/
+```
+
+- [ ] **Step 6.3: Audit the others — write the decision in the PR body**
+
+For each surviving builtin, read `builtins/<name>/manifest.json` and `builtins/<name>/src/index.html` (or equivalent) and write a one-line decision in the PR description:
+
+```
+- zombie-horde: DELETE — Sprint-2 demo, no R alignment
+- where-are-my-files: KEEP — R1 (returning-user orientation)
+- quick-start: KEEP — first-run UX
+- connect-your-ai: DECIDE after Task 8 lands — may be redundant with the wizard
+- the-worlds-your-oyster: DELETE — poetic, no R alignment (proposal)
+- import-from-ai: KEEP — adjacent to R5 paste-from-another-AI flow
+```
+
+Act on the DELETEs in this PR. Reviewers can push back on the `the-worlds-your-oyster` cut if there's disagreement.
+
+- [ ] **Step 6.4: Wipe local userland then boot**
+
+```bash
+rm -rf userland/apps/zombie-horde/ userland/apps/the-worlds-your-oyster/  # if also deleting
+npm run dev
+```
+
+The bootstrap loop at `server/src/index.ts:224-231` re-syncs every entry in `builtins/` into `userland/apps/`. With zombie-horde gone from source, it never lands in userland.
+
+- [ ] **Step 6.5: Click-through**
+
+Open the app. The bare Home view no longer shows a zombie game tile. The surviving builtin tiles render correctly.
+
+- [ ] **Step 6.6: CHANGELOG + commit + PR**
+
+```markdown
+- **Built-in app cleanup.** The Sprint-2 zombie-horde demo and the poetic-but-off-spine "the-worlds-your-oyster" builtin are removed. The remaining built-ins — quick-start, connect-your-ai, where-are-my-files, import-from-ai — earn their place against the R1–R7 requirements.
+```
+
+---
+
+## Task 7: Collapse artefact kinds (7 → 3)
+
+> **Goal:** `notes`, `app`, `diagram`. Absorb `deck`, `wireframe`, `map`, `table` into `notes`. This removes the visual menu that implies Oyster generates decks / wireframes / maps / tables — which it hasn't done since Sprint-2 anyway.
+
+**Branch:** `chore/collapse-artefact-kinds`
+**Worktree:** `~/Dev/oyster.worktrees/chore-collapse-artefact-kinds/`
+
+**Files:**
+- Modify: `shared/types.ts:1-3` — change `ARTIFACT_KINDS` to `["app", "diagram", "notes"]`
+- Modify: `shared/types.ts:7-9` — update `shouldOpenFullscreen` to drop the `deck` branch (now `notes` opens non-fullscreen, `app` and `diagram` open fullscreen)
+- Modify: `server/src/mcp-server.ts:680` — the legacy hardcoded enum in `update_artifact` tool: replace `z.enum(["app", "deck", "map", "notes", "diagram", "wireframe", "table"])` with `z.enum(["app", "diagram", "notes"])`
+- Modify: `server/src/mcp-server.ts:653` — the `create_artifact` tool's `artifact_kind: z.enum(ARTIFACT_KINDS).describe("Default file extension: ...")` — update the description to reflect the new 3 kinds
+- Modify: `server/src/db.ts:10` — `artifact_kind  TEXT NOT NULL,` stays (string column, no enum constraint). Add a **data migration** that maps existing rows: `UPDATE artifacts SET artifact_kind = 'notes' WHERE artifact_kind IN ('deck', 'wireframe', 'map', 'table');`
+- Modify: `web/src/components/ArtifactIcon.tsx` — drop the per-kind icon glyphs for the removed kinds; map them to the notes glyph if any persisted rows escaped the migration
+- Search: `grep -rn "\"deck\"\|\"wireframe\"\|\"map\"\|\"table\"" web/src/ server/src/ shared/` and update every callsite that switch-cases on the old kinds
+- Modify: `CHANGELOG.md`
+
+**Verification:**
+- Grep gate (in source): `grep -rn "\"deck\"\|\"wireframe\"\|\"map\"\|\"table\"" web/src/ server/src/ shared/ | grep -v "^.*\.md:"` → zero matches
+- Migration gate: with an existing DB containing rows with `artifact_kind = 'deck'`, boot the server; verify the migration ran (one-shot UPDATE) and those rows now read `'notes'`. Use `sqlite3 userland/db/oyster.db "SELECT DISTINCT artifact_kind FROM artifacts;"` and confirm only `app`, `diagram`, `notes` appear.
+- MCP gate: a connected agent calling `create_artifact` with `artifact_kind: "deck"` gets a validation error; calling with `artifact_kind: "notes"` succeeds.
+- Click-through gate: existing artefacts still render; their tile icons match the surviving kinds.
+
+- [ ] **Step 7.1: Worktree**
+
+```bash
+git worktree add -b chore/collapse-artefact-kinds ~/Dev/oyster.worktrees/chore-collapse-artefact-kinds origin/main
+cd ~/Dev/oyster.worktrees/chore-collapse-artefact-kinds
+```
+
+- [ ] **Step 7.2: Update `shared/types.ts`**
+
+Change lines 1–3:
+```ts
+export const ARTIFACT_KINDS = [
+  "app", "diagram", "notes",
+] as const;
+```
+
+Change lines 7–9:
+```ts
+export function shouldOpenFullscreen(kind: ArtifactKind): boolean {
+  return kind === "app" || kind === "diagram";
+}
+```
+
+- [ ] **Step 7.3: Add the DB migration**
+
+Read `server/src/db.ts` first to understand the existing migration shape. Project convention is additive idempotent migrations with try/catch (per CLAUDE.md). Add at the appropriate point in the migration chain:
+
+```ts
+// Sprint 6 surgery (0.10.0): collapse 7 artefact kinds → 3. Map deprecated
+// kinds (deck, wireframe, map, table) onto notes; existing rows are
+// updated in place. Idempotent — runs every boot but is a no-op once the
+// data is converged.
+try {
+  db.prepare(
+    `UPDATE artifacts SET artifact_kind = 'notes'
+       WHERE artifact_kind IN ('deck', 'wireframe', 'map', 'table')`,
+  ).run();
+} catch (err) {
+  console.warn(`[db] artefact_kind migration failed: ${err instanceof Error ? err.message : err}`);
+}
+```
+
+- [ ] **Step 7.4: Update `server/src/mcp-server.ts`**
+
+Two changes:
+
+1. Line 680 — replace the hardcoded enum:
+   ```ts
+   artifact_kind: z.enum(["app", "diagram", "notes"]).optional().describe("Correct the artifact kind if it was inferred incorrectly."),
+   ```
+
+2. Line 653 — `artifact_kind: z.enum(ARTIFACT_KINDS).describe(...)` — update the description to:
+   ```ts
+   artifact_kind: z.enum(ARTIFACT_KINDS).describe("Default file extension: notes→.md, diagram→.mmd, app→.html."),
+   ```
+
+The const-satisfies guard at line 22 (`as const satisfies readonly ArtifactKind[]`) now enforces 3 kinds at compile time — if there's any remaining hardcoded list that fell out of sync, tsc tells you.
+
+- [ ] **Step 7.5: Audit callsites**
+
+```bash
+grep -rn "\"deck\"\|\"wireframe\"\|\"map\"\|\"table\"" web/src/ server/src/ shared/
+```
+
+For each hit, either delete (if it's a switch case on the kind for behaviour that's now moot), or remap to `"notes"` (if it's a fallback). Specific known hits:
+- `web/src/App.tsx:482-483` — `a.artifactKind !== "app"` filter for viewer navigation — unaffected
+- `web/src/data/artifacts-api.ts` if there are any kind-specific exports — probably none
+- `server/src/icon-generator.ts:217-225` — `typePalette` map — **this file is deleted in Task 4**, irrelevant if Task 4 lands first
+
+If Task 7 lands before Task 4, you may need to also patch `icon-generator.ts:217-225` to drop the deprecated kind entries. Easier to land Task 4 first.
+
+- [ ] **Step 7.6: ArtifactIcon update**
+
+In `web/src/components/ArtifactIcon.tsx`, find the icon-glyph switch on `artifactKind` and remove the cases for the removed kinds (or remap them all to the notes glyph as a graceful fallback for any legacy persisted row that escapes migration).
+
+- [ ] **Step 7.7: Typecheck + boot + verify**
+
+```bash
+cd server && npx tsc --noEmit && cd ..
+cd web && npx tsc --noEmit && cd ..
+npm run build && npm run dev
+```
+
+```bash
+sqlite3 userland/db/oyster.db "SELECT DISTINCT artifact_kind FROM artifacts;"
+```
+Expected: only `app`, `diagram`, `notes` (or empty if no artefacts).
+
+- [ ] **Step 7.8: CHANGELOG + commit + PR**
+
+```markdown
+- **Three artefact kinds, not seven.** The surface now describes the kinds Oyster actually surfaces in 2026: **notes**, **app**, **diagram**. Decks, wireframes, maps, and tables collapse into notes — kinds that promised generative pipelines Oyster doesn't run. Existing artefacts are migrated on first boot.
+```
+
+---
+
+## Task 8: First-run "connect your agent" wizard
+
+> **Replaces:** the deleted `opencode providers login` flow from Task 1. The new wizard is a static, AI-free piece of UX: it shows the MCP endpoint URL, gives copy-paste snippets for Claude Code / Cursor / OpenCode, and confirms once an MCP client connects.
+
+**Branch:** `feat/first-run-mcp-wizard`
+**Worktree:** `~/Dev/oyster.worktrees/feat-first-run-mcp-wizard/`
+
+**Files:**
+- Modify: `web/src/components/OnboardingDock.tsx` — the existing dock is a likely host for the wizard's CTA. Read it (617 lines) first to find the right insertion point.
+- Create: `web/src/components/ConnectAgentWizard.tsx` — the new modal/panel with the MCP URL, copy buttons, and a "Connected!" state driven by the existing SSE `mcp_client_connected` event (see `server/src/index.ts:825` — UI events stream emits these)
+- Modify: `bin/oyster.mjs` — the welcome banner already prints `Mission control for the AI era.`; the wizard's job is the next step the user takes after opening the browser. No CLI changes needed if the banner already directs them to the URL.
+- Modify: `CHANGELOG.md` — `### Added`
+
+**Verification:**
+- Fresh-userland gate: `rm -rf userland/; npm run dev`; open the browser; the wizard appears prominently on first run, dimisses on completion, and does not reappear on subsequent boots (state in localStorage or in the DB's `app_state` table)
+- Click-through: click "Copy MCP URL" — clipboard contains `http://localhost:3333/mcp/` (dev) or `http://localhost:4444/mcp/` (installed)
+- SSE gate: while the wizard is showing, connect a Claude Code session to the MCP endpoint — the wizard transitions to a "Connected — you're set" state within a few seconds
+- No-AI gate: the wizard never references "opencode", "providers login", or "API key"; it's pure connect-your-own-agent UX
+
+- [ ] **Step 8.1–8.N (sketched, fill in during execution):**
+
+1. Worktree (`feat/first-run-mcp-wizard`)
+2. Read `OnboardingDock.tsx` to understand the existing onboarding flow + where to anchor the wizard
+3. Read `server/src/index.ts` around line 825 (`mcp_client_connected` event broadcast) to confirm the SSE event shape — the wizard subscribes to it
+4. Write `ConnectAgentWizard.tsx` with three states: (a) intro + copy URL + per-agent snippets; (b) waiting for connection; (c) connected (auto-dismiss with celebratory animation, 3-second fade)
+5. Wire it into App.tsx as a modal gated on first-run signal (e.g., `spaces.length === 0 && !localStorage.getItem("oyster-mcp-onboarded")`)
+6. Add a vitest unit test for the snippet generation (`expect(buildClaudeCodeSnippet("http://localhost:3333/mcp/")).toContain('"oyster":')`) — this is small enough to TDD properly. Place in `server/test/wizard-snippets.test.ts` if the snippet logic lives server-side, or `web/test/...` if it's client-side
+7. Manual click-through with Claude Code as the test client
+8. CHANGELOG: `- **Connect-your-agent wizard on first run.** Fresh installs open a static guide showing the MCP endpoint URL with copy-paste snippets for Claude Code, Cursor, and OpenCode. The wizard auto-dismisses the moment your agent connects. No AI provider configuration required — Oyster is pure workspace, you bring the agent.`
+9. Commit + PR
+
+The wizard's full implementation is detailed enough to deserve its own writing-plans pass once Task 1 has merged — the design depends on how the OnboardingDock evolves and how the existing `setup_proposal` flow already shapes user expectations. Recommendation: write a focused plan at `docs/plans/2026-05-XX-first-run-mcp-wizard.md` after Task 1 lands.
+
+---
+
+## Task 9: Pricing-page Pro-tier strap decision
+
+> **Tracked separately as #467.** Not in scope for the surgery's code work. The plan acknowledges it because closing #465 cleanly may depend on the strap line being aligned with the new "Bring whichever agents you prefer" positioning. If #467 isn't decided by the time Tasks 1–8 are merged, file a final follow-up note on #465 pointing at #467, then close.
+
+No worktree needed for this — it's a copy decision tracked in #467, manifesting as a one-line change to `docs/pricing.html`.
+
+---
+
+## Self-review
+
+This plan was reviewed against:
+
+1. **Spec coverage:** Every cut named in #465's handover (chat bar + OpenCode, Ultra Hardcore PTY trigger, handleFixError, fal.ai icon generator, local_process runtime, zombie-horde, artefact-kind collapse, first-run wizard, pricing strap) has a task. The "preserve pty-manager.ts" constraint from #470 is explicit in Task 2.
+
+2. **Placeholder scan:** No "TBD", "handle later", or "similar to Task N" placeholders. Two known abstractions:
+   - Task 5's detailed step-by-step is shaped rather than fully literal because process-manager's split is dependent on what Task 4 leaves behind — the executor adapts after running the post-Task-4 grep.
+   - Task 8 is sketched rather than fully literal because the wizard's design touches OnboardingDock and SetupProposalPanel in ways that need a fresh look once Task 1 has shipped. The plan explicitly recommends a follow-up writing-plans pass for it.
+
+3. **Type consistency:** `ArtifactKind` collapse is type-checked at compile time via the `satisfies readonly ArtifactKind[]` guard at `server/src/mcp-server.ts:22`. The DB migration in Task 7 covers existing rows.
+
+4. **Verification model:** Adapted to the project's reality (no existing test suite). Every task has a grep gate, a boot gate, and a click-through gate. Vitest unit tests are added only where new non-trivial logic lands (Task 8).
+
+5. **Order:** Strict — Task 1 first (load-bearing), Task 4 before Task 5, Task 8 after Task 1. Tasks 2, 3, 6, 7 are independent post-keystone.
+
+6. **Scope discipline:** No backwards-compatibility shims, no defensive `// removed in 0.10.0` comments left in the source. CHANGELOG carries the user-visible record; git carries the code record. CLAUDE.md updated where it referenced the deleted architecture.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/plans/2026-05-14-0.10.0-surgery.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for Tasks 1, 4, 5, 8 (where the code changes are non-trivial). After Task 1 merges, Tasks 2, 3, 6, 7 can dispatch in parallel.
+
+**2. Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints for review. Good for Tasks 2, 3, 6 (mostly deletions).
+
+**Which approach?**
+
+If Subagent-Driven chosen:
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Fresh subagent per task + two-stage review (post-task self-check, then human review before merge)
+
+If Inline Execution chosen:
+- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
+- Batch execution with checkpoints after each task's boot-clean gate


### PR DESCRIPTION
## Summary

Adds the detailed implementation plan for the 0.10.0 surgery work (#465). Companion to the existing #465 checklist — not a replacement.

## Why now

The plan has been floating untracked across several sessions. Items 4 ([fal.ai icon generator, #485](https://github.com/oyster-to/oyster/pull/485)) and 6 ([Sprint-2 demo builtins, #487](https://github.com/oyster-to/oyster/pull/487)) have already shipped against it. Items 1, 2, 3, 5, and 7 remain — each non-trivial enough to benefit from a pre-decomposed playbook.

## What's in it

1366 lines covering all seven cut targets from the yellow-pen audit:

1. **Bundled OpenCode + in-app chat bar** (the keystone; cuts 5 dependents)
2. Ultra Hardcore PTY mode
3. AI-fixes-crashed-artefacts
4. ~~fal.ai icon generator~~ (shipped via #485)
5. \`local_process\` app runtime
6. ~~\`builtins/zombie-horde/\`~~ (shipped via #487)
7. First-run \`opencode providers login\` replacement

Each cut target has: exact files + line numbers, replacement code where applicable, acceptance checks, and dependencies on prior cuts.

## What this PR is NOT

- Not new code. No schema changes, no UI, no behaviour change.
- Doesn't supersede #465 — that issue stays the canonical checklist.
- Doesn't commit Oyster to executing the remaining items on any schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)