### PR TITLE
chore: one workspace, one Oyster per machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ shared/types.js
 userland/
 server/registry.json
 
+# Dev-mode handshake file (server writes the bound port for the Vite proxy)
+.dev-port
+
 # Discovery PoC output (contains real paths/emails)
 scripts/discovery-poc-last.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **One Oyster per machine.** Dev mode and the installed package now share a single workspace at `~/Oyster/` instead of dev getting its own `./userland/` copy. Starting a second Oyster against the same workspace is refused with a clear *"already running on port X (pid Y)"* message rather than racing against the first one on the SQLite DB and `.dev-port` file. Set `OYSTER_USERLAND=/some/path` if you genuinely want an isolated worktree (and a different `OYSTER_PORT`).
 - **Sessions bind to the most specific matching folder.** Attaching `~/Repo` then later `~/Repo/web` now moves sessions that ran in `~/Repo/web` over to the more specific source automatically. Manually-pinned sessions are immune.
 - **Attaching a folder no longer requires it to exist on disk.** The orphan-tile attach flow used to throw when the folder had been renamed since the sessions ran. Attach succeeds; the tile renders with the amber *Path missing* chip; the longest-prefix heuristic claims the matching sessions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Browser → http://localhost:4444
 
 **OpenCode** — AI engine, spawned as a subprocess by the server. Not user-facing. Configured via `.opencode/agents/oyster.md` and `.opencode/config.toml`.
 
-**SQLite** (`~/Oyster/db/oyster.db` installed; `./userland/db/oyster.db` dev) — artefact and space registry. Fast, local, no infrastructure.
+**SQLite** (`~/Oyster/db/oyster.db`) — artefact and space registry. Fast, local, no infrastructure. Dev and the installed package share the same workspace; a single-instance lockfile (`~/Oyster/.oyster.lock`) makes two concurrent servers impossible. Override with `OYSTER_USERLAND=/some/other/path` only for an isolated worktree.
 
 **Memory (v1)** — SQLite FTS5-backed `remember` / `recall` / `forget` / `list_memories` tools in `server/src/memory-store.ts`. Richer cross-session / graph-based memory is future work.
 
@@ -87,7 +87,7 @@ npm run build:changelog  # renders CHANGELOG.md → docs/changelog.html
 - Never write to SQLite directly from agent — use MCP tools
 - `source_origin: 'ai_generated'` on all agent-created artifacts
 - SQLite migrations are additive `ALTER TABLE ... ADD COLUMN` with try/catch (idempotent)
-- User workspace lives at `~/Oyster/` (installed) or `./userland/` (dev), split into `db/`, `config/`, `apps/`, `backups/`, `spaces/`. See `docs/plans/archived/userland-layout.md` for the full layout.
+- User workspace lives at `~/Oyster/`, split into `db/`, `config/`, `apps/`, `backups/`, `spaces/`. Dev and the installed package share this directory and cannot run concurrently (lockfile enforced). See `docs/plans/archived/userland-layout.md` for the full layout.
 - Always use feature branches, never commit to main directly
 - Add a `CHANGELOG.md` entry in the same PR as any user-visible change; run `npm run build:changelog` to refresh `docs/changelog.html` (also auto-runs via the `version` lifecycle on `npm run release`)
 - Changelog style is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/): terse bullets under Added / Changed / Fixed / Security, each one a user-visible outcome (bold lead-in, 1–2 lines max). No internal file paths, MCP tool names, route names, or implementation detail — those belong in the PR. If a section runs past ~6 bullets or any bullet runs past two lines, cut it down before tagging.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:changelog": "node scripts/build-changelog.mjs",
     "preview:banner": "node scripts/preview-banner.mjs",
     "serve:docs": "npm run build:changelog && npx --yes serve@14 docs",
-    "dev": "npx concurrently -n web,server -c blue,green \"npx wait-on file:userland/.dev-port && cd web && npm run dev\" \"cd server && npm run dev\"",
+    "dev": "npx concurrently -n web,server -c blue,green \"npx wait-on file:.dev-port && cd web && npm run dev\" \"cd server && npm run dev\"",
     "dev:web": "cd web && npm run dev",
     "dev:server": "cd server && npm run dev",
     "version": "npm run build:changelog && git add docs/changelog.html",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import {
   type ArtifactKind,
 } from "./process-manager.js";
 import Database from "better-sqlite3";
+import { acquireLock, AlreadyRunningError, releaseLock, setLockPort } from "./single-instance-lock.js";
 import { initDb } from "./db.js";
 import { SqliteArtifactStore } from "./artifact-store.js";
 import { SqliteSessionStore } from "./session-store.js";
@@ -117,9 +118,10 @@ const WORKSPACE = process.env.OYSTER_WORKSPACE || PACKAGE_ROOT;
 const PROJECT_ROOT = PACKAGE_ROOT;
 // ── Oyster userland layout (#207) ──
 //
-//   OYSTER_HOME — the user's Oyster workspace root.
-//     Installed → ~/Oyster/            (visible; migrated from ~/.oyster/userland/)
-//     Dev       → ./userland/          (unchanged; feature-branch dev writes here)
+//   OYSTER_HOME — the user's Oyster workspace root. Always `~/Oyster/`
+//     unless `OYSTER_USERLAND` overrides (e.g. an isolated worktree).
+//     Dev mode and the installed package share one workspace by design —
+//     `single-instance-lock` makes a second concurrent server impossible.
 //   DB_DIR      — oyster.db, memory.db. At OYSTER_HOME/db/.
 //   APPS_DIR    — installed app bundles (builtins + community). At OYSTER_HOME/apps/.
 //   SPACES_DIR  — one folder per user space. At OYSTER_HOME/spaces/.
@@ -129,7 +131,7 @@ const PROJECT_ROOT = PACKAGE_ROOT;
 // opencode-ai's own config (opencode.json, .opencode/) stays at OYSTER_HOME
 // root because opencode discovers it via CWD walk-up; moving it would
 // require a spawn-flag change out of scope for this PR.
-const OYSTER_HOME = process.env.OYSTER_USERLAND || (isInstalledPackage ? join(homedir(), "Oyster") : join(PACKAGE_ROOT, "userland"));
+const OYSTER_HOME = process.env.OYSTER_USERLAND || join(homedir(), "Oyster");
 const DB_DIR = join(OYSTER_HOME, "db");
 const CONFIG_DIR = join(OYSTER_HOME, "config");
 const APPS_DIR = join(OYSTER_HOME, "apps");
@@ -238,6 +240,19 @@ bootTime("runStartupBackup", () => runStartupBackup(OYSTER_HOME));
 setImportStatePath(OYSTER_HOME);
 
 bootTime("bootstrapUserland", () => bootstrapUserland());
+
+// ── Single-instance lock ──
+// Refuse to start if another Oyster server already owns this workspace.
+// Stale locks (recorded pid is dead) are reclaimed automatically.
+try {
+  acquireLock(OYSTER_HOME);
+} catch (err) {
+  if (err instanceof AlreadyRunningError) {
+    console.error(`\n${err.message}\n`);
+    process.exit(1);
+  }
+  throw err;
+}
 
 // ── Clean environment (no OpenAI key leak to subprocesses) ──
 
@@ -684,8 +699,8 @@ startGenerationTimer((id, filePath, builtin) => {
 });
 startAutoApprover(getOpenCodePort, (file) => handleFileEdited(file, ARTIFACTS_DIR));
 
-process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); process.exit(0); });
-process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); process.exit(0); });
+process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); releaseLock(OYSTER_HOME); process.exit(0); });
+process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); releaseLock(OYSTER_HOME); process.exit(0); });
 process.on("uncaughtException", (err) => {
   console.error(`[oyster] uncaught exception: ${err.message}`);
   markShuttingDown();
@@ -972,6 +987,7 @@ function findPort(preferred: number, maxAttempts = 10): Promise<number> {
 }
 
 const port = await bootTimeAsync("findPort", () => findPort(PREFERRED_PORT));
+setLockPort(OYSTER_HOME, port);
 
 // Write OpenCode config with the actual port so MCP URL is always correct.
 // ?internal=1 lets the /mcp handler distinguish OpenCode's own traffic from

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -143,16 +143,18 @@ const BACKUPS_DIR = join(OYSTER_HOME, "backups");
 // Alias to OYSTER_HOME to minimise the surface of this PR.
 const USERLAND_DIR = OYSTER_HOME;
 
-// Dev handshake: write the actual bound port to userland/.dev-port so the
-// Vite dev server proxies to *this* backend, not whichever Oyster happens
-// to be on 3333. Each worktree has its own userland → its own file → no
-// cross-talk. Removed on shutdown so a stale file fails loud (connection
+// Dev handshake: write the actual bound port to ./.dev-port (repo root) so
+// the Vite dev server proxies to *this* backend, not whichever Oyster
+// happens to be on 3333. Lives at the repo root rather than under
+// OYSTER_HOME because each worktree has its own checkout → its own file →
+// no cross-talk, and so the file stays alongside `package.json`'s `npm run
+// dev` wait-on. Removed on shutdown so a stale file fails loud (connection
 // refused) rather than silent (talking to the wrong server). The pre-listen
 // delete closes the race where wait-on would otherwise succeed against a
 // crashed prior run's stale file. Declared up here (not next to listen())
 // so the SIGTERM/SIGINT handlers registered below don't hit a const TDZ if
 // a signal arrives mid-boot.
-const DEV_PORT_FILE = join(USERLAND_DIR, ".dev-port");
+const DEV_PORT_FILE = join(PACKAGE_ROOT, ".dev-port");
 function clearDevPortFile() {
   try { rmSync(DEV_PORT_FILE, { force: true }); } catch { /* best effort */ }
 }
@@ -699,22 +701,30 @@ startGenerationTimer((id, filePath, builtin) => {
 });
 startAutoApprover(getOpenCodePort, (file) => handleFileEdited(file, ARTIFACTS_DIR));
 
-process.on("SIGTERM", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); releaseLock(OYSTER_HOME); process.exit(0); });
-process.on("SIGINT", () => { markShuttingDown(); killOpenCode(); db.close(); memoryProvider.close(); clearDevPortFile(); releaseLock(OYSTER_HOME); process.exit(0); });
-process.on("uncaughtException", (err) => {
-  console.error(`[oyster] uncaught exception: ${err.message}`);
+// Shutdown cleanup. Wrap each step so a throw in (say) killOpenCode doesn't
+// stop the dev-port file and the workspace lock from being cleared — a stale
+// lock left behind is more annoying than the failure that triggered the exit.
+function shutdown(code: number): never {
   markShuttingDown();
   try { killOpenCode(); } catch { /* best effort */ }
+  try { db.close(); } catch { /* best effort */ }
+  try { memoryProvider.close(); } catch { /* best effort */ }
+  try { clearDevPortFile(); } catch { /* best effort */ }
+  try { releaseLock(OYSTER_HOME); } catch { /* best effort */ }
+  process.exit(code);
+}
+process.on("SIGTERM", () => shutdown(0));
+process.on("SIGINT", () => shutdown(0));
+process.on("uncaughtException", (err) => {
+  console.error(`[oyster] uncaught exception: ${err.message}`);
   // Fail fast — the server is in an unknown state with opencode-ai dead and
   // restart disabled. Exiting non-zero lets the user restart cleanly rather
   // than leaving a zombie that silently drops every chat message.
-  process.exit(1);
+  shutdown(1);
 });
 process.on("unhandledRejection", (err) => {
   console.error(`[oyster] unhandled rejection: ${err instanceof Error ? err.message : err}`);
-  markShuttingDown();
-  try { killOpenCode(); } catch { /* best effort */ }
-  process.exit(1);
+  shutdown(1);
 });
 
 // ── UI push events (SSE) ──

--- a/server/src/single-instance-lock.ts
+++ b/server/src/single-instance-lock.ts
@@ -10,8 +10,13 @@
 // with `releaseLock` in the SIGTERM/SIGINT handlers. `setLockPort` is best-
 // effort and just lets the "already running" message print the bound port
 // instead of `null`.
+//
+// Atomicity: creation goes through `openSync(path, "wx")` (O_EXCL) so two
+// processes starting at the same moment can't both win. Updates (setLockPort)
+// write to a sibling temp file and `renameSync` over the lock, which is an
+// atomic replace on POSIX and Windows alike — readers never see a torn file.
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, renameSync, unlinkSync, writeSync } from "node:fs";
 import { join } from "node:path";
 
 const LOCK_FILE = ".oyster.lock";
@@ -49,9 +54,20 @@ function isPidAlive(pid: number): boolean {
   }
 }
 
+function writeLockExclusive(path: string, data: LockData): void {
+  // "wx" = create-and-fail-if-exists, atomic at the syscall level. The
+  // EEXIST signal is what lets us detect the race in acquireLock.
+  const fd = openSync(path, "wx");
+  try {
+    writeSync(fd, JSON.stringify(data));
+  } finally {
+    closeSync(fd);
+  }
+}
+
 export class AlreadyRunningError extends Error {
   constructor(public existing: LockData, workspaceDir: string) {
-    const portStr = existing.port ? ` on port ${existing.port}` : "";
+    const portStr = existing.port != null ? ` on port ${existing.port}` : "";
     super(
       `Oyster is already running${portStr} (pid ${existing.pid}).\n` +
       `Workspace: ${workspaceDir}\n` +
@@ -62,23 +78,61 @@ export class AlreadyRunningError extends Error {
 }
 
 export function acquireLock(workspaceDir: string): void {
-  const existing = readLock(workspaceDir);
-  if (existing && isPidAlive(existing.pid) && existing.pid !== process.pid) {
-    throw new AlreadyRunningError(existing, workspaceDir);
+  const path = lockPath(workspaceDir);
+  const data: LockData = { pid: process.pid, port: null, startedAt: new Date().toISOString() };
+  // Two attempts is enough: the first either succeeds (no lock) or surfaces
+  // an existing lock. If that existing lock is stale (pid dead) we unlink
+  // and retry once. A still-alive lock the second time would only happen
+  // if a third process raced in between — at that point we honour it and
+  // refuse, which is the correct outcome.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      writeLockExclusive(path, data);
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      const existing = readLock(workspaceDir);
+      if (existing && isPidAlive(existing.pid) && existing.pid !== process.pid) {
+        throw new AlreadyRunningError(existing, workspaceDir);
+      }
+      // Stale or unreadable lock — unlink and retry. Unlink itself can race
+      // (another process clears it first); ENOENT is fine.
+      try { unlinkSync(path); } catch (rmErr) {
+        if ((rmErr as NodeJS.ErrnoException).code !== "ENOENT") throw rmErr;
+      }
+    }
   }
-  writeFileSync(
-    lockPath(workspaceDir),
-    JSON.stringify({ pid: process.pid, port: null, startedAt: new Date().toISOString() } satisfies LockData),
-    "utf8",
-  );
+  // Two consecutive EEXISTs with a live-looking lock on the second read:
+  // give the second one priority and refuse, even though we don't have
+  // a parsed LockData (readLock returned null at that point).
+  const last = readLock(workspaceDir);
+  if (last && isPidAlive(last.pid) && last.pid !== process.pid) {
+    throw new AlreadyRunningError(last, workspaceDir);
+  }
 }
 
 export function setLockPort(workspaceDir: string, port: number): void {
   const data = readLock(workspaceDir);
   if (!data || data.pid !== process.pid) return;
+  const target = lockPath(workspaceDir);
+  const tmp = `${target}.${process.pid}.tmp`;
   try {
-    writeFileSync(lockPath(workspaceDir), JSON.stringify({ ...data, port } satisfies LockData), "utf8");
-  } catch { /* non-fatal */ }
+    // Write whole file to a sibling tmp path, then atomic rename. Readers
+    // either see the old contents or the new contents — never a partial
+    // file. The pid suffix on the tmp filename keeps two unrelated workers
+    // from clobbering each other's tmp (defensive; in practice only one
+    // process ever owns this lock).
+    const fd = openSync(tmp, "w");
+    try {
+      writeSync(fd, JSON.stringify({ ...data, port } satisfies LockData));
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmp, target);
+  } catch {
+    try { unlinkSync(tmp); } catch { /* tmp may not exist */ }
+    /* non-fatal: the error message just won't include the port */
+  }
 }
 
 export function releaseLock(workspaceDir: string): void {

--- a/server/src/single-instance-lock.ts
+++ b/server/src/single-instance-lock.ts
@@ -1,0 +1,88 @@
+// Single-instance enforcement per workspace.
+//
+// Two Oyster servers writing to the same `~/Oyster/` would race on the SQLite
+// WAL, double-spawn the OpenCode subprocess, and fight over the .dev-port
+// handshake file. The lock makes this structurally impossible: at boot we
+// write `<workspace>/.oyster.lock` with our pid; if a live process already
+// holds it, we refuse to start. Stale locks (pid is dead) are reclaimed.
+//
+// Pair `acquireLock` once at startup (after bootstrapUserland, before initDb)
+// with `releaseLock` in the SIGTERM/SIGINT handlers. `setLockPort` is best-
+// effort and just lets the "already running" message print the bound port
+// instead of `null`.
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const LOCK_FILE = ".oyster.lock";
+
+interface LockData {
+  pid: number;
+  port: number | null;
+  startedAt: string;
+}
+
+function lockPath(workspaceDir: string): string {
+  return join(workspaceDir, LOCK_FILE);
+}
+
+function readLock(workspaceDir: string): LockData | null {
+  const p = lockPath(workspaceDir);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, "utf8")) as LockData;
+  } catch {
+    return null;
+  }
+}
+
+// `process.kill(pid, 0)` doesn't send a signal — it just probes whether the
+// pid is reachable. EPERM means "exists but we can't signal it" (different
+// user, sandbox); count that as alive too. ESRCH means the pid is gone.
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export class AlreadyRunningError extends Error {
+  constructor(public existing: LockData, workspaceDir: string) {
+    const portStr = existing.port ? ` on port ${existing.port}` : "";
+    super(
+      `Oyster is already running${portStr} (pid ${existing.pid}).\n` +
+      `Workspace: ${workspaceDir}\n` +
+      `Quit the running instance before starting another.`,
+    );
+    this.name = "AlreadyRunningError";
+  }
+}
+
+export function acquireLock(workspaceDir: string): void {
+  const existing = readLock(workspaceDir);
+  if (existing && isPidAlive(existing.pid) && existing.pid !== process.pid) {
+    throw new AlreadyRunningError(existing, workspaceDir);
+  }
+  writeFileSync(
+    lockPath(workspaceDir),
+    JSON.stringify({ pid: process.pid, port: null, startedAt: new Date().toISOString() } satisfies LockData),
+    "utf8",
+  );
+}
+
+export function setLockPort(workspaceDir: string, port: number): void {
+  const data = readLock(workspaceDir);
+  if (!data || data.pid !== process.pid) return;
+  try {
+    writeFileSync(lockPath(workspaceDir), JSON.stringify({ ...data, port } satisfies LockData), "utf8");
+  } catch { /* non-fatal */ }
+}
+
+export function releaseLock(workspaceDir: string): void {
+  const data = readLock(workspaceDir);
+  if (!data || data.pid !== process.pid) return;
+  try { unlinkSync(lockPath(workspaceDir)); } catch { /* non-fatal */ }
+}


### PR DESCRIPTION
## Summary

Two problems collapsed into one fix:

1. **Workspace split.** Dev mode wrote to `./userland/`, installed package wrote to `~/Oyster/`. Two DBs, two vaults, UI that looked different under `oyster` vs `npm run dev`. No users to protect from a shared workspace; pre-shipping divergence between dev and prod data was purely a hindrance. Default is now always `~/Oyster/`.
2. **Two concurrent servers possible.** Even with one workspace, nothing stopped someone running the installed `oyster` and `npm run dev` simultaneously — they'd race on the SQLite WAL, fight over the `.dev-port` file, and double-spawn OpenCode. Now refused at boot via `~/Oyster/.oyster.lock`.

The lockfile records `{pid, port, startedAt}`. A second Oyster reads it, liveness-checks the pid (`process.kill(pid, 0)`, accepts `EPERM` as alive), and exits with a clear *"Oyster is already running on port X (pid Y). Quit the running instance before starting another."* message. Stale locks (recorded pid dead) are reclaimed automatically. Graceful shutdown (SIGTERM/SIGINT) deletes the lock.

**Escape hatch:** `OYSTER_USERLAND=/some/other/path npm run dev` still works for an isolated worktree — pair with `OYSTER_PORT` so the second server binds somewhere else.

## Files

- `server/src/single-instance-lock.ts` — new module
- `server/src/index.ts` — drop dev-mode workspace fallback; acquire lock after \`bootstrapUserland\`, before \`initDb\`; record port after \`findPort\`; release on SIGTERM/SIGINT
- `CLAUDE.md` — drop \`./userland/\` from the workspace description
- \`CHANGELOG.md\` — \`[Unreleased]\` Changed entry

## Test plan

- [ ] \`npm run dev\` from a fresh checkout writes to \`~/Oyster/\` (verify SQLite path).
- [ ] Start one Oyster, then try to start a second — clear "already running" message, exits 1.
- [ ] kill -9 the first; second start reclaims the lock cleanly.
- [ ] Ctrl-C on running server leaves no lockfile behind.
- [ ] \`OYSTER_USERLAND=./userland OYSTER_PORT=3333 npm run dev\` still works for an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)