### PR TITLE
Unify sign-in + space switcher into one sticky top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Oyster are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1]
+
+### Changed
+
+- **Top bar is now one sticky pill.** Account and space switcher share a single bar pinned to the top of every view. Signed-in shows an avatar (email + sign-out in the click-menu); signed-out shows a *Sign in* pill in the same slot.
+
 ## [0.9.0] - 2026-05-16
 
 A project's identity now lives in a `.oyster/id` file inside its folder. Renaming, moving, or `git push`ing the folder no longer orphans its sessions — the marker travels with the folder and is recognised everywhere. Eleven sessions across three beta cycles (0.9.0-beta.0/1/2) collapsed into this release.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,7 +312,7 @@
   </div>
 
   <nav class="version-pills" aria-label="Jump to version">
-      <a class="version-pill" href="#v-0-9-0">0.9</a>
+      <a class="version-pill" href="#v-0-9-1">0.9</a>
       <a class="version-pill" href="#v-0-8-2">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
       <a class="version-pill" href="#v-0-6-0">0.6</a>
@@ -325,6 +325,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-0-9-1"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.0...v0.9.1" rel="noopener noreferrer"><span class="release-version">0.9.1</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>Top bar is now one sticky pill.</strong> Account and space switcher share a single bar pinned to the top of every view. Signed-in shows an avatar (email + sign-out in the click-menu); signed-out shows a <em>Sign in</em> pill in the same slot.</li>
+</ul>
 <h2 id="v-0-9-0"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.8.2...v0.9.0" rel="noopener noreferrer"><span class="release-version">0.9.0</span></a><span class="release-date"> — 2026-05-16</span></h2>
 <p>A project&#39;s identity now lives in a <code>.oyster/id</code> file inside its folder. Renaming, moving, or <code>git push</code>ing the folder no longer orphans its sessions — the marker travels with the folder and is recognised everywhere. Eleven sessions across three beta cycles (0.9.0-beta.0/1/2) collapsed into this release.</p>
 <h3>Added</h3>

--- a/docs/mockups/topbar-signin.html
+++ b/docs/mockups/topbar-signin.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Oyster — Top bar + sign-in mockup</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --desktop-bg: #1e1f36;
+    --window-chrome: rgba(35, 36, 64, 0.75);
+    --accent: #7c6bff;
+    --accent-bright: #a597ff;
+    --text: #e8e9f0;
+    --text-dim: rgba(232, 233, 240, 0.5);
+    --icon-hover: rgba(124, 107, 255, 0.08);
+    --glass-border: rgba(255, 255, 255, 0.08);
+    --font-mono: 'IBM Plex Mono', monospace;
+    --font-body: 'Space Grotesk', sans-serif;
+    --pip-active: #34d399;
+    --pip-waiting: #fbbf24;
+    --pip-disconnected: #f87171;
+    --home-border: rgba(255, 255, 255, 0.08);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--font-body);
+    background: var(--desktop-bg);
+    color: var(--text);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page { max-width: 1500px; margin: 0 auto; padding: 28px 24px 120px; }
+  h1 { font-size: 14px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 4px; font-weight: 500; font-family: var(--font-mono); }
+  .sub { color: var(--text-dim); font-size: 12px; margin-bottom: 28px; }
+  .toggle-row { display: flex; gap: 8px; margin: 18px 0 12px; align-items: center; }
+  .toggle-row .label { font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-family: var(--font-mono); }
+  .toggle-row button {
+    font-family: var(--font-mono); font-size: 11px; padding: 5px 10px;
+    background: transparent; color: var(--text-dim);
+    border: 1px solid var(--glass-border); border-radius: 999px; cursor: pointer;
+  }
+  .toggle-row button.on { color: var(--text); background: rgba(124,107,255,0.18); border-color: rgba(124,107,255,0.5); }
+
+  .opt {
+    margin-top: 36px;
+    border: 1px solid var(--glass-border);
+    border-radius: 14px;
+    overflow: hidden;
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(0,0,0,0.06));
+  }
+  .opt-head { padding: 14px 18px 0; }
+  .opt-head h2 { font-size: 14px; letter-spacing: 0.04em; color: var(--text); font-weight: 600; }
+  .opt-head p { color: var(--text-dim); font-size: 12px; margin-top: 4px; line-height: 1.5; }
+  .opt-stage {
+    position: relative;
+    margin-top: 14px;
+    background:
+      radial-gradient(60% 50% at 80% 0%, rgba(124,107,255,0.10), transparent 70%),
+      radial-gradient(40% 40% at 10% 100%, rgba(251,191,36,0.05), transparent 70%),
+      var(--desktop-bg);
+    height: 360px;
+    overflow: hidden;
+  }
+
+  /* ── shared pill styles ── */
+  .pill-bar {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 3px 4px; border-radius: 9999px;
+    background: rgba(13, 14, 26, 0.6);
+    border: 1px solid var(--home-border);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+  }
+  .pill {
+    position: relative; display: inline-flex; align-items: center; gap: 6px;
+    padding: 5px 12px; border-radius: 9999px; border: none;
+    background: rgba(255,255,255,0.025);
+    color: var(--text-dim);
+    font-family: var(--font-body); font-size: 0.78rem; font-weight: 500;
+    cursor: pointer; white-space: nowrap;
+    transition: color .2s, background .2s;
+  }
+  .pill:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+  .pill.icon-only { padding: 5px 9px; }
+  .pill.selected { color: #fff; background: var(--accent); }
+  .pill .pip-count { display: inline-flex; align-items: center; gap: 4px; font-family: var(--font-mono); font-size: 9px; font-weight: 300; letter-spacing: -0.02em; }
+  .pill .pip { display:inline-block; width:6px; height:6px; border-radius:50%; }
+  .pip.active { background: var(--pip-active); box-shadow: 0 0 8px var(--pip-active); }
+  .pip.waiting { background: var(--pip-waiting); box-shadow: 0 0 8px var(--pip-waiting); }
+  .pip.disconn { background: var(--pip-disconnected); box-shadow: 0 0 8px var(--pip-disconnected); }
+  .pill.italic .label { font-style: italic; }
+  .pill svg { display: block; }
+
+  /* shared sticky topbar container that hosts a layout option */
+  .topbar {
+    position: sticky; top: 0;
+    display: flex; align-items: center;
+    padding: 12px 16px;
+    z-index: 5;
+  }
+
+  /* ── option A: merged ── auth chip absorbed into the same dark pill bar ── */
+  .opt-A .topbar { justify-content: center; }
+  .opt-A .auth-merged {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px; border-radius: 9999px;
+    background: rgba(255,255,255,0.025);
+    color: var(--text-dim);
+    cursor: pointer; transition: background .2s, color .2s;
+  }
+  .opt-A .auth-merged:hover { background: rgba(255,255,255,0.08); color: var(--text); }
+  .opt-A .auth-merged.signed-out { font-family: var(--font-body); font-size: 0.78rem; padding: 5px 12px; }
+  .opt-A .avatar {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), #c8a8ff);
+    display:inline-flex; align-items:center; justify-content:center;
+    color: #1e1f36; font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  }
+  .opt-A .divider {
+    width: 1px; height: 18px;
+    background: rgba(255,255,255,0.10);
+    margin: 0 2px;
+  }
+
+  /* ── option B: two pills, sticky row, balanced ── */
+  .opt-B .topbar { justify-content: space-between; padding: 12px 24px; }
+  .opt-B .auth-chip {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 5px 12px 5px 5px; border-radius: 9999px;
+    background: rgba(13, 14, 26, 0.6);
+    border: 1px solid var(--home-border);
+    backdrop-filter: blur(16px);
+    color: var(--text);
+    font-family: var(--font-mono); font-size: 0.72rem;
+    cursor: pointer; transition: background .2s;
+  }
+  .opt-B .auth-chip:hover { background: rgba(28, 30, 50, 0.7); }
+  .opt-B .auth-chip.signed-out { padding: 5px 14px; font-family: var(--font-body); font-size: 0.78rem; }
+  .opt-B .avatar {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), #c8a8ff);
+    display:inline-flex; align-items:center; justify-content:center;
+    color: #1e1f36; font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  }
+  .opt-B .center { flex: 1; display: flex; justify-content: center; }
+  .opt-B .right-spacer { width: 180px; }
+
+  /* ── option C: auth on the right of the same pill bar (avatar only) ── */
+  .opt-C .topbar { justify-content: center; }
+  .opt-C .auth-right {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 8px 3px 3px; border-radius: 9999px;
+    background: rgba(255,255,255,0.025);
+    color: var(--text-dim);
+    font-family: var(--font-mono); font-size: 0.72rem;
+    cursor: pointer; transition: background .2s, color .2s;
+  }
+  .opt-C .auth-right:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+  .opt-C .auth-right.signed-out { padding: 5px 12px; font-family: var(--font-body); font-size: 0.78rem; }
+  .opt-C .avatar {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), #c8a8ff);
+    display:inline-flex; align-items:center; justify-content:center;
+    color: #1e1f36; font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  }
+  .opt-C .divider {
+    width: 1px; height: 18px;
+    background: rgba(255,255,255,0.10);
+    margin: 0 4px;
+  }
+
+  /* fake content under each stage so scroll demonstrates sticky */
+  .fake-content {
+    padding: 80px 32px 32px;
+    max-width: 1100px;
+    margin: 0 auto;
+    color: var(--text);
+  }
+  .fake-content h3 { font-size: 2rem; letter-spacing: -0.02em; font-weight: 600; margin-bottom: 6px; }
+  .fake-content p { color: var(--text-dim); font-size: 14px; margin-bottom: 16px; }
+  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+  .card {
+    aspect-ratio: 1 / 1.1; border-radius: 10px;
+    background: rgba(255,255,255,0.025);
+    border: 1px solid var(--glass-border);
+  }
+
+  /* state labels */
+  .stage-label {
+    position: absolute; top: 10px; right: 14px; z-index: 6;
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .stage-label .dot {
+    display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px;
+    background: var(--pip-active); box-shadow: 0 0 8px var(--pip-active);
+  }
+  body.signed-out .stage-label .dot { background: var(--pip-disconnected); box-shadow: 0 0 8px var(--pip-disconnected); }
+  body.signed-out .stage-label .text::after { content: "signed-out"; }
+  body.signed-in  .stage-label .text::after { content: "signed-in"; }
+
+  body.signed-in  .when-signed-out { display: none !important; }
+  body.signed-out .when-signed-in  { display: none !important; }
+
+  .legend {
+    margin-top: 22px;
+    padding: 14px 18px;
+    border: 1px dashed var(--glass-border);
+    border-radius: 10px;
+    color: var(--text-dim); font-size: 12px; line-height: 1.6;
+  }
+  .legend code { font-family: var(--font-mono); color: var(--text); background: rgba(255,255,255,0.04); padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+<body class="signed-in">
+<div class="page">
+  <h1>Oyster — Top bar + sign-in</h1>
+  <div class="sub">Two finalists: A (avatar at the front) vs C (avatar at the back). Both condensed — email lives in the click-menu, not on the bar. Scroll any stage to confirm stickiness. Toggle states to compare.</div>
+
+  <div class="toggle-row">
+    <span class="label">State:</span>
+    <button id="toggle-in"  class="on">Signed-in (matthew@slight.me)</button>
+    <button id="toggle-out">Signed-out</button>
+  </div>
+
+  <!-- ─────────── Option A — Merged into one pill bar (condensed, avatar at front) ─────────── -->
+  <div class="opt opt-A">
+    <div class="opt-head">
+      <h2>A · Avatar head — account at the front of the switcher pill bar</h2>
+      <p>Condensed: signed-in shows just the avatar (email + sign-out live in the click-menu). Signed-out shows a compact "Sign in" pill. One bar, one object, identity reads first (Western left-to-right scan order).</p>
+    </div>
+    <div class="opt-stage" data-stage>
+      <div class="stage-label"><span class="dot"></span><span class="text"></span></div>
+      <div class="topbar">
+        <div class="pill-bar">
+          <!-- auth: signed-in (avatar only) -->
+          <button class="auth-merged when-signed-in" title="matthew@slight.me · click for menu" aria-label="Account">
+            <span class="avatar">M</span>
+          </button>
+          <!-- auth: signed-out -->
+          <button class="auth-merged signed-out when-signed-out">Sign in</button>
+          <span class="divider"></span>
+          <!-- space switcher -->
+          <button class="pill icon-only selected" title="Home">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M11.03 2.59a1.5 1.5 0 0 1 1.94 0l7.5 6.363A1.5 1.5 0 0 1 21 10.097V19.5a2.5 2.5 0 0 1-2.5 2.5H15v-4a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v4H5.5A2.5 2.5 0 0 1 3 19.5v-9.403a1.5 1.5 0 0 1 .53-1.137l7.5-6.37Z"/></svg>
+          </button>
+          <button class="pill icon-only" title="Pro">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/></svg>
+          </button>
+          <button class="pill">
+            <span class="pip-count"><span class="pip active"></span>1</span>
+            <span class="pip-count"><span class="pip disconn"></span>5</span>
+            <span class="label">oyster</span>
+          </button>
+          <button class="pill">
+            <span class="pip-count"><span class="pip disconn"></span>3</span>
+            <span class="label">tokinvest</span>
+          </button>
+          <button class="pill"><span class="label">blunderfixer</span></button>
+          <button class="pill"><span class="label">kps</span></button>
+          <button class="pill italic"><span class="label">Unsorted</span></button>
+        </div>
+      </div>
+      <div class="fake-content">
+        <h3>Everything active.</h3>
+        <p>Scroll — the bar above stays pinned.</p>
+        <div class="grid">
+          <div class="card"></div><div class="card"></div><div class="card"></div><div class="card"></div>
+          <div class="card"></div><div class="card"></div><div class="card"></div><div class="card"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─────────── Option C — Avatar on the right of the same pill ─────────── -->
+  <div class="opt opt-C">
+    <div class="opt-head">
+      <h2>C · Avatar tail — account at the back of the switcher pill bar</h2>
+      <p>Same one-bar treatment as A, but identity sits on the right end (Mac menu-bar / Gmail convention — account is "off to the side"). Switcher leads, account trails.</p>
+    </div>
+    <div class="opt-stage" data-stage>
+      <div class="stage-label"><span class="dot"></span><span class="text"></span></div>
+      <div class="topbar">
+        <div class="pill-bar">
+          <button class="pill icon-only selected" title="Home">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M11.03 2.59a1.5 1.5 0 0 1 1.94 0l7.5 6.363A1.5 1.5 0 0 1 21 10.097V19.5a2.5 2.5 0 0 1-2.5 2.5H15v-4a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v4H5.5A2.5 2.5 0 0 1 3 19.5v-9.403a1.5 1.5 0 0 1 .53-1.137l7.5-6.37Z"/></svg>
+          </button>
+          <button class="pill icon-only" title="Pro">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2 4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z"/></svg>
+          </button>
+          <button class="pill">
+            <span class="pip-count"><span class="pip active"></span>1</span>
+            <span class="pip-count"><span class="pip disconn"></span>5</span>
+            <span class="label">oyster</span>
+          </button>
+          <button class="pill">
+            <span class="pip-count"><span class="pip disconn"></span>3</span>
+            <span class="label">tokinvest</span>
+          </button>
+          <button class="pill"><span class="label">blunderfixer</span></button>
+          <button class="pill"><span class="label">kps</span></button>
+          <button class="pill italic"><span class="label">Unsorted</span></button>
+          <span class="divider"></span>
+          <!-- auth chip — signed-in: avatar only (email on hover/click menu) -->
+          <button class="auth-right when-signed-in" title="matthew@slight.me · click for menu" aria-label="Account">
+            <span class="avatar">M</span>
+          </button>
+          <!-- auth: signed-out -->
+          <button class="auth-right signed-out when-signed-out">Sign in</button>
+        </div>
+      </div>
+      <div class="fake-content">
+        <h3>Everything active.</h3>
+        <p>Scroll — single bar, avatar at the end.</p>
+        <div class="grid">
+          <div class="card"></div><div class="card"></div><div class="card"></div><div class="card"></div>
+          <div class="card"></div><div class="card"></div><div class="card"></div><div class="card"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="legend">
+    <strong style="color: var(--text);">Notes on integration (not part of the visual decision):</strong><br>
+    • Sticky behaviour: top bar moves out of the <code>.home-scroll</code> container up to the App shell so it spans every view, not just Home.<br>
+    • Signing-in state (pending device-flow): the same chip expands inline to show "Sign-in opened in a new tab" + Cancel — replaces the current <code>.auth-badge--pending</code> column card.<br>
+    • Sign-out menu: dropdown anchored to the chip, same Framer Motion shared-layout approach as the pill selection.<br>
+    • Typography choice for the email: keeping <code>var(--font-mono)</code> reads as "identity / system value" — distinguishes it from the prose pills.
+  </div>
+</div>
+
+<script>
+  // make each stage a scroll container so the sticky topbar actually sticks
+  document.querySelectorAll('[data-stage]').forEach(el => {
+    el.style.overflowY = 'auto';
+  });
+  // state toggle
+  const inBtn = document.getElementById('toggle-in');
+  const outBtn = document.getElementById('toggle-out');
+  function setState(s) {
+    document.body.classList.toggle('signed-in', s === 'in');
+    document.body.classList.toggle('signed-out', s === 'out');
+    inBtn.classList.toggle('on', s === 'in');
+    outBtn.classList.toggle('on', s === 'out');
+  }
+  inBtn.onclick = () => setState('in');
+  outBtn.onclick = () => setState('out');
+</script>
+</body>
+</html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,7 +8,6 @@ import { TerminalWindow } from "./components/TerminalWindow";
 import { SpotlightSearch } from "./components/SpotlightSearch";
 import { OnboardingDock } from "./components/OnboardingDock";
 import { SetupProposalPanel } from "./components/SetupProposalPanel";
-import { AuthBadge } from "./components/AuthBadge";
 import { windowsReducer } from "./stores/windows";
 import {
   type Artifact,
@@ -423,7 +422,6 @@ export default function App() {
 
   return (
     <div className="oyster-shell">
-      <AuthBadge />
       {!connected && (
         <div className="connection-banner">
           <span>Oyster server not connected</span>

--- a/web/src/components/AuthBadge.css
+++ b/web/src/components/AuthBadge.css
@@ -1,103 +1,164 @@
-.auth-badge {
-  position: absolute;
-  top: 12px;
-  left: 16px;
-  z-index: 5;
-  font-family: var(--font-mono);
-  font-size: 12px;
+/* Account chip — leftmost element of the home-breadcrumb pill bar.
+   Sized to align with the breadcrumb pills (5px vertical padding,
+   9999px radius). No absolute positioning — the chip flows inline. */
+
+.auth-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
-.auth-badge--pending {
+.auth-chip--ghost {
+  /* Loading slot — same width as the avatar pill so the bar doesn't
+     reflow when whoami resolves. */
+  width: 30px;
+  height: 28px;
+}
+
+.auth-chip__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px;
+  border: none;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text-dim);
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.auth-chip__pill:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.auth-chip__pill--signin {
+  padding: 5px 12px;
+}
+
+.auth-chip__pill--avatar {
+  /* Initial-as-glyph — matches the home/shield icon pills in shape and
+     weight so the bar reads as one row of equal-height tokens. */
+  padding: 5px 9px;
+  min-width: 28px;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text);
+  user-select: none;
+}
+
+.auth-chip__pill--pending {
+  padding: 4px 10px 4px 6px;
+  color: var(--text);
+}
+
+.auth-chip__pending-label {
+  font-size: 0.72rem;
+}
+
+.auth-chip__spinner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(255, 255, 255, 0.2);
+  border-top-color: var(--accent-bright);
+  animation: auth-chip-spin 0.8s linear infinite;
+}
+
+@keyframes auth-chip-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Menu popover — anchored under the chip. Matches breadcrumb glass
+   treatment but with a solid surface for legibility. */
+.auth-chip__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 50;
+  min-width: 220px;
+  padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 8px 12px;
-  background: var(--window-chrome);
-  backdrop-filter: blur(var(--glass-blur));
+  background: rgba(13, 14, 26, 0.92);
   border: 1px solid var(--glass-border);
-  border-radius: 8px;
-  color: var(--text-dim);
-  max-width: 280px;
+  border-radius: 10px;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
 }
 
-.auth-badge__hint {
+.auth-chip__menu-email {
+  padding: 6px 10px 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
   color: var(--text);
+  border-bottom: 1px solid var(--glass-border);
+  word-break: break-all;
 }
 
-.auth-badge__link {
+.auth-chip__menu-hint {
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.auth-chip__menu-link {
+  display: block;
+  padding: 6px 10px;
+  font-size: 11px;
   color: var(--accent-bright);
   text-decoration: none;
-  font-size: 11px;
-}
-
-.auth-badge__link:hover {
-  text-decoration: underline;
-}
-
-.auth-badge__chip {
-  font-family: inherit;
-  font-size: inherit;
-  padding: 6px 10px;
-  background: var(--window-chrome);
-  backdrop-filter: blur(var(--glass-blur));
-  border: 1px solid var(--glass-border);
   border-radius: 6px;
-  color: var(--text);
-  cursor: pointer;
-  transition: background 120ms ease;
 }
 
-.auth-badge__chip:hover {
+.auth-chip__menu-link:hover {
+  text-decoration: underline;
   background: var(--icon-hover);
 }
 
-.auth-badge__menu {
-  margin-top: 4px;
-  background: var(--window-body);
-  backdrop-filter: blur(var(--glass-blur));
-  border: 1px solid var(--glass-border);
-  border-radius: 6px;
-  overflow: hidden;
-  min-width: 120px;
-}
-
-.auth-badge__menu-item {
+.auth-chip__menu-item {
   display: block;
   width: 100%;
-  padding: 8px 12px;
+  padding: 8px 10px;
   background: transparent;
   border: 0;
+  border-radius: 6px;
   text-align: left;
-  font-family: inherit;
-  font-size: inherit;
+  font-family: var(--font-body);
+  font-size: 13px;
   color: var(--text);
   cursor: pointer;
 }
 
-.auth-badge__menu-item:hover {
+.auth-chip__menu-item:hover {
   background: var(--icon-hover);
 }
 
-.auth-badge__cancel {
-  margin-top: 4px;
-  padding: 4px 8px;
-  background: transparent;
-  border: 1px solid var(--glass-border);
-  border-radius: 4px;
-  color: var(--text-dim);
-  font-family: inherit;
-  font-size: 11px;
-  cursor: pointer;
-  align-self: flex-start;
+.auth-chip__menu-item--danger:hover {
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
 }
 
-.auth-badge__cancel:hover {
-  color: var(--text);
-  background: var(--icon-hover);
-}
-
-.auth-badge__error {
-  margin-top: 4px;
+.auth-chip__menu-error {
+  padding: 6px 10px;
   font-size: 11px;
   color: #f87171;
+}
+
+/* Divider slot kept for ARIA / DOM stability but visually hidden —
+   the pill gap between auth chip and space pills is enough to
+   separate identity from navigation. */
+.home-breadcrumb-divider {
+  display: none;
 }

--- a/web/src/components/AuthBadge.css
+++ b/web/src/components/AuthBadge.css
@@ -155,10 +155,3 @@
   font-size: 11px;
   color: #f87171;
 }
-
-/* Divider slot kept for ARIA / DOM stability but visually hidden —
-   the pill gap between auth chip and space pills is enough to
-   separate identity from navigation. */
-.home-breadcrumb-divider {
-  display: none;
-}

--- a/web/src/components/AuthBadge.tsx
+++ b/web/src/components/AuthBadge.tsx
@@ -45,6 +45,13 @@ export function AuthBadge() {
       timeoutRef.current = null;
     }
   };
+  // Tracks the in-flight /api/auth/login fetch for the current sign-in
+  // attempt. Lets handleCancelSignIn and a restart from handleSignIn
+  // abort the old fetch + ignore any stale response so a late-arriving
+  // body can't reanimate a cancelled flow (or override a successful
+  // newer one). Each attempt also captures its own controller so the
+  // device_code timer can no-op if it's superseded.
+  const signInAbortRef = useRef<AbortController | null>(null);
 
   // Initial whoami + SSE subscription. The server emits `auth_changed`
   // when the device-flow poll resolves or sign-out completes; we
@@ -74,6 +81,8 @@ export function AuthBadge() {
       cancelled = true;
       unsub();
       clearAbortTimeout();
+      signInAbortRef.current?.abort();
+      signInAbortRef.current = null;
     };
   }, []);
 
@@ -124,27 +133,40 @@ export function AuthBadge() {
   }, [menuOpen]);
 
   const handleSignIn = async () => {
-    // If a previous flow is still pending, restart cleanly. The local
-    // server's startSignIn() also aborts the old poll on its end.
+    // Abort any previous attempt's fetch + timer. The local server's
+    // startSignIn() also aborts the old poll on its end. The controller
+    // is captured per-attempt so a late response from a superseded
+    // attempt can no-op without touching the new one's state.
+    signInAbortRef.current?.abort();
     clearAbortTimeout();
+    const controller = new AbortController();
+    signInAbortRef.current = controller;
     setPhase("signing-in");
     setPending(null);
     setSignOutError(null);
     setMenuOpen(true); // surface the hint+cancel popover immediately
     try {
-      const res = await fetch("/api/auth/login", { method: "POST" });
+      const res = await fetch("/api/auth/login", { method: "POST", signal: controller.signal });
       if (!res.ok) throw new Error(String(res.status));
       const body = (await res.json()) as SignInPending;
+      // Defence-in-depth: even if the abort raced past the network
+      // layer, drop the body if this attempt has been superseded.
+      if (controller.signal.aborted || signInAbortRef.current !== controller) return;
       setPending(body);
       // Mirror the server-side device_code TTL on the client. If the
       // poll ages out or the cloud 410s, no auth_changed event will
-      // fire; this timer is what flips the UI back to signed-out.
+      // fire; this timer is what flips the UI back to signed-out. The
+      // controller-identity guard makes the callback a no-op if a
+      // later attempt or sign-out has already moved on.
       timeoutRef.current = setTimeout(() => {
+        if (signInAbortRef.current !== controller) return;
         setPhase("signed-out");
         setPending(null);
         setMenuOpen(false);
       }, body.expires_in * 1000);
     } catch (err) {
+      // AbortError = explicit cancel/restart, never a real failure.
+      if (controller.signal.aborted) return;
       console.error("[auth] login failed:", err);
       setPhase("signed-out");
       setMenuOpen(false);
@@ -152,6 +174,8 @@ export function AuthBadge() {
   };
 
   const handleCancelSignIn = () => {
+    signInAbortRef.current?.abort();
+    signInAbortRef.current = null;
     clearAbortTimeout();
     setPending(null);
     setPhase("signed-out");

--- a/web/src/components/AuthBadge.tsx
+++ b/web/src/components/AuthBadge.tsx
@@ -1,8 +1,8 @@
-// Top-left badge showing the signed-in account, with a single click
-// to start sign-in or sign out. Mounted at App-shell level so it sits
-// above any space's surface. Auth state syncs over SSE — the local
-// server emits `auth_changed` whenever the device-flow poll lands or
-// the user signs out.
+// Account chip rendered as the leftmost element of the home-breadcrumb
+// pill bar. Signed-in shows an avatar-only pill; email + sign-out live
+// in the click-menu. Signed-out shows a compact "Sign in" pill in the
+// same slot. Auth state syncs over SSE — the local server emits
+// `auth_changed` whenever the device-flow poll lands or the user signs out.
 
 import { useEffect, useRef, useState } from "react";
 import { subscribeUiEvents } from "../data/ui-events";
@@ -21,12 +21,17 @@ interface SignInPending {
   expires_in: number;
 }
 
+function avatarInitial(email: string): string {
+  return email.trim().charAt(0).toUpperCase() || "?";
+}
+
 export function AuthBadge() {
   const [phase, setPhase] = useState<Phase>("loading");
   const [user, setUser] = useState<AuthUser | null>(null);
   const [pending, setPending] = useState<SignInPending | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [signOutError, setSignOutError] = useState<string | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
 
   // Client-side timeout that mirrors the device_code TTL on the Worker.
   // Without it, the badge can stay stuck in `signing-in` indefinitely:
@@ -105,6 +110,19 @@ export function AuthBadge() {
     };
   }, [phase, pending]);
 
+  // Click-outside closes the menu. The menu is anchored to the chip and
+  // floats over the breadcrumb; without this, opening it then clicking
+  // a space pill leaves it dangling above the new selection.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!wrapRef.current) return;
+      if (!wrapRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [menuOpen]);
+
   const handleSignIn = async () => {
     // If a previous flow is still pending, restart cleanly. The local
     // server's startSignIn() also aborts the old poll on its end.
@@ -112,6 +130,7 @@ export function AuthBadge() {
     setPhase("signing-in");
     setPending(null);
     setSignOutError(null);
+    setMenuOpen(true); // surface the hint+cancel popover immediately
     try {
       const res = await fetch("/api/auth/login", { method: "POST" });
       if (!res.ok) throw new Error(String(res.status));
@@ -123,10 +142,12 @@ export function AuthBadge() {
       timeoutRef.current = setTimeout(() => {
         setPhase("signed-out");
         setPending(null);
+        setMenuOpen(false);
       }, body.expires_in * 1000);
     } catch (err) {
       console.error("[auth] login failed:", err);
       setPhase("signed-out");
+      setMenuOpen(false);
     }
   };
 
@@ -134,6 +155,7 @@ export function AuthBadge() {
     clearAbortTimeout();
     setPending(null);
     setPhase("signed-out");
+    setMenuOpen(false);
   };
 
   const handleSignOut = async () => {
@@ -163,61 +185,91 @@ export function AuthBadge() {
   };
 
   if (phase === "loading") {
-    return null; // avoid a flash of "Sign in" before whoami resolves
-  }
-
-  if (phase === "signing-in" && pending) {
-    return (
-      <div className="auth-badge auth-badge--pending">
-        <span className="auth-badge__hint">Sign-in opened in a new tab — enter your email there.</span>
-        <a className="auth-badge__link" href={pending.sign_in_url} target="_blank" rel="noreferrer">
-          Or open the sign-in page manually
-        </a>
-        <button type="button" className="auth-badge__cancel" onClick={handleCancelSignIn}>
-          Cancel
-        </button>
-      </div>
-    );
+    // Reserve the slot so the bar doesn't jump when whoami resolves.
+    return <div className="auth-chip auth-chip--ghost" aria-hidden="true" />;
   }
 
   if (phase === "signing-in") {
     return (
-      <div className="auth-badge auth-badge--pending">
-        <span>Starting sign-in…</span>
-        <button type="button" className="auth-badge__cancel" onClick={handleCancelSignIn}>
-          Cancel
+      <div className="auth-chip auth-chip--wrap" ref={wrapRef}>
+        <button
+          type="button"
+          className="auth-chip__pill auth-chip__pill--pending"
+          onClick={() => setMenuOpen((v) => !v)}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+        >
+          <span className="auth-chip__spinner" aria-hidden="true" />
+          <span className="auth-chip__pending-label">Signing in…</span>
         </button>
+        {menuOpen && (
+          <div className="auth-chip__menu" role="menu">
+            <div className="auth-chip__menu-hint">
+              {pending
+                ? "Sign-in opened in a new tab — enter your email there."
+                : "Starting sign-in…"}
+            </div>
+            {pending && (
+              <a
+                className="auth-chip__menu-link"
+                href={pending.sign_in_url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open sign-in page manually
+              </a>
+            )}
+            <button
+              type="button"
+              className="auth-chip__menu-item auth-chip__menu-item--danger"
+              onClick={handleCancelSignIn}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
     );
   }
 
   if (phase === "signed-in" && user) {
     return (
-      <div className="auth-badge">
+      <div className="auth-chip auth-chip--wrap" ref={wrapRef}>
         <button
           type="button"
-          className="auth-badge__chip"
+          className="auth-chip__pill auth-chip__pill--avatar"
           onClick={() => setMenuOpen((v) => !v)}
           aria-haspopup="menu"
           aria-expanded={menuOpen}
+          title={user.email}
+          aria-label={`Account ${user.email}`}
         >
-          {user.email}
+          {avatarInitial(user.email)}
         </button>
         {menuOpen && (
-          <div className="auth-badge__menu" role="menu">
-            <button type="button" className="auth-badge__menu-item" onClick={handleSignOut}>
+          <div className="auth-chip__menu" role="menu">
+            <div className="auth-chip__menu-email">{user.email}</div>
+            <button
+              type="button"
+              className="auth-chip__menu-item"
+              onClick={handleSignOut}
+            >
               Sign out
             </button>
+            {signOutError && <div className="auth-chip__menu-error">{signOutError}</div>}
           </div>
         )}
-        {signOutError && <div className="auth-badge__error">{signOutError}</div>}
       </div>
     );
   }
 
   return (
-    <div className="auth-badge">
-      <button type="button" className="auth-badge__chip" onClick={handleSignIn}>
+    <div className="auth-chip auth-chip--wrap" ref={wrapRef}>
+      <button
+        type="button"
+        className="auth-chip__pill auth-chip__pill--signin"
+        onClick={handleSignIn}
+      >
         Sign in
       </button>
     </div>

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1431,11 +1431,16 @@
  * page (one canonical inter-space nav, two surfaces).
  */
 .home-breadcrumb {
-  position: relative;
-  z-index: 1;
+  /* Sticky at the top of the scroll container so the bar (auth chip +
+     space switcher) stays pinned as the feed scrolls under it. The
+     padding-top adds the same breathing room the breadcrumb used to
+     have before it pinned. */
+  position: sticky;
+  top: 0;
+  z-index: 4;
   max-width: 1100px;
   margin: 0 auto;
-  padding: 32px 32px 0;
+  padding: 16px 32px 12px;
   display: flex;
   align-items: center;
 }

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -651,11 +651,10 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             identity + navigation share one sticky bar at the top of
             every view. Always renders, so the Sign-in CTA is reachable
             even on a brand-new workspace with no spaces yet. */}
-        <nav className="home-breadcrumb" aria-label="Spaces">
+        <nav className="home-breadcrumb" aria-label="Account and spaces">
             <LayoutGroup id="home-breadcrumb">
             <div className="home-breadcrumb-inner">
             <AuthBadge />
-            <span className="home-breadcrumb-divider" aria-hidden="true" />
             <button
               type="button"
               className={`home-breadcrumb-pill home-breadcrumb-pill--home${isHomeView && !showElsewhere && !showVault ? " selected" : ""}`}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -9,6 +9,7 @@ import { useAuthSignedIn } from "../../hooks/useAuthSignedIn";
 import { useMyDeviceId } from "../../hooks/useMyDeviceId";
 import { useSpaceProjects } from "../../hooks/useSpaceProjects";
 import { parseTimestamp } from "../../utils/parseTimestamp";
+import { AuthBadge } from "../AuthBadge";
 import { Desktop } from "../Desktop";
 import { InspectorPanel, type ActivePanel } from "../InspectorPanel";
 import { SessionInspector } from "../SessionInspector";
@@ -645,11 +646,16 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             badges for non-zero active/waiting/disconnected counts so the
             at-a-glance dashboard info lives in the nav itself; no need
             for a separate "Spaces" content section that would just
-            duplicate the same data. */}
-        {(realSpaces.length > 0 || orphanCounts.total > 0) && (
-          <nav className="home-breadcrumb" aria-label="Spaces">
+            duplicate the same data. The leftmost slot is the account
+            chip (avatar when signed-in / "Sign in" when signed-out) so
+            identity + navigation share one sticky bar at the top of
+            every view. Always renders, so the Sign-in CTA is reachable
+            even on a brand-new workspace with no spaces yet. */}
+        <nav className="home-breadcrumb" aria-label="Spaces">
             <LayoutGroup id="home-breadcrumb">
             <div className="home-breadcrumb-inner">
+            <AuthBadge />
+            <span className="home-breadcrumb-divider" aria-hidden="true" />
             <button
               type="button"
               className={`home-breadcrumb-pill home-breadcrumb-pill--home${isHomeView && !showElsewhere && !showVault ? " selected" : ""}`}
@@ -753,7 +759,6 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             </div>
             </LayoutGroup>
           </nav>
-        )}
 
         {showVaultPage ? (
           <VaultInfo />


### PR DESCRIPTION
## Summary

- Account chip and space switcher now share a single bar pinned to the top of every view. Was: floating *Sign in / email* card top-left + a non-sticky pill bar that scrolled away.
- Signed-in: initial-as-glyph avatar pill (email + sign-out in click-menu).
- Signed-out: *Sign in* pill in the same slot.
- Signing-in: spinner pill with the device-flow hint + manual link + cancel in the menu (replaces the wide pending card).
- `AuthBadge` is now an inline chip inside `home-breadcrumb-inner`; the breadcrumb itself is `position: sticky; top: 0` and renders unconditionally so the Sign-in CTA is reachable from a brand-new workspace.
- Mockup HTML kept under `docs/mockups/topbar-signin.html` for reference.

Part of 0.9.1.

## Test plan

- [ ] Signed-out: `Sign in` pill is the leftmost element in the dark pill bar; clicking starts the device flow and opens the popover with the hint + manual link + cancel.
- [ ] Signed-in: avatar (initial) pill is the leftmost element; clicking opens menu with email + Sign out.
- [ ] Scroll the feed — the top bar stays pinned.
- [ ] Brand-new workspace with zero spaces: top bar still renders so Sign in is reachable.
- [ ] Switch spaces — selected pill background animates as before (Framer Motion shared-layout intact).
- [ ] Cancel mid-sign-in returns to signed-out cleanly; device-code TTL flips back to signed-out on expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)