### PR TITLE
feat: artefact resilience — recover tombstoned rows + backfill creation links

### DIFF
--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -7,6 +7,7 @@ import type { SpaceStore } from "./space-store.js";
 import type { Artifact, ArtifactKind, ArtifactStatus } from "../../shared/types.js";
 import { isPortOpen, isStarting, clearStarting, getGeneratedArtifactEntries } from "./process-manager.js";
 import { resolveArtifactPathViaProjects } from "./resolve-artifact-path.js";
+import { artifactTouchFromToolUse } from "./watchers/claude-code.js";
 import { slugify, inferKindFromPath, toArtifactKind } from "./utils.js";
 import { debug, debugEnabled } from "./debug.js";
 
@@ -374,6 +375,14 @@ export class ArtifactService {
       source_ref: null,
     });
 
+    // Backfill session→artefact links. The watcher's live touch-detection
+    // only fires when the artefact already exists in the DB at tool_use
+    // time. Artefacts created via raw `Write` then registered later miss
+    // every session that touched them. Scan recent assistant events for
+    // tool_use blocks at this path and create matching session_artifacts
+    // rows.
+    this.backfillTouchesForNewArtefact(id, absPath);
+
     return {
       id,
       label: params.label,
@@ -386,6 +395,45 @@ export class ArtifactService {
       createdAt: new Date().toISOString(),
       groupName: params.group_name || undefined,
     };
+  }
+
+  // Look back at recent assistant events for tool_use blocks at this
+  // path; for each, insert a session_artifacts row with the role implied
+  // by the tool (Write → create, Edit → modify, Read → read). Deduped on
+  // (session_id, role) so we don't multiply duplicate touches when the
+  // same session called Write three times. Bounded to 30 days to keep
+  // the scan cheap; very old artefacts won't backfill, which is fine —
+  // the value is closing the loop for fresh creations.
+  private backfillTouchesForNewArtefact(artifactId: string, absPath: string): void {
+    const events = this.db
+      .prepare(
+        `SELECT session_id, raw
+           FROM session_events
+          WHERE role = 'assistant'
+            AND raw IS NOT NULL
+            AND raw LIKE ?
+            AND ts > datetime('now', '-30 days')`,
+      )
+      .all("%" + absPath + "%") as Array<{ session_id: string; raw: string }>;
+    const seen = new Set<string>(); // `${session_id}:${role}` keys already inserted
+    const insert = this.db.prepare(
+      "INSERT INTO session_artifacts (session_id, artifact_id, role) VALUES (?, ?, ?)",
+    );
+    for (const row of events) {
+      let parsed: unknown;
+      try { parsed = JSON.parse(row.raw); } catch { continue; }
+      const content = (parsed as { message?: { content?: unknown[] } })?.message?.content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        const touch = artifactTouchFromToolUse(block);
+        if (!touch || touch.path !== absPath) continue;
+        const key = `${row.session_id}:${touch.role}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        try { insert.run(row.session_id, artifactId, touch.role); }
+        catch { /* FK to sessions might fail if session was deleted; ignore */ }
+      }
+    }
   }
 
   // ── Creation ──

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -1,10 +1,12 @@
 import { existsSync, mkdirSync, writeFileSync, unlinkSync, statSync } from "node:fs";
 import { resolve, basename, dirname, join, sep } from "node:path";
 import crypto from "node:crypto";
+import type Database from "better-sqlite3";
 import type { ArtifactStore, ArtifactRow } from "./artifact-store.js";
 import type { SpaceStore } from "./space-store.js";
 import type { Artifact, ArtifactKind, ArtifactStatus } from "../../shared/types.js";
 import { isPortOpen, isStarting, clearStarting, getGeneratedArtifactEntries } from "./process-manager.js";
+import { resolveArtifactPathViaProjects } from "./resolve-artifact-path.js";
 import { slugify, inferKindFromPath, toArtifactKind } from "./utils.js";
 import { debug, debugEnabled } from "./debug.js";
 
@@ -105,7 +107,7 @@ export class ArtifactService {
     this.getCloudOnlyPublications = source;
   }
 
-  constructor(private store: ArtifactStore, private workerBase: string, private viewerBase: string, private userlandDir?: string, private spaceStore?: SpaceStore) {}
+  constructor(private db: Database.Database, private store: ArtifactStore, private workerBase: string, private viewerBase: string, private userlandDir?: string, private spaceStore?: SpaceStore) {}
 
   async getAllArtifacts(onArtifactRemoved?: (id: string, filePath: string) => void): Promise<Artifact[]> {
     const allRows = this.store.getAll();
@@ -124,13 +126,34 @@ export class ArtifactService {
     for (const row of allRows) {
       const storagePath = storagePathOf(row);
       if (storagePath) {
+        let effectivePath = storagePath;
         if (!pathExistsOrThrow(storagePath)) {
-          this.store.remove(row.id);
-          this.invalidateArchivedPaths();
-          onArtifactRemoved?.(row.id, storagePath);
-          continue;
+          // Before tombstoning, try to recover via project_paths — the
+          // file may have just moved with a folder rename. Same primitive
+          // as lookupProject for sessions: walk up the path, find the
+          // owning project, try the same relative remainder under each
+          // of the project's other cached folders.
+          const recovered = resolveArtifactPathViaProjects(this.db, storagePath);
+          if (recovered) {
+            this.store.update(row.id, {
+              storage_config: JSON.stringify({ path: recovered.newPath }),
+              project_id: recovered.projectId,
+            });
+            this.invalidateArchivedPaths();
+            // Refresh in-memory view so downstream rowToArtifact + the
+            // pathByRowIdx cache see the new path immediately. No need
+            // to re-SELECT — we know exactly what we just wrote.
+            row.storage_config = JSON.stringify({ path: recovered.newPath });
+            row.project_id = recovered.projectId;
+            effectivePath = recovered.newPath;
+          } else {
+            this.store.remove(row.id);
+            this.invalidateArchivedPaths();
+            onArtifactRemoved?.(row.id, storagePath);
+            continue;
+          }
         }
-        pathByRowIdx.set(rows.length, storagePath);
+        pathByRowIdx.set(rows.length, effectivePath);
       }
       rows.push(row);
     }

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -405,16 +405,27 @@ export class ArtifactService {
   // the scan cheap; very old artefacts won't backfill, which is fine —
   // the value is closing the loop for fresh creations.
   private backfillTouchesForNewArtefact(artifactId: string, absPath: string): void {
+    // - `role IN ('assistant', 'tool')` — the watcher stores pure
+    //   tool-call turns as `tool` (see renderEvent in
+    //   watchers/claude-code.ts), not `assistant`. The old
+    //   `role = 'assistant'` filter missed the common case.
+    // - `instr(raw, ?) > 0` instead of `raw LIKE '%' || ? || '%'` —
+    //   sidesteps `_` / `%` wildcards in file paths that would
+    //   false-match unrelated events.
+    // - LIMIT 10000 + ORDER BY id DESC — bounded scan against
+    //   potentially-huge session_events. 10000 is plenty for the
+    //   "I just wrote this file" case the backfill targets.
     const events = this.db
       .prepare(
         `SELECT session_id, raw
            FROM session_events
-          WHERE role = 'assistant'
+          WHERE role IN ('assistant', 'tool')
             AND raw IS NOT NULL
-            AND raw LIKE ?
-            AND ts > datetime('now', '-30 days')`,
+            AND instr(raw, ?) > 0
+          ORDER BY id DESC
+          LIMIT 10000`,
       )
-      .all("%" + absPath + "%") as Array<{ session_id: string; raw: string }>;
+      .all(absPath) as Array<{ session_id: string; raw: string }>;
     const seen = new Set<string>(); // `${session_id}:${role}` keys already inserted
     const insert = this.db.prepare(
       "INSERT INTO session_artifacts (session_id, artifact_id, role) VALUES (?, ?, ?)",

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { join } from "node:path";
-import { resolveArtifactPathViaProjects } from "./resolve-artifact-path.js";
+import { existsSync } from "node:fs";
+import { resolveArtifactPathViaProjects, findProjectAtAncestor } from "./resolve-artifact-path.js";
 
 export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -539,12 +540,72 @@ export function initDb(userlandDir: string): Database.Database {
       let oldPath: string | undefined;
       try { oldPath = (JSON.parse(row.storage_config) as { path?: string }).path; } catch { /* malformed config, skip */ }
       if (!oldPath) continue;
+      if (existsSync(oldPath)) {
+        // File came back at the same path — undelete in place; stamp
+        // project_id from the ancestor walk.
+        const projectId = findProjectAtAncestor(db, oldPath);
+        update.run(row.storage_config, projectId, row.id);
+        continue;
+      }
       const recovered = resolveArtifactPathViaProjects(db, oldPath);
       if (recovered) {
         update.run(JSON.stringify({ path: recovered.newPath }), recovered.projectId, row.id);
       }
     }
   }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Artefact dedup: after recovery, multiple LIVE rows can point at the
+  // same storage_config.path (e.g. one already-recovered + one survivor
+  // at the same target). Collapse — keep the row with the most
+  // session_artifacts touches (tiebreaker: most recent created_at).
+  // Loser's links migrate to winner (with (session_id, role) dedup so we
+  // don't multiply duplicate touches), losers soft-deleted.
+  // Idempotent — after the collapse, exactly one live row per path.
+  // ─────────────────────────────────────────────────────────────────────────
+  db.exec(`
+    CREATE TEMP TABLE IF NOT EXISTS artefact_dedup_winners AS
+    WITH ranked AS (
+      SELECT
+        a.id,
+        json_extract(a.storage_config, '$.path') AS path,
+        ROW_NUMBER() OVER (
+          PARTITION BY json_extract(a.storage_config, '$.path')
+          ORDER BY
+            (SELECT COUNT(*) FROM session_artifacts sa WHERE sa.artifact_id = a.id) DESC,
+            a.created_at DESC
+        ) AS rn
+      FROM artifacts a
+      WHERE a.removed_at IS NULL
+        AND a.storage_kind = 'filesystem'
+        AND json_extract(a.storage_config, '$.path') IS NOT NULL
+    )
+    SELECT loser.id AS loser_id, winner.id AS winner_id
+      FROM ranked loser
+      JOIN ranked winner ON winner.path = loser.path AND winner.rn = 1
+     WHERE loser.rn > 1;
+  `);
+  // Drop loser-side links that would duplicate a (session_id, role) the
+  // winner already owns — session_artifacts has a surrogate id PK so
+  // naive UPDATE would otherwise multiply the same touch.
+  db.exec(`
+    DELETE FROM session_artifacts
+     WHERE artifact_id IN (SELECT loser_id FROM artefact_dedup_winners)
+       AND EXISTS (
+         SELECT 1
+           FROM session_artifacts sa
+           JOIN artefact_dedup_winners m ON m.winner_id = sa.artifact_id
+          WHERE sa.session_id = session_artifacts.session_id
+            AND sa.role = session_artifacts.role
+            AND m.loser_id = session_artifacts.artifact_id
+       );
+    UPDATE session_artifacts
+       SET artifact_id = (SELECT winner_id FROM artefact_dedup_winners WHERE loser_id = session_artifacts.artifact_id)
+     WHERE artifact_id IN (SELECT loser_id FROM artefact_dedup_winners);
+    UPDATE artifacts SET removed_at = datetime('now')
+     WHERE id IN (SELECT loser_id FROM artefact_dedup_winners);
+    DROP TABLE artefact_dedup_winners;
+  `);
 
   // One-time canonical-form migration for paths and cwds. The longest-prefix
   // binding SQL compares `sessions.cwd` against `sources.path` via substr

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { join } from "node:path";
+import { resolveArtifactPathViaProjects } from "./resolve-artifact-path.js";
 
 export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -517,6 +518,33 @@ export function initDb(userlandDir: string): Database.Database {
             AND (artifacts.space_id IS NULL OR artifacts.space_id != p.space_id)
        );
   `);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tombstone recovery: artefacts the OLD self-heal tombstoned because
+  // their folder happened to be renamed. For each soft-deleted row, try
+  // the resolver — if the file is reachable under another cached path of
+  // the same project, undelete + update path + stamp project_id. Truly
+  // missing files stay tombstoned. JS-side because it needs filesystem
+  // checks; safe to run on every boot — recovered rows are no longer
+  // selected on subsequent passes (`removed_at IS NOT NULL` filter).
+  // ─────────────────────────────────────────────────────────────────────────
+  const tombstones = db
+    .prepare("SELECT id, storage_config FROM artifacts WHERE removed_at IS NOT NULL AND storage_kind = 'filesystem'")
+    .all() as Array<{ id: string; storage_config: string }>;
+  if (tombstones.length > 0) {
+    const update = db.prepare(
+      "UPDATE artifacts SET removed_at = NULL, storage_config = ?, project_id = ?, updated_at = datetime('now') WHERE id = ?",
+    );
+    for (const row of tombstones) {
+      let oldPath: string | undefined;
+      try { oldPath = (JSON.parse(row.storage_config) as { path?: string }).path; } catch { /* malformed config, skip */ }
+      if (!oldPath) continue;
+      const recovered = resolveArtifactPathViaProjects(db, oldPath);
+      if (recovered) {
+        update.run(JSON.stringify({ path: recovered.newPath }), recovered.projectId, row.id);
+      }
+    }
+  }
 
   // One-time canonical-form migration for paths and cwds. The longest-prefix
   // binding SQL compares `sessions.cwd` against `sources.path` via substr

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -290,7 +290,7 @@ const VIEWER_BASE = process.env.OYSTER_VIEWER_BASE
 // — that lives at OYSTER_HOME root (URL-addressable via /artifacts/icons/...),
 // not inside DB_DIR. spaceStore is passed in so the service can enumerate
 // local spaces when filtering cloud-only publications.
-const artifactService = new ArtifactService(store, WORKER_BASE, VIEWER_BASE, OYSTER_HOME, spaceStore);
+const artifactService = new ArtifactService(db, store, WORKER_BASE, VIEWER_BASE, OYSTER_HOME, spaceStore);
 
 const memoryProvider = new SqliteFtsMemoryProvider(DB_DIR);
 await bootTimeAsync("memoryProvider.init", () => memoryProvider.init());

--- a/server/src/resolve-artifact-path.ts
+++ b/server/src/resolve-artifact-path.ts
@@ -9,11 +9,29 @@
 // `store.remove(id)`) and by a one-shot boot migration that heals
 // tombstones produced by the old self-heal.
 
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import type Database from "better-sqlite3";
 
 const MAX_WALK_DEPTH = 32;
+
+// True iff the path definitely doesn't exist (ENOENT / ENOTDIR). Any
+// other stat error — permissions, slow drive timeout — re-throws or
+// returns true (we treat transient IO failures as "still here" so we
+// don't tombstone artefacts whose backing drives are temporarily slow).
+function pathExistsOrThrow(path: string): boolean {
+  try {
+    statSync(path);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    // Anything else (EACCES, EIO, EBUSY, etc.) is a transient or
+    // permission issue. Treat as "exists, can't tell" so we don't
+    // false-tombstone or false-recover.
+    return true;
+  }
+}
 
 export interface ArtifactPathResolution {
   newPath: string;
@@ -32,16 +50,20 @@ export function findProjectAtAncestor(
 ): string | null {
   let dir = dirname(path);
   for (let i = 0; i < MAX_WALK_DEPTH; i++) {
-    const row = db
+    // LIMIT 2 + abstain on multi-match — if two live projects share a
+    // cached path (rare but possible from a buggy attach), picking
+    // arbitrarily would silently route the artefact to the wrong one.
+    const rows = db
       .prepare(
-        `SELECT pp.project_id
+        `SELECT DISTINCT pp.project_id
            FROM project_paths pp
            JOIN projects p ON p.id = pp.project_id
           WHERE pp.path = ? AND p.removed_at IS NULL
-          LIMIT 1`,
+          LIMIT 2`,
       )
-      .get(dir) as { project_id: string } | undefined;
-    if (row) return row.project_id;
+      .all(dir) as Array<{ project_id: string }>;
+    if (rows.length === 1) return rows[0].project_id;
+    if (rows.length > 1) return null; // ambiguous — abstain
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -61,20 +83,21 @@ export function resolveArtifactPathViaProjects(
   let owningProjectId: string | null = null;
   let owningAncestor: string | null = null;
   for (let i = 0; i < MAX_WALK_DEPTH; i++) {
-    const row = db
+    const rows = db
       .prepare(
-        `SELECT pp.project_id
+        `SELECT DISTINCT pp.project_id
            FROM project_paths pp
            JOIN projects p ON p.id = pp.project_id
           WHERE pp.path = ? AND p.removed_at IS NULL
-          LIMIT 1`,
+          LIMIT 2`,
       )
-      .get(dir) as { project_id: string } | undefined;
-    if (row) {
-      owningProjectId = row.project_id;
+      .all(dir) as Array<{ project_id: string }>;
+    if (rows.length === 1) {
+      owningProjectId = rows[0].project_id;
       owningAncestor = dir;
       break;
     }
+    if (rows.length > 1) return null; // ambiguous owner — abstain
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
@@ -91,7 +114,10 @@ export function resolveArtifactPathViaProjects(
   const matches: string[] = [];
   for (const { path: candidate } of others) {
     const candidatePath = join(candidate, rel);
-    if (existsSync(candidatePath)) matches.push(candidatePath);
+    // Stat-based check: only ENOENT/ENOTDIR counts as missing. A
+    // permission glitch or busy drive returns "exists, can't tell" so
+    // we don't silently miss a real candidate.
+    if (pathExistsOrThrow(candidatePath)) matches.push(candidatePath);
   }
   if (matches.length !== 1) return null;
   return { newPath: matches[0], projectId: owningProjectId };

--- a/server/src/resolve-artifact-path.ts
+++ b/server/src/resolve-artifact-path.ts
@@ -20,6 +20,35 @@ export interface ArtifactPathResolution {
   projectId: string;
 }
 
+// Walk up `path` looking for an ancestor that's cached in project_paths
+// against a live project. Returns that project's id, or null when no
+// ancestor matches. The deepest match wins (nested projects). Used both
+// by the resolver (to know which project to search siblings under) and
+// by the tombstone-recovery migration (to stamp project_id on rows
+// whose original path is back).
+export function findProjectAtAncestor(
+  db: Database.Database,
+  path: string,
+): string | null {
+  let dir = dirname(path);
+  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
+    const row = db
+      .prepare(
+        `SELECT pp.project_id
+           FROM project_paths pp
+           JOIN projects p ON p.id = pp.project_id
+          WHERE pp.path = ? AND p.removed_at IS NULL
+          LIMIT 1`,
+      )
+      .get(dir) as { project_id: string } | undefined;
+    if (row) return row.project_id;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
 export function resolveArtifactPathViaProjects(
   db: Database.Database,
   originalPath: string,

--- a/server/src/resolve-artifact-path.ts
+++ b/server/src/resolve-artifact-path.ts
@@ -1,0 +1,69 @@
+// Find an artefact's new location after a folder rename, by leveraging
+// the project_paths cache. Same primitive lookupProject uses for
+// sessions: walk up the stored path looking for an ancestor that's
+// known as a project's cached folder; once found, try the same relative
+// remainder under each of that project's OTHER cached paths and return
+// the unique match. Ambiguous or no-match → null.
+//
+// Used by the artefact-service self-heal (replaces a blunt
+// `store.remove(id)`) and by a one-shot boot migration that heals
+// tombstones produced by the old self-heal.
+
+import { existsSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import type Database from "better-sqlite3";
+
+const MAX_WALK_DEPTH = 32;
+
+export interface ArtifactPathResolution {
+  newPath: string;
+  projectId: string;
+}
+
+export function resolveArtifactPathViaProjects(
+  db: Database.Database,
+  originalPath: string,
+): ArtifactPathResolution | null {
+  // 1. Walk up from the artefact's stored path; stop at the deepest
+  //    ancestor that's cached in project_paths against a live project.
+  //    Nested projects: the deepest ancestor wins, so a file in
+  //    `<outer>/<inner>/x.md` resolves via `<inner>` not `<outer>`.
+  let dir = dirname(originalPath);
+  let owningProjectId: string | null = null;
+  let owningAncestor: string | null = null;
+  for (let i = 0; i < MAX_WALK_DEPTH; i++) {
+    const row = db
+      .prepare(
+        `SELECT pp.project_id
+           FROM project_paths pp
+           JOIN projects p ON p.id = pp.project_id
+          WHERE pp.path = ? AND p.removed_at IS NULL
+          LIMIT 1`,
+      )
+      .get(dir) as { project_id: string } | undefined;
+    if (row) {
+      owningProjectId = row.project_id;
+      owningAncestor = dir;
+      break;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (!owningProjectId || !owningAncestor) return null;
+
+  // 2. Compute the relative remainder + every OTHER cached path of this
+  //    project. Try each candidate; collect the ones that actually exist
+  //    on disk. Exactly one match → that's the new path. 0 or 2+ → bail.
+  const rel = relative(owningAncestor, originalPath);
+  const others = db
+    .prepare("SELECT path FROM project_paths WHERE project_id = ? AND path != ?")
+    .all(owningProjectId, owningAncestor) as Array<{ path: string }>;
+  const matches: string[] = [];
+  for (const { path: candidate } of others) {
+    const candidatePath = join(candidate, rel);
+    if (existsSync(candidatePath)) matches.push(candidatePath);
+  }
+  if (matches.length !== 1) return null;
+  return { newPath: matches[0], projectId: owningProjectId };
+}

--- a/server/test/artifact-service-create-backfill.test.ts
+++ b/server/test/artifact-service-create-backfill.test.ts
@@ -63,16 +63,58 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
     expect(link).toEqual({ session_id: "sess-1", role: "create" });
   });
 
-  it("does not create duplicate links when register is called twice in quick succession", async () => {
+  it("does not duplicate links when register is called a second time (resurrect path skips backfill)", async () => {
     const filePath = join(folder, "x.md");
     writeFileSync(filePath, "ok");
     recordWriteEvent("sess-1", filePath);
 
+    // First call: inserts + backfills → 1 link.
     const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "x", id: "fixed-id" }, [folder]);
-    // Same id → registerArtifact's "resurrect" path; we shouldn't backfill again.
-    // Simulate by inserting a manual session_artifacts row pre-second-call.
-    const before = db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number };
-    expect(before.c).toBe(1);
+    expect((db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number }).c).toBe(1);
+
+    // Soft-delete + re-register: hits the resurrect branch (existing
+    // row with removed_at set). That branch must NOT re-run the
+    // backfill — the original link is still there, so adding another
+    // would produce a duplicate touch.
+    db.prepare("UPDATE artifacts SET removed_at = datetime('now') WHERE id = ?").run("fixed-id");
+    await service.registerArtifact({ path: filePath, space_id: "work", label: "x", id: "fixed-id" }, [folder]);
+    expect((db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number }).c).toBe(1);
+  });
+
+  it("backfills from role='tool' events too (the watcher stores pure tool-call turns as role='tool')", async () => {
+    const filePath = join(folder, "tool-only.md");
+    writeFileSync(filePath, "ok");
+    // No prose text — a pure tool-call assistant turn that the watcher
+    // would store as role='tool' rather than 'assistant'.
+    db.prepare("INSERT INTO session_events (session_id, role, text, raw) VALUES ('sess-1', 'tool', '[Write]', ?)").run(
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Write", input: { file_path: filePath } }] } }),
+    );
+
+    const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "tool" }, [folder]);
+
+    const link = db.prepare("SELECT session_id, role FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { session_id: string; role: string };
+    expect(link).toEqual({ session_id: "sess-1", role: "create" });
+  });
+
+  it("doesn't false-match when the file path contains LIKE wildcards (`%`, `_`)", async () => {
+    // A real folder with an underscore in the name. Without instr-based
+    // matching (or escape on LIKE), `_` would wildcard a single char and
+    // the backfill could match an unrelated event.
+    const wildPath = join(folder, "report_v1.md");
+    writeFileSync(wildPath, "ok");
+    // Event mentions a DIFFERENT file whose path matches the LIKE
+    // pattern `report_v1.md` if `_` is wildcarded: `reportXv1.md`.
+    // The raw JSON contains "reportXv1.md" — would match `%report_v1%`
+    // under naive LIKE.
+    db.prepare("INSERT INTO session_events (session_id, role, text, raw) VALUES ('sess-1', 'assistant', '', ?)").run(
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Write", input: { file_path: join(folder, "reportXv1.md") } }] } }),
+    );
+
+    const art = await service.registerArtifact({ path: wildPath, space_id: "work", label: "wild" }, [folder]);
+
+    // No false match — the event mentions reportXv1.md, not report_v1.md.
+    const count = db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number };
+    expect(count.c).toBe(0);
   });
 
   it("does nothing when no recent session_events mention this path", async () => {

--- a/server/test/artifact-service-create-backfill.test.ts
+++ b/server/test/artifact-service-create-backfill.test.ts
@@ -1,0 +1,117 @@
+// registerArtifact backfills session→creation links by scanning recent
+// session_events for Write/Edit/Read tool_use blocks at the artefact's
+// path. Closes the provenance loop for artefacts that were created via
+// the raw `Write` tool (e.g. the yellow-pen-audit report) and registered
+// later — the watcher's live touch-detection only fires when the artefact
+// already exists in the DB at tool_use time.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { ArtifactService } from "../src/artifact-service.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+describe("ArtifactService.registerArtifact — session→creation link backfill", () => {
+  let userland: string;
+  let folder: string;
+  let db: Database.Database;
+  let service: ArtifactService;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-csb-userland-"));
+    folder = mkdtempSync(join(tmpdir(), "oyster-csb-folder-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work', 'Work', '#000', 'none')`);
+    db.prepare("INSERT INTO sessions (id, agent, state, space_id) VALUES (?, 'claude-code', 'done', 'work')").run("sess-1");
+    service = new ArtifactService(db, new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to", userland);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(userland, { recursive: true, force: true });
+    rmSync(folder, { recursive: true, force: true });
+  });
+
+  function recordWriteEvent(sessionId: string, filePath: string) {
+    const raw = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", name: "Write", input: { file_path: filePath } }],
+      },
+    });
+    db.prepare(
+      "INSERT INTO session_events (session_id, role, text, raw) VALUES (?, 'assistant', '', ?)",
+    ).run(sessionId, raw);
+  }
+
+  it("backfills a `create` link when a session wrote to this file before the artefact was registered", async () => {
+    const filePath = join(folder, "report.md");
+    writeFileSync(filePath, "ok");
+    recordWriteEvent("sess-1", filePath);
+
+    const art = await service.registerArtifact(
+      { path: filePath, space_id: "work", label: "report" },
+      [folder],
+    );
+
+    const link = db.prepare(
+      "SELECT session_id, role FROM session_artifacts WHERE artifact_id = ?",
+    ).get(art.id) as { session_id: string; role: string };
+    expect(link).toEqual({ session_id: "sess-1", role: "create" });
+  });
+
+  it("does not create duplicate links when register is called twice in quick succession", async () => {
+    const filePath = join(folder, "x.md");
+    writeFileSync(filePath, "ok");
+    recordWriteEvent("sess-1", filePath);
+
+    const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "x", id: "fixed-id" }, [folder]);
+    // Same id → registerArtifact's "resurrect" path; we shouldn't backfill again.
+    // Simulate by inserting a manual session_artifacts row pre-second-call.
+    const before = db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number };
+    expect(before.c).toBe(1);
+  });
+
+  it("does nothing when no recent session_events mention this path", async () => {
+    const filePath = join(folder, "untouched.md");
+    writeFileSync(filePath, "ok");
+    // No recordWriteEvent — no prior writes for this path.
+
+    const art = await service.registerArtifact(
+      { path: filePath, space_id: "work", label: "u" },
+      [folder],
+    );
+
+    const count = db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number };
+    expect(count.c).toBe(0);
+  });
+
+  it("backfills Edit and Read tool_uses too, with the correct role", async () => {
+    const filePath = join(folder, "edited.md");
+    writeFileSync(filePath, "ok");
+    db.prepare("INSERT INTO sessions (id, agent, state, space_id) VALUES ('sess-2', 'claude-code', 'done', 'work')").run();
+    db.prepare("INSERT INTO sessions (id, agent, state, space_id) VALUES ('sess-3', 'claude-code', 'done', 'work')").run();
+    // sess-1 Wrote, sess-2 Edited, sess-3 Read
+    recordWriteEvent("sess-1", filePath);
+    db.prepare("INSERT INTO session_events (session_id, role, text, raw) VALUES ('sess-2', 'assistant', '', ?)").run(
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Edit", input: { file_path: filePath } }] } }),
+    );
+    db.prepare("INSERT INTO session_events (session_id, role, text, raw) VALUES ('sess-3', 'assistant', '', ?)").run(
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: { file_path: filePath } }] } }),
+    );
+
+    const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "e" }, [folder]);
+
+    const links = db.prepare(
+      "SELECT session_id, role FROM session_artifacts WHERE artifact_id = ? ORDER BY session_id",
+    ).all(art.id) as Array<{ session_id: string; role: string }>;
+    expect(links).toEqual([
+      { session_id: "sess-1", role: "create" },
+      { session_id: "sess-2", role: "modify" },
+      { session_id: "sess-3", role: "read" },
+    ]);
+  });
+});

--- a/server/test/artifact-service-self-heal.test.ts
+++ b/server/test/artifact-service-self-heal.test.ts
@@ -1,0 +1,90 @@
+// ArtifactService.getAllArtifacts self-heal: when a filesystem-backed
+// artefact's stored path is missing on disk, we used to soft-delete the
+// row outright. That tombstoned artefacts on every folder rename — the
+// same path-fragility problem the projects refactor fixed for sessions.
+// Now we try `resolveArtifactPathViaProjects` first; if the file moved
+// with the rename (still findable under another cached path of the same
+// project), the row gets its path + projectId updated in-place instead.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { ArtifactService } from "../src/artifact-service.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+const PROJ_ID = "11111111-2222-3333-4444-555555555555";
+
+describe("ArtifactService.getAllArtifacts self-heal — resolver path", () => {
+  let userland: string;
+  let oldDir: string;
+  let newDir: string;
+  let db: Database.Database;
+  let service: ArtifactService;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-sh-userland-"));
+    oldDir = mkdtempSync(join(tmpdir(), "oyster-sh-old-"));
+    newDir = mkdtempSync(join(tmpdir(), "oyster-sh-new-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work', 'Work', '#000', 'none')`);
+    db.prepare(`INSERT INTO projects (id, space_id, name) VALUES (?, 'work', 'Proj')`).run(PROJ_ID);
+    db.prepare(`INSERT INTO project_paths (project_id, path) VALUES (?, ?)`).run(PROJ_ID, oldDir);
+    db.prepare(`INSERT INTO project_paths (project_id, path) VALUES (?, ?)`).run(PROJ_ID, newDir);
+    service = new ArtifactService(db, new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to", userland);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(userland, { recursive: true, force: true });
+    rmSync(oldDir, { recursive: true, force: true });
+    rmSync(newDir, { recursive: true, force: true });
+  });
+
+  function seedFilesystemArtifact(id: string, path: string, project_id: string | null = null) {
+    db.prepare(
+      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)
+       VALUES (?, 'work', ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+    ).run(id, "doc", JSON.stringify({ path }), project_id);
+  }
+
+  it("updates the artefact path + project_id when the file is recoverable via project_paths", async () => {
+    mkdirSync(join(newDir, "docs"), { recursive: true });
+    writeFileSync(join(newDir, "docs", "report.md"), "ok");
+    seedFilesystemArtifact("art-1", join(oldDir, "docs", "report.md"));
+
+    const result = await service.getAllArtifacts(() => {});
+
+    // Row survives (NOT tombstoned).
+    expect(result.find((a) => a.id === "art-1")).toBeDefined();
+    const row = db.prepare("SELECT storage_config, project_id, removed_at FROM artifacts WHERE id = 'art-1'").get() as { storage_config: string; project_id: string | null; removed_at: string | null };
+    expect(row.removed_at).toBeNull();
+    expect(JSON.parse(row.storage_config)).toEqual({ path: join(newDir, "docs", "report.md") });
+    expect(row.project_id).toBe(PROJ_ID); // stamped while we were there
+  });
+
+  it("falls back to the old soft-delete behaviour when the resolver returns nothing", async () => {
+    // Path is missing AND not recoverable via project_paths (no matching file anywhere).
+    seedFilesystemArtifact("art-2", join(oldDir, "totally-gone.md"));
+
+    const result = await service.getAllArtifacts(() => {});
+
+    expect(result.find((a) => a.id === "art-2")).toBeUndefined();
+    const row = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'art-2'").get() as { removed_at: string | null };
+    expect(row.removed_at).not.toBeNull(); // tombstoned, as before
+  });
+
+  it("doesn't touch artefacts whose path still exists on disk", async () => {
+    writeFileSync(join(newDir, "ok.md"), "ok");
+    seedFilesystemArtifact("art-3", join(newDir, "ok.md"));
+
+    const result = await service.getAllArtifacts(() => {});
+
+    expect(result.find((a) => a.id === "art-3")).toBeDefined();
+    const row = db.prepare("SELECT storage_config, removed_at FROM artifacts WHERE id = 'art-3'").get() as { storage_config: string; removed_at: string | null };
+    expect(row.removed_at).toBeNull();
+    expect(JSON.parse(row.storage_config)).toEqual({ path: join(newDir, "ok.md") });
+  });
+});

--- a/server/test/artifact-service.test.ts
+++ b/server/test/artifact-service.test.ts
@@ -78,7 +78,7 @@ describe("artifact wire format — publication", () => {
   beforeEach(() => {
     db = makeDb();
     const store = new SqliteArtifactStore(db);
-    service = new ArtifactService(store, "https://oyster.to", "https://share.oyster.to");
+    service = new ArtifactService(db, store, "https://oyster.to", "https://share.oyster.to");
   });
 
   it("omits the publication field when share_token is NULL", async () => {
@@ -125,7 +125,7 @@ describe("artifact wire format — cloud-only ghosts", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
+    service = new ArtifactService(db, new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("synthesises a cloudOnly ghost using the cloud label, falling back to artifact_id", async () => {
@@ -192,7 +192,7 @@ describe("artifact wire format — pin (#387)", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
+    service = new ArtifactService(db, new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("omits pinnedAt when pinned_at is NULL", async () => {
@@ -217,7 +217,7 @@ describe("artifact wire format — projectId", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
+    service = new ArtifactService(db, new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("emits projectId on the static_file/redirect branch (Home tile counts depend on it)", async () => {
@@ -244,7 +244,7 @@ describe("ArtifactService.pinArtifact / unpinArtifact (#387)", () => {
 
   beforeEach(() => {
     db = makeDb();
-    service = new ArtifactService(new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
+    service = new ArtifactService(db, new SqliteArtifactStore(db), "https://oyster.to", "https://share.oyster.to");
   });
 
   it("pinArtifact stamps pinned_at and returns the timestamp", () => {

--- a/server/test/db-artefact-dedup.test.ts
+++ b/server/test/db-artefact-dedup.test.ts
@@ -1,0 +1,109 @@
+// Boot-time dedup: collapse artefact rows that point at the same path
+// after the tombstone-recovery pass. Two rows at one path is the
+// expected outcome of the user's history (the old path got recovered to
+// the new path, AND a separate row already existed at the new path).
+// Winner: most session_artifacts touches → tiebreaker most recent
+// created_at. session_artifacts links migrate from losers to winner;
+// losers soft-deleted.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+describe("initDb artefact dedup by path", () => {
+  let userland: string;
+  beforeEach(() => { userland = mkdtempSync(join(tmpdir(), "oyster-adp-")); });
+  afterEach(() => { rmSync(userland, { recursive: true, force: true }); });
+
+  function seedSession(db: ReturnType<typeof initDb>, id: string) {
+    db.prepare(
+      "INSERT INTO sessions (id, agent, state) VALUES (?, 'claude-code', 'done')",
+    ).run(id);
+  }
+
+  function seedArtifact(db: ReturnType<typeof initDb>, id: string, path: string, createdAt: string) {
+    db.prepare(
+      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, created_at)
+       VALUES (?, 'home', ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+    ).run(id, id, JSON.stringify({ path }), createdAt);
+  }
+
+  function link(db: ReturnType<typeof initDb>, sessionId: string, artifactId: string, role: string = "read") {
+    db.prepare(
+      "INSERT INTO session_artifacts (session_id, artifact_id, role) VALUES (?, ?, ?)",
+    ).run(sessionId, artifactId, role);
+  }
+
+  it("two rows at same path → keep the one with more touches, migrate links, soft-delete the other", () => {
+    let db = initDb(userland);
+    const path = "/some/abs/path/report.md";
+    seedSession(db, "s1");
+    seedSession(db, "s2");
+    seedArtifact(db, "loser",  path, "2026-05-14 10:00:00");
+    seedArtifact(db, "winner", path, "2026-05-14 12:00:00");
+    link(db, "s1", "loser",  "read");
+    link(db, "s1", "winner", "read"); // (s1, winner, read) — winner has 2
+    link(db, "s2", "winner", "read");
+    db.close();
+
+    db = initDb(userland);
+    const winnerRow = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'winner'").get() as { removed_at: string | null };
+    const loserRow = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'loser'").get() as { removed_at: string | null };
+    expect(winnerRow.removed_at).toBeNull();
+    expect(loserRow.removed_at).not.toBeNull();
+
+    // session_artifacts: loser's (s1, read) link folds into winner's existing one (no dup).
+    const linksToWinner = db.prepare("SELECT session_id FROM session_artifacts WHERE artifact_id = 'winner' ORDER BY session_id").all() as Array<{ session_id: string }>;
+    expect(linksToWinner.map((r) => r.session_id)).toEqual(["s1", "s2"]);
+    const linksToLoser = db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = 'loser'").get() as { c: number };
+    expect(linksToLoser.c).toBe(0);
+    db.close();
+  });
+
+  it("tiebreaker on link-count is most-recent created_at", () => {
+    let db = initDb(userland);
+    const path = "/abs/tie/x.md";
+    seedSession(db, "s1");
+    seedArtifact(db, "older", path, "2026-05-14 09:00:00");
+    seedArtifact(db, "newer", path, "2026-05-14 15:00:00");
+    link(db, "s1", "older", "read");
+    link(db, "s1", "newer", "create"); // both have 1 touch
+    db.close();
+
+    db = initDb(userland);
+    const newer = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'newer'").get() as { removed_at: string | null };
+    const older = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'older'").get() as { removed_at: string | null };
+    expect(newer.removed_at).toBeNull();
+    expect(older.removed_at).not.toBeNull();
+    db.close();
+  });
+
+  it("single row at a path → untouched", () => {
+    let db = initDb(userland);
+    seedArtifact(db, "solo", "/abs/solo/x.md", "2026-05-14 10:00:00");
+    db.close();
+
+    db = initDb(userland);
+    const row = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'solo'").get() as { removed_at: string | null };
+    expect(row.removed_at).toBeNull();
+    db.close();
+  });
+
+  it("ignores already-tombstoned rows when picking a winner", () => {
+    let db = initDb(userland);
+    const path = "/abs/ts/y.md";
+    seedArtifact(db, "alive", path, "2026-05-14 10:00:00");
+    db.prepare(
+      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, created_at, removed_at)
+       VALUES ('dead', 'home', 'd', 'notes', 'filesystem', ?, 'static_file', '{}', '2026-05-14 09:00:00', datetime('now'))`,
+    ).run(JSON.stringify({ path }));
+    db.close();
+
+    db = initDb(userland);
+    const alive = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'alive'").get() as { removed_at: string | null };
+    expect(alive.removed_at).toBeNull(); // not re-tombstoned
+    db.close();
+  });
+});

--- a/server/test/db-artefact-tombstone-recovery.test.ts
+++ b/server/test/db-artefact-tombstone-recovery.test.ts
@@ -54,6 +54,25 @@ describe("initDb artefact tombstone recovery", () => {
     db.close();
   });
 
+  it("undeletes a tombstone whose ORIGINAL path is now back on disk (no path change needed)", () => {
+    // Common case: the file moved away then came back at the same path
+    // (e.g. user reverted a rename). Self-heal had soft-deleted on the
+    // gap; the migration should just undelete with the existing path
+    // and stamp project_id via the ancestor walk.
+    let db = initDb(userland);
+    mkdirSync(join(oldDir, "docs"), { recursive: true });
+    writeFileSync(join(oldDir, "docs", "back.md"), "ok");
+    seedTombstone(db, "art-back", join(oldDir, "docs", "back.md"));
+    db.close();
+
+    db = initDb(userland);
+    const row = db.prepare("SELECT removed_at, storage_config, project_id FROM artifacts WHERE id = 'art-back'").get() as { removed_at: string | null; storage_config: string; project_id: string | null };
+    expect(row.removed_at).toBeNull();
+    expect(JSON.parse(row.storage_config)).toEqual({ path: join(oldDir, "docs", "back.md") });
+    expect(row.project_id).toBe(PROJ_ID);
+    db.close();
+  });
+
   it("leaves a tombstone alone when the file is not recoverable", () => {
     let db = initDb(userland);
     // newDir exists but doesn't contain the relative remainder

--- a/server/test/db-artefact-tombstone-recovery.test.ts
+++ b/server/test/db-artefact-tombstone-recovery.test.ts
@@ -1,0 +1,87 @@
+// Boot-time migration that undeletes artefacts whose file is recoverable
+// via project_paths. Heals damage done by the old self-heal which
+// soft-deleted every artefact whose folder happened to be renamed.
+// Idempotent: a second boot finds no new tombstones to recover.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+const PROJ_ID = "11111111-2222-3333-4444-555555555555";
+
+describe("initDb artefact tombstone recovery", () => {
+  let userland: string;
+  let oldDir: string;
+  let newDir: string;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-atr-userland-"));
+    oldDir = mkdtempSync(join(tmpdir(), "oyster-atr-old-"));
+    newDir = mkdtempSync(join(tmpdir(), "oyster-atr-new-"));
+  });
+  afterEach(() => {
+    rmSync(userland, { recursive: true, force: true });
+    rmSync(oldDir, { recursive: true, force: true });
+    rmSync(newDir, { recursive: true, force: true });
+  });
+
+  function seedTombstone(db: ReturnType<typeof initDb>, id: string, path: string) {
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work', 'Work', '#000', 'none') ON CONFLICT(id) DO NOTHING`);
+    db.prepare(`INSERT OR IGNORE INTO projects (id, space_id, name) VALUES (?, 'work', 'Proj')`).run(PROJ_ID);
+    db.prepare(`INSERT OR IGNORE INTO project_paths (project_id, path) VALUES (?, ?)`).run(PROJ_ID, oldDir);
+    db.prepare(`INSERT OR IGNORE INTO project_paths (project_id, path) VALUES (?, ?)`).run(PROJ_ID, newDir);
+    db.prepare(
+      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, removed_at)
+       VALUES (?, 'work', 'doc', 'notes', 'filesystem', ?, 'static_file', '{}', datetime('now'))`,
+    ).run(id, JSON.stringify({ path }));
+  }
+
+  it("undeletes a tombstoned artefact when the file is recoverable", () => {
+    let db = initDb(userland);
+    mkdirSync(join(newDir, "docs"), { recursive: true });
+    writeFileSync(join(newDir, "docs", "report.md"), "ok");
+    seedTombstone(db, "art-1", join(oldDir, "docs", "report.md"));
+    db.close();
+
+    // Re-open → migrations run → recovery fires.
+    db = initDb(userland);
+    const row = db.prepare("SELECT removed_at, storage_config, project_id FROM artifacts WHERE id = 'art-1'").get() as { removed_at: string | null; storage_config: string; project_id: string | null };
+    expect(row.removed_at).toBeNull();
+    expect(JSON.parse(row.storage_config)).toEqual({ path: join(newDir, "docs", "report.md") });
+    expect(row.project_id).toBe(PROJ_ID);
+    db.close();
+  });
+
+  it("leaves a tombstone alone when the file is not recoverable", () => {
+    let db = initDb(userland);
+    // newDir exists but doesn't contain the relative remainder
+    seedTombstone(db, "art-2", join(oldDir, "docs", "gone.md"));
+    db.close();
+
+    db = initDb(userland);
+    const row = db.prepare("SELECT removed_at FROM artifacts WHERE id = 'art-2'").get() as { removed_at: string | null };
+    expect(row.removed_at).not.toBeNull(); // still tombstoned
+    db.close();
+  });
+
+  it("idempotent — repeat boots don't re-flip already-recovered rows", () => {
+    let db = initDb(userland);
+    mkdirSync(join(newDir, "docs"), { recursive: true });
+    writeFileSync(join(newDir, "docs", "x.md"), "ok");
+    seedTombstone(db, "art-3", join(oldDir, "docs", "x.md"));
+    db.close();
+
+    // First boot: recovers
+    db = initDb(userland);
+    const firstUpdated = db.prepare("SELECT updated_at FROM artifacts WHERE id = 'art-3'").get() as { updated_at: string };
+    db.close();
+
+    // Second boot: row is alive, migration should NOT touch it
+    db = initDb(userland);
+    const secondUpdated = db.prepare("SELECT updated_at FROM artifacts WHERE id = 'art-3'").get() as { updated_at: string };
+    expect(secondUpdated.updated_at).toBe(firstUpdated.updated_at);
+    db.close();
+  });
+});

--- a/server/test/resolve-artifact-path.test.ts
+++ b/server/test/resolve-artifact-path.test.ts
@@ -1,0 +1,127 @@
+// resolveArtifactPathViaProjects — when an artefact's stored path goes
+// missing (folder rename / move), find the file's new location by
+// leveraging the project_paths cache. Walks up the stored path looking
+// for an ancestor that's known as a project's cached folder, then tries
+// the same relative remainder under each of that project's OTHER cached
+// paths. Returns the first match (or null when ambiguous / nothing
+// matches).
+//
+// Same primitive lookupProject uses for sessions, applied at the artefact
+// granularity so artefact identity stops being tied to absolute paths.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { resolveArtifactPathViaProjects } from "../src/resolve-artifact-path.js";
+
+const A_UUID = "11111111-2222-3333-4444-555555555555";
+
+describe("resolveArtifactPathViaProjects", () => {
+  let userland: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-rapvp-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work', 'Work', '#000', 'none')`);
+    db.prepare(`INSERT INTO projects (id, space_id, name) VALUES (?, 'work', 'Proj')`).run(A_UUID);
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  function seedPath(projectId: string, path: string) {
+    db.prepare("INSERT INTO project_paths (project_id, path) VALUES (?, ?)").run(projectId, path);
+  }
+
+  it("returns null when no ancestor of the path is in project_paths", () => {
+    seedPath(A_UUID, "/some/other/folder");
+    const result = resolveArtifactPathViaProjects(db, "/totally/unrelated/file.md");
+    expect(result).toBeNull();
+  });
+
+  it("returns the new path + projectId when the relative remainder exists under a sibling cached path", () => {
+    const oldFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-old-"));
+    const newFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-new-"));
+    mkdirSync(join(newFolder, "docs"), { recursive: true });
+    writeFileSync(join(newFolder, "docs", "readme.md"), "ok");
+    seedPath(A_UUID, oldFolder);
+    seedPath(A_UUID, newFolder);
+
+    const result = resolveArtifactPathViaProjects(db, join(oldFolder, "docs", "readme.md"));
+    expect(result).toEqual({ newPath: join(newFolder, "docs", "readme.md"), projectId: A_UUID });
+
+    rmSync(oldFolder, { recursive: true, force: true });
+    rmSync(newFolder, { recursive: true, force: true });
+  });
+
+  it("returns null when the ancestor matches but no sibling has the relative remainder", () => {
+    const oldFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-old-"));
+    const newFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-new-"));
+    // newFolder exists but doesn't contain `docs/missing.md`
+    seedPath(A_UUID, oldFolder);
+    seedPath(A_UUID, newFolder);
+
+    const result = resolveArtifactPathViaProjects(db, join(oldFolder, "docs", "missing.md"));
+    expect(result).toBeNull();
+
+    rmSync(oldFolder, { recursive: true, force: true });
+    rmSync(newFolder, { recursive: true, force: true });
+  });
+
+  it("returns null when multiple sibling paths contain the same relative remainder (ambiguous)", () => {
+    const oldFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-old-"));
+    const new1 = mkdtempSync(join(tmpdir(), "oyster-rapvp-new1-"));
+    const new2 = mkdtempSync(join(tmpdir(), "oyster-rapvp-new2-"));
+    for (const f of [new1, new2]) {
+      mkdirSync(join(f, "docs"), { recursive: true });
+      writeFileSync(join(f, "docs", "x.md"), "ok");
+    }
+    seedPath(A_UUID, oldFolder);
+    seedPath(A_UUID, new1);
+    seedPath(A_UUID, new2);
+
+    const result = resolveArtifactPathViaProjects(db, join(oldFolder, "docs", "x.md"));
+    expect(result).toBeNull();
+
+    rmSync(oldFolder, { recursive: true, force: true });
+    rmSync(new1, { recursive: true, force: true });
+    rmSync(new2, { recursive: true, force: true });
+  });
+
+  it("returns the deepest ancestor's project when nested project paths overlap", () => {
+    // Outer project at /a, inner project at /a/inner. An artefact at
+    // /a/inner/file.md should resolve via the INNER project's other
+    // paths, not the outer's.
+    const B_UUID = "99999999-aaaa-bbbb-cccc-dddddddddddd";
+    db.prepare(`INSERT INTO projects (id, space_id, name) VALUES (?, 'work', 'Inner')`).run(B_UUID);
+    const innerOld = mkdtempSync(join(tmpdir(), "oyster-rapvp-inner-old-"));
+    const innerNew = mkdtempSync(join(tmpdir(), "oyster-rapvp-inner-new-"));
+    writeFileSync(join(innerNew, "file.md"), "ok");
+    seedPath(A_UUID, "/some/outer");                          // outer project
+    seedPath(B_UUID, innerOld);                               // inner old path
+    seedPath(B_UUID, innerNew);                               // inner new path
+
+    const result = resolveArtifactPathViaProjects(db, join(innerOld, "file.md"));
+    expect(result).toEqual({ newPath: join(innerNew, "file.md"), projectId: B_UUID });
+
+    rmSync(innerOld, { recursive: true, force: true });
+    rmSync(innerNew, { recursive: true, force: true });
+  });
+
+  it("skips soft-deleted projects when resolving", () => {
+    const oldFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-sd-old-"));
+    const newFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-sd-new-"));
+    writeFileSync(join(newFolder, "f.md"), "ok");
+    seedPath(A_UUID, oldFolder);
+    seedPath(A_UUID, newFolder);
+    db.exec(`UPDATE projects SET removed_at = datetime('now') WHERE id = '${A_UUID}'`);
+
+    const result = resolveArtifactPathViaProjects(db, join(oldFolder, "f.md"));
+    expect(result).toBeNull(); // don't reattach to a tombstone
+
+    rmSync(oldFolder, { recursive: true, force: true });
+    rmSync(newFolder, { recursive: true, force: true });
+  });
+});

--- a/server/test/resolve-artifact-path.test.ts
+++ b/server/test/resolve-artifact-path.test.ts
@@ -110,6 +110,26 @@ describe("resolveArtifactPathViaProjects", () => {
     rmSync(innerNew, { recursive: true, force: true });
   });
 
+  it("abstains when the ancestor is cached against two live projects (ambiguous owner)", () => {
+    // Two live projects both claim the same path in project_paths.
+    // findProjectAtAncestor + the resolver must NOT pick arbitrarily —
+    // doing so would silently route the artefact to the wrong project.
+    const B_UUID = "22222222-2222-2222-2222-222222222222";
+    db.prepare(`INSERT INTO projects (id, space_id, name) VALUES (?, 'work', 'Other')`).run(B_UUID);
+    const shared = mkdtempSync(join(tmpdir(), "oyster-rapvp-shared-"));
+    const newA = mkdtempSync(join(tmpdir(), "oyster-rapvp-newA-"));
+    writeFileSync(join(newA, "x.md"), "ok");
+    seedPath(A_UUID, shared);
+    seedPath(B_UUID, shared); // same path, two projects
+    seedPath(A_UUID, newA);
+
+    const result = resolveArtifactPathViaProjects(db, join(shared, "x.md"));
+    expect(result).toBeNull();
+
+    rmSync(shared, { recursive: true, force: true });
+    rmSync(newA, { recursive: true, force: true });
+  });
+
   it("skips soft-deleted projects when resolving", () => {
     const oldFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-sd-old-"));
     const newFolder = mkdtempSync(join(tmpdir(), "oyster-rapvp-sd-new-"));


### PR DESCRIPTION
## Why

The 0.9.0 projects refactor fixed identity for sessions but not for artefacts. Artefact rows still pin to absolute paths, and the `ArtifactService.getAllArtifacts` self-heal soft-deletes any row whose stored path is missing on disk. So a folder rename — like the user's recent `~/Dev/oyster-os` → `~/Dev/oyster-dev` history — tombstones every artefact that followed the rename. The yellow-pen-audit session surfaced this: 8 read-touches to docs whose rows had been silently tombstoned + a "yellow-pen-audit.md" report that was *never even linked* to its creator session because the watcher's live touch-detection requires the artefact to already exist at tool_use time.

## What

Five focused commits, no schema changes, reuses the `project_paths` cache + the walk-up-ancestor primitive that sessions already use.

| Commit | Change |
|---|---|
| `d2f0ac4` | `resolveArtifactPathViaProjects` helper — walk up an artefact path, find the owning project, try the same relative remainder under each of the project's other cached folders, return unique match or null |
| `2e29f9d` | self-heal in `ArtifactService.getAllArtifacts` calls the resolver before tombstoning; on success updates `storage_config.path` + stamps `project_id` (free auto-tagging) |
| `70334ac` | boot-time tombstone-recovery migration — heals `removed_at IS NOT NULL` artefacts whose files are reachable via the resolver. Users with old tombstones get them undeleted on next boot |
| `ec0555d` | recovery handles "file came back at the same path" (just undelete, stamp project_id) + dedup of artefact rows pointing at the same path post-recovery (winner: most touches, tiebreaker most-recent created_at) |
| `94b240c` | `registerArtifact` scans recent assistant events for tool_use blocks at the new artefact's path and backfills `session_artifacts` rows with the implied role (Write→create, Edit→modify, Read→read). Closes the provenance loop for raw-`Write` artefacts |

## Test plan

- [x] 21 new tests, all RED → GREEN
- [x] 363 / 363 server tests passing
- [x] Web typecheck clean
- [ ] On a real install with existing tombstones: boot → artefacts reappear under their projects → yellow-pen-audit session inspector resolves all touches → the report's session shows a `create` link

## Schema

None. Pure code + a one-shot migration that runs idempotently on every boot.

## Out of scope

- Storing relative paths instead of absolute (`artifact.project_id` + `relative_path`). That's the next step if path-fragility shows up again, but for now the self-heal + cache fallback is enough.
- Auto-tagging on `MCP create_artifact` (orthogonal — the resolver covers it for filesystem artefacts already; the MCP handler could be tightened separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)