### PR TITLE
docs(changelog): artefact resilience fix (PR #500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Top bar is now one sticky pill.** Account and space switcher share a single bar pinned to the top of every view. Signed-in shows an avatar (email + sign-out in the click-menu); signed-out shows a *Sign in* pill in the same slot.
 
+### Fixed
+
+- **Artefacts survive folder renames.** When a file's folder moves, Oyster now reattaches the artefact to its new location via the project's other known paths instead of removing it from the surface. On first start after upgrading, artefacts that were previously dropped this way are restored automatically.
+- **Sessions that wrote a file before it became an artefact are now linked.** Registering an artefact backfills *created / modified / read* links from recent session activity, so the surface attributes provenance correctly even when the file was written via raw tools first and registered later.
+
 ## [0.9.0] - 2026-05-16
 
 A project's identity now lives in a `.oyster/id` file inside its folder. Renaming, moving, or `git push`ing the folder no longer orphans its sessions — the marker travels with the folder and is recognised everywhere. Eleven sessions across three beta cycles (0.9.0-beta.0/1/2) collapsed into this release.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -330,6 +330,11 @@
 <ul>
 <li><strong>Top bar is now one sticky pill.</strong> Account and space switcher share a single bar pinned to the top of every view. Signed-in shows an avatar (email + sign-out in the click-menu); signed-out shows a <em>Sign in</em> pill in the same slot.</li>
 </ul>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Artefacts survive folder renames.</strong> When a file&#39;s folder moves, Oyster now reattaches the artefact to its new location via the project&#39;s other known paths instead of removing it from the surface. On first start after upgrading, artefacts that were previously dropped this way are restored automatically.</li>
+<li><strong>Sessions that wrote a file before it became an artefact are now linked.</strong> Registering an artefact backfills <em>created / modified / read</em> links from recent session activity, so the surface attributes provenance correctly even when the file was written via raw tools first and registered later.</li>
+</ul>
 <h2 id="v-0-9-0"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.8.2...v0.9.0" rel="noopener noreferrer"><span class="release-version">0.9.0</span></a><span class="release-date"> — 2026-05-16</span></h2>
 <p>A project&#39;s identity now lives in a <code>.oyster/id</code> file inside its folder. Renaming, moving, or <code>git push</code>ing the folder no longer orphans its sessions — the marker travels with the folder and is recognised everywhere. Eleven sessions across three beta cycles (0.9.0-beta.0/1/2) collapsed into this release.</p>
 <h3>Added</h3>


### PR DESCRIPTION
## Summary

- Adds the missing CHANGELOG entries for the artefact resilience work merged in #500 — entry was forgotten in the original PR.
- Two `Fixed` bullets under `[0.9.1]`:
  - Artefacts survive folder renames (live self-heal via project_paths + first-start tombstone-recovery migration).
  - Sessions that wrote a file before it became an artefact are now linked (`registerArtifact` backfills recent touches).

## Test plan

- [x] `npm run build:changelog` regenerates `docs/changelog.html` cleanly
- [ ] Eyeball the rendered changelog entry on the resulting preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)