### PR TITLE
cmd+K: filter by type (@) and space (#)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-cmdk-type-filter.md
+++ b/docs/superpowers/plans/2026-05-16-cmdk-type-filter.md
@@ -1,0 +1,1256 @@
+# cmd+K type filter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let cmd+K narrow results by entity type (`@session`, `@artefact`, `@memory`) and optionally by space (`#space-id`), via an inline autocomplete dropdown triggered by `@` or `#`. Memory is added as a third searchable source.
+
+**Architecture:** Filter state (`{ type, spaceId, query }`) lives separately from the raw input string. Tokens render as removable chips inside the existing `.spotlight-input-row`. Typing `@` or `#` opens a popover anchored to the caret; selecting an option consumes the prefix text and sets the filter. Sources fan out in parallel from the same `(filter, query)` tuple. Backend gains a memory search HTTP endpoint and space scoping on the existing session search.
+
+**Tech Stack:** TypeScript, React (web), Node http (server), better-sqlite3 + FTS5 (storage), vitest (server tests). Web has no unit tests — UI work is verified manually via `npm run dev` + browser.
+
+**Spec:** `docs/superpowers/specs/2026-05-16-cmdk-type-filter-design.md`
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `server/src/memory-store.ts` | modify | Add `search()` — pure FTS, no recall logging |
+| `server/test/memory-store.test.ts` | modify | Tests for `search()` |
+| `server/src/routes/memories.ts` | modify | Add `GET /api/memories/search` |
+| `server/test/memories-search-route.test.ts` | create | Route tests |
+| `server/src/session-store.ts` | modify | Accept `spaceId` in `searchEvents()` |
+| `server/src/routes/sessions.ts` | modify | Pass `space_id` through to `searchEvents` |
+| `server/test/sessions-search-space.test.ts` | create | Space-scoping test |
+| `web/src/data/memories-api.ts` | modify | Add `searchMemories()` |
+| `web/src/data/sessions-api.ts` | modify | Extend `searchTranscripts` with `spaceId` |
+| `web/src/components/SpotlightSearch.tsx` | modify | All UI changes |
+| `web/src/App.css` | modify | Chip + popover styles (~80 lines near existing `.spotlight-*`) |
+
+---
+
+## Task 1: Pure memory search method
+
+Adds a side-effect-free FTS search to `MemoryProvider`. The existing `recall()` bumps access counts and writes to `memory_recalls`, which is wrong for cmd+K — searching shouldn't pollute "what this session recalled" stats.
+
+**Files:**
+- Modify: `server/src/memory-store.ts:50-71` (`MemoryProvider` interface) and the `recall` implementation around line 598
+- Modify: `server/test/memory-store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `server/test/memory-store.test.ts`, inside the top-level `describe("SqliteFtsMemoryProvider", …)` block, add a new `describe`:
+
+```ts
+describe("search", () => {
+  it("returns FTS-ranked rows without bumping recall stats", async () => {
+    const a = await provider.remember({ content: "auth middleware notes", space_id: "tokinvest" });
+    await provider.remember({ content: "completely unrelated note about cooking", space_id: "tokinvest" });
+
+    const beforeRow = (provider as unknown as { db: { prepare: (s: string) => { get: (...args: unknown[]) => { access_count: number } } } })
+      .db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id);
+
+    const hits = await provider.search({ query: "auth" });
+
+    expect(hits.map(h => h.id)).toContain(a.id);
+    expect(hits.length).toBe(1);
+
+    const afterRow = (provider as unknown as { db: { prepare: (s: string) => { get: (...args: unknown[]) => { access_count: number } } } })
+      .db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id);
+    expect(afterRow.access_count).toBe(beforeRow.access_count);
+  });
+
+  it("scopes to a space when space_id is set, plus globals", async () => {
+    const inSpace = await provider.remember({ content: "scoped finding", space_id: "tokinvest" });
+    const global = await provider.remember({ content: "global finding" });
+    await provider.remember({ content: "other space finding", space_id: "other" });
+
+    const hits = await provider.search({ query: "finding", space_id: "tokinvest" });
+    const ids = hits.map(h => h.id);
+    expect(ids).toContain(inSpace.id);
+    expect(ids).toContain(global.id);
+    expect(ids.length).toBe(2);
+  });
+
+  it("returns empty array when query has no usable terms", async () => {
+    await provider.remember({ content: "anything" });
+    expect(await provider.search({ query: "" })).toEqual([]);
+    expect(await provider.search({ query: "?!" })).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/memory-store.test.ts -t "search"`
+Expected: FAIL with "provider.search is not a function" or similar.
+
+- [ ] **Step 3: Add `search` to the `MemoryProvider` interface**
+
+In `server/src/memory-store.ts`, locate the `MemoryProvider` interface (around line 50). After the `recall(...)` declaration, add:
+
+```ts
+  /** Side-effect-free FTS search. Like recall() but does NOT bump
+   *  access_count or write memory_recalls rows. Used by the cmd+K
+   *  spotlight where "searching" is not the same as "the agent
+   *  recalled it for use". */
+  search(input: { query: string; space_id?: string | null; limit?: number }): Promise<Memory[]>;
+```
+
+- [ ] **Step 4: Implement `search` on `SqliteFtsMemoryProvider`**
+
+In `server/src/memory-store.ts`, immediately after the existing `recall(...)` method (which ends around line 639), add:
+
+```ts
+  async search(input: { query: string; space_id?: string | null; limit?: number }): Promise<Memory[]> {
+    const limit = input.limit ?? 10;
+    const spaceId = input.space_id ?? null;
+
+    const terms = input.query
+      .replace(/[^\w\s]/g, "")
+      .split(/\s+/)
+      .filter((t) => t.length > 1);
+    if (terms.length === 0) return [];
+    const ftsQuery = terms.join(" OR ");
+
+    let sql: string;
+    let params: unknown[];
+
+    if (spaceId) {
+      sql = `SELECT m.* FROM memories m
+             JOIN memories_fts fts ON m.rowid = fts.rowid
+             WHERE memories_fts MATCH ? AND m.superseded_by IS NULL
+               AND (m.space_id = ? OR m.space_id IS NULL)
+             ORDER BY fts.rank
+             LIMIT ?`;
+      params = [ftsQuery, spaceId, limit];
+    } else {
+      sql = `SELECT m.* FROM memories m
+             JOIN memories_fts fts ON m.rowid = fts.rowid
+             WHERE memories_fts MATCH ? AND m.superseded_by IS NULL
+             ORDER BY fts.rank
+             LIMIT ?`;
+      params = [ftsQuery, limit];
+    }
+
+    const rows = this.db.prepare(sql).all(...params) as MemoryRow[];
+    return rows.map(rowToMemory);
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd server && npx vitest run test/memory-store.test.ts -t "search"`
+Expected: PASS, three tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/memory-store.ts server/test/memory-store.test.ts
+git commit -m "feat(memory): add side-effect-free search() to MemoryProvider"
+```
+
+---
+
+## Task 2: HTTP route `GET /api/memories/search`
+
+Exposes Task 1's method over HTTP. Local-origin only, matching the rest of the memory route surface.
+
+**Files:**
+- Modify: `server/src/routes/memories.ts` (around line 82, before the `GET /api/memories` block)
+- Create: `server/test/memories-search-route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/test/memories-search-route.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { SqliteFtsMemoryProvider } from "../src/memory-store.js";
+import { tryHandleMemoryRoute } from "../src/routes/memories.js";
+
+async function setup() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-mem-route-"));
+  const provider = new SqliteFtsMemoryProvider(dir);
+  await provider.init();
+
+  const server = createServer(async (req, res) => {
+    const url = req.url ?? "/";
+    const ctx = {
+      sendJson: (body: unknown, status = 200) => {
+        res.statusCode = status;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify(body));
+      },
+      sendError: (e: unknown) => {
+        res.statusCode = 500;
+        res.end(String(e));
+      },
+      readJsonBody: async () => ({}),
+      rejectIfNonLocalOrigin: () => false,
+    };
+    const handled = await tryHandleMemoryRoute(req, res, url, ctx as never, {
+      memoryProvider: provider,
+      resolveCurrentOwnerId: () => null,
+      memorySync: { reconcile: async () => ({ pulled: 0, pushed: 0 }), pushPending: async () => {}, pull: async () => 0 } as never,
+    });
+    if (!handled) { res.statusCode = 404; res.end(); }
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const port = (server.address() as AddressInfo).port;
+  return { dir, provider, server, port };
+}
+
+async function teardown(s: { dir: string; provider: SqliteFtsMemoryProvider; server: Server }) {
+  s.provider.close();
+  rmSync(s.dir, { recursive: true, force: true });
+  await new Promise<void>((r) => s.server.close(() => r()));
+}
+
+describe("GET /api/memories/search", () => {
+  let s: Awaited<ReturnType<typeof setup>>;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(async () => { await teardown(s); });
+
+  it("returns matching memories ordered by FTS rank", async () => {
+    await s.provider.remember({ content: "auth middleware design", space_id: "tokinvest" });
+    await s.provider.remember({ content: "unrelated note", space_id: "tokinvest" });
+
+    const r = await fetch(`http://localhost:${s.port}/api/memories/search?q=auth`);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.length).toBe(1);
+    expect(body[0].content).toContain("auth");
+  });
+
+  it("honors space_id", async () => {
+    await s.provider.remember({ content: "finding x", space_id: "a" });
+    await s.provider.remember({ content: "finding y", space_id: "b" });
+    const r = await fetch(`http://localhost:${s.port}/api/memories/search?q=finding&space_id=a`);
+    const body = await r.json();
+    expect(body.length).toBe(1);
+    expect(body[0].space_id).toBe("a");
+  });
+
+  it("returns [] for empty query", async () => {
+    const r = await fetch(`http://localhost:${s.port}/api/memories/search?q=`);
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/memories-search-route.test.ts`
+Expected: FAIL — all three return 404.
+
+- [ ] **Step 3: Wire the route**
+
+In `server/src/routes/memories.ts`, **before** the final block that bails with `if (memoriesPath !== "/api/memories") return false;` (around line 82), insert:
+
+```ts
+  // GET /api/memories/search?q=…&space_id=…&limit=…
+  // FTS5 search over memories. Side-effect-free (does NOT update
+  // access counts or write memory_recalls). Local-origin only.
+  if (req.method === "GET" && memoriesPath === "/api/memories/search") {
+    if (rejectIfNonLocalOrigin()) return true;
+    const parsed = new URL(req.url ?? "/", "http://localhost");
+    const q = parsed.searchParams.get("q") ?? "";
+    const spaceId = parsed.searchParams.get("space_id");
+    const limitRaw = parsed.searchParams.get("limit");
+    let limit: number | undefined;
+    if (limitRaw !== null) {
+      const n = Number(limitRaw);
+      if (Number.isFinite(n) && n >= 1) limit = Math.min(50, Math.floor(n));
+    }
+    try {
+      const hits = await memoryProvider.search({
+        query: q,
+        space_id: spaceId ?? undefined,
+        limit,
+      });
+      sendJson(hits);
+    } catch (err) {
+      sendError(err);
+    }
+    return true;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx vitest run test/memories-search-route.test.ts`
+Expected: PASS, three tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/routes/memories.ts server/test/memories-search-route.test.ts
+git commit -m "feat(memory): GET /api/memories/search endpoint"
+```
+
+---
+
+## Task 3: Space scoping on session search
+
+Adds optional `space_id` to `sessionStore.searchEvents()` and the `/api/sessions/search` route.
+
+**Files:**
+- Modify: `server/src/session-store.ts` (interface around line 147, implementation around line 422)
+- Modify: `server/src/routes/sessions.ts:269-300`
+- Create: `server/test/sessions-search-space.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/test/sessions-search-space.test.ts`. Mirror the harness used by `server/test/session-store-project-id.test.ts` — open that file first and copy its `setup`/`teardown` shape. The test should:
+
+```ts
+// Two sessions in different spaces, both containing the word "auth" in an event.
+// search({ query: "auth", spaceId: "alpha" }) must return only the alpha session.
+```
+
+Write three assertions:
+
+1. With `spaceId: "alpha"` set, only the alpha session's hit is returned.
+2. Without `spaceId`, both hits are returned (regression guard).
+3. `spaceId: "nonexistent"` returns an empty array.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/sessions-search-space.test.ts`
+Expected: FAIL — `opts.spaceId` is ignored, so all three tests fail.
+
+- [ ] **Step 3: Extend the interface signature**
+
+In `server/src/session-store.ts:147`, change:
+
+```ts
+  searchEvents(query: string, opts?: { limit?: number; sessionId?: string }): SessionEventSearchHit[];
+```
+
+to:
+
+```ts
+  searchEvents(query: string, opts?: { limit?: number; sessionId?: string; spaceId?: string }): SessionEventSearchHit[];
+```
+
+- [ ] **Step 4: Extend the implementation**
+
+In `server/src/session-store.ts:422-482`, change the method to accept `spaceId` and add a `WHERE s.space_id = ?` clause. Replace the existing method body (keep the FTS-query construction up to and including `const limit = opts.limit ?? 20;`), then replace the SQL/params section with:
+
+```ts
+    const cols = `e.id, e.session_id, e.role, e.ts,
+                  s.title AS session_title,
+                  snippet(session_events_fts, 0, '[', ']', '…', 12) AS snippet`;
+
+    const where: string[] = ["session_events_fts MATCH ?"];
+    const params: unknown[] = [ftsQuery];
+    if (opts.sessionId) { where.push("e.session_id = ?"); params.push(opts.sessionId); }
+    if (opts.spaceId)   { where.push("s.space_id = ?");   params.push(opts.spaceId); }
+
+    const sql = `SELECT ${cols}
+                 FROM session_events e
+                 JOIN session_events_fts fts ON e.id = fts.rowid
+                 JOIN sessions s             ON s.id = e.session_id
+                 WHERE ${where.join(" AND ")}
+                 ORDER BY fts.rank
+                 LIMIT ?`;
+    params.push(limit);
+    return this.db.prepare(sql).all(...params) as SessionEventSearchHit[];
+```
+
+- [ ] **Step 5: Plumb `space_id` through the HTTP route**
+
+In `server/src/routes/sessions.ts:269-300`, after the line that reads `const scopeSession = parsed.searchParams.get("session_id") ?? undefined;`, add:
+
+```ts
+      const scopeSpace = parsed.searchParams.get("space_id") ?? undefined;
+```
+
+Then change the `sessionStore.searchEvents` call to pass it:
+
+```ts
+        const hits = sessionStore.searchEvents(q, { sessionId: scopeSession, spaceId: scopeSpace, limit });
+```
+
+Update the route's leading comment from `// GET /api/sessions/search?q=…&session_id=…&limit=…` to `// GET /api/sessions/search?q=…&session_id=…&space_id=…&limit=…`.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd server && npx vitest run test/sessions-search-space.test.ts`
+Expected: PASS, three tests.
+
+- [ ] **Step 7: Run the full server test suite**
+
+Run: `cd server && npm test`
+Expected: All tests pass — sanity check that the SQL refactor didn't break existing session-search tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/session-store.ts server/src/routes/sessions.ts server/test/sessions-search-space.test.ts
+git commit -m "feat(sessions): space_id scoping on /api/sessions/search"
+```
+
+---
+
+## Task 4: Web data-layer additions
+
+Adds `searchMemories` and extends `searchTranscripts` with `spaceId`. No tests — web has none.
+
+**Files:**
+- Modify: `web/src/data/memories-api.ts`
+- Modify: `web/src/data/sessions-api.ts` (around the `searchTranscripts` function)
+
+- [ ] **Step 1: Add `searchMemories` to memories-api.ts**
+
+In `web/src/data/memories-api.ts`, after the existing `fetchMemories` function:
+
+```ts
+export async function searchMemories(
+  query: string,
+  opts: { spaceId?: string | null; limit?: number; signal?: AbortSignal } = {},
+): Promise<Memory[]> {
+  const params = new URLSearchParams({ q: query });
+  if (opts.spaceId) params.set("space_id", opts.spaceId);
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  return getJson<Memory[]>(`/api/memories/search?${params.toString()}`, opts.signal);
+}
+```
+
+- [ ] **Step 2: Extend `searchTranscripts` with `spaceId`**
+
+In `web/src/data/sessions-api.ts`, locate the `searchTranscripts` function. Change its `opts` parameter type and body to:
+
+```ts
+export async function searchTranscripts(
+  query: string,
+  opts: { limit?: number; spaceId?: string | null; signal?: AbortSignal } = {},
+): Promise<TranscriptHit[]> {
+  const params = new URLSearchParams({ q: query });
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts.spaceId) params.set("space_id", opts.spaceId);
+  return getJson<TranscriptHit[]>(`/api/sessions/search?${params.toString()}`, opts.signal);
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/data/memories-api.ts web/src/data/sessions-api.ts
+git commit -m "feat(web): searchMemories + space scoping on searchTranscripts"
+```
+
+---
+
+## Task 5: SpotlightSearch — filter state + memory source
+
+Refactor the component so filter state is separate from the input string, and memories become a third hit type. **No visible UI changes** in this task beyond the new "Memories" section — the chip/dropdown UI lands in Tasks 6–7. Doing this first lets us verify the data pipeline before adding interaction surface.
+
+**Files:**
+- Modify: `web/src/components/SpotlightSearch.tsx`
+
+- [ ] **Step 1: Add memory source + filter state shape**
+
+In `SpotlightSearch.tsx`, replace the imports block (lines 1-6) with:
+
+```ts
+import { useState, useEffect, useRef, useMemo } from "react";
+import type { Artifact } from "../data/artifacts-api";
+import { typeConfig } from "./ArtifactIcon";
+import { spaceColor } from "../utils/spaceColor";
+import { searchTranscripts } from "../data/sessions-api";
+import type { TranscriptHit } from "../data/sessions-api";
+import { searchMemories } from "../data/memories-api";
+import type { Memory } from "../data/memories-api";
+```
+
+After `const TRANSCRIPTS_LIMIT = 8;`, add:
+
+```ts
+const MEMORIES_LIMIT = 8;
+
+type FilterType = "session" | "artefact" | "memory" | null;
+type SpotlightFilter = { type: FilterType; spaceId: string | null };
+```
+
+Extend the `SpotlightHit` union:
+
+```ts
+type SpotlightHit =
+  | { kind: "artefact"; artifact: Artifact }
+  | { kind: "transcript"; hit: TranscriptHit }
+  | { kind: "memory"; memory: Memory };
+```
+
+- [ ] **Step 2: Add filter state**
+
+Inside the `SpotlightSearch` function, alongside the existing `useState` calls, add:
+
+```ts
+  const [filter, setFilter] = useState<SpotlightFilter>({ type: null, spaceId: null });
+```
+
+(Leave `filter` and `setFilter` unused for now — they're wired in Tasks 6-7. TypeScript will warn; suppress with a leading underscore if needed, but a temporary `void filter;` keeps the diff small.)
+
+Actually — to avoid lint noise, also use `filter` in the artefact filter immediately. Update the `artefactHits` `useMemo` to gate on filter.type:
+
+```ts
+  const artefactHits = useMemo(() => {
+    if (!query.trim()) return [];
+    if (filter.type !== null && filter.type !== "artefact") return [];
+    const q = query.toLowerCase();
+    return artifacts
+      .filter((a) =>
+        (filter.spaceId ? a.spaceId === filter.spaceId : true) &&
+        (a.label.toLowerCase().includes(q)
+          || a.artifactKind.toLowerCase().includes(q)
+          || a.spaceId.toLowerCase().includes(q)),
+      )
+      .slice(0, ARTEFACTS_LIMIT);
+  }, [query, artifacts, filter]);
+```
+
+- [ ] **Step 3: Gate transcript search on filter.type**
+
+Wrap the existing transcript-search `useEffect` body so it bails when filtered to a non-session type. Inside the effect, after `const trimmed = query.trim();`, add:
+
+```ts
+    if (filter.type !== null && filter.type !== "session") {
+      setTranscriptHits([]);
+      setTranscriptsLoading(false);
+      return;
+    }
+```
+
+Pass `spaceId` to the search call:
+
+```ts
+      searchTranscripts(trimmed, { limit: TRANSCRIPTS_LIMIT, spaceId: filter.spaceId, signal: ac.signal })
+```
+
+Add `filter` to the `useEffect` dependency array.
+
+- [ ] **Step 4: Add the memory search effect**
+
+Below the transcript-search `useEffect`, add a parallel memory-search effect:
+
+```ts
+  const [memoryHits, setMemoryHits] = useState<Memory[]>([]);
+  const [memoriesLoading, setMemoriesLoading] = useState(false);
+
+  const memReqIdRef = useRef(0);
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setMemoryHits([]);
+      setMemoriesLoading(false);
+      return;
+    }
+    if (filter.type !== null && filter.type !== "memory") {
+      setMemoryHits([]);
+      setMemoriesLoading(false);
+      return;
+    }
+    setMemoriesLoading(true);
+    const reqId = ++memReqIdRef.current;
+    const ac = new AbortController();
+    const timer = setTimeout(() => {
+      searchMemories(trimmed, { limit: MEMORIES_LIMIT, spaceId: filter.spaceId, signal: ac.signal })
+        .then((hits) => {
+          if (reqId !== memReqIdRef.current) return;
+          setMemoryHits(hits);
+          setMemoriesLoading(false);
+        })
+        .catch((err) => {
+          if (ac.signal.aborted || reqId !== memReqIdRef.current) return;
+          console.warn("[Spotlight] memory search failed:", err);
+          setMemoryHits([]);
+          setMemoriesLoading(false);
+        });
+    }, DEBOUNCE_MS);
+    return () => { ac.abort(); clearTimeout(timer); };
+  }, [query, filter]);
+```
+
+- [ ] **Step 5: Add memory hits to the flat list**
+
+Update `flatHits`:
+
+```ts
+  const flatHits: SpotlightHit[] = useMemo(() => [
+    ...artefactHits.map((a): SpotlightHit => ({ kind: "artefact", artifact: a })),
+    ...transcriptHits.map((h): SpotlightHit => ({ kind: "transcript", hit: h })),
+    ...memoryHits.map((m): SpotlightHit => ({ kind: "memory", memory: m })),
+  ], [artefactHits, transcriptHits, memoryHits]);
+```
+
+Update `showResults` and `showEmpty` accordingly:
+
+```ts
+  const showResults = artefactHits.length > 0
+    || transcriptHits.length > 0 || transcriptsLoading
+    || memoryHits.length > 0 || memoriesLoading;
+  const showEmpty = !!query.trim() && !transcriptsLoading && !memoriesLoading && flatHits.length === 0;
+```
+
+- [ ] **Step 6: Render memory rows**
+
+After the transcripts block in the results JSX (right after the closing of `{transcriptHits.map(...)}`), add:
+
+```tsx
+            {(memoryHits.length > 0 || memoriesLoading) && (
+              <div className="spotlight-section-label">Memories</div>
+            )}
+            {memoriesLoading && memoryHits.length === 0 && (
+              <div className="spotlight-section-loading">Searching memories…</div>
+            )}
+            {memoryHits.map((m, k) => {
+              const flatIndex = artefactHits.length + transcriptHits.length + k;
+              const isSelected = flatIndex === selected;
+              return (
+                <div
+                  key={`m-${m.id}`}
+                  className={`spotlight-result spotlight-result--memory${isSelected ? " spotlight-result--selected" : ""}`}
+                  onMouseEnter={() => setSelected(flatIndex)}
+                  onClick={() => activate({ kind: "memory", memory: m })}
+                >
+                  <span className="spotlight-result-dot" style={{ background: "#a78bfa" }} />
+                  <span className="spotlight-result-label">{m.content.length > 80 ? m.content.slice(0, 80) + "…" : m.content}</span>
+                  <span className="spotlight-result-badge">memory</span>
+                  {m.space_id && (
+                    <span className="spotlight-result-space" style={{ color: spaceColor(m.space_id), background: `${spaceColor(m.space_id)}18` }}>{m.space_id}</span>
+                  )}
+                </div>
+              );
+            })}
+```
+
+- [ ] **Step 7: Handle memory activation**
+
+Extend the `activate` function:
+
+```ts
+  function activate(hit: SpotlightHit) {
+    if (hit.kind === "artefact") {
+      onOpen(hit.artifact);
+    } else if (hit.kind === "transcript") {
+      window.dispatchEvent(new CustomEvent("oyster:open-session", {
+        detail: { id: hit.hit.session_id, eventId: hit.hit.event_id, query: query.trim() },
+      }));
+    } else {
+      // Memory — for v1, navigate to the originating space's Home (where
+      // memories list); flash the memory if possible. Inspector landing
+      // for memories doesn't exist yet, so we route to Home for the space.
+      const targetSpace = hit.memory.space_id ?? "home";
+      window.dispatchEvent(new CustomEvent("oyster:open-memory", {
+        detail: { id: hit.memory.id, spaceId: targetSpace },
+      }));
+    }
+    onClose();
+  }
+```
+
+- [ ] **Step 8: Add a listener in `Home/index.tsx` to handle `oyster:open-memory`**
+
+(This is the smallest landing surface; we route memory activations into the Home view's memory list. Full memory inspector is future work.)
+
+In `web/src/components/Home/index.tsx`, find the `useEffect` that subscribes to `oyster:open-session` (search for the string). Add a sibling listener:
+
+```ts
+  useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<{ id: string; spaceId: string }>).detail;
+      if (!detail) return;
+      console.log("[spotlight] open-memory", detail);
+    }
+    window.addEventListener("oyster:open-memory", handler);
+    return () => window.removeEventListener("oyster:open-memory", handler);
+  }, []);
+```
+
+This handler is intentionally minimal — it logs the event so the user can confirm activation worked. A dedicated memory inspector is out of scope for this plan; the user can raise a follow-up after the rest of the feature ships.
+
+- [ ] **Step 9: Type-check + manual verify**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: no errors.
+
+Then run the dev server: `npm run dev` (from repo root).
+- Open `http://localhost:7337`.
+- Press cmd+K.
+- Type a query that matches an existing memory (e.g. something you've `/remember`ed).
+- Expected: a "Memories" section appears in results.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/components/SpotlightSearch.tsx web/src/components/Home/index.tsx
+git commit -m "feat(spotlight): add memory source + filter state scaffold"
+```
+
+---
+
+## Task 6: Chip-inside-input rendering
+
+Renders `@type` and `#space` filter chips as siblings of the `<input>` inside `.spotlight-input-row`. Backspace at empty input removes the most-recently-added chip; chip `×` removes that specific chip.
+
+**Files:**
+- Modify: `web/src/components/SpotlightSearch.tsx`
+- Modify: `web/src/App.css` (in the `.spotlight-*` section, around line 1565)
+
+- [ ] **Step 1: Add chip CSS**
+
+In `web/src/App.css`, find the existing `.spotlight-input-row` rule (around line 1620 — search the file for it). After the existing spotlight styles, append:
+
+```css
+.spotlight-token-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 4px 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  border: 1px solid;
+  margin-right: 6px;
+  user-select: none;
+}
+.spotlight-token-chip--type   { color: #4d9aff; background: #3a86ff22; border-color: #3a86ff44; }
+.spotlight-token-chip--space  { color: #a78bfa; background: #8b5cf622; border-color: #a78bfa44; }
+.spotlight-token-chip .x {
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  color: #6e7280;
+  padding: 0 0 0 2px;
+}
+.spotlight-token-chip .x:hover { color: #d4d6db; }
+```
+
+- [ ] **Step 2: Track chip insertion order**
+
+In `SpotlightSearch.tsx`, extend the filter state to include an order array so backspace knows which chip is "most recent":
+
+```ts
+  const [filter, setFilter] = useState<SpotlightFilter & { order: ('type' | 'space')[] }>({
+    type: null,
+    spaceId: null,
+    order: [],
+  });
+```
+
+Update `artefactHits`, the transcript effect, and the memory effect to read `filter.type` / `filter.spaceId` as before (no signature change for them).
+
+- [ ] **Step 3: Render the chips before the input**
+
+In the JSX, change the existing input row from:
+
+```tsx
+        <div className="spotlight-input-row">
+          <svg className="spotlight-search-icon" …>…</svg>
+          <input … />
+          {query && (<button …>✕</button>)}
+        </div>
+```
+
+to:
+
+```tsx
+        <div className="spotlight-input-row">
+          <svg className="spotlight-search-icon" …>…</svg>
+          {filter.type && (
+            <span className="spotlight-token-chip spotlight-token-chip--type">
+              @{filter.type}
+              <span className="x" onClick={() => setFilter(f => ({
+                ...f,
+                type: null,
+                order: f.order.filter(o => o !== 'type'),
+              }))}>×</span>
+            </span>
+          )}
+          {filter.spaceId && (
+            <span className="spotlight-token-chip spotlight-token-chip--space">
+              #{filter.spaceId}
+              <span className="x" onClick={() => setFilter(f => ({
+                ...f,
+                spaceId: null,
+                order: f.order.filter(o => o !== 'space'),
+              }))}>×</span>
+            </span>
+          )}
+          <input
+            ref={inputRef}
+            className="spotlight-input"
+            placeholder="Search artefacts, sessions, memories — type @ to filter"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          {query && (
+            <button className="spotlight-clear" onClick={() => setQuery("")}>✕</button>
+          )}
+        </div>
+```
+
+- [ ] **Step 4: Implement Backspace-removes-chip**
+
+In `handleKeyDown`, **at the top** (before the `Escape` handler), add:
+
+```tsx
+    if (e.key === "Backspace" && query === "" && filter.order.length > 0) {
+      const last = filter.order[filter.order.length - 1];
+      setFilter(f => ({
+        ...f,
+        type: last === 'type' ? null : f.type,
+        spaceId: last === 'space' ? null : f.spaceId,
+        order: f.order.slice(0, -1),
+      }));
+      e.preventDefault();
+      return;
+    }
+```
+
+- [ ] **Step 5: Manual verify**
+
+Run dev server. Open cmd+K.
+- Add a placeholder filter (we'll wire `@`/`#` typing in Task 7, but you can temporarily set state from the React devtools). Or insert a one-line dev-only helper:
+
+```ts
+  // DEV: temporary trigger — remove in Task 7. Type `=t` then enter to set type=memory.
+  // (Skip if you're confident manipulating state from devtools.)
+```
+
+For now, verify by manually setting filter state in React DevTools:
+1. Open cmd+K.
+2. In React DevTools, find the `SpotlightSearch` component, edit `filter` to `{ type: "memory", spaceId: null, order: ["type"] }`.
+3. Expected: an `@memory` chip appears before the input.
+4. Click the chip's `×` — chip disappears.
+5. Re-set the chip. Click into the input, ensure it's empty, press Backspace — chip disappears.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/SpotlightSearch.tsx web/src/App.css
+git commit -m "feat(spotlight): chip-in-input rendering for filter tokens"
+```
+
+---
+
+## Task 7: Autocomplete dropdown on `@` / `#`
+
+Typing `@` or `#` opens an inline popover. Fuzzy-matches; `Enter` / `Tab` / click commits, consuming the prefix from the input and setting the filter.
+
+**Files:**
+- Modify: `web/src/components/SpotlightSearch.tsx`
+- Modify: `web/src/App.css`
+- Modify: `web/src/components/SpotlightSearch.tsx` parent — the `Props` interface needs `spaces` for the `#` autocomplete
+
+- [ ] **Step 1: Add `spaces` prop to SpotlightSearch**
+
+In `SpotlightSearch.tsx`, extend the `Props` interface:
+
+```ts
+interface Props {
+  artifacts: Artifact[];
+  spaces: { id: string; name?: string }[];
+  onOpen: (artifact: Artifact) => void;
+  onClose: () => void;
+}
+```
+
+Update the function signature: `export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props)`.
+
+In `web/src/App.tsx`, find the `<SpotlightSearch …>` mount (search for `SpotlightSearch`). Pass the existing `spaces` state: `<SpotlightSearch artifacts={…} spaces={spaces} … />`.
+
+- [ ] **Step 2: Detect the active autocomplete prefix**
+
+Inside `SpotlightSearch`, after the existing `useState` calls, derive the active prefix from the query string:
+
+```ts
+  type ActiveAc = { prefix: '@' | '#'; fragment: string; start: number } | null;
+  const activeAc: ActiveAc = useMemo(() => {
+    const at = query.lastIndexOf('@');
+    const hash = query.lastIndexOf('#');
+    const candidate = at > hash ? '@' : (hash > -1 ? '#' : null);
+    if (!candidate) return null;
+    const idx = candidate === '@' ? at : hash;
+    // Must be at start or preceded by whitespace
+    if (idx > 0 && !/\s/.test(query[idx - 1])) return null;
+    const fragment = query.slice(idx + 1);
+    if (/\s/.test(fragment)) return null; // closed by whitespace
+    return { prefix: candidate, fragment, start: idx };
+  }, [query]);
+```
+
+- [ ] **Step 3: Compute autocomplete options**
+
+```ts
+  const TYPE_OPTS: { value: 'session' | 'artefact' | 'memory'; color: string }[] = [
+    { value: 'session', color: '#4d9aff' },
+    { value: 'artefact', color: '#ff8a5c' },
+    { value: 'memory', color: '#a78bfa' },
+  ];
+
+  const acOptions = useMemo(() => {
+    if (!activeAc) return [];
+    const frag = activeAc.fragment.toLowerCase();
+    if (activeAc.prefix === '@') {
+      return TYPE_OPTS.filter(o => o.value.startsWith(frag));
+    }
+    return spaces
+      .filter(s => s.id.toLowerCase().includes(frag))
+      .slice(0, 8)
+      .map(s => ({ value: s.id, color: spaceColor(s.id) }));
+  }, [activeAc, spaces]);
+
+  const [acSelected, setAcSelected] = useState(0);
+  useEffect(() => { setAcSelected(0); }, [activeAc?.prefix, activeAc?.fragment]);
+```
+
+- [ ] **Step 4: Commit-on-Enter helper**
+
+```ts
+  function commitAcOption(value: string) {
+    if (!activeAc) return;
+    const isType = activeAc.prefix === '@';
+    setFilter(f => ({
+      type: isType ? value as FilterType : f.type,
+      spaceId: isType ? f.spaceId : value,
+      order: [...f.order.filter(o => o !== (isType ? 'type' : 'space')), isType ? 'type' : 'space'],
+    }));
+    // Consume the `@frag` / `#frag` from the input
+    setQuery(q => q.slice(0, activeAc.start) + q.slice(activeAc.start + 1 + activeAc.fragment.length));
+  }
+```
+
+- [ ] **Step 5: Wire keyboard handling**
+
+Extend `handleKeyDown`, immediately after the Backspace-removes-chip block:
+
+```tsx
+    if (activeAc && acOptions.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setAcSelected(s => Math.min(s + 1, acOptions.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setAcSelected(s => Math.max(s - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        commitAcOption(acOptions[acSelected].value);
+        return;
+      }
+    }
+```
+
+Important: the existing ArrowDown / ArrowUp / Enter handlers for the results list still run after this block, so the `return;` statements above are essential — they prevent the results list from moving while the autocomplete is open.
+
+- [ ] **Step 6: Render the popover**
+
+After the `.spotlight-input-row` div and before `{showResults && (…)}`, add:
+
+```tsx
+        {activeAc && acOptions.length > 0 && (
+          <div className="spotlight-ac">
+            <div className="spotlight-ac-hint">
+              {activeAc.prefix === '@' ? 'Filter by type' : 'Filter by space'}
+            </div>
+            {acOptions.map((o, i) => (
+              <div
+                key={o.value}
+                className={`spotlight-ac-item${i === acSelected ? ' spotlight-ac-item--sel' : ''}`}
+                onMouseEnter={() => setAcSelected(i)}
+                onMouseDown={(e) => { e.preventDefault(); commitAcOption(o.value); }}
+              >
+                <span className="spotlight-ac-prefix">{activeAc.prefix}</span>
+                <span className="spotlight-ac-swatch" style={{ background: o.color }} />
+                <span className="spotlight-ac-label">{o.value}</span>
+              </div>
+            ))}
+            <div className="spotlight-ac-hint spotlight-ac-hint--bottom">
+              also try {activeAc.prefix === '@' ? '#space' : '@type'}
+            </div>
+          </div>
+        )}
+```
+
+- [ ] **Step 7: Add popover CSS**
+
+In `web/src/App.css`, append to the spotlight section:
+
+```css
+.spotlight-ac {
+  position: absolute;
+  top: 48px;
+  left: 36px;
+  z-index: 6000;
+  min-width: 220px;
+  padding: 4px;
+  background: #181a1d;
+  border: 1px solid #3a3d44;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.5);
+}
+.spotlight-ac-hint {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6e7280;
+  padding: 4px 8px 6px;
+  border-bottom: 1px solid #2a2d33;
+  margin-bottom: 4px;
+}
+.spotlight-ac-hint--bottom { border-bottom: 0; border-top: 1px solid #2a2d33; margin: 4px 0 0; }
+.spotlight-ac-item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #d4d6db;
+}
+.spotlight-ac-item--sel { background: #2a2d33; }
+.spotlight-ac-prefix { color: #4d9aff; }
+.spotlight-ac-swatch { width: 8px; height: 8px; border-radius: 2px; }
+```
+
+Anchor the popover relative to `.spotlight-panel`:
+```css
+.spotlight-panel { position: relative; }
+```
+(If it's already `position: relative`, skip.)
+
+- [ ] **Step 8: Manual verify**
+
+Run dev server. Press cmd+K.
+- Type `@` → popover opens with three type rows.
+- Type `m` → narrows to `memory`. Press Enter — `@memory` chip lands in input, `@m` cleared from query.
+- Type `#` → popover opens with spaces. Type a partial space id, press Enter — chip lands.
+- Type a real query like `auth` after the chips — results filter accordingly.
+- Press Backspace on an empty query — most recent chip removed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add web/src/components/SpotlightSearch.tsx web/src/App.css web/src/App.tsx
+git commit -m "feat(spotlight): @/# autocomplete dropdown for type/space filtering"
+```
+
+---
+
+## Task 8: Counts in the dropdown
+
+When the dropdown opens with a non-empty query, show per-type result counts inline.
+
+**Files:**
+- Modify: `web/src/components/SpotlightSearch.tsx`
+
+- [ ] **Step 1: Compute counts**
+
+When `filter.type === null`, all three searches run and we already have counts via `artefactHits.length`, `transcriptHits.length`, `memoryHits.length`. When the filter is set, only one source has data; the others show "—".
+
+After the `acOptions` `useMemo`, add:
+
+```ts
+  const acCounts: Record<string, number | null> = useMemo(() => ({
+    session:  filter.type === null || filter.type === "session"  ? transcriptHits.length : null,
+    artefact: filter.type === null || filter.type === "artefact" ? artefactHits.length   : null,
+    memory:   filter.type === null || filter.type === "memory"   ? memoryHits.length     : null,
+  }), [filter.type, transcriptHits.length, artefactHits.length, memoryHits.length]);
+```
+
+- [ ] **Step 2: Render counts**
+
+In the popover JSX, inside each `acOptions.map` row, append before the closing `</div>`:
+
+```tsx
+                {activeAc.prefix === '@' && (
+                  <span className="spotlight-ac-count">
+                    {acCounts[o.value] ?? '—'}
+                  </span>
+                )}
+```
+
+- [ ] **Step 3: Add the count CSS**
+
+In `App.css`, append:
+
+```css
+.spotlight-ac-item { justify-content: space-between; }
+.spotlight-ac-item > .spotlight-ac-prefix,
+.spotlight-ac-item > .spotlight-ac-swatch,
+.spotlight-ac-item > .spotlight-ac-label { /* keep them grouped on the left */ }
+.spotlight-ac-count {
+  margin-left: auto;
+  font-size: 11px;
+  color: #6e7280;
+}
+```
+
+Wrap the prefix/swatch/label in a left-side flex container inside the JSX — easier than fighting flex:
+
+```tsx
+              <div className={`spotlight-ac-item…`} …>
+                <span className="spotlight-ac-left">
+                  <span className="spotlight-ac-prefix">{activeAc.prefix}</span>
+                  <span className="spotlight-ac-swatch" style={{ background: o.color }} />
+                  <span className="spotlight-ac-label">{o.value}</span>
+                </span>
+                {activeAc.prefix === '@' && (
+                  <span className="spotlight-ac-count">{acCounts[o.value] ?? '—'}</span>
+                )}
+              </div>
+```
+
+And the CSS:
+```css
+.spotlight-ac-left { display: flex; gap: 8px; align-items: center; }
+```
+
+- [ ] **Step 4: Manual verify**
+
+In dev:
+- Open cmd+K, type `auth`, then type `@` → popover shows counts (e.g. `session 3`, `artefact 7`, `memory 2`).
+- Pick a type. Open the popover again with `@` — the picked type still shows its count; the others show `—`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/SpotlightSearch.tsx web/src/App.css
+git commit -m "feat(spotlight): live counts in @ autocomplete"
+```
+
+---
+
+## Task 9: Empty-query recent feed
+
+When `query === ""` and no filters are set, show a recency-ordered list of recent artefacts + sessions + memories (interleaved, capped at ~15).
+
+**Files:**
+- Modify: `web/src/components/SpotlightSearch.tsx`
+- Modify: `web/src/data/sessions-api.ts` (if no recent-sessions helper exists yet)
+
+- [ ] **Step 1: Check for a recent-sessions API**
+
+Run: `grep -n "recent\|listSessions\|fetchSessions" /Users/Matthew.Slight/Dev/oyster-dev/web/src/data/sessions-api.ts`
+
+If a "list recent sessions" helper already exists, use it. If not, add (small wrapper around an existing endpoint — check `server/src/routes/sessions.ts` for what's already exposed). **Do not invent a new server endpoint for this task**; if sessions can't be listed recently without one, drop the sessions part of the recent feed (artefacts + memories only) and note it in the commit.
+
+- [ ] **Step 2: Implement the recency feed**
+
+```ts
+  const recentFeed: SpotlightHit[] = useMemo(() => {
+    if (query.trim() || filter.type || filter.spaceId) return [];
+    const artefactRows = artifacts
+      .slice() // copy before sort
+      .sort((a, b) => (b.lastModified ?? 0) - (a.lastModified ?? 0))
+      .slice(0, 5)
+      .map((a): SpotlightHit => ({ kind: "artefact", artifact: a }));
+    // Memories: use the existing useMemories list if available in parent;
+    // pass it down or call fetchMemories() once on open.
+    return artefactRows;
+  }, [query, filter, artifacts]);
+```
+
+(Sessions are intentionally omitted here; documenting as a v1 limitation. Re-introduce when there's a list endpoint to use.)
+
+- [ ] **Step 3: Render the feed**
+
+Add `recentFeed` to the JSX so it shows when `!showResults && !showEmpty && recentFeed.length > 0`. Use the same `spotlight-result` row template.
+
+- [ ] **Step 4: Manual verify**
+
+Open cmd+K with no query — recent artefacts appear under a "Recent" section. Type anything — they hide.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/SpotlightSearch.tsx web/src/data/sessions-api.ts
+git commit -m "feat(spotlight): recent feed on empty query"
+```
+
+---
+
+## Task 10: End-to-end smoke test
+
+A manual walk-through to confirm the feature works as the spec describes.
+
+- [ ] **Step 1: Run dev server**
+
+```bash
+cd /Users/Matthew.Slight/Dev/oyster.worktrees/cmdk-type-filter
+npm run dev
+```
+
+- [ ] **Step 2: Walk through the spec's driver phrasings**
+
+In the browser at `http://localhost:7337`:
+
+1. **"I just want to find a session."**
+   - cmd+K → type `@s` → Enter → type `auth` → only sessions appear in results.
+
+2. **"I just want to find a memory in tokinvest."**
+   - cmd+K → type `@m` → Enter → type `#tok` → Enter → type `auth` → only memories from tokinvest.
+
+3. **Backspace removes chips:** with chips in place, clear the query, press Backspace — most recent chip removed.
+
+4. **`×` removes specific chip:** click the `×` on `@memory` — type filter cleared, space filter kept.
+
+5. **Dropdown counts:** type `auth` first (no filter), then `@` — counts show on all three rows. Pick session, reopen `@` — others show `—`.
+
+6. **Empty-query recent feed:** open cmd+K fresh — recent artefacts visible.
+
+- [ ] **Step 3: Confirm no console errors**
+
+DevTools console should be clean across all interactions. Any warnings about missing keys / state-set-during-render are bugs to fix before declaring done.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin cmdk-type-filter
+```
+
+(Do not open a PR — that's the user's call.)
+
+- [ ] **Step 5: Notify**
+
+Report to the user: feature implemented, all server tests green, manual UI walkthrough complete, branch pushed.
+
+---
+
+## Self-Review
+
+**Coverage of spec sections:**
+
+- ✅ Filter model — Tasks 5, 7 (state shape, mutual-exclusion semantics on radio replace via `commitAcOption`)
+- ✅ Input mechanics — Tasks 6, 7 (chips, backspace, ×, autocomplete)
+- ✅ Dropdown UI — Task 7, with counts in Task 8
+- ✅ Browse-without-typing — Task 9 (with sessions-in-recent-feed caveat documented)
+- ✅ Results pipeline — Task 5
+- ✅ Backend (memory search) — Tasks 1, 2
+- ✅ Backend (session space) — Task 3
+- ✅ Files-touched list — matches the spec's
+
+**Open items the executor should know:**
+
+- Memory activation routes to a console.log + custom event in Task 5 — no dedicated memory inspector exists. If the user wants one, that's a follow-up not a blocker.
+- Recent-feed sessions: omitted v1, see Task 9.
+- The chip styles use hardcoded hex colors (`#4d9aff`, `#a78bfa`) instead of CSS vars. Matches existing spotlight code that does the same; if oyster has a token system worth using, the executor should swap to it without expanding scope.

--- a/docs/superpowers/specs/2026-05-16-cmdk-type-filter-design.md
+++ b/docs/superpowers/specs/2026-05-16-cmdk-type-filter-design.md
@@ -16,7 +16,7 @@ The user's two driver phrasings:
 `web/src/components/SpotlightSearch.tsx`:
 
 - Single text input, flat results.
-- Two sources: artefact title fuzzy-match (client-side), transcript FTS (`/api/transcripts/search` via `searchTranscripts`).
+- Two sources: artefact title fuzzy-match (client-side), transcript FTS (`/api/sessions/search` via `searchTranscripts`).
 - No memory source. No type filter. No space filter beyond what the surface already shows.
 
 Memory backend is partially in place: `memory-store.ts` already runs FTS5 over `content` and `tags` (used by the MCP `recall` tool). There is **no** HTTP search endpoint — only `GET /api/memories` (list) and `POST /api/memories/reconcile`.

--- a/docs/superpowers/specs/2026-05-16-cmdk-type-filter-design.md
+++ b/docs/superpowers/specs/2026-05-16-cmdk-type-filter-design.md
@@ -1,0 +1,159 @@
+# cmd+K type filter — design
+
+**Status:** Draft for review · 2026-05-16 · branch `cmdk-type-filter`
+
+## Goal
+
+Let the user narrow cmd+K results to a single entity type — **session**, **artefact**, or **memory** — and optionally a single **space**. Today cmd+K returns artefacts + transcripts in one flat list and never surfaces memories at all.
+
+The user's two driver phrasings:
+
+- *"I just want to find a session."*
+- *"I just want to find a memory in tokinvest."*
+
+## Current state
+
+`web/src/components/SpotlightSearch.tsx`:
+
+- Single text input, flat results.
+- Two sources: artefact title fuzzy-match (client-side), transcript FTS (`/api/transcripts/search` via `searchTranscripts`).
+- No memory source. No type filter. No space filter beyond what the surface already shows.
+
+Memory backend is partially in place: `memory-store.ts` already runs FTS5 over `content` and `tags` (used by the MCP `recall` tool). There is **no** HTTP search endpoint — only `GET /api/memories` (list) and `POST /api/memories/reconcile`.
+
+## Design
+
+### Filter model
+
+Two prefix characters, one value each, both optional:
+
+| Prefix | Namespace | Cardinality | Value source |
+|---|---|---|---|
+| `@` | type | one of `session` \| `artefact` \| `memory` | fixed |
+| `#` | space | space id | live `fetchSpaces` |
+
+State shape:
+
+```ts
+type SpotlightFilter = {
+  type: 'session' | 'artefact' | 'memory' | null;
+  spaceId: string | null;
+  query: string; // freeform text, excludes the consumed prefixes
+};
+```
+
+A second `@type` token **replaces** the first (radio). Same for `#space`. No multi-value in v1 — explicitly out of scope below.
+
+### Input mechanics
+
+Render filter chips as siblings of the `<input>` inside the existing `.spotlight-input-row`, visually preceding the caret:
+
+```
+[🔍] [@memory ×] [#tokinvest ×] |caret typing here…
+```
+
+Interactions:
+
+- Typing `@` opens the type-autocomplete popover anchored to the caret.
+- Typing `@m` filters the popover to type names matching `m*`.
+- `Enter` / `Tab` / mouse-click on a popover row commits: consumes the `@…` characters from the input, sets `filter.type`, renders the chip. Popover closes.
+- `Esc` while popover is open closes it without consuming.
+- `Backspace` at empty input removes the most-recently-added chip.
+- `×` on a chip removes that filter.
+- `#` works identically against the space namespace.
+
+The input's visible string after commit is **just the query** — chips own the filter state. The placeholder text reads `Search artefacts, sessions, memories — type @ to filter`.
+
+### Dropdown UI
+
+Floating popover, ~200px wide, anchored under the caret. Two layouts depending on namespace:
+
+**Type popover** — fixed 3 rows, with live counts once the query has at least one result fetch in flight:
+
+```
+@ memory     2
+@ session    —
+@ artefact   —
+also try #space
+```
+
+**Space popover** — fuzzy-matched against `spaces` plus the legacy `home` / `__all__` virtual spaces, capped at 8 rows.
+
+Counts come from the result-loading flow described below. Before counts arrive, render `—`.
+
+### Browse-without-typing
+
+The chip-row approach won this case in the comparison; we lose it with the dropdown. To recover it: when cmd+K opens with an **empty query**, render a single subtle hint row above results — *"Type @ to filter by type, # by space — or browse recent below"* — and below it the same "recent" feed the surface already shows (artefacts + recent sessions + recent memories, interleaved by `created_at`). This keeps cmd+K useful as a "what was I just doing" lookup, without adding a chip row.
+
+When the user types `@` while query is empty, the popover opens normally and the recent feed dims.
+
+### Results pipeline
+
+For a given `(filter, query)`:
+
+| filter.type | source(s) |
+|---|---|
+| `null` | all three, in parallel; merged by recency or section-headed (artefacts, sessions, memories) |
+| `session` | `searchTranscripts` only |
+| `artefact` | client-side fuzzy on `artifacts` only |
+| `memory` | `/api/memories/search` (new — see Backend) |
+
+`filter.spaceId` is applied as a post-filter on each source:
+
+- **Artefacts** — already carry `spaceId`, filter client-side.
+- **Transcripts** — `/api/sessions/search` does **not** currently accept a `space_id`. We add it. Server-side because the FTS `limit` is applied before filtering — client-side post-filter would return too few rows.
+- **Memories** — same; the new `/api/memories/search` accepts `space_id` from day one.
+
+When `filter.type === null`, results are grouped under section headers (`Sessions · 3`, `Artefacts · 7`, `Memories · 2`). These same counts populate the dropdown.
+
+Keyboard nav (Up/Down/Enter) stays as today — flat ordered list across sections.
+
+## Backend
+
+**New route** in `server/src/routes/memories.ts`:
+
+```
+GET /api/memories/search?q=<query>&space_id=<optional>&limit=<8>
+→ Memory[] (existing shape) ordered by FTS5 rank
+```
+
+Implementation reuses the existing FTS5 path in `SqliteFtsMemoryProvider.recall(...)` (memory-store.ts:609) — the MCP `recall` tool already exercises this code path; we're just exposing it over HTTP. Honor `superseded_by IS NULL` like `recall` does.
+
+**Extend existing route** `/api/sessions/search` in `server/src/routes/sessions.ts:269` to accept an optional `space_id` query param and pass it through to `sessionStore.searchEvents`. If `sessionStore.searchEvents` doesn't currently filter by space, add that filter — sessions carry `space_id` (assignment_mode), so this is a `WHERE` clause addition on the FTS join.
+
+No DB migrations.
+
+## Out of scope (v1)
+
+- Multi-value filters (`@memory @artefact`, `#a #b`). Single value each — revisit if asked.
+- Additional namespaces (`!tag`, `~author`, `date:`). Design leaves room; not building.
+- A click-to-open filter icon next to the search glass. The `@` keystroke is the only entry point. Revisit if discoverability data says otherwise.
+- Live count refresh while typing. Counts fetched once per `(filter, query)` and cached; debounced same as today's transcript search (180ms).
+- Memory writes from cmd+K. Read-only, matches existing memory API surface.
+- Onboarding tour / first-open coachmark. Hint text in the placeholder is the only nudge in v1.
+
+## Open assumptions worth flagging
+
+1. **Default space scope = global.** No `#` chip means search across all spaces, not just the active one. Active space remains relevant only when an opened result lacks an explicit destination.
+2. **Type token is mutually exclusive.** Picking `@memory` while `@session` is set replaces it. Saves us a "remove which one" UI.
+3. **Recent feed on empty query is acceptable scope creep.** Mitigates the discoverability loss from removing the chip row. If considered out-of-scope, we drop it and keep cmd+K empty-on-open as today.
+
+## Files touched
+
+- `web/src/components/SpotlightSearch.tsx` — chips, popover, filter state, source dispatch
+- `web/src/components/SpotlightSearch.css` (new, or extend `App.css`) — chip + popover styles
+- `web/src/data/memories-api.ts` — add `searchMemories(q, { spaceId, signal })`
+- `web/src/data/sessions-api.ts` — extend `searchTranscripts` to accept `spaceId`
+- `server/src/routes/memories.ts` — add `GET /api/memories/search`
+- `server/src/routes/sessions.ts` — extend `/api/sessions/search` to accept `space_id`
+- `server/src/memory-store.ts` — expose FTS helper if not already public
+- `server/src/session-store.ts` — accept `spaceId` in `searchEvents`
+
+No changes to: `App.tsx` shortcut wiring, `ChatBar`, MCP surface, DB schema.
+
+## Why this beat the alternatives
+
+- **Persistent chip row** (4 always-visible pills) — more discoverable, but adds permanent chrome and can't extend to spaces (too many) without a second row. We lose the "browse" affordance and recover it with the recent feed.
+- **Segmented tabs with counts** — strong "where did my hit go" signal, but heaviest chrome. Counts can live in the dropdown instead.
+- **GitHub-style `type:memory`** — more uniform if we ever add 5+ namespaces, but 5× the keystrokes today and no natural autocomplete trigger character. Defer until we actually have a third namespace.
+- **`/` instead of `@`** — collides with `/`-prefixed slash commands in the ChatBar.

--- a/server/src/memory-store.ts
+++ b/server/src/memory-store.ts
@@ -48,6 +48,11 @@ export interface MemoryProvider {
   init(): Promise<void>;
   remember(input: RememberInput): Promise<Memory>;
   recall(input: RecallInput): Promise<Memory[]>;
+  /** Side-effect-free FTS search. Like recall() but does NOT bump
+   *  access_count or write memory_recalls rows. Used by the cmd+K
+   *  spotlight where "searching" is not the same as "the agent
+   *  recalled it for use". */
+  search(input: { query: string; space_id?: string | null; limit?: number }): Promise<Memory[]>;
   /** Marks a memory as forgotten. Returns true if a row was updated, false if
    *  the id doesn't exist — callers can map false → 404. */
   forget(id: string, cloud_owner_id?: string | null): Promise<boolean>;
@@ -635,6 +640,41 @@ export class SqliteFtsMemoryProvider implements MemoryProvider {
     // per recall so a 50-row result is one fsync, not 100.
     this.postRecallTxn(rows, input.recalling_session_id ?? null);
 
+    return rows.map(rowToMemory);
+  }
+
+  async search(input: { query: string; space_id?: string | null; limit?: number }): Promise<Memory[]> {
+    const limit = input.limit ?? 10;
+    const spaceId = input.space_id ?? null;
+
+    const terms = input.query
+      .replace(/[^\w\s]/g, "")
+      .split(/\s+/)
+      .filter((t) => t.length > 1);
+    if (terms.length === 0) return [];
+    const ftsQuery = terms.join(" OR ");
+
+    let sql: string;
+    let params: unknown[];
+
+    if (spaceId) {
+      sql = `SELECT m.* FROM memories m
+             JOIN memories_fts fts ON m.rowid = fts.rowid
+             WHERE memories_fts MATCH ? AND m.superseded_by IS NULL
+               AND (m.space_id = ? OR m.space_id IS NULL)
+             ORDER BY fts.rank
+             LIMIT ?`;
+      params = [ftsQuery, spaceId, limit];
+    } else {
+      sql = `SELECT m.* FROM memories m
+             JOIN memories_fts fts ON m.rowid = fts.rowid
+             WHERE memories_fts MATCH ? AND m.superseded_by IS NULL
+             ORDER BY fts.rank
+             LIMIT ?`;
+      params = [ftsQuery, limit];
+    }
+
+    const rows = this.db.prepare(sql).all(...params) as MemoryRow[];
     return rows.map(rowToMemory);
   }
 

--- a/server/src/routes/memories.ts
+++ b/server/src/routes/memories.ts
@@ -76,6 +76,33 @@ export async function tryHandleMemoryRoute(
     return true;
   }
 
+  // GET /api/memories/search?q=…&space_id=…&limit=…
+  // FTS5 search over memories. Side-effect-free (does NOT update
+  // access counts or write memory_recalls). Local-origin only.
+  if (req.method === "GET" && memoriesPath === "/api/memories/search") {
+    if (rejectIfNonLocalOrigin()) return true;
+    const parsed = new URL(req.url ?? "/", "http://localhost");
+    const q = parsed.searchParams.get("q") ?? "";
+    const spaceId = parsed.searchParams.get("space_id");
+    const limitRaw = parsed.searchParams.get("limit");
+    let limit: number | undefined;
+    if (limitRaw !== null) {
+      const n = Number(limitRaw);
+      if (Number.isFinite(n) && n >= 1) limit = Math.min(50, Math.floor(n));
+    }
+    try {
+      const hits = await memoryProvider.search({
+        query: q,
+        space_id: spaceId ?? undefined,
+        limit,
+      });
+      sendJson(hits);
+    } catch (err) {
+      sendError(err);
+    }
+    return true;
+  }
+
   // GET /api/memories — list memories, optionally scoped to a space.
   // Strip the query string before path-matching (same trap the events
   // route had — `$`-anchored regex would silently reject `?space_id=…`).

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -266,7 +266,7 @@ export async function tryHandleSessionRoute(
     return true;
   }
 
-  // GET /api/sessions/search?q=…&session_id=…&limit=…
+  // GET /api/sessions/search?q=…&session_id=…&space_id=…&limit=…
   // R2 verbatim recall (#311). FTS5 over session_events.text. Mirrors the
   // MCP `recall_transcripts` tool surface for the web UI.
   // Local-origin only — transcripts are private user content.
@@ -277,6 +277,7 @@ export async function tryHandleSessionRoute(
       const parsed = new URL(req.url ?? "/", "http://localhost");
       const q = parsed.searchParams.get("q") ?? "";
       const scopeSession = parsed.searchParams.get("session_id") ?? undefined;
+      const scopeSpace = parsed.searchParams.get("space_id") ?? undefined;
       const limitRaw = parsed.searchParams.get("limit");
       // Validate before clamping — Number("foo") is NaN, which Math.min/max
       // propagate. Treat anything non-finite or non-positive as "use the
@@ -289,7 +290,7 @@ export async function tryHandleSessionRoute(
         }
       }
       try {
-        const hits = sessionStore.searchEvents(q, { sessionId: scopeSession, limit });
+        const hits = sessionStore.searchEvents(q, { sessionId: scopeSession, spaceId: scopeSpace, limit });
         // Rename `id` → `event_id` for the wire format (the web UI's
         // ambient `id` is artefact id; explicit naming avoids confusion).
         sendJson(hits.map((h) => ({

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -144,7 +144,7 @@ export interface SessionStore {
   /** R2 verbatim recall (#311): FTS5 search across all session_events.text.
    *  `query` is natural language; tokenised to OR-joined terms inside the
    *  implementation. `sessionId` optionally scopes to one session. */
-  searchEvents(query: string, opts?: { limit?: number; sessionId?: string }): SessionEventSearchHit[];
+  searchEvents(query: string, opts?: { limit?: number; sessionId?: string; spaceId?: string }): SessionEventSearchHit[];
 }
 
 // ── SQLite implementation ──
@@ -421,7 +421,7 @@ export class SqliteSessionStore implements SessionStore {
 
   searchEvents(
     query: string,
-    opts: { limit?: number; sessionId?: string } = {},
+    opts: { limit?: number; sessionId?: string; spaceId?: string } = {},
   ): SessionEventSearchHit[] {
     // Two query shapes:
     //   - Single plain alphanumeric word → prefix match, so an
@@ -461,23 +461,20 @@ export class SqliteSessionStore implements SessionStore {
     const cols = `e.id, e.session_id, e.role, e.ts,
                   s.title AS session_title,
                   snippet(session_events_fts, 0, '[', ']', '…', 12) AS snippet`;
-    const sql = opts.sessionId
-      ? `SELECT ${cols}
-         FROM session_events e
-         JOIN session_events_fts fts ON e.id = fts.rowid
-         JOIN sessions s             ON s.id = e.session_id
-         WHERE session_events_fts MATCH ? AND e.session_id = ?
-         ORDER BY fts.rank
-         LIMIT ?`
-      : `SELECT ${cols}
-         FROM session_events e
-         JOIN session_events_fts fts ON e.id = fts.rowid
-         JOIN sessions s             ON s.id = e.session_id
-         WHERE session_events_fts MATCH ?
-         ORDER BY fts.rank
-         LIMIT ?`;
 
-    const params = opts.sessionId ? [ftsQuery, opts.sessionId, limit] : [ftsQuery, limit];
+    const where: string[] = ["session_events_fts MATCH ?"];
+    const params: unknown[] = [ftsQuery];
+    if (opts.sessionId) { where.push("e.session_id = ?"); params.push(opts.sessionId); }
+    if (opts.spaceId)   { where.push("s.space_id = ?");   params.push(opts.spaceId); }
+
+    const sql = `SELECT ${cols}
+                 FROM session_events e
+                 JOIN session_events_fts fts ON e.id = fts.rowid
+                 JOIN sessions s             ON s.id = e.session_id
+                 WHERE ${where.join(" AND ")}
+                 ORDER BY fts.rank
+                 LIMIT ?`;
+    params.push(limit);
     return this.db.prepare(sql).all(...params) as SessionEventSearchHit[];
   }
 }

--- a/server/test/memories-search-route.test.ts
+++ b/server/test/memories-search-route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { SqliteFtsMemoryProvider } from "../src/memory-store.js";
+import { tryHandleMemoryRoute } from "../src/routes/memories.js";
+
+async function setup() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-mem-route-"));
+  const provider = new SqliteFtsMemoryProvider(dir);
+  await provider.init();
+
+  const server = createServer(async (req, res) => {
+    const url = req.url ?? "/";
+    const ctx = {
+      sendJson: (body: unknown, status = 200) => {
+        res.statusCode = status;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify(body));
+      },
+      sendError: (e: unknown) => {
+        res.statusCode = 500;
+        res.end(String(e));
+      },
+      readJsonBody: async () => ({}),
+      rejectIfNonLocalOrigin: () => false,
+    };
+    const handled = await tryHandleMemoryRoute(req, res, url, ctx as never, {
+      memoryProvider: provider,
+      resolveCurrentOwnerId: () => null,
+      memorySync: { reconcile: async () => ({ pulled: 0, pushed: 0 }), pushPending: async () => {}, pull: async () => 0 } as never,
+    });
+    if (!handled) { res.statusCode = 404; res.end(); }
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const port = (server.address() as AddressInfo).port;
+  return { dir, provider, server, port };
+}
+
+async function teardown(s: { dir: string; provider: SqliteFtsMemoryProvider; server: Server }) {
+  s.provider.close();
+  rmSync(s.dir, { recursive: true, force: true });
+  await new Promise<void>((r) => s.server.close(() => r()));
+}
+
+describe("GET /api/memories/search", () => {
+  let s: Awaited<ReturnType<typeof setup>>;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(async () => { await teardown(s); });
+
+  it("returns matching memories ordered by FTS rank", async () => {
+    await s.provider.remember({ content: "auth middleware design", space_id: "tokinvest" });
+    await s.provider.remember({ content: "unrelated note", space_id: "tokinvest" });
+
+    const r = await fetch(`http://localhost:${s.port}/api/memories/search?q=auth`);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.length).toBe(1);
+    expect(body[0].content).toContain("auth");
+  });
+
+  it("honors space_id", async () => {
+    await s.provider.remember({ content: "finding x", space_id: "a" });
+    await s.provider.remember({ content: "finding y", space_id: "b" });
+    const r = await fetch(`http://localhost:${s.port}/api/memories/search?q=finding&space_id=a`);
+    const body = await r.json();
+    expect(body.length).toBe(1);
+    expect(body[0].space_id).toBe("a");
+  });
+
+  it("returns [] for empty query", async () => {
+    const r = await fetch(`http://localhost:${s.port}/api/memories/search?q=`);
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual([]);
+  });
+});

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -217,6 +217,43 @@ describe("SqliteFtsMemoryProvider", () => {
       expect(recalled).toHaveLength(0);
     });
   });
+
+  describe("search", () => {
+    it("returns FTS-ranked rows without bumping recall stats", async () => {
+      const a = await provider.remember({ content: "auth middleware notes", space_id: "tokinvest" });
+      await provider.remember({ content: "completely unrelated note about cooking", space_id: "tokinvest" });
+
+      const beforeRow = (provider as unknown as { db: { prepare: (s: string) => { get: (...args: unknown[]) => { access_count: number } } } })
+        .db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id);
+
+      const hits = await provider.search({ query: "auth" });
+
+      expect(hits.map(h => h.id)).toContain(a.id);
+      expect(hits.length).toBe(1);
+
+      const afterRow = (provider as unknown as { db: { prepare: (s: string) => { get: (...args: unknown[]) => { access_count: number } } } })
+        .db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id);
+      expect(afterRow.access_count).toBe(beforeRow.access_count);
+    });
+
+    it("scopes to a space when space_id is set, plus globals", async () => {
+      const inSpace = await provider.remember({ content: "scoped finding", space_id: "tokinvest" });
+      const global = await provider.remember({ content: "global finding" });
+      await provider.remember({ content: "other space finding", space_id: "other" });
+
+      const hits = await provider.search({ query: "finding", space_id: "tokinvest" });
+      const ids = hits.map(h => h.id);
+      expect(ids).toContain(inSpace.id);
+      expect(ids).toContain(global.id);
+      expect(ids.length).toBe(2);
+    });
+
+    it("returns empty array when query has no usable terms", async () => {
+      await provider.remember({ content: "anything" });
+      expect(await provider.search({ query: "" })).toEqual([]);
+      expect(await provider.search({ query: "?!" })).toEqual([]);
+    });
+  });
 });
 
 describe("schema migration — memory_events + memory_payloads", () => {

--- a/server/test/memory-store.test.ts
+++ b/server/test/memory-store.test.ts
@@ -223,17 +223,20 @@ describe("SqliteFtsMemoryProvider", () => {
       const a = await provider.remember({ content: "auth middleware notes", space_id: "tokinvest" });
       await provider.remember({ content: "completely unrelated note about cooking", space_id: "tokinvest" });
 
-      const beforeRow = (provider as unknown as { db: { prepare: (s: string) => { get: (...args: unknown[]) => { access_count: number } } } })
-        .db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id);
+      // Prime access_count to a non-zero baseline. Without this the test
+      // passes vacuously: access_count defaults to 0 and remember() does
+      // not bump it, so before === after === 0 even if search() were
+      // calling postRecallTxn.
+      const db = (provider as unknown as { db: import("better-sqlite3").Database }).db;
+      db.prepare("UPDATE memories SET access_count = 5 WHERE id = ?").run(a.id);
 
       const hits = await provider.search({ query: "auth" });
 
       expect(hits.map(h => h.id)).toContain(a.id);
       expect(hits.length).toBe(1);
 
-      const afterRow = (provider as unknown as { db: { prepare: (s: string) => { get: (...args: unknown[]) => { access_count: number } } } })
-        .db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id);
-      expect(afterRow.access_count).toBe(beforeRow.access_count);
+      const after = db.prepare("SELECT access_count FROM memories WHERE id = ?").get(a.id) as { access_count: number };
+      expect(after.access_count).toBe(5);
     });
 
     it("scopes to a space when space_id is set, plus globals", async () => {

--- a/server/test/sessions-search-space.test.ts
+++ b/server/test/sessions-search-space.test.ts
@@ -1,0 +1,66 @@
+// Drives space-scoping on SqliteSessionStore.searchEvents (cmd+K type
+// filter). Without scoping, an "@space alpha" filter in the spotlight
+// would still surface session-event hits from other spaces. Pin the
+// SQL contract here so the route can pass `space_id` through with
+// confidence.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+describe("SqliteSessionStore.searchEvents (space_id scoping)", () => {
+  let dir: string;
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "oyster-ss-search-space-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  function setupTwoSpaces() {
+    const db = initDb(dir);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('alpha', 'Alpha', '#000', 'none')`);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('beta',  'Beta',  '#111', 'none')`);
+
+    const store = new SqliteSessionStore(db);
+    store.upsertSession({
+      id: "sess-alpha",
+      space_id: "alpha",
+      agent: "claude-code",
+      state: "active",
+      title: "Alpha session",
+    });
+    store.upsertSession({
+      id: "sess-beta",
+      space_id: "beta",
+      agent: "claude-code",
+      state: "active",
+      title: "Beta session",
+    });
+
+    store.insertEvent({ session_id: "sess-alpha", role: "user", text: "please fix the auth bug" });
+    store.insertEvent({ session_id: "sess-beta",  role: "user", text: "auth flow needs review" });
+
+    return store;
+  }
+
+  it("returns only the alpha session's hit when spaceId='alpha'", () => {
+    const store = setupTwoSpaces();
+    const hits = store.searchEvents("auth", { spaceId: "alpha" });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].session_id).toBe("sess-alpha");
+  });
+
+  it("returns hits from both spaces when no spaceId is given", () => {
+    const store = setupTwoSpaces();
+    const hits = store.searchEvents("auth");
+    const sessionIds = hits.map((h) => h.session_id).sort();
+    expect(sessionIds).toEqual(["sess-alpha", "sess-beta"]);
+  });
+
+  it("returns an empty array when spaceId is a nonexistent space", () => {
+    const store = setupTwoSpaces();
+    const hits = store.searchEvents("auth", { spaceId: "nonexistent" });
+    expect(hits).toEqual([]);
+  });
+});

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1766,18 +1766,10 @@ body {
 }
 .spotlight-token-chip .x:hover { color: #d4d6db; }
 
-.spotlight-panel { position: relative; }
 .spotlight-ac {
-  position: absolute;
-  top: 48px;
-  left: 36px;
-  z-index: 6000;
-  min-width: 220px;
-  padding: 4px;
-  background: #181a1d;
-  border: 1px solid #3a3d44;
-  border-radius: 6px;
-  box-shadow: 0 6px 18px rgba(0,0,0,0.5);
+  padding: 4px 8px 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(0, 0, 0, 0.18);
 }
 .spotlight-ac-hint {
   font-size: 10px;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1790,10 +1790,17 @@ body {
   border-radius: 4px;
   cursor: pointer;
   color: #d4d6db;
+  justify-content: space-between;
 }
 .spotlight-ac-item--sel { background: #2a2d33; }
 .spotlight-ac-prefix { color: #4d9aff; }
 .spotlight-ac-swatch { width: 8px; height: 8px; border-radius: 2px; }
+.spotlight-ac-left { display: flex; gap: 8px; align-items: center; }
+.spotlight-ac-count {
+  margin-left: auto;
+  font-size: 11px;
+  color: #6e7280;
+}
 
 /* ── Hardcore Gate Modal ── */
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1744,6 +1744,28 @@ body {
   font-family: var(--font-mono);
 }
 
+.spotlight-token-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 4px 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  border: 1px solid;
+  margin-right: 6px;
+  user-select: none;
+}
+.spotlight-token-chip--type   { color: #4d9aff; background: #3a86ff22; border-color: #3a86ff44; }
+.spotlight-token-chip--space  { color: #a78bfa; background: #8b5cf622; border-color: #a78bfa44; }
+.spotlight-token-chip .x {
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  color: #6e7280;
+  padding: 0 0 0 2px;
+}
+.spotlight-token-chip .x:hover { color: #d4d6db; }
+
 /* ── Hardcore Gate Modal ── */
 
 .hardcore-gate-overlay {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1766,6 +1766,43 @@ body {
 }
 .spotlight-token-chip .x:hover { color: #d4d6db; }
 
+.spotlight-panel { position: relative; }
+.spotlight-ac {
+  position: absolute;
+  top: 48px;
+  left: 36px;
+  z-index: 6000;
+  min-width: 220px;
+  padding: 4px;
+  background: #181a1d;
+  border: 1px solid #3a3d44;
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.5);
+}
+.spotlight-ac-hint {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6e7280;
+  padding: 4px 8px 6px;
+  border-bottom: 1px solid #2a2d33;
+  margin-bottom: 4px;
+}
+.spotlight-ac-hint--bottom { border-bottom: 0; border-top: 1px solid #2a2d33; margin: 4px 0 0; padding: 6px 8px 4px; }
+.spotlight-ac-item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #d4d6db;
+}
+.spotlight-ac-item--sel { background: #2a2d33; }
+.spotlight-ac-prefix { color: #4d9aff; }
+.spotlight-ac-swatch { width: 8px; height: 8px; border-radius: 2px; }
+
 /* ── Hardcore Gate Modal ── */
 
 .hardcore-gate-overlay {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -617,6 +617,7 @@ export default function App() {
       {spotlightOpen && (
         <SpotlightSearch
           artifacts={artifacts}
+          spaces={spaces}
           onOpen={handleArtifactClick}
           onClose={() => setSpotlightOpen(false)}
         />

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -563,6 +563,16 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     return () => window.removeEventListener("oyster:open-session", handler);
   }, []);
 
+  useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent<{ id: string; spaceId: string }>).detail;
+      if (!detail) return;
+      console.log("[spotlight] open-memory", detail);
+    }
+    window.addEventListener("oyster:open-memory", handler);
+    return () => window.removeEventListener("oyster:open-memory", handler);
+  }, []);
+
   // Manual refresh: calls reconcile immediately (bypasses throttle), then
   // refreshes the memories list on success.
   const handleManualReconcile = useCallback(async () => {

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -201,6 +201,23 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
     ...memoryHits.map((m): SpotlightHit => ({ kind: "memory", memory: m })),
   ], [artefactHits, transcriptHits, memoryHits]);
 
+  // Empty-query feed: most-recently-touched artefacts. The Artifact type
+  // has no separate "last modified" — createdAt is the closest signal,
+  // and pinnedAt (when set) is a strictly more recent user touch, so we
+  // take the max of the two. Renders only when there's no query and no
+  // chips active. Sessions/memories deliberately not included in v1.
+  const recentFeed = useMemo(() => {
+    if (query.trim() || filter.type || filter.spaceId) return [];
+    return artifacts
+      .slice()
+      .sort((a, b) => {
+        const ta = Math.max(a.pinnedAt ?? 0, Date.parse(a.createdAt) || 0);
+        const tb = Math.max(b.pinnedAt ?? 0, Date.parse(b.createdAt) || 0);
+        return tb - ta;
+      })
+      .slice(0, 10);
+  }, [query, filter.type, filter.spaceId, artifacts]);
+
   useEffect(() => {
     // Reset highlighted result when the query changes.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -296,7 +313,7 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
 
   return (
     <div className="spotlight-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className={`spotlight-panel${showResults || showEmpty || (activeAc && acOptions.length > 0) ? " spotlight-panel--expanded" : ""}`}>
+      <div className={`spotlight-panel${showResults || showEmpty || (activeAc && acOptions.length > 0) || recentFeed.length > 0 ? " spotlight-panel--expanded" : ""}`}>
         <div className="spotlight-input-row">
           <svg className="spotlight-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
@@ -437,6 +454,27 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
 
         {showEmpty && (
           <div className="spotlight-empty">No results for "{query}"</div>
+        )}
+
+        {!showResults && !showEmpty && recentFeed.length > 0 && (
+          <div className="spotlight-results">
+            <div className="spotlight-section-label">Recent</div>
+            {recentFeed.map((a) => {
+              const cfg = typeConfig[a.artifactKind] ?? typeConfig.app;
+              return (
+                <div
+                  key={`r-${a.id}`}
+                  className="spotlight-result"
+                  onClick={() => { onOpen(a); onClose(); }}
+                >
+                  <span className="spotlight-result-dot" style={{ background: cfg.color }} />
+                  <span className="spotlight-result-label">{a.label}</span>
+                  <span className="spotlight-result-badge">{a.artifactKind}</span>
+                  <span className="spotlight-result-space" style={{ color: spaceColor(a.spaceId), background: `${spaceColor(a.spaceId)}18` }}>{a.spaceId}</span>
+                </div>
+              );
+            })}
+          </div>
         )}
       </div>
     </div>

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -9,6 +9,7 @@ import type { Memory } from "../data/memories-api";
 
 interface Props {
   artifacts: Artifact[];
+  spaces: { id: string; name?: string }[];
   onOpen: (artifact: Artifact) => void;
   onClose: () => void;
 }
@@ -21,12 +22,18 @@ const DEBOUNCE_MS = 180;
 type FilterType = "session" | "artefact" | "memory" | null;
 type SpotlightFilter = { type: FilterType; spaceId: string | null };
 
+const TYPE_OPTS: { value: 'session' | 'artefact' | 'memory'; color: string }[] = [
+  { value: 'session', color: '#4d9aff' },
+  { value: 'artefact', color: '#ff8a5c' },
+  { value: 'memory', color: '#a78bfa' },
+];
+
 type SpotlightHit =
   | { kind: "artefact"; artifact: Artifact }
   | { kind: "transcript"; hit: TranscriptHit }
   | { kind: "memory"; memory: Memory };
 
-export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
+export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
   const [transcriptHits, setTranscriptHits] = useState<TranscriptHit[]>([]);
@@ -44,6 +51,49 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  type ActiveAc = { prefix: '@' | '#'; fragment: string; start: number } | null;
+  const activeAc: ActiveAc = useMemo(() => {
+    const at = query.lastIndexOf('@');
+    const hash = query.lastIndexOf('#');
+    const candidate = at > hash ? '@' : (hash > -1 ? '#' : null);
+    if (!candidate) return null;
+    const idx = candidate === '@' ? at : hash;
+    if (idx > 0 && !/\s/.test(query[idx - 1])) return null;
+    const fragment = query.slice(idx + 1);
+    if (/\s/.test(fragment)) return null;
+    return { prefix: candidate, fragment, start: idx };
+  }, [query]);
+
+  const acOptions = useMemo(() => {
+    if (!activeAc) return [];
+    const frag = activeAc.fragment.toLowerCase();
+    if (activeAc.prefix === '@') {
+      return TYPE_OPTS.filter(o => o.value.startsWith(frag));
+    }
+    return spaces
+      .filter(s => s.id.toLowerCase().includes(frag))
+      .slice(0, 8)
+      .map(s => ({ value: s.id, color: spaceColor(s.id) }));
+  }, [activeAc, spaces]);
+
+  const [acSelected, setAcSelected] = useState(0);
+  useEffect(() => {
+    // Reset highlighted autocomplete option when the active prefix/fragment changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setAcSelected(0);
+  }, [activeAc?.prefix, activeAc?.fragment]);
+
+  function commitAcOption(value: string) {
+    if (!activeAc) return;
+    const isType = activeAc.prefix === '@';
+    setFilter(f => ({
+      type: isType ? (value as FilterType) : f.type,
+      spaceId: isType ? f.spaceId : value,
+      order: [...f.order.filter(o => o !== (isType ? 'type' : 'space')), isType ? 'type' : 'space'],
+    }));
+    setQuery(q => q.slice(0, activeAc.start) + q.slice(activeAc.start + 1 + activeAc.fragment.length));
+  }
 
   const artefactHits = useMemo(() => {
     if (!query.trim()) return [];
@@ -194,6 +244,23 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
       e.preventDefault();
       return;
     }
+    if (activeAc && acOptions.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setAcSelected(s => Math.min(s + 1, acOptions.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setAcSelected(s => Math.max(s - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        commitAcOption(acOptions[acSelected].value);
+        return;
+      }
+    }
     if (e.key === "Escape") { onClose(); return; }
     // Arrow keys are no-ops on an empty list — without this guard,
     // ArrowDown's Math.min(s+1, -1) would set selected to -1.
@@ -260,6 +327,29 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
             <button className="spotlight-clear" onClick={() => setQuery("")}>✕</button>
           )}
         </div>
+
+        {activeAc && acOptions.length > 0 && (
+          <div className="spotlight-ac">
+            <div className="spotlight-ac-hint">
+              {activeAc.prefix === '@' ? 'Filter by type' : 'Filter by space'}
+            </div>
+            {acOptions.map((o, i) => (
+              <div
+                key={o.value}
+                className={`spotlight-ac-item${i === acSelected ? ' spotlight-ac-item--sel' : ''}`}
+                onMouseEnter={() => setAcSelected(i)}
+                onMouseDown={(e) => { e.preventDefault(); commitAcOption(o.value); }}
+              >
+                <span className="spotlight-ac-prefix">{activeAc.prefix}</span>
+                <span className="spotlight-ac-swatch" style={{ background: o.color }} />
+                <span className="spotlight-ac-label">{o.value}</span>
+              </div>
+            ))}
+            <div className="spotlight-ac-hint spotlight-ac-hint--bottom">
+              also try {activeAc.prefix === '@' ? '#space' : '@type'}
+            </div>
+          </div>
+        )}
 
         {showResults && (
           <div className="spotlight-results" ref={listRef}>

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -77,6 +77,12 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       .map(s => ({ value: s.id, color: spaceColor(s.id) }));
   }, [activeAc, spaces]);
 
+  const acCounts: Record<string, number | null> = useMemo(() => ({
+    session:  filter.type === null || filter.type === "session"  ? transcriptHits.length : null,
+    artefact: filter.type === null || filter.type === "artefact" ? artefactHits.length   : null,
+    memory:   filter.type === null || filter.type === "memory"   ? memoryHits.length     : null,
+  }), [filter.type, transcriptHits.length, artefactHits.length, memoryHits.length]);
+
   const [acSelected, setAcSelected] = useState(0);
   useEffect(() => {
     // Reset highlighted autocomplete option when the active prefix/fragment changes.
@@ -340,9 +346,14 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
                 onMouseEnter={() => setAcSelected(i)}
                 onMouseDown={(e) => { e.preventDefault(); commitAcOption(o.value); }}
               >
-                <span className="spotlight-ac-prefix">{activeAc.prefix}</span>
-                <span className="spotlight-ac-swatch" style={{ background: o.color }} />
-                <span className="spotlight-ac-label">{o.value}</span>
+                <span className="spotlight-ac-left">
+                  <span className="spotlight-ac-prefix">{activeAc.prefix}</span>
+                  <span className="spotlight-ac-swatch" style={{ background: o.color }} />
+                  <span className="spotlight-ac-label">{o.value}</span>
+                </span>
+                {activeAc.prefix === '@' && (
+                  <span className="spotlight-ac-count">{acCounts[o.value] ?? '—'}</span>
+                )}
               </div>
             ))}
             <div className="spotlight-ac-hint spotlight-ac-hint--bottom">

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -33,7 +33,11 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
   const [transcriptsLoading, setTranscriptsLoading] = useState(false);
   const [memoryHits, setMemoryHits] = useState<Memory[]>([]);
   const [memoriesLoading, setMemoriesLoading] = useState(false);
-  const [filter, setFilter] = useState<SpotlightFilter>({ type: null, spaceId: null });
+  const [filter, setFilter] = useState<SpotlightFilter & { order: ('type' | 'space')[] }>({
+    type: null,
+    spaceId: null,
+    order: [],
+  });
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -57,9 +61,9 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
 
   // Debounced transcript search. AbortController cancels the request,
   // but a fetch that has already resolved before we abort can still
-  // run its .then() with stale results. The reqIdRef guard rejects any
+  // run its .then() with stale results. The transcriptReqIdRef guard rejects any
   // result that doesn't match the most recently issued request.
-  const reqIdRef = useRef(0);
+  const transcriptReqIdRef = useRef(0);
   useEffect(() => {
     const trimmed = query.trim();
     if (!trimmed) {
@@ -73,17 +77,17 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
       return;
     }
     setTranscriptsLoading(true);
-    const reqId = ++reqIdRef.current;
+    const reqId = ++transcriptReqIdRef.current;
     const ac = new AbortController();
     const timer = setTimeout(() => {
       searchTranscripts(trimmed, { limit: TRANSCRIPTS_LIMIT, spaceId: filter.spaceId, signal: ac.signal })
         .then((hits) => {
-          if (reqId !== reqIdRef.current) return;
+          if (reqId !== transcriptReqIdRef.current) return;
           setTranscriptHits(hits);
           setTranscriptsLoading(false);
         })
         .catch((err) => {
-          if (ac.signal.aborted || reqId !== reqIdRef.current) return;
+          if (ac.signal.aborted || reqId !== transcriptReqIdRef.current) return;
           console.warn("[Spotlight] transcript search failed:", err);
           setTranscriptHits([]);
           setTranscriptsLoading(false);
@@ -97,7 +101,7 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
 
   // Debounced memory search — mirrors the transcript effect:
   // request id + abort controller protect against stale resolutions.
-  const memReqIdRef = useRef(0);
+  const memoryReqIdRef = useRef(0);
   useEffect(() => {
     const trimmed = query.trim();
     if (!trimmed) {
@@ -111,23 +115,26 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
       return;
     }
     setMemoriesLoading(true);
-    const reqId = ++memReqIdRef.current;
+    const reqId = ++memoryReqIdRef.current;
     const ac = new AbortController();
     const timer = setTimeout(() => {
       searchMemories(trimmed, { limit: MEMORIES_LIMIT, spaceId: filter.spaceId, signal: ac.signal })
         .then((hits) => {
-          if (reqId !== memReqIdRef.current) return;
+          if (reqId !== memoryReqIdRef.current) return;
           setMemoryHits(hits);
           setMemoriesLoading(false);
         })
         .catch((err) => {
-          if (ac.signal.aborted || reqId !== memReqIdRef.current) return;
+          if (ac.signal.aborted || reqId !== memoryReqIdRef.current) return;
           console.warn("[Spotlight] memory search failed:", err);
           setMemoryHits([]);
           setMemoriesLoading(false);
         });
     }, DEBOUNCE_MS);
-    return () => { ac.abort(); clearTimeout(timer); };
+    return () => {
+      ac.abort();
+      clearTimeout(timer);
+    };
   }, [query, filter]);
 
   // Flat ordered list — used by keyboard nav. Artefacts first, then
@@ -176,6 +183,17 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Backspace" && query === "" && filter.order.length > 0) {
+      const last = filter.order[filter.order.length - 1];
+      setFilter(f => ({
+        ...f,
+        type: last === 'type' ? null : f.type,
+        spaceId: last === 'space' ? null : f.spaceId,
+        order: f.order.slice(0, -1),
+      }));
+      e.preventDefault();
+      return;
+    }
     if (e.key === "Escape") { onClose(); return; }
     // Arrow keys are no-ops on an empty list — without this guard,
     // ArrowDown's Math.min(s+1, -1) would set selected to -1.
@@ -210,10 +228,30 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
           <svg className="spotlight-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
           </svg>
+          {filter.type && (
+            <span className="spotlight-token-chip spotlight-token-chip--type">
+              @{filter.type}
+              <span className="x" onClick={() => setFilter(f => ({
+                ...f,
+                type: null,
+                order: f.order.filter(o => o !== 'type'),
+              }))}>×</span>
+            </span>
+          )}
+          {filter.spaceId && (
+            <span className="spotlight-token-chip spotlight-token-chip--space">
+              #{filter.spaceId}
+              <span className="x" onClick={() => setFilter(f => ({
+                ...f,
+                spaceId: null,
+                order: f.order.filter(o => o !== 'space'),
+              }))}>×</span>
+            </span>
+          )}
           <input
             ref={inputRef}
             className="spotlight-input"
-            placeholder="Search artefacts, transcripts…"
+            placeholder="Search artefacts, sessions, memories — type @ to filter"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -128,6 +128,10 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       return;
     }
     if (filter.type !== null && filter.type !== "session") {
+      // Bump the ref so any in-flight fetch from a previous effect run
+      // (filter was set, request resolved between change and abort)
+      // fails its reqId guard and doesn't overwrite the cleared state.
+      transcriptReqIdRef.current++;
       setTranscriptHits([]);
       setTranscriptsLoading(false);
       return;
@@ -166,6 +170,8 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       return;
     }
     if (filter.type !== null && filter.type !== "memory") {
+      // Same stale-request guard as the transcript effect — see comment there.
+      memoryReqIdRef.current++;
       setMemoryHits([]);
       setMemoriesLoading(false);
       return;
@@ -195,7 +201,7 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
 
   // Flat ordered list — used by keyboard nav. Artefacts first, then
   // transcript hits, then memory hits.
-  const flatHits: SpotlightHit[] = useMemo(() => [
+  const searchHits: SpotlightHit[] = useMemo(() => [
     ...artefactHits.map((a): SpotlightHit => ({ kind: "artefact", artifact: a })),
     ...transcriptHits.map((h): SpotlightHit => ({ kind: "transcript", hit: h })),
     ...memoryHits.map((m): SpotlightHit => ({ kind: "memory", memory: m })),
@@ -217,6 +223,13 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       })
       .slice(0, 10);
   }, [query, filter.type, filter.spaceId, artifacts]);
+
+  // Whichever list is on screen drives keyboard nav. The recent feed only
+  // shows when searchHits is empty AND query/filter are empty, so the two
+  // never overlap.
+  const flatHits: SpotlightHit[] = searchHits.length > 0
+    ? searchHits
+    : recentFeed.map((a): SpotlightHit => ({ kind: "artefact", artifact: a }));
 
   useEffect(() => {
     // Reset highlighted result when the query changes.
@@ -284,7 +297,17 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
         return;
       }
     }
-    if (e.key === "Escape") { onClose(); return; }
+    if (e.key === "Escape") {
+      // If autocomplete is open, first Escape dismisses it (by deleting
+      // the @ / # prefix from the query); a second Escape closes Spotlight.
+      if (activeAc) {
+        e.preventDefault();
+        setQuery(q => q.slice(0, activeAc.start) + q.slice(activeAc.start + 1 + activeAc.fragment.length));
+        return;
+      }
+      onClose();
+      return;
+    }
     // Arrow keys are no-ops on an empty list — without this guard,
     // ArrowDown's Math.min(s+1, -1) would set selected to -1.
     if ((e.key === "ArrowDown" || e.key === "ArrowUp") && flatHits.length === 0) {
@@ -457,15 +480,17 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
         )}
 
         {!showResults && !showEmpty && recentFeed.length > 0 && (
-          <div className="spotlight-results">
+          <div className="spotlight-results" ref={listRef}>
             <div className="spotlight-section-label">Recent</div>
-            {recentFeed.map((a) => {
+            {recentFeed.map((a, i) => {
               const cfg = typeConfig[a.artifactKind] ?? typeConfig.app;
+              const isSelected = i === selected;
               return (
                 <div
                   key={`r-${a.id}`}
-                  className="spotlight-result"
-                  onClick={() => { onOpen(a); onClose(); }}
+                  className={`spotlight-result${isSelected ? " spotlight-result--selected" : ""}`}
+                  onMouseEnter={() => setSelected(i)}
+                  onClick={() => activate({ kind: "artefact", artifact: a })}
                 >
                   <span className="spotlight-result-dot" style={{ background: cfg.color }} />
                   <span className="spotlight-result-label">{a.label}</span>

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -77,12 +77,6 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       .map(s => ({ value: s.id, color: spaceColor(s.id) }));
   }, [activeAc, spaces]);
 
-  const acCounts: Record<string, number | null> = useMemo(() => ({
-    session:  filter.type === null || filter.type === "session"  ? transcriptHits.length : null,
-    artefact: filter.type === null || filter.type === "artefact" ? artefactHits.length   : null,
-    memory:   filter.type === null || filter.type === "memory"   ? memoryHits.length     : null,
-  }), [filter.type, transcriptHits.length, artefactHits.length, memoryHits.length]);
-
   const [acSelected, setAcSelected] = useState(0);
   useEffect(() => {
     // Reset highlighted autocomplete option when the active prefix/fragment changes.
@@ -114,6 +108,12 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       )
       .slice(0, ARTEFACTS_LIMIT);
   }, [query, artifacts, filter]);
+
+  const acCounts: Record<string, number | null> = useMemo(() => ({
+    session:  filter.type === null || filter.type === "session"  ? transcriptHits.length : null,
+    artefact: filter.type === null || filter.type === "artefact" ? artefactHits.length   : null,
+    memory:   filter.type === null || filter.type === "memory"   ? memoryHits.length     : null,
+  }), [filter.type, transcriptHits.length, artefactHits.length, memoryHits.length]);
 
   // Debounced transcript search. AbortController cancels the request,
   // but a fetch that has already resolved before we abort can still

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -290,7 +290,7 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
 
   return (
     <div className="spotlight-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className={`spotlight-panel${showResults || showEmpty ? " spotlight-panel--expanded" : ""}`}>
+      <div className={`spotlight-panel${showResults || showEmpty || (activeAc && acOptions.length > 0) ? " spotlight-panel--expanded" : ""}`}>
         <div className="spotlight-input-row">
           <svg className="spotlight-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -4,6 +4,8 @@ import { typeConfig } from "./ArtifactIcon";
 import { spaceColor } from "../utils/spaceColor";
 import { searchTranscripts } from "../data/sessions-api";
 import type { TranscriptHit } from "../data/sessions-api";
+import { searchMemories } from "../data/memories-api";
+import type { Memory } from "../data/memories-api";
 
 interface Props {
   artifacts: Artifact[];
@@ -13,17 +15,25 @@ interface Props {
 
 const ARTEFACTS_LIMIT = 8;
 const TRANSCRIPTS_LIMIT = 8;
+const MEMORIES_LIMIT = 8;
 const DEBOUNCE_MS = 180;
+
+type FilterType = "session" | "artefact" | "memory" | null;
+type SpotlightFilter = { type: FilterType; spaceId: string | null };
 
 type SpotlightHit =
   | { kind: "artefact"; artifact: Artifact }
-  | { kind: "transcript"; hit: TranscriptHit };
+  | { kind: "transcript"; hit: TranscriptHit }
+  | { kind: "memory"; memory: Memory };
 
 export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState(0);
   const [transcriptHits, setTranscriptHits] = useState<TranscriptHit[]>([]);
   const [transcriptsLoading, setTranscriptsLoading] = useState(false);
+  const [memoryHits, setMemoryHits] = useState<Memory[]>([]);
+  const [memoriesLoading, setMemoriesLoading] = useState(false);
+  const [filter, setFilter] = useState<SpotlightFilter>({ type: null, spaceId: null });
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -33,15 +43,17 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
 
   const artefactHits = useMemo(() => {
     if (!query.trim()) return [];
+    if (filter.type !== null && filter.type !== "artefact") return [];
     const q = query.toLowerCase();
     return artifacts
       .filter((a) =>
-        a.label.toLowerCase().includes(q)
-        || a.artifactKind.toLowerCase().includes(q)
-        || a.spaceId.toLowerCase().includes(q),
+        (filter.spaceId ? a.spaceId === filter.spaceId : true) &&
+        (a.label.toLowerCase().includes(q)
+          || a.artifactKind.toLowerCase().includes(q)
+          || a.spaceId.toLowerCase().includes(q)),
       )
       .slice(0, ARTEFACTS_LIMIT);
-  }, [query, artifacts]);
+  }, [query, artifacts, filter]);
 
   // Debounced transcript search. AbortController cancels the request,
   // but a fetch that has already resolved before we abort can still
@@ -55,11 +67,16 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
       setTranscriptsLoading(false);
       return;
     }
+    if (filter.type !== null && filter.type !== "session") {
+      setTranscriptHits([]);
+      setTranscriptsLoading(false);
+      return;
+    }
     setTranscriptsLoading(true);
     const reqId = ++reqIdRef.current;
     const ac = new AbortController();
     const timer = setTimeout(() => {
-      searchTranscripts(trimmed, { limit: TRANSCRIPTS_LIMIT, signal: ac.signal })
+      searchTranscripts(trimmed, { limit: TRANSCRIPTS_LIMIT, spaceId: filter.spaceId, signal: ac.signal })
         .then((hits) => {
           if (reqId !== reqIdRef.current) return;
           setTranscriptHits(hits);
@@ -76,14 +93,50 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
       ac.abort();
       clearTimeout(timer);
     };
-  }, [query]);
+  }, [query, filter]);
+
+  // Debounced memory search — mirrors the transcript effect:
+  // request id + abort controller protect against stale resolutions.
+  const memReqIdRef = useRef(0);
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setMemoryHits([]);
+      setMemoriesLoading(false);
+      return;
+    }
+    if (filter.type !== null && filter.type !== "memory") {
+      setMemoryHits([]);
+      setMemoriesLoading(false);
+      return;
+    }
+    setMemoriesLoading(true);
+    const reqId = ++memReqIdRef.current;
+    const ac = new AbortController();
+    const timer = setTimeout(() => {
+      searchMemories(trimmed, { limit: MEMORIES_LIMIT, spaceId: filter.spaceId, signal: ac.signal })
+        .then((hits) => {
+          if (reqId !== memReqIdRef.current) return;
+          setMemoryHits(hits);
+          setMemoriesLoading(false);
+        })
+        .catch((err) => {
+          if (ac.signal.aborted || reqId !== memReqIdRef.current) return;
+          console.warn("[Spotlight] memory search failed:", err);
+          setMemoryHits([]);
+          setMemoriesLoading(false);
+        });
+    }, DEBOUNCE_MS);
+    return () => { ac.abort(); clearTimeout(timer); };
+  }, [query, filter]);
 
   // Flat ordered list — used by keyboard nav. Artefacts first, then
-  // transcript hits below.
+  // transcript hits, then memory hits.
   const flatHits: SpotlightHit[] = useMemo(() => [
     ...artefactHits.map((a): SpotlightHit => ({ kind: "artefact", artifact: a })),
     ...transcriptHits.map((h): SpotlightHit => ({ kind: "transcript", hit: h })),
-  ], [artefactHits, transcriptHits]);
+    ...memoryHits.map((m): SpotlightHit => ({ kind: "memory", memory: m })),
+  ], [artefactHits, transcriptHits, memoryHits]);
 
   useEffect(() => {
     // Reset highlighted result when the query changes.
@@ -99,7 +152,7 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
   function activate(hit: SpotlightHit) {
     if (hit.kind === "artefact") {
       onOpen(hit.artifact);
-    } else {
+    } else if (hit.kind === "transcript") {
       // Bridge to Home's activePanel via a window event — Spotlight is
       // mounted at App level and doesn't have direct access to Home's
       // setActivePanel. eventId asks the inspector to scroll to + flash
@@ -112,6 +165,11 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
           eventId: hit.hit.event_id,
           query: query.trim(),
         },
+      }));
+    } else {
+      const targetSpace = hit.memory.space_id ?? "home";
+      window.dispatchEvent(new CustomEvent("oyster:open-memory", {
+        detail: { id: hit.memory.id, spaceId: targetSpace },
       }));
     }
     onClose();
@@ -140,8 +198,10 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
     }
   }
 
-  const showResults = artefactHits.length > 0 || transcriptHits.length > 0 || transcriptsLoading;
-  const showEmpty = !!query.trim() && !transcriptsLoading && flatHits.length === 0;
+  const showResults = artefactHits.length > 0
+    || transcriptHits.length > 0 || transcriptsLoading
+    || memoryHits.length > 0 || memoriesLoading;
+  const showEmpty = !!query.trim() && !transcriptsLoading && !memoriesLoading && flatHits.length === 0;
 
   return (
     <div className="spotlight-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
@@ -204,6 +264,32 @@ export function SpotlightSearch({ artifacts, onOpen, onClose }: Props) {
                   </span>
                   <span className="spotlight-result-session">{h.session_title ?? h.session_id.slice(0, 8)}</span>
                   <span className="spotlight-result-role">{h.role}</span>
+                </div>
+              );
+            })}
+
+            {(memoryHits.length > 0 || memoriesLoading) && (
+              <div className="spotlight-section-label">Memories</div>
+            )}
+            {memoriesLoading && memoryHits.length === 0 && (
+              <div className="spotlight-section-loading">Searching memories…</div>
+            )}
+            {memoryHits.map((m, k) => {
+              const flatIndex = artefactHits.length + transcriptHits.length + k;
+              const isSelected = flatIndex === selected;
+              return (
+                <div
+                  key={`m-${m.id}`}
+                  className={`spotlight-result spotlight-result--memory${isSelected ? " spotlight-result--selected" : ""}`}
+                  onMouseEnter={() => setSelected(flatIndex)}
+                  onClick={() => activate({ kind: "memory", memory: m })}
+                >
+                  <span className="spotlight-result-dot" style={{ background: "#a78bfa" }} />
+                  <span className="spotlight-result-label">{m.content.length > 80 ? m.content.slice(0, 80) + "…" : m.content}</span>
+                  <span className="spotlight-result-badge">memory</span>
+                  {m.space_id && (
+                    <span className="spotlight-result-space" style={{ color: spaceColor(m.space_id), background: `${spaceColor(m.space_id)}18` }}>{m.space_id}</span>
+                  )}
                 </div>
               );
             })}

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -341,7 +341,7 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
           <input
             ref={inputRef}
             className="spotlight-input"
-            placeholder="Search artefacts, sessions, memories — type @ to filter"
+            placeholder="Search artefacts, sessions, memories — type @ or # to filter"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/web/src/data/memories-api.ts
+++ b/web/src/data/memories-api.ts
@@ -20,6 +20,16 @@ export async function fetchMemories(spaceId?: string | null, signal?: AbortSigna
   return getJson<Memory[]>(url, signal);
 }
 
+export async function searchMemories(
+  query: string,
+  opts: { spaceId?: string | null; limit?: number; signal?: AbortSignal } = {},
+): Promise<Memory[]> {
+  const params = new URLSearchParams({ q: query });
+  if (opts.spaceId) params.set("space_id", opts.spaceId);
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  return getJson<Memory[]>(`/api/memories/search?${params.toString()}`, opts.signal);
+}
+
 export interface CreateMemoryInput {
   content: string;
   space_id?: string | null;

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -122,10 +122,11 @@ export interface TranscriptHit {
 
 export async function searchTranscripts(
   query: string,
-  opts: { limit?: number; signal?: AbortSignal } = {},
+  opts: { limit?: number; spaceId?: string | null; signal?: AbortSignal } = {},
 ): Promise<TranscriptHit[]> {
   const params = new URLSearchParams({ q: query });
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts.spaceId) params.set("space_id", opts.spaceId);
   return getJson<TranscriptHit[]>(`/api/sessions/search?${params.toString()}`, opts.signal);
 }
 


### PR DESCRIPTION
## Summary
- cmd+K Spotlight now scopes results by **type** (`@session` / `@artefact` / `@memory`) and **space** (`#<space-id>`), via an inline autocomplete dropdown on `@` or `#`. Filters render as removable chips inside the input; Backspace at empty input pops the most-recent chip.
- Memory is added as a third searchable source (existing `recall` FTS5 path, exposed via new side-effect-free `GET /api/memories/search`). `/api/sessions/search` gains `space_id` scoping.
- Empty cmd+K shows recent artefacts under "Recent" so the panel is useful before typing.

Design spec: `docs/superpowers/specs/2026-05-16-cmdk-type-filter-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-16-cmdk-type-filter.md`

## Test plan
- [ ] Server: `cd server && npm test` — 351 tests green, including new memory-search + sessions-space tests
- [ ] Web: `cd web && npx tsc --noEmit` — clean
- [ ] cmd+K → `@s` Enter → only sessions appear when typing
- [ ] cmd+K → `@m` Enter → `#tok…` Enter → memories from that space only
- [ ] Chips remove via `×` and Backspace-on-empty
- [ ] `@` autocomplete shows live counts; counts are `—` for types currently filtered out
- [ ] Empty cmd+K shows the "Recent" artefacts feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)