### PR TITLE
Redesign oyster.to — Pearl in Orbit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **Redesigned oyster.to.** New editorial typography (Sora + Instrument Serif italic), cosmic background with orbital arcs, refreshed hero with luminous device frame, and a stronger "Pearl in Orbit" look across the homepage, pricing, plugins, MCP, and changelog pages.
 - **Top bar is now one sticky pill.** Account and space switcher share a single bar pinned to the top of every view. Signed-in shows an avatar (email + sign-out in the click-menu); signed-out shows a *Sign in* pill in the same slot.
 
 ### Fixed

--- a/docs/assets/oyster.css
+++ b/docs/assets/oyster.css
@@ -1,0 +1,289 @@
+/* ============================================
+   OYSTER DESIGN SYSTEM — Pearl in Orbit
+   Shared chrome (fonts, vars, body, cosmos, nav,
+   buttons, headline patterns, footer) used by
+   every oyster.to page.
+   ============================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Sora:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+:root {
+  --bg: #04060d;
+  --bg-2: #080b1c;
+  --bg-3: #0d1126;
+  --ink: #f3f4ff;
+  --ink-2: rgba(243, 244, 255, 0.66);
+  --ink-3: rgba(243, 244, 255, 0.42);
+  --ink-4: rgba(243, 244, 255, 0.22);
+  --accent: #8b76ff;
+  --accent-2: #a99eff;
+  --signal: #7be7ff;
+  --plasma: #ff8de0;
+  --star: #ffd97a;
+  --good: #4ade80;
+  --warn: #fbbf24;
+  --bad: #f87171;
+
+  --serif: 'Instrument Serif', 'Times New Roman', serif;
+  --sans: 'Sora', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html {
+  scroll-padding-top: 80px;
+  scroll-behavior: smooth;
+  overflow-x: clip;
+  max-width: 100vw;
+}
+
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  min-height: 100vh;
+  overflow-x: clip;
+  max-width: 100vw;
+  position: relative;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'ss01' on, 'cv11' on;
+}
+
+/* ============================================
+   COSMIC BACKGROUND
+   ============================================ */
+.cosmos {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse 1100px 700px at 22% 8%, rgba(139, 118, 255, 0.09) 0%, transparent 60%),
+    radial-gradient(ellipse 800px 600px at 80% 18%, rgba(123, 231, 255, 0.05) 0%, transparent 65%),
+    linear-gradient(180deg, #04060d 0%, #050714 50%, #04060d 100%);
+}
+.cosmos::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255,255,255,0.012) 1px, transparent 1px);
+  background-size: 3px 3px;
+  mix-blend-mode: overlay;
+  opacity: 0.4;
+}
+.stars { position: absolute; inset: 0; }
+.stars div {
+  position: absolute;
+  width: 1px; height: 1px;
+  background: #fff;
+  border-radius: 50%;
+}
+.stars-far div { opacity: 0.35; }
+.stars-near div { width: 1.5px; height: 1.5px; opacity: 0.7; }
+.star-twinkle {
+  animation: oy-twinkle var(--dur, 6s) ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
+}
+@keyframes oy-twinkle {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 0.15; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .star-twinkle { animation: none; }
+}
+
+/* ============================================
+   NAV
+   ============================================ */
+.nav {
+  position: fixed;
+  top: 18px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: max-content;
+  max-width: calc(100vw - 20px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px 6px 5px 4px;
+  background: rgba(13, 16, 36, 0.72);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 4px 32px rgba(0, 0, 0, 0.5),
+    0 0 60px rgba(139, 118, 255, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+.nav-logo {
+  width: 22px; height: 22px;
+  margin: 0 6px 0 12px;
+  object-fit: contain;
+  filter: drop-shadow(0 0 6px rgba(139, 118, 255, 0.5));
+}
+/* Logo wrapped in <a> — tight circular hover, no text-link padding */
+.nav a:has(.nav-logo) {
+  padding: 4px;
+  margin: 0 2px 0 8px;
+  border-radius: 50%;
+  line-height: 0;
+}
+.nav a:has(.nav-logo):hover {
+  background: rgba(139, 118, 255, 0.16);
+}
+.nav a:has(.nav-logo) .nav-logo {
+  margin: 0;
+  display: block;
+}
+.nav a {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink-2);
+  text-decoration: none;
+  padding: 7px 16px;
+  border-radius: 9999px;
+  transition: color 0.2s ease, background 0.2s ease;
+  letter-spacing: -0.01em;
+}
+.nav a:hover {
+  color: #fff;
+  background: rgba(139, 118, 255, 0.18);
+}
+.nav a.active {
+  color: #fff;
+  background: rgba(139, 118, 255, 0.16);
+}
+@media (max-width: 560px) {
+  .nav { padding: 4px 4px 4px 2px; gap: 0; }
+  .nav a { padding: 6px 10px; font-size: 12px; }
+  .nav-logo { width: 20px; height: 20px; margin: 0 4px 0 8px; }
+}
+@media (max-width: 400px) {
+  .nav a { padding: 5px 8px; font-size: 11px; }
+  .nav-logo { margin: 0 2px 0 6px; }
+}
+
+@keyframes oy-breathe { 50% { opacity: 0.45; } }
+
+/* ============================================
+   CTA BUTTONS
+   ============================================ */
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 26px;
+  border-radius: 9999px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  text-decoration: none;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.cta:hover { transform: translateY(-1px); }
+.cta-primary {
+  background: linear-gradient(180deg, #9d8cff 0%, #8b76ff 100%);
+  color: #fff;
+  box-shadow:
+    0 4px 24px rgba(139, 118, 255, 0.45),
+    0 0 60px rgba(139, 118, 255, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+.cta-primary:hover {
+  box-shadow:
+    0 8px 36px rgba(139, 118, 255, 0.55),
+    0 0 100px rgba(139, 118, 255, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+.cta-secondary {
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(8px);
+}
+.cta-secondary:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+.cta svg { width: 14px; height: 14px; }
+@keyframes oy-shimmer {
+  0% { transform: translateX(-100%) skewX(-15deg); }
+  100% { transform: translateX(200%) skewX(-15deg); }
+}
+.cta::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.22) 50%, transparent 100%);
+  transform: translateX(-100%) skewX(-15deg);
+}
+.cta:hover::after {
+  animation: oy-shimmer 0.85s ease-in-out 1 forwards;
+}
+
+.cta-row {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ============================================
+   TYPOGRAPHY PATTERNS
+   ============================================ */
+
+/* Editorial serif accent — for accent words inside headlines */
+.accent-serif {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.accent-serif-soft {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: var(--accent-2);
+}
+
+/* Section h2 used on supporting pages */
+.section-h2 {
+  font-family: var(--sans);
+  font-size: clamp(30px, 3.4vw, 44px);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+}
+
+/* ============================================
+   FOOTER
+   ============================================ */
+.site-footer {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-4);
+  padding: 60px 28px 60px;
+  letter-spacing: 0.06em;
+}
+.site-footer .heart { color: var(--plasma); }
+.site-footer a { color: var(--ink-3); text-decoration: none; transition: color 0.2s; }
+.site-footer a:hover { color: var(--ink); }

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -5,89 +5,50 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Changelog — Oyster</title>
   <meta name="description" content="Every shipped change to Oyster, newest first.">
-  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/oyster.css">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html { scroll-behavior: smooth; scroll-padding-top: 24px; }
-    body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #0a0b14;
-      color: #e0e0e0;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
-    .bg {
-      position: fixed;
-      inset: 0;
-      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
-                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
-                  #0a0b14;
-      z-index: 0;
-    }
-    .back-nav {
-      position: fixed;
-      top: 16px;
-      left: 0;
-      right: 0;
-      z-index: 10;
-      display: flex;
-      justify-content: center;
-    }
-    .back-bar {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 20px;
-      background: rgba(20, 22, 40, 0.9);
-      backdrop-filter: blur(16px);
-      -webkit-backdrop-filter: blur(16px);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 9999px;
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
-    }
-    .back-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-family: inherit;
-      font-size: 13px;
-      font-weight: 500;
-      color: rgba(255,255,255,0.5);
-      text-decoration: none;
-      transition: color 0.15s;
-    }
-    .back-link:hover { color: #fff; }
-
     .hero {
       position: relative;
-      z-index: 1;
-      max-width: 820px;
+      z-index: 2;
+      max-width: 880px;
       margin: 0 auto;
-      padding: 120px 24px 0;
+      padding: 160px 28px 0;
       text-align: center;
     }
     h1 {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(32px, 5vw, 48px);
-      font-weight: 700;
-      line-height: 1.15;
-      color: #fff;
-      margin-bottom: 16px;
+      font-family: var(--sans);
+      font-size: clamp(40px, 6.5vw, 88px);
+      font-weight: 800;
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+      color: var(--ink);
+      margin-bottom: 22px;
+    }
+    h1 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
     }
     .subtitle {
       font-size: 18px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.5);
-      max-width: 560px;
+      line-height: 1.55;
+      color: var(--ink-2);
+      max-width: 540px;
       margin: 0 auto;
+      letter-spacing: -0.005em;
     }
 
     .version-pills {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 820px;
-      margin: 48px auto 0;
-      padding: 0 24px;
+      margin: 56px auto 0;
+      padding: 0 28px;
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
@@ -97,49 +58,49 @@
       display: inline-flex;
       align-items: center;
       padding: 6px 14px;
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 11px;
       font-weight: 500;
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      color: rgba(255, 255, 255, 0.55);
-      background: rgba(20, 22, 40, 0.7);
-      border: 1px solid rgba(124, 107, 255, 0.18);
+      letter-spacing: 0.06em;
+      color: var(--ink-3);
+      background: rgba(20, 23, 44, 0.6);
+      border: 1px solid rgba(139, 118, 255, 0.16);
       border-radius: 9999px;
       text-decoration: none;
       transition: color 0.15s, border-color 0.15s, background 0.15s, transform 0.15s;
     }
     .version-pill:hover {
-      color: #fff;
-      border-color: rgba(124, 107, 255, 0.45);
-      background: rgba(124, 107, 255, 0.12);
+      color: var(--ink);
+      border-color: rgba(139, 118, 255, 0.45);
+      background: rgba(139, 118, 255, 0.14);
       transform: translateY(-1px);
     }
 
     .entries {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 760px;
       margin: 0 auto;
-      padding: 48px 24px 120px;
+      padding: 56px 28px 120px;
     }
     .entries h2 {
       display: flex;
       align-items: baseline;
-      gap: 12px;
+      gap: 14px;
       flex-wrap: wrap;
-      margin: 64px 0 24px;
-      padding-bottom: 12px;
-      border-bottom: 1px solid rgba(124, 107, 255, 0.18);
-      scroll-margin-top: 24px;
+      margin: 72px 0 26px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid rgba(139, 118, 255, 0.20);
+      scroll-margin-top: 80px;
     }
     .entries h2:first-child { margin-top: 0; }
     .release-version {
-      font-family: 'Barlow', sans-serif;
-      font-size: 28px;
+      font-family: var(--sans);
+      font-size: 32px;
       font-weight: 700;
-      color: #fff;
-      letter-spacing: -0.5px;
+      color: var(--ink);
+      letter-spacing: -0.025em;
+      line-height: 1.05;
     }
     .release-version-link {
       text-decoration: none;
@@ -147,50 +108,55 @@
       transition: opacity 0.15s;
     }
     .release-version-link:hover .release-version {
-      color: #a99eff;
+      color: var(--accent-2);
     }
     .release-date {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 12px;
+      font-family: var(--mono);
+      font-size: 11px;
       font-weight: 500;
-      letter-spacing: 1px;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
-      color: rgba(169, 158, 255, 0.7);
+      color: var(--accent-2);
     }
     .entries h3 {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 11px;
+      font-family: var(--mono);
+      font-size: 10px;
       font-weight: 600;
-      letter-spacing: 2px;
+      letter-spacing: 0.18em;
       text-transform: uppercase;
-      color: rgba(169, 158, 255, 0.85);
-      margin: 28px 0 12px;
+      color: var(--star);
+      margin: 32px 0 14px;
     }
     .entries h4 {
-      font-family: 'Barlow', sans-serif;
-      font-size: 18px;
-      font-weight: 700;
-      color: #fff;
-      margin: 20px 0 8px;
+      font-family: var(--sans);
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--ink);
+      margin: 22px 0 8px;
+      letter-spacing: -0.01em;
     }
     .entries p {
+      font-family: var(--sans);
       font-size: 15px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.62);
+      line-height: 1.65;
+      color: var(--ink-2);
       margin-bottom: 10px;
+      letter-spacing: -0.005em;
     }
     .entries ul {
       list-style: none;
       padding: 0;
-      margin: 0 0 16px;
+      margin: 0 0 18px;
     }
     .entries li {
       position: relative;
       padding-left: 20px;
       margin-bottom: 8px;
+      font-family: var(--sans);
       font-size: 15px;
-      line-height: 1.65;
-      color: rgba(255, 255, 255, 0.62);
+      line-height: 1.6;
+      color: var(--ink-2);
+      letter-spacing: -0.005em;
     }
     .entries li::before {
       content: "";
@@ -200,116 +166,126 @@
       width: 4px;
       height: 4px;
       border-radius: 50%;
-      background: rgba(124, 107, 255, 0.6);
+      background: var(--accent);
+      opacity: 0.7;
     }
-    .entries li > ul {
-      margin: 8px 0 0;
-    }
+    .entries li > ul { margin: 8px 0 0; }
     .entries strong {
-      color: rgba(255, 255, 255, 0.82);
+      color: var(--ink);
       font-weight: 600;
     }
     .entries code {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 13px;
-      background: rgba(124, 107, 255, 0.1);
-      color: #a99eff;
+      background: rgba(139, 118, 255, 0.12);
+      color: var(--accent-2);
       padding: 2px 6px;
       border-radius: 4px;
     }
     .entries a {
-      color: #a99eff;
+      color: var(--accent-2);
       text-decoration: none;
       border-bottom: 1px dotted rgba(169, 158, 255, 0.4);
     }
-    .entries a:hover { color: #fff; border-bottom-color: #fff; }
+    .entries a:hover { color: var(--ink); border-bottom-color: var(--ink); }
 
     .install-section {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 640px;
       margin: 0 auto;
-      padding: 0 24px 100px;
+      padding: 0 28px 80px;
       text-align: center;
     }
     .install-label {
-      font-family: 'Barlow', sans-serif;
+      font-family: var(--sans);
       font-size: 28px;
       font-weight: 700;
-      color: #fff;
+      letter-spacing: -0.02em;
+      color: var(--ink);
       margin-bottom: 24px;
     }
+    .terminal-frame {
+      position: relative;
+      max-width: 480px;
+      margin: 0 auto;
+      isolation: isolate;
+    }
+    .terminal-frame::before {
+      content: '';
+      position: absolute;
+      inset: -30px -40px;
+      background:
+        radial-gradient(ellipse 60% 60% at 50% 100%, rgba(139, 118, 255, 0.45) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 50% at 50% 0%, rgba(123, 231, 255, 0.20) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
+    }
     .terminal {
-      background: rgba(8, 9, 18, 0.95);
-      border: 2px solid rgba(124, 107, 255, 0.14);
-      border-radius: 12px;
-      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      background: rgba(13, 16, 36, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.6);
       overflow: hidden;
+      backdrop-filter: blur(14px);
       text-align: left;
     }
     .terminal-bar {
       display: flex;
       align-items: center;
-      padding: 12px 16px;
-      background: rgba(0, 0, 0, 0.25);
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.04);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
       position: relative;
     }
     .terminal-dots { display: flex; gap: 6px; }
     .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
     .terminal-title {
       position: absolute; left: 0; right: 0; text-align: center;
-      font-size: 11px; color: rgba(255,255,255,0.25);
-      font-family: 'IBM Plex Mono', monospace; pointer-events: none;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-4);
+      letter-spacing: 0.06em;
+      pointer-events: none;
     }
     .terminal-body {
-      padding: 20px 24px 24px;
+      padding: 22px 24px;
       display: flex; flex-direction: column; gap: 10px;
     }
-    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
+    .terminal-line .prompt { color: var(--ink-4); font-family: var(--mono); font-size: 14px; }
     .terminal-line code {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: clamp(16px, 2.5vw, 20px);
-      color: #a99eff;
+      font-family: var(--mono);
+      font-size: clamp(15px, 2.2vw, 18px);
+      color: var(--accent-2);
       background: none;
       padding: 0;
     }
 
-    .footer {
-      position: relative;
-      z-index: 1;
-      text-align: center;
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.3);
-      padding: 0 24px 60px;
-    }
-    .footer .heart { color: #e25555; }
-    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
-    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
-
     @media (max-width: 600px) {
-      .hero { padding-top: 100px; }
-      .entries { padding-top: 48px; }
+      .hero { padding-top: 110px; }
+      .entries { padding-top: 40px; }
     }
   </style>
 </head>
 <body>
-  <div class="bg"></div>
-
-  <div class="back-nav">
-    <div class="back-bar">
-      <a class="back-link" href="/">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
-        </svg>
-        oyster.to
-      </a>
-    </div>
+  <div class="cosmos" aria-hidden="true">
+    <div class="stars stars-far" id="stars-far"></div>
+    <div class="stars stars-near" id="stars-near"></div>
   </div>
 
-  <div class="hero">
-    <h1>Changelog</h1>
-    <p class="subtitle">Every shipped change, newest first.</p>
-  </div>
+  <nav class="nav">
+    <a href="/"><img src="logo.png" alt="Oyster" class="nav-logo" /></a>
+    <a href="/#install">Install</a>
+    <a href="/plugins">Plugins</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/changelog" class="active">Changelog</a>
+  </nav>
+
+  <section class="hero">
+    <h1><span class="accent">Every</span> shipped change.</h1>
+    <p class="subtitle">Newest first. The full release log of what's shipping in Oyster.</p>
+  </section>
 
   <nav class="version-pills" aria-label="Jump to version">
       <a class="version-pill" href="#v-0-9-1">0.9</a>
@@ -328,6 +304,7 @@
 <h2 id="v-0-9-1"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.0...v0.9.1" rel="noopener noreferrer"><span class="release-version">0.9.1</span></a></h2>
 <h3>Changed</h3>
 <ul>
+<li><strong>Redesigned oyster.to.</strong> New editorial typography (Sora + Instrument Serif italic), cosmic background with orbital arcs, refreshed hero with luminous device frame, and a stronger &quot;Pearl in Orbit&quot; look across the homepage, pricing, plugins, MCP, and changelog pages.</li>
 <li><strong>Top bar is now one sticky pill.</strong> Account and space switcher share a single bar pinned to the top of every view. Signed-in shows an avatar (email + sign-out in the click-menu); signed-out shows a <em>Sign in</em> pill in the same slot.</li>
 </ul>
 <h3>Fixed</h3>
@@ -959,26 +936,53 @@
 
   </main>
 
-  <div class="install-section">
+  <section class="install-section">
     <div class="install-label">Don't have Oyster yet?</div>
-    <div class="terminal">
-      <div class="terminal-bar">
-        <div class="terminal-dots">
-          <span style="background: #ff5f57;"></span>
-          <span style="background: #febc2e;"></span>
-          <span style="background: #28c840;"></span>
+    <div class="terminal-frame">
+      <div class="terminal">
+        <div class="terminal-bar">
+          <div class="terminal-dots">
+            <span style="background: #ff5f57;"></span>
+            <span style="background: #febc2e;"></span>
+            <span style="background: #28c840;"></span>
+          </div>
+          <span class="terminal-title">terminal</span>
         </div>
-        <span class="terminal-title">terminal</span>
-      </div>
-      <div class="terminal-body">
-        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
-        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+        <div class="terminal-body">
+          <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+          <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <div class="footer">
+  <div class="site-footer">
     <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
   </div>
+
+  <script>
+    (function () {
+      function seed(s) { return function () { s = (s * 9301 + 49297) % 233280; return s / 233280; }; }
+      const rand = seed(42);
+      function makeStars(el, count, twinkle) {
+        if (!el) return;
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const d = document.createElement('div');
+          d.style.left = (rand() * 100).toFixed(2) + '%';
+          d.style.top = (rand() * 100).toFixed(2) + '%';
+          if (twinkle && rand() < 0.18) {
+            d.classList.add('star-twinkle');
+            d.style.setProperty('--dur', (2.5 + rand() * 4).toFixed(2) + 's');
+            d.style.setProperty('--delay', (rand() * 5).toFixed(2) + 's');
+          }
+          frag.appendChild(d);
+        }
+        el.appendChild(frag);
+      }
+      makeStars(document.getElementById('stars-far'), 80, false);
+      makeStars(document.getElementById('stars-near'), 22, true);
+    })();
+  </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,101 +6,376 @@
   <title>Oyster — Mission control for your agents.</title>
   <meta name="description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
 
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="Oyster">
-  <meta property="og:title" content="Oyster — Mission control for your agents.">
-  <meta property="og:description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
-  <meta property="og:url" content="https://oyster.to/">
-  <meta property="og:image" content="https://oyster.to/social-preview.jpg">
-  <meta property="og:image:width" content="1280">
-  <meta property="og:image:height" content="640">
-  <meta property="og:image:alt" content="Oyster — Mission control for your agents.">
-
-  <!-- Twitter / X card -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Oyster — Mission control for your agents.">
-  <meta name="twitter:description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
-  <meta name="twitter:image" content="https://oyster.to/social-preview.jpg">
-  <meta name="twitter:image:alt" content="Oyster — Mission control for your agents.">
-
-  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/oyster.css">
   <link rel="stylesheet" href="assets/hero-mock.css">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html { scroll-padding-top: 60px; }
+    /* ============================================
+       OYSTER v2 — Pearl in Orbit
+       Page-specific styles. Design tokens (:root vars,
+       html/body base, fonts) live in assets/oyster.css.
+       ============================================ */
 
-    body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #0a0b14;
-      color: #e0e0e0;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
+    /* ============================================
+       COSMIC BACKGROUND SYSTEM
+       ============================================ */
 
-    .bg {
+    .cosmos {
       position: fixed;
       inset: 0;
-      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
-                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
-                  #0a0b14;
       z-index: 0;
+      pointer-events: none;
+      overflow: hidden;
+      background:
+        radial-gradient(ellipse 1100px 700px at 22% 8%, rgba(139, 118, 255, 0.09) 0%, transparent 60%),
+        radial-gradient(ellipse 800px 600px at 80% 18%, rgba(123, 231, 255, 0.05) 0%, transparent 65%),
+        linear-gradient(180deg, #04060d 0%, #050714 50%, #04060d 100%);
     }
 
-    /* Hero */
+    /* Subtle grain texture — adds depth without busyness */
+    .cosmos::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image: radial-gradient(rgba(255,255,255,0.012) 1px, transparent 1px);
+      background-size: 3px 3px;
+      mix-blend-mode: overlay;
+      opacity: 0.4;
+    }
+
+    /* Starfield — 2 sparse parallax layers (filled via JS) */
+    .stars { position: absolute; inset: 0; }
+    .stars div {
+      position: absolute;
+      width: 1px; height: 1px;
+      background: #fff;
+      border-radius: 50%;
+    }
+    .stars-far div { opacity: 0.35; }
+    .stars-near div { width: 1.5px; height: 1.5px; opacity: 0.7; }
+
+    /* A few twinkling featured stars */
+    .star-twinkle {
+      animation: twinkle var(--dur, 6s) ease-in-out infinite;
+      animation-delay: var(--delay, 0s);
+    }
+    @keyframes twinkle {
+      0%, 100% { opacity: 0.7; }
+      50% { opacity: 0.15; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .star-twinkle { animation: none; }
+    }
+
+    /* Orbital arcs — the visual signature. SVG placed absolute, very low opacity. */
+    .orbit-svg {
+      position: absolute;
+      pointer-events: none;
+      overflow: visible;
+    }
+    @media (max-width: 900px) {
+      .orbit-svg { display: none; }
+    }
+    .orbit-svg circle, .orbit-svg ellipse {
+      fill: none;
+      stroke: rgba(255, 255, 255, 0.10);
+      stroke-width: 1;
+    }
+    .orbit-svg .orbit-dashed {
+      stroke-dasharray: 3 6;
+    }
+    .orbit-dot {
+      fill: var(--accent-2);
+      filter: drop-shadow(0 0 10px var(--accent-2));
+    }
+    .orbit-dot.signal { fill: var(--signal); filter: drop-shadow(0 0 10px var(--signal)); }
+    .orbit-dot.plasma { fill: var(--plasma); filter: drop-shadow(0 0 10px var(--plasma)); }
+    .orbit-dot.warm { fill: var(--star); filter: drop-shadow(0 0 10px var(--star)); }
+
+    .orbit-rotate {
+      transform-origin: var(--ox, 50%) var(--oy, 50%);
+      animation: orbit-spin var(--dur, 80s) linear infinite;
+    }
+    @keyframes orbit-spin {
+      to { transform: rotate(360deg); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .orbit-rotate { animation: none; }
+    }
+
+    /* ============================================
+       NAV
+       ============================================ */
+    .nav {
+      position: fixed;
+      top: 18px;
+      left: 0;
+      right: 0;
+      margin: 0 auto;
+      width: max-content;
+      max-width: calc(100vw - 20px);
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      padding: 5px 6px 5px 4px;
+      background: rgba(13, 16, 36, 0.72);
+      backdrop-filter: blur(18px) saturate(140%);
+      -webkit-backdrop-filter: blur(18px) saturate(140%);
+      border-radius: 9999px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow:
+        0 4px 32px rgba(0, 0, 0, 0.5),
+        0 0 60px rgba(139, 118, 255, 0.08),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    }
+    .nav-logo {
+      width: 22px; height: 22px;
+      margin: 0 6px 0 12px;
+      object-fit: contain;
+      filter: drop-shadow(0 0 6px rgba(139, 118, 255, 0.5));
+    }
+    .nav-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 0 12px 0 4px;
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      color: rgba(74, 222, 128, 0.9);
+      text-transform: uppercase;
+    }
+    .nav-status .pip {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--good);
+      box-shadow: 0 0 8px var(--good);
+      animation: breathe 2.2s ease-in-out infinite;
+    }
+    @keyframes breathe { 50% { opacity: 0.45; } }
+
+    .nav-sep {
+      width: 1px;
+      height: 14px;
+      background: rgba(255, 255, 255, 0.08);
+      margin: 0 4px;
+    }
+    .nav a {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--ink-2);
+      text-decoration: none;
+      padding: 7px 16px;
+      border-radius: 9999px;
+      transition: color 0.2s ease, background 0.2s ease;
+      letter-spacing: -0.01em;
+    }
+    .nav a:hover {
+      color: #fff;
+      background: rgba(139, 118, 255, 0.18);
+    }
+    @media (max-width: 560px) {
+      .nav { padding: 4px 4px 4px 2px; gap: 0; }
+      .nav a { padding: 6px 10px; font-size: 12px; }
+      .nav-logo { width: 20px; height: 20px; margin: 0 4px 0 8px; }
+    }
+    @media (max-width: 400px) {
+      .nav a { padding: 5px 8px; font-size: 11px; }
+      .nav-logo { margin: 0 2px 0 6px; }
+    }
+
+    /* ============================================
+       HERO
+       ============================================ */
     .hero {
       position: relative;
-      z-index: 1;
-      max-width: 900px;
+      z-index: 2;
+      max-width: 1280px;
       margin: 0 auto;
-      padding: 180px 24px 80px;
+      padding: 170px 28px 60px;
       text-align: center;
     }
 
-    h1 {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(36px, 6vw, 56px);
-      font-weight: 700;
-      line-height: 1.15;
-      margin-bottom: 32px;
-      color: #fff;
+    /* Pearl orb — iridescent satellite behind hero (subtle) */
+    .pearl-orb {
+      position: absolute;
+      top: 80px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 560px;
+      height: 560px;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.08) 0%, transparent 40%),
+        conic-gradient(from 220deg,
+          rgba(139, 118, 255, 0.22) 0deg,
+          rgba(123, 231, 255, 0.14) 100deg,
+          rgba(255, 141, 224, 0.18) 200deg,
+          rgba(139, 118, 255, 0.22) 360deg);
+      filter: blur(80px);
+      opacity: 0.55;
+      pointer-events: none;
+      animation: pearl-rotate 90s linear infinite, pearl-pulse 12s ease-in-out infinite;
     }
-    h1 .dim { color: rgba(255, 255, 255, 0.45); }
+    @keyframes pearl-rotate { to { transform: translateX(-50%) rotate(360deg); } }
+    @keyframes pearl-pulse {
+      0%, 100% { opacity: 0.45; }
+      50% { opacity: 0.62; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .pearl-orb { animation: none; }
+    }
+
+    /* Mission HUD chrome — tasteful marginalia */
+    .hud-marker {
+      position: absolute;
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      color: var(--ink-4);
+      text-transform: uppercase;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      z-index: 3;
+      pointer-events: none;
+    }
+    .hud-marker .tick {
+      width: 8px; height: 8px;
+      border: 1px solid var(--ink-4);
+      transform: rotate(45deg);
+      flex-shrink: 0;
+    }
+    .hud-marker .pip {
+      width: 5px; height: 5px; border-radius: 50%;
+      background: var(--good); box-shadow: 0 0 6px var(--good);
+      animation: breathe 2.2s ease-in-out infinite;
+    }
+    .hud-tl { top: 110px; left: 36px; }
+    .hud-tr { top: 110px; right: 36px; }
+    @media (max-width: 900px) {
+      .hud-marker { display: none; }
+    }
+
+    /* Headline */
+    /* Early-access badge — clipped to the corner of "Mission control" */
+    .title-tag-wrap { position: relative; display: inline-block; }
+    .title-tag {
+      position: absolute;
+      top: -14px; right: -96px;
+      transform: rotate(7deg);
+      font-family: var(--sans);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      padding: 7px 16px;
+      border-radius: 6px;
+      background: var(--star);
+      color: #1a1a2e;
+      box-shadow: 0 8px 24px rgba(255, 217, 122, 0.45);
+      white-space: nowrap;
+    }
+    @media (max-width: 900px) {
+      h1 { padding-top: 56px; }
+      .title-tag-wrap { position: static; }
+      .title-tag {
+        top: 8px;
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%) rotate(-3deg);
+      }
+    }
+
+    h1 {
+      font-family: var(--sans);
+      font-size: clamp(52px, 9.2vw, 132px);
+      font-weight: 800;
+      line-height: 0.94;
+      letter-spacing: -0.045em;
+      margin-bottom: 36px;
+      color: var(--ink);
+      position: relative;
+      z-index: 2;
+    }
+    h1 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
 
     .subtitle {
-      font-size: 18px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.7);
-      max-width: 540px;
-      margin: 0 auto 48px;
+      font-family: var(--sans);
+      font-size: clamp(17px, 1.6vw, 20px);
+      font-weight: 400;
+      line-height: 1.55;
+      color: var(--ink-2);
+      max-width: 620px;
+      margin: 0 auto 44px;
+      letter-spacing: -0.005em;
+      position: relative;
+      z-index: 2;
     }
 
     .cta-row {
       display: flex;
-      gap: 16px;
+      gap: 14px;
       justify-content: center;
       flex-wrap: wrap;
-      margin-bottom: 72px;
+      margin-bottom: 28px;
+      position: relative;
+      z-index: 2;
     }
 
     .cta {
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      padding: 14px 28px;
+      padding: 14px 26px;
       border-radius: 9999px;
-      font-size: 15px;
+      font-family: var(--sans);
+      font-size: 14px;
       font-weight: 500;
+      letter-spacing: -0.005em;
       text-decoration: none;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
       position: relative;
       overflow: hidden;
+      cursor: pointer;
+      border: 1px solid transparent;
     }
     .cta:hover { transform: translateY(-1px); }
-    .cta-primary { background: #7c6bff; color: #fff; box-shadow: 0 4px 20px rgba(124, 107, 255, 0.3); }
-    .cta-primary:hover { box-shadow: 0 8px 32px rgba(124, 107, 255, 0.4); }
-    .cta-secondary { background: rgba(255, 255, 255, 0.06); color: rgba(255, 255, 255, 0.8); }
-    .cta-secondary:hover { background: rgba(255, 255, 255, 0.1); }
+    .cta-primary {
+      background: linear-gradient(180deg, #9d8cff 0%, #8b76ff 100%);
+      color: #fff;
+      box-shadow:
+        0 4px 24px rgba(139, 118, 255, 0.45),
+        0 0 60px rgba(139, 118, 255, 0.25),
+        inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    }
+    .cta-primary:hover {
+      box-shadow:
+        0 8px 36px rgba(139, 118, 255, 0.55),
+        0 0 100px rgba(139, 118, 255, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    }
+    .cta-secondary {
+      background: rgba(255, 255, 255, 0.04);
+      color: rgba(255, 255, 255, 0.85);
+      border-color: rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(8px);
+    }
+    .cta-secondary:hover {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(255, 255, 255, 0.16);
+    }
+    .cta svg { width: 14px; height: 14px; }
 
     /* Shimmer on hover */
     @keyframes shimmer {
@@ -111,73 +386,269 @@
       content: '';
       position: absolute;
       inset: 0;
-      background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.2) 50%, transparent 100%);
+      background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.22) 50%, transparent 100%);
       transform: translateX(-100%) skewX(-15deg);
     }
     .cta:hover::after {
-      animation: shimmer 0.8s ease-in-out 1 forwards;
+      animation: shimmer 0.85s ease-in-out 1 forwards;
     }
 
-    .hero-img {
-      width: 100%;
-      max-width: 760px;
-      border-radius: 16px;
-      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
-      margin: 0 auto 0;
-      display: block;
+    /* Hint micro-line */
+    .hero-hint {
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      color: var(--ink-4);
+      text-transform: uppercase;
+      margin-top: 22px;
+      position: relative;
+      z-index: 2;
+    }
+    .hero-hint code {
+      font-family: var(--mono);
+      color: var(--accent-2);
+      background: rgba(139, 118, 255, 0.10);
+      padding: 3px 8px;
+      border-radius: 5px;
+      margin: 0 4px;
+      text-transform: none;
+      letter-spacing: 0;
+      font-size: 12px;
     }
 
-    /* Hero mock styles live in assets/hero-mock.css */
-
-    /* Feature sections */
-    .feature-section {
+    /* Hero device frame — tight rim glow (à la GitHub Copilot) */
+    .hero-stage {
+      position: relative;
+      max-width: 1180px;
+      margin: 84px auto 0;
+      padding: 0 12px;
+    }
+    .hero-stage .hero-mock {
       position: relative;
       z-index: 1;
-      max-width: 900px;
-      margin: 0 auto;
-      padding: 120px 24px;
-      display: flex;
-      align-items: center;
-      gap: 72px;
+      margin-top: 0;
+      max-width: 1140px;
+      border: 1px solid rgba(255, 255, 255, 0.10);
+      box-shadow:
+        /* Crisp top rim */
+        inset 0 1px 0 rgba(169, 158, 255, 0.45),
+        /* Tight halo above the device */
+        0 -2px 40px rgba(139, 118, 255, 0.55),
+        0 -8px 80px rgba(139, 118, 255, 0.45),
+        /* Wide ambient bloom */
+        0 0 140px rgba(139, 118, 255, 0.25),
+        0 20px 80px rgba(123, 231, 255, 0.10),
+        /* Standard depth shadow */
+        0 40px 100px rgba(0, 0, 0, 0.65);
     }
-    .feature-section.reverse { flex-direction: row-reverse; }
+    /* Side rim accents — colored edges that bleed up the frame */
+    .hero-stage::before,
+    .hero-stage::after {
+      content: '';
+      position: absolute;
+      top: -90px;
+      width: 320px;
+      height: 380px;
+      pointer-events: none;
+      filter: blur(60px);
+      z-index: 0;
+      opacity: 0.85;
+    }
+    .hero-stage::before {
+      left: -40px;
+      background: radial-gradient(ellipse 70% 60% at 60% 60%, rgba(139, 118, 255, 0.55) 0%, transparent 70%);
+    }
+    .hero-stage::after {
+      right: -40px;
+      background: radial-gradient(ellipse 70% 60% at 40% 60%, rgba(123, 231, 255, 0.40) 0%, transparent 70%);
+    }
+    @media (max-width: 900px) {
+      .hero-stage::before, .hero-stage::after { display: none; }
+    }
 
-    @media (max-width: 700px) {
-      .feature-section, .feature-section.reverse { flex-direction: column; gap: 40px; padding: 80px 24px; }
+    /* Telemetry strip under hero */
+    .telemetry {
+      position: relative;
+      z-index: 2;
+      max-width: 920px;
+      margin: 32px auto 0;
+      padding: 0 12px;
     }
-
-    .feature-text { flex: 1; }
-    .feature-text h3 {
-      font-family: 'Barlow', sans-serif;
-      font-size: 26px;
-      font-weight: 700;
-      color: #fff;
-      margin-bottom: 16px;
-    }
-    .feature-text p {
-      font-size: 16px;
-      color: rgba(255, 255, 255, 0.5);
-      line-height: 1.75;
-    }
-
-    .feature-mock {
-      flex-shrink: 0;
-      width: 360px;
-      max-width: 100%;
-    }
-
-    /* Mock UI components */
-    .mock-panel {
-      background: rgba(13, 14, 26, 0.9);
-      backdrop-filter: blur(24px);
+    .telemetry-inner {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0;
+      padding: 18px 24px;
+      background: rgba(13, 16, 36, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.06);
       border-radius: 16px;
-      padding: 24px;
-      box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+      backdrop-filter: blur(10px);
+    }
+    .tel-cell {
+      padding: 0 22px;
+      border-left: 1px dashed rgba(255, 255, 255, 0.08);
+    }
+    .tel-cell:first-child { border-left: 0; padding-left: 0; }
+    .tel-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.12em;
+      color: var(--ink-4);
+      text-transform: uppercase;
+      margin-bottom: 6px;
+    }
+    .tel-value {
+      font-family: var(--sans);
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--ink);
+      letter-spacing: -0.02em;
+    }
+    .tel-value .accent { color: var(--accent-2); font-family: var(--serif); font-style: italic; font-weight: 400; }
+    .tel-value .signal { color: var(--signal); }
+    @media (max-width: 720px) {
+      .telemetry-inner { grid-template-columns: repeat(2, 1fr); gap: 14px; }
+      .tel-cell { border-left: 0; padding: 0; }
+    }
+
+    /* ============================================
+       SECTION BOILERPLATE
+       ============================================ */
+
+    .section {
+      position: relative;
+      z-index: 2;
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 200px 28px 0;
+    }
+    .section-divider {
+      position: relative;
+      max-width: 920px;
+      margin: 120px auto 0;
+      padding: 0 28px;
+      height: 1px;
+    }
+    .section-divider::before {
+      content: '';
+      position: absolute;
+      left: 28px; right: 28px; top: 0;
+      height: 1px;
+      background: linear-gradient(90deg,
+        transparent 0%,
+        rgba(255,255,255,0.08) 30%,
+        rgba(255,255,255,0.08) 70%,
+        transparent 100%);
+    }
+    .section-divider::after {
+      content: '';
+      position: absolute;
+      left: 50%; top: -3px;
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 12px var(--accent);
+      transform: translateX(-50%);
+      animation: breathe 2.2s ease-in-out infinite;
+    }
+
+    .feature {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      align-items: center;
+      gap: 88px;
+    }
+    .feature.reverse { direction: rtl; }
+    .feature.reverse > * { direction: ltr; }
+
+    @media (max-width: 820px) {
+      .section { padding: 128px 24px 0; }
+      .feature, .feature.reverse { grid-template-columns: 1fr; gap: 40px; direction: ltr; }
+    }
+
+    .feature-meta {
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.16em;
+      color: var(--ink-4);
+      text-transform: uppercase;
+      margin-bottom: 18px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .feature-meta::before {
+      content: '';
+      width: 22px; height: 1px;
+      background: rgba(139, 118, 255, 0.5);
+    }
+
+    .feature h2 {
+      font-family: var(--sans);
+      font-size: clamp(30px, 3.4vw, 44px);
+      font-weight: 600;
+      line-height: 1.05;
+      letter-spacing: -0.025em;
+      color: var(--ink);
+      margin-bottom: 18px;
+    }
+    .feature h2 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      color: var(--accent-2);
+    }
+    .feature p {
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.65;
+      color: var(--ink-2);
+      letter-spacing: -0.005em;
+    }
+    .feature p code {
+      font-family: var(--mono);
+      font-size: 0.88em;
+      color: var(--accent-2);
+      background: rgba(139, 118, 255, 0.10);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    /* Mock panel with aurora glow frame (à la GitHub workflow) */
+    .mock-frame {
+      position: relative;
+      isolation: isolate;
+    }
+    .mock-frame::before {
+      content: '';
+      position: absolute;
+      inset: -40px -24px;
+      background:
+        radial-gradient(ellipse 60% 50% at 30% 10%, rgba(139, 118, 255, 0.22) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 60% at 80% 90%, rgba(123, 231, 255, 0.14) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
+      opacity: 0.7;
+    }
+
+    .mock-panel {
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.96) 0%, rgba(14, 16, 34, 0.96) 100%);
+      backdrop-filter: blur(24px);
+      border-radius: 18px;
+      padding: 22px;
+      box-shadow:
+        0 20px 60px rgba(0, 0, 0, 0.55),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.10);
       position: relative;
       overflow: hidden;
-    }
-    .mock-panel {
-      transition: transform 0.15s ease;
+      transition: transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
+      will-change: transform;
     }
 
     .mock-chatbar {
@@ -185,71 +656,83 @@
       align-items: center;
       gap: 10px;
       padding: 10px 14px;
-      background: rgba(13, 14, 26, 0.95);
+      background: rgba(8, 10, 22, 0.95);
       border-radius: 9999px;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
     }
     .mock-chatbar-icon {
-      width: 30px; height: 30px;
+      width: 28px; height: 28px;
       border-radius: 50%;
-      background: #7c6bff;
+      background: linear-gradient(180deg, var(--accent-2), var(--accent));
       display: flex; align-items: center; justify-content: center;
       flex-shrink: 0;
+      box-shadow: 0 0 12px rgba(139, 118, 255, 0.5);
     }
-    .mock-chatbar-icon svg { width: 14px; height: 14px; fill: #fff; }
+    .mock-chatbar-icon svg { width: 13px; height: 13px; fill: #fff; }
     .mock-chatbar-text {
       flex: 1;
       font-size: 13px;
-      color: rgba(255, 255, 255, 0.7);
+      color: var(--ink-2);
+      font-family: var(--mono);
     }
     .mock-chatbar-text code {
-      background: rgba(124, 107, 255, 0.15);
-      color: #a99eff;
+      background: rgba(139, 118, 255, 0.14);
+      color: var(--accent-2);
       padding: 2px 6px;
       border-radius: 4px;
       font-size: 12px;
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
     }
 
     .mock-response {
-      margin-top: 16px;
-      padding: 12px 16px;
-      background: rgba(255, 255, 255, 0.04);
+      margin-top: 14px;
+      padding: 12px 14px;
+      background: rgba(255, 255, 255, 0.03);
       border-radius: 12px;
       font-size: 13px;
-      color: rgba(255, 255, 255, 0.6);
+      color: var(--ink-2);
+      border: 1px solid rgba(255, 255, 255, 0.04);
     }
-    .mock-response .label { color: #a99eff; font-weight: 600; font-size: 12px; margin-bottom: 6px; }
+    .mock-response .label {
+      color: var(--accent-2);
+      font-weight: 600;
+      font-size: 11px;
+      margin-bottom: 6px;
+      font-family: var(--mono);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
 
     .mock-pills {
       display: flex;
       gap: 8px;
-      margin-top: 16px;
+      margin-top: 14px;
       justify-content: center;
     }
     .mock-pill {
       padding: 6px 0;
       font-size: 13px;
-      color: rgba(255, 255, 255, 0.4);
+      font-family: var(--mono);
+      color: var(--ink-4);
       background: none;
       transition: all 0.3s ease;
     }
     .mock-pill.active {
-      background: #7c6bff;
+      background: linear-gradient(180deg, var(--accent-2), var(--accent));
       color: #fff;
-      font-weight: 600;
+      font-weight: 500;
       padding: 6px 16px;
       border-radius: 9999px;
+      box-shadow: 0 4px 16px rgba(139, 118, 255, 0.4);
     }
 
     .mock-grid {
       display: grid;
       grid-template-columns: repeat(3, 1fr);
-      gap: 16px;
+      gap: 14px;
     }
-    .mock-artifact {
-      text-align: center;
-    }
+    .mock-artifact { text-align: center; }
     .mock-artifact-icon {
       width: 56px; height: 56px;
       border-radius: 14px;
@@ -258,20 +741,22 @@
       object-fit: cover;
     }
     .mock-artifact:hover .mock-artifact-icon {
-      transform: scale(1.1);
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+      transform: scale(1.08) translateY(-2px);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
     }
     .mock-artifact-label {
       font-size: 11px;
-      color: rgba(255, 255, 255, 0.5);
+      color: var(--ink-3);
+      font-family: var(--mono);
     }
 
     .mock-autocomplete {
       margin-top: 10px;
-      background: rgba(13, 14, 26, 0.95);
+      background: rgba(8, 10, 22, 0.95);
       border-radius: 12px;
       padding: 4px;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
     }
     .mock-autocomplete-item {
       display: flex;
@@ -280,41 +765,27 @@
       padding: 10px 14px;
       border-radius: 8px;
       font-size: 13px;
+      font-family: var(--mono);
     }
-    .mock-autocomplete-item.active {
-      background: rgba(255, 255, 255, 0.06);
-    }
-    .mock-autocomplete-item .name { color: #a99eff; font-weight: 500; }
-    .mock-autocomplete-item .space { color: rgba(255, 255, 255, 0.35); font-size: 12px; }
+    .mock-autocomplete-item.active { background: rgba(255, 255, 255, 0.05); }
+    .mock-autocomplete-item .name { color: var(--accent-2); font-weight: 500; }
 
     /* Typing animation */
     .typing-text {
       display: inline;
-      border-right: 2px solid #a99eff;
+      border-right: 2px solid var(--accent-2);
       animation: blink 0.8s step-end infinite;
     }
-    @keyframes blink {
-      50% { border-color: transparent; }
-    }
+    @keyframes blink { 50% { border-color: transparent; } }
 
     /* Staggered fade-in */
-    .fade-in { opacity: 0; animation: fadeIn 0.4s ease forwards; }
-    .fade-in-1 { animation-delay: 0.8s; }
-    .fade-in-2 { animation-delay: 1.2s; }
-    .fade-in-3 { animation-delay: 1.6s; }
-    @keyframes fadeIn {
-      from { opacity: 0; transform: translateY(8px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
+    .fade-in { opacity: 0; }
 
-    /* Building animation */
-    .mock-building {
-      margin-top: 16px;
-      overflow: hidden;
-    }
+    /* Build animation */
+    .mock-building { margin-top: 14px; overflow: hidden; }
     .build-progress {
       height: 3px;
-      background: rgba(124, 107, 255, 0.15);
+      background: rgba(139, 118, 255, 0.15);
       border-radius: 2px;
       margin-bottom: 12px;
       overflow: hidden;
@@ -322,131 +793,458 @@
     .build-progress-bar {
       height: 100%;
       width: 0;
-      background: #7c6bff;
+      background: linear-gradient(90deg, var(--accent), var(--signal));
       border-radius: 2px;
-      animation: buildFill 2s ease-in-out infinite;
-    }
-    @keyframes buildFill {
-      0% { width: 0; }
-      60% { width: 100%; }
-      100% { width: 100%; }
     }
     .build-artifact {
       display: flex;
       align-items: center;
       gap: 10px;
       padding: 10px 14px;
-      background: rgba(255, 255, 255, 0.04);
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.04);
       border-radius: 10px;
       opacity: 0;
-      animation: fadeIn 0.5s ease forwards;
-      animation-delay: 1.8s;
     }
     .build-artifact-icon {
       width: 36px; height: 36px;
       border-radius: 10px;
       background: linear-gradient(135deg, #36d399, #059669);
       flex-shrink: 0;
+      box-shadow: 0 0 14px rgba(54, 211, 153, 0.4);
     }
-    .build-artifact-text { font-size: 12px; color: rgba(255, 255, 255, 0.6); }
-    .build-artifact-text strong { color: #fff; display: block; margin-bottom: 2px; }
+    .build-artifact-text { font-size: 12px; color: var(--ink-2); font-family: var(--mono); }
+    .build-artifact-text strong { color: #fff; display: block; margin-bottom: 2px; font-family: var(--sans); font-weight: 600; font-size: 13px; }
 
-    /* Pill switch animation */
-    .pill-switch .mock-pill {
-      transition: all 0.3s ease;
+    /* MCP tabs */
+    .mcp-tabs-wrap {
+      padding: 0;
+      overflow: hidden;
+    }
+    .mcp-tab-row {
+      display: flex; gap: 2px; padding: 6px 6px 0;
+      background: rgba(0,0,0,0.2);
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+    }
+    .mcp-tab {
+      padding: 9px 14px;
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--ink-4);
+      background: none;
+      border: none;
+      cursor: pointer;
+      border-radius: 8px 8px 0 0;
+      transition: all 0.15s;
+    }
+    .mcp-tab.active {
+      color: #fff;
+      background: rgba(139, 118, 255, 0.16);
+    }
+    .mcp-body { padding: 16px; }
+    .mcp-body .term-label {
+      font-size: 10px; color: var(--ink-4);
+      font-family: var(--mono); margin-bottom: 8px;
+      letter-spacing: 0.06em; text-transform: uppercase;
+    }
+    .mcp-body pre {
+      font-family: var(--mono); font-size: 11.5px;
+      color: #e6e6f0; white-space: pre-wrap; margin: 0; line-height: 1.55;
+    }
+    .mcp-tools {
+      display: flex; gap: 6px; flex-wrap: wrap; margin-top: 14px;
+    }
+    .mcp-tool {
+      padding: 4px 10px;
+      border-radius: 6px;
+      font-size: 10.5px;
+      color: var(--ink-3);
+      background: rgba(139,118,255,0.10);
+      border: 1px solid rgba(139,118,255,0.18);
+      font-family: var(--mono);
     }
 
-    /* Dynamic UI carousel */
-    #dynamic-ui-carousel {
+    /* Earth-orbit visual — Pro section signature */
+    .earth-orbit {
       position: relative;
+      aspect-ratio: 16/10;
+      width: 100%;
+      overflow: hidden;
+      border-radius: 18px;
+      background: radial-gradient(ellipse 60% 50% at 50% 130%, rgba(20, 60, 140, 0.45) 0%, transparent 70%), #060819;
     }
-    .dui-view {
+    .earth-orbit .planet {
       position: absolute;
-      inset: 0;
-      opacity: 0;
-      transition: opacity 0.6s ease;
+      left: -10%; right: -10%; bottom: -68%;
+      aspect-ratio: 1;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 30% 30%, rgba(149, 200, 255, 0.35) 0%, transparent 35%),
+        radial-gradient(circle at 70% 80%, rgba(80, 50, 160, 0.6) 0%, transparent 50%),
+        linear-gradient(180deg, #2a3a78 0%, #0a1238 60%, #050714 100%);
+      box-shadow:
+        inset -40px -30px 80px rgba(0, 0, 0, 0.6),
+        inset 30px 30px 80px rgba(123, 231, 255, 0.10),
+        0 0 100px rgba(123, 231, 255, 0.20);
+    }
+    .earth-orbit .horizon-glow {
+      position: absolute;
+      left: -20%; right: -20%; bottom: 28%;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, rgba(123, 231, 255, 0.5), rgba(255, 255, 255, 0.7), rgba(123, 231, 255, 0.5), transparent);
+      filter: blur(1.5px);
+      box-shadow: 0 0 24px rgba(123, 231, 255, 0.4);
+    }
+    .earth-orbit .orbit-path {
+      position: absolute; inset: 0;
       pointer-events: none;
     }
-    .dui-view.dui-active {
-      opacity: 1;
-      position: relative;
-      pointer-events: auto;
+    .earth-orbit .devices {
+      position: absolute;
+      left: 0; right: 0;
+      bottom: 28px;
+      display: flex; justify-content: space-around;
+      gap: 12px;
+      padding: 0 20px;
     }
-
-    /* Bottom CTA */
-    .bottom-cta {
+    .earth-orbit .device {
+      display: flex; flex-direction: column; align-items: center; gap: 8px;
       position: relative;
-      z-index: 1;
-      max-width: 800px;
-      margin: 0 auto;
-      padding: 80px 24px 40px;
-      text-align: center;
+      z-index: 2;
     }
-
-    /* Footer */
-    .footer {
-      position: relative;
-      z-index: 1;
-      text-align: center;
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.3);
-      padding: 40px 24px 80px;
-    }
-    .footer .heart { color: #e25555; }
-    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
-    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
-
-
-    /* Nav */
-    .nav {
-      position: fixed;
-      top: 16px;
-      left: 50%;
-      transform: translateX(-50%);
-      z-index: 100;
-      display: flex;
-      gap: 4px;
-      padding: 4px;
-      background: rgba(20, 22, 40, 0.9);
-      backdrop-filter: blur(16px);
-      -webkit-backdrop-filter: blur(16px);
-      border-radius: 9999px;
+    .earth-orbit .device-disc {
+      width: 44px; height: 44px;
+      border-radius: 50%;
+      background: rgba(13, 16, 36, 0.95);
       border: 1px solid rgba(255, 255, 255, 0.12);
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--ink);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
     }
-    .nav-logo {
-      width: 24px;
-      height: 24px;
-      margin: 2px 4px 2px 14px;
-      object-fit: contain;
-      vertical-align: middle;
-      position: relative;
-      top: 1px;
+    .earth-orbit .device-disc.center {
+      background: linear-gradient(180deg, rgba(139, 118, 255, 0.95), rgba(110, 90, 220, 0.95));
+      border-color: rgba(169, 158, 255, 0.6);
+      box-shadow: 0 0 24px rgba(139, 118, 255, 0.6), 0 8px 24px rgba(0, 0, 0, 0.5);
     }
-    .nav a {
-      font-size: 13px;
+    .earth-orbit .device-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+      text-align: center;
+      line-height: 1.3;
+    }
+    .earth-orbit .device-label strong {
+      display: block;
+      color: var(--ink);
       font-weight: 500;
-      color: rgba(255, 255, 255, 0.7);
-      text-decoration: none;
+      letter-spacing: 0.04em;
+      margin-bottom: 2px;
+    }
+
+    /* Pro section icons */
+    .pro-row {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 14px;
+      background: rgba(255, 255, 255, 0.02);
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      border-radius: 12px;
+    }
+    .pro-row + .pro-row { margin-top: 10px; }
+    .pro-icon {
+      width: 36px; height: 36px;
+      border-radius: 10px;
+      background: linear-gradient(135deg, rgba(139,118,255,0.20), rgba(123,231,255,0.18));
+      border: 1px solid rgba(139, 118, 255, 0.30);
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--accent-2);
+      flex-shrink: 0;
+    }
+    .pro-row strong {
+      font-family: var(--sans); font-weight: 600;
+      font-size: 13px; color: #fff;
+      display: block; margin-bottom: 2px;
+    }
+    .pro-row span.meta {
+      font-family: var(--mono); font-size: 11px; color: var(--ink-3);
+    }
+
+    /* 4-column benefit row */
+    .benefit-row {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 0;
+      padding: 28px 0 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+      margin-top: 32px;
+    }
+    .benefit {
+      padding: 22px 28px;
+      border-left: 1px solid rgba(255, 255, 255, 0.06);
+    }
+    .benefit:first-child { border-left: 0; }
+    .benefit-icon {
+      display: inline-flex;
+      width: 36px; height: 36px;
+      border-radius: 10px;
+      background: rgba(139, 118, 255, 0.12);
+      border: 1px solid rgba(139, 118, 255, 0.22);
+      align-items: center; justify-content: center;
+      color: var(--accent-2);
+      margin-bottom: 14px;
+    }
+    .benefit strong {
+      font-family: var(--sans);
+      font-weight: 600;
+      font-size: 14px;
+      color: var(--ink);
+      display: block;
+      margin-bottom: 6px;
+      letter-spacing: -0.01em;
+    }
+    .benefit span {
+      font-family: var(--sans);
+      font-size: 13px;
+      color: var(--ink-3);
+      line-height: 1.55;
+    }
+    .benefit code {
+      font-family: var(--mono); font-size: 0.9em;
+      color: var(--accent-2);
+      background: rgba(139, 118, 255, 0.10);
+      padding: 1px 5px; border-radius: 4px;
+    }
+    @media (max-width: 820px) {
+      .benefit-row { grid-template-columns: repeat(2, 1fr); gap: 0; }
+      .benefit { border-left: 0; padding: 18px 6px; border-top: 1px solid rgba(255,255,255,0.05); }
+      .benefit:first-child, .benefit:nth-child(2) { border-top: 0; }
+      .benefit:nth-child(odd) { border-right: 1px solid rgba(255,255,255,0.05); }
+    }
+
+    .coming-soon {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 4px;
+      background: var(--warn);
+      color: #1a1a2e;
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      transform: rotate(-2deg);
+      box-shadow: 0 2px 8px rgba(251, 191, 36, 0.4);
+      margin-bottom: 14px;
+    }
+
+    /* ============================================
+       INSTALL — Launchpad
+       ============================================ */
+    .launchpad {
+      position: relative;
+      z-index: 2;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 140px 28px 0;
+      text-align: center;
+    }
+    .launchpad-meta {
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      color: var(--ink-4);
+      text-transform: uppercase;
+      margin-bottom: 18px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .launchpad-meta .pip {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--good); box-shadow: 0 0 8px var(--good);
+      animation: breathe 2.2s ease-in-out infinite;
+    }
+    .launchpad h2 {
+      font-family: var(--sans);
+      font-size: clamp(34px, 4.5vw, 56px);
+      font-weight: 600;
+      line-height: 1.02;
+      letter-spacing: -0.03em;
+      color: var(--ink);
+      margin-bottom: 14px;
+    }
+    .launchpad h2 .dim {
+      color: rgba(243, 244, 255, 0.32);
+      font-weight: 500;
+    }
+    .launchpad h2 .accent {
+      font-family: var(--serif); font-style: italic; font-weight: 400;
+      letter-spacing: -0.01em;
+      background: linear-gradient(180deg, var(--ink) 0%, var(--accent-2) 70%);
+      -webkit-background-clip: text; background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .launchpad p {
+      font-size: 17px;
+      color: var(--ink-2);
+      max-width: 480px;
+      margin: 0 auto 36px;
+      letter-spacing: -0.005em;
+      line-height: 1.55;
+    }
+
+    .os-toggle {
+      display: inline-flex;
+      background: rgba(8, 10, 22, 0.8);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 9999px;
+      padding: 3px;
+      margin-bottom: 18px;
+    }
+    .os-toggle button {
       padding: 7px 18px;
       border-radius: 9999px;
-      transition: color 0.2s ease, background 0.2s ease;
+      font-size: 12px;
+      font-family: var(--sans);
+      font-weight: 500;
+      border: none;
+      cursor: pointer;
+      background: transparent;
+      color: var(--ink-3);
+      transition: all 0.2s ease;
     }
-    .nav a:hover {
+    .os-toggle button.active {
+      background: linear-gradient(180deg, var(--accent-2), var(--accent));
       color: #fff;
-      background: rgba(124, 107, 255, 0.15);
+      box-shadow: 0 4px 14px rgba(139, 118, 255, 0.35);
     }
-    @media (max-width: 480px) {
-      .nav { gap: 2px; padding: 6px 4px; }
-      .nav a { padding: 7px 10px; font-size: 12px; }
-      .nav-logo { margin: 2px 2px 2px 8px; }
+
+    .terminal-frame {
+      position: relative;
+      max-width: 480px;
+      margin: 0 auto;
+      isolation: isolate;
+    }
+    .terminal-frame::before {
+      content: '';
+      position: absolute;
+      inset: -36px -50px;
+      background:
+        radial-gradient(ellipse 60% 60% at 50% 100%, rgba(139, 118, 255, 0.55) 0%, transparent 60%),
+        radial-gradient(ellipse 50% 50% at 50% 0%, rgba(123, 231, 255, 0.25) 0%, transparent 60%);
+      filter: blur(40px);
+      z-index: -1;
+      pointer-events: none;
+    }
+    .terminal {
+      background: rgba(13, 16, 36, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+      overflow: hidden;
+      backdrop-filter: blur(14px);
+    }
+    .terminal-bar {
+      position: relative;
+      display: flex; align-items: center;
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.04);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    }
+    .terminal-bar .dots { display: flex; gap: 6px; }
+    .terminal-bar .dots span {
+      width: 10px; height: 10px; border-radius: 50%;
+    }
+    .terminal-bar .dots .r { background: #ff5f57; }
+    .terminal-bar .dots .y { background: #febc2e; }
+    .terminal-bar .dots .g { background: #28c840; }
+    .terminal-bar .win-prompt {
+      font-family: var(--mono); font-size: 11px;
+      color: var(--ink-4);
+    }
+    .terminal-bar .title {
+      position: absolute; left: 0; right: 0;
+      text-align: center;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-4);
+      letter-spacing: 0.06em;
+      pointer-events: none;
+    }
+    .terminal-body {
+      padding: 22px 24px;
+      display: flex; flex-direction: column; gap: 10px;
+      text-align: left;
+    }
+    .terminal-body .line {
+      font-family: var(--mono);
+      font-size: clamp(13px, 2.2vw, 17px);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .terminal-body .line .prompt { color: var(--ink-4); }
+    .terminal-body .line .cmd { color: var(--accent-2); }
+    .terminal-body .alt {
+      margin-top: 6px;
+      font-family: var(--mono);
+      font-size: 11.5px;
+    }
+    .terminal-body .alt .label { color: var(--warn); font-weight: 500; }
+    .terminal-body .alt .dim { color: var(--ink-4); }
+    .terminal-body .alt .cmd { color: var(--accent-2); }
+
+    /* ============================================
+       BOTTOM CTA + FOOTER
+       ============================================ */
+    .bottom-cta {
+      position: relative;
+      z-index: 2;
+      text-align: center;
+      padding: 120px 28px 40px;
+    }
+    .footer {
+      position: relative;
+      z-index: 2;
+      text-align: center;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-4);
+      padding: 40px 28px 60px;
+      letter-spacing: 0.06em;
+    }
+    .footer .heart { color: var(--plasma); }
+    .footer a { color: var(--ink-3); text-decoration: none; transition: color 0.2s; }
+    .footer a:hover { color: var(--ink); }
+    .footer .signoff {
+      margin-top: 16px;
+      font-size: 10px;
+      letter-spacing: 0.2em;
+      color: var(--ink-4);
+      text-transform: uppercase;
+    }
+    .footer .signoff .pip {
+      display: inline-block;
+      width: 5px; height: 5px; border-radius: 50%;
+      background: var(--good);
+      box-shadow: 0 0 6px var(--good);
+      margin-right: 6px;
+      vertical-align: middle;
+      animation: breathe 2.2s ease-in-out infinite;
     }
   </style>
 </head>
 <body>
-  <div class="bg"></div>
+  <!-- COSMIC BACKGROUND -->
+  <div class="cosmos" aria-hidden="true">
+    <div class="stars stars-far" id="stars-far"></div>
+    <div class="stars stars-near" id="stars-near"></div>
+  </div>
 
-  <!-- Nav -->
+  <!-- NAV -->
   <nav class="nav" id="nav">
     <img src="logo.png" alt="Oyster" class="nav-logo" />
     <a href="#install">Install</a>
@@ -455,357 +1253,395 @@
     <a href="/changelog">Changelog</a>
   </nav>
 
-  <!-- Hero -->
-  <div class="hero">
-    <h1>Mission control for your agents.</h1>
+  <!-- HERO -->
+  <section class="hero">
+    <div class="pearl-orb" aria-hidden="true"></div>
+
+    <!-- Orbital arcs — the visual signature of the page -->
+    <svg class="orbit-svg" aria-hidden="true" width="1600" height="900" viewBox="-800 -450 1600 900"
+         style="top: 80px; left: 50%; transform: translateX(-50%); width: 1600px; height: 900px;">
+      <ellipse cx="0" cy="120" rx="620" ry="260" class="orbit-dashed" stroke="rgba(169,158,255,0.22)"/>
+      <ellipse cx="0" cy="180" rx="820" ry="340" stroke="rgba(255,255,255,0.10)"/>
+      <ellipse cx="0" cy="100" rx="440" ry="180" stroke="rgba(139,118,255,0.20)"/>
+      <!-- orbital satellites along the arcs -->
+      <g class="orbit-rotate" style="--dur: 60s;">
+        <circle cx="620" cy="120" r="4" class="orbit-dot"/>
+      </g>
+      <g class="orbit-rotate" style="--dur: 90s; animation-direction: reverse;">
+        <circle cx="-820" cy="180" r="3.5" class="orbit-dot signal"/>
+      </g>
+      <g class="orbit-rotate" style="--dur: 45s;">
+        <circle cx="-440" cy="100" r="3" class="orbit-dot warm"/>
+      </g>
+    </svg>
+
+    <h1>
+      <span class="title-tag-wrap">Mission control<span class="title-tag">v0.9 · EARLY ACCESS</span></span><br>for your <span class="accent">agents.</span>
+    </h1>
     <p class="subtitle">
-      Keep your AI work organised, synced and ready to share across devices, with memory and publishing built in. Use whichever agents you prefer.
+      Keep your AI work organised, synced and ready to use across devices, with memory and publishing built in. Use whichever agents you prefer.
     </p>
     <div class="cta-row">
-      <a href="#install" class="cta cta-primary">Get started</a>
-      <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">View on GitHub</a>
+      <a href="#install" class="cta cta-primary">
+        Launch Oyster
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </a>
+      <a href="https://github.com/mattslight/oyster" class="cta cta-secondary">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.9 1.2 1.9 1.2 1.1 1.9 2.9 1.4 3.6 1 .1-.8.4-1.4.8-1.7-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"/></svg>
+        View on GitHub
+      </a>
     </div>
-    <div class="hero-mock" aria-hidden="true">
-      <div class="hero-mock-chrome">
-        <span class="dot dot-r"></span>
-        <span class="dot dot-y"></span>
-        <span class="dot dot-g"></span>
-        <span class="hero-mock-chrome-title">Oyster</span>
-      </div>
+    <div class="hero-hint">Boot sequence — <code>npm i -g oyster-os</code> then <code>oyster</code></div>
 
-      <div class="hm-preview" aria-hidden="true">
-        <div class="hm-preview-chrome">
+    <!-- HERO DEVICE STAGE -->
+    <div class="hero-stage">
+      <div class="hero-mock" aria-hidden="true">
+        <div class="hero-mock-chrome">
           <span class="dot dot-r"></span>
           <span class="dot dot-y"></span>
           <span class="dot dot-g"></span>
-          <span class="hm-preview-title" id="hm-preview-title">Preview</span>
-        </div>
-        <div class="hm-preview-body" id="hm-preview-body"></div>
-      </div>
-
-      <div class="hm-side" aria-hidden="true">
-        <div class="hm-side-head">
-          <span class="hm-status" id="hm-side-status"></span>
-          <span class="hm-side-title" id="hm-side-title"></span>
-        </div>
-        <div class="hm-side-meta" id="hm-side-meta"></div>
-        <div id="hm-side-body"></div>
-      </div>
-      <div class="hero-mock-body">
-        <div class="hero-mock-breadcrumb">
-          <span class="hm-pill hm-pill-icon hm-pill-active" aria-label="Home">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
-          </span>
-          <span class="hm-pill" data-space="acme-app">
-            <span class="pip pip-g"></span>
-            acme-app
-          </span>
-          <span class="hm-pill" data-space="pitch-deck">
-            <span class="pip pip-a"></span>
-            pitch-deck
-          </span>
-          <span class="hm-pill" data-space="field-notes">
-            <span class="pip pip-r"></span>
-            field-notes
-          </span>
+          <span class="hero-mock-chrome-title">Oyster</span>
         </div>
 
-        <div>
-          <div class="hm-section-head">
-            <span class="hm-section-name">Sessions</span>
-            <span class="hm-chips">
-              <span class="hm-chip hm-chip-selected"><span class="pip pip-g"></span>2 active</span>
-              <span class="hm-chip"><span class="pip pip-a"></span>1 awaiting</span>
-              <span class="hm-chip"><span class="pip pip-r"></span>1 disconnected</span>
+        <div class="hm-preview" aria-hidden="true">
+          <div class="hm-preview-chrome">
+            <span class="dot dot-r"></span>
+            <span class="dot dot-y"></span>
+            <span class="dot dot-g"></span>
+            <span class="hm-preview-title" id="hm-preview-title">Preview</span>
+          </div>
+          <div class="hm-preview-body" id="hm-preview-body"></div>
+        </div>
+
+        <div class="hm-side" aria-hidden="true">
+          <div class="hm-side-head">
+            <span class="hm-status" id="hm-side-status"></span>
+            <span class="hm-side-title" id="hm-side-title"></span>
+          </div>
+          <div class="hm-side-meta" id="hm-side-meta"></div>
+          <div id="hm-side-body"></div>
+        </div>
+
+        <div class="hero-mock-body">
+          <div class="hero-mock-breadcrumb">
+            <span class="hm-pill hm-pill-icon hm-pill-active" aria-label="Home">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
             </span>
+            <span class="hm-pill" data-space="acme-app"><span class="pip pip-g"></span>acme-app</span>
+            <span class="hm-pill" data-space="pitch-deck"><span class="pip pip-a"></span>pitch-deck</span>
+            <span class="hm-pill" data-space="field-notes"><span class="pip pip-r"></span>field-notes</span>
           </div>
-          <div class="hm-tiles">
-            <div class="hm-tile" data-space="acme-app" data-session="s1">
-              <span class="hm-status hm-status-g"></span>
-              <div class="hm-tile-body">
-                <div class="hm-tile-title">Refactor checkout flow</div>
-                <div class="hm-tile-meta">claude-code · acme-app</div>
-              </div>
-              <span class="hm-tile-time">2m ago</span>
-            </div>
-            <div class="hm-tile" data-space="pitch-deck" data-session="s2">
-              <span class="hm-status hm-status-a"></span>
-              <div class="hm-tile-body">
-                <div class="hm-tile-title">Stakeholder pitch v3</div>
-                <div class="hm-tile-meta">cursor · pitch-deck</div>
-              </div>
-              <span class="hm-tile-time">awaiting</span>
-            </div>
-            <div class="hm-tile" data-space="acme-app" data-session="s3">
-              <span class="hm-status hm-status-r"></span>
-              <div class="hm-tile-body">
-                <div class="hm-tile-title">Investigate API latency</div>
-                <div class="hm-tile-meta">claude-code · acme-app</div>
-              </div>
-              <span class="hm-tile-time">1h ago</span>
-            </div>
-            <div class="hm-tile" data-space="field-notes" data-session="s4">
-              <span class="hm-status hm-status-d"></span>
-              <div class="hm-tile-body">
-                <div class="hm-tile-title">Weekly retro write-up</div>
-                <div class="hm-tile-meta">claude-code · field-notes</div>
-              </div>
-              <span class="hm-tile-time">yesterday</span>
-            </div>
-          </div>
-        </div>
 
-        <div>
-          <div class="hm-section-head">
-            <span class="hm-section-name">Memories</span>
-            <span class="hm-section-meta">23 · 4 pinned</span>
-          </div>
-          <div class="hm-mems">
-            <div class="hm-mem" data-space="acme-app" data-memory="m1">
-              <div class="hm-mem-text">Customer prefers email summaries on Fridays — keep under 200 words and lead with decisions, not analysis.</div>
-              <div class="hm-mem-meta">
-                <span class="hm-mem-space">acme-app</span>
-                <span class="hm-mem-sep">·</span>
-                <span>claude-code</span>
-                <span class="hm-mem-sep">·</span>
-                <span>4h ago</span>
+          <div>
+            <div class="hm-section-head">
+              <span class="hm-section-name">Sessions</span>
+              <span class="hm-chips">
+                <span class="hm-chip hm-chip-selected"><span class="pip pip-g"></span>2 active</span>
+                <span class="hm-chip"><span class="pip pip-a"></span>1 awaiting</span>
+                <span class="hm-chip"><span class="pip pip-r"></span>1 disconnected</span>
+              </span>
+            </div>
+            <div class="hm-tiles">
+              <div class="hm-tile" data-space="acme-app" data-session="s1">
+                <span class="hm-status hm-status-g"></span>
+                <div class="hm-tile-body">
+                  <div class="hm-tile-title">Refactor checkout flow</div>
+                  <div class="hm-tile-meta">claude-code · acme-app</div>
+                </div>
+                <span class="hm-tile-time">2m ago</span>
+              </div>
+              <div class="hm-tile" data-space="pitch-deck" data-session="s2">
+                <span class="hm-status hm-status-a"></span>
+                <div class="hm-tile-body">
+                  <div class="hm-tile-title">Stakeholder pitch v3</div>
+                  <div class="hm-tile-meta">cursor · pitch-deck</div>
+                </div>
+                <span class="hm-tile-time">awaiting</span>
+              </div>
+              <div class="hm-tile" data-space="acme-app" data-session="s3">
+                <span class="hm-status hm-status-r"></span>
+                <div class="hm-tile-body">
+                  <div class="hm-tile-title">Investigate API latency</div>
+                  <div class="hm-tile-meta">claude-code · acme-app</div>
+                </div>
+                <span class="hm-tile-time">1h ago</span>
+              </div>
+              <div class="hm-tile" data-space="field-notes" data-session="s4">
+                <span class="hm-status hm-status-d"></span>
+                <div class="hm-tile-body">
+                  <div class="hm-tile-title">Weekly retro write-up</div>
+                  <div class="hm-tile-meta">claude-code · field-notes</div>
+                </div>
+                <span class="hm-tile-time">yesterday</span>
               </div>
             </div>
-            <div class="hm-mem" data-space="pitch-deck" data-memory="m2">
-              <div class="hm-mem-text">Pitch deck needs the revised pricing slide before Wednesday's stakeholder review.</div>
-              <div class="hm-mem-meta">
-                <span class="hm-mem-space">pitch-deck</span>
-                <span class="hm-mem-sep">·</span>
-                <span>cursor</span>
-                <span class="hm-mem-sep">·</span>
-                <span>yesterday</span>
-              </div>
-            </div>
           </div>
-        </div>
 
-        <div>
-          <div class="hm-section-head">
-            <span class="hm-section-name">Artefacts</span>
-            <span class="hm-section-meta">12 · across 3 spaces</span>
+          <div>
+            <div class="hm-section-head">
+              <span class="hm-section-name">Memories</span>
+              <span class="hm-section-meta">23 · 4 pinned</span>
+            </div>
+            <div class="hm-mems">
+              <div class="hm-mem" data-space="acme-app" data-memory="m1">
+                <div class="hm-mem-text">Customer prefers email summaries on Fridays — keep under 200 words and lead with decisions, not analysis.</div>
+                <div class="hm-mem-meta">
+                  <span class="hm-mem-space">acme-app</span>
+                  <span class="hm-mem-sep">·</span><span>claude-code</span>
+                  <span class="hm-mem-sep">·</span><span>4h ago</span>
+                </div>
+              </div>
+              <div class="hm-mem" data-space="pitch-deck" data-memory="m2">
+                <div class="hm-mem-text">Pitch deck needs the revised pricing slide before Wednesday's stakeholder review.</div>
+                <div class="hm-mem-meta">
+                  <span class="hm-mem-space">pitch-deck</span>
+                  <span class="hm-mem-sep">·</span><span>cursor</span>
+                  <span class="hm-mem-sep">·</span><span>yesterday</span>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="hm-art-grid">
-            <div class="hm-art-cell" data-space="acme-app" data-artefact="onboarding">
-              <div class="hm-art" style="background: linear-gradient(135deg, #ff9a5a, #f06d3f);">
-                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7.5" height="7.5" rx="1.6"/><rect x="13.5" y="3" width="7.5" height="7.5" rx="1.6"/><rect x="3" y="13.5" width="7.5" height="7.5" rx="1.6"/><rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.6"/></svg>
-              </div>
-              <span class="hm-art-label">Onboarding</span>
+
+          <div>
+            <div class="hm-section-head">
+              <span class="hm-section-name">Artefacts</span>
+              <span class="hm-section-meta">12 · across 3 spaces</span>
             </div>
-            <div class="hm-art-cell" data-space="pitch-deck" data-artefact="pitch">
-              <div class="hm-art" style="background: linear-gradient(135deg, #34d4c0, #1d4ed8);">
-                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"/><path d="M9 21h6M12 17v4"/><path d="M7 12V9M11 12V8M15 12V10"/></svg>
+            <div class="hm-art-grid">
+              <div class="hm-art-cell" data-space="acme-app" data-artefact="onboarding">
+                <div class="hm-art" style="background: linear-gradient(135deg, #ff9a5a, #f06d3f);">
+                  <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7.5" height="7.5" rx="1.6"/><rect x="13.5" y="3" width="7.5" height="7.5" rx="1.6"/><rect x="3" y="13.5" width="7.5" height="7.5" rx="1.6"/><rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.6"/></svg>
+                </div>
+                <span class="hm-art-label">Onboarding</span>
               </div>
-              <span class="hm-art-label">Q4 Pitch</span>
-            </div>
-            <div class="hm-art-cell" data-space="acme-app" data-artefact="auth">
-              <div class="hm-art" style="background: linear-gradient(135deg, #f472b6, #be123c);">
-                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.6"/><circle cx="18" cy="6" r="2.6"/><circle cx="12" cy="18" r="2.6"/><path d="M7.6 8l3.4 7.5M16.4 8l-3.4 7.5"/></svg>
+              <div class="hm-art-cell" data-space="pitch-deck" data-artefact="pitch">
+                <div class="hm-art" style="background: linear-gradient(135deg, #34d4c0, #1d4ed8);">
+                  <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4" width="19" height="13" rx="2"/><path d="M9 21h6M12 17v4"/><path d="M7 12V9M11 12V8M15 12V10"/></svg>
+                </div>
+                <span class="hm-art-label">Q4 Pitch</span>
               </div>
-              <span class="hm-art-label">Auth flow</span>
-            </div>
-            <div class="hm-art-cell" data-space="acme-app" data-artefact="settings">
-              <div class="hm-art" style="background: linear-gradient(135deg, #93c5fd, #0891b2);">
-                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2.5"/><path d="M3 9h18M9 21V9"/></svg>
+              <div class="hm-art-cell" data-space="acme-app" data-artefact="auth">
+                <div class="hm-art" style="background: linear-gradient(135deg, #f472b6, #be123c);">
+                  <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.6"/><circle cx="18" cy="6" r="2.6"/><circle cx="12" cy="18" r="2.6"/><path d="M7.6 8l3.4 7.5M16.4 8l-3.4 7.5"/></svg>
+                </div>
+                <span class="hm-art-label">Auth flow</span>
               </div>
-              <span class="hm-art-label">Settings UI</span>
-            </div>
-            <div class="hm-art-cell" data-space="field-notes" data-artefact="launch">
-              <div class="hm-art" style="background: linear-gradient(135deg, #fcd34d, #ea580c);">
-                <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/><path d="M9 13h6M9 17h4"/></svg>
+              <div class="hm-art-cell" data-space="acme-app" data-artefact="settings">
+                <div class="hm-art" style="background: linear-gradient(135deg, #93c5fd, #0891b2);">
+                  <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2.5"/><path d="M3 9h18M9 21V9"/></svg>
+                </div>
+                <span class="hm-art-label">Settings UI</span>
               </div>
-              <span class="hm-art-label">Launch list</span>
-            </div>
-            <div class="hm-art-cell">
-              <div class="hm-art hm-art-more">
-                <span class="hm-art-more-text">+ 7</span>
+              <div class="hm-art-cell" data-space="field-notes" data-artefact="launch">
+                <div class="hm-art" style="background: linear-gradient(135deg, #fcd34d, #ea580c);">
+                  <svg class="hm-art-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/><path d="M9 13h6M9 17h4"/></svg>
+                </div>
+                <span class="hm-art-label">Launch list</span>
               </div>
-              <span class="hm-art-label" style="opacity: 0;">&nbsp;</span>
+              <div class="hm-art-cell">
+                <div class="hm-art hm-art-more">
+                  <span class="hm-art-more-text">+ 7</span>
+                </div>
+                <span class="hm-art-label" style="opacity: 0;">&nbsp;</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Feature 1: See every agent at work (Sessions — shipped 0.5.0) — leads the page -->
-  <div class="feature-section" id="features">
-    <div class="feature-text">
-      <h3>See your agent at work.</h3>
-      <p>Oyster watches your Claude Code sessions automatically — live transcripts, the files your agent edited, the memories it captured, all on Home and all searchable. No setup, no MCP wiring needed. Cursor, Codex and OpenCode watchers are next.</p>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel">
-        <div style="font-size: 11px; font-weight: 600; color: rgba(255,255,255,0.5); text-transform: uppercase; letter-spacing: 2px; font-family: 'Barlow', sans-serif; margin-bottom: 12px;">Sessions</div>
-        <div style="display: flex; flex-direction: column; gap: 6px;">
-          <div style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.03); border-radius: 8px;">
-            <span style="width: 8px; height: 8px; border-radius: 50%; background: #4ade80; box-shadow: 0 0 8px #4ade80; flex-shrink: 0;"></span>
-            <div style="flex: 1; min-width: 0;">
-              <div style="font-size: 12px; color: rgba(255,255,255,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Refactor session inspector</div>
-              <div style="font-size: 10px; color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace;">claude-code · oyster-os</div>
-            </div>
-            <span style="font-size: 10px; color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace;">2m ago</span>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- Feature 1: See your agent at work -->
+  <section class="section" id="features">
+    <div class="feature">
+      <div>
+        <h2>See your <span class="accent">agents</span> at work.</h2>
+        <p>Oyster watches your Claude Code sessions automatically — live transcripts, the files your agent edited, the memories it captured, all on Home and all searchable. No setup, no MCP wiring needed. Cursor, Codex and OpenCode watchers are next.</p>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel">
+          <div style="font-family: var(--mono); font-size: 10px; font-weight: 500; color: var(--ink-4); text-transform: uppercase; letter-spacing: 0.16em; margin-bottom: 14px; display: flex; align-items: center; gap: 10px;">
+            <span style="width: 6px; height: 6px; border-radius: 50%; background: var(--good); box-shadow: 0 0 8px var(--good); animation: breathe 2.2s ease-in-out infinite;"></span>
+            Live Sessions
           </div>
-          <div style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.03); border-radius: 8px;">
-            <span style="width: 8px; height: 8px; border-radius: 50%; background: #fbbf24; box-shadow: 0 0 8px #fbbf24; flex-shrink: 0;"></span>
-            <div style="flex: 1; min-width: 0;">
-              <div style="font-size: 12px; color: rgba(255,255,255,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Pricing page rework</div>
-              <div style="font-size: 10px; color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace;">cursor · oyster-os</div>
+          <div style="display: flex; flex-direction: column; gap: 6px;">
+            <div style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.025); border: 1px solid rgba(255,255,255,0.04); border-radius: 10px;">
+              <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--good); box-shadow: 0 0 8px var(--good); flex-shrink: 0;"></span>
+              <div style="flex: 1; min-width: 0;">
+                <div style="font-size: 13px; color: rgba(255,255,255,0.92); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 500;">Refactor session inspector</div>
+                <div style="font-size: 11px; color: var(--ink-3); font-family: var(--mono);">claude-code · oyster-os</div>
+              </div>
+              <span style="font-size: 11px; color: var(--ink-3); font-family: var(--mono);">2m ago</span>
             </div>
-            <span style="font-size: 10px; color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace;">awaiting</span>
-          </div>
-          <div style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.03); border-radius: 8px;">
-            <span style="width: 8px; height: 8px; border-radius: 50%; background: #f87171; box-shadow: 0 0 8px #f87171; flex-shrink: 0;"></span>
-            <div style="flex: 1; min-width: 0;">
-              <div style="font-size: 12px; color: rgba(255,255,255,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Investigate scanner perf</div>
-              <div style="font-size: 10px; color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace;">claude-code · blunderfixer</div>
+            <div style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.025); border: 1px solid rgba(255,255,255,0.04); border-radius: 10px;">
+              <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--warn); box-shadow: 0 0 8px var(--warn); flex-shrink: 0;"></span>
+              <div style="flex: 1; min-width: 0;">
+                <div style="font-size: 13px; color: rgba(255,255,255,0.92); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 500;">Pricing page rework</div>
+                <div style="font-size: 11px; color: var(--ink-3); font-family: var(--mono);">cursor · oyster-os</div>
+              </div>
+              <span style="font-size: 11px; color: var(--ink-3); font-family: var(--mono);">awaiting</span>
             </div>
-            <span style="font-size: 10px; color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace;">1h ago</span>
+            <div style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: rgba(255,255,255,0.025); border: 1px solid rgba(255,255,255,0.04); border-radius: 10px;">
+              <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--bad); box-shadow: 0 0 8px var(--bad); flex-shrink: 0;"></span>
+              <div style="flex: 1; min-width: 0;">
+                <div style="font-size: 13px; color: rgba(255,255,255,0.92); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: 500;">Investigate scanner perf</div>
+                <div style="font-size: 11px; color: var(--ink-3); font-family: var(--mono);">claude-code · blunderfixer</div>
+              </div>
+              <span style="font-size: 11px; color: var(--ink-3); font-family: var(--mono);">1h ago</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <!-- Feature 2: Work with full context. -->
-  <div class="feature-section reverse">
-    <div class="feature-text">
-      <h3>Work with full context.</h3>
-      <p>Your AI sees every space, project, and artefact. Ask it to summarise across projects, find connections, or act on something specific — it has the full picture.</p>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel" id="mock-context">
-        <div class="mock-chatbar">
-          <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
-          <div class="mock-chatbar-text"><code><span class="typing-text" data-text="summarise progress across all projects"></span></code></div>
-        </div>
-        <div class="mock-autocomplete">
-          <div class="mock-autocomplete-item active fade-in fade-in-1">
-            <span class="name">3 spaces · 12 artefacts · full context</span>
+  <!-- Feature 2: Work with full context -->
+  <section class="section">
+    <div class="feature reverse">
+      <div>
+        <h2>Work with <span class="accent">full</span> context.</h2>
+        <p>Your AI sees every space, project, and artefact. Ask it to summarise across projects, find connections, or act on something specific — it has the full picture.</p>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel" id="mock-context">
+          <div class="mock-chatbar">
+            <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
+            <div class="mock-chatbar-text"><code><span class="typing-text" data-text="summarise progress across all projects"></span></code></div>
+          </div>
+          <div class="mock-autocomplete">
+            <div class="mock-autocomplete-item active fade-in fade-in-1">
+              <span class="name">3 spaces · 12 artefacts · full context</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
   <!-- Feature 3: Switch context instantly -->
-  <div class="feature-section">
-    <div class="feature-text">
-      <h3>Switch context instantly.</h3>
-      <p>Jump between project spaces with a single shortcut. Your brain switches context — your agents should keep up.</p>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel" id="mock-switch">
-        <div class="mock-chatbar">
-          <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
-          <div class="mock-chatbar-text"><code><span class="typing-text" id="switch-typing" data-text="#home"></span></code></div>
-        </div>
-        <div class="mock-pills pill-switch" id="pill-switch">
-          <span class="mock-pill active" data-idx="0">home</span>
-          <span class="mock-pill" data-idx="1">research</span>
-          <span class="mock-pill" data-idx="2">clients</span>
-          <span class="mock-pill" data-idx="3">ops</span>
+  <section class="section">
+    <div class="feature">
+      <div>
+        <h2>Switch context <span class="accent">instantly.</span></h2>
+        <p>Jump between project spaces with a single shortcut. Your brain switches context — your agents should keep up.</p>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel" id="mock-switch">
+          <div class="mock-chatbar">
+            <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
+            <div class="mock-chatbar-text"><code><span class="typing-text" id="switch-typing" data-text="#home"></span></code></div>
+          </div>
+          <div class="mock-pills pill-switch" id="pill-switch">
+            <span class="mock-pill active" data-idx="0">home</span>
+            <span class="mock-pill" data-idx="1">research</span>
+            <span class="mock-pill" data-idx="2">clients</span>
+            <span class="mock-pill" data-idx="3">ops</span>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <!-- Feature 4: Drop in a folder. Get organised. -->
-  <div class="feature-section reverse">
-    <div class="feature-text">
-      <h3>Drop in a project. Get organised.</h3>
-      <p>Point Oyster at any project and it picks up what's inside — sessions, documents, presentations, diagrams, apps. Your existing work lands on the surface automatically.</p>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel" id="mock-import">
-        <div class="mock-chatbar">
-          <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
-          <div class="mock-chatbar-text"><span class="typing-text" data-text="onboard ~/Dev/my-project"></span></div>
-        </div>
-        <div class="mock-response fade-in fade-in-2">
-          <div class="label">Oyster</div>
-          <div style="margin-top: 6px; display: flex; flex-direction: column; gap: 6px;">
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span style="width: 8px; height: 8px; border-radius: 50%; background: #36d399; flex-shrink: 0;"></span>
-              <span style="font-size: 12px;">3 apps discovered</span>
-            </div>
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span style="width: 8px; height: 8px; border-radius: 50%; background: #4dc9f6; flex-shrink: 0;"></span>
-              <span style="font-size: 12px;">5 docs imported</span>
-            </div>
-            <div style="display: flex; align-items: center; gap: 8px;">
-              <span style="width: 8px; height: 8px; border-radius: 50%; background: #a78bfa; flex-shrink: 0;"></span>
-              <span style="font-size: 12px;">2 diagrams found</span>
+  <!-- Feature 4: Drop in a project -->
+  <section class="section">
+    <div class="feature reverse">
+      <div>
+        <h2>Drop in a project.<br><span class="accent">Get organised.</span></h2>
+        <p>Point Oyster at any project and it picks up what's inside — sessions, documents, presentations, diagrams, apps. Your existing work lands on the surface automatically.</p>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel" id="mock-import">
+          <div class="mock-chatbar">
+            <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
+            <div class="mock-chatbar-text"><span class="typing-text" data-text="onboard ~/Dev/my-project"></span></div>
+          </div>
+          <div class="mock-response fade-in fade-in-2">
+            <div class="label">Oyster</div>
+            <div style="margin-top: 6px; display: flex; flex-direction: column; gap: 6px;">
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--good); box-shadow: 0 0 6px var(--good); flex-shrink: 0;"></span>
+                <span style="font-size: 12px;">3 apps discovered</span>
+              </div>
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--signal); box-shadow: 0 0 6px var(--signal); flex-shrink: 0;"></span>
+                <span style="font-size: 12px;">5 docs imported</span>
+              </div>
+              <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--accent-2); box-shadow: 0 0 6px var(--accent-2); flex-shrink: 0;"></span>
+                <span style="font-size: 12px;">2 diagrams found</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
   <!-- Feature 5: Act, not just chat -->
-  <div class="feature-section">
-    <div class="feature-text">
-      <h3>Act, not just chat.</h3>
-      <p>Oyster doesn't just answer questions. It opens artefacts, switches spaces, creates documents, and manages your workspace from the prompt bar.</p>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel" id="mock-act">
-        <div class="mock-chatbar">
-          <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
-          <div class="mock-chatbar-text"><span class="typing-text" data-text="create a summary of Q1"></span></div>
-        </div>
-        <div class="mock-building">
-          <div class="build-progress"><div class="build-progress-bar"></div></div>
-          <div class="build-artifact">
-            <div class="build-artifact-icon"></div>
-            <div class="build-artifact-text">
-              <strong>Q1 Summary</strong>
-              Added to research space
+  <section class="section">
+    <div class="feature">
+      <div>
+        <h2><span class="accent">Act,</span> not just chat.</h2>
+        <p>Oyster doesn't just answer questions. It opens artefacts, switches spaces, creates documents, and manages your workspace from the prompt bar.</p>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel" id="mock-act">
+          <div class="mock-chatbar">
+            <div class="mock-chatbar-icon"><svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg></div>
+            <div class="mock-chatbar-text"><span class="typing-text" data-text="create a summary of Q1"></span></div>
+          </div>
+          <div class="mock-building">
+            <div class="build-progress"><div class="build-progress-bar"></div></div>
+            <div class="build-artifact">
+              <div class="build-artifact-icon"></div>
+              <div class="build-artifact-text">
+                <strong>Q1 Summary</strong>
+                Added to research space
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <!-- Feature 6: Bring your own AI -->
-  <div class="feature-section reverse">
-    <div class="feature-text">
-      <h3>Built on MCP. Bring Your Own Agents.</h3>
-      <p>Oyster is an MCP server. That means any agent that speaks the protocol — Claude Code, Cursor, VS Code, Windsurf, or your own — can control your workspace. Create documents, organise spaces, open artefacts. One standard, every agent.</p>
-      <a href="/mcp" class="cta cta-secondary" style="margin-top: 18px; display: inline-flex;">Detailed setup →</a>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel" style="padding: 0; overflow: hidden;">
-        <div style="display: flex; gap: 2px; padding: 6px 6px 0; background: rgba(255,255,255,0.02);">
-          <button onclick="showMcpTab('claude-code')" class="mcp-tab mcp-tab-active" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Claude Code</button>
-          <button onclick="showMcpTab('cursor')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Cursor</button>
-          <button onclick="showMcpTab('vscode')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">VS Code</button>
-          <button onclick="showMcpTab('windsurf')" class="mcp-tab" style="padding: 8px 14px; font-size: 11px; font-family: 'Barlow', sans-serif; font-weight: 500; color: rgba(255,255,255,0.4); background: none; border: none; cursor: pointer; border-radius: 6px 6px 0 0; transition: all 0.15s;">Windsurf</button>
-        </div>
-        <div style="padding: 16px;">
-          <div id="mcp-claude-code" class="mcp-panel" style="display: block;">
-            <div style="font-size: 10px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace; margin-bottom: 6px;">terminal</div>
-            <pre style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #e0e0e8; white-space: pre-wrap; margin: 0;">claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/</pre>
+  <!-- Feature 6: Built on MCP -->
+  <section class="section">
+    <div class="feature reverse">
+      <div>
+        <h2>Built on MCP.<br><span class="accent">Bring your own</span> agents.</h2>
+        <p>Oyster is an MCP server. That means any agent that speaks the protocol — Claude Code, Cursor, VS Code, Windsurf, or your own — can control your workspace. Create documents, organise spaces, open artefacts. One standard, every agent.</p>
+        <a href="/mcp" class="cta cta-secondary" style="margin-top: 22px; display: inline-flex;">Detailed setup →</a>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel mcp-tabs-wrap">
+          <div class="mcp-tab-row">
+            <button onclick="showMcpTab(event, 'claude-code')" class="mcp-tab active">Claude Code</button>
+            <button onclick="showMcpTab(event, 'cursor')" class="mcp-tab">Cursor</button>
+            <button onclick="showMcpTab(event, 'vscode')" class="mcp-tab">VS Code</button>
+            <button onclick="showMcpTab(event, 'windsurf')" class="mcp-tab">Windsurf</button>
           </div>
-          <div id="mcp-cursor" class="mcp-panel" style="display: none;">
-            <div style="font-size: 10px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace; margin-bottom: 6px;">.cursor/mcp.json</div>
-            <pre style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #e0e0e8; white-space: pre-wrap; margin: 0;">{
+          <div class="mcp-body">
+            <div id="mcp-claude-code" class="mcp-panel" style="display: block;">
+              <div class="term-label">terminal</div>
+              <pre>claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/</pre>
+            </div>
+            <div id="mcp-cursor" class="mcp-panel" style="display: none;">
+              <div class="term-label">.cursor/mcp.json</div>
+              <pre>{
   "mcpServers": {
     "oyster": {
       "url": "http://localhost:4444/mcp/"
     }
   }
 }</pre>
-          </div>
-          <div id="mcp-vscode" class="mcp-panel" style="display: none;">
-            <div style="font-size: 10px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace; margin-bottom: 6px;">.vscode/mcp.json</div>
-            <pre style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #e0e0e8; white-space: pre-wrap; margin: 0;">{
+            </div>
+            <div id="mcp-vscode" class="mcp-panel" style="display: none;">
+              <div class="term-label">.vscode/mcp.json</div>
+              <pre>{
   "servers": {
     "oyster": {
       "type": "http",
@@ -813,137 +1649,186 @@
     }
   }
 }</pre>
-          </div>
-          <div id="mcp-windsurf" class="mcp-panel" style="display: none;">
-            <div style="font-size: 10px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace; margin-bottom: 6px;">~/.codeium/windsurf/mcp_config.json</div>
-            <pre style="font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #e0e0e8; white-space: pre-wrap; margin: 0;">{
+            </div>
+            <div id="mcp-windsurf" class="mcp-panel" style="display: none;">
+              <div class="term-label">~/.codeium/windsurf/mcp_config.json</div>
+              <pre>{
   "mcpServers": {
     "oyster": {
       "serverUrl": "http://localhost:4444/mcp/"
     }
   }
 }</pre>
-          </div>
-          <div style="display: flex; gap: 5px; flex-wrap: wrap; margin-top: 14px;">
-            <span style="padding: 4px 10px; border-radius: 6px; font-size: 10px; color: rgba(255,255,255,0.4); background: rgba(124,107,255,0.1); font-family: 'IBM Plex Mono', monospace;">create_artifact</span>
-            <span style="padding: 4px 10px; border-radius: 6px; font-size: 10px; color: rgba(255,255,255,0.4); background: rgba(124,107,255,0.1); font-family: 'IBM Plex Mono', monospace;">onboard_space</span>
-            <span style="padding: 4px 10px; border-radius: 6px; font-size: 10px; color: rgba(255,255,255,0.4); background: rgba(124,107,255,0.1); font-family: 'IBM Plex Mono', monospace;">open_artifact</span>
-            <span style="padding: 4px 10px; border-radius: 6px; font-size: 10px; color: rgba(255,255,255,0.4); background: rgba(124,107,255,0.1); font-family: 'IBM Plex Mono', monospace;">switch_space</span>
-            <span style="padding: 4px 10px; border-radius: 6px; font-size: 10px; color: rgba(255,255,255,0.4); background: rgba(124,107,255,0.1); font-family: 'IBM Plex Mono', monospace;">remember</span>
-            <span style="padding: 4px 10px; border-radius: 6px; font-size: 10px; color: rgba(255,255,255,0.4); background: rgba(124,107,255,0.1); font-family: 'IBM Plex Mono', monospace;">move_session</span>
+            </div>
+            <div class="mcp-tools">
+              <span class="mcp-tool">create_artifact</span>
+              <span class="mcp-tool">onboard_space</span>
+              <span class="mcp-tool">open_artifact</span>
+              <span class="mcp-tool">switch_space</span>
+              <span class="mcp-tool">remember</span>
+              <span class="mcp-tool">move_session</span>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <!-- Feature 7: Plan and brainstorm without cluttering your codebase. -->
-  <div class="feature-section">
-    <div class="feature-text">
-      <h3>Brainstorm without clutter.</h3>
-      <p>Notes, decks, diagrams, mockups — the project work that doesn't belong in <code style="font-family: 'IBM Plex Mono', monospace; font-size: 0.85em; color: #a99eff;">git</code>. Oyster keeps it tied to your project but separate from your code. Visible, searchable, launchable.</p>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel">
-        <div class="mock-grid">
-          <div class="mock-artifact">
-            <img class="mock-artifact-icon" src="screenshots/icons/kanban.png" alt="">
-            <div class="mock-artifact-label">Sprint Board</div>
-          </div>
-          <div class="mock-artifact">
-            <img class="mock-artifact-icon" src="screenshots/icons/deck.png" alt="">
-            <div class="mock-artifact-label">Series A Pitch</div>
-          </div>
-          <div class="mock-artifact">
-            <img class="mock-artifact-icon" src="screenshots/icons/error-test.png" alt="">
-            <div class="mock-artifact-label">Error Analysis</div>
-          </div>
-          <div class="mock-artifact">
-            <img class="mock-artifact-icon" src="screenshots/icons/blunderfixer.png" alt="">
-            <div class="mock-artifact-label">Chess Study</div>
-          </div>
-          <div class="mock-artifact">
-            <img class="mock-artifact-icon" src="screenshots/icons/capabilities.png" alt="">
-            <div class="mock-artifact-label">Design Brief</div>
+  <!-- Feature 7: Brainstorm without clutter -->
+  <section class="section">
+    <div class="feature">
+      <div>
+        <h2>Brainstorm <span class="accent">without</span> clutter.</h2>
+        <p>Notes, decks, diagrams, mockups — the project work that doesn't belong in <code>git</code>. Oyster keeps it tied to your project but separate from your code. Visible, searchable, launchable.</p>
+      </div>
+      <div class="mock-frame">
+        <div class="mock-panel">
+          <div class="mock-grid">
+            <div class="mock-artifact">
+              <img class="mock-artifact-icon" src="screenshots/icons/kanban.png" alt="">
+              <div class="mock-artifact-label">Sprint Board</div>
+            </div>
+            <div class="mock-artifact">
+              <img class="mock-artifact-icon" src="screenshots/icons/deck.png" alt="">
+              <div class="mock-artifact-label">Series A Pitch</div>
+            </div>
+            <div class="mock-artifact">
+              <img class="mock-artifact-icon" src="screenshots/icons/error-test.png" alt="">
+              <div class="mock-artifact-label">Error Analysis</div>
+            </div>
+            <div class="mock-artifact">
+              <img class="mock-artifact-icon" src="screenshots/icons/blunderfixer.png" alt="">
+              <div class="mock-artifact-label">Chess Study</div>
+            </div>
+            <div class="mock-artifact">
+              <img class="mock-artifact-icon" src="screenshots/icons/capabilities.png" alt="">
+              <div class="mock-artifact-label">Design Brief</div>
+            </div>
+            <div class="mock-artifact">
+              <img class="mock-artifact-icon" src="screenshots/icons/car-racer.png" alt="">
+              <div class="mock-artifact-label">Race HUD</div>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <!-- Feature 8: Coming soon — Oyster Pro -->
-  <div class="feature-section reverse">
-    <div class="feature-text">
-      <p style="display: inline-block; background: #fbbf24; color: #1a1a2e; font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; padding: 4px 12px; border-radius: 4px; transform: rotate(-2deg); font-family: 'IBM Plex Mono', monospace; box-shadow: 0 2px 8px rgba(251,191,36,0.4); margin-bottom: 16px;">Coming soon</p>
-      <h3>Oyster Pro — your work, anywhere.</h3>
-      <p>Sync · Memory · Publish. Your spaces and artifacts on every device, your AI's brain shared across every agent, and shareable links for anything you publish.</p>
-      <a href="/pricing" class="cta cta-secondary" style="margin-top: 18px; display: inline-flex;">See pricing</a>
-    </div>
-    <div class="feature-mock">
-      <div class="mock-panel" style="display: flex; flex-direction: column; gap: 12px;">
-        <div style="display: flex; align-items: center; gap: 12px;">
-          <span style="width: 32px; height: 32px; border-radius: 8px; background: rgba(124,107,255,0.14); border: 1px solid rgba(124,107,255,0.28); display: inline-flex; align-items: center; justify-content: center; color: #a99eff; flex-shrink: 0;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 0 1 15-6.7L21 8M21 3v5h-5M21 12a9 9 0 0 1-15 6.7L3 16M3 21v-5h5"/></svg>
-          </span>
-          <div>
-            <div style="font-size: 12px; font-weight: 600; color: rgba(255,255,255,0.9);">Sync</div>
-            <div style="font-size: 11px; color: rgba(255,255,255,0.45);">Phone, iPad, every laptop</div>
-          </div>
-        </div>
-        <div style="display: flex; align-items: center; gap: 12px;">
-          <span style="width: 32px; height: 32px; border-radius: 8px; background: rgba(124,107,255,0.14); border: 1px solid rgba(124,107,255,0.28); display: inline-flex; align-items: center; justify-content: center; color: #a99eff; flex-shrink: 0;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a3 3 0 0 0-3 3v.5a3 3 0 0 0-3 3v.5a3 3 0 0 0-2 2.83V13a3 3 0 0 0 2 2.83V18a3 3 0 0 0 3 3 3 3 0 0 0 3-3v0a3 3 0 0 0 3 3 3 3 0 0 0 3-3v-2.17A3 3 0 0 0 20 13v-1.17a3 3 0 0 0-2-2.83V8.5a3 3 0 0 0-3-3V5a3 3 0 0 0-3-3z"/></svg>
-          </span>
-          <div>
-            <div style="font-size: 12px; font-weight: 600; color: rgba(255,255,255,0.9);">Memory</div>
-            <div style="font-size: 11px; color: rgba(255,255,255,0.45);">One brain, every agent</div>
-          </div>
-        </div>
-        <div style="display: flex; align-items: center; gap: 12px;">
-          <span style="width: 32px; height: 32px; border-radius: 8px; background: rgba(124,107,255,0.14); border: 1px solid rgba(124,107,255,0.28); display: inline-flex; align-items: center; justify-content: center; color: #a99eff; flex-shrink: 0;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20"/></svg>
-          </span>
-          <div>
-            <div style="font-size: 12px; font-weight: 600; color: rgba(255,255,255,0.9);">Publish</div>
-            <div style="font-size: 11px; color: rgba(255,255,255,0.45);">Shareable links, you control access</div>
+  <!-- Feature 8: Pro -->
+  <section class="section">
+    <div class="feature reverse">
+      <div>
+        <span class="coming-soon">T-Minus · Soon</span>
+        <h2>Oyster Pro — <span class="accent">your work,</span> anywhere.</h2>
+        <p>Sync · Memory · Publish. Your spaces and artefacts on every device, your AI's brain shared across every agent, and shareable links for anything you publish.</p>
+        <a href="/pricing" class="cta cta-secondary" style="margin-top: 22px; display: inline-flex;">See pricing</a>
+      </div>
+      <div class="mock-frame">
+        <div class="earth-orbit">
+          <div class="planet"></div>
+          <div class="horizon-glow"></div>
+          <svg class="orbit-path" viewBox="0 0 600 380" preserveAspectRatio="none">
+            <defs>
+              <linearGradient id="orbitGrad" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stop-color="rgba(123, 231, 255, 0)"/>
+                <stop offset="50%" stop-color="rgba(169, 158, 255, 0.9)"/>
+                <stop offset="100%" stop-color="rgba(255, 141, 224, 0)"/>
+              </linearGradient>
+            </defs>
+            <path d="M 30 260 Q 300 60 570 260" fill="none" stroke="url(#orbitGrad)" stroke-width="1.5" stroke-dasharray="4 6"/>
+          </svg>
+          <div class="devices">
+            <div class="device">
+              <span class="device-disc">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="12" rx="1.5"/><path d="M2 20h20M8 16l-1 4M16 16l1 4"/></svg>
+              </span>
+              <div class="device-label"><strong>Created on</strong>MacBook Pro</div>
+            </div>
+            <div class="device">
+              <span class="device-disc center">
+                <img src="logo.png" alt="" style="width: 22px; height: 22px; object-fit: contain;"/>
+              </span>
+              <div class="device-label"><strong>Synced to</strong>Oyster Cloud</div>
+            </div>
+            <div class="device">
+              <span class="device-disc">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="2.5"/><path d="M11 18h2"/></svg>
+              </span>
+              <div class="device-label"><strong>Available on</strong>iPhone &amp; Web</div>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <!-- npx install -->
-  <div class="bottom-cta" id="install" style="padding-bottom: 0;">
-    <h3 style="font-size: clamp(28px, 4vw, 40px); font-weight: 700; color: #fff; margin-bottom: 16px;">From zero to workspace in one command.</h3>
-    <p style="font-size: 16px; color: rgba(255,255,255,0.45); margin-bottom: 40px; max-width: 460px; margin-left: auto; margin-right: auto;">No sign-ups, no config files, no onboarding flow. Your surface opens in the browser, ready to go.</p>
-    <div style="display: inline-flex; flex-direction: column; align-items: center; gap: 16px;">
-    <!-- OS toggle -->
-    <div style="display: inline-flex; background: rgba(13,14,26,0.8); border-radius: 9999px; padding: 3px;">
-      <button onclick="setOS('mac')" id="os-mac" style="padding: 6px 18px; border-radius: 9999px; font-size: 12px; border: none; cursor: pointer; background: #7c6bff; color: #fff; font-family: inherit; font-weight: 500; transition: all 0.2s ease;">macOS / Linux</button>
-      <button onclick="setOS('win')" id="os-win" style="padding: 6px 18px; border-radius: 9999px; font-size: 12px; border: none; cursor: pointer; background: transparent; color: rgba(255,255,255,0.5); font-family: inherit; font-weight: 500; transition: all 0.2s ease;">Windows</button>
-    </div>
-    <div style=" background: rgba(30,32,50,0.95); border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; box-shadow: 0 24px 64px rgba(0,0,0,0.5); overflow: hidden; width: 100%; max-width: 420px;">
-      <div style="position: relative; display: flex; align-items: center; padding: 10px 14px; background: rgba(255,255,255,0.06);">
-        <div id="dots-mac" style="display: flex; gap: 6px;">
-          <span style="width: 10px; height: 10px; border-radius: 50%; background: #ff5f57;"></span>
-          <span style="width: 10px; height: 10px; border-radius: 50%; background: #febc2e;"></span>
-          <span style="width: 10px; height: 10px; border-radius: 50%; background: #28c840;"></span>
-        </div>
-        <div id="dots-win" style="display: none; gap: 6px;">
-          <span style="font-size: 11px; color: rgba(255,255,255,0.3); font-family: 'IBM Plex Mono', monospace;">C:\&gt;</span>
-        </div>
-        <span style="position: absolute; left: 0; right: 0; text-align: center; font-size: 11px; color: rgba(255,255,255,0.25); font-family: 'IBM Plex Mono', monospace; pointer-events: none;" id="term-title">terminal</span>
+  <!-- 4-COLUMN BENEFIT ROW -->
+  <section class="section">
+    <div class="benefit-row">
+      <div class="benefit">
+        <span class="benefit-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 6v6c0 5 3.5 9 8 10 4.5-1 8-5 8-10V6l-8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+        </span>
+        <strong>Your data. Your rules.</strong>
+        <span>Local-first by default. Your workspace lives in <code>~/Oyster</code>.</span>
       </div>
-      <div style="padding: 20px 24px 24px; display: flex; flex-direction: column; gap: 10px; text-align: left;">
-        <div style="white-space: nowrap;"><span id="prompt-char" style="color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px;">$ </span><code style="font-family: 'IBM Plex Mono', monospace; font-size: clamp(14px, 2.5vw, 20px); color: #a99eff;">npm install -g oyster-os</code></div>
-        <div><span id="prompt-char2" style="color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px;">$ </span><code style="font-family: 'IBM Plex Mono', monospace; font-size: clamp(14px, 2.5vw, 20px); color: #a99eff;">oyster</code></div>
-        <div style="margin-top: 6px; font-size: 12px; font-family: 'IBM Plex Mono', monospace; white-space: nowrap;"><span style="color: #fbbf24; font-weight: 500;">no install?</span> <span style="color: rgba(255,255,255,0.35);">try:</span> <span id="prompt-char3" style="color: rgba(255,255,255,0.35);">$ </span><span style="color: #a99eff;">npx oyster-os</span></div>
+      <div class="benefit">
+        <span class="benefit-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+        </span>
+        <strong>Built for speed.</strong>
+        <span>Instant search. Real-time updates. SQLite local. No cloud latency.</span>
+      </div>
+      <div class="benefit">
+        <span class="benefit-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+        </span>
+        <strong>Bring your own agents.</strong>
+        <span>Any MCP client works — Claude Code, Cursor, VS Code, Windsurf.</span>
+      </div>
+      <div class="benefit">
+        <span class="benefit-icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z"/><path d="M9 14l2 2 4-4"/></svg>
+        </span>
+        <strong>Ship with confidence.</strong>
+        <span>From idea to launch — every artefact in one command centre.</span>
       </div>
     </div>
-    </div>
-  </div>
+  </section>
 
-  <!-- Bottom CTA -->
+  <!-- LAUNCHPAD (install) -->
+  <section class="launchpad" id="install">
+    <h2>From zero to <span class="dim">work</span>space in <span class="accent">one command.</span></h2>
+    <p>No sign-ups, no config files, no onboarding flow. Your surface opens in the browser, ready to go.</p>
+
+    <div class="os-toggle">
+      <button id="os-mac" class="active" onclick="setOS('mac')">macOS / Linux</button>
+      <button id="os-win" onclick="setOS('win')">Windows</button>
+    </div>
+
+    <div class="terminal-frame">
+      <div class="terminal">
+        <div class="terminal-bar">
+          <div class="dots" id="dots-mac">
+            <span class="r"></span><span class="y"></span><span class="g"></span>
+          </div>
+          <div id="dots-win" style="display: none;" class="win-prompt">C:\&gt;</div>
+          <span class="title" id="term-title">terminal</span>
+        </div>
+        <div class="terminal-body">
+          <div class="line"><span class="prompt" id="prompt-char">$ </span><span class="cmd">npm install -g oyster-os</span></div>
+          <div class="line"><span class="prompt" id="prompt-char2">$ </span><span class="cmd">oyster</span></div>
+          <div class="alt">
+            <span class="label">no install?</span>
+            <span class="dim">try:</span>
+            <span id="prompt-char3" class="dim">$ </span><span class="cmd">npx oyster-os</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- BOTTOM CTA -->
   <div class="bottom-cta">
     <div class="cta-row">
       <a href="https://github.com/mattslight/oyster#quick-start" target="_blank" rel="noopener noreferrer" class="cta cta-primary">README.md</a>
@@ -951,12 +1836,48 @@
     </div>
   </div>
 
-  <!-- Footer -->
   <div class="footer">
     <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
   </div>
+
   <script>
-    // Smooth scroll for nav links
+    // ============================================
+    // STARFIELD GENERATOR
+    // ============================================
+    (function () {
+      function seed(seed) {
+        return function () {
+          seed = (seed * 9301 + 49297) % 233280;
+          return seed / 233280;
+        };
+      }
+      const rand = seed(42);
+      function makeStars(el, count, opts) {
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const s = document.createElement('div');
+          s.style.left = (rand() * 100).toFixed(2) + '%';
+          s.style.top = (rand() * 100).toFixed(2) + '%';
+          if (opts.twinkle && rand() < 0.18) {
+            s.classList.add('star-twinkle');
+            s.style.setProperty('--dur', (2.5 + rand() * 4).toFixed(2) + 's');
+            s.style.setProperty('--delay', (rand() * 5).toFixed(2) + 's');
+          }
+          frag.appendChild(s);
+        }
+        el.appendChild(frag);
+      }
+      const far = document.getElementById('stars-far');
+      const mid = document.getElementById('stars-mid');
+      const near = document.getElementById('stars-near');
+      if (far) makeStars(far, 110, { twinkle: false });
+      if (mid) makeStars(mid, 65, { twinkle: true });
+      if (near) makeStars(near, 28, { twinkle: true });
+    })();
+
+    // ============================================
+    // SMOOTH SCROLL
+    // ============================================
     document.getElementById('nav').querySelectorAll('a[href^="#"]').forEach(a => {
       a.addEventListener('click', e => {
         e.preventDefault();
@@ -965,152 +1886,159 @@
       });
     });
 
-    // 3D tilt on mock panels
+    // ============================================
+    // PARALLAX (mouse) on hero
+    // ============================================
+    const hero = document.querySelector('.hero');
+    const pearl = document.querySelector('.pearl-orb');
+    const farLayer = document.getElementById('stars-far');
+    const midLayer = document.getElementById('stars-mid');
+    const nearLayer = document.getElementById('stars-near');
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches === false) {
+      window.addEventListener('mousemove', (e) => {
+        const x = (e.clientX / window.innerWidth - 0.5);
+        const y = (e.clientY / window.innerHeight - 0.5);
+        if (farLayer) farLayer.style.transform = `translate3d(${x * -8}px, ${y * -8}px, 0)`;
+        if (midLayer) midLayer.style.transform = `translate3d(${x * -16}px, ${y * -16}px, 0)`;
+        if (nearLayer) nearLayer.style.transform = `translate3d(${x * -28}px, ${y * -28}px, 0)`;
+        if (pearl) pearl.style.transform = `translateX(calc(-50% + ${x * 24}px)) translateY(${y * 18}px)`;
+      });
+    }
+
+    // ============================================
+    // 3D tilt on mock panels (kept from v1)
+    // ============================================
+    // Low-gravity tilt — gentler rotation, long ease-out settle.
+    // The CSS transition does the heavy lifting (1.1s ease-out), so we
+    // throttle the mouse-driven target via rAF for buttery follow.
     document.querySelectorAll('.mock-panel').forEach(panel => {
+      let raf = null, targetX = 0, targetY = 0;
+      function apply() {
+        panel.style.transform = `perspective(900px) rotateY(${targetX * 4.5}deg) rotateX(${-targetY * 4.5}deg) translateZ(0)`;
+        raf = null;
+      }
       panel.addEventListener('mousemove', e => {
         const rect = panel.getBoundingClientRect();
-        const x = (e.clientX - rect.left) / rect.width - 0.5;
-        const y = (e.clientY - rect.top) / rect.height - 0.5;
-        panel.style.transform = `perspective(600px) rotateY(${x * 8}deg) rotateX(${-y * 8}deg)`;
+        targetX = (e.clientX - rect.left) / rect.width - 0.5;
+        targetY = (e.clientY - rect.top) / rect.height - 0.5;
+        if (!raf) raf = requestAnimationFrame(apply);
       });
       panel.addEventListener('mouseleave', () => {
-        panel.style.transform = 'perspective(600px) rotateY(0) rotateX(0)';
+        targetX = 0; targetY = 0;
+        panel.style.transform = 'perspective(900px) rotateY(0) rotateX(0)';
       });
     });
 
-    // Looping typing animation for each mock panel
+    // ============================================
+    // LOOPING TYPING ANIMATIONS (preserved from v1)
+    // ============================================
+    // Pre-fill typing text so panels are legible before they enter the viewport.
+    // The IntersectionObserver then replays the typing animation once on first view.
     function animatePanel(panel) {
       const typingEl = panel.querySelector('.typing-text');
       const fadeEls = panel.querySelectorAll('.fade-in');
       const response = panel.querySelector('.mock-response');
       const building = panel.querySelector('.mock-building');
 
-      function reset() {
-        if (typingEl) { typingEl.textContent = ''; typingEl.style.borderRight = '2px solid #a99eff'; }
-        fadeEls.forEach(el => { el.style.opacity = '0'; el.style.transform = 'translateY(8px)'; });
-        if (response) { response.style.opacity = '0'; response.style.transform = 'translateY(8px)'; }
-        if (building) {
-          building.querySelector('.build-progress-bar').style.width = '0';
-          building.querySelector('.build-artifact').style.opacity = '0';
-        }
+      // Pre-fill so it's always readable (no empty state)
+      if (typingEl) {
+        typingEl.textContent = typingEl.dataset.text || '';
+        typingEl.style.borderRight = '2px solid transparent';
+      }
+      fadeEls.forEach(el => { el.style.opacity = '1'; el.style.transform = 'translateY(0)'; });
+      if (response) { response.style.opacity = '1'; response.style.transform = 'translateY(0)'; }
+      if (building) {
+        const bar = building.querySelector('.build-progress-bar');
+        const artifact = building.querySelector('.build-artifact');
+        bar.style.width = '100%';
+        artifact.style.opacity = '1';
       }
 
-      function run() {
-        reset();
+      // Animate ONCE when first scrolled into view
+      function playOnce() {
+        if (typingEl) { typingEl.textContent = ''; typingEl.style.borderRight = '2px solid var(--accent-2)'; }
+        fadeEls.forEach(el => { el.style.opacity = '0'; el.style.transform = 'translateY(8px)'; el.style.transition = 'opacity 0.4s ease, transform 0.4s ease'; });
+        if (response) { response.style.opacity = '0'; response.style.transform = 'translateY(8px)'; response.style.transition = 'opacity 0.4s ease, transform 0.4s ease'; }
+        if (building) {
+          const bar = building.querySelector('.build-progress-bar');
+          const artifact = building.querySelector('.build-artifact');
+          bar.style.width = '0';
+          bar.style.transition = 'width 1.5s ease-in-out';
+          artifact.style.opacity = '0';
+          artifact.style.transition = 'opacity 0.4s ease';
+        }
+
         const text = typingEl ? typingEl.dataset.text : '';
         let i = 0;
-
-        // Type
         const typeInterval = setInterval(() => {
           if (!typingEl) return clearInterval(typeInterval);
           typingEl.textContent = text.slice(0, ++i);
           if (i >= text.length) {
             clearInterval(typeInterval);
             typingEl.style.borderRight = '2px solid transparent';
-
-            // Show results after typing
             fadeEls.forEach((el, idx) => {
               setTimeout(() => {
-                el.style.transition = 'opacity 0.4s ease, transform 0.4s ease';
                 el.style.opacity = '1';
                 el.style.transform = 'translateY(0)';
               }, 300 + idx * 400);
             });
-
             if (response) {
-              setTimeout(() => {
-                response.style.transition = 'opacity 0.4s ease, transform 0.4s ease';
-                response.style.opacity = '1';
-                response.style.transform = 'translateY(0)';
-              }, 600);
+              setTimeout(() => { response.style.opacity = '1'; response.style.transform = 'translateY(0)'; }, 600);
             }
-
             if (building) {
               const bar = building.querySelector('.build-progress-bar');
               const artifact = building.querySelector('.build-artifact');
-              bar.style.transition = 'width 1.5s ease-in-out';
               bar.style.width = '100%';
-              setTimeout(() => {
-                artifact.style.transition = 'opacity 0.4s ease';
-                artifact.style.opacity = '1';
-              }, 1600);
+              setTimeout(() => { artifact.style.opacity = '1'; }, 1600);
             }
           }
-        }, 60);
+        }, 55);
       }
-
-      // Loop: run, wait, reset, wait, run again
-      function loop() {
-        run();
-        setTimeout(() => { reset(); setTimeout(loop, 1000); }, 5000);
-      }
-
-      // Start when visible
       const obs = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting) { obs.disconnect(); loop(); }
-      }, { threshold: 0.3 });
+        if (entries[0].isIntersecting) { obs.disconnect(); playOnce(); }
+      }, { threshold: 0.35 });
       obs.observe(panel);
     }
-
     document.querySelectorAll('.mock-panel[id]').forEach(animatePanel);
 
-    // Switch panel — cycles typing + pill through all spaces
+    // SWITCH panel — cycles slowly through spaces. Keep visible state at all times.
     const switchPanel = document.getElementById('mock-switch');
     if (switchPanel) {
       const pills = switchPanel.querySelectorAll('.mock-pill');
       const typingEl = document.getElementById('switch-typing');
       const names = ['#home', '#research', '#clients', '#ops'];
       let idx = 0;
+      // Pre-fill so legible before scroll
+      typingEl.textContent = names[0];
+      typingEl.style.borderRight = '2px solid transparent';
 
-      // Remove from generic animatePanel since we handle it here
-      function switchLoop() {
-        // Update pill
+      function switchTick() {
+        idx = (idx + 1) % names.length;
         pills.forEach(p => p.classList.remove('active'));
         pills[idx].classList.add('active');
-
-        // Type the name
         const text = names[idx];
         let i = 0;
         typingEl.textContent = '';
-        typingEl.style.borderRight = '2px solid #a99eff';
+        typingEl.style.borderRight = '2px solid var(--accent-2)';
         const interval = setInterval(() => {
           typingEl.textContent = text.slice(0, ++i);
           if (i >= text.length) {
             clearInterval(interval);
             typingEl.style.borderRight = '2px solid transparent';
           }
-        }, 60);
-
-        idx = (idx + 1) % names.length;
-        setTimeout(switchLoop, 2500);
+        }, 55);
       }
-
-      // Start when visible
       const switchObs = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting) { switchObs.disconnect(); switchLoop(); }
-      }, { threshold: 0.3 });
+        if (entries[0].isIntersecting) {
+          switchObs.disconnect();
+          setInterval(switchTick, 3200);
+        }
+      }, { threshold: 0.35 });
       switchObs.observe(switchPanel);
     }
-    // Dynamic UI carousel — cycles kanban → chart → list
-    const duiCarousel = document.getElementById('dynamic-ui-carousel');
-    if (duiCarousel) {
-      const views = duiCarousel.querySelectorAll('.dui-view');
-      let duiIdx = 0;
-      function cycleDui() {
-        views[duiIdx].classList.remove('dui-active');
-        duiIdx = (duiIdx + 1) % views.length;
-        views[duiIdx].classList.add('dui-active');
-      }
-      const duiObs = new IntersectionObserver(entries => {
-        if (entries[0].isIntersecting) {
-          duiObs.disconnect();
-          setInterval(cycleDui, 3000);
-        }
-      }, { threshold: 0.3 });
-      duiObs.observe(duiCarousel);
-    }
-    // OS toggle for terminal mockup
-    window.setOS = function(os) {
+
+    // OS toggle
+    window.setOS = function (os) {
       const mac = os === 'mac';
       document.getElementById('dots-mac').style.display = mac ? 'flex' : 'none';
       document.getElementById('dots-win').style.display = mac ? 'none' : 'flex';
@@ -1118,29 +2046,17 @@
       document.getElementById('prompt-char').textContent = mac ? '$ ' : 'C:\\> ';
       document.getElementById('prompt-char2').textContent = mac ? '$ ' : 'C:\\> ';
       document.getElementById('prompt-char3').textContent = mac ? '$ ' : 'C:\\> ';
-      document.getElementById('os-mac').style.background = mac ? '#7c6bff' : 'transparent';
-      document.getElementById('os-mac').style.color = mac ? '#fff' : 'rgba(255,255,255,0.5)';
-      document.getElementById('os-win').style.background = mac ? 'transparent' : '#7c6bff';
-      document.getElementById('os-win').style.color = mac ? 'rgba(255,255,255,0.5)' : '#fff';
+      document.getElementById('os-mac').classList.toggle('active', mac);
+      document.getElementById('os-win').classList.toggle('active', !mac);
     };
 
-    // MCP client tabs
-    function showMcpTab(name) {
+    // MCP tabs
+    window.showMcpTab = function (e, name) {
       document.querySelectorAll('.mcp-panel').forEach(p => p.style.display = 'none');
-      document.querySelectorAll('.mcp-tab').forEach(t => {
-        t.classList.remove('mcp-tab-active');
-        t.style.color = 'rgba(255,255,255,0.4)';
-        t.style.background = 'none';
-      });
+      document.querySelectorAll('.mcp-tab').forEach(t => t.classList.remove('active'));
       document.getElementById('mcp-' + name).style.display = 'block';
-      event.target.classList.add('mcp-tab-active');
-      event.target.style.color = '#fff';
-      event.target.style.background = 'rgba(124,107,255,0.15)';
-    }
-    // Set initial active tab style
-    document.querySelector('.mcp-tab-active').style.color = '#fff';
-    document.querySelector('.mcp-tab-active').style.background = 'rgba(124,107,255,0.15)';
-
+      e.target.classList.add('active');
+    };
   </script>
   <script src="assets/hero-mock.js" defer></script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,24 @@
   <title>Oyster — Mission control for your agents.</title>
   <meta name="description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
 
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Oyster">
+  <meta property="og:title" content="Oyster — Mission control for your agents.">
+  <meta property="og:description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
+  <meta property="og:url" content="https://oyster.to/">
+  <meta property="og:image" content="https://oyster.to/social-preview.jpg">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="640">
+  <meta property="og:image:alt" content="Oyster — Mission control for your agents.">
+
+  <!-- Twitter / X card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Oyster — Mission control for your agents.">
+  <meta name="twitter:description" content="Oyster keeps your AI work synced, remembered and publishable across devices and agents.">
+  <meta name="twitter:image" content="https://oyster.to/social-preview.jpg">
+  <meta name="twitter:image:alt" content="Oyster — Mission control for your agents.">
+
   <link rel="stylesheet" href="assets/oyster.css">
   <link rel="stylesheet" href="assets/hero-mock.css">
   <style>
@@ -19,53 +37,7 @@
        COSMIC BACKGROUND SYSTEM
        ============================================ */
 
-    .cosmos {
-      position: fixed;
-      inset: 0;
-      z-index: 0;
-      pointer-events: none;
-      overflow: hidden;
-      background:
-        radial-gradient(ellipse 1100px 700px at 22% 8%, rgba(139, 118, 255, 0.09) 0%, transparent 60%),
-        radial-gradient(ellipse 800px 600px at 80% 18%, rgba(123, 231, 255, 0.05) 0%, transparent 65%),
-        linear-gradient(180deg, #04060d 0%, #050714 50%, #04060d 100%);
-    }
-
-    /* Subtle grain texture — adds depth without busyness */
-    .cosmos::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background-image: radial-gradient(rgba(255,255,255,0.012) 1px, transparent 1px);
-      background-size: 3px 3px;
-      mix-blend-mode: overlay;
-      opacity: 0.4;
-    }
-
-    /* Starfield — 2 sparse parallax layers (filled via JS) */
-    .stars { position: absolute; inset: 0; }
-    .stars div {
-      position: absolute;
-      width: 1px; height: 1px;
-      background: #fff;
-      border-radius: 50%;
-    }
-    .stars-far div { opacity: 0.35; }
-    .stars-near div { width: 1.5px; height: 1.5px; opacity: 0.7; }
-
-    /* A few twinkling featured stars */
-    .star-twinkle {
-      animation: twinkle var(--dur, 6s) ease-in-out infinite;
-      animation-delay: var(--delay, 0s);
-    }
-    @keyframes twinkle {
-      0%, 100% { opacity: 0.7; }
-      50% { opacity: 0.15; }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .star-twinkle { animation: none; }
-    }
+    /* .cosmos, .cosmos::after, .stars, .star-twinkle live in assets/oyster.css */
 
     /* Orbital arcs — the visual signature. SVG placed absolute, very low opacity. */
     .orbit-svg {
@@ -333,65 +305,7 @@
       z-index: 2;
     }
 
-    .cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 14px 26px;
-      border-radius: 9999px;
-      font-family: var(--sans);
-      font-size: 14px;
-      font-weight: 500;
-      letter-spacing: -0.005em;
-      text-decoration: none;
-      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
-      position: relative;
-      overflow: hidden;
-      cursor: pointer;
-      border: 1px solid transparent;
-    }
-    .cta:hover { transform: translateY(-1px); }
-    .cta-primary {
-      background: linear-gradient(180deg, #9d8cff 0%, #8b76ff 100%);
-      color: #fff;
-      box-shadow:
-        0 4px 24px rgba(139, 118, 255, 0.45),
-        0 0 60px rgba(139, 118, 255, 0.25),
-        inset 0 1px 0 rgba(255, 255, 255, 0.25);
-    }
-    .cta-primary:hover {
-      box-shadow:
-        0 8px 36px rgba(139, 118, 255, 0.55),
-        0 0 100px rgba(139, 118, 255, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.3);
-    }
-    .cta-secondary {
-      background: rgba(255, 255, 255, 0.04);
-      color: rgba(255, 255, 255, 0.85);
-      border-color: rgba(255, 255, 255, 0.08);
-      backdrop-filter: blur(8px);
-    }
-    .cta-secondary:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: rgba(255, 255, 255, 0.16);
-    }
-    .cta svg { width: 14px; height: 14px; }
-
-    /* Shimmer on hover */
-    @keyframes shimmer {
-      0% { transform: translateX(-100%) skewX(-15deg); }
-      100% { transform: translateX(200%) skewX(-15deg); }
-    }
-    .cta::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.22) 50%, transparent 100%);
-      transform: translateX(-100%) skewX(-15deg);
-    }
-    .cta:hover::after {
-      animation: shimmer 0.85s ease-in-out 1 forwards;
-    }
+    /* .cta and its variants live in assets/oyster.css */
 
     /* Hint micro-line */
     .hero-hint {
@@ -1868,10 +1782,8 @@
         el.appendChild(frag);
       }
       const far = document.getElementById('stars-far');
-      const mid = document.getElementById('stars-mid');
       const near = document.getElementById('stars-near');
       if (far) makeStars(far, 110, { twinkle: false });
-      if (mid) makeStars(mid, 65, { twinkle: true });
       if (near) makeStars(near, 28, { twinkle: true });
     })();
 
@@ -1892,14 +1804,12 @@
     const hero = document.querySelector('.hero');
     const pearl = document.querySelector('.pearl-orb');
     const farLayer = document.getElementById('stars-far');
-    const midLayer = document.getElementById('stars-mid');
     const nearLayer = document.getElementById('stars-near');
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches === false) {
       window.addEventListener('mousemove', (e) => {
         const x = (e.clientX / window.innerWidth - 0.5);
         const y = (e.clientY / window.innerHeight - 0.5);
         if (farLayer) farLayer.style.transform = `translate3d(${x * -8}px, ${y * -8}px, 0)`;
-        if (midLayer) midLayer.style.transform = `translate3d(${x * -16}px, ${y * -16}px, 0)`;
         if (nearLayer) nearLayer.style.transform = `translate3d(${x * -28}px, ${y * -28}px, 0)`;
         if (pearl) pearl.style.transform = `translateX(calc(-50% + ${x * 24}px)) translateY(${y * 18}px)`;
       });

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -5,123 +5,102 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bring Your Own AI — Oyster</title>
   <meta name="description" content="Bring your own AI — connect Claude Code, Cursor, VS Code, Windsurf or any MCP-compatible tool to Oyster.">
-  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/oyster.css">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #0a0b14;
-      color: #e0e0e0;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
-
-    .bg {
-      position: fixed;
-      inset: 0;
-      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
-                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
-                  #0a0b14;
-      z-index: 0;
-    }
-
-    /* Back nav */
-    .back-nav {
-      position: fixed;
-      top: 16px;
-      left: 0;
-      right: 0;
-      z-index: 10;
-      display: flex;
-      justify-content: center;
-    }
-    .back-bar {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 20px;
-      background: rgba(20, 22, 40, 0.9);
-      backdrop-filter: blur(16px);
-      -webkit-backdrop-filter: blur(16px);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 9999px;
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
-    }
-    .back-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-family: inherit;
-      font-size: 13px;
-      font-weight: 500;
-      color: rgba(255,255,255,0.5);
-      text-decoration: none;
-      transition: color 0.15s;
-    }
-    .back-link:hover { color: #fff; }
-
-    /* Hero */
     .hero {
       position: relative;
-      z-index: 1;
-      max-width: 800px;
+      z-index: 2;
+      max-width: 880px;
       margin: 0 auto;
-      padding: 120px 24px 0;
+      padding: 160px 28px 0;
       text-align: center;
     }
-
     h1 {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(32px, 5vw, 48px);
-      font-weight: 700;
-      line-height: 1.15;
-      color: #fff;
-      margin-bottom: 16px;
+      font-family: var(--sans);
+      font-size: clamp(40px, 6.5vw, 88px);
+      font-weight: 800;
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+      color: var(--ink);
+      margin-bottom: 22px;
     }
-
+    h1 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
     .subtitle {
       font-size: 18px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.5);
-      max-width: 520px;
+      line-height: 1.55;
+      color: var(--ink-2);
+      max-width: 540px;
       margin: 0 auto;
+      letter-spacing: -0.005em;
     }
 
-    /* Sections */
+    /* Section blocks */
     .section {
       position: relative;
-      z-index: 1;
-      max-width: 640px;
+      z-index: 2;
+      max-width: 720px;
       margin: 0 auto;
-      padding: 0 24px;
+      padding: 80px 28px 0;
     }
-
     .section-label {
-      font-family: 'Barlow', sans-serif;
-      font-size: 13px;
-      font-weight: 600;
-      letter-spacing: 2.5px;
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
-      color: #7c6bff;
-      margin-bottom: 20px;
-      margin-top: 80px;
+      color: var(--ink-4);
+      margin-bottom: 18px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .section-label::before {
+      content: '';
+      width: 22px; height: 1px;
+      background: rgba(139, 118, 255, 0.5);
     }
 
-    /* Tabs */
-    .tabs {
+    /* Tabbed config block — aurora-glow framed (matches index.html MCP feature) */
+    .config-frame {
+      position: relative;
+      isolation: isolate;
+    }
+    .config-frame::before {
+      content: '';
+      position: absolute;
+      inset: -40px -24px;
+      background:
+        radial-gradient(ellipse 60% 50% at 30% 10%, rgba(139, 118, 255, 0.22) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 60% at 80% 90%, rgba(123, 231, 255, 0.14) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
+    }
+    .tab-row {
       display: flex;
       gap: 2px;
-      background: rgba(255,255,255,0.03);
-      border-radius: 12px 12px 0 0;
-      padding: 4px 4px 0;
+      padding: 6px 6px 0;
+      background: rgba(8, 10, 22, 0.6);
+      border-radius: 14px 14px 0 0;
       overflow-x: auto;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-bottom: none;
     }
     .tab {
-      padding: 12px 20px;
-      font-size: 13px;
-      font-family: inherit;
+      padding: 10px 16px;
+      font-family: var(--mono);
+      font-size: 12px;
       font-weight: 500;
-      color: rgba(255,255,255,0.35);
+      color: var(--ink-4);
       background: none;
       border: none;
       cursor: pointer;
@@ -129,65 +108,70 @@
       white-space: nowrap;
       transition: color 0.15s, background 0.15s;
     }
-    .tab:hover { color: rgba(255,255,255,0.7); }
+    .tab:hover { color: var(--ink-2); }
     .tab.active {
       color: #fff;
-      background: rgba(124,107,255,0.12);
+      background: rgba(139, 118, 255, 0.16);
     }
 
-    /* Code panels */
     .panels {
-      background: rgba(13, 14, 26, 0.9);
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.96) 0%, rgba(14, 16, 34, 0.96) 100%);
       backdrop-filter: blur(24px);
       -webkit-backdrop-filter: blur(24px);
-      border: 1px solid rgba(255,255,255,0.06);
+      border: 1px solid rgba(255, 255, 255, 0.10);
       border-top: none;
-      border-radius: 0 0 16px 16px;
-      padding: 24px;
-      box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+      border-radius: 0 0 14px 14px;
+      padding: 22px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
       position: relative;
     }
     .panel { display: none; }
     .panel.active { display: block; }
-
     .panel-label {
-      font-size: 11px;
-      color: rgba(255,255,255,0.3);
+      font-family: var(--mono);
+      font-size: 10px;
+      color: var(--ink-4);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
       margin-bottom: 10px;
-      font-family: 'IBM Plex Mono', monospace;
+      padding-right: 70px;
     }
-
     pre {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 13px;
       line-height: 1.6;
-      color: #e0e0e8;
+      color: #e6e6f0;
       white-space: pre-wrap;
       word-break: break-all;
+      margin: 0;
     }
-
     .copy-btn {
       position: absolute;
-      top: 16px;
-      right: 16px;
-      background: rgba(124,107,255,0.12);
-      border: 1px solid rgba(124,107,255,0.2);
-      color: rgba(255,255,255,0.5);
+      top: 14px;
+      right: 14px;
+      background: rgba(139, 118, 255, 0.22);
+      border: 1px solid rgba(139, 118, 255, 0.40);
+      color: var(--ink);
       font-size: 11px;
-      font-family: 'IBM Plex Mono', monospace;
-      padding: 5px 12px;
+      font-family: var(--mono);
+      padding: 6px 12px;
       border-radius: 6px;
       cursor: pointer;
-      transition: all 0.15s;
+      outline: none;
+      z-index: 2;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
     }
     .copy-btn:hover {
-      background: rgba(124,107,255,0.25);
+      background: rgba(139, 118, 255, 0.32);
       color: #fff;
     }
+    .copy-btn:focus-visible {
+      box-shadow: 0 0 0 2px rgba(139, 118, 255, 0.5);
+    }
     .copy-btn.copied {
-      background: rgba(80,200,120,0.15);
-      border-color: rgba(80,200,120,0.3);
-      color: rgba(80,200,120,0.8);
+      background: rgba(74, 222, 128, 0.15);
+      border-color: rgba(74, 222, 128, 0.30);
+      color: rgba(74, 222, 128, 0.95);
     }
 
     /* Examples */
@@ -195,27 +179,31 @@
       display: flex;
       flex-direction: column;
       gap: 0;
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.6) 0%, rgba(14, 16, 34, 0.6) 100%);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 14px;
+      padding: 6px 22px;
     }
     .example {
       display: flex;
       align-items: baseline;
       gap: 14px;
-      padding: 14px 0;
-      border-bottom: 1px solid rgba(255,255,255,0.04);
+      padding: 16px 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
     }
     .example:last-child { border-bottom: none; }
     .example-prompt {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 13px;
-      color: #a99eff;
+      color: var(--accent-2);
       flex-shrink: 0;
     }
     .example-arrow {
-      color: rgba(255,255,255,0.15);
+      color: var(--ink-4);
       flex-shrink: 0;
     }
     .example-result {
-      color: rgba(255,255,255,0.45);
+      color: var(--ink-2);
       font-size: 14px;
     }
 
@@ -223,166 +211,166 @@
     .tools {
       display: flex;
       flex-wrap: wrap;
-      gap: 8px;
+      gap: 6px;
     }
     .tool {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 11px;
-      padding: 6px 14px;
-      border-radius: 8px;
-      background: rgba(124,107,255,0.08);
-      border: 1px solid rgba(124,107,255,0.08);
-      color: rgba(255,255,255,0.45);
+      padding: 5px 11px;
+      border-radius: 6px;
+      background: rgba(139, 118, 255, 0.10);
+      border: 1px solid rgba(139, 118, 255, 0.18);
+      color: var(--ink-2);
       transition: all 0.15s;
     }
     .tool:hover {
-      background: rgba(124,107,255,0.15);
-      color: rgba(255,255,255,0.7);
+      background: rgba(139, 118, 255, 0.18);
+      color: var(--ink);
     }
 
     .note {
       font-size: 14px;
-      color: rgba(255,255,255,0.35);
-      margin-top: 16px;
-      line-height: 1.7;
+      color: var(--ink-3);
+      margin-top: 18px;
+      line-height: 1.65;
     }
 
     /* Install CTA */
     .install-section {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 640px;
-      margin: 80px auto 0;
-      padding: 0 24px 100px;
+      margin: 100px auto 0;
+      padding: 0 28px;
       text-align: center;
     }
     .install-label {
-      font-family: 'Barlow', sans-serif;
+      font-family: var(--sans);
       font-size: 28px;
       font-weight: 700;
-      color: #fff;
+      letter-spacing: -0.02em;
+      color: var(--ink);
       margin-bottom: 24px;
     }
+    .terminal-frame {
+      position: relative;
+      max-width: 480px;
+      margin: 0 auto;
+      isolation: isolate;
+    }
+    .terminal-frame::before {
+      content: '';
+      position: absolute;
+      inset: -30px -40px;
+      background:
+        radial-gradient(ellipse 60% 60% at 50% 100%, rgba(139, 118, 255, 0.45) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 50% at 50% 0%, rgba(123, 231, 255, 0.20) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
+    }
     .terminal {
-      background: rgba(13, 14, 26, 0.95);
-      border: 1px solid rgba(255,255,255,0.08);
-      border-radius: 12px;
-      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      background: rgba(13, 16, 36, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.6);
       overflow: hidden;
+      backdrop-filter: blur(14px);
       text-align: left;
     }
     .terminal-bar {
       display: flex;
       align-items: center;
-      padding: 12px 16px;
-      border-bottom: 1px solid rgba(255,255,255,0.04);
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.04);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
       position: relative;
     }
-    .terminal-dots {
-      display: flex;
-      gap: 6px;
-    }
-    .terminal-dots span {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-    }
+    .terminal-dots { display: flex; gap: 6px; }
+    .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
     .terminal-title {
-      position: absolute;
-      left: 0;
-      right: 0;
-      text-align: center;
+      position: absolute; left: 0; right: 0; text-align: center;
+      font-family: var(--mono);
       font-size: 11px;
-      color: rgba(255,255,255,0.25);
-      font-family: 'IBM Plex Mono', monospace;
+      color: var(--ink-4);
+      letter-spacing: 0.06em;
       pointer-events: none;
     }
     .terminal-body {
-      padding: 20px 24px 24px;
+      padding: 22px 24px;
       display: flex;
       flex-direction: column;
       gap: 10px;
     }
-    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
-    .terminal-line code { font-family: 'IBM Plex Mono', monospace; font-size: clamp(16px, 2.5vw, 20px); color: #a99eff; }
+    .terminal-line .prompt { color: var(--ink-4); font-family: var(--mono); font-size: 14px; }
+    .terminal-line code { font-family: var(--mono); font-size: clamp(15px, 2.2vw, 18px); color: var(--accent-2); }
     .terminal-hint {
       margin-top: 6px;
-      font-size: 12px;
-      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11.5px;
+      font-family: var(--mono);
     }
-    .terminal-hint .yellow { color: #fbbf24; font-weight: 500; }
-    .terminal-hint .dim { color: rgba(255,255,255,0.35); }
-
-    /* Footer */
-    .footer {
-      position: relative;
-      z-index: 1;
-      text-align: center;
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.3);
-      padding: 0 24px 60px;
-    }
-    .footer .heart { color: #e25555; }
-    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
-    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
+    .terminal-hint .yellow { color: var(--warn); font-weight: 500; }
+    .terminal-hint .dim { color: var(--ink-4); }
+    .terminal-hint .cmd { color: var(--accent-2); }
 
     @media (max-width: 600px) {
       .example { flex-direction: column; gap: 4px; }
       .example-arrow { display: none; }
-      .hero { padding-top: 100px; }
+      .hero { padding-top: 110px; }
     }
   </style>
 </head>
 <body>
-  <div class="bg"></div>
-
-  <div class="back-nav">
-    <div class="back-bar">
-      <a class="back-link" href="/">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
-        </svg>
-        oyster.to
-      </a>
-    </div>
+  <div class="cosmos" aria-hidden="true">
+    <div class="stars stars-far" id="stars-far"></div>
+    <div class="stars stars-near" id="stars-near"></div>
   </div>
 
-  <div class="hero">
-    <h1>Bring Your Own AI.</h1>
+  <nav class="nav">
+    <a href="/"><img src="logo.png" alt="Oyster" class="nav-logo" /></a>
+    <a href="/#install">Install</a>
+    <a href="/plugins">Plugins</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/changelog">Changelog</a>
+  </nav>
+
+  <section class="hero">
+    <h1>Bring your <span class="accent">own</span> AI.</h1>
     <p class="subtitle">Oyster is an MCP server. Any AI that speaks the protocol can control your workspace.</p>
-  </div>
+  </section>
 
-  <div class="section">
+  <section class="section">
     <div class="section-label">Quick start</div>
 
-    <div class="tabs">
-      <button class="tab active" onclick="showTab('claude')">Claude Code</button>
-      <button class="tab" onclick="showTab('cursor')">Cursor</button>
-      <button class="tab" onclick="showTab('vscode')">VS Code</button>
-      <button class="tab" onclick="showTab('windsurf')">Windsurf</button>
-    </div>
-    <div class="panels">
-      <button class="copy-btn" onclick="copyCode(this)">copy</button>
-
-      <div id="panel-claude" class="panel active">
-        <div class="panel-label">run in your terminal</div>
-        <pre>claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/</pre>
+    <div class="config-frame">
+      <div class="tab-row">
+        <button class="tab active" onclick="showTab(event, 'claude')">Claude Code</button>
+        <button class="tab" onclick="showTab(event, 'cursor')">Cursor</button>
+        <button class="tab" onclick="showTab(event, 'vscode')">VS Code</button>
+        <button class="tab" onclick="showTab(event, 'windsurf')">Windsurf</button>
       </div>
+      <div class="panels">
+        <button class="copy-btn" onclick="copyCode(this)">copy</button>
 
-      <div id="panel-cursor" class="panel">
-        <div class="panel-label">.cursor/mcp.json</div>
-        <pre>{
+        <div id="panel-claude" class="panel active">
+          <div class="panel-label">run in your terminal</div>
+          <pre>claude mcp add --scope user --transport http oyster http://localhost:4444/mcp/</pre>
+        </div>
+
+        <div id="panel-cursor" class="panel">
+          <div class="panel-label">.cursor/mcp.json</div>
+          <pre>{
   "mcpServers": {
     "oyster": {
       "url": "http://localhost:4444/mcp/"
     }
   }
 }</pre>
-      </div>
+        </div>
 
-      <div id="panel-vscode" class="panel">
-        <div class="panel-label">.vscode/mcp.json</div>
-        <pre>{
+        <div id="panel-vscode" class="panel">
+          <div class="panel-label">.vscode/mcp.json</div>
+          <pre>{
   "servers": {
     "oyster": {
       "type": "http",
@@ -390,21 +378,22 @@
     }
   }
 }</pre>
-      </div>
+        </div>
 
-      <div id="panel-windsurf" class="panel">
-        <div class="panel-label">~/.codeium/windsurf/mcp_config.json</div>
-        <pre>{
+        <div id="panel-windsurf" class="panel">
+          <div class="panel-label">~/.codeium/windsurf/mcp_config.json</div>
+          <pre>{
   "mcpServers": {
     "oyster": {
       "serverUrl": "http://localhost:4444/mcp/"
     }
   }
 }</pre>
+        </div>
       </div>
     </div>
 
-    <div class="section-label">What you can do</div>
+    <div class="section-label" style="margin-top: 60px;">What you can do</div>
     <div class="examples">
       <div class="example">
         <span class="example-prompt">"Create a deck about Q2 results"</span>
@@ -433,7 +422,7 @@
       </div>
     </div>
 
-    <div class="section-label">Available tools</div>
+    <div class="section-label" style="margin-top: 60px;">Available tools</div>
     <div class="tools">
       <span class="tool">get_context</span>
       <span class="tool">list_spaces</span>
@@ -455,48 +444,74 @@
       <span class="tool">list_memories</span>
     </div>
     <p class="note">Your AI can chain these together. Ask it to onboard a project, create a summary, and organise everything into spaces — all from one prompt.</p>
-  </div>
+  </section>
 
-  <div class="install-section">
+  <section class="install-section">
     <div class="install-label">Don't have Oyster yet?</div>
-    <div class="terminal">
-      <div class="terminal-bar">
-        <div class="terminal-dots">
-          <span style="background: #ff5f57;"></span>
-          <span style="background: #febc2e;"></span>
-          <span style="background: #28c840;"></span>
+    <div class="terminal-frame">
+      <div class="terminal">
+        <div class="terminal-bar">
+          <div class="terminal-dots">
+            <span style="background: #ff5f57;"></span>
+            <span style="background: #febc2e;"></span>
+            <span style="background: #28c840;"></span>
+          </div>
+          <span class="terminal-title">terminal</span>
         </div>
-        <span class="terminal-title">terminal</span>
-      </div>
-      <div class="terminal-body">
-        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
-        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
-        <div class="terminal-hint"><span class="yellow">no install?</span> <span class="dim">try:</span> <span class="dim">$ </span><span style="color: #a99eff;">npx oyster-os</span></div>
+        <div class="terminal-body">
+          <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+          <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+          <div class="terminal-hint"><span class="yellow">no install?</span> <span class="dim">try:</span> <span class="dim">$ </span><span class="cmd">npx oyster-os</span></div>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <div class="footer">
+  <div class="site-footer" style="padding-top: 100px;">
     <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
   </div>
 
   <script>
-    function showTab(name) {
-      document.querySelectorAll('.tab').forEach(function(t) { t.classList.remove('active'); });
-      document.querySelectorAll('.panel').forEach(function(p) { p.classList.remove('active'); });
-      event.target.classList.add('active');
+    // Sparse starfield
+    (function () {
+      function seed(s) { return function () { s = (s * 9301 + 49297) % 233280; return s / 233280; }; }
+      const rand = seed(42);
+      function makeStars(el, count, twinkle) {
+        if (!el) return;
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const d = document.createElement('div');
+          d.style.left = (rand() * 100).toFixed(2) + '%';
+          d.style.top = (rand() * 100).toFixed(2) + '%';
+          if (twinkle && rand() < 0.18) {
+            d.classList.add('star-twinkle');
+            d.style.setProperty('--dur', (2.5 + rand() * 4).toFixed(2) + 's');
+            d.style.setProperty('--delay', (rand() * 5).toFixed(2) + 's');
+          }
+          frag.appendChild(d);
+        }
+        el.appendChild(frag);
+      }
+      makeStars(document.getElementById('stars-far'), 80, false);
+      makeStars(document.getElementById('stars-near'), 22, true);
+    })();
+
+    function showTab(e, name) {
+      document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
+      document.querySelectorAll('.panel').forEach((p) => p.classList.remove('active'));
+      e.target.classList.add('active');
       document.getElementById('panel-' + name).classList.add('active');
-      var btn = document.querySelector('.copy-btn');
+      const btn = document.querySelector('.copy-btn');
       btn.textContent = 'copy';
       btn.classList.remove('copied');
     }
 
     function copyCode(btn) {
-      var active = document.querySelector('.panel.active pre');
-      navigator.clipboard.writeText(active.textContent).then(function() {
+      const active = document.querySelector('.panel.active pre');
+      navigator.clipboard.writeText(active.textContent).then(() => {
         btn.textContent = 'copied';
         btn.classList.add('copied');
-        setTimeout(function() { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
+        setTimeout(() => { btn.textContent = 'copy'; btn.classList.remove('copied'); }, 2000);
       });
     }
   </script>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -5,135 +5,105 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Plugins — Oyster</title>
   <meta name="description" content="Community plugins for Oyster. Static apps, tools, and widgets that run on your workspace surface.">
-  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/oyster.css">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #0a0b14;
-      color: #e0e0e0;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
-
-    .bg {
-      position: fixed;
-      inset: 0;
-      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
-                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
-                  #0a0b14;
-      z-index: 0;
-    }
-
-    /* Back nav */
-    .back-nav {
-      position: fixed;
-      top: 16px;
-      left: 0;
-      right: 0;
-      z-index: 10;
-      display: flex;
-      justify-content: center;
-    }
-    .back-bar {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 20px;
-      background: rgba(20, 22, 40, 0.9);
-      backdrop-filter: blur(16px);
-      -webkit-backdrop-filter: blur(16px);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 9999px;
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
-    }
-    .back-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-family: inherit;
-      font-size: 13px;
-      font-weight: 500;
-      color: rgba(255,255,255,0.5);
-      text-decoration: none;
-      transition: color 0.15s;
-    }
-    .back-link:hover { color: #fff; }
-
-    /* Hero */
+    /* Page-specific styles */
     .hero {
       position: relative;
-      z-index: 1;
-      max-width: 800px;
+      z-index: 2;
+      max-width: 880px;
       margin: 0 auto;
-      padding: 120px 24px 0;
+      padding: 160px 28px 40px;
       text-align: center;
     }
     h1 {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(32px, 5vw, 48px);
-      font-weight: 700;
-      line-height: 1.15;
-      color: #fff;
-      margin-bottom: 16px;
+      font-family: var(--sans);
+      font-size: clamp(40px, 6.5vw, 88px);
+      font-weight: 800;
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+      color: var(--ink);
+      margin-bottom: 22px;
     }
-    .rename-strike {
-      color: rgba(255, 255, 255, 0.32);
+    h1 .strike {
+      color: var(--ink-4);
       text-decoration: line-through;
-      text-decoration-thickness: 4px;
-      text-decoration-color: rgba(255, 255, 255, 0.6);
-      font-weight: 500;
-      margin-right: 0.25em;
+      text-decoration-thickness: 3px;
+      text-decoration-color: var(--ink-3);
+      font-weight: 600;
+      margin-right: 0.15em;
+    }
+    h1 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.01em;
+      background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
     }
     .subtitle {
       font-size: 18px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.5);
+      line-height: 1.55;
+      color: var(--ink-2);
       max-width: 560px;
       margin: 0 auto;
+      letter-spacing: -0.005em;
     }
 
-    /* Section */
     .section {
       position: relative;
-      z-index: 1;
-      max-width: 820px;
+      z-index: 2;
+      max-width: 1080px;
       margin: 0 auto;
-      padding: 0 24px;
+      padding: 60px 28px 0;
     }
     .section-label {
-      font-family: 'Barlow', sans-serif;
-      font-size: 13px;
-      font-weight: 600;
-      letter-spacing: 2.5px;
+      font-family: var(--mono);
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
-      color: #7c6bff;
-      margin-bottom: 20px;
-      margin-top: 80px;
+      color: var(--ink-4);
+      margin-bottom: 22px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .section-label::before {
+      content: '';
+      width: 22px; height: 1px;
+      background: rgba(139, 118, 255, 0.5);
     }
 
     /* Plugin grid */
     .plugins {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
       gap: 16px;
     }
     .plugin-card {
-      background: rgba(17, 19, 34, 0.88);
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.86) 0%, rgba(14, 16, 34, 0.86) 100%);
       backdrop-filter: blur(20px);
       -webkit-backdrop-filter: blur(20px);
-      border: 2px solid rgba(124, 107, 255, 0.14);
+      border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 16px;
-      padding: 24px;
+      padding: 22px;
       display: flex;
       flex-direction: column;
       gap: 14px;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+      box-shadow:
+        0 12px 36px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
       transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
     }
     .plugin-card:hover {
-      border-color: rgba(124, 107, 255, 0.4);
-      box-shadow: 0 12px 36px rgba(0, 0, 0, 0.4);
+      border-color: rgba(139, 118, 255, 0.32);
+      box-shadow:
+        0 16px 48px rgba(0, 0, 0, 0.45),
+        0 0 0 1px rgba(139, 118, 255, 0.10),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08);
       transform: translateY(-2px);
     }
     .plugin-header {
@@ -143,36 +113,38 @@
       gap: 12px;
     }
     .plugin-name {
-      font-family: 'Barlow', sans-serif;
-      font-size: 20px;
-      font-weight: 700;
-      color: #fff;
+      font-family: var(--sans);
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--ink);
+      letter-spacing: -0.01em;
     }
     .plugin-author {
-      font-size: 12px;
-      color: rgba(255, 255, 255, 0.4);
-      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      color: var(--ink-4);
+      font-family: var(--mono);
     }
     .plugin-author a {
       color: inherit;
       text-decoration: none;
       transition: color 0.15s;
     }
-    .plugin-author a:hover { color: #a99eff; }
+    .plugin-author a:hover { color: var(--accent-2); }
     .plugin-desc {
       font-size: 14px;
       line-height: 1.6;
-      color: rgba(255, 255, 255, 0.55);
+      color: var(--ink-2);
       flex-grow: 1;
     }
     .plugin-install {
       position: relative;
-      background: rgba(8, 9, 18, 0.9);
+      background: rgba(8, 10, 22, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.05);
       border-radius: 8px;
-      padding: 10px 44px 10px 12px;
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 11px;
-      color: #a99eff;
+      padding: 10px 50px 10px 12px;
+      font-family: var(--mono);
+      font-size: 11.5px;
+      color: var(--accent-2);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -182,24 +154,24 @@
       top: 50%;
       right: 6px;
       transform: translateY(-50%);
-      background: rgba(124, 107, 255, 0.12);
-      border: 1px solid rgba(124, 107, 255, 0.2);
-      color: rgba(255, 255, 255, 0.5);
+      background: rgba(139, 118, 255, 0.12);
+      border: 1px solid rgba(139, 118, 255, 0.22);
+      color: var(--ink-2);
       font-size: 10px;
-      font-family: 'IBM Plex Mono', monospace;
-      padding: 4px 8px;
+      font-family: var(--mono);
+      padding: 4px 9px;
       border-radius: 5px;
       cursor: pointer;
       transition: all 0.15s;
     }
     .copy-inline:hover {
-      background: rgba(124, 107, 255, 0.25);
+      background: rgba(139, 118, 255, 0.22);
       color: #fff;
     }
     .copy-inline.copied {
-      background: rgba(80, 200, 120, 0.15);
-      border-color: rgba(80, 200, 120, 0.3);
-      color: rgba(80, 200, 120, 0.9);
+      background: rgba(74, 222, 128, 0.15);
+      border-color: rgba(74, 222, 128, 0.30);
+      color: rgba(74, 222, 128, 0.95);
     }
     .copy-inline.error {
       background: rgba(248, 113, 113, 0.15);
@@ -216,222 +188,244 @@
       display: inline-flex;
       align-items: center;
       gap: 6px;
-      font-size: 12px;
-      color: rgba(255, 255, 255, 0.4);
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-3);
       text-decoration: none;
       transition: color 0.15s;
     }
-    .plugin-link:hover { color: #a99eff; }
+    .plugin-link:hover { color: var(--accent-2); }
 
-    /* Empty / error / loading states */
     .state {
       text-align: center;
       padding: 40px 24px;
-      color: rgba(255, 255, 255, 0.4);
+      color: var(--ink-3);
       font-size: 14px;
     }
     .state a {
-      color: #a99eff;
+      color: var(--accent-2);
       text-decoration: none;
+      border-bottom: 1px dotted rgba(169, 158, 255, 0.4);
     }
-    .state a:hover { color: #fff; }
+    .state a:hover { color: #fff; border-bottom-color: #fff; }
 
     /* Submit CTA */
     .submit-section {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 640px;
       margin: 80px auto 0;
-      padding: 0 24px;
+      padding: 0 28px;
       text-align: center;
     }
     .submit-card {
-      background: rgba(17, 19, 34, 0.88);
-      border: 2px solid rgba(124, 107, 255, 0.14);
-      border-radius: 16px;
-      padding: 32px 24px;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.92) 0%, rgba(14, 16, 34, 0.92) 100%);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 18px;
+      padding: 36px 28px;
+      box-shadow:
+        0 16px 56px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
+      position: relative;
+      isolation: isolate;
+    }
+    .submit-card::before {
+      content: '';
+      position: absolute;
+      inset: -40px -24px;
+      background:
+        radial-gradient(ellipse 60% 50% at 30% 10%, rgba(139, 118, 255, 0.22) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 60% at 80% 90%, rgba(123, 231, 255, 0.14) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
     }
     .submit-title {
-      font-family: 'Barlow', sans-serif;
+      font-family: var(--sans);
       font-size: 28px;
       font-weight: 700;
-      color: #fff;
+      letter-spacing: -0.02em;
+      color: var(--ink);
       margin-bottom: 8px;
     }
     .submit-desc {
       font-size: 14px;
-      color: rgba(255, 255, 255, 0.5);
-      line-height: 1.7;
-      margin-bottom: 20px;
+      color: var(--ink-2);
+      line-height: 1.65;
+      margin-bottom: 22px;
     }
-    .submit-cta {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 12px 22px;
-      background: #7c6bff;
-      color: #fff;
-      font-size: 14px;
-      font-weight: 500;
-      border-radius: 9999px;
-      text-decoration: none;
-      box-shadow: 0 4px 20px rgba(124, 107, 255, 0.3);
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
-      position: relative;
-      overflow: hidden;
-    }
-    .submit-cta:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 32px rgba(124, 107, 255, 0.4);
-    }
-    @keyframes submitShimmer {
-      0% { transform: translateX(-100%) skewX(-15deg); }
-      100% { transform: translateX(200%) skewX(-15deg); }
-    }
-    .submit-cta::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.2) 50%, transparent 100%);
-      transform: translateX(-100%) skewX(-15deg);
-    }
-    .submit-cta:hover::after {
-      animation: submitShimmer 0.8s ease-in-out 1 forwards;
+    .submit-desc code {
+      font-family: var(--mono);
+      font-size: 0.9em;
+      color: var(--accent-2);
+      background: rgba(139, 118, 255, 0.10);
+      padding: 1px 6px;
+      border-radius: 4px;
     }
 
-    /* Install CTA */
+    /* Install bottom CTA */
     .install-section {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 640px;
-      margin: 60px auto 0;
-      padding: 0 24px 100px;
+      margin: 80px auto 0;
+      padding: 0 28px;
       text-align: center;
     }
     .install-label {
-      font-family: 'Barlow', sans-serif;
+      font-family: var(--sans);
       font-size: 28px;
       font-weight: 700;
-      color: #fff;
+      letter-spacing: -0.02em;
+      color: var(--ink);
       margin-bottom: 24px;
     }
+    .terminal-frame {
+      position: relative;
+      max-width: 480px;
+      margin: 0 auto;
+      isolation: isolate;
+    }
+    .terminal-frame::before {
+      content: '';
+      position: absolute;
+      inset: -30px -40px;
+      background:
+        radial-gradient(ellipse 60% 60% at 50% 100%, rgba(139, 118, 255, 0.45) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 50% at 50% 0%, rgba(123, 231, 255, 0.20) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
+    }
     .terminal {
-      background: rgba(8, 9, 18, 0.95);
-      border: 2px solid rgba(124, 107, 255, 0.14);
-      border-radius: 12px;
-      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      background: rgba(13, 16, 36, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.6);
       overflow: hidden;
+      backdrop-filter: blur(14px);
       text-align: left;
     }
     .terminal-bar {
       display: flex;
       align-items: center;
-      padding: 12px 16px;
-      background: rgba(0, 0, 0, 0.25);
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.04);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
       position: relative;
     }
     .terminal-dots { display: flex; gap: 6px; }
     .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
     .terminal-title {
       position: absolute; left: 0; right: 0; text-align: center;
-      font-size: 11px; color: rgba(255,255,255,0.25);
-      font-family: 'IBM Plex Mono', monospace; pointer-events: none;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-4);
+      letter-spacing: 0.06em;
+      pointer-events: none;
     }
     .terminal-body {
-      padding: 20px 24px 24px;
+      padding: 22px 24px;
       display: flex; flex-direction: column; gap: 10px;
     }
-    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
-    .terminal-line code { font-family: 'IBM Plex Mono', monospace; font-size: clamp(16px, 2.5vw, 20px); color: #a99eff; }
-
-    /* Footer */
-    .footer {
-      position: relative;
-      z-index: 1;
-      text-align: center;
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.3);
-      padding: 0 24px 60px;
-    }
-    .footer .heart { color: #e25555; }
-    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
-    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
+    .terminal-line .prompt { color: var(--ink-4); font-family: var(--mono); font-size: 14px; }
+    .terminal-line code { font-family: var(--mono); font-size: clamp(15px, 2.2vw, 18px); color: var(--accent-2); }
 
     @media (max-width: 600px) {
-      .hero { padding-top: 100px; }
+      .hero { padding-top: 110px; }
       .plugins { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
-  <div class="bg"></div>
-
-  <div class="back-nav">
-    <div class="back-bar">
-      <a class="back-link" href="/">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
-        </svg>
-        oyster.to
-      </a>
-    </div>
+  <div class="cosmos" aria-hidden="true">
+    <div class="stars stars-far" id="stars-far"></div>
+    <div class="stars stars-near" id="stars-near"></div>
   </div>
 
-  <div class="hero">
-    <h1><span class="rename-strike" aria-hidden="true">Plugins.</span> Pearls.</h1>
+  <nav class="nav">
+    <a href="/"><img src="logo.png" alt="Oyster" class="nav-logo" /></a>
+    <a href="/#install">Install</a>
+    <a href="/plugins" class="active">Plugins</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/changelog">Changelog</a>
+  </nav>
+
+  <section class="hero">
+    <h1><span class="strike" aria-hidden="true">Plugins.</span> <span class="accent">Pearls.</span></h1>
     <p class="subtitle">Apps, tools, and widgets the community drops inside your shell. Install any with a single command.</p>
-  </div>
+  </section>
 
-  <div class="section">
+  <section class="section">
     <div class="section-label">Available</div>
     <div id="plugins" class="plugins">
       <div class="state">Loading plugins&hellip;</div>
     </div>
-  </div>
+  </section>
 
-  <div class="submit-section">
+  <section class="submit-section">
     <div class="submit-card">
       <div class="submit-title">Built a plugin?</div>
-      <p class="submit-desc">The registry is an open repo. Submit a PR adding one entry to <code style="font-family:'IBM Plex Mono', monospace; color:#a99eff;">community-plugins.json</code> and your plugin lands here.</p>
-      <a class="submit-cta" href="https://github.com/mattslight/oyster-community-plugins">
+      <p class="submit-desc">The registry is an open repo. Submit a PR adding one entry to <code>community-plugins.json</code> and your plugin lands here.</p>
+      <a class="cta cta-primary" href="https://github.com/mattslight/oyster-community-plugins">
         Submit a plugin
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M7 17l10-10"/><path d="M7 7h10v10"/>
-        </svg>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17l10-10"/><path d="M7 7h10v10"/></svg>
       </a>
     </div>
-  </div>
+  </section>
 
-  <div class="install-section">
+  <section class="install-section">
     <div class="install-label">Don't have Oyster yet?</div>
-    <div class="terminal">
-      <div class="terminal-bar">
-        <div class="terminal-dots">
-          <span style="background: #ff5f57;"></span>
-          <span style="background: #febc2e;"></span>
-          <span style="background: #28c840;"></span>
+    <div class="terminal-frame">
+      <div class="terminal">
+        <div class="terminal-bar">
+          <div class="terminal-dots">
+            <span style="background: #ff5f57;"></span>
+            <span style="background: #febc2e;"></span>
+            <span style="background: #28c840;"></span>
+          </div>
+          <span class="terminal-title">terminal</span>
         </div>
-        <span class="terminal-title">terminal</span>
-      </div>
-      <div class="terminal-body">
-        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
-        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+        <div class="terminal-body">
+          <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+          <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <div class="footer">
+  <div class="site-footer">
     <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
   </div>
 
   <script>
+    // Generate sparse starfield
+    (function () {
+      function seed(s) { return function () { s = (s * 9301 + 49297) % 233280; return s / 233280; }; }
+      const rand = seed(42);
+      function makeStars(el, count, twinkle) {
+        if (!el) return;
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const d = document.createElement('div');
+          d.style.left = (rand() * 100).toFixed(2) + '%';
+          d.style.top = (rand() * 100).toFixed(2) + '%';
+          if (twinkle && rand() < 0.18) {
+            d.classList.add('star-twinkle');
+            d.style.setProperty('--dur', (2.5 + rand() * 4).toFixed(2) + 's');
+            d.style.setProperty('--delay', (rand() * 5).toFixed(2) + 's');
+          }
+          frag.appendChild(d);
+        }
+        el.appendChild(frag);
+      }
+      makeStars(document.getElementById('stars-far'), 80, false);
+      makeStars(document.getElementById('stars-near'), 22, true);
+    })();
+
     const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-community-plugins/main/community-plugins.json";
     const FALLBACK_URL = "https://cdn.jsdelivr.net/gh/mattslight/oyster-community-plugins@main/community-plugins.json";
 
-    // Strict patterns — the registry is user-submitted via PR, and the
-    // install command is copied into a user's shell. Reject anything that
-    // could smuggle shell metacharacters through `id` / `repo`.
     const ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
     const REPO_PATTERN = /^[A-Za-z0-9_.-]{1,64}\/[A-Za-z0-9_.-]{1,64}$/;
 
@@ -463,7 +457,6 @@
     }
 
     function installCommand(plugin) {
-      // id has been validated against strict patterns; safe to interpolate.
       return `oyster install ${plugin.id}`;
     }
 
@@ -499,9 +492,7 @@
     }
 
     function setCopyState(btn, label, cls) {
-      if (btn._copyTimeoutId) {
-        clearTimeout(btn._copyTimeoutId);
-      }
+      if (btn._copyTimeoutId) clearTimeout(btn._copyTimeoutId);
       btn.textContent = label;
       btn.classList.remove("copied", "error");
       if (cls) btn.classList.add(cls);

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -16,6 +16,62 @@
       padding: 170px 28px 0;
       text-align: center;
     }
+
+    /* Constellation — quiet space accent, off-axis so it doesn't fight the headline */
+    .constellation {
+      position: absolute;
+      top: 140px;
+      right: -20px;
+      width: 200px;
+      height: 240px;
+      pointer-events: none;
+      z-index: 1;
+      opacity: 0.85;
+    }
+    .constellation .link {
+      stroke: rgba(255, 255, 255, 0.22);
+      stroke-width: 1;
+      stroke-dasharray: 3 6;
+      fill: none;
+    }
+    .constellation .star {
+      fill: #fff;
+      filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.45));
+    }
+    .constellation .star.glow {
+      fill: var(--accent-2);
+      filter: drop-shadow(0 0 10px var(--accent-2));
+    }
+    .constellation .star.warm {
+      fill: var(--star);
+      filter: drop-shadow(0 0 8px var(--star));
+    }
+    .constellation .label {
+      fill: var(--ink-4);
+      font-family: var(--mono);
+      font-size: 8px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .constellation .twinkle {
+      animation: hero-twinkle var(--dur, 4s) ease-in-out infinite;
+      animation-delay: var(--delay, 0s);
+      transform-origin: center;
+      transform-box: fill-box;
+    }
+    @keyframes hero-twinkle {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .constellation .twinkle { animation: none; }
+    }
+    @media (max-width: 900px) {
+      .constellation { opacity: 0.6; width: 150px; height: 180px; top: 80px; }
+    }
+    @media (max-width: 640px) {
+      .constellation { display: none; }
+    }
     h1 {
       font-family: var(--sans);
       font-size: clamp(48px, 8vw, 96px);
@@ -68,12 +124,12 @@
     }
     .pro-eyebrow {
       font-family: var(--mono);
-      font-size: 11px;
+      font-size: 13px;
       font-weight: 600;
-      letter-spacing: 0.18em;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
       color: var(--star);
-      margin-bottom: 14px;
+      margin-bottom: 16px;
     }
     .hero-strong-tight {
       font-family: var(--sans);
@@ -81,7 +137,7 @@
       font-weight: 500;
       line-height: 1.25;
       letter-spacing: -0.015em;
-      color: var(--ink);
+      color: var(--ink-2);
       margin-bottom: 14px;
     }
     .hero-strong-tight .accent {
@@ -91,6 +147,7 @@
       letter-spacing: -0.005em;
       color: var(--accent-2);
     }
+    .hero-strong-tight .bright { color: var(--ink); font-weight: 600; }
     .subtitle {
       font-size: 16px;
       line-height: 1.65;
@@ -496,12 +553,34 @@
   </nav>
 
   <section class="hero">
+    <!-- Ursa Minor — the Little Dipper. Polaris (the North Star) is the
+         brightest, top-right; Kochab marks the bottom-right of the bowl.
+         A guiding-star metaphor for "mission control". -->
+    <svg class="constellation" viewBox="0 0 200 240" aria-hidden="true">
+      <!-- Handle: Polaris → Yildun → Epsilon → Zeta -->
+      <path class="link" d="M 170 40 L 145 80"/>
+      <path class="link" d="M 145 80 L 120 120"/>
+      <path class="link" d="M 120 120 L 100 160"/>
+      <!-- Bowl: Zeta → Eta → Kochab → Pherkad → Zeta -->
+      <path class="link" d="M 100 160 L 50 150"/>
+      <path class="link" d="M 50 150 L 40 210"/>
+      <path class="link" d="M 40 210 L 90 215"/>
+      <path class="link" d="M 90 215 L 100 160"/>
+      <!-- Stars: Polaris = accent glow; Kochab = warm; rest white -->
+      <circle class="star glow twinkle" style="--dur: 4s;" cx="170" cy="40" r="3.5"/>
+      <circle class="star twinkle" style="--dur: 5.5s; --delay: 1.2s;" cx="145" cy="80" r="1.8"/>
+      <circle class="star twinkle" style="--dur: 4.5s; --delay: 0.6s;" cx="120" cy="120" r="2"/>
+      <circle class="star twinkle" style="--dur: 6s; --delay: 1.8s;" cx="100" cy="160" r="2.2"/>
+      <circle class="star twinkle" style="--dur: 5s; --delay: 2.4s;" cx="50" cy="150" r="2"/>
+      <circle class="star twinkle" style="--dur: 5.5s; --delay: 0.9s;" cx="40" cy="210" r="1.6"/>
+      <circle class="star warm twinkle" style="--dur: 4.2s; --delay: 1.5s;" cx="90" cy="215" r="2.8"/>
+    </svg>
     <h1>Free <span class="accent">without</span> limits.</h1>
     <p class="hero-strong">No sign-up. No strings. Yours to keep.</p>
     <div class="pro-stanza">
       <div class="pro-eyebrow">Oyster Pro</div>
-      <p class="hero-strong-tight">Smarter work — <span class="accent">anywhere</span>, any device, any agent.</p>
-      <p class="subtitle">Optional. Adds <strong>Sync</strong>, <strong>Memory</strong>, and <strong>Publish</strong>.</p>
+      <p class="hero-strong-tight">Smarter work — <span class="accent">anywhere</span>, <span class="bright">any device, any agent.</span></p>
+      <p class="subtitle">Adds <strong>Sync</strong>, <strong>Memory</strong>, and <strong>Publish</strong>.</p>
     </div>
   </section>
 
@@ -599,7 +678,7 @@
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Universal memory (local)</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Plugins &amp; MCP integration</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Bring any AI</li>
-          <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Local-only mode</li>
+          <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>Local-first — your data stays on your machine</li>
           <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>All your data, exportable</li>
         </ul>
         <a href="/#install" class="tier-cta tier-cta--ghost">Install</a>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -5,145 +5,115 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pricing — Oyster</title>
   <meta name="description" content="Oyster is free without limits — no sign-up, no strings. Oyster Pro is optional and adds Sync, Memory, and Publish — anywhere, any device, any agent.">
-  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/oyster.css">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #0a0b14;
-      color: #e0e0e0;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
-    .bg {
-      position: fixed; inset: 0;
-      background:
-        radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
-        radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
-        #0a0b14;
-      z-index: 0;
-    }
-
-    /* Back nav */
-    .back-nav { position: fixed; top: 16px; left: 0; right: 0; z-index: 10; display: flex; justify-content: center; }
-    .back-bar {
-      display: inline-flex; align-items: center; gap: 8px;
-      padding: 8px 20px;
-      background: rgba(20, 22, 40, 0.9);
-      backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 9999px;
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
-    }
-    .back-link {
-      display: inline-flex; align-items: center; gap: 6px;
-      font-family: inherit; font-size: 13px; font-weight: 500;
-      color: rgba(255, 255, 255, 0.5);
-      text-decoration: none; transition: color 0.15s;
-    }
-    .back-link:hover { color: #fff; }
-
     /* Hero */
     .hero {
-      position: relative; z-index: 1;
-      max-width: 760px; margin: 0 auto;
-      padding: 140px 24px 0;
+      position: relative;
+      z-index: 2;
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 170px 28px 0;
       text-align: center;
     }
-    .eyebrow {
-      display: inline-flex; align-items: center; gap: 8px;
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
-      color: #fbbf24;
-      margin-bottom: 18px;
-    }
-    .eyebrow-pill {
-      padding: 2px 8px; border-radius: 999px;
-      background: rgba(124, 107, 255, 0.18);
-      color: #a99eff;
-      font-size: 9px; font-weight: 600; letter-spacing: 0.06em;
-    }
     h1 {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(48px, 8vw, 80px);
-      font-weight: 700; line-height: 1.05;
-      color: #fff; margin-bottom: 18px;
-      letter-spacing: -0.02em;
+      font-family: var(--sans);
+      font-size: clamp(48px, 8vw, 96px);
+      font-weight: 800;
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+      color: var(--ink);
+      margin-bottom: 22px;
     }
-    /* Slogan accent — chunky purple underline under the headline phrase,
-       à la Obsidian's green underline. Marks the line as a brand promise
-       rather than a feature claim. */
-    .headline-mark {
-      display: inline-block;
-      padding-bottom: 6px;
-      border-bottom: 5px solid #7c6bff;
-      border-radius: 2px;
+    h1 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
     }
     .hero-strong {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(20px, 3vw, 28px);
-      font-weight: 700; line-height: 1.35;
-      color: #fff;
-      margin-bottom: 0;
-    }
-    .hero-strong-tight {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(18px, 2.4vw, 22px);
-      font-weight: 600; line-height: 1.4;
-      color: #fff;
-      margin-bottom: 10px;
+      font-family: var(--sans);
+      font-size: clamp(20px, 2.4vw, 24px);
+      font-weight: 500;
+      line-height: 1.45;
+      color: var(--ink);
+      letter-spacing: -0.01em;
     }
     .pro-stanza {
-      margin-top: 80px;
+      position: relative;
+      margin-top: 56px;
+      padding-top: 48px;
     }
-    .pro-eyebrow-plain {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 12px; letter-spacing: 0.22em; text-transform: uppercase;
-      color: #fbbf24;
-      margin-bottom: 12px;
+    .pro-stanza::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 50%;
+      transform: translateX(-50%);
+      width: 280px; height: 1px;
+      background: linear-gradient(90deg, transparent, rgba(139, 118, 255, 0.4), transparent);
+    }
+    .pro-stanza::after {
+      content: '';
+      position: absolute;
+      top: -3px; left: 50%;
+      transform: translateX(-50%);
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 10px var(--accent);
+    }
+    .pro-eyebrow {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--star);
+      margin-bottom: 14px;
+    }
+    .hero-strong-tight {
+      font-family: var(--sans);
+      font-size: clamp(22px, 3vw, 32px);
+      font-weight: 700;
+      line-height: 1.1;
+      letter-spacing: -0.02em;
+      color: var(--ink);
+      margin-bottom: 14px;
+    }
+    .hero-strong-tight .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      color: var(--accent-2);
     }
     .subtitle {
-      font-size: 16px; line-height: 1.65;
-      color: rgba(255, 255, 255, 0.55);
-      max-width: 560px; margin: 0 auto;
+      font-size: 16px;
+      line-height: 1.65;
+      color: var(--ink-2);
+      max-width: 560px;
+      margin: 0 auto;
     }
-    .subtitle strong { color: rgba(255, 255, 255, 0.8); font-weight: 600; }
-    .hero-ctas { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
-    .cta {
-      display: inline-flex; align-items: center; gap: 8px;
-      padding: 12px 22px; border-radius: 9999px;
-      font-family: inherit; font-size: 14px; font-weight: 600;
-      text-decoration: none; cursor: pointer;
-      transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s, background 0.15s;
-      border: 1px solid transparent;
-    }
-    .cta--primary {
-      background: #7c6bff; color: #fff;
-      box-shadow: 0 4px 20px rgba(124, 107, 255, 0.3);
-      opacity: 0.7; cursor: not-allowed;
-    }
-    .cta--secondary {
-      background: transparent; color: #fff;
-      border-color: rgba(255, 255, 255, 0.18);
-    }
-    .cta--secondary:hover {
-      background: rgba(255, 255, 255, 0.04);
-      border-color: rgba(255, 255, 255, 0.32);
-    }
+    .subtitle strong { color: var(--ink); font-weight: 600; }
 
-    /* Primitives — Sync / Memory / Publish */
+    /* Primitive sticky cards */
     .primitives {
-      position: relative; z-index: 1;
+      position: relative; z-index: 2;
       max-width: 980px; margin: 0 auto;
-      padding: 160px 24px 0;
+      padding: 140px 28px 0;
     }
     .primitive {
       background: rgba(17, 19, 34, 0.96);
       backdrop-filter: blur(24px); -webkit-backdrop-filter: blur(24px);
-      border: 1px solid rgba(124, 107, 255, 0.18);
+      border: 1px solid rgba(139, 118, 255, 0.18);
       border-radius: 22px;
       padding: 48px 44px;
-      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55), 0 2px 0 rgba(255, 255, 255, 0.03) inset;
+      box-shadow:
+        0 24px 60px rgba(0, 0, 0, 0.55),
+        inset 0 2px 0 rgba(255, 255, 255, 0.03);
       display: grid;
       grid-template-columns: 56px 1fr;
       gap: 28px;
@@ -154,9 +124,9 @@
       margin-bottom: 140px;
       transition: transform 0.3s ease-out;
     }
-    .primitive:nth-child(1) { top: 100px; }
-    .primitive:nth-child(2) { top: 144px; }
-    .primitive:nth-child(3) { top: 188px; }
+    .primitive:nth-child(1) { top: 80px; }
+    .primitive:nth-child(2) { top: 116px; }
+    .primitive:nth-child(3) { top: 152px; }
     .primitive:last-child { margin-bottom: 0; }
     .primitive-pro-tag {
       position: absolute;
@@ -164,38 +134,51 @@
       display: inline-flex; align-items: center;
       padding: 5px 11px;
       border-radius: 999px;
-      background: rgba(125, 249, 255, 0.08);
-      border: 1px solid rgba(125, 249, 255, 0.32);
-      color: #7df9ff;
-      font-family: 'IBM Plex Mono', monospace;
+      background: rgba(123, 231, 255, 0.08);
+      border: 1px solid rgba(123, 231, 255, 0.32);
+      color: var(--signal);
+      font-family: var(--mono);
       font-size: 10px;
-      font-weight: 600;
+      font-weight: 500;
       letter-spacing: 0.16em;
       text-transform: uppercase;
     }
     .primitive-icon {
       width: 56px; height: 56px;
       border-radius: 14px;
-      background: rgba(124, 107, 255, 0.14);
-      border: 1px solid rgba(124, 107, 255, 0.28);
+      background: rgba(139, 118, 255, 0.14);
+      border: 1px solid rgba(139, 118, 255, 0.28);
       display: inline-flex; align-items: center; justify-content: center;
-      color: #a99eff;
+      color: var(--accent-2);
     }
     .primitive-name {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase;
-      color: #fbbf24; margin-bottom: 6px;
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--star);
+      margin-bottom: 8px;
     }
     .primitive h2 {
-      font-family: 'Barlow', sans-serif;
-      font-size: 28px; font-weight: 700;
-      color: #fff; margin-bottom: 14px;
-      letter-spacing: -0.01em;
+      font-family: var(--sans);
+      font-size: clamp(28px, 3.4vw, 36px);
+      font-weight: 700;
+      color: var(--ink);
+      margin-bottom: 14px;
+      letter-spacing: -0.025em;
+      line-height: 1.05;
+    }
+    .primitive h2 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      color: var(--accent-2);
     }
     .primitive-desc {
-      font-size: 15px; line-height: 1.7;
-      color: rgba(255, 255, 255, 0.6);
-      margin-bottom: 20px;
+      font-size: 15px; line-height: 1.65;
+      color: var(--ink-2);
+      margin-bottom: 22px;
       max-width: 560px;
     }
     .primitive-bullets {
@@ -207,13 +190,13 @@
     .primitive-bullets li {
       display: flex; align-items: center; gap: 10px;
       font-size: 14px;
-      color: rgba(255, 255, 255, 0.7);
+      color: var(--ink-2);
     }
     .primitive-bullets li::before {
       content: ""; flex: none;
       width: 4px; height: 4px;
       border-radius: 50%;
-      background: #7c6bff; opacity: 0.7;
+      background: var(--accent); opacity: 0.7;
     }
     @media (max-width: 640px) {
       .primitives { padding-top: 96px; }
@@ -226,29 +209,35 @@
       .primitive-pro-tag { top: 16px; right: 16px; }
     }
 
-    /* Pricing */
+    /* Pricing tiers */
     .pricing {
-      position: relative; z-index: 1;
+      position: relative; z-index: 2;
       max-width: 980px; margin: 96px auto 120px;
-      padding: 0 24px;
+      padding: 0 28px;
     }
-    .pricing-head {
-      text-align: center;
-      margin-bottom: 36px;
+    .pricing-head { text-align: center; margin-bottom: 40px; }
+    .pricing-h2 {
+      font-family: var(--sans);
+      font-size: clamp(34px, 4.5vw, 56px);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1.02;
+      color: var(--ink);
+      margin-bottom: 14px;
     }
-    .pricing-label {
-      font-family: 'Barlow', sans-serif;
-      font-size: 13px; font-weight: 600;
-      letter-spacing: 2.5px; text-transform: uppercase;
-      color: #7c6bff;
-      margin-bottom: 12px;
+    .pricing-h2 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      color: var(--accent-2);
     }
     .pricing-sub {
-      font-size: 15px; line-height: 1.6;
-      color: rgba(255, 255, 255, 0.55);
+      font-size: 16px; line-height: 1.6;
+      color: var(--ink-2);
       max-width: 540px; margin: 0 auto;
     }
-    .pricing-sub strong { color: #fff; font-weight: 700; }
+    .pricing-sub strong { color: var(--ink); font-weight: 600; }
     .pricing-grid {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
@@ -259,158 +248,165 @@
     }
     .tier {
       position: relative;
-      background: rgba(17, 19, 34, 0.88);
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.92) 0%, rgba(14, 16, 34, 0.92) 100%);
       backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      border-radius: 16px;
+      border: 1px solid rgba(255, 255, 255, 0.10);
+      border-radius: 18px;
       padding: 32px;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+      box-shadow:
+        0 12px 40px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06);
     }
     .tier--featured {
-      background: #111322;
-      backdrop-filter: none;
-      -webkit-backdrop-filter: none;
-      border-color: rgba(125, 249, 255, 0.7);
+      border-color: rgba(123, 231, 255, 0.5);
       box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.08),
-        0 0 0 1px rgba(125, 249, 255, 0.4),
-        0 0 10px rgba(125, 249, 255, 0.5),
-        0 0 24px rgba(125, 249, 255, 0.28),
-        0 0 50px rgba(125, 249, 255, 0.14),
-        0 12px 40px rgba(0, 0, 0, 0.5);
-    }
-    .tier:not(.tier--featured) {
-      z-index: 2;
+        inset 0 1px 0 rgba(255, 255, 255, 0.10),
+        0 0 0 1px rgba(123, 231, 255, 0.3),
+        0 0 24px rgba(123, 231, 255, 0.2),
+        0 0 60px rgba(123, 231, 255, 0.10),
+        0 16px 50px rgba(0, 0, 0, 0.5);
     }
     .tier-name {
-      font-family: 'Barlow', sans-serif;
-      font-size: 34px; font-weight: 700;
-      color: #fff;
-      letter-spacing: -0.02em;
-      line-height: 1.1;
+      font-family: var(--sans);
+      font-size: 32px;
+      font-weight: 700;
+      color: var(--ink);
+      letter-spacing: -0.025em;
+      line-height: 1.05;
     }
     .tier-tagline {
-      font-size: 19px; color: rgba(255, 255, 255, 0.7);
-      margin-top: 8px;
-      margin-bottom: 32px;
+      font-family: var(--sans);
+      font-size: 18px;
+      color: var(--ink-2);
+      margin-top: 6px;
+      margin-bottom: 28px;
     }
     .tier-price {
       display: flex; align-items: baseline; gap: 8px;
       margin-bottom: 16px;
     }
     .tier-price-amount {
-      font-family: 'Barlow', sans-serif;
+      font-family: var(--sans);
       font-size: 56px; font-weight: 700;
-      color: #fff; line-height: 1;
+      color: var(--ink); line-height: 1;
+      letter-spacing: -0.03em;
     }
     .tier-price-amount::first-letter {
       font-size: 0.55em;
-      font-weight: 600;
+      font-weight: 500;
       vertical-align: 0.45em;
       margin-right: 2px;
-      color: rgba(255, 255, 255, 0.7);
+      color: var(--ink-2);
     }
     .tier-price-unit {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 12px;
-      color: rgba(255, 255, 255, 0.4);
+      color: var(--ink-4);
     }
     .tier-price-note {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 11px;
-      color: rgba(255, 255, 255, 0.4);
+      color: var(--ink-4);
       margin-bottom: 22px;
       letter-spacing: 0.04em;
     }
     .tier-pledge {
       display: flex; flex-wrap: wrap;
       gap: 0 14px;
-      font-family: 'Space Grotesk', sans-serif;
-      font-size: 13px; font-weight: 600;
-      color: #a99eff;
+      font-family: var(--sans);
+      font-size: 13px; font-weight: 500;
+      color: var(--accent-2);
       margin-bottom: 22px;
-      letter-spacing: 0.01em;
     }
-    .tier-pledge .sep {
-      color: rgba(169, 158, 255, 0.45);
-    }
+    .tier-pledge .sep { color: rgba(169, 158, 255, 0.45); }
     .tier-coming {
       display: inline-flex; align-items: center;
       padding: 4px 10px; border-radius: 999px;
-      background: rgba(124, 107, 255, 0.18);
-      color: #a99eff;
-      font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+      background: rgba(139, 118, 255, 0.18);
+      color: var(--accent-2);
+      font-family: var(--mono);
+      font-size: 10px; font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
       margin-bottom: 18px;
     }
     .tier-features {
       list-style: none;
       display: flex; flex-direction: column; gap: 10px;
-      margin-bottom: 24px;
+      margin-bottom: 26px;
     }
     .tier-features li {
       display: flex; align-items: flex-start; gap: 10px;
       font-size: 14px; line-height: 1.5;
-      color: rgba(255, 255, 255, 0.7);
+      color: var(--ink-2);
     }
-    .tier-features svg { flex: none; margin-top: 3px; color: #7c6bff; }
-    .tier-features li.tier-features-plus { font-weight: 500; color: #fff; }
-    .tier-features li.tier-features-add svg { color: #fbbf24; }
+    .tier-features svg { flex: none; margin-top: 3px; color: var(--accent); }
+    .tier-features li.tier-features-plus { font-weight: 500; color: var(--ink); }
+    .tier-features li.tier-features-add svg { color: var(--star); }
     .tier-feature-primitive-name {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 11px;
-      letter-spacing: 0.16em;
+      letter-spacing: 0.14em;
       text-transform: uppercase;
-      color: #fbbf24;
+      color: var(--star);
     }
     .tier-cta {
       display: inline-flex; align-items: center; gap: 8px;
-      padding: 11px 22px; border-radius: 9999px;
-      font-family: inherit; font-size: 13px; font-weight: 600;
+      padding: 12px 24px; border-radius: 9999px;
+      font-family: var(--sans); font-size: 13px; font-weight: 500;
       text-decoration: none; cursor: pointer;
       border: 1px solid transparent;
       transition: background 0.15s, border-color 0.15s, transform 0.15s;
     }
     .tier-cta--ghost {
       background: rgba(255, 255, 255, 0.04);
-      color: rgba(255, 255, 255, 0.6);
+      color: var(--ink-2);
       border-color: rgba(255, 255, 255, 0.12);
       cursor: default;
     }
+    .tier-cta--ghost:hover { background: rgba(255, 255, 255, 0.08); color: var(--ink); }
     .tier-cta--primary {
-      background: #7c6bff; color: #fff;
-      box-shadow: 0 4px 20px rgba(124, 107, 255, 0.3);
+      background: linear-gradient(180deg, #9d8cff 0%, #8b76ff 100%);
+      color: #fff;
+      box-shadow: 0 4px 20px rgba(139, 118, 255, 0.4);
       cursor: pointer;
-      transition: background 0.15s, transform 0.05s, box-shadow 0.15s;
     }
     .tier-cta--primary:hover {
-      background: #8d7eff;
-      box-shadow: 0 6px 24px rgba(124, 107, 255, 0.4);
+      box-shadow: 0 6px 28px rgba(139, 118, 255, 0.5);
+      transform: translateY(-1px);
     }
     .tier-cta--primary:active { transform: scale(0.98); }
+    .tier-fineprint {
+      display: block;
+      font-family: var(--mono);
+      font-size: 10px;
+      color: var(--ink-4);
+      margin-top: 12px;
+      letter-spacing: 0.04em;
+    }
 
     /* Waitlist modal */
     .waitlist-modal {
-      position: fixed; inset: 0; z-index: 100;
+      position: fixed; inset: 0; z-index: 200;
       display: flex; align-items: center; justify-content: center;
       padding: 24px;
     }
     .waitlist-modal[hidden] { display: none; }
     .waitlist-modal-backdrop {
       position: absolute; inset: 0;
-      background: rgba(5, 8, 16, 0.72);
+      background: rgba(4, 6, 13, 0.78);
       backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
     }
     .waitlist-modal-card {
       position: relative;
-      background: #111322;
-      border: 1px solid rgba(125, 249, 255, 0.4);
+      background: linear-gradient(180deg, rgba(20, 23, 44, 0.96) 0%, rgba(14, 16, 34, 0.96) 100%);
+      border: 1px solid rgba(123, 231, 255, 0.32);
       border-radius: 18px;
       padding: 32px 30px 28px;
       max-width: 440px; width: 100%;
       box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.06),
-        0 0 0 1px rgba(125, 249, 255, 0.2),
-        0 0 24px rgba(125, 249, 255, 0.22),
+        inset 0 1px 0 rgba(255, 255, 255, 0.06),
+        0 0 24px rgba(123, 231, 255, 0.22),
         0 24px 80px rgba(0, 0, 0, 0.6);
       animation: waitlist-rise 0.22s ease-out;
     }
@@ -422,22 +418,20 @@
       position: absolute; top: 10px; right: 12px;
       width: 32px; height: 32px;
       background: transparent; border: none;
-      color: rgba(255, 255, 255, 0.5);
+      color: var(--ink-3);
       font-family: inherit; font-size: 22px; line-height: 1;
       cursor: pointer; border-radius: 999px;
       transition: color 0.15s, background 0.15s;
     }
-    .waitlist-modal-close:hover {
-      color: #fff; background: rgba(255, 255, 255, 0.06);
-    }
+    .waitlist-modal-close:hover { color: var(--ink); background: rgba(255, 255, 255, 0.06); }
     .waitlist-modal-card h3 {
-      font-family: 'Barlow', sans-serif;
-      font-size: 22px; font-weight: 700; color: #fff;
+      font-family: var(--sans);
+      font-size: 22px; font-weight: 700; color: var(--ink);
       margin-bottom: 8px; letter-spacing: -0.01em;
     }
     .waitlist-modal-blurb {
       font-size: 14px; line-height: 1.5;
-      color: rgba(255, 255, 255, 0.55);
+      color: var(--ink-2);
       margin-bottom: 22px;
     }
     .waitlist-modal-form { display: flex; gap: 8px; }
@@ -448,68 +442,62 @@
       border: 1px solid rgba(255, 255, 255, 0.12);
       border-radius: 9999px;
       font-family: inherit; font-size: 14px;
-      color: #fff; outline: none;
+      color: var(--ink); outline: none;
       transition: border-color 0.15s, background 0.15s;
     }
-    .waitlist-modal-form input[type=email]::placeholder { color: rgba(255, 255, 255, 0.3); }
+    .waitlist-modal-form input[type=email]::placeholder { color: var(--ink-4); }
     .waitlist-modal-form input[type=email]:focus {
-      border-color: rgba(125, 249, 255, 0.6);
+      border-color: rgba(123, 231, 255, 0.6);
       background: rgba(255, 255, 255, 0.06);
     }
     .waitlist-submit {
       padding: 12px 22px;
-      background: #7df9ff; color: #050810;
+      background: var(--signal); color: #050810;
       border: none; border-radius: 9999px;
-      font-family: inherit; font-size: 14px; font-weight: 600;
+      font-family: var(--sans); font-size: 14px; font-weight: 600;
       cursor: pointer; white-space: nowrap;
       transition: background 0.15s, transform 0.05s;
     }
     .waitlist-submit:hover { background: #a5fbff; }
     .waitlist-submit:active { transform: scale(0.98); }
     .waitlist-submit:disabled {
-      background: rgba(125, 249, 255, 0.35);
+      background: rgba(123, 231, 255, 0.35);
       color: rgba(5, 8, 16, 0.6);
       cursor: not-allowed;
     }
     .waitlist-modal-status {
       margin-top: 14px;
       font-size: 13px; line-height: 1.5;
-      color: rgba(255, 255, 255, 0.6);
+      color: var(--ink-2);
     }
-    .waitlist-modal-status.is-success { color: #7df9ff; }
-    .waitlist-modal-status.is-error { color: #ff8a8a; }
+    .waitlist-modal-status.is-success { color: var(--signal); }
+    .waitlist-modal-status.is-error { color: var(--bad); }
     @media (max-width: 480px) {
       .waitlist-modal-form { flex-direction: column; }
       .waitlist-submit { width: 100%; }
     }
-    .tier-fineprint {
-      display: block;
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 10px;
-      color: rgba(255, 255, 255, 0.35);
-      margin-top: 10px;
-      letter-spacing: 0.04em;
-    }
   </style>
 </head>
 <body>
-  <div class="bg"></div>
+  <div class="cosmos" aria-hidden="true">
+    <div class="stars stars-far" id="stars-far"></div>
+    <div class="stars stars-near" id="stars-near"></div>
+  </div>
 
-  <nav class="back-nav">
-    <div class="back-bar">
-      <a href="/" class="back-link">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
-        Back to Oyster
-      </a>
-    </div>
+  <nav class="nav">
+    <a href="/"><img src="logo.png" alt="Oyster" class="nav-logo" /></a>
+    <a href="/#install">Install</a>
+    <a href="/plugins">Plugins</a>
+    <a href="/pricing" class="active">Pricing</a>
+    <a href="/changelog">Changelog</a>
   </nav>
 
   <section class="hero">
-    <h1><span class="headline-mark">Free without limits.</span></h1>
+    <h1>Free <span class="accent">without</span> limits.</h1>
     <p class="hero-strong">No sign-up. No strings. Yours to keep.</p>
     <div class="pro-stanza">
-      <div class="pro-eyebrow-plain">Oyster Pro</div>
-      <p class="hero-strong-tight">Smarter work — anywhere, any device, any agent.</p>
+      <div class="pro-eyebrow">Oyster Pro</div>
+      <p class="hero-strong-tight">Smarter work — <span class="accent">anywhere</span>, any device, any agent.</p>
       <p class="subtitle">Optional. Adds <strong>Sync</strong>, <strong>Memory</strong>, and <strong>Publish</strong>.</p>
     </div>
   </section>
@@ -523,7 +511,7 @@
       </span>
       <div>
         <div class="primitive-name">Sync</div>
-        <h2>Your Oyster, every device.</h2>
+        <h2>Your Oyster, <span class="accent">every</span> device.</h2>
         <p class="primitive-desc">
           Start a conversation on your laptop. Pick it up on your iPad. Your spaces, artifacts,
           and live sessions follow you between devices — switch mid-thought, no manual
@@ -545,7 +533,7 @@
       </span>
       <div>
         <div class="primitive-name">Memory</div>
-        <h2>One brain, every agent.</h2>
+        <h2>One brain, <span class="accent">every</span> agent.</h2>
         <p class="primitive-desc">
           Claude, Cursor, Codex, the next one — every agent you use shares the same memory of your work.
           Pick up a session anywhere, switch tools mid-thought, and your AI keeps the context.
@@ -567,7 +555,7 @@
       </span>
       <div>
         <div class="primitive-name">Publish</div>
-        <h2>Your artifacts, ready to share.</h2>
+        <h2>Your artifacts, <span class="accent">ready</span> to share.</h2>
         <p class="primitive-desc">
           Turn any artifact into a shareable link in one click — a deck, a wireframe, a finished piece of work.
           Public, unlisted, or password-protected. Send it to a client, post it on social, hand off
@@ -586,7 +574,7 @@
 
   <section class="pricing" id="pricing">
     <div class="pricing-head">
-      <div class="pricing-label">Pricing</div>
+      <h2 class="pricing-h2">Two plans, <span class="accent">one</span> Oyster.</h2>
       <p class="pricing-sub"><strong>Oyster stays free, forever.</strong> Pro adds Sync, Memory, and Publish for users who want their work to follow them.</p>
     </div>
     <div class="pricing-grid">
@@ -599,10 +587,8 @@
           <span class="tier-price-unit">/ month</span>
         </div>
         <div class="tier-pledge">
-          <span>No sign-up</span>
-          <span class="sep">·</span>
-          <span>No strings</span>
-          <span class="sep">·</span>
+          <span>No sign-up</span><span class="sep">·</span>
+          <span>No strings</span><span class="sep">·</span>
           <span>Yours to keep</span>
         </div>
         <ul class="tier-features">
@@ -654,91 +640,116 @@
     </div>
   </div>
 
+  <div class="site-footer">
+    <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
+  </div>
+
   <script>
-  (function () {
-    const trigger = document.querySelector('[data-waitlist-open]');
-    const modal = document.querySelector('.waitlist-modal');
-    if (!trigger || !modal) return;
-    const form = modal.querySelector('#waitlist-form');
-    const input = form.querySelector('input[name=email]');
-    const submit = form.querySelector('.waitlist-submit');
-    const status = modal.querySelector('.waitlist-modal-status');
-    const closers = modal.querySelectorAll('[data-waitlist-close]');
-
-    function setStatus(message, kind) {
-      status.hidden = !message;
-      status.className = 'waitlist-modal-status' + (kind ? ' is-' + kind : '');
-      status.textContent = message || '';
-    }
-    function reset() {
-      setStatus('', '');
-      submit.disabled = false;
-      submit.textContent = 'Join';
-      input.disabled = false;
-      form.hidden = false;
-      input.value = '';
-    }
-    function open() {
-      reset();
-      modal.hidden = false;
-      modal.setAttribute('aria-hidden', 'false');
-      requestAnimationFrame(() => input.focus());
-    }
-    function close() {
-      modal.hidden = true;
-      modal.setAttribute('aria-hidden', 'true');
-    }
-
-    trigger.addEventListener('click', open);
-    closers.forEach((c) => c.addEventListener('click', close));
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && !modal.hidden) close();
-    });
-
-    // Open the modal automatically when arriving via #waitlist
-    // (e.g. the in-app "Join the waitlist" CTA links here).
-    if (window.location.hash === '#waitlist') open();
-
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const email = input.value.trim();
-      if (!email) {
-        setStatus('Please enter your email address.', 'error');
-        input.focus();
-        return;
-      }
-
-      submit.disabled = true;
-      submit.textContent = 'Joining…';
-      setStatus('', '');
-
-      try {
-        const res = await fetch('/api/waitlist', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ email, source: 'pricing-page' }),
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok) {
-          if (data.error === 'invalid_email') {
-            setStatus("That doesn't look like a valid email.", 'error');
-          } else {
-            setStatus('Something went wrong. Please try again.', 'error');
+    // Sparse starfield
+    (function () {
+      function seed(s) { return function () { s = (s * 9301 + 49297) % 233280; return s / 233280; }; }
+      const rand = seed(42);
+      function makeStars(el, count, twinkle) {
+        if (!el) return;
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const d = document.createElement('div');
+          d.style.left = (rand() * 100).toFixed(2) + '%';
+          d.style.top = (rand() * 100).toFixed(2) + '%';
+          if (twinkle && rand() < 0.18) {
+            d.classList.add('star-twinkle');
+            d.style.setProperty('--dur', (2.5 + rand() * 4).toFixed(2) + 's');
+            d.style.setProperty('--delay', (rand() * 5).toFixed(2) + 's');
           }
-          submit.disabled = false;
-          submit.textContent = 'Join';
-          return;
+          frag.appendChild(d);
         }
-        form.hidden = true;
-        setStatus("You're on the list. Check your email for confirmation.", 'success');
-      } catch (err) {
-        setStatus('Network error. Please try again.', 'error');
+        el.appendChild(frag);
+      }
+      makeStars(document.getElementById('stars-far'), 80, false);
+      makeStars(document.getElementById('stars-near'), 22, true);
+    })();
+
+    (function () {
+      const trigger = document.querySelector('[data-waitlist-open]');
+      const modal = document.querySelector('.waitlist-modal');
+      if (!trigger || !modal) return;
+      const form = modal.querySelector('#waitlist-form');
+      const input = form.querySelector('input[name=email]');
+      const submit = form.querySelector('.waitlist-submit');
+      const status = modal.querySelector('.waitlist-modal-status');
+      const closers = modal.querySelectorAll('[data-waitlist-close]');
+
+      function setStatus(message, kind) {
+        status.hidden = !message;
+        status.className = 'waitlist-modal-status' + (kind ? ' is-' + kind : '');
+        status.textContent = message || '';
+      }
+      function reset() {
+        setStatus('', '');
         submit.disabled = false;
         submit.textContent = 'Join';
+        input.disabled = false;
+        form.hidden = false;
+        input.value = '';
       }
-    });
-  })();
-  </script>
+      function open() {
+        reset();
+        modal.hidden = false;
+        modal.setAttribute('aria-hidden', 'false');
+        requestAnimationFrame(() => input.focus());
+      }
+      function close() {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden', 'true');
+      }
 
+      trigger.addEventListener('click', open);
+      closers.forEach((c) => c.addEventListener('click', close));
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !modal.hidden) close();
+      });
+
+      if (window.location.hash === '#waitlist') open();
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = input.value.trim();
+        if (!email) {
+          setStatus('Please enter your email address.', 'error');
+          input.focus();
+          return;
+        }
+
+        submit.disabled = true;
+        submit.textContent = 'Joining…';
+        setStatus('', '');
+
+        try {
+          const res = await fetch('/api/waitlist', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ email, source: 'pricing-page' }),
+          });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok) {
+            if (data.error === 'invalid_email') {
+              setStatus("That doesn't look like a valid email.", 'error');
+            } else {
+              setStatus('Something went wrong. Please try again.', 'error');
+            }
+            submit.disabled = false;
+            submit.textContent = 'Join';
+            return;
+          }
+          form.hidden = true;
+          setStatus("You're on the list. Check your email for confirmation.", 'success');
+        } catch (err) {
+          setStatus('Network error. Please try again.', 'error');
+          submit.disabled = false;
+          submit.textContent = 'Join';
+        }
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -69,6 +69,7 @@
     .pro-eyebrow {
       font-family: var(--mono);
       font-size: 11px;
+      font-weight: 600;
       letter-spacing: 0.18em;
       text-transform: uppercase;
       color: var(--star);
@@ -76,10 +77,10 @@
     }
     .hero-strong-tight {
       font-family: var(--sans);
-      font-size: clamp(22px, 3vw, 32px);
-      font-weight: 700;
-      line-height: 1.1;
-      letter-spacing: -0.02em;
+      font-size: clamp(18px, 2.3vw, 24px);
+      font-weight: 500;
+      line-height: 1.25;
+      letter-spacing: -0.015em;
       color: var(--ink);
       margin-bottom: 14px;
     }
@@ -154,6 +155,7 @@
     .primitive-name {
       font-family: var(--mono);
       font-size: 11px;
+      font-weight: 600;
       letter-spacing: 0.18em;
       text-transform: uppercase;
       color: var(--star);
@@ -346,6 +348,7 @@
     .tier-feature-primitive-name {
       font-family: var(--mono);
       font-size: 11px;
+      font-weight: 600;
       letter-spacing: 0.14em;
       text-transform: uppercase;
       color: var(--star);

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -179,89 +179,50 @@ const html = `<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Changelog — Oyster</title>
   <meta name="description" content="Every shipped change to Oyster, newest first.">
-  <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/oyster.css">
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html { scroll-behavior: smooth; scroll-padding-top: 24px; }
-    body {
-      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
-      background: #0a0b14;
-      color: #e0e0e0;
-      min-height: 100vh;
-      overflow-x: hidden;
-    }
-    .bg {
-      position: fixed;
-      inset: 0;
-      background: radial-gradient(ellipse at 30% 20%, rgba(88, 60, 180, 0.25) 0%, transparent 60%),
-                  radial-gradient(ellipse at 70% 80%, rgba(40, 50, 160, 0.2) 0%, transparent 60%),
-                  #0a0b14;
-      z-index: 0;
-    }
-    .back-nav {
-      position: fixed;
-      top: 16px;
-      left: 0;
-      right: 0;
-      z-index: 10;
-      display: flex;
-      justify-content: center;
-    }
-    .back-bar {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      padding: 8px 20px;
-      background: rgba(20, 22, 40, 0.9);
-      backdrop-filter: blur(16px);
-      -webkit-backdrop-filter: blur(16px);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      border-radius: 9999px;
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
-    }
-    .back-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-family: inherit;
-      font-size: 13px;
-      font-weight: 500;
-      color: rgba(255,255,255,0.5);
-      text-decoration: none;
-      transition: color 0.15s;
-    }
-    .back-link:hover { color: #fff; }
-
     .hero {
       position: relative;
-      z-index: 1;
-      max-width: 820px;
+      z-index: 2;
+      max-width: 880px;
       margin: 0 auto;
-      padding: 120px 24px 0;
+      padding: 160px 28px 0;
       text-align: center;
     }
     h1 {
-      font-family: 'Barlow', sans-serif;
-      font-size: clamp(32px, 5vw, 48px);
-      font-weight: 700;
-      line-height: 1.15;
-      color: #fff;
-      margin-bottom: 16px;
+      font-family: var(--sans);
+      font-size: clamp(40px, 6.5vw, 88px);
+      font-weight: 800;
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+      color: var(--ink);
+      margin-bottom: 22px;
+    }
+    h1 .accent {
+      font-family: var(--serif);
+      font-style: italic;
+      font-weight: 400;
+      letter-spacing: -0.005em;
+      background: linear-gradient(180deg, #fff 0%, var(--accent-2) 50%, var(--signal) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
     }
     .subtitle {
       font-size: 18px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.5);
-      max-width: 560px;
+      line-height: 1.55;
+      color: var(--ink-2);
+      max-width: 540px;
       margin: 0 auto;
+      letter-spacing: -0.005em;
     }
 
     .version-pills {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 820px;
-      margin: 48px auto 0;
-      padding: 0 24px;
+      margin: 56px auto 0;
+      padding: 0 28px;
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
@@ -271,49 +232,49 @@ const html = `<!DOCTYPE html>
       display: inline-flex;
       align-items: center;
       padding: 6px 14px;
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 11px;
       font-weight: 500;
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      color: rgba(255, 255, 255, 0.55);
-      background: rgba(20, 22, 40, 0.7);
-      border: 1px solid rgba(124, 107, 255, 0.18);
+      letter-spacing: 0.06em;
+      color: var(--ink-3);
+      background: rgba(20, 23, 44, 0.6);
+      border: 1px solid rgba(139, 118, 255, 0.16);
       border-radius: 9999px;
       text-decoration: none;
       transition: color 0.15s, border-color 0.15s, background 0.15s, transform 0.15s;
     }
     .version-pill:hover {
-      color: #fff;
-      border-color: rgba(124, 107, 255, 0.45);
-      background: rgba(124, 107, 255, 0.12);
+      color: var(--ink);
+      border-color: rgba(139, 118, 255, 0.45);
+      background: rgba(139, 118, 255, 0.14);
       transform: translateY(-1px);
     }
 
     .entries {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 760px;
       margin: 0 auto;
-      padding: 48px 24px 120px;
+      padding: 56px 28px 120px;
     }
     .entries h2 {
       display: flex;
       align-items: baseline;
-      gap: 12px;
+      gap: 14px;
       flex-wrap: wrap;
-      margin: 64px 0 24px;
-      padding-bottom: 12px;
-      border-bottom: 1px solid rgba(124, 107, 255, 0.18);
-      scroll-margin-top: 24px;
+      margin: 72px 0 26px;
+      padding-bottom: 14px;
+      border-bottom: 1px solid rgba(139, 118, 255, 0.20);
+      scroll-margin-top: 80px;
     }
     .entries h2:first-child { margin-top: 0; }
     .release-version {
-      font-family: 'Barlow', sans-serif;
-      font-size: 28px;
+      font-family: var(--sans);
+      font-size: 32px;
       font-weight: 700;
-      color: #fff;
-      letter-spacing: -0.5px;
+      color: var(--ink);
+      letter-spacing: -0.025em;
+      line-height: 1.05;
     }
     .release-version-link {
       text-decoration: none;
@@ -321,50 +282,55 @@ const html = `<!DOCTYPE html>
       transition: opacity 0.15s;
     }
     .release-version-link:hover .release-version {
-      color: #a99eff;
+      color: var(--accent-2);
     }
     .release-date {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 12px;
+      font-family: var(--mono);
+      font-size: 11px;
       font-weight: 500;
-      letter-spacing: 1px;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
-      color: rgba(169, 158, 255, 0.7);
+      color: var(--accent-2);
     }
     .entries h3 {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: 11px;
+      font-family: var(--mono);
+      font-size: 10px;
       font-weight: 600;
-      letter-spacing: 2px;
+      letter-spacing: 0.18em;
       text-transform: uppercase;
-      color: rgba(169, 158, 255, 0.85);
-      margin: 28px 0 12px;
+      color: var(--star);
+      margin: 32px 0 14px;
     }
     .entries h4 {
-      font-family: 'Barlow', sans-serif;
-      font-size: 18px;
-      font-weight: 700;
-      color: #fff;
-      margin: 20px 0 8px;
+      font-family: var(--sans);
+      font-size: 17px;
+      font-weight: 600;
+      color: var(--ink);
+      margin: 22px 0 8px;
+      letter-spacing: -0.01em;
     }
     .entries p {
+      font-family: var(--sans);
       font-size: 15px;
-      line-height: 1.7;
-      color: rgba(255, 255, 255, 0.62);
+      line-height: 1.65;
+      color: var(--ink-2);
       margin-bottom: 10px;
+      letter-spacing: -0.005em;
     }
     .entries ul {
       list-style: none;
       padding: 0;
-      margin: 0 0 16px;
+      margin: 0 0 18px;
     }
     .entries li {
       position: relative;
       padding-left: 20px;
       margin-bottom: 8px;
+      font-family: var(--sans);
       font-size: 15px;
-      line-height: 1.65;
-      color: rgba(255, 255, 255, 0.62);
+      line-height: 1.6;
+      color: var(--ink-2);
+      letter-spacing: -0.005em;
     }
     .entries li::before {
       content: "";
@@ -374,116 +340,126 @@ const html = `<!DOCTYPE html>
       width: 4px;
       height: 4px;
       border-radius: 50%;
-      background: rgba(124, 107, 255, 0.6);
+      background: var(--accent);
+      opacity: 0.7;
     }
-    .entries li > ul {
-      margin: 8px 0 0;
-    }
+    .entries li > ul { margin: 8px 0 0; }
     .entries strong {
-      color: rgba(255, 255, 255, 0.82);
+      color: var(--ink);
       font-weight: 600;
     }
     .entries code {
-      font-family: 'IBM Plex Mono', monospace;
+      font-family: var(--mono);
       font-size: 13px;
-      background: rgba(124, 107, 255, 0.1);
-      color: #a99eff;
+      background: rgba(139, 118, 255, 0.12);
+      color: var(--accent-2);
       padding: 2px 6px;
       border-radius: 4px;
     }
     .entries a {
-      color: #a99eff;
+      color: var(--accent-2);
       text-decoration: none;
       border-bottom: 1px dotted rgba(169, 158, 255, 0.4);
     }
-    .entries a:hover { color: #fff; border-bottom-color: #fff; }
+    .entries a:hover { color: var(--ink); border-bottom-color: var(--ink); }
 
     .install-section {
       position: relative;
-      z-index: 1;
+      z-index: 2;
       max-width: 640px;
       margin: 0 auto;
-      padding: 0 24px 100px;
+      padding: 0 28px 80px;
       text-align: center;
     }
     .install-label {
-      font-family: 'Barlow', sans-serif;
+      font-family: var(--sans);
       font-size: 28px;
       font-weight: 700;
-      color: #fff;
+      letter-spacing: -0.02em;
+      color: var(--ink);
       margin-bottom: 24px;
     }
+    .terminal-frame {
+      position: relative;
+      max-width: 480px;
+      margin: 0 auto;
+      isolation: isolate;
+    }
+    .terminal-frame::before {
+      content: '';
+      position: absolute;
+      inset: -30px -40px;
+      background:
+        radial-gradient(ellipse 60% 60% at 50% 100%, rgba(139, 118, 255, 0.45) 0%, transparent 65%),
+        radial-gradient(ellipse 50% 50% at 50% 0%, rgba(123, 231, 255, 0.20) 0%, transparent 65%);
+      filter: blur(36px);
+      z-index: -1;
+      pointer-events: none;
+    }
     .terminal {
-      background: rgba(8, 9, 18, 0.95);
-      border: 2px solid rgba(124, 107, 255, 0.14);
-      border-radius: 12px;
-      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      background: rgba(13, 16, 36, 0.85);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.6);
       overflow: hidden;
+      backdrop-filter: blur(14px);
       text-align: left;
     }
     .terminal-bar {
       display: flex;
       align-items: center;
-      padding: 12px 16px;
-      background: rgba(0, 0, 0, 0.25);
+      padding: 10px 14px;
+      background: rgba(255, 255, 255, 0.04);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.04);
       position: relative;
     }
     .terminal-dots { display: flex; gap: 6px; }
     .terminal-dots span { width: 10px; height: 10px; border-radius: 50%; }
     .terminal-title {
       position: absolute; left: 0; right: 0; text-align: center;
-      font-size: 11px; color: rgba(255,255,255,0.25);
-      font-family: 'IBM Plex Mono', monospace; pointer-events: none;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-4);
+      letter-spacing: 0.06em;
+      pointer-events: none;
     }
     .terminal-body {
-      padding: 20px 24px 24px;
+      padding: 22px 24px;
       display: flex; flex-direction: column; gap: 10px;
     }
-    .terminal-line .prompt { color: rgba(255,255,255,0.35); font-family: 'IBM Plex Mono', monospace; font-size: 14px; }
+    .terminal-line .prompt { color: var(--ink-4); font-family: var(--mono); font-size: 14px; }
     .terminal-line code {
-      font-family: 'IBM Plex Mono', monospace;
-      font-size: clamp(16px, 2.5vw, 20px);
-      color: #a99eff;
+      font-family: var(--mono);
+      font-size: clamp(15px, 2.2vw, 18px);
+      color: var(--accent-2);
       background: none;
       padding: 0;
     }
 
-    .footer {
-      position: relative;
-      z-index: 1;
-      text-align: center;
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.3);
-      padding: 0 24px 60px;
-    }
-    .footer .heart { color: #e25555; }
-    .footer a { color: rgba(255, 255, 255, 0.4); text-decoration: none; }
-    .footer a:hover { color: rgba(255, 255, 255, 0.6); }
-
     @media (max-width: 600px) {
-      .hero { padding-top: 100px; }
-      .entries { padding-top: 48px; }
+      .hero { padding-top: 110px; }
+      .entries { padding-top: 40px; }
     }
   </style>
 </head>
 <body>
-  <div class="bg"></div>
-
-  <div class="back-nav">
-    <div class="back-bar">
-      <a class="back-link" href="/">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/>
-        </svg>
-        oyster.to
-      </a>
-    </div>
+  <div class="cosmos" aria-hidden="true">
+    <div class="stars stars-far" id="stars-far"></div>
+    <div class="stars stars-near" id="stars-near"></div>
   </div>
 
-  <div class="hero">
-    <h1>Changelog</h1>
-    <p class="subtitle">Every shipped change, newest first.</p>
-  </div>
+  <nav class="nav">
+    <a href="/"><img src="logo.png" alt="Oyster" class="nav-logo" /></a>
+    <a href="/#install">Install</a>
+    <a href="/plugins">Plugins</a>
+    <a href="/pricing">Pricing</a>
+    <a href="/changelog" class="active">Changelog</a>
+  </nav>
+
+  <section class="hero">
+    <h1><span class="accent">Every</span> shipped change.</h1>
+    <p class="subtitle">Newest first. The full release log of what's shipping in Oyster.</p>
+  </section>
 
   <nav class="version-pills" aria-label="Jump to version">
       ${pills}
@@ -493,27 +469,54 @@ const html = `<!DOCTYPE html>
 ${cleanedRendered}
   </main>
 
-  <div class="install-section">
+  <section class="install-section">
     <div class="install-label">Don't have Oyster yet?</div>
-    <div class="terminal">
-      <div class="terminal-bar">
-        <div class="terminal-dots">
-          <span style="background: #ff5f57;"></span>
-          <span style="background: #febc2e;"></span>
-          <span style="background: #28c840;"></span>
+    <div class="terminal-frame">
+      <div class="terminal">
+        <div class="terminal-bar">
+          <div class="terminal-dots">
+            <span style="background: #ff5f57;"></span>
+            <span style="background: #febc2e;"></span>
+            <span style="background: #28c840;"></span>
+          </div>
+          <span class="terminal-title">terminal</span>
         </div>
-        <span class="terminal-title">terminal</span>
-      </div>
-      <div class="terminal-body">
-        <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
-        <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+        <div class="terminal-body">
+          <div class="terminal-line"><span class="prompt">$ </span><code>npm install -g oyster-os</code></div>
+          <div class="terminal-line"><span class="prompt">$ </span><code>oyster</code></div>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 
-  <div class="footer">
+  <div class="site-footer">
     <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
   </div>
+
+  <script>
+    (function () {
+      function seed(s) { return function () { s = (s * 9301 + 49297) % 233280; return s / 233280; }; }
+      const rand = seed(42);
+      function makeStars(el, count, twinkle) {
+        if (!el) return;
+        const frag = document.createDocumentFragment();
+        for (let i = 0; i < count; i++) {
+          const d = document.createElement('div');
+          d.style.left = (rand() * 100).toFixed(2) + '%';
+          d.style.top = (rand() * 100).toFixed(2) + '%';
+          if (twinkle && rand() < 0.18) {
+            d.classList.add('star-twinkle');
+            d.style.setProperty('--dur', (2.5 + rand() * 4).toFixed(2) + 's');
+            d.style.setProperty('--delay', (rand() * 5).toFixed(2) + 's');
+          }
+          frag.appendChild(d);
+        }
+        el.appendChild(frag);
+      }
+      makeStars(document.getElementById('stars-far'), 80, false);
+      makeStars(document.getElementById('stars-near'), 22, true);
+    })();
+  </script>
 </body>
 </html>
 `;


### PR DESCRIPTION
## Summary
- Rebuilds the oyster.to marketing site with a more editorial, mission-control look — bigger Sora 800 + Instrument Serif italic display type, cosmic background with starfield + orbital arcs, luminous device frame on the hero.
- Pricing, plugins, MCP, and changelog pages all reskinned to match via a new shared `docs/assets/oyster.css` design system (fonts, colors, nav, cosmos, CTAs, footer).
- Changelog template in `scripts/build-changelog.mjs` ported to the new system and regenerated.

## Test plan
- [ ] Visual pass on `/` desktop + mobile (iPhone XR / iPad portrait & landscape)
- [ ] `/plugins` — registry loads, copy-buttons work
- [ ] `/pricing` — sticky stack of Sync/Memory/Publish primitives works, waitlist modal opens & submits
- [ ] `/mcp` — tabbed config copy works, no inner-hairline regression
- [ ] `/changelog` — version pills jump correctly
- [ ] `npm run build:changelog` reruns cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)