### PR TITLE
Site polish — atmosphere, mobile fixes, copy

### DIFF
--- a/docs/assets/hero-mock.css
+++ b/docs/assets/hero-mock.css
@@ -116,7 +116,12 @@
 /* Section heads + sessions */
 .hm-section-head {
   display: flex; align-items: baseline; justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
   margin-bottom: 10px;
+}
+@media (max-width: 520px) {
+  .hm-section-head { flex-direction: column; align-items: flex-start; }
 }
 .hm-section-name {
   font-family: 'Barlow', sans-serif;

--- a/docs/assets/oyster.css
+++ b/docs/assets/oyster.css
@@ -62,6 +62,16 @@ body {
     radial-gradient(ellipse 1100px 700px at 22% 8%, rgba(139, 118, 255, 0.09) 0%, transparent 60%),
     radial-gradient(ellipse 800px 600px at 80% 18%, rgba(123, 231, 255, 0.05) 0%, transparent 65%),
     linear-gradient(180deg, #04060d 0%, #050714 50%, #04060d 100%);
+  /* Very slow hue drift on the nebula. Stars are white so they're
+     unaffected; only the colored radial gradients breathe. */
+  animation: cosmos-hue-drift 90s ease-in-out infinite;
+}
+@keyframes cosmos-hue-drift {
+  0%, 100% { filter: hue-rotate(0deg); }
+  50% { filter: hue-rotate(18deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cosmos { animation: none; }
 }
 .cosmos::after {
   content: '';
@@ -91,6 +101,40 @@ body {
 }
 @media (prefers-reduced-motion: reduce) {
   .star-twinkle { animation: none; }
+}
+
+/* One tasteful drifting comet. ~35s flight, low intensity. */
+.comet {
+  position: absolute;
+  top: var(--y, 18%);
+  left: -12vw;
+  width: 160px; height: 1px;
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0) 40%, rgba(255,255,255,0.5) 90%, #fff 100%);
+  filter: drop-shadow(0 0 4px rgba(255, 217, 122, 0.45));
+  animation: comet-fly 35s linear infinite;
+  animation-delay: var(--delay, 0s);
+  opacity: 0;
+  transform: rotate(12deg);
+}
+.comet::after {
+  content: '';
+  position: absolute;
+  right: -1px; top: -1px;
+  width: 2.5px; height: 2.5px;
+  background: var(--star);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--star), 0 0 16px rgba(255, 217, 122, 0.4);
+}
+@keyframes comet-fly {
+  0%, 5% { transform: translate(0, 0) rotate(12deg); opacity: 0; }
+  10% { opacity: 0.9; }
+  35% { opacity: 0.9; }
+  /* Long invisible tail of the cycle so only ~12s of every 35s shows the comet — feels rare, not constant. */
+  40% { transform: translate(125vw, 30vh) rotate(12deg); opacity: 0; }
+  100% { transform: translate(125vw, 30vh) rotate(12deg); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .comet { display: none; }
 }
 
 /* ============================================

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -272,6 +272,7 @@
   <div class="cosmos" aria-hidden="true">
     <div class="stars stars-far" id="stars-far"></div>
     <div class="stars stars-near" id="stars-near"></div>
+    <div class="comet" style="--y: 26%;"></div>
   </div>
 
   <nav class="nav">
@@ -980,8 +981,8 @@
         }
         el.appendChild(frag);
       }
-      makeStars(document.getElementById('stars-far'), 80, false);
-      makeStars(document.getElementById('stars-near'), 22, true);
+      makeStars(document.getElementById('stars-far'), 200, false);
+      makeStars(document.getElementById('stars-near'), 60, true);
     })();
   </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -330,6 +330,9 @@
       letter-spacing: 0;
       font-size: 12px;
     }
+    @media (max-width: 600px) {
+      .hero-hint { display: none; }
+    }
 
     /* Hero device frame — tight rim glow (à la GitHub Copilot) */
     .hero-stage {
@@ -1156,6 +1159,7 @@
   <div class="cosmos" aria-hidden="true">
     <div class="stars stars-far" id="stars-far"></div>
     <div class="stars stars-near" id="stars-near"></div>
+    <div class="comet" style="--y: 22%;"></div>
   </div>
 
   <!-- NAV -->
@@ -1276,7 +1280,7 @@
                 <span class="hm-status hm-status-r"></span>
                 <div class="hm-tile-body">
                   <div class="hm-tile-title">Investigate API latency</div>
-                  <div class="hm-tile-meta">claude-code · acme-app</div>
+                  <div class="hm-tile-meta">codex · acme-app</div>
                 </div>
                 <span class="hm-tile-time">1h ago</span>
               </div>
@@ -1284,7 +1288,7 @@
                 <span class="hm-status hm-status-d"></span>
                 <div class="hm-tile-body">
                   <div class="hm-tile-title">Weekly retro write-up</div>
-                  <div class="hm-tile-meta">claude-code · field-notes</div>
+                  <div class="hm-tile-meta">opencode · field-notes</div>
                 </div>
                 <span class="hm-tile-time">yesterday</span>
               </div>
@@ -1752,6 +1756,7 @@
 
   <div class="footer">
     <p>Built with <span class="heart">&hearts;</span> by <a href="https://github.com/mattslight">Matthew Slight</a></p>
+    <p class="signoff">End of transmission</p>
   </div>
 
   <script>
@@ -1783,8 +1788,8 @@
       }
       const far = document.getElementById('stars-far');
       const near = document.getElementById('stars-near');
-      if (far) makeStars(far, 110, { twinkle: false });
-      if (near) makeStars(near, 28, { twinkle: true });
+      if (far) makeStars(far, 200, { twinkle: false });
+      if (near) makeStars(near, 60, { twinkle: true });
     })();
 
     // ============================================
@@ -1809,9 +1814,9 @@
       window.addEventListener('mousemove', (e) => {
         const x = (e.clientX / window.innerWidth - 0.5);
         const y = (e.clientY / window.innerHeight - 0.5);
-        if (farLayer) farLayer.style.transform = `translate3d(${x * -8}px, ${y * -8}px, 0)`;
-        if (nearLayer) nearLayer.style.transform = `translate3d(${x * -28}px, ${y * -28}px, 0)`;
-        if (pearl) pearl.style.transform = `translateX(calc(-50% + ${x * 24}px)) translateY(${y * 18}px)`;
+        if (farLayer) farLayer.style.transform = `translate3d(${x * -16}px, ${y * -12}px, 0)`;
+        if (nearLayer) nearLayer.style.transform = `translate3d(${x * -52}px, ${y * -36}px, 0)`;
+        if (pearl) pearl.style.transform = `translateX(calc(-50% + ${x * 40}px)) translateY(${y * 28}px)`;
       });
     }
 

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -324,6 +324,7 @@
   <div class="cosmos" aria-hidden="true">
     <div class="stars stars-far" id="stars-far"></div>
     <div class="stars stars-near" id="stars-near"></div>
+    <div class="comet" style="--y: 20%;"></div>
   </div>
 
   <nav class="nav">
@@ -492,8 +493,8 @@
         }
         el.appendChild(frag);
       }
-      makeStars(document.getElementById('stars-far'), 80, false);
-      makeStars(document.getElementById('stars-near'), 22, true);
+      makeStars(document.getElementById('stars-far'), 200, false);
+      makeStars(document.getElementById('stars-near'), 60, true);
     })();
 
     function showTab(e, name) {

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -341,6 +341,7 @@
   <div class="cosmos" aria-hidden="true">
     <div class="stars stars-far" id="stars-far"></div>
     <div class="stars stars-near" id="stars-near"></div>
+    <div class="comet" style="--y: 24%;"></div>
   </div>
 
   <nav class="nav">
@@ -419,8 +420,8 @@
         }
         el.appendChild(frag);
       }
-      makeStars(document.getElementById('stars-far'), 80, false);
-      makeStars(document.getElementById('stars-near'), 22, true);
+      makeStars(document.getElementById('stars-far'), 200, false);
+      makeStars(document.getElementById('stars-near'), 60, true);
     })();
 
     const REGISTRY_URL = "https://raw.githubusercontent.com/mattslight/oyster-community-plugins/main/community-plugins.json";

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -542,6 +542,7 @@
   <div class="cosmos" aria-hidden="true">
     <div class="stars stars-far" id="stars-far"></div>
     <div class="stars stars-near" id="stars-near"></div>
+    <div class="comet" style="--y: 16%;"></div>
   </div>
 
   <nav class="nav">
@@ -747,8 +748,8 @@
         }
         el.appendChild(frag);
       }
-      makeStars(document.getElementById('stars-far'), 80, false);
-      makeStars(document.getElementById('stars-near'), 22, true);
+      makeStars(document.getElementById('stars-far'), 200, false);
+      makeStars(document.getElementById('stars-near'), 60, true);
     })();
 
     (function () {

--- a/scripts/build-changelog.mjs
+++ b/scripts/build-changelog.mjs
@@ -446,6 +446,7 @@ const html = `<!DOCTYPE html>
   <div class="cosmos" aria-hidden="true">
     <div class="stars stars-far" id="stars-far"></div>
     <div class="stars stars-near" id="stars-near"></div>
+    <div class="comet" style="--y: 26%;"></div>
   </div>
 
   <nav class="nav">
@@ -513,8 +514,8 @@ ${cleanedRendered}
         }
         el.appendChild(frag);
       }
-      makeStars(document.getElementById('stars-far'), 80, false);
-      makeStars(document.getElementById('stars-near'), 22, true);
+      makeStars(document.getElementById('stars-far'), 200, false);
+      makeStars(document.getElementById('stars-near'), 60, true);
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
Follow-up polish pass after the Pearl in Orbit redesign (PR #503).

**Atmosphere:** Denser starfield (×2.5), one slow drifting comet per page, gentle hue-drift on the nebula gradients, wider mouse-parallax on the homepage. All animations honour `prefers-reduced-motion`.

**Mobile:** Hero-mock session header now stacks above its chips under 520px (was orphaning a chip); the "Boot sequence" hint hides under 600px (the install terminal below shows the same info more legibly).

**Other:** Diversify the example sessions in the hero device to one of each agent (Claude Code · Cursor · Codex · OpenCode). Restore "End of transmission" footer sign-off.

## Test plan
- [ ] `/` desktop — starfield denser, occasional comet drifts left → right, hue subtly shifts
- [ ] `/` mobile — sessions head stacks, boot-sequence hint hidden
- [ ] All four agent names visible in the hero device sessions list
- [ ] Reduced-motion: nebula, stars, comet all freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)