### PR TITLE
feat(docs): scroll-triggered fade-up reveal across site

### DIFF
--- a/docs/assets/oyster.css
+++ b/docs/assets/oyster.css
@@ -331,3 +331,25 @@ body {
 .site-footer .heart { color: var(--plasma); }
 .site-footer a { color: var(--ink-3); text-decoration: none; transition: color 0.2s; }
 .site-footer a:hover { color: var(--ink); }
+
+/* ============================================
+   REVEAL ON SCROLL
+   Children of [data-reveal] fade + lift in once when the
+   wrapper enters the lower portion of the viewport.
+   Activated only when JS sets .js-reveal on <html>
+   (the head script omits it under prefers-reduced-motion).
+   ============================================ */
+.js-reveal [data-reveal] > * {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.8s cubic-bezier(0.2, 0.4, 0.2, 1),
+              transform 0.8s cubic-bezier(0.2, 0.4, 0.2, 1);
+  will-change: opacity, transform;
+}
+.js-reveal [data-reveal] > *:nth-child(2) { transition-delay: 0.12s; }
+.js-reveal [data-reveal] > *:nth-child(3) { transition-delay: 0.24s; }
+.js-reveal [data-reveal] > *:nth-child(4) { transition-delay: 0.36s; }
+.js-reveal [data-reveal].is-visible > * {
+  opacity: 1;
+  transform: none;
+}

--- a/docs/assets/oyster.css
+++ b/docs/assets/oyster.css
@@ -352,4 +352,5 @@ body {
 .js-reveal [data-reveal].is-visible > * {
   opacity: 1;
   transform: none;
+  will-change: auto;
 }

--- a/docs/assets/reveal.js
+++ b/docs/assets/reveal.js
@@ -1,0 +1,22 @@
+// Reveal-on-scroll. The head script on each page adds `js-reveal` to
+// <html> only when prefers-reduced-motion is not set, so this no-ops
+// for users who opt out of motion.
+(function () {
+  if (!document.documentElement.classList.contains('js-reveal')) return;
+  if (!('IntersectionObserver' in window)) return;
+
+  var targets = document.querySelectorAll('[data-reveal]');
+  if (!targets.length) return;
+
+  var obs = new IntersectionObserver(function (entries) {
+    for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i];
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        obs.unobserve(entry.target);
+      }
+    }
+  }, { threshold: 0, rootMargin: '0px 0px -25% 0px' });
+
+  targets.forEach(function (el) { obs.observe(el); });
+})();

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -6,6 +6,11 @@
   <title>Changelog — Oyster</title>
   <meta name="description" content="Every shipped change to Oyster, newest first.">
   <link rel="stylesheet" href="assets/oyster.css">
+  <script>
+    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.documentElement.classList.add('js-reveal');
+    }
+  </script>
   <style>
     .hero {
       position: relative;
@@ -301,7 +306,7 @@
       <a class="version-pill" href="#v-0-0-x">0.0</a>
   </nav>
 
-  <main class="entries">
+  <main class="entries" data-reveal>
 <h2 id="v-0-9-1"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.0...v0.9.1" rel="noopener noreferrer"><span class="release-version">0.9.1</span></a><span class="release-date"> — 2026-05-16</span></h2>
 <h3>Added</h3>
 <ul>
@@ -945,7 +950,7 @@
 
   </main>
 
-  <section class="install-section">
+  <section class="install-section" data-reveal>
     <div class="install-label">Don't have Oyster yet?</div>
     <div class="terminal-frame">
       <div class="terminal">
@@ -993,5 +998,6 @@
       makeStars(document.getElementById('stars-near'), 60, true);
     })();
   </script>
+  <script src="assets/reveal.js" defer></script>
 </body>
 </html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -7,7 +7,10 @@
   <meta name="description" content="Every shipped change to Oyster, newest first.">
   <link rel="stylesheet" href="assets/oyster.css">
   <script>
-    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    if (
+      'IntersectionObserver' in window &&
+      (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches)
+    ) {
       document.documentElement.classList.add('js-reveal');
     }
   </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,12 @@
 
   <link rel="stylesheet" href="assets/oyster.css">
   <link rel="stylesheet" href="assets/hero-mock.css">
+  <script>
+    // Set before paint so .section hidden state is in effect before sections render.
+    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.documentElement.classList.add('js-reveal');
+    }
+  </script>
   <style>
     /* ============================================
        OYSTER v2 — Pearl in Orbit
@@ -1239,6 +1245,7 @@
       vertical-align: middle;
       animation: breathe 2.2s ease-in-out infinite;
     }
+
   </style>
 </head>
 <body>
@@ -1557,7 +1564,7 @@
 
   <!-- Feature 1: See your agent at work -->
   <section class="section" id="features">
-    <div class="feature">
+    <div class="feature" data-reveal>
       <div>
         <h2>See your <span class="accent">agents</span> at work.</h2>
         <p>Oyster watches your Claude Code sessions automatically — live transcripts, the files your agent edited, the memories it captured, all on Home and all searchable. No setup, no MCP wiring needed. Cursor, Codex and OpenCode watchers are next.</p>
@@ -1601,7 +1608,7 @@
 
   <!-- Feature 2: Work with full context -->
   <section class="section">
-    <div class="feature reverse">
+    <div class="feature reverse" data-reveal>
       <div>
         <h2>Work with <span class="accent">full</span> context.</h2>
         <p>Your AI sees every space, project, and artefact. Ask it to summarise across projects, find connections, or act on something specific — it has the full picture.</p>
@@ -1624,7 +1631,7 @@
 
   <!-- Feature 3: Switch context instantly -->
   <section class="section">
-    <div class="feature">
+    <div class="feature" data-reveal>
       <div>
         <h2>Switch context <span class="accent">instantly.</span></h2>
         <p>Jump between project spaces with a single shortcut. Your brain switches context — your agents should keep up.</p>
@@ -1648,7 +1655,7 @@
 
   <!-- Feature 4: Drop in a project -->
   <section class="section">
-    <div class="feature reverse">
+    <div class="feature reverse" data-reveal>
       <div>
         <h2>Drop in a project.<br><span class="accent">Get organised.</span></h2>
         <p>Point Oyster at any project and it picks up what's inside — sessions, documents, presentations, diagrams, apps. Your existing work lands on the surface automatically.</p>
@@ -1683,7 +1690,7 @@
 
   <!-- Feature 5: Act, not just chat -->
   <section class="section">
-    <div class="feature">
+    <div class="feature" data-reveal>
       <div>
         <h2><span class="accent">Act,</span> not just chat.</h2>
         <p>Oyster doesn't just answer questions. It opens artefacts, switches spaces, creates documents, and manages your workspace from the prompt bar.</p>
@@ -1711,7 +1718,7 @@
 
   <!-- Feature 6: Built on MCP -->
   <section class="section">
-    <div class="feature reverse">
+    <div class="feature reverse" data-reveal>
       <div>
         <h2>Built on MCP.<br><span class="accent">Bring your own</span> agents.</h2>
         <p>Oyster is an MCP server. That means any agent that speaks the protocol — Claude Code, Cursor, VS Code, Windsurf, or your own — can control your workspace. Create documents, organise spaces, open artefacts. One standard, every agent.</p>
@@ -1777,7 +1784,7 @@
 
   <!-- Feature 7: Brainstorm without clutter -->
   <section class="section">
-    <div class="feature">
+    <div class="feature" data-reveal>
       <div>
         <h2>Brainstorm <span class="accent">without</span> clutter.</h2>
         <p>Notes, decks, diagrams, mockups — the project work that doesn't belong in <code>git</code>. Oyster keeps it tied to your project but separate from your code. Visible, searchable, launchable.</p>
@@ -1817,7 +1824,7 @@
 
   <!-- Feature 8: Pro -->
   <section class="section">
-    <div class="feature reverse">
+    <div class="feature reverse" data-reveal>
       <div>
         <span class="coming-soon">T-Minus · Soon</span>
         <h2>Oyster Pro — <span class="accent">your work,</span> anywhere.</h2>
@@ -1898,7 +1905,7 @@
   </section>
 
   <!-- LAUNCHPAD (install) -->
-  <section class="launchpad" id="install">
+  <section class="launchpad" id="install" data-reveal>
     <h2>From zero to <span class="dim">work</span>space in <span class="accent">one command.</span></h2>
     <p>No sign-ups, no config files, no onboarding flow. Your surface opens in the browser, ready to go.</p>
 
@@ -2245,7 +2252,9 @@
       document.getElementById('mcp-' + name).style.display = 'block';
       e.target.classList.add('active');
     };
+
   </script>
   <script src="assets/hero-mock.js" defer></script>
+  <script src="assets/reveal.js" defer></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,8 +27,13 @@
   <link rel="stylesheet" href="assets/oyster.css">
   <link rel="stylesheet" href="assets/hero-mock.css">
   <script>
-    // Set before paint so .section hidden state is in effect before sections render.
-    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    // Set before paint so the [data-reveal] hidden state is in effect
+    // before the marked elements render. Gated on IntersectionObserver
+    // support so browsers without it never hide the content.
+    if (
+      'IntersectionObserver' in window &&
+      (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches)
+    ) {
       document.documentElement.classList.add('js-reveal');
     }
   </script>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -7,7 +7,10 @@
   <meta name="description" content="Bring your own AI — connect Claude Code, Cursor, VS Code, Windsurf or any MCP-compatible tool to Oyster.">
   <link rel="stylesheet" href="assets/oyster.css">
   <script>
-    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    if (
+      'IntersectionObserver' in window &&
+      (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches)
+    ) {
       document.documentElement.classList.add('js-reveal');
     }
   </script>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -6,6 +6,11 @@
   <title>Bring Your Own AI — Oyster</title>
   <meta name="description" content="Bring your own AI — connect Claude Code, Cursor, VS Code, Windsurf or any MCP-compatible tool to Oyster.">
   <link rel="stylesheet" href="assets/oyster.css">
+  <script>
+    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.documentElement.classList.add('js-reveal');
+    }
+  </script>
   <style>
     .hero {
       position: relative;
@@ -340,7 +345,7 @@
     <p class="subtitle">Oyster is an MCP server. Any AI that speaks the protocol can control your workspace.</p>
   </section>
 
-  <section class="section">
+  <section class="section" data-reveal>
     <div class="section-label">Quick start</div>
 
     <div class="config-frame">
@@ -447,7 +452,7 @@
     <p class="note">Your AI can chain these together. Ask it to onboard a project, create a summary, and organise everything into spaces — all from one prompt.</p>
   </section>
 
-  <section class="install-section">
+  <section class="install-section" data-reveal>
     <div class="install-label">Don't have Oyster yet?</div>
     <div class="terminal-frame">
       <div class="terminal">
@@ -516,5 +521,6 @@
       });
     }
   </script>
+  <script src="assets/reveal.js" defer></script>
 </body>
 </html>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -7,7 +7,10 @@
   <meta name="description" content="Community plugins for Oyster. Static apps, tools, and widgets that run on your workspace surface.">
   <link rel="stylesheet" href="assets/oyster.css">
   <script>
-    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    if (
+      'IntersectionObserver' in window &&
+      (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches)
+    ) {
       document.documentElement.classList.add('js-reveal');
     }
   </script>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -6,6 +6,11 @@
   <title>Plugins — Oyster</title>
   <meta name="description" content="Community plugins for Oyster. Static apps, tools, and widgets that run on your workspace surface.">
   <link rel="stylesheet" href="assets/oyster.css">
+  <script>
+    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.documentElement.classList.add('js-reveal');
+    }
+  </script>
   <style>
     /* Page-specific styles */
     .hero {
@@ -357,14 +362,14 @@
     <p class="subtitle">Apps, tools, and widgets the community drops inside your shell. Install any with a single command.</p>
   </section>
 
-  <section class="section">
+  <section class="section" data-reveal>
     <div class="section-label">Available</div>
     <div id="plugins" class="plugins">
       <div class="state">Loading plugins&hellip;</div>
     </div>
   </section>
 
-  <section class="submit-section">
+  <section class="submit-section" data-reveal>
     <div class="submit-card">
       <div class="submit-title">Built a plugin?</div>
       <p class="submit-desc">The registry is an open repo. Submit a PR adding one entry to <code>community-plugins.json</code> and your plugin lands here.</p>
@@ -375,7 +380,7 @@
     </div>
   </section>
 
-  <section class="install-section">
+  <section class="install-section" data-reveal>
     <div class="install-label">Don't have Oyster yet?</div>
     <div class="terminal-frame">
       <div class="terminal">
@@ -592,5 +597,6 @@
 
     load();
   </script>
+  <script src="assets/reveal.js" defer></script>
 </body>
 </html>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -7,7 +7,10 @@
   <meta name="description" content="Oyster is free without limits — no sign-up, no strings. Oyster Pro is optional and adds Sync, Memory, and Publish — anywhere, any device, any agent.">
   <link rel="stylesheet" href="assets/oyster.css">
   <script>
-    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    if (
+      'IntersectionObserver' in window &&
+      (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches)
+    ) {
       document.documentElement.classList.add('js-reveal');
     }
   </script>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -6,6 +6,11 @@
   <title>Pricing — Oyster</title>
   <meta name="description" content="Oyster is free without limits — no sign-up, no strings. Oyster Pro is optional and adds Sync, Memory, and Publish — anywhere, any device, any agent.">
   <link rel="stylesheet" href="assets/oyster.css">
+  <script>
+    if (!window.matchMedia || !matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      document.documentElement.classList.add('js-reveal');
+    }
+  </script>
   <style>
     /* Hero */
     .hero {
@@ -655,7 +660,7 @@
 
   </section>
 
-  <section class="pricing" id="pricing">
+  <section class="pricing" id="pricing" data-reveal>
     <div class="pricing-head">
       <h2 class="pricing-h2">Two plans, <span class="accent">one</span> Oyster.</h2>
       <p class="pricing-sub"><strong>Oyster stays free, forever.</strong> Pro adds Sync, Memory, and Publish for users who want their work to follow them.</p>
@@ -834,5 +839,6 @@
       });
     })();
   </script>
+  <script src="assets/reveal.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Marketing pages now fade + lift their main content blocks in once as you scroll, mirroring the pattern github.com uses on its landing page. Shared CSS lives in oyster.css keyed on `[data-reveal]`, with the IntersectionObserver in a new `assets/reveal.js`. A head script on each page sets `js-reveal` on <html> only when motion isn't reduced, so prefers-reduced-motion users skip it entirely.

Applied to index, changelog, mcp, and plugins on all major sections; pricing reveals the plans grid only (the sticky primitives stack stays untouched).