### PR TITLE
feat(docs): purposeful dividers on 4-pillar benefit row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Rocket Ship title screen got an 80s arcade glow-up.** Chunky pixel-art rocket with a flickering flame hovers above the *ROCKET SHIP* title, the controls panel uses an enlarged ★ and a plain `!` for asteroids, the HUD reads `SCORE: N`, and the CRT bezel corners are more pronounced.
 - **Post-game flow: flag → name → leaderboard → title → new game.** A new #1 high score celebrates with the flag *before* the initials prompt, and the attract sequence is steppable — a key on the leaderboard view advances to the title-card; only the title-card starts a new game.
+- **Four-pillar dividers feel intentional.** On the oyster.to homepage, the four benefits row now sits on a soft cyan-violet-pink gradient rail (matching the orbital arcs elsewhere), and the column separators are slightly more present so the divisions read as designed structure rather than near-invisible hairlines.
 
 ### Fixed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -316,6 +316,7 @@
 <ul>
 <li><strong>Rocket Ship title screen got an 80s arcade glow-up.</strong> Chunky pixel-art rocket with a flickering flame hovers above the <em>ROCKET SHIP</em> title, the controls panel uses an enlarged ★ and a plain <code>!</code> for asteroids, the HUD reads <code>SCORE: N</code>, and the CRT bezel corners are more pronounced.</li>
 <li><strong>Post-game flow: flag → name → leaderboard → title → new game.</strong> A new #1 high score celebrates with the flag <em>before</em> the initials prompt, and the attract sequence is steppable — a key on the leaderboard view advances to the title-card; only the title-card starts a new game.</li>
+<li><strong>Four-pillar dividers feel intentional.</strong> On the oyster.to homepage, the four benefits row now sits on a soft cyan-violet-pink gradient rail (matching the orbital arcs elsewhere), and the column separators are slightly more present so the divisions read as designed structure rather than near-invisible hairlines.</li>
 </ul>
 <h3>Fixed</h3>
 <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1005,16 +1005,29 @@
 
     /* 4-column benefit row */
     .benefit-row {
+      position: relative;
       display: grid;
       grid-template-columns: repeat(4, 1fr);
       gap: 0;
       padding: 28px 0 0;
-      border-top: 1px solid rgba(255, 255, 255, 0.06);
       margin-top: 32px;
+    }
+    /* top rail — same cyan→violet→pink gradient used for the orbit path above */
+    .benefit-row::before {
+      content: "";
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 1px;
+      background: linear-gradient(90deg,
+        rgba(123, 231, 255, 0) 0%,
+        rgba(123, 231, 255, 0.22) 18%,
+        rgba(169, 158, 255, 0.55) 50%,
+        rgba(255, 141, 224, 0.22) 82%,
+        rgba(255, 141, 224, 0) 100%);
     }
     .benefit {
       padding: 22px 28px;
-      border-left: 1px solid rgba(255, 255, 255, 0.06);
+      border-left: 1px solid rgba(255, 255, 255, 0.16);
     }
     .benefit:first-child { border-left: 0; }
     .benefit-icon {
@@ -1050,9 +1063,9 @@
     }
     @media (max-width: 820px) {
       .benefit-row { grid-template-columns: repeat(2, 1fr); gap: 0; }
-      .benefit { border-left: 0; padding: 18px 6px; border-top: 1px solid rgba(255,255,255,0.05); }
+      .benefit { border-left: 0; padding: 18px 6px; border-top: 1px solid rgba(255,255,255,0.14); }
       .benefit:first-child, .benefit:nth-child(2) { border-top: 0; }
-      .benefit:nth-child(odd) { border-right: 1px solid rgba(255,255,255,0.05); }
+      .benefit:nth-child(odd) { border-right: 1px solid rgba(255,255,255,0.14); }
     }
 
     .coming-soon {


### PR DESCRIPTION
## Summary

- Replace the 6%-white top hairline on the 4-pillar benefit row with a soft cyan→violet→pink gradient rail — same gradient stops as the orbit-path SVG directly above, so the divider reads as part of the site's existing visual language rather than an accidental line.
- Bump the vertical column-separators from `rgba(255,255,255,0.06)` → `rgba(255,255,255,0.16)` (still 1px hairlines, just slightly more present so the divisions read as designed structure).
- Mobile 2×2 grid hairlines bumped from `0.05` → `0.14` for consistency.

CSS-only change in `docs/index.html`; structure and content unchanged.

## Changelog

Entry added under `[Unreleased] → Changed` in `CHANGELOG.md`. `docs/changelog.html` updated with a surgical edit of the new `<li>` only — `npm run build:changelog` produces a different (smaller) output than the committed file because of pre-existing manual additions (parallax / reveal animations / external script refs). Worth a follow-up to either fold those back into the build script or commit a clean regen, but out of scope here.

## Test plan

- [ ] Open `docs/index.html` locally and scroll to the 4-pillar section (between the orbit/devices block and the "From zero to workspace" install block)
- [ ] Confirm the top divider is a faint horizontal gradient, brightest in the middle, fading to transparent at both edges
- [ ] Confirm the three vertical separators between columns are visible but understated hairlines
- [ ] Resize to ≤820px: 2×2 grid, hairlines on top/right between cells, no gradient artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)