### PR TITLE
chore(changelog): drop the four-pillar dividers entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Rocket Ship title screen got an 80s arcade glow-up.** Chunky pixel-art rocket with a flickering flame hovers above the *ROCKET SHIP* title, the controls panel uses an enlarged ★ and a plain `!` for asteroids, the HUD reads `SCORE: N`, and the CRT bezel corners are more pronounced.
 - **Post-game flow: flag → name → leaderboard → title → new game.** A new #1 high score celebrates with the flag *before* the initials prompt, and the attract sequence is steppable — a key on the leaderboard view advances to the title-card; only the title-card starts a new game.
-- **Four-pillar dividers feel intentional.** On the oyster.to homepage, the four benefits row now sits on a soft cyan-violet-pink gradient rail (matching the orbital arcs elsewhere), and the column separators are slightly more present so the divisions read as designed structure rather than near-invisible hairlines.
 
 ### Fixed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -312,7 +312,6 @@
 <ul>
 <li><strong>Rocket Ship title screen got an 80s arcade glow-up.</strong> Chunky pixel-art rocket with a flickering flame hovers above the <em>ROCKET SHIP</em> title, the controls panel uses an enlarged ★ and a plain <code>!</code> for asteroids, the HUD reads <code>SCORE: N</code>, and the CRT bezel corners are more pronounced.</li>
 <li><strong>Post-game flow: flag → name → leaderboard → title → new game.</strong> A new #1 high score celebrates with the flag <em>before</em> the initials prompt, and the attract sequence is steppable — a key on the leaderboard view advances to the title-card; only the title-card starts a new game.</li>
-<li><strong>Four-pillar dividers feel intentional.</strong> On the oyster.to homepage, the four benefits row now sits on a soft cyan-violet-pink gradient rail (matching the orbital arcs elsewhere), and the column separators are slightly more present so the divisions read as designed structure rather than near-invisible hairlines.</li>
 </ul>
 <h3>Fixed</h3>
 <ul>


### PR DESCRIPTION
## Summary

- Removes the *Four-pillar dividers feel intentional* bullet added in #515 from both `CHANGELOG.md` and `docs/changelog.html`.
- That change was a subtle CSS polish to the marketing homepage — not something a user would actually notice — and the bullet was written in implementation terms ("gradient rail", "column separators", "hairlines"). Belongs in the PR description, not the release notes.

## Test plan

- [ ] `CHANGELOG.md` *[Unreleased] → Changed* now lists only the two Rocket Ship entries
- [ ] `docs/changelog.html` *Unreleased → Changed* matches
- [ ] No other entries touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)