### PR TITLE
Rocket Ship: mobile touch controls + fullscreen breakout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Added
 
+- **Rocket Ship on mobile.** On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to *TAP* labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right.
 - **Mute toggle on the Rocket Ship title screen.** Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.
 
 ### Changed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -306,6 +306,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.1...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Added</h3>
 <ul>
+<li><strong>Rocket Ship on mobile.</strong> On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to <em>TAP</em> labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right.</li>
 <li><strong>Mute toggle on the Rocket Ship title screen.</strong> Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.</li>
 </ul>
 <h3>Changed</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -438,9 +438,67 @@
       border: 0;
       display: block;
     }
+    /* × close button — lives on the host (not inside the iframe) so the
+       click handler can call shutoff() directly with no postMessage
+       handshake. Hidden by default; only shown on the mobile breakpoint
+       when the rocket is launched. Desktop users close via the chrome
+       dots above the device mock. */
+    .hero-mock-rocket-exit {
+      position: absolute;
+      top: 14px;
+      right: 14px;
+      z-index: 2;
+      display: none;
+      width: 44px;
+      height: 44px;
+      border-radius: 8px;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: rgba(255, 255, 255, 0.85);
+      font-family: 'Press Start 2P', ui-monospace, monospace;
+      font-size: 22px;
+      line-height: 1;
+      padding: 0;
+      cursor: pointer;
+      align-items: center;
+      justify-content: center;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .hero-mock-rocket-exit:hover,
+    .hero-mock-rocket-exit:focus {
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.7);
+      outline: none;
+    }
+    @media (max-width: 700px) {
+      .hero-mock.is-launched .hero-mock-rocket-exit { display: flex; }
+    }
     .hero-mock.is-launched .hero-mock-rocket {
       opacity: 1;
       pointer-events: auto;
+    }
+    /* On mobile, break the rocket out of the tiny device mock and cover
+       the whole viewport so the game is actually playable. The CRT
+       shutoff animation still works (it's a transform-scale).
+
+       The body.is-rocket-launched class is set by the easter-egg IIFE on
+       launch and removed after CRT shutoff completes. We use it (not the
+       :has() trick) so older Safari still works, and so the rule only
+       costs paint while the rocket is up. Raising .hero's z-index above
+       the nav (z:100) is what lets the in-.hero rocket overlay actually
+       cover the page chrome instead of rendering behind it. */
+    @media (max-width: 700px) {
+      /* .hero h1 has z-index:2 and .cta-row has its own context too, both
+         of which beat the default .hero-mock z-index:1. Lift the mock above
+         them while the rocket is up so the fullscreen iframe actually
+         covers the hero text and buttons. */
+      body.is-rocket-launched .hero { z-index: 999; }
+      body.is-rocket-launched .hero-stage .hero-mock { z-index: 50; }
+      .hero-mock.is-launched .hero-mock-rocket {
+        position: fixed;
+        inset: 0;
+        z-index: 1000;
+      }
     }
     /* Hide the surface while the rocket is up — but bring it BACK as
        soon as CRT shutdown starts, so the collapsing dot reveals
@@ -455,6 +513,10 @@
       max-width: 1180px;
       margin: 84px auto 0;
       padding: 0 12px;
+    }
+    @media (max-width: 700px) {
+      .hero { padding-left: 14px; padding-right: 14px; }
+      .hero-stage { padding: 0 4px; }
     }
     .hero-stage .hero-mock {
       position: relative;
@@ -1355,6 +1417,7 @@
              to assistive tech only when visible. -->
         <div class="hero-mock-rocket" aria-hidden="true">
           <iframe data-src="rocket-ship.html" title="Rocket Ship" loading="lazy"></iframe>
+          <button type="button" class="hero-mock-rocket-exit" id="hero-mock-rocket-exit" aria-label="Exit rocket ship">×</button>
         </div>
 
         <div class="hm-preview" aria-hidden="true">
@@ -2015,6 +2078,7 @@
         setTimeout(() => {
           mock.classList.remove('is-launched');
           mock.classList.remove('is-shutting-down');
+          document.body.classList.remove('is-rocket-launched');
           if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'true');
           killIframe();
           shuttingDown = false;
@@ -2027,8 +2091,21 @@
         if (mock.classList.contains('is-launched')) return;
         if (frame) frame.src = frame.dataset.src;
         mock.classList.add('is-launched');
+        // Flag body so the mobile fullscreen CSS can lift .hero above the
+        // nav's stacking context — without this the page chrome renders
+        // over the iframe even though the iframe is z-index 1000.
+        document.body.classList.add('is-rocket-launched');
         if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'false');
       }
+
+      // Host-side close button (shown only on the mobile fullscreen
+      // breakout, CSS-gated). Calling shutoff() directly here avoids the
+      // postMessage round-trip and the file:// targetOrigin pitfall.
+      const exitBtn = document.getElementById('hero-mock-rocket-exit');
+      if (exitBtn) exitBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        shutoff();
+      });
 
       mock.querySelectorAll('.hero-mock-chrome .dot').forEach(dot => {
         dot.addEventListener('click', (e) => {

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -64,6 +64,74 @@
     filter: contrast(1.02) brightness(1.18) saturate(1.3);
   }
 
+  /* On-screen touch controls — only on coarse-pointer devices and only once
+     the splash dismisses (tube.is-ready). Two thumb clusters: turn-pair in
+     the bottom-left, thrust in the bottom-right. */
+  .touch-controls {
+    position: absolute;
+    inset: auto 0 0 0;
+    display: none;
+    justify-content: space-between;
+    align-items: flex-end;
+    padding: clamp(14px, 3vw, 28px);
+    pointer-events: none;
+    z-index: 6;
+  }
+  .tube.is-ready .touch-controls { display: flex; }
+  @media (hover: hover) and (pointer: fine) {
+    .touch-controls { display: none !important; }
+  }
+  .touch-controls .tc-group {
+    display: flex;
+    gap: clamp(10px, 2vw, 16px);
+    pointer-events: none;
+  }
+  .touch-controls .tc-btn {
+    pointer-events: auto;
+    width: clamp(56px, 11vw, 80px);
+    height: clamp(56px, 11vw, 80px);
+    border-radius: 12px;
+    border: 2px solid rgba(45, 212, 255, 0.6);
+    background: rgba(0, 0, 0, 0.35);
+    color: #2dd4ff;
+    font-family: 'Press Start 2P', ui-monospace, monospace;
+    font-size: clamp(20px, 4vw, 30px);
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+    transition: background 0.08s, border-color 0.08s;
+  }
+  .touch-controls .tc-btn:active,
+  .touch-controls .tc-btn.is-pressed {
+    background: rgba(45, 212, 255, 0.25);
+    border-color: #2dd4ff;
+    color: #fff;
+  }
+  .touch-controls .tc-thrust {
+    width: clamp(72px, 14vw, 100px);
+    height: clamp(72px, 14vw, 100px);
+    border-color: rgba(255, 132, 0, 0.7);
+    color: #ff8800;
+  }
+  .touch-controls .tc-thrust:active,
+  .touch-controls .tc-thrust.is-pressed {
+    background: rgba(255, 132, 0, 0.25);
+    border-color: #ff8800;
+    color: #fff;
+  }
+
+  /* Splash control labels: keyboard by default, touch alternatives shown
+     only on coarse-pointer devices. */
+  .splash .controls .touch-only { display: none; }
+  @media (pointer: coarse) {
+    .splash .controls .key-only { display: none; }
+    .splash .controls .touch-only { display: block; }
+  }
+
   /* CRT scanlines + RGB sub-pixel overlay */
   /* CRT layers sit ABOVE the splash/gameover/celebrate panels so the scanlines
      + vignette read on every screen, not just gameplay. pointer-events:none
@@ -300,6 +368,14 @@
   }
   .splash .sound-toggle:hover,
   .splash .sound-toggle:focus { opacity: 1; outline: none; }
+  /* At narrow widths the host's × sits top-right; flip ♪ to top-left so
+     both stay reachable. */
+  @media (max-width: 500px) {
+    .splash .sound-toggle {
+      right: auto;
+      left: clamp(10px, 1.6vw, 18px);
+    }
+  }
   .splash .sound-toggle.is-muted {
     color: rgba(255, 255, 255, 0.32);
     text-decoration: line-through;
@@ -597,6 +673,15 @@
     <canvas id="c"></canvas>
     <div class="overlay"></div>
     <div class="vignette"></div>
+    <div class="touch-controls" aria-hidden="true">
+      <div class="tc-group tc-turn">
+        <button type="button" class="tc-btn" id="tc-left"   aria-label="Turn left"  tabindex="-1">◀</button>
+        <button type="button" class="tc-btn" id="tc-right"  aria-label="Turn right" tabindex="-1">▶</button>
+      </div>
+      <div class="tc-group tc-fire">
+        <button type="button" class="tc-btn tc-thrust" id="tc-thrust" aria-label="Thrust" tabindex="-1">▲</button>
+      </div>
+    </div>
     <div class="splash" id="splash">
       <div class="boot">
         <div class="boot-msg">SYSTEM BOOT</div>
@@ -640,8 +725,8 @@
           <div class="title">ROCKET<br>SHIP</div>
           <div class="start">INSERT COIN TO PLAY</div>
           <div class="controls">
-            <div class="key">↑ / W</div><div class="desc">THRUST</div>
-            <div class="key">← →</div><div class="desc">TURN</div>
+            <div class="key key-only">↑ / W</div><div class="key touch-only">TAP ▲</div><div class="desc">THRUST</div>
+            <div class="key key-only">← →</div><div class="key touch-only">TAP ◀ ▶</div><div class="desc">TURN</div>
             <div class="key">★</div><div class="desc">COLLECT THE STARS</div>
             <div class="key">!</div><div class="desc">AVOID THE ASTEROIDS</div>
           </div>
@@ -807,20 +892,32 @@ window.addEventListener('keydown', e => {
 });
 window.addEventListener('keyup', e => keys[e.key] = false);
 
-// Touch controls — passive: false so preventDefault is honoured everywhere
+// Touch controls — driven by the on-screen buttons (◀ ▶ ▲) overlaid on the
+// tube. Buttons set the same flags the keyboard does so the rest of the game
+// loop doesn't need to know where the input came from.
+const isTouchDevice = window.matchMedia && matchMedia('(pointer: coarse)').matches;
 let touchThrust = false;
-let touchX = null;
-canvas.addEventListener('touchstart', e => {
-  e.preventDefault();
-  touchThrust = true;
-  touchX = e.touches[0].clientX;
-}, { passive: false });
-canvas.addEventListener('touchmove', e => {
-  e.preventDefault();
-  touchX = e.touches[0].clientX;
-}, { passive: false });
-canvas.addEventListener('touchend', () => { touchThrust = false; touchX = null; });
-canvas.addEventListener('touchcancel', () => { touchThrust = false; touchX = null; });
+(function bindTouchButtons() {
+  const left   = document.getElementById('tc-left');
+  const right  = document.getElementById('tc-right');
+  const thrust = document.getElementById('tc-thrust');
+  function bind(btn, onDown, onUp) {
+    if (!btn) return;
+    const down = e => { e.preventDefault(); btn.classList.add('is-pressed'); onDown(); };
+    const up   = e => { if (e) e.preventDefault(); btn.classList.remove('is-pressed'); onUp(); };
+    btn.addEventListener('pointerdown', down);
+    btn.addEventListener('pointerup', up);
+    btn.addEventListener('pointercancel', up);
+    btn.addEventListener('pointerleave', up);
+    // Stop pointer events from bubbling to the splash's global dismiss listener.
+    ['pointerdown', 'mousedown', 'touchstart'].forEach(ev => {
+      btn.addEventListener(ev, e => e.stopPropagation(), { passive: false });
+    });
+  }
+  bind(left,   () => keys['ArrowLeft']  = true, () => keys['ArrowLeft']  = false);
+  bind(right,  () => keys['ArrowRight'] = true, () => keys['ArrowRight'] = false);
+  bind(thrust, () => touchThrust = true,        () => touchThrust = false);
+})();
 
 // Mouse control — release tracked on window (and window blur) so a drag
 // that ends outside the canvas / iframe still clears the steering state.
@@ -1040,12 +1137,11 @@ function update() {
     hasMoved = true;
   }
 
-  // Touch/mouse steering
-  if ((touchThrust && touchX !== null) || (mouseDown && mouseX !== null)) {
-    // Nullish — `||` would treat a perfectly valid touch at clientX=0 as missing.
-    const tx = touchX !== null ? touchX : mouseX;
+  // Mouse steering — point rocket toward horizontal mouse position while
+  // dragging. Touch users get explicit ◀ / ▶ buttons instead.
+  if (mouseDown && mouseX !== null) {
     const center = W / 2;
-    const diff = (tx - center) / (W / 2);
+    const diff = (mouseX - center) / (W / 2);
     rocket.angle += diff * 0.06;
   }
 
@@ -1259,7 +1355,9 @@ function draw() {
     const t = (performance.now() - movedAt) / HINT_FADE_MS;
     hintAlpha = t >= 1 ? 0 : 0.7 * (1 - t);
   }
-  if (hintAlpha > 0.001) {
+  // On touch devices the ◀ ▶ ▲ buttons are self-explanatory and the hint
+  // text just overlaps them, so skip drawing it entirely.
+  if (hintAlpha > 0.001 && !isTouchDevice) {
     ctx.fillStyle = `rgba(255,255,255,${hintAlpha.toFixed(3)})`;
     ctx.font = '11px "Press Start 2P", ui-monospace, monospace';
     ctx.textAlign = 'center';
@@ -1314,6 +1412,10 @@ loop();
   if (!bgm) return;
   bgm.volume = 0.45;
 })();
+
+// Mark the body when embedded so the host can target embedded-only styles
+// if needed. The close button lives on the host page now (see index.html).
+if (window.self !== window.top) document.body.classList.add('is-embedded');
 
 // Sound toggle on the splash. Persists muted state to localStorage and
 // mirrors it onto every <audio> element so both BGM and SFX go silent.
@@ -1673,10 +1775,11 @@ const Splash = (function () {
     // don't bubble out of an iframe, so without postMessage the outer
     // ESC-to-shutoff listener never fires while focus is in the game.
     if (e.key === 'Escape') {
-      // Target the current origin explicitly — never broadcast the close
-      // signal to a cross-origin parent (matters if the game is ever
-      // embedded elsewhere).
-      try { window.parent.postMessage({ type: 'oyster-rocket-close' }, location.origin); } catch (_) {}
+      // '*' targetOrigin because location.origin is the literal string
+      // "null" on file:// and won't match any real origin, breaking the
+      // close handshake. The parent verifies e.source against its iframe
+      // ref so this still can't be spoofed by a third-party tab.
+      try { window.parent.postMessage({ type: 'oyster-rocket-close' }, '*'); } catch (_) {}
       return;
     }
     tryDismiss();


### PR DESCRIPTION
## Summary

- **On-screen touch controls.** ◀ ▶ ▲ buttons overlay the canvas on coarse-pointer devices once the splash dismisses. Buttons drive the same input flags as the keyboard, so the rest of the game loop is unchanged.
- **Splash labels swap on touch** — `TAP ▲ THRUST` / `TAP ◀ ▶ TURN` instead of arrow-key icons. In-game keyboard hint is suppressed entirely on touch (it was overlapping the buttons).
- **Mobile fullscreen breakout.** Launching the rocket on a phone takes it out of the tiny device mock and into a position:fixed viewport-cover. `.hero` stacking context lifted above the nav so the iframe actually obscures page chrome instead of rendering behind it.
- **× close button on the host.** Lives next to the iframe (not inside it). Click → `shutoff()` directly, no postMessage handshake — the iframe approach was broken under `file://` because `location.origin` returns the string `"null"` and that fails as a `postMessage` targetOrigin.
- **♪ stays reachable.** Flips to top-left at narrow iframe widths so it doesn't sit under the host's ×.

## Test plan

- [ ] On a real phone, open the homepage and tap the red or yellow device dot — rocket launches fullscreen, page chrome fully hidden
- [ ] Three on-screen buttons appear once the splash dismisses; ◀ ▶ rotate, ▲ thrusts
- [ ] Splash shows `TAP ▲ THRUST` / `TAP ◀ ▶ TURN` instead of keyboard labels
- [ ] Tap × in the top-right → CRT shutoff fires and returns to the homepage
- [ ] Tap ♪ in the top-left → mute persists across reloads
- [ ] At ≥ 700px viewport (tablet/desktop), no × shown; close via chrome dots
- [ ] Desktop mouse + keyboard still works (drag-to-steer, arrow keys, WASD, ESC to exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)