### PR TITLE
Rocket Ship: tap-friendly text + lock body scroll on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Rocket Ship on phones reads as tappable.** *INSERT COIN* / *PRESS ANY KEY* / *PRESS ANY KEY TO RESTART* swap to *TAP TO PLAY* / *TAP TO CONTINUE* / *TAP TO RESTART* on touch devices. The page underneath is also locked while the game is up — no more peeking through at the bottom or showing the scrollbar.
 - **Pixel font now used everywhere in Rocket Ship.** Arrow keys, the star, the music note, the in-game HUD and the game-over hint all render in the proper 8-bit typeface instead of falling back to system fonts.
 - **Title music plays during the title screen** when the page is loaded directly. Previously the autoplay-blocked path either dropped the title theme or stacked it on top of the game music.
 - **In-game hint stays until you actually fly.** The *Arrow keys / WASD…* overlay persists at full opacity until the player provides any thrust/turn input, then eases out smoothly instead of timing out after 5 seconds.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -316,6 +316,7 @@
 </ul>
 <h3>Fixed</h3>
 <ul>
+<li><strong>Rocket Ship on phones reads as tappable.</strong> <em>INSERT COIN</em> / <em>PRESS ANY KEY</em> / <em>PRESS ANY KEY TO RESTART</em> swap to <em>TAP TO PLAY</em> / <em>TAP TO CONTINUE</em> / <em>TAP TO RESTART</em> on touch devices. The page underneath is also locked while the game is up — no more peeking through at the bottom or showing the scrollbar.</li>
 <li><strong>Pixel font now used everywhere in Rocket Ship.</strong> Arrow keys, the star, the music note, the in-game HUD and the game-over hint all render in the proper 8-bit typeface instead of falling back to system fonts.</li>
 <li><strong>Title music plays during the title screen</strong> when the page is loaded directly. Previously the autoplay-blocked path either dropped the title theme or stacked it on top of the game music.</li>
 <li><strong>In-game hint stays until you actually fly.</strong> The <em>Arrow keys / WASD…</em> overlay persists at full opacity until the player provides any thrust/turn input, then eases out smoothly instead of timing out after 5 seconds.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2082,6 +2082,13 @@
         if (frame) frame.src = 'about:blank';
       }
 
+      // Remembered across launch/shutoff so we can restore the user's
+      // scroll position. body { position: fixed } anchors the page at
+      // top:0 by default; we offset by -lockedScrollY while locked, then
+      // window.scrollTo() back to it on unlock so closing the rocket
+      // doesn't snap the user to the top of the page.
+      let lockedScrollY = 0;
+
       function shutoff() {
         if (shuttingDown || !mock.classList.contains('is-launched')) return;
         shuttingDown = true;
@@ -2097,6 +2104,8 @@
           mock.classList.remove('is-shutting-down');
           document.documentElement.classList.remove('is-rocket-launched');
           document.body.classList.remove('is-rocket-launched');
+          document.body.style.top = '';
+          window.scrollTo(0, lockedScrollY);
           if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'true');
           killIframe();
           shuttingDown = false;
@@ -2113,6 +2122,8 @@
         // the nav's stacking context AND lock page scroll. Without the
         // stacking lift the page chrome renders over the iframe; without
         // the scroll lock the page underneath peeks through at the edges.
+        lockedScrollY = window.scrollY;
+        document.body.style.top = `-${lockedScrollY}px`;
         document.documentElement.classList.add('is-rocket-launched');
         document.body.classList.add('is-rocket-launched');
         if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'false');

--- a/docs/index.html
+++ b/docs/index.html
@@ -494,10 +494,27 @@
          covers the hero text and buttons. */
       body.is-rocket-launched .hero { z-index: 999; }
       body.is-rocket-launched .hero-stage .hero-mock { z-index: 50; }
+      /* Lock body scroll so the page underneath doesn't peek through at
+         the bottom and the scrollbar disappears. position:fixed prevents
+         iOS rubber-banding from revealing the page edges. */
+      html.is-rocket-launched,
+      body.is-rocket-launched {
+        overflow: hidden;
+        overscroll-behavior: none;
+      }
+      body.is-rocket-launched {
+        position: fixed;
+        inset: 0;
+        width: 100%;
+      }
       .hero-mock.is-launched .hero-mock-rocket {
         position: fixed;
         inset: 0;
         z-index: 1000;
+        /* 100dvh tracks the dynamic viewport (mobile browsers shrink it
+           when the URL bar shows), preventing a thin letterbox at the
+           bottom that exposes the page chrome behind. */
+        height: 100dvh;
       }
     }
     /* Hide the surface while the rocket is up — but bring it BACK as
@@ -2078,6 +2095,7 @@
         setTimeout(() => {
           mock.classList.remove('is-launched');
           mock.classList.remove('is-shutting-down');
+          document.documentElement.classList.remove('is-rocket-launched');
           document.body.classList.remove('is-rocket-launched');
           if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'true');
           killIframe();
@@ -2091,9 +2109,11 @@
         if (mock.classList.contains('is-launched')) return;
         if (frame) frame.src = frame.dataset.src;
         mock.classList.add('is-launched');
-        // Flag body so the mobile fullscreen CSS can lift .hero above the
-        // nav's stacking context — without this the page chrome renders
-        // over the iframe even though the iframe is z-index 1000.
+        // Flag body+html so the mobile fullscreen CSS can lift .hero above
+        // the nav's stacking context AND lock page scroll. Without the
+        // stacking lift the page chrome renders over the iframe; without
+        // the scroll lock the page underneath peeks through at the edges.
+        document.documentElement.classList.add('is-rocket-launched');
         document.body.classList.add('is-rocket-launched');
         if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'false');
       }

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -124,12 +124,14 @@
     color: #fff;
   }
 
-  /* Splash control labels: keyboard by default, touch alternatives shown
-     only on coarse-pointer devices. */
-  .splash .controls .touch-only { display: none; }
+  /* Show keyboard hints by default; swap to touch labels on coarse
+     pointers. display:revert lets each element fall back to its natural
+     display value (div → block, span → inline) so the utility works in
+     both block and inline contexts. */
+  .touch-only { display: none; }
   @media (pointer: coarse) {
-    .splash .controls .key-only { display: none; }
-    .splash .controls .touch-only { display: block; }
+    .key-only { display: none; }
+    .touch-only { display: revert; }
   }
 
   /* CRT scanlines + RGB sub-pixel overlay */
@@ -723,7 +725,7 @@
             <rect class="flame flame-4" x="10" y="27" width="2" height="2" fill="#ffffff"/>
           </svg>
           <div class="title">ROCKET<br>SHIP</div>
-          <div class="start">INSERT COIN TO PLAY</div>
+          <div class="start"><span class="key-only">INSERT COIN TO PLAY</span><span class="touch-only">TAP TO PLAY</span></div>
           <div class="controls">
             <div class="key key-only">↑ / W</div><div class="key touch-only">TAP ▲</div><div class="desc">THRUST</div>
             <div class="key key-only">← →</div><div class="key touch-only">TAP ◀ ▶</div><div class="desc">TURN</div>
@@ -731,12 +733,12 @@
             <div class="key">!</div><div class="desc">AVOID THE ASTEROIDS</div>
           </div>
           <div class="hiscore-row" id="hiscore-row">HIGH SCORE <span class="hs-val" id="hs-val-splash">000</span> <span class="hs-initials" id="hs-initials-splash">---</span></div>
-          <div class="credit">© OYSTER 2026 — PRESS ANY KEY</div>
+          <div class="credit">© OYSTER 2026 — <span class="key-only">PRESS ANY KEY</span><span class="touch-only">TAP TO PLAY</span></div>
         </div>
         <div class="leaderboard splash-view">
           <div class="lb-title">HIGH SCORES</div>
           <ol class="lb-list" id="lb-list"></ol>
-          <div class="credit">© OYSTER 2026 — PRESS ANY KEY</div>
+          <div class="credit">© OYSTER 2026 — <span class="key-only">PRESS ANY KEY</span><span class="touch-only">TAP TO PLAY</span></div>
         </div>
       </div>
       <button class="sound-toggle" id="sound-toggle" type="button" aria-label="Toggle sound" tabindex="-1">♪</button>
@@ -748,13 +750,13 @@
         <span class="flag-pole"></span>
         <span class="flag-cloth"><span class="flag-text">1<small>ST</small></span></span>
       </div>
-      <div class="celebrate-sub">PRESS ANY KEY</div>
+      <div class="celebrate-sub"><span class="key-only">PRESS ANY KEY</span><span class="touch-only">TAP TO CONTINUE</span></div>
     </div>
     <div class="gameover" id="gameover">
       <div class="title go-title">GAME OVER</div>
       <div class="go-score">SCORE <span id="go-score-val">0</span></div>
       <div class="go-hiscore" id="go-hiscore"></div>
-      <div class="go-prompt" id="go-prompt">PRESS ANY KEY TO RESTART</div>
+      <div class="go-prompt" id="go-prompt"><span class="key-only">PRESS ANY KEY TO RESTART</span><span class="touch-only">TAP TO RESTART</span></div>
       <!-- High-score initial entry, shown only when score beats the current record -->
       <div class="go-initials" id="go-initials" hidden>
         <div class="go-initials-label">NEW HIGH SCORE — ENTER INITIALS</div>


### PR DESCRIPTION
## Summary

- **Touch users now know to tap.** Splash CTA, credit lines, celebration screen, and game-over prompt swap from *PRESS ANY KEY* to *TAP TO PLAY / CONTINUE / RESTART* on `(pointer: coarse)`. Previously a real-device tester couldn't get past the splash because every cue said "press a key".
- **Page locked under the fullscreen rocket.** Body underneath was leaking through as a thin letterbox at the bottom, and the scrollbar was visible. Now `html+body` get `overflow:hidden` + `body{position:fixed; inset:0}` while launched, and the iframe overlay is sized to `100dvh` so mobile URL-bar transitions don't expose page chrome.
- **Generalised `.key-only` / `.touch-only`.** Old rule was scoped to `.splash .controls` and hard-coded `display:block`. Now uses `display:revert` so the same classes work inside spans (for inline text swaps) and divs alike.

## Test plan

- [ ] On a real phone, open homepage and tap the rocket dot — splash says *INSERT COIN TO PLAY* + *TAP TO PLAY* hint
- [ ] Tap anywhere on the splash → game starts (no longer stuck on a "press a key" prompt)
- [ ] No page content visible at the bottom edge; no scrollbar
- [ ] Crash the rocket → game over says *TAP TO RESTART*; tap → restart
- [ ] Beat the high score → celebration says *TAP TO CONTINUE*
- [ ] Tap × → returns to homepage with no scroll jump
- [ ] Desktop unchanged: still says *PRESS ANY KEY*, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)