### PR TITLE
Fix Rocket Ship tap + audio on iOS (revert aggressive scroll lock)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -494,27 +494,16 @@
          covers the hero text and buttons. */
       body.is-rocket-launched .hero { z-index: 999; }
       body.is-rocket-launched .hero-stage .hero-mock { z-index: 50; }
-      /* Lock body scroll so the page underneath doesn't peek through at
-         the bottom and the scrollbar disappears. position:fixed prevents
-         iOS rubber-banding from revealing the page edges. */
+      /* Lock scroll the cheap way — overflow:hidden on html+body. The
+         previous position:fixed approach made the iframe's hit-testing
+         flaky on iOS Safari (taps near the bottom missed the iframe
+         entirely, so splash-dismiss and audio-unlock never fired). */
       html.is-rocket-launched,
-      body.is-rocket-launched {
-        overflow: hidden;
-        overscroll-behavior: none;
-      }
-      body.is-rocket-launched {
-        position: fixed;
-        inset: 0;
-        width: 100%;
-      }
+      body.is-rocket-launched { overflow: hidden; }
       .hero-mock.is-launched .hero-mock-rocket {
         position: fixed;
         inset: 0;
         z-index: 1000;
-        /* 100dvh tracks the dynamic viewport (mobile browsers shrink it
-           when the URL bar shows), preventing a thin letterbox at the
-           bottom that exposes the page chrome behind. */
-        height: 100dvh;
       }
     }
     /* Hide the surface while the rocket is up — but bring it BACK as
@@ -2082,13 +2071,6 @@
         if (frame) frame.src = 'about:blank';
       }
 
-      // Remembered across launch/shutoff so we can restore the user's
-      // scroll position. body { position: fixed } anchors the page at
-      // top:0 by default; we offset by -lockedScrollY while locked, then
-      // window.scrollTo() back to it on unlock so closing the rocket
-      // doesn't snap the user to the top of the page.
-      let lockedScrollY = 0;
-
       function shutoff() {
         if (shuttingDown || !mock.classList.contains('is-launched')) return;
         shuttingDown = true;
@@ -2104,8 +2086,6 @@
           mock.classList.remove('is-shutting-down');
           document.documentElement.classList.remove('is-rocket-launched');
           document.body.classList.remove('is-rocket-launched');
-          document.body.style.top = '';
-          window.scrollTo(0, lockedScrollY);
           if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'true');
           killIframe();
           shuttingDown = false;
@@ -2119,11 +2099,7 @@
         if (frame) frame.src = frame.dataset.src;
         mock.classList.add('is-launched');
         // Flag body+html so the mobile fullscreen CSS can lift .hero above
-        // the nav's stacking context AND lock page scroll. Without the
-        // stacking lift the page chrome renders over the iframe; without
-        // the scroll lock the page underneath peeks through at the edges.
-        lockedScrollY = window.scrollY;
-        document.body.style.top = `-${lockedScrollY}px`;
+        // the nav's stacking context AND lock page scroll.
         document.documentElement.classList.add('is-rocket-launched');
         document.body.classList.add('is-rocket-launched');
         if (rocketOverlay) rocketOverlay.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary

Reverts the `body { position: fixed; inset: 0 }` + iframe `height: 100dvh` from #518. Those caused tap-to-dismiss and audio to silently fail on real iOS Safari.

## What went wrong in #518

- **`inset:0` + `height:100dvh` conflict.** When iOS's URL bar shows, dvh < layout viewport. Per spec, height wins → iframe is shorter than the viewport → a strip at the bottom isn't covered by the iframe → taps there hit the page below, not the game.
- **`body { position: fixed }`** also interacts poorly with iframe hit-testing on iOS Safari in some configurations.

Either way, the `window.touchstart` listener inside the rocket-ship iframe never fired → `tryDismiss()` was never called → splash stayed up → no user gesture meant `bgm.play()` stayed blocked by the autoplay policy.

## What's left

Minimal lock: `overflow: hidden` on `html` + `body`. iframe stays `position: fixed; inset: 0` so it covers the viewport.

## Trade-offs vs #518

- Scroll position no longer captured/restored (no `body{position:fixed}` to need it for).
- Scrollbar may flash briefly on launch (overflow:hidden alone doesn't prevent that).
- iOS rubber-banding can momentarily show page edges.

Functionality > polish here — completely broken tap is worse than a flash of scrollbar.

## Test plan

- [ ] On a real iOS phone: tap the rocket dot, splash boots, **tap to dismiss works**
- [ ] Title music plays after the first dismiss tap
- [ ] Game starts, on-screen buttons work
- [ ] × in top-right closes the game
- [ ] No regression on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)