### PR TITLE
Rocket Ship: mobile polish — initials entry, no Copy popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Added
 
-- **Rocket Ship on mobile.** On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to *TAP* labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right.
+- **Rocket Ship on mobile.** On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to *TAP* labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right. High-score initials can be entered with the same buttons: ◀ ▶ cycle the letter, ▲ advances to the next slot or saves.
 - **Mute toggle on the Rocket Ship title screen.** Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.
 
 ### Changed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -306,7 +306,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.1...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Added</h3>
 <ul>
-<li><strong>Rocket Ship on mobile.</strong> On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to <em>TAP</em> labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right.</li>
+<li><strong>Rocket Ship on mobile.</strong> On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to <em>TAP</em> labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right. High-score initials can be entered with the same buttons: ◀ ▶ cycle the letter, ▲ advances to the next slot or saves.</li>
 <li><strong>Mute toggle on the Rocket Ship title screen.</strong> Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.</li>
 </ul>
 <h3>Changed</h3>

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -23,6 +23,13 @@
     overflow: hidden;
     height: 100vh;
     width: 100vw;
+    /* Suppress iOS text selection / Copy popup when a tap drifts slightly
+       during gameplay or on the splash. Everything in the game is visual
+       — nothing should be selectable. */
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
   }
 
   /* Screen container — old CRT bezel (warm-gray molded plastic) */

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -772,7 +772,7 @@
           <span class="go-slot" data-slot="1">A</span>
           <span class="go-slot" data-slot="2">A</span>
         </div>
-        <div class="go-initials-hint">↑↓ CHANGE · ←→ MOVE · ENTER SAVE</div>
+        <div class="go-initials-hint"><span class="key-only">↑↓ CHANGE · ←→ MOVE · ENTER SAVE</span><span class="touch-only">◀ ▶ LETTER · ▲ NEXT</span></div>
       </div>
     </div>
   </div>
@@ -923,9 +923,20 @@ let touchThrust = false;
       btn.addEventListener(ev, e => e.stopPropagation(), { passive: false });
     });
   }
-  bind(left,   () => keys['ArrowLeft']  = true, () => keys['ArrowLeft']  = false);
-  bind(right,  () => keys['ArrowRight'] = true, () => keys['ArrowRight'] = false);
-  bind(thrust, () => touchThrust = true,        () => touchThrust = false);
+  // While the game-over overlay is up, the on-screen buttons drive initials
+  // entry instead of game motion: ◀/▶ cycle the active letter, ▲ advances
+  // slots (and saves on the last one). The game-over IIFE returns true if
+  // it consumed the action so we skip setting the game-input flags.
+  function goConsumed(action) {
+    const handler = window.__rocketGameOverTouch;
+    return !!(handler && handler(action));
+  }
+  bind(left,   () => { if (!goConsumed('letter-prev')) keys['ArrowLeft']  = true; },
+                () => keys['ArrowLeft']  = false);
+  bind(right,  () => { if (!goConsumed('letter-next')) keys['ArrowRight'] = true; },
+                () => keys['ArrowRight'] = false);
+  bind(thrust, () => { if (!goConsumed('advance'))     touchThrust        = true; },
+                () => touchThrust = false);
 })();
 
 // Mouse control — release tracked on window (and window blur) so a drag
@@ -1870,6 +1881,48 @@ const Splash = (function () {
 
   // Expose for triggerGameOver -> setTimeout fade-in
   window.__rocketShowGameOver = showGameOverWith;
+
+  // Touch routing for the game-over overlay. Returns true if the action was
+  // consumed so the touch-button bindings know to suppress their game
+  // (rotate/thrust) side-effects. Three actions mapped from the on-screen
+  // buttons: ◀/▶ cycle the active letter, ▲ advances to the next slot or
+  // saves on the last one.
+  window.__rocketGameOverTouch = function (action) {
+    if (!ov.classList.contains('is-visible')) return false;
+    if (enteringInitials) {
+      const idx = CHARS.indexOf(letters[activeSlot]);
+      if (action === 'letter-prev') {
+        letters[activeSlot] = CHARS[(idx - 1 + CHARS.length) % CHARS.length];
+      } else if (action === 'letter-next') {
+        letters[activeSlot] = CHARS[(idx + 1) % CHARS.length];
+      } else if (action === 'advance') {
+        if (activeSlot < 2) {
+          activeSlot++;
+        } else {
+          addToLeaderboard(pendingScore, letters.join(''));
+          enteringInitials = false;
+          ov.classList.remove('is-visible');
+          Splash.enterAttractMode();
+        }
+      }
+      paintSlots();
+      return true;
+    }
+    // Non-initials game-over: any touch button dismisses, matching the
+    // keyboard "any key" behavior.
+    ov.classList.remove('is-visible');
+    Splash.enterAttractMode();
+    return true;
+  };
+
+  // Tap anywhere outside a button to dismiss when not entering initials —
+  // mirrors the keydown handler below.
+  window.addEventListener('touchstart', (e) => {
+    if (!ov.classList.contains('is-visible')) return;
+    if (enteringInitials) return; // initials uses the on-screen buttons
+    ov.classList.remove('is-visible');
+    Splash.enterAttractMode();
+  }, { passive: true });
 
   window.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') return;


### PR DESCRIPTION
## Summary

Two mobile polish fixes for the Rocket Ship easter egg:

- **Initials entry on touch.** The high-score initials prompt was keyboard-only — mobile players couldn't save a top-10 score. Wires the existing on-screen ◀ ▶ ▲ buttons into the game-over overlay: ◀/▶ cycle the active letter, ▲ advances to the next slot (and saves on the third). Hint text under the slots swaps from the keyboard glyphs to *◀ ▶ LETTER · ▲ NEXT* on touch. Non-initials game-overs also dismiss on any tap now (matches the keyboard "any key" behavior).
- **No iOS Copy popup on splash drag.** A tap that drifted slightly was triggering iOS's text-selection popup. Adds \`user-select: none\` + \`-webkit-touch-callout: none\` + \`-webkit-tap-highlight-color: transparent\` at the body level so the whole game is treated as a gesture surface.

## Test plan

- [ ] Real phone: tap the rocket dot, splash boots, tap-and-drag → no Copy popup
- [ ] Crash and beat the high score → ◀/▶ cycle letters, ▲ advances, ▲ on last slot saves and returns to attract mode
- [ ] Crash without beating high score → tap anywhere dismisses to attract mode
- [ ] Desktop unchanged: keyboard still works for initials and the hint still shows keyboard glyphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)