### PR TITLE
feat(docs): full-width CTAs on phone-sized screens

### DIFF
--- a/docs/assets/oyster.css
+++ b/docs/assets/oyster.css
@@ -314,6 +314,12 @@ body {
   justify-content: center;
   flex-wrap: wrap;
 }
+/* Phone-sized screens only — stack the CTAs and let each one fill the width.
+   Tablets keep the inline pill row. */
+@media (max-width: 560px) {
+  .cta-row { flex-direction: column; flex-wrap: nowrap; }
+  .cta-row .cta { width: 100%; justify-content: center; }
+}
 
 /* ============================================
    TYPOGRAPHY PATTERNS


### PR DESCRIPTION
## Summary

At ≤560px (the existing mobile breakpoint convention in `oyster.css`), the `.cta-row` flex container stacks vertically and each `.cta` button fills the available width. Tablet and desktop keep the existing inline pill row.

Applies to both `.cta-row` instances:
- Hero: *Launch Oyster* + *View on GitHub*
- Bottom CTA: *README.md* + *View on GitHub*

Standalone CTAs (the "Detailed setup →" and "See pricing" buttons outside a `.cta-row`) are unaffected.

## Test plan

- [ ] At ≥561px viewport width: CTAs render as two centered pills side-by-side (unchanged)
- [ ] At ≤560px viewport: CTAs stack vertically, each filling the row width
- [ ] Check both the hero (top of page) and the bottom CTA section before the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)