### PR TITLE
fix(rocket-ship): preserve persisted mute state for Web Audio SFX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Rocket Ship SFX now honour the mute toggle.** Muting the ♪ button silenced the music as expected, but shots and explosions still played at full volume on the next boot — they now go silent too.
 - **Rocket Ship on phones reads as tappable.** *INSERT COIN* / *PRESS ANY KEY* / *PRESS ANY KEY TO RESTART* swap to *TAP TO PLAY* / *TAP TO CONTINUE* / *TAP TO RESTART* on touch devices. The page underneath is also locked while the game is up — no more peeking through at the bottom or showing the scrollbar.
 - **Pixel font now used everywhere in Rocket Ship.** Arrow keys, the star, the music note, the in-game HUD and the game-over hint all render in the proper 8-bit typeface instead of falling back to system fonts.
 - **Title music plays during the title screen** when the page is loaded directly. Previously the autoplay-blocked path either dropped the title theme or stacked it on top of the game music.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -316,6 +316,7 @@
 </ul>
 <h3>Fixed</h3>
 <ul>
+<li><strong>Rocket Ship SFX now honour the mute toggle.</strong> Muting the ♪ button silenced the music as expected, but shots and explosions still played at full volume on the next boot — they now go silent too.</li>
 <li><strong>Rocket Ship on phones reads as tappable.</strong> <em>INSERT COIN</em> / <em>PRESS ANY KEY</em> / <em>PRESS ANY KEY TO RESTART</em> swap to <em>TAP TO PLAY</em> / <em>TAP TO CONTINUE</em> / <em>TAP TO RESTART</em> on touch devices. The page underneath is also locked while the game is up — no more peeking through at the bottom or showing the scrollbar.</li>
 <li><strong>Pixel font now used everywhere in Rocket Ship.</strong> Arrow keys, the star, the music note, the in-game HUD and the game-over hint all render in the proper 8-bit typeface instead of falling back to system fonts.</li>
 <li><strong>Title music plays during the title screen</strong> when the page is loaded directly. Previously the autoplay-blocked path either dropped the title theme or stacked it on top of the game music.</li>

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -1484,10 +1484,13 @@ const SFX_FILES = {
 // That call lands here before this line would have executed under `let`,
 // which would throw a TDZ ReferenceError, halt the script, and prevent
 // the splash IIFE further down from registering its click handlers.
+// `sfxMuted` has no initializer for the same reason: the IIFE has
+// already assigned it, and `= false` would run afterwards and clobber
+// the persisted value back to unmuted.
 var audioCtx = null;
 var sfxMasterGain = null;
 var sfxBuffers = {};
-var sfxMuted = false;
+var sfxMuted;
 
 // Called from the first user gesture (see Splash IIFE). Idempotent —
 // creates the context, kicks off all decodes in parallel, and resumes


### PR DESCRIPTION
## Summary

- The sound-toggle IIFE at module init in `docs/rocket-ship.html` calls `setSfxMuted(m)` to apply the persisted muted state. That sets the hoisted `sfxMuted` variable to `true` for previously-muted users.
- A few lines later, `var sfxMuted = false` runs and clobbers that back. The audio elements stay silent (via `.muted`), but `sfxMasterGain.gain.value = sfxMuted ? 0 : 1` reads `false` once the Web Audio context spins up, so shots and explosions play at full volume on the next boot.
- Dropping the `= false` initializer fixes it; the existing var-vs-let comment is extended to explain why.

Found by Copilot review on #524.

## Test plan

- [ ] Open Rocket Ship, mute via ♪, reload — confirm shots/explosions are silent after the first user gesture.
- [ ] Unmute, reload — confirm SFX play at normal volume.
- [ ] Boot fresh (no localStorage entry) — confirm default is unmuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)