### PR TITLE
Viewer access redirect: owner bypass + signin handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Rocket Ship on mobile.** On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to *TAP* labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right. High-score initials can be entered with the same buttons: ◀ ▶ cycle the letter, ▲ advances to the next slot or saves.
 - **Mute toggle on the Rocket Ship title screen.** Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.
+- **Sign in to view your own protected shares.** A password-protected share now offers a "Have access? Sign in to view" option alongside the password field; if you're signed in to Oyster as the owner, you skip the password.
 
 ### Changed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -308,6 +308,7 @@
 <ul>
 <li><strong>Rocket Ship on mobile.</strong> On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to <em>TAP</em> labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right. High-score initials can be entered with the same buttons: ◀ ▶ cycle the letter, ▲ advances to the next slot or saves.</li>
 <li><strong>Mute toggle on the Rocket Ship title screen.</strong> Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.</li>
+<li><strong>Sign in to view your own protected shares.</strong> A password-protected share now offers a &quot;Have access? Sign in to view&quot; option alongside the password field; if you&#39;re signed in to Oyster as the owner, you skip the password.</li>
 </ul>
 <h3>Changed</h3>
 <ul>

--- a/docs/superpowers/plans/2026-05-18-viewer-access-redirect.md
+++ b/docs/superpowers/plans/2026-05-18-viewer-access-redirect.md
@@ -1,0 +1,1722 @@
+# Viewer access redirect — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a viewer-access bridge so an authorised visitor can reach a protected share without retyping the password — covering owner bypass for `password` mode and fixing the broken cross-host handoff for `signin` mode.
+
+**Architecture:** A new `oyster.to`-hosted endpoint (where the apex session cookie lives) checks access, mints a single-use D1-backed nonce, and 302s the browser to `share.oyster.to/p/<token>?key=<nonce>`. The publish worker consumes the nonce and sets the existing `oyster_view_<token>` cookie (generalised to be a "recent-access proof for the artefact" honoured by both `password` and `signin` modes). `share_token` is in the consume `WHERE` clause so a nonce minted for one share cannot be burned against another. `/raw` cannot consume nonces — a required `consumeNonce` flag on `resolveViewerAccess` makes this an API contract.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), D1 (SQLite at the edge), vitest + `@cloudflare/vitest-pool-workers`, Web Crypto for HMAC cookie signing.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md`.
+
+**Branch:** `feat/viewer-access-redirect` (already checked out).
+
+---
+
+## File structure
+
+### Create
+
+| Path | Purpose |
+|---|---|
+| `infra/auth-worker/migrations/0011_viewer_access_nonces.sql` | D1 table for short-lived access nonces |
+| `infra/oyster-publish/src/access-nonce.ts` | `mintAccessNonce` + `consumeAccessNonce` (the atomic single-use machinery) |
+| `infra/oyster-publish/test/access-nonce.test.ts` | Unit tests for the nonce module |
+| `infra/oyster-publish/test/access-redirect-handler.test.ts` | Integration tests for the new `GET /api/publish/access-redirect/:token` endpoint |
+| `infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts` | Cross-host cookie-scoping regression — proves the bug today's tests miss |
+
+### Modify
+
+| Path | Why |
+|---|---|
+| `infra/oyster-publish/test/fixtures/seed.ts` | Mirror the new D1 table in the test schema |
+| `infra/oyster-publish/src/viewer-access.ts` | New `ok_via_nonce` kind; required `{ consumeNonce }` option; `signin` mode honours viewer cookie |
+| `infra/oyster-publish/src/viewer-render.ts` | Add `referrer-policy: no-referrer` in `cacheHeaders()` |
+| `infra/oyster-publish/src/viewer-pages.ts` | Add "Have access? Sign in to view" link on the password-gate page |
+| `infra/oyster-publish/src/worker.ts` | New `/api/publish/access-redirect/:token` route; handle `ok_via_nonce`; pass `consumeNonce` flag from all three viewer call sites |
+| `infra/oyster-publish/test/viewer-handler.test.ts` | Existing unauth signin-mode test asserts the new redirect target; add owner-bypass + replay + wrong-share + Referrer-Policy assertions |
+| `infra/auth-worker/src/return-path.ts` | Allow `/api/publish/access-redirect/<token>` as a post-sign-in return target |
+| `infra/auth-worker/test/return-path.test.ts` | Tests for the new allowlisted path |
+| `CHANGELOG.md` | One user-visible bullet under `Added` |
+
+### Pre-implementation audit item (out of code-changes scope)
+
+Audit production log sinks (Cloudflare Logpush, Workers Analytics Engine, `wrangler tail` defaults) for query-string capture on `/p/<token>?key=…` and `/api/publish/access-redirect/<token>` paths. If any sink captures full URLs by default, disable that capture or scrub `?key=` for the path. This is operational, not code — record findings in the PR description.
+
+---
+
+## Task 1: Migration + test schema for `viewer_access_nonces`
+
+**Files:**
+- Create: `infra/auth-worker/migrations/0011_viewer_access_nonces.sql`
+- Modify: `infra/oyster-publish/test/fixtures/seed.ts:6-64` (append the new `CREATE TABLE` + index to `SCHEMA_SQL`)
+
+- [ ] **Step 1: Create the migration file**
+
+Create `infra/auth-worker/migrations/0011_viewer_access_nonces.sql` with this exact content:
+
+```sql
+-- 0011_viewer_access_nonces.sql — single-use access nonces for the viewer access redirect.
+--
+-- Used by /api/publish/access-redirect/<token> to mint a short-lived, opaque
+-- handoff token that share.oyster.to consumes. The viewer worker enforces
+-- single-use via an atomic UPDATE ... WHERE consumed_at IS NULL, with
+-- share_token in the WHERE clause so a nonce minted for share A cannot be
+-- burned against share B's URL. user_id is for audit only; it is never
+-- surfaced in any response.
+--
+-- TTL is 60s (enforced in application code). Mint is opportunistic and
+-- deletes expired rows on each insert, so the table stays small.
+
+CREATE TABLE viewer_access_nonces (
+  nonce        TEXT    PRIMARY KEY,
+  share_token  TEXT    NOT NULL,
+  user_id      TEXT    NOT NULL,
+  expires_at   INTEGER NOT NULL,
+  consumed_at  INTEGER,
+  created_at   INTEGER NOT NULL
+);
+
+CREATE INDEX idx_viewer_access_nonces_expires
+  ON viewer_access_nonces(expires_at);
+```
+
+- [ ] **Step 2: Update the test fixture schema**
+
+Edit `infra/oyster-publish/test/fixtures/seed.ts`. Inside the `SCHEMA_SQL` string (the multi-line template that contains the other `CREATE TABLE` statements), append the same DDL right before the closing backtick:
+
+```sql
+CREATE TABLE viewer_access_nonces (
+  nonce        TEXT    PRIMARY KEY,
+  share_token  TEXT    NOT NULL,
+  user_id      TEXT    NOT NULL,
+  expires_at   INTEGER NOT NULL,
+  consumed_at  INTEGER,
+  created_at   INTEGER NOT NULL
+);
+CREATE INDEX idx_viewer_access_nonces_expires
+  ON viewer_access_nonces(expires_at);
+```
+
+Also update the leading comment block in `SCHEMA_SQL` to include the new migration in the "Keep in sync with" list:
+
+```
+--   infra/auth-worker/migrations/0011_viewer_access_nonces.sql (viewer_access_nonces)
+```
+
+- [ ] **Step 3: Verify the publish test suite still runs cleanly**
+
+Run: `cd infra/oyster-publish && npm test -- --run`
+Expected: existing tests still pass. The new table is present but not yet referenced.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/auth-worker/migrations/0011_viewer_access_nonces.sql \
+        infra/oyster-publish/test/fixtures/seed.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): add viewer_access_nonces table
+
+Single-use, short-lived access nonces backing the viewer access redirect.
+Mirrors into the publish-worker test fixture schema.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Nonce mint/consume helpers (TDD)
+
+**Files:**
+- Create: `infra/oyster-publish/src/access-nonce.ts`
+- Create: `infra/oyster-publish/test/access-nonce.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `infra/oyster-publish/test/access-nonce.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { applySchema } from "./fixtures/seed";
+import { mintAccessNonce, consumeAccessNonce } from "../src/access-nonce";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+describe("access-nonce — mint + consume", () => {
+  it("a freshly minted nonce consumes once and only once", async () => {
+    const nonce = await mintAccessNonce(env, "tok_a", "user_1");
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(true);
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(false);
+  });
+
+  it("consume with a wrong share_token returns false AND leaves the row unconsumed", async () => {
+    // Regression for the atomic-share_token-in-WHERE invariant. If consume
+    // updates before asserting the share_token, the row is burned and the
+    // legitimate consumption against tok_a would then fail.
+    const nonce = await mintAccessNonce(env, "tok_a", "user_1");
+    expect(await consumeAccessNonce(env, nonce, "tok_b")).toBe(false);
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(true);
+  });
+
+  it("an expired nonce cannot be consumed", async () => {
+    const nonce = await mintAccessNonce(env, "tok_a", "user_1");
+    // Force-expire the row.
+    await env.DB.prepare(
+      "UPDATE viewer_access_nonces SET expires_at = ? WHERE nonce = ?",
+    ).bind(Date.now() - 1, nonce).run();
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(false);
+  });
+
+  it("a never-minted nonce cannot be consumed", async () => {
+    expect(await consumeAccessNonce(env, "no-such-nonce-1234567x", "tok_a")).toBe(false);
+  });
+
+  it("mint opportunistically deletes expired rows", async () => {
+    const stale = await mintAccessNonce(env, "tok_a", "user_1");
+    await env.DB.prepare(
+      "UPDATE viewer_access_nonces SET expires_at = ? WHERE nonce = ?",
+    ).bind(Date.now() - 1, stale).run();
+
+    await mintAccessNonce(env, "tok_b", "user_2");  // triggers cleanup
+
+    const stillThere = await env.DB.prepare(
+      "SELECT 1 AS x FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(stale).first<{ x: number }>();
+    expect(stillThere).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/access-nonce.test.ts`
+Expected: FAIL with "Cannot find module '../src/access-nonce'".
+
+- [ ] **Step 3: Implement the nonce module**
+
+Create `infra/oyster-publish/src/access-nonce.ts`:
+
+```ts
+// Short-lived, single-use access nonces for the viewer access redirect.
+// Spec: docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+//
+// Mint: oyster.to/api/publish/access-redirect/<token> after the access
+// predicate passes. Consume: share.oyster.to/p/<token>?key=<nonce> on the
+// viewer pre-check. The atomic UPDATE pins share_token in the WHERE clause
+// so a nonce minted for one share cannot consume against another.
+
+import type { Env } from "./types";
+
+const TTL_MS = 60_000;
+
+/**
+ * Mint a fresh nonce bound to (share_token, user_id). Also opportunistically
+ * deletes expired rows. Returns the nonce — 22 base64url chars, 128 bits of
+ * entropy.
+ */
+export async function mintAccessNonce(
+  env: Env,
+  shareToken: string,
+  userId: string,
+): Promise<string> {
+  const now = Date.now();
+
+  // Opportunistic cleanup. The expires_at index makes this a range scan;
+  // the table is small (60s TTL bounds the steady-state size).
+  await env.DB.prepare(
+    "DELETE FROM viewer_access_nonces WHERE expires_at < ?",
+  ).bind(now).run();
+
+  const nonce = base64urlRandom(16);  // 16 bytes → 22 chars
+  await env.DB.prepare(
+    `INSERT INTO viewer_access_nonces
+       (nonce, share_token, user_id, expires_at, consumed_at, created_at)
+     VALUES (?, ?, ?, ?, NULL, ?)`,
+  ).bind(nonce, shareToken, userId, now + TTL_MS, now).run();
+  return nonce;
+}
+
+/**
+ * Returns true iff this call atomically transitioned the nonce for THIS
+ * share_token from unconsumed-and-live to consumed. Wrong share_token,
+ * wrong nonce, expired, or already-consumed all return false WITHOUT any
+ * side effect on the row.
+ */
+export async function consumeAccessNonce(
+  env: Env,
+  nonce: string,
+  shareToken: string,
+): Promise<boolean> {
+  const now = Date.now();
+  const res = await env.DB.prepare(
+    `UPDATE viewer_access_nonces
+        SET consumed_at = ?
+      WHERE nonce       = ?
+        AND share_token = ?
+        AND consumed_at IS NULL
+        AND expires_at  > ?`,
+  ).bind(now, nonce, shareToken, now).run();
+  return (res.meta?.changes ?? 0) === 1;
+}
+
+function base64urlRandom(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  let bin = "";
+  for (const b of buf) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/access-nonce.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/access-nonce.ts \
+        infra/oyster-publish/test/access-nonce.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): mint/consume helpers for viewer access nonces
+
+Single-use, 60s TTL, atomic UPDATE with share_token in the WHERE clause
+(a nonce minted for share A cannot consume against share B). Opportunistic
+cleanup of expired rows on mint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Return-path allowlist accepts the access-redirect path
+
+**Files:**
+- Modify: `infra/auth-worker/src/return-path.ts`
+- Modify: `infra/auth-worker/test/return-path.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `infra/auth-worker/test/return-path.test.ts`, append a new describe block at the end of the file (before the final closing line):
+
+```ts
+describe("validateReturnPath — accepts access-redirect path", () => {
+  it("accepts /api/publish/access-redirect/<token>", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/abc123"))
+      .toBe("/api/publish/access-redirect/abc123");
+  });
+
+  it("accepts /api/publish/access-redirect/<token> with - and _ in the token", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/AaBb_-_-9"))
+      .toBe("/api/publish/access-redirect/AaBb_-_-9");
+  });
+
+  it("rejects /api/publish/access-redirect/ with no token", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/")).toBeNull();
+  });
+
+  it("rejects /api/publish/access-redirect/<token>/extra", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/abc123/raw")).toBeNull();
+  });
+
+  it("rejects /api/publish/access-redirect/<token>?evil=1", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/abc?x=1")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd infra/auth-worker && npm test -- --run test/return-path.test.ts`
+Expected: the two "accepts" tests FAIL (validator returns null); the "rejects" tests PASS already.
+
+- [ ] **Step 3: Update the validator**
+
+Edit `infra/auth-worker/src/return-path.ts`. Replace the body of the file with:
+
+```ts
+// Generic post-sign-in redirect target validation for #316 and the
+// viewer access redirect (2026-05-18 spec).
+//
+// Allowlist matches the share-viewer route AND the access-redirect route,
+// and nothing else. We reject /p/<token>/raw because that's the iframe-
+// content endpoint — landing a user there would strand them with no
+// navigation. We reject query strings and fragments so attackers cannot
+// smuggle params through the validator.
+
+const SHARE_VIEWER_PATH    = /^\/p\/[A-Za-z0-9_-]+$/;
+const ACCESS_REDIRECT_PATH = /^\/api\/publish\/access-redirect\/[A-Za-z0-9_-]+$/;
+const MAX_PATH_LEN = 256;
+
+export function validateReturnPath(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") return null;
+  if (raw.length === 0 || raw.length > MAX_PATH_LEN) return null;
+  // JS regex `$` matches before a trailing newline; reject any control
+  // chars (especially CR/LF) explicitly so they never reach a Location header.
+  if (/[\x00-\x1f\x7f]/.test(raw)) return null;
+  if (SHARE_VIEWER_PATH.test(raw) || ACCESS_REDIRECT_PATH.test(raw)) return raw;
+  return null;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd infra/auth-worker && npm test -- --run test/return-path.test.ts`
+Expected: PASS (all tests, including existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/auth-worker/src/return-path.ts \
+        infra/auth-worker/test/return-path.test.ts
+git commit -m "$(cat <<'EOF'
+feat(auth): allowlist access-redirect path as a post-sign-in return target
+
+Without this, the auth worker drops ?return=/api/publish/access-redirect/...
+and the post-sign-in handoff strands the user on a generic page.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Signin mode honours `oyster_view_<token>` cookie
+
+The signin-mode switch case in `viewer-access.ts` currently only checks `resolveSession()`. After the access-redirect mints the cookie, the clean-URL follow-up GET hits the signin case again — and would loop if we don't accept the cookie here too. This task is the cookie-acceptance change. Task 5 then adds the nonce pre-check.
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-access.ts`
+- Modify: `infra/oyster-publish/test/viewer-handler.test.ts:381-407` (existing signin describe block)
+
+- [ ] **Step 1: Write the failing test — signin mode with viewer cookie only**
+
+In `infra/oyster-publish/test/viewer-handler.test.ts`, inside the existing `describe("GET /p/:token — signin mode", ...)` block, add this test before the closing `});`:
+
+```ts
+it("signed-in cookie-only visitor (no apex session) → content", async () => {
+  // Models the post-nonce-consumption follow-up GET: the viewer cookie
+  // was minted by the consume handler, but the apex session cookie was
+  // NEVER on share.oyster.to in the first place. Without the signin-mode
+  // cookie acceptance change, this would loop back to access-redirect.
+  const u = await seedUser();
+  const { shareToken } = await seedActiveOpenWithBody({
+    ownerUserId: u.id, artifactId: "art3cookie", body: "# private",
+  });
+  await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+    .bind(shareToken).run();
+
+  const viewerCookie = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+  const res = await call(getReq(`/p/${shareToken}`, {
+    cookie: `oyster_view_${shareToken}=${viewerCookie}`,  // no oyster_session
+  }));
+  expect(res.status).toBe(200);
+  expect(await res.text()).toContain("private");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts -t "cookie-only"`
+Expected: FAIL — status is 302 (redirect to sign-in), not 200.
+
+- [ ] **Step 3: Update `viewer-access.ts` — signin honours cookie**
+
+Edit `infra/oyster-publish/src/viewer-access.ts`. Replace the entire file with:
+
+```ts
+// Access dispatch for the public viewer.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Access dispatch)
+//       docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+//
+// `oyster_view_<token>` is treated as a generic recent-access proof for
+// the artefact: any successful gate-clearing path (password POST,
+// owner-via-nonce, signin-via-nonce) mints it, and both password and
+// signin modes accept it. Without that semantics, the post-nonce
+// clean-URL follow-up GET in signin mode would loop back to access-
+// redirect because the apex session is not visible on share.oyster.to.
+
+import { resolveSession } from "./worker";
+import { verifyViewerCookie } from "./viewer-cookie";
+import type { Env, PublicationRow } from "./types";
+
+export type ViewerAccess =
+  | { kind: "ok"; row: PublicationRow }
+  | { kind: "gate"; row: PublicationRow; error?: "wrong_password" }
+  | { kind: "redirect"; location: string }
+  | { kind: "gone"; row: PublicationRow }
+  | { kind: "not_found" };
+
+export async function resolveViewerAccess(
+  req: Request,
+  env: Env,
+  shareToken: string,
+): Promise<ViewerAccess> {
+  // Step 1: row lookup.
+  const row = await env.DB.prepare(
+    "SELECT * FROM published_artifacts WHERE share_token = ?",
+  ).bind(shareToken).first<PublicationRow>();
+  if (!row) return { kind: "not_found" };
+
+  // Step 2: gone check.
+  if (row.unpublished_at !== null && row.unpublished_at !== undefined) {
+    return { kind: "gone", row };
+  }
+
+  // Step 3: mode dispatch.
+  switch (row.mode) {
+    case "open":
+      return { kind: "ok", row };
+
+    case "password": {
+      if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      return { kind: "gate", row };
+    }
+
+    case "signin": {
+      // Honour the viewer cookie as a generic recent-access proof. The
+      // apex `oyster_session` is host-only on oyster.to and is NOT
+      // visible on share.oyster.to in production (auth-worker #397), so
+      // resolveSession() returns null in the cross-host case — the
+      // cookie is the only access proof we'll see on this host.
+      if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      const session = await resolveSession(req, env);
+      if (!session) {
+        return {
+          kind: "redirect",
+          location: `https://oyster.to/api/publish/access-redirect/${shareToken}`,
+        };
+      }
+      return { kind: "ok", row };
+    }
+
+    default:
+      // Unreachable per the D1 CHECK constraint, but typescript-safe.
+      return { kind: "not_found" };
+  }
+}
+
+export function readCookie(req: Request, name: string): string | null {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]+)`));
+  return m && m[1] ? m[1] : null;
+}
+
+async function hasValidViewerCookie(
+  req: Request,
+  shareToken: string,
+  secret: string,
+): Promise<boolean> {
+  const value = readCookie(req, `oyster_view_${shareToken}`);
+  if (!value) return false;
+  return await verifyViewerCookie(value, shareToken, secret);
+}
+```
+
+- [ ] **Step 4: Update the existing unsigned-visitor test for the new redirect target**
+
+Still in `infra/oyster-publish/test/viewer-handler.test.ts`, find the existing test at the top of the signin describe block and update its expectation:
+
+```ts
+it("unsigned visitor → 302 to /api/publish/access-redirect/<token>", async () => {
+  const u = await seedUser();
+  const token = await seedActivePublication({
+    ownerUserId: u.id, artifactId: "art3", mode: "signin",
+  });
+  const res = await call(getReq(`/p/${token}`));
+  expect(res.status).toBe(302);
+  const location = res.headers.get("location") ?? "";
+  expect(location).toBe(`https://oyster.to/api/publish/access-redirect/${token}`);
+});
+```
+
+(The test title also changes — it was "→ 302 to /auth/sign-in?return=/p/<token>".)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts`
+Expected: PASS — both the cookie-only test and the updated unsigned-visitor test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/oyster-publish/src/viewer-access.ts \
+        infra/oyster-publish/test/viewer-handler.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): signin mode honours oyster_view_<token> cookie
+
+oyster_view_<token> is now treated as a generic recent-access proof,
+honoured by both password and signin modes. Without this, the
+post-nonce-consumption clean-URL GET in signin mode loops back to
+access-redirect because the apex session is not visible on share.oyster.to.
+Unsigned-visitor redirect target updated to access-redirect endpoint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `resolveViewerAccess` takes a required `consumeNonce` option
+
+This task adds the `?key=` pre-check, the new `ok_via_nonce` access kind, and forces every caller (`/p`, `/raw`, password POST) to opt in or out explicitly. `/raw` MUST pass `false`.
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-access.ts`
+- Modify: `infra/oyster-publish/src/worker.ts` (three call sites)
+
+- [ ] **Step 1: Write failing tests — `/raw` must not consume, `/p` does**
+
+Append to `infra/oyster-publish/test/viewer-handler.test.ts` (inside the file, at the bottom before the final closing of describes):
+
+```ts
+describe("nonce pre-check — consumeNonce flag", () => {
+  it("/p/<token>?key=<valid_nonce> consumes the nonce and returns ok_via_nonce", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_n1", body: "# nonce content",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const nonce = await mintAccessNonce(env, shareToken, u.id);
+    const res = await call(getReq(`/p/${shareToken}?key=${nonce}`));
+    // The handler 302s to the clean URL; assert on the redirect itself
+    // here. Cookie + clean URL + headers are asserted in Task 6.
+    expect(res.status).toBe(302);
+
+    // Nonce row is consumed.
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).not.toBeNull();
+  });
+
+  it("/p/<token>/raw?key=<valid_nonce> does NOT consume the nonce", async () => {
+    // Regression for the explicit consumeNonce: false on /raw. If a future
+    // change drops the flag, this test fails.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_n_raw", body: "<h1>iframe</h1>",
+      artifactKind: "app", contentType: "text/html",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const nonce = await mintAccessNonce(env, shareToken, u.id);
+    await call(getReq(`/p/${shareToken}/raw?key=${nonce}`));
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+
+    // The nonce remains usable on the proper /p endpoint.
+    expect(await consumeAccessNonce(env, nonce, shareToken)).toBe(true);
+  });
+
+  it("/p/<token>?key=<wrong_share> falls through silently AND leaves the nonce unconsumed", async () => {
+    const u = await seedUser();
+    const tokA = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_A", mode: "signin" });
+    const tokB = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_B", mode: "signin" });
+
+    const nonce = await mintAccessNonce(env, tokA, u.id);
+    const res = await call(getReq(`/p/${tokB}?key=${nonce}`));
+    // signin mode, no cookie/session → 302 to access-redirect (silent fall-through).
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://oyster.to/api/publish/access-redirect/${tokB}`,
+    );
+
+    // Nonce is still alive for its real share.
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+  });
+});
+```
+
+And add these imports at the top of the test file (alongside the existing imports from `./fixtures/seed`):
+
+```ts
+import { mintAccessNonce, consumeAccessNonce } from "../src/access-nonce";
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts -t "consumeNonce flag"`
+Expected: all three FAIL — the `?key=` query is currently ignored, so the nonce stays unconsumed and `/p` does not 302 with the expected shape.
+
+- [ ] **Step 3: Add the option + pre-check to `resolveViewerAccess`**
+
+Edit `infra/oyster-publish/src/viewer-access.ts`. Replace the file with:
+
+```ts
+// Access dispatch for the public viewer.
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Access dispatch)
+//       docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+//
+// `oyster_view_<token>` is treated as a generic recent-access proof for
+// the artefact: any successful gate-clearing path (password POST,
+// owner-via-nonce, signin-via-nonce) mints it, and both password and
+// signin modes accept it. Without that semantics, the post-nonce
+// clean-URL follow-up GET in signin mode would loop back to access-
+// redirect because the apex session is not visible on share.oyster.to.
+//
+// The `consumeNonce` option on resolveViewerAccess is REQUIRED on every
+// call site so that /raw cannot accidentally start consuming nonces
+// without a deliberate edit. /p passes true, /raw and the password POST
+// pass false.
+
+import { resolveSession } from "./worker";
+import { verifyViewerCookie } from "./viewer-cookie";
+import { consumeAccessNonce } from "./access-nonce";
+import type { Env, PublicationRow } from "./types";
+
+export type ViewerAccess =
+  | { kind: "ok"; row: PublicationRow }
+  | { kind: "ok_via_nonce"; row: PublicationRow }
+  | { kind: "gate"; row: PublicationRow; error?: "wrong_password" }
+  | { kind: "redirect"; location: string }
+  | { kind: "gone"; row: PublicationRow }
+  | { kind: "not_found" };
+
+export interface ResolveOptions {
+  /**
+   * When true, a valid `?key=<nonce>` consumes the nonce and yields
+   * `ok_via_nonce`. When false, the `?key=` parameter is ignored entirely
+   * (the caller is responsible for any cookie-based check). /p MUST pass
+   * true; /raw and the password POST handler MUST pass false. Making the
+   * flag required prevents a future regression from silently turning the
+   * iframe endpoint into a nonce-consuming endpoint.
+   */
+  consumeNonce: boolean;
+}
+
+export async function resolveViewerAccess(
+  req: Request,
+  env: Env,
+  shareToken: string,
+  opts: ResolveOptions,
+): Promise<ViewerAccess> {
+  // Step 1: row lookup.
+  const row = await env.DB.prepare(
+    "SELECT * FROM published_artifacts WHERE share_token = ?",
+  ).bind(shareToken).first<PublicationRow>();
+  if (!row) return { kind: "not_found" };
+
+  // Step 2: gone check.
+  if (row.unpublished_at !== null && row.unpublished_at !== undefined) {
+    return { kind: "gone", row };
+  }
+
+  // Step 3: nonce pre-check (caller opt-in). Open mode never needs a
+  // nonce — the viewer would serve content anyway. Invalid / expired /
+  // wrong-share nonces fall through silently — no oracle.
+  if (opts.consumeNonce && (row.mode === "password" || row.mode === "signin")) {
+    const key = new URL(req.url).searchParams.get("key");
+    if (key && await consumeAccessNonce(env, key, shareToken)) {
+      return { kind: "ok_via_nonce", row };
+    }
+  }
+
+  // Step 4: mode dispatch.
+  switch (row.mode) {
+    case "open":
+      return { kind: "ok", row };
+
+    case "password": {
+      if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      return { kind: "gate", row };
+    }
+
+    case "signin": {
+      if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      const session = await resolveSession(req, env);
+      if (!session) {
+        return {
+          kind: "redirect",
+          location: `https://oyster.to/api/publish/access-redirect/${shareToken}`,
+        };
+      }
+      return { kind: "ok", row };
+    }
+
+    default:
+      return { kind: "not_found" };
+  }
+}
+
+export function readCookie(req: Request, name: string): string | null {
+  const cookie = req.headers.get("Cookie");
+  if (!cookie) return null;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]+)`));
+  return m && m[1] ? m[1] : null;
+}
+
+async function hasValidViewerCookie(
+  req: Request,
+  shareToken: string,
+  secret: string,
+): Promise<boolean> {
+  const value = readCookie(req, `oyster_view_${shareToken}`);
+  if (!value) return false;
+  return await verifyViewerCookie(value, shareToken, secret);
+}
+```
+
+- [ ] **Step 4: Update all three callers in `worker.ts` to pass the flag**
+
+Edit `infra/oyster-publish/src/worker.ts`. Find these three call sites and update each to pass `{ consumeNonce }`:
+
+Around line 699 (in `handleViewerGet`):
+
+```ts
+async function handleViewerGet(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken, { consumeNonce: true });
+  // ...rest unchanged...
+}
+```
+
+Around line 718 (in `handleViewerRaw`):
+
+```ts
+async function handleViewerRaw(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken, { consumeNonce: false });
+  // ...rest unchanged...
+}
+```
+
+Around line 739 (in `handleViewerPost`):
+
+```ts
+async function handleViewerPost(req: Request, env: Env, shareToken: string): Promise<Response> {
+  const access = await resolveViewerAccess(req, env, shareToken, { consumeNonce: false });
+  // ...rest unchanged...
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts`
+Expected: PASS — the three new pre-check tests pass; existing tests still pass (no behaviour change for non-`?key=` paths).
+
+Note: `ok_via_nonce` is not yet handled in `handleViewerGet` — that's Task 6. The current 302 the test asserts on is the existing default-case behaviour (any kind not handled falls through to the switch statement). TypeScript's exhaustiveness check may fail at compile time; if so, add a `case "ok_via_nonce":` that throws "TODO Task 6" temporarily — Task 6 replaces it.
+
+Actually safer: add the placeholder now so compilation succeeds. Add to the switch statement at the bottom of `handleViewerGet`:
+
+```ts
+case "ok_via_nonce":
+  // Placeholder — real handling lands in Task 6.
+  throw new Error("ok_via_nonce: handler not yet implemented (Task 6)");
+```
+
+Re-run the test — the `/p?key=` test will now throw instead of 302. Adjust that single assertion temporarily to `expect(res.status).toBe(500)` and add a `// TODO Task 6: assert 302 + cookie + clean URL` comment. Task 6 reverts the assertion.
+
+If you prefer not to touch the test twice, skip the consume assertion for now and re-enable in Task 6 — but the rest of this task should compile and the wrong-share + /raw assertions should pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/oyster-publish/src/viewer-access.ts \
+        infra/oyster-publish/src/worker.ts \
+        infra/oyster-publish/test/viewer-handler.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): nonce pre-check on resolveViewerAccess with required consumeNonce flag
+
+/p opts in (consumeNonce: true), /raw and the password POST opt out
+(consumeNonce: false). Making the flag required prevents a future
+regression from silently turning /raw into a nonce-consuming endpoint.
+share_token in the consume WHERE clause means a nonce minted for one
+share cannot burn against another. ok_via_nonce handler arrives in the
+next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Handle `ok_via_nonce` in `handleViewerGet`
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts` (handleViewerGet switch)
+- Modify: `infra/oyster-publish/test/viewer-handler.test.ts` (extend the nonce-flag describe with golden-path assertions)
+
+- [ ] **Step 1: Replace the placeholder test with the golden-path assertions**
+
+In `infra/oyster-publish/test/viewer-handler.test.ts`, find the first test of the `consumeNonce flag` describe (the one that asserts `res.status === 302` after `getReq(/p/<token>?key=<nonce>)`). Replace it with this fuller version:
+
+```ts
+it("/p/<token>?key=<valid_nonce> sets viewer cookie, 302s to clean URL, no-referrer", async () => {
+  const u = await seedUser();
+  const { shareToken } = await seedActiveOpenWithBody({
+    ownerUserId: u.id, artifactId: "art_n1", body: "# nonce content",
+  });
+  await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+    .bind(shareToken).run();
+
+  const nonce = await mintAccessNonce(env, shareToken, u.id);
+  const res = await call(getReq(`/p/${shareToken}?key=${nonce}`));
+
+  expect(res.status).toBe(302);
+  expect(res.headers.get("location")).toBe(`/p/${shareToken}`);
+  expect(res.headers.get("cache-control")).toBe("private, no-store");
+  expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+
+  const setCookie = res.headers.get("set-cookie") ?? "";
+  expect(setCookie).toContain(`oyster_view_${shareToken}=`);
+  expect(setCookie).toContain(`Path=/p/${shareToken}`);
+  expect(setCookie).toContain("HttpOnly");
+  expect(setCookie).toContain("SameSite=Lax");
+
+  // Follow-up GET with the cookie returns content. We pass NO oyster_session
+  // here on purpose — the cookie is the only proof on share.oyster.to.
+  const cookieValue = setCookie.match(/oyster_view_[^=]+=([^;]+)/)?.[1] ?? "";
+  const follow = await call(getReq(`/p/${shareToken}`, {
+    cookie: `oyster_view_${shareToken}=${cookieValue}`,
+  }));
+  expect(follow.status).toBe(200);
+  expect(await follow.text()).toContain("nonce content");
+});
+```
+
+Also add the replay test in the same describe block:
+
+```ts
+it("a replayed key falls through to the standard mode dispatch", async () => {
+  const u = await seedUser();
+  const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_replay", mode: "signin" });
+  const nonce = await mintAccessNonce(env, token, u.id);
+
+  // First call consumes.
+  const first = await call(getReq(`/p/${token}?key=${nonce}`));
+  expect(first.status).toBe(302);
+  expect(first.headers.get("location")).toBe(`/p/${token}`);
+
+  // Second call with the same (now-consumed) key behaves identically to
+  // a no-key request: signin mode, no cookie → 302 to access-redirect.
+  const second = await call(getReq(`/p/${token}?key=${nonce}`));
+  expect(second.status).toBe(302);
+  expect(second.headers.get("location"))
+    .toBe(`https://oyster.to/api/publish/access-redirect/${token}`);
+});
+```
+
+- [ ] **Step 2: Run to verify the first test fails (placeholder throws)**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts -t "sets viewer cookie"`
+Expected: FAIL — currently throws "ok_via_nonce: handler not yet implemented".
+
+- [ ] **Step 3: Implement the `ok_via_nonce` handler**
+
+Edit `infra/oyster-publish/src/worker.ts`. Find the `handleViewerGet` switch. Replace the placeholder `case "ok_via_nonce":` block with this real implementation:
+
+```ts
+case "ok_via_nonce": {
+  // The visitor proved they have access (owner of a password share, or
+  // any signed-in user for a signin share) via /api/publish/access-redirect.
+  // Mint the standard recent-access cookie and 302 to the clean URL so
+  // that ?key=<nonce> does not linger in the address bar / Referer.
+  const cookieValue = await signViewerCookie(access.row.share_token, env.VIEWER_COOKIE_SECRET);
+  const host = new URL(req.url).host;
+  const secureFlag = isLoopback(host) ? "" : " Secure;";
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "set-cookie": `oyster_view_${access.row.share_token}=${cookieValue}; HttpOnly;${secureFlag} SameSite=Lax; Path=/p/${access.row.share_token}; Max-Age=86400`,
+      "location": `/p/${access.row.share_token}`,
+      "cache-control": "private, no-store",
+      "referrer-policy": "no-referrer",
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts`
+Expected: PASS — the golden-path test and the replay test both pass; existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/worker.ts \
+        infra/oyster-publish/test/viewer-handler.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): handle ok_via_nonce — set recent-access cookie, 302 to clean URL
+
+Sets oyster_view_<token> (24h, HttpOnly, SameSite=Lax, Path-scoped)
+and 302s to /p/<token> with the ?key= stripped. cache-control: no-store
+and referrer-policy: no-referrer on the redirect so the nonce-bearing URL
+does not surface in caches or Referer headers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: New endpoint `GET /api/publish/access-redirect/:token`
+
+**Files:**
+- Modify: `infra/oyster-publish/src/worker.ts` (register route + handler)
+- Create: `infra/oyster-publish/test/access-redirect-handler.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `infra/oyster-publish/test/access-redirect-handler.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import {
+  applySchema, seedUser, seedActivePublication, retirePublication,
+} from "./fixtures/seed";
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (env as any).VIEWER_PASSWORD_LIMIT = { limit: async () => ({ success: true }) };
+});
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function getReq(path: string, opts: { cookie?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  return new Request(`https://oyster.to${path}`, { method: "GET", headers });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+const PATH = (t: string) => `/api/publish/access-redirect/${t}`;
+
+describe("GET /api/publish/access-redirect/:token", () => {
+  it("returns 404 for an unknown token", async () => {
+    const res = await call(getReq(PATH("no-such")));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 410 for a retired publication", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art1", mode: "open" });
+    await retirePublication(token);
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(410);
+  });
+
+  it("open mode → 302 straight to viewer with no key", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art1", mode: "open" });
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`https://share.oyster.to/p/${token}`);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(new URL(res.headers.get("location")!).searchParams.get("key")).toBeNull();
+  });
+
+  it("signin mode + no session → 302 to sign-in with return target", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art2", mode: "signin" });
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.origin + loc.pathname).toBe("https://oyster.to/auth/sign-in");
+    expect(loc.searchParams.get("return")).toBe(PATH(token));
+  });
+
+  it("signin mode + session → 302 to viewer with a fresh ?key= and a row in viewer_access_nonces", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art2", mode: "signin" });
+    const res = await call(getReq(PATH(token), { cookie: `oyster_session=${u.sessionToken}` }));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+    const key = loc.searchParams.get("key");
+    expect(key).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+    const row = await env.DB.prepare(
+      "SELECT share_token, user_id, consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(key).first<{ share_token: string; user_id: string; consumed_at: number | null }>();
+    expect(row?.share_token).toBe(token);
+    expect(row?.user_id).toBe(u.id);
+    expect(row?.consumed_at).toBeNull();
+  });
+
+  it("password mode + no session → 302 to sign-in with return target", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art3", mode: "password" });
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.searchParams.get("return")).toBe(PATH(token));
+  });
+
+  it("password mode + owner session → 302 to viewer with a fresh ?key=", async () => {
+    const owner = await seedUser();
+    const token = await seedActivePublication({
+      ownerUserId: owner.id, artifactId: "art4", mode: "password",
+    });
+    const res = await call(getReq(PATH(token), { cookie: `oyster_session=${owner.sessionToken}` }));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+    expect(loc.searchParams.get("key")).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  });
+
+  it("password mode + non-owner session → 403 page (no nonce minted)", async () => {
+    const owner = await seedUser({ id: "user_owner" });
+    const other = await seedUser({ id: "user_other" });
+    const token = await seedActivePublication({
+      ownerUserId: owner.id, artifactId: "art5", mode: "password",
+    });
+    const res = await call(getReq(PATH(token), { cookie: `oyster_session=${other.sessionToken}` }));
+    expect(res.status).toBe(403);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    // Body should give them a way back to the public gate.
+    expect(await res.text()).toContain(`/p/${token}`);
+
+    // No nonce minted.
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM viewer_access_nonces WHERE share_token = ?",
+    ).bind(token).first<{ n: number }>();
+    expect(count?.n).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/access-redirect-handler.test.ts`
+Expected: all tests FAIL — endpoint doesn't exist; everything returns 404 (the worker's default).
+
+- [ ] **Step 3: Add a 403 page renderer to `viewer-pages.ts`**
+
+Edit `infra/oyster-publish/src/viewer-pages.ts`. Add this exported function (place it after `notFoundPage` and before `internalErrorPage`):
+
+```ts
+export function noAccessPage(shareToken: string): string {
+  return basePage("No access", `
+    <div class="icon">🔒</div>
+    <h1>You don't have access to this share</h1>
+    <p class="hint">This publication belongs to a different account.</p>
+    <p><a href="/p/${escapeHtml(shareToken)}">Enter the password instead</a></p>
+  `);
+}
+```
+
+- [ ] **Step 4: Register the route and implement the handler in `worker.ts`**
+
+Edit `infra/oyster-publish/src/worker.ts`. At the top of the fetch handler, **before** the existing `if (url.pathname.startsWith("/api/publish/") && req.method === "DELETE")` block, add:
+
+```ts
+if (url.pathname.startsWith("/api/publish/access-redirect/") && req.method === "GET") {
+  const token = url.pathname.slice("/api/publish/access-redirect/".length);
+  if (!token || token.includes("/")) {
+    return new Response("Not Found", { status: 404 });
+  }
+  return handleAccessRedirect(req, env, token);
+}
+```
+
+Also extend the `viewer-pages` import at the top to include `noAccessPage`:
+
+```ts
+import {
+  passwordGatePage, gonePage, notFoundPage, noAccessPage, internalErrorPage, rateLimitedPage,
+} from "./viewer-pages";
+```
+
+And add a `mintAccessNonce` import:
+
+```ts
+import { mintAccessNonce } from "./access-nonce";
+```
+
+Then add the handler function somewhere below the existing `handleViewerGet` group (after `handleViewerPost`):
+
+```ts
+async function handleAccessRedirect(req: Request, env: Env, shareToken: string): Promise<Response> {
+  type Row = { mode: "open" | "password" | "signin"; owner_user_id: string; unpublished_at: number | null };
+  const row = await env.DB.prepare(
+    "SELECT mode, owner_user_id, unpublished_at FROM published_artifacts WHERE share_token = ?",
+  ).bind(shareToken).first<Row>();
+
+  if (!row) return htmlPage(404, notFoundPage());
+  if (row.unpublished_at !== null) return htmlPage(410, gonePage());
+
+  // Open mode: no gate to clear, no nonce to mint.
+  if (row.mode === "open") {
+    return redirectNoStore(`https://share.oyster.to/p/${shareToken}`);
+  }
+
+  const session = await resolveSession(req, env);
+  if (!session) {
+    return redirectNoStore(
+      `https://oyster.to/auth/sign-in?return=${encodeURIComponent(`/api/publish/access-redirect/${shareToken}`)}`,
+    );
+  }
+
+  // Access predicates — widen the password case to an ACL when sharing-
+  // to-specific-user lands. resolveSession() in this worker returns flat
+  // { id, email, tier } (see top of this file).
+  let mayAccess = false;
+  if (row.mode === "signin")   mayAccess = true;
+  if (row.mode === "password") mayAccess = session.id === row.owner_user_id;
+
+  if (!mayAccess) return htmlPage(403, noAccessPage(shareToken));
+
+  const nonce = await mintAccessNonce(env, shareToken, session.id);
+  return redirectNoStore(`https://share.oyster.to/p/${shareToken}?key=${nonce}`);
+}
+
+function redirectNoStore(location: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location,
+      "cache-control": "private, no-store",
+    },
+  });
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/access-redirect-handler.test.ts`
+Expected: PASS — all 8 tests.
+
+Run also: `cd infra/oyster-publish && npm test -- --run`
+Expected: PASS — no regressions elsewhere.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/oyster-publish/src/viewer-pages.ts \
+        infra/oyster-publish/src/worker.ts \
+        infra/oyster-publish/test/access-redirect-handler.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): GET /api/publish/access-redirect/:token
+
+The owner-bypass / signin-handoff endpoint. Lives on oyster.to where the
+apex session cookie is visible, checks ownership/membership, mints a
+single-use nonce, and 302s the browser to share.oyster.to with the key.
+Open mode skips the nonce. Non-owner of a password share gets a 403
+page that links back to the public password gate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Gate-page link — "Have access? Sign in to view"
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-pages.ts`
+- Modify: `infra/oyster-publish/test/viewer-handler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `infra/oyster-publish/test/viewer-handler.test.ts`:
+
+```ts
+describe("password gate — sign-in link", () => {
+  it('shows "Have access? Sign in to view" link pointing at access-redirect', async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art_gate", mode: "password",
+    });
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Have access?");
+    expect(body).toContain(`https://oyster.to/api/publish/access-redirect/${token}`);
+  });
+
+  it("link is present on the wrong-password error state too", async () => {
+    const u = await seedUser();
+    // Use a real PBKDF2 hash so the password check can run, then submit a wrong password.
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art_gate2", mode: "password",
+      // Hash for "correct-password" — but we'll submit "wrong" to trigger the error block.
+      passwordHash: "pbkdf2$100000$AAAA$BBBB",  // bogus but well-formed; verifyPbkdf2 returns false
+    });
+    const res = await call(postReq(`/p/${token}`, { password: "wrong" }));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Incorrect password.");
+    expect(body).toContain("Have access?");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts -t "sign-in link"`
+Expected: FAIL — the gate page does not yet contain "Have access?".
+
+- [ ] **Step 3: Update `passwordGatePage`**
+
+Edit `infra/oyster-publish/src/viewer-pages.ts`. Replace the `passwordGatePage` function with:
+
+```ts
+export function passwordGatePage(shareToken: string, opts?: { error?: "wrong_password" }): string {
+  const errorBlock = opts?.error === "wrong_password"
+    ? `<p class="err">Incorrect password.</p>`
+    : "";
+  const tokenSafe = escapeHtml(shareToken);
+  return basePage("Password required", `
+    <div class="icon">🔒</div>
+    <h1>Password required</h1>
+    <p class="hint">This share is password-protected.</p>
+    ${errorBlock}
+    <form method="POST" action="/p/${tokenSafe}">
+      <input type="password" name="password" placeholder="Password" autofocus required>
+      <button type="submit">Unlock</button>
+    </form>
+    <p class="hint-link">Have access? <a href="https://oyster.to/api/publish/access-redirect/${tokenSafe}">Sign in to view</a></p>
+  `);
+}
+```
+
+Also extend the page-style block inside `basePage()` so `.hint-link` is laid out cleanly. Find the existing `<style>` and add this rule next to the other selectors (e.g. after the `.tag` rule):
+
+```css
+.hint-link { font-size: 0.85rem; color: var(--muted); margin-top: 1.25rem; }
+.hint-link a { color: inherit; text-decoration: underline; }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts -t "sign-in link"`
+Expected: PASS — both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/viewer-pages.ts \
+        infra/oyster-publish/test/viewer-handler.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): password gate offers "Have access? Sign in to view"
+
+Links to /api/publish/access-redirect/<token>. The "Have access?"
+phrasing (rather than "Own this share?") is forward-compatible with
+the ACL widening for share-to-specific-user.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Referrer-Policy on the final rendered viewer responses
+
+**Files:**
+- Modify: `infra/oyster-publish/src/viewer-render.ts:37-48` (the `cacheHeaders` helper)
+- Modify: `infra/oyster-publish/test/viewer-handler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `infra/oyster-publish/test/viewer-handler.test.ts`:
+
+```ts
+describe("rendered viewer responses — Referrer-Policy", () => {
+  it("open-mode markdown render carries referrer-policy: no-referrer", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_rp_open", body: "# hi",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+
+  it("password-mode (post-unlock) render carries referrer-policy: no-referrer", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_rp_pw", body: "# secret",
+    });
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET mode = 'password', password_hash = 'pbkdf2$100000$AAAA$BBBB' WHERE share_token = ?",
+    ).bind(shareToken).run();
+
+    // Hand-mint a valid viewer cookie so we exercise the rendered response path.
+    const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+    const res = await call(getReq(`/p/${shareToken}`, {
+      cookie: `oyster_view_${shareToken}=${cookieValue}`,
+    }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts -t "Referrer-Policy"`
+Expected: FAIL — header is currently absent on rendered responses.
+
+- [ ] **Step 3: Update `cacheHeaders`**
+
+Edit `infra/oyster-publish/src/viewer-render.ts`. Replace the `cacheHeaders` function with:
+
+```ts
+export function cacheHeaders(row: PublicationRow, contentType: string): HeadersInit {
+  const headers: Record<string, string> = { "content-type": contentType };
+  if (row.mode === "open") {
+    headers["cache-control"] = "public, max-age=60, must-revalidate";
+    headers["etag"] = `"${row.share_token}-${row.updated_at}"`;
+  } else {
+    headers["cache-control"] = "private, no-store";
+  }
+  // Block content-type sniffing across all responses.
+  headers["x-content-type-options"] = "nosniff";
+  // Defence in depth: don't surface URL info on subresource fetches or
+  // onward navigation from the rendered page. Consistent with the
+  // nonce-consumption 302; matters most if a future change introduces
+  // any URL-shaped sensitive parameter on the viewer URL.
+  headers["referrer-policy"] = "no-referrer";
+  return headers;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/viewer-handler.test.ts`
+Expected: PASS — the two new Referrer-Policy tests, plus all previous tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/oyster-publish/src/viewer-render.ts \
+        infra/oyster-publish/test/viewer-handler.test.ts
+git commit -m "$(cat <<'EOF'
+feat(publish): referrer-policy: no-referrer on rendered viewer responses
+
+Defence in depth alongside the same header on the nonce-consumption 302.
+Prevents any URL-shaped sensitive parameter from leaking via subresource
+or onward-navigation Referer.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Cross-host cookie-scoping regression test
+
+This is the dedicated test file the spec calls out — it models real browser cookie behaviour (the apex session is NOT sent to `share.oyster.to`) and proves both the original loop AND the fix.
+
+**Files:**
+- Create: `infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts`:
+
+```ts
+// Regression: signin-mode handoff across the oyster.to / share.oyster.to
+// cookie boundary.
+//
+// Production reality: the auth-worker sets `oyster_session` host-only on
+// oyster.to (no Domain=), so browsers DO NOT send it to share.oyster.to.
+// Tests in viewer-handler.test.ts that forge the cookie onto a
+// share.oyster.to request hide this — they bypass the host-scoping the
+// browser would enforce.
+//
+// This file models the real behaviour: cookies on oyster.to vs not on
+// share.oyster.to, and asserts:
+//   (a) without the access-redirect, signin mode is a closed loop, and
+//   (b) with the access-redirect, the visitor can reach content.
+
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, seedActiveOpenWithBody } from "./fixtures/seed";
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (env as any).VIEWER_PASSWORD_LIMIT = { limit: async () => ({ success: true }) };
+});
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function req(absUrl: string, opts: { cookie?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  return new Request(absUrl, { method: "GET", headers });
+}
+
+async function call(r: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(r, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("signin mode across the oyster.to / share.oyster.to cookie boundary", () => {
+  it("direct signin-mode visit to share.oyster.to without apex cookie → redirect to access-redirect", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_loop1", body: "# private",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    // Real browser: would NOT send oyster.to-host-only cookie to share.oyster.to.
+    const res = await call(req(`https://share.oyster.to/p/${shareToken}`));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location"))
+      .toBe(`https://oyster.to/api/publish/access-redirect/${shareToken}`);
+  });
+
+  it("oyster.to/p/<token> 308s to share.oyster.to even with an apex session — loop is real", async () => {
+    // Demonstrates that the cookie boundary is enforced by the worker's
+    // own legacy-origin 308: even though oyster.to/p sees the cookie,
+    // the redirect strips the host and the next hop is share.oyster.to,
+    // where the cookie cannot follow. Combined with the previous test,
+    // this is the closed loop that existed before access-redirect.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_loop2", body: "# private",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const res = await call(req(`https://oyster.to/p/${shareToken}`, {
+      cookie: `oyster_session=${u.sessionToken}`,
+    }));
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe(`https://share.oyster.to/p/${shareToken}`);
+  });
+
+  it("access-redirect on oyster.to sees the apex session and produces a working cross-host handoff", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_loop3", body: "# private content",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    // Step 1: oyster.to sees the apex cookie (host-only on oyster.to).
+    const step1 = await call(req(
+      `https://oyster.to/api/publish/access-redirect/${shareToken}`,
+      { cookie: `oyster_session=${u.sessionToken}` },
+    ));
+    expect(step1.status).toBe(302);
+    const handoff = new URL(step1.headers.get("location")!);
+    expect(handoff.origin + handoff.pathname).toBe(`https://share.oyster.to/p/${shareToken}`);
+    const nonce = handoff.searchParams.get("key");
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+    // Step 2: share.oyster.to consumes the nonce — NO apex cookie sent
+    // here, matching real browser cookie scoping.
+    const step2 = await call(req(handoff.toString()));
+    expect(step2.status).toBe(302);
+    expect(step2.headers.get("location")).toBe(`/p/${shareToken}`);
+    const setCookie = step2.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oyster_view_${shareToken}=`);
+    const cookieValue = setCookie.match(/oyster_view_[^=]+=([^;]+)/)?.[1] ?? "";
+
+    // Step 3: clean URL follow-up — still no apex cookie, only the
+    // recent-access proof — must serve content.
+    const step3 = await call(req(`https://share.oyster.to/p/${shareToken}`, {
+      cookie: `oyster_view_${shareToken}=${cookieValue}`,
+    }));
+    expect(step3.status).toBe(200);
+    expect(await step3.text()).toContain("private content");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they pass**
+
+Run: `cd infra/oyster-publish && npm test -- --run test/signin-mode-cookie-boundary.test.ts`
+Expected: PASS — all 3 tests. (These tests describe behaviour that should already be in place after Tasks 4–7.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts
+git commit -m "$(cat <<'EOF'
+test(publish): cross-host cookie-scoping regression for signin mode
+
+Models real browser cookie behaviour (apex oyster_session NOT sent to
+share.oyster.to). Proves the original closed loop and the working
+access-redirect handoff end-to-end. Catches future regressions where the
+fix gets unwound or signin mode is otherwise re-tied to the apex cookie
+boundary.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: CHANGELOG entry + regenerate docs/changelog.html
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/changelog.html` (auto-generated)
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Edit `CHANGELOG.md`. Under the current "Unreleased" or topmost section, add one bullet under `Added` (create the `### Added` heading if absent). The bullet — user-visible only, no internal terminology:
+
+```markdown
+- **Sign in to view your own protected shares.** A password-protected share now offers a "Have access? Sign in to view" option alongside the password field; if you're signed in to Oyster as the owner, you skip the password.
+```
+
+- [ ] **Step 2: Regenerate the static changelog page**
+
+Run: `cd /Users/Matthew.Slight/Dev/oyster-dev && npm run build:changelog`
+Expected: rewrites `docs/changelog.html`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md docs/changelog.html
+git commit -m "$(cat <<'EOF'
+docs(changelog): sign in to view your own protected shares
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Full-suite sanity + PR
+
+- [ ] **Step 1: Run the full test suites that the change touches**
+
+```bash
+cd /Users/Matthew.Slight/Dev/oyster-dev/infra/oyster-publish && npm test -- --run
+cd /Users/Matthew.Slight/Dev/oyster-dev/infra/auth-worker && npm test -- --run
+```
+
+Expected: all tests pass in both packages. No skipped tests introduced.
+
+- [ ] **Step 2: Type-check the whole repo**
+
+```bash
+cd /Users/Matthew.Slight/Dev/oyster-dev && npm run build
+```
+
+Expected: clean build. (`npm run build` runs `tsc` for web + server + copies web into server/dist/public/, per CLAUDE.md.)
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/viewer-access-redirect
+gh pr create --title "Viewer access redirect: owner bypass + signin handoff" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `GET oyster.to/api/publish/access-redirect/:token` — owners of password shares (and any signed-in visitor for signin shares) get a single-click bypass.
+- D1 `viewer_access_nonces` table with atomic single-use semantics; `share_token` is in the consume `WHERE` clause so a nonce minted for one share cannot be burned against another.
+- Fixes a production bug in `signin` mode where the apex/share cookie split made the handoff a closed loop. `oyster_view_<token>` is now a generic recent-access proof honoured by both password and signin modes.
+- `resolveViewerAccess` takes a required `{ consumeNonce }` option so `/raw` cannot accidentally start consuming nonces in a future change.
+- New "Have access? Sign in to view" link on the password gate.
+- Referrer-Policy: no-referrer on the nonce-consumption 302 AND on rendered viewer responses (defence in depth).
+
+## Test plan
+
+- [x] `infra/oyster-publish` test suite green (incl. new `access-nonce`, `access-redirect-handler`, `signin-mode-cookie-boundary`, and additions to `viewer-handler`).
+- [x] `infra/auth-worker` test suite green (incl. new `return-path` cases).
+- [x] Full TypeScript build clean.
+- [ ] Manual: publish a password share locally; visit `share.oyster.to/p/<token>` while signed in; click "Sign in to view"; confirm 302 → consumption → content with no password prompt.
+- [ ] Manual: same flow while signed out → sign in flow → bypass.
+- [ ] Manual: non-owner clicks "Sign in to view" → 403 page with link back to the public gate.
+- [ ] **Audit Cloudflare Logpush / Workers Analytics / wrangler tail for query-string capture on viewer URLs; disable or scrub `?key=` capture before merge.**
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+
+| Spec section | Plan task(s) |
+|---|---|
+| D1 table `viewer_access_nonces` | Task 1 |
+| `mintAccessNonce` / `consumeAccessNonce` with atomic share_token-in-WHERE | Task 2 |
+| Return-path allowlist accepts access-redirect path | Task 3 |
+| Signin mode honours `oyster_view_<token>` cookie | Task 4 |
+| `consumeNonce` required option on `resolveViewerAccess`; `/raw` MUST pass false; new `ok_via_nonce` kind | Task 5 |
+| `handleViewerGet` handles `ok_via_nonce` — cookie + clean URL + cache-control + referrer-policy | Task 6 |
+| `GET /api/publish/access-redirect/:token` full matrix (open / signin × auth / password × owner / non-owner / unauth) | Task 7 |
+| 403 page for non-owner of password share | Task 7 (Step 3) |
+| Gate-page "Have access? Sign in to view" link | Task 8 |
+| `referrer-policy: no-referrer` on rendered viewer responses | Task 9 |
+| Cross-host cookie-scoping regression test | Task 10 |
+| CHANGELOG entry | Task 11 |
+| Platform-log audit | Task 12 PR checklist (operational, not code) |
+| Future: ACL widening | Documented inline in Task 7 handler ("widen the password case to an ACL") — no code change |
+
+No gaps.
+
+**Placeholder scan:** searched for TBD, TODO, "implement later", "similar to Task N" — none. Every step has the actual code or command. The one "TODO Task 6" mention in Task 5 Step 5 is a *transient* placeholder used during that single task and immediately replaced in Task 6.
+
+**Type consistency:**
+- `mintAccessNonce(env, shareToken, userId)` and `consumeAccessNonce(env, nonce, shareToken)` — same signatures everywhere they appear.
+- `resolveViewerAccess(req, env, shareToken, opts)` — four-arg signature consistent across the function definition and all three callers in `worker.ts`.
+- `noAccessPage(shareToken)` — single param, used in handler and imported in worker.ts.
+- `hasValidViewerCookie(req, shareToken, secret)` — private helper, used twice within `viewer-access.ts`.
+- `ViewerAccess` union extended with `ok_via_nonce` in Task 5, handled in Task 6 — no naming drift.
+
+Looks coherent.

--- a/docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+++ b/docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
@@ -217,7 +217,10 @@ Without this change, the auth worker silently drops the `?return=` parameter and
 
 ### Viewer pre-check — `infra/oyster-publish/src/viewer-access.ts`
 
-Add a new access kind and a `?key=` pre-check before the mode switch:
+Two changes:
+
+1. Add a `?key=` pre-check before the mode switch, gated by an **explicit `consumeNonce` flag** on the resolver API so that `/raw` can never accidentally consume a nonce.
+2. Make the `signin` case accept the `oyster_view_<token>` cookie as a valid access proof, alongside the apex session check. Without this, the clean redirect after nonce consumption loops back to `signin → resolveSession → null` and bounces the visitor to sign-in again.
 
 ```ts
 export type ViewerAccess =
@@ -228,24 +231,78 @@ export type ViewerAccess =
   | { kind: "gone"; row: PublicationRow }
   | { kind: "not_found" };
 
-export async function resolveViewerAccess(req, env, shareToken) {
+export interface ResolveOptions {
+  /**
+   * When true, a valid `?key=<nonce>` consumes the nonce and yields
+   * `ok_via_nonce`. When false, the `?key=` parameter is ignored
+   * (the caller is responsible for any cookie-based check).
+   * Only `/p/<token>` passes true; `/raw` MUST pass false.
+   */
+  consumeNonce: boolean;
+}
+
+export async function resolveViewerAccess(
+  req: Request,
+  env: Env,
+  shareToken: string,
+  opts: ResolveOptions,
+): Promise<ViewerAccess> {
   const row = await fetchRow(...);
   if (!row) return { kind: "not_found" };
   if (row.unpublished_at != null) return { kind: "gone", row };
 
-  // Nonce pre-check: applies to password + signin modes; open mode never
-  // needs one. Invalid/expired/wrong-share nonces fall through silently —
-  // no oracle on whether a presented nonce was real.
-  const key = new URL(req.url).searchParams.get("key");
-  if (key && (row.mode === "password" || row.mode === "signin")) {
-    if (await consumeAccessNonce(env, key, shareToken)) {
-      return { kind: "ok_via_nonce", row };
+  // Nonce pre-check: only when the caller has opted in. Applies to
+  // password + signin modes; open mode never needs one. Invalid /
+  // expired / wrong-share nonces fall through silently — no oracle
+  // on whether a presented nonce was real.
+  if (opts.consumeNonce) {
+    const key = new URL(req.url).searchParams.get("key");
+    if (key && (row.mode === "password" || row.mode === "signin")) {
+      if (await consumeAccessNonce(env, key, shareToken)) {
+        return { kind: "ok_via_nonce", row };
+      }
     }
   }
 
-  // ...existing mode switch (open/password/signin) unchanged...
+  switch (row.mode) {
+    case "open":
+      return { kind: "ok", row };
+
+    case "password": {
+      // Existing path — cookie verifies the recent-access proof.
+      if (await checkViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      return { kind: "gate", row };
+    }
+
+    case "signin": {
+      // CHANGED: the viewer cookie is a recent-access proof for the
+      // artefact regardless of which gate-clearing path minted it
+      // (password POST, owner-via-nonce, signin-via-nonce). Honour it
+      // first; only fall back to apex session if no cookie. Without
+      // this, the post-consumption clean redirect loops back through
+      // signin → resolveSession → null on share.oyster.to.
+      if (await checkViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      const session = await resolveSession(req, env);
+      if (!session) {
+        return {
+          kind: "redirect",
+          location: `https://oyster.to/api/publish/access-redirect/${shareToken}`,
+        };
+      }
+      return { kind: "ok", row };
+    }
+  }
 }
+
+// `checkViewerCookie` is the existing read-cookie + verifyViewerCookie
+// pair extracted into a single helper for reuse across modes.
 ```
+
+Note the signin redirect target is now the new access-redirect endpoint, not `/auth/sign-in` directly — the redirect path handles the unauth case, mints a nonce post-sign-in, and produces a working cross-host handoff. The existing direct sign-in redirect is preserved as a fallback only for visitors who hit `/p/<token>` with no `?key=` on `share.oyster.to` directly.
 
 ### Viewer-side handling of `ok_via_nonce`
 
@@ -268,7 +325,13 @@ case "ok_via_nonce": {
 }
 ```
 
-`handleViewerRaw` (the `/raw` iframe endpoint) gets the same nonce pre-check but should not consume — `/raw` is loaded as the inner iframe of `/p/<token>`, and the visitor already has the cookie from the outer-page redirect. Practically, the nonce will already be consumed by the time `/raw` is reached, so this just means: don't 500 if a `?key=` is on the URL; just treat as no-key and rely on cookie. (Defence in depth: if a nonce ever did appear on a `/raw` request, the consume-then-redirect flow is wrong for `/raw` because the iframe body must be the response body, not a 302.)
+### `/raw` MUST NOT consume nonces
+
+`handleViewerRaw` calls `resolveViewerAccess(req, env, token, { consumeNonce: false })`. Because the flag is required on the resolver API, any future change to `/raw` cannot accidentally start consuming nonces without a deliberate edit to the call site.
+
+Rationale: `/raw` is loaded as the inner iframe of `/p/<token>`. By the time the iframe loads, the outer page has already consumed the nonce, set `oyster_view_<token>`, and stripped the key from the URL. The iframe carries the cookie and uses the standard mode dispatch. The consume-then-redirect flow is also semantically wrong for `/raw` — the iframe body must be the response body, not a 302.
+
+If a `?key=` ever does appear on a `/raw` URL (defensively constructed, mis-pasted, or a future code change misroutes a nonce), it is simply ignored — the nonce stays unconsumed and remains usable at the proper `/p/<token>?key=…` URL.
 
 ### Cookie semantics — generalised
 
@@ -303,7 +366,7 @@ The "Have access?" phrasing rather than "Own this share?" anticipates the ACL wi
 |---|---|
 | Nonce replay within TTL | Single-use enforced by atomic `UPDATE ... WHERE consumed_at IS NULL`. Second click on the same URL falls through silently to the gate. |
 | Nonce cross-share misuse | `share_token` is in the consume `WHERE` clause. A nonce minted for share A presented at share B does not consume and returns false. |
-| Nonce in URL → browser history | 302 → 302 chain means the `?key=…` URL is never the final history entry; the cleaned `/p/<token>` URL replaces it. |
+| Nonce in URL → visible address / shareable links | The consumption 302 immediately redirects the browser to the cleaned `/p/<token>` URL, so the final visible URL in the address bar carries no key. Precise browser-history retention of intermediate redirect targets is user-agent-specific and not relied on; the security claim is "the user does not see, share, or screenshot the key-bearing URL", not "the key URL is absent from history". |
 | Nonce in Referer to subresources | `referrer-policy: no-referrer` on the consumption 302 strips Referer for the destination's initial GET and its subresource fetches. |
 | Nonce in server logs | `mintAccessNonce` and `consumeAccessNonce` log only counts/booleans, never the nonce value. The endpoint logs the share token, not the query string. |
 | Nonce theft from server | A leaked nonce is single-use, 60s lifetime, and bound to one `share_token`. The blast radius is "view this one artefact once within a minute"; the cookie minted on consumption is bound to that same artefact too. |
@@ -332,20 +395,20 @@ Cover the full matrix:
 | token not found | 404 page |
 | publication retired | 410 gone page |
 | mode=open | 302 → `share.oyster.to/p/<token>` (no key) |
-| mode=signin, no session | 302 → `/auth/sign-in?return=…` |
+| mode=signin, no session | 302 → `/auth/sign-in?return=/api/publish/access-redirect/<token>` |
 | mode=signin, session | 302 → `…?key=<22 chars>` and a row exists in `viewer_access_nonces` |
-| mode=password, no session | 302 → `/auth/sign-in?return=…` |
+| mode=password, no session | 302 → `/auth/sign-in?return=/api/publish/access-redirect/<token>` |
 | mode=password, session = owner | 302 → `…?key=…` |
 | mode=password, session ≠ owner | 403 page |
 | All 302s | include `cache-control: private, no-store` |
 
 ### Viewer integration — `infra/oyster-publish/test/viewer-handler.test.ts` additions
 
-- Owner-bypass golden path: mint nonce for `(token, owner)`, GET `/p/<token>?key=<nonce>`, expect 302 to `/p/<token>` with `set-cookie: oyster_view_<token>=...`, `referrer-policy: no-referrer`. Then GET `/p/<token>` with that cookie → 200 content.
-- Same path for `signin` mode (any signed-in user, not just owner).
+- Owner-bypass golden path (password mode): mint nonce for `(token, owner)`, GET `/p/<token>?key=<nonce>`, expect 302 to `/p/<token>` with `set-cookie: oyster_view_<token>=...`, `referrer-policy: no-referrer`. Then GET `/p/<token>` with that cookie → 200 content.
+- **Signin-mode end-to-end (regression for the cookie-honouring fix):** mint nonce for `(token, signed-in user)`, GET `/p/<token>?key=<nonce>`, follow the 302, then GET `/p/<token>` with only the `oyster_view_<token>` cookie set and **no `oyster_session` cookie at all** (modelling the cross-host browser reality) — expect 200 content. Without the signin-mode cookie acceptance change this final GET would 302 back to access-redirect / sign-in, looping.
 - Replay: a second GET `/p/<token>?key=<nonce>` (after consumption) falls through to the password gate (or signin redirect) — i.e., behaviour identical to no-key.
 - Wrong-share nonce on `/p/<other_token>?key=<nonce>` falls through; the nonce remains consumable on its real token afterwards. (Regression for the atomic-WHERE fix.)
-- `/raw?key=...` on an iframe-kind share doesn't 500; treated as no-key (cookie covers it after outer-page consumption).
+- **`/raw` MUST NOT consume nonces:** GET `/raw?key=<valid_nonce>` returns the existing no-cookie behaviour for an iframe-kind share (gate redirect or 404 per current logic). Critically, after the call, `SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?` is still `NULL`, and a subsequent GET `/p/<token>?key=<nonce>` succeeds. This is the regression for the explicit `consumeNonce` flag — a future code change that drops the flag on the `/raw` resolver call will fail this test.
 
 ### Cookie-scoping regression — `infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts` (new)
 

--- a/docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+++ b/docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
@@ -302,7 +302,7 @@ export async function resolveViewerAccess(
 // pair extracted into a single helper for reuse across modes.
 ```
 
-Note the signin redirect target is now the new access-redirect endpoint, not `/auth/sign-in` directly — the redirect path handles the unauth case, mints a nonce post-sign-in, and produces a working cross-host handoff. The existing direct sign-in redirect is preserved as a fallback only for visitors who hit `/p/<token>` with no `?key=` on `share.oyster.to` directly.
+Note the signin redirect target is now the new access-redirect endpoint, not `/auth/sign-in` directly — the redirect path handles the unauth case, mints a nonce post-sign-in, and produces a working cross-host handoff. There is no parallel direct-to-sign-in path; all signin-mode viewer misses route through `/api/publish/access-redirect/<token>`.
 
 ### Viewer-side handling of `ok_via_nonce`
 
@@ -367,8 +367,8 @@ The "Have access?" phrasing rather than "Own this share?" anticipates the ACL wi
 | Nonce replay within TTL | Single-use enforced by atomic `UPDATE ... WHERE consumed_at IS NULL`. Second click on the same URL falls through silently to the gate. |
 | Nonce cross-share misuse | `share_token` is in the consume `WHERE` clause. A nonce minted for share A presented at share B does not consume and returns false. |
 | Nonce in URL → visible address / shareable links | The consumption 302 immediately redirects the browser to the cleaned `/p/<token>` URL, so the final visible URL in the address bar carries no key. Precise browser-history retention of intermediate redirect targets is user-agent-specific and not relied on; the security claim is "the user does not see, share, or screenshot the key-bearing URL", not "the key URL is absent from history". |
-| Nonce in Referer to subresources | `referrer-policy: no-referrer` on the consumption 302 strips Referer for the destination's initial GET and its subresource fetches. |
-| Nonce in server logs | `mintAccessNonce` and `consumeAccessNonce` log only counts/booleans, never the nonce value. The endpoint logs the share token, not the query string. |
+| Nonce in Referer to subresources | `referrer-policy: no-referrer` on the consumption 302 strips Referer for the destination's initial GET and its subresource fetches. Additionally, the **final rendered viewer responses** (`renderMarkdownPage` / `renderMermaidPage` / `renderChromeWithIframe` / `renderRawHtmlBody` / `renderImageInline`) also emit `referrer-policy: no-referrer` — added in the shared `cacheHeaders()` helper. Defence in depth so any future URL-shaped sensitive parameter (or a paste-edited share URL) cannot leak via subresource or onward-navigation Referer from the rendered page itself. |
+| Nonce in application logs | `mintAccessNonce` and `consumeAccessNonce` log only counts/booleans, never the nonce value. The endpoint logs the share token, not the query string. **Platform-level request logs (Cloudflare Logpush / `wrangler tail` / Workers Analytics Engine) are out of band of application code and must be reviewed separately** — if any of these capture the full request URL by default, the query string will include the nonce. Action item before implementation: audit the production log sinks for query-string capture and either disable or scrub `?key=` on the access-redirect destination paths. |
 | Nonce theft from server | A leaked nonce is single-use, 60s lifetime, and bound to one `share_token`. The blast radius is "view this one artefact once within a minute"; the cookie minted on consumption is bound to that same artefact too. |
 | Ownership change after mint | `consumeAccessNonce` does not re-check ownership; the row stores `user_id` for audit only. Ownership transfers in Oyster are not a current feature; the predicate runs at mint time. |
 | Cross-site request forgery against `/api/publish/access-redirect/...` | The endpoint is `GET` with no side effects beyond a D1 insert that only matters if the visitor follows the resulting 302. The session is `SameSite=Lax`, so a cross-site `GET` does carry the session — but the consequence is a wasted nonce, not an authenticated action against the artefact. |
@@ -404,7 +404,7 @@ Cover the full matrix:
 
 ### Viewer integration — `infra/oyster-publish/test/viewer-handler.test.ts` additions
 
-- Owner-bypass golden path (password mode): mint nonce for `(token, owner)`, GET `/p/<token>?key=<nonce>`, expect 302 to `/p/<token>` with `set-cookie: oyster_view_<token>=...`, `referrer-policy: no-referrer`. Then GET `/p/<token>` with that cookie → 200 content.
+- Owner-bypass golden path (password mode): mint nonce for `(token, owner)`, GET `/p/<token>?key=<nonce>`, expect 302 to `/p/<token>` with `set-cookie: oyster_view_<token>=...`, `referrer-policy: no-referrer`. Then GET `/p/<token>` with that cookie → 200 content, and the 200 response **also carries `referrer-policy: no-referrer`** (asserts the `cacheHeaders()` change).
 - **Signin-mode end-to-end (regression for the cookie-honouring fix):** mint nonce for `(token, signed-in user)`, GET `/p/<token>?key=<nonce>`, follow the 302, then GET `/p/<token>` with only the `oyster_view_<token>` cookie set and **no `oyster_session` cookie at all** (modelling the cross-host browser reality) — expect 200 content. Without the signin-mode cookie acceptance change this final GET would 302 back to access-redirect / sign-in, looping.
 - Replay: a second GET `/p/<token>?key=<nonce>` (after consumption) falls through to the password gate (or signin redirect) — i.e., behaviour identical to no-key.
 - Wrong-share nonce on `/p/<other_token>?key=<nonce>` falls through; the nonce remains consumable on its real token afterwards. (Regression for the atomic-WHERE fix.)

--- a/docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+++ b/docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
@@ -1,0 +1,423 @@
+# Viewer access redirect — design
+
+**Status:** Draft for review · 2026-05-18 · branch `feat/viewer-access-redirect`
+
+## Goal
+
+Let an authorised visitor reach a protected share without retyping the password — specifically:
+
+1. The **owner** of a password-protected share can view their own publication while signed in to Oyster, with no password prompt.
+2. Any visitor sitting at the password gate can choose **"Have access? Sign in to view"** as an alternative to typing the password. After sign-in, if they have access (today: ownership; tomorrow: an ACL membership), they get in.
+3. The mechanism is general enough to also fix `signin` mode, which is currently broken in production for the cross-host case (see below).
+
+Future scope — sharing to specific other Oyster users by id — is out of scope for v1. The mechanism we build here is the slot where that ACL widens.
+
+## Current state
+
+### Publish modes (already in place)
+
+`published_artifacts.mode` is one of:
+
+- `open` — public link, no gate.
+- `password` — visitor types a password; PBKDF2-verified by the viewer worker; on success, a 24h HMAC cookie `oyster_view_<token>` is set scoped to `/p/<token>`.
+- `signin` — visitor must have a valid `oyster_session` cookie at request time.
+
+### Cookie scoping — the load-bearing constraint
+
+`infra/auth-worker/src/worker.ts:138-141` sets `oyster_session` as **host-only on `oyster.to`** (production) — no `Domain=` attribute. This is intentional (#397): untrusted published content runs on `share.oyster.to`, so the apex session cookie must not leak across the host boundary.
+
+`infra/oyster-publish/wrangler.toml` routes `oyster.to/p/*`, `www.oyster.to/p/*`, and `share.oyster.to/p/*` all to the same `oyster-publish` worker. The worker's top-of-handler 308 redirect (`worker.ts:60-74`) sends every `oyster.to/p/*` and `www.oyster.to/p/*` request to `share.oyster.to/p/*` so the cookie boundary is enforced for viewer traffic.
+
+### What the constraint breaks today
+
+The signin-mode dispatch in `viewer-access.ts:44-50` calls `resolveSession(req, env)` on `share.oyster.to`. Because the apex session cookie does not cross the host boundary, `resolveSession` returns null and the dispatch 302s the visitor to `oyster.to/auth/sign-in?return=/p/<token>`. After sign-in the visitor lands on `oyster.to/p/<token>`, which the worker 308s to `share.oyster.to/p/<token>` — where the cookie is again invisible. The loop is unbroken.
+
+The test at `viewer-handler.test.ts:393-405` ("signed-in visitor → content") only passes because the vitest-pool-workers harness forges the cookie directly onto the `share.oyster.to` request, bypassing the real cookie boundary. **In production, signin mode is non-functional.**
+
+There is no existing handoff mechanism that bridges `oyster.to`'s session to `share.oyster.to`'s viewer. This design is that mechanism.
+
+## Non-goals
+
+- Ambient client-side ownership detection (CORS fetch from gate page back to `oyster.to`). Adds CORS attack surface and exposes a session-bound endpoint to a sibling subdomain. Manual "Sign in" click is fine.
+- Persistent owner cookie on `share.oyster.to`. Same security boundary; not worth a second auth concept on the publish-content host.
+- Replacing the password gate. Visitors who don't have an Oyster account or who want to share with non-Oyster recipients still use the password flow.
+- ACL widening (share-to-specific-user). Scoped here only as a foreseen extension point.
+
+## Design
+
+### Architecture overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Visitor's browser                                               │
+└─┬───────────────────────────────────────────────────────────────┘
+  │ 1. GET share.oyster.to/p/<token>             (no session cookie here)
+  ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ oyster-publish worker (share.oyster.to)                         │
+│   resolveViewerAccess → mode=password, no cookie → { gate }     │
+└─┬───────────────────────────────────────────────────────────────┘
+  │ 2. render password-gate page with "Sign in to view" link
+  ▼
+  ┌─ Visitor clicks "Sign in to view" ─┐
+  │ link target:                       │
+  │ oyster.to/api/publish/access-redirect/<token>
+  ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ oyster-publish worker (oyster.to)            (session visible)  │
+│   - no session  → 302 to sign-in (return=this URL)              │
+│   - session, mode=signin             → mint nonce               │
+│   - session, mode=password + owner   → mint nonce               │
+│   - session, mode=password, non-owner → 403 page                │
+│   - session, mode=open               → 302 to viewer (no nonce) │
+└─┬───────────────────────────────────────────────────────────────┘
+  │ 3. 302 → share.oyster.to/p/<token>?key=<nonce>
+  ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ oyster-publish worker (share.oyster.to)                         │
+│   resolveViewerAccess pre-check:                                │
+│     consumeNonce(nonce, share_token)                            │
+│   - hit  → { kind: ok_via_nonce }                               │
+│   - miss → fall through to mode dispatch (gate / signin etc.)   │
+└─┬───────────────────────────────────────────────────────────────┘
+  │ 4. handleViewerGet sets oyster_view_<token> cookie (24h)
+  │    302 → share.oyster.to/p/<token>     (key stripped)
+  │    headers: cache-control: private, no-store; referrer-policy: no-referrer
+  ▼
+  Browser follows → next GET has cookie → ok → content rendered
+```
+
+### Data model
+
+New table in `infra/auth-worker/migrations/` (same database the publish worker already binds to):
+
+```sql
+CREATE TABLE viewer_access_nonces (
+  nonce        TEXT PRIMARY KEY,        -- 22-char base64url (128 bits of entropy)
+  share_token  TEXT NOT NULL,
+  user_id      TEXT NOT NULL,           -- for audit; never surfaced in any response
+  expires_at   INTEGER NOT NULL,        -- unix ms
+  consumed_at  INTEGER,                 -- null until single use
+  created_at   INTEGER NOT NULL
+);
+CREATE INDEX idx_viewer_access_nonces_expires ON viewer_access_nonces(expires_at);
+```
+
+No FK on `share_token` because the source-of-truth row may be the live `published_artifacts` row or, post-retirement, gone — the nonce should fail consumption either way and the table holds its own invariants.
+
+### Nonce module — `infra/oyster-publish/src/access-nonce.ts`
+
+```ts
+const TTL_MS = 60_000;
+
+export async function mintAccessNonce(
+  env: Env,
+  shareToken: string,
+  userId: string,
+): Promise<string> {
+  const nonce = base64urlRandom(16);           // 16 bytes → 22 chars
+  const now = Date.now();
+  // Opportunistic cleanup of expired rows. The table is small (60s TTL,
+  // capped by mint rate), so an unindexed sweep on each mint is fine; the
+  // expires_at index makes it a range scan.
+  await env.DB.prepare(
+    "DELETE FROM viewer_access_nonces WHERE expires_at < ?"
+  ).bind(now).run();
+  await env.DB.prepare(
+    `INSERT INTO viewer_access_nonces
+       (nonce, share_token, user_id, expires_at, consumed_at, created_at)
+     VALUES (?, ?, ?, ?, NULL, ?)`
+  ).bind(nonce, shareToken, userId, now + TTL_MS, now).run();
+  return nonce;
+}
+
+/** Returns true iff this call atomically transitioned the nonce
+ *  for THIS share_token from unconsumed-and-live to consumed.
+ *  Wrong share_token, wrong nonce, expired, or already-consumed
+ *  all return false without any side effect. */
+export async function consumeAccessNonce(
+  env: Env,
+  nonce: string,
+  shareToken: string,
+): Promise<boolean> {
+  const now = Date.now();
+  const res = await env.DB.prepare(
+    `UPDATE viewer_access_nonces
+        SET consumed_at = ?
+      WHERE nonce       = ?
+        AND share_token = ?
+        AND consumed_at IS NULL
+        AND expires_at  > ?`
+  ).bind(now, nonce, shareToken, now).run();
+  return (res.meta?.changes ?? 0) === 1;
+}
+```
+
+**Critical:** `share_token` is in the `WHERE` clause, not a post-hoc assertion. A nonce minted for share A presented against share B's URL does not consume the row — it just returns false, leaving the legitimate share-A consumption intact.
+
+### Endpoint — `GET oyster.to/api/publish/access-redirect/:token`
+
+In `infra/oyster-publish/src/worker.ts`, new top-level route. Pseudocode:
+
+```ts
+async function handleAccessRedirect(req: Request, env: Env, shareToken: string) {
+  const row = await env.DB.prepare(
+    "SELECT mode, owner_user_id, unpublished_at FROM published_artifacts WHERE share_token = ?"
+  ).bind(shareToken).first<PubRow>();
+
+  if (!row) return htmlPage(404, notFoundPage());
+  if (row.unpublished_at !== null) return htmlPage(410, gonePage());
+
+  // Open mode: nothing to gate; send the visitor straight to the viewer.
+  if (row.mode === "open") {
+    return redirectNoStore(`https://share.oyster.to/p/${shareToken}`);
+  }
+
+  const session = await resolveSession(req, env);
+  if (!session) {
+    // Cookie is host-only on oyster.to, so this is the only host where the
+    // session is visible. Round-trip through sign-in and return to this URL.
+    return redirectNoStore(
+      `https://oyster.to/auth/sign-in?return=${encodeURIComponent(`/api/publish/access-redirect/${shareToken}`)}`
+    );
+  }
+
+  // Access predicates — extend the password case for ACLs.
+  // resolveSession() in this worker returns a flat { id, email, tier }
+  // (see infra/oyster-publish/src/worker.ts:resolveSession).
+  let mayAccess = false;
+  if (row.mode === "signin")   mayAccess = true;
+  if (row.mode === "password") mayAccess = session.id === row.owner_user_id;
+
+  if (!mayAccess) return htmlPage(403, noAccessPage(shareToken));
+
+  const nonce = await mintAccessNonce(env, shareToken, session.id);
+  return redirectNoStore(`https://share.oyster.to/p/${shareToken}?key=${nonce}`);
+}
+```
+
+The `redirectNoStore` helper sets `cache-control: private, no-store`. (The `?key=…` URL must never be cached.)
+
+### Return-path allowlist
+
+`infra/auth-worker/src/return-path.ts:8` currently accepts only `^/p/<token>$`. Extend the validator to also accept the access-redirect path:
+
+```ts
+const SHARE_VIEWER_PATH      = /^\/p\/[A-Za-z0-9_-]+$/;
+const ACCESS_REDIRECT_PATH   = /^\/api\/publish\/access-redirect\/[A-Za-z0-9_-]+$/;
+
+export function validateReturnPath(raw): string | null {
+  // ...existing length/control-char checks...
+  if (SHARE_VIEWER_PATH.test(raw) || ACCESS_REDIRECT_PATH.test(raw)) return raw;
+  return null;
+}
+```
+
+Without this change, the auth worker silently drops the `?return=` parameter and the user lands somewhere generic after sign-in.
+
+### Viewer pre-check — `infra/oyster-publish/src/viewer-access.ts`
+
+Add a new access kind and a `?key=` pre-check before the mode switch:
+
+```ts
+export type ViewerAccess =
+  | { kind: "ok"; row: PublicationRow }
+  | { kind: "ok_via_nonce"; row: PublicationRow }   // NEW
+  | { kind: "gate"; row: PublicationRow; error?: "wrong_password" }
+  | { kind: "redirect"; location: string }
+  | { kind: "gone"; row: PublicationRow }
+  | { kind: "not_found" };
+
+export async function resolveViewerAccess(req, env, shareToken) {
+  const row = await fetchRow(...);
+  if (!row) return { kind: "not_found" };
+  if (row.unpublished_at != null) return { kind: "gone", row };
+
+  // Nonce pre-check: applies to password + signin modes; open mode never
+  // needs one. Invalid/expired/wrong-share nonces fall through silently —
+  // no oracle on whether a presented nonce was real.
+  const key = new URL(req.url).searchParams.get("key");
+  if (key && (row.mode === "password" || row.mode === "signin")) {
+    if (await consumeAccessNonce(env, key, shareToken)) {
+      return { kind: "ok_via_nonce", row };
+    }
+  }
+
+  // ...existing mode switch (open/password/signin) unchanged...
+}
+```
+
+### Viewer-side handling of `ok_via_nonce`
+
+In `handleViewerGet`:
+
+```ts
+case "ok_via_nonce": {
+  const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+  const host = new URL(req.url).host;
+  const secureFlag = isLoopback(host) ? "" : " Secure;";
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "set-cookie": `oyster_view_${shareToken}=${cookieValue}; HttpOnly;${secureFlag} SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
+      "location": `/p/${shareToken}`,
+      "cache-control": "private, no-store",
+      "referrer-policy": "no-referrer",
+    },
+  });
+}
+```
+
+`handleViewerRaw` (the `/raw` iframe endpoint) gets the same nonce pre-check but should not consume — `/raw` is loaded as the inner iframe of `/p/<token>`, and the visitor already has the cookie from the outer-page redirect. Practically, the nonce will already be consumed by the time `/raw` is reached, so this just means: don't 500 if a `?key=` is on the URL; just treat as no-key and rely on cookie. (Defence in depth: if a nonce ever did appear on a `/raw` request, the consume-then-redirect flow is wrong for `/raw` because the iframe body must be the response body, not a 302.)
+
+### Cookie semantics — generalised
+
+`oyster_view_<token>` is **a recent-access proof for the artefact**, not specifically "password entered". The HMAC + TTL scheme in `viewer-cookie.ts` already encodes nothing more than "this visitor cleared an access check for `<token>` at time T, signed by the worker secret"; today it is minted only by the password POST handler, but the design treats it as the canonical access-proof for any successful gate-clearing path:
+
+| Gate-clearing path | Mints `oyster_view_<token>` |
+|---|---|
+| Password POST + correct password (existing) | yes (existing) |
+| Owner via nonce — `ok_via_nonce` | yes (new) |
+| Signin-mode visitor via nonce — `ok_via_nonce` | yes (new) |
+| Open mode | no — no gate to clear |
+
+Spec / comment changes in `viewer-cookie.ts` describe the cookie generically. The cookie name stays `oyster_view_<token>`; no schema change.
+
+### Gate-page copy
+
+`passwordGatePage(shareToken)` in `viewer-pages.ts` adds a single new affordance below the password form. It renders in both the empty-form and wrong-password states (the wrong-password error block sits above the form, so the link below is visible in both):
+
+```html
+<p class="hint-link">
+  Have access? <a href="https://oyster.to/api/publish/access-redirect/<token>">Sign in to view</a>
+</p>
+```
+
+`<token>` is HTML-escaped via the existing `escapeHtml` helper.
+
+The "Have access?" phrasing rather than "Own this share?" anticipates the ACL widening — the same line is correct today (where "access" = ownership) and after the ACL ships (where "access" = ownership OR ACL membership).
+
+## Security considerations
+
+| Concern | Mitigation |
+|---|---|
+| Nonce replay within TTL | Single-use enforced by atomic `UPDATE ... WHERE consumed_at IS NULL`. Second click on the same URL falls through silently to the gate. |
+| Nonce cross-share misuse | `share_token` is in the consume `WHERE` clause. A nonce minted for share A presented at share B does not consume and returns false. |
+| Nonce in URL → browser history | 302 → 302 chain means the `?key=…` URL is never the final history entry; the cleaned `/p/<token>` URL replaces it. |
+| Nonce in Referer to subresources | `referrer-policy: no-referrer` on the consumption 302 strips Referer for the destination's initial GET and its subresource fetches. |
+| Nonce in server logs | `mintAccessNonce` and `consumeAccessNonce` log only counts/booleans, never the nonce value. The endpoint logs the share token, not the query string. |
+| Nonce theft from server | A leaked nonce is single-use, 60s lifetime, and bound to one `share_token`. The blast radius is "view this one artefact once within a minute"; the cookie minted on consumption is bound to that same artefact too. |
+| Ownership change after mint | `consumeAccessNonce` does not re-check ownership; the row stores `user_id` for audit only. Ownership transfers in Oyster are not a current feature; the predicate runs at mint time. |
+| Cross-site request forgery against `/api/publish/access-redirect/...` | The endpoint is `GET` with no side effects beyond a D1 insert that only matters if the visitor follows the resulting 302. The session is `SameSite=Lax`, so a cross-site `GET` does carry the session — but the consequence is a wasted nonce, not an authenticated action against the artefact. |
+| Open redirect via `?return=` | Existing `validateReturnPath` allowlist; extended to include the access-redirect path only. |
+| Untrusted content on `share.oyster.to` reading the session | Unchanged — the apex cookie still does not leak across hosts. The nonce in the URL is the *only* data passed across, and it conveys nothing the apex hasn't already authorised. |
+
+## Test plan
+
+### Nonce module — `infra/oyster-publish/test/access-nonce.test.ts`
+
+- Mint then consume → `true`; row's `consumed_at` is set.
+- Consume the same nonce twice → first `true`, second `false`.
+- Consume with wrong `share_token` → `false`; row remains unconsumed. **Then** consume with the correct `share_token` → still succeeds. This is the regression that catches the "consume first, assert later" bug pattern.
+- Consume an expired nonce → `false`.
+- Consume a never-minted nonce → `false`.
+- Mint also opportunistically deletes expired rows.
+
+### Access-redirect handler — `infra/oyster-publish/test/access-redirect-handler.test.ts`
+
+Cover the full matrix:
+
+| Setup | Expected |
+|---|---|
+| token not found | 404 page |
+| publication retired | 410 gone page |
+| mode=open | 302 → `share.oyster.to/p/<token>` (no key) |
+| mode=signin, no session | 302 → `/auth/sign-in?return=…` |
+| mode=signin, session | 302 → `…?key=<22 chars>` and a row exists in `viewer_access_nonces` |
+| mode=password, no session | 302 → `/auth/sign-in?return=…` |
+| mode=password, session = owner | 302 → `…?key=…` |
+| mode=password, session ≠ owner | 403 page |
+| All 302s | include `cache-control: private, no-store` |
+
+### Viewer integration — `infra/oyster-publish/test/viewer-handler.test.ts` additions
+
+- Owner-bypass golden path: mint nonce for `(token, owner)`, GET `/p/<token>?key=<nonce>`, expect 302 to `/p/<token>` with `set-cookie: oyster_view_<token>=...`, `referrer-policy: no-referrer`. Then GET `/p/<token>` with that cookie → 200 content.
+- Same path for `signin` mode (any signed-in user, not just owner).
+- Replay: a second GET `/p/<token>?key=<nonce>` (after consumption) falls through to the password gate (or signin redirect) — i.e., behaviour identical to no-key.
+- Wrong-share nonce on `/p/<other_token>?key=<nonce>` falls through; the nonce remains consumable on its real token afterwards. (Regression for the atomic-WHERE fix.)
+- `/raw?key=...` on an iframe-kind share doesn't 500; treated as no-key (cookie covers it after outer-page consumption).
+
+### Cookie-scoping regression — `infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts` (new)
+
+Models real browser cookie scoping by **not** passing `oyster_session` on requests to `share.oyster.to`, and confirms the production loop that the in-process test harness has been hiding:
+
+```ts
+it("signin mode without access-redirect is a closed loop across the host boundary", async () => {
+  // 1. Visitor with apex session lands on share.oyster.to/p/<token>.
+  //    Real browser would NOT send the host-only oyster.to cookie here.
+  const res1 = await call(getReq(`https://share.oyster.to/p/${token}`));  // no cookie
+  expect(res1.status).toBe(302);
+  const loc = new URL(res1.headers.get("location")!);
+  expect(loc.origin + loc.pathname).toBe("https://oyster.to/auth/sign-in");
+  expect(loc.searchParams.get("return")).toBe(`/p/${token}`);
+
+  // 2. Simulate post-sign-in: visitor lands on oyster.to/p/<token>.
+  //    The apex session IS visible here, but the publish worker 308s
+  //    every oyster.to/p/* to share.oyster.to/p/* unconditionally.
+  const res2 = await call(getReq(`https://oyster.to/p/${token}`,
+    { cookie: `oyster_session=${u.sessionToken}` }));
+  expect(res2.status).toBe(308);
+  expect(res2.headers.get("location"))
+    .toBe(`https://share.oyster.to/p/${token}`);
+
+  // 3. Browser follows to share.oyster.to — cookie is dropped at the
+  //    host boundary again. Same as step 1. The loop is unbroken.
+  const res3 = await call(getReq(`https://share.oyster.to/p/${token}`));
+  expect(res3.status).toBe(302);  // back to /auth/sign-in
+});
+
+it("signin mode is reachable via /api/publish/access-redirect/<token>", async () => {
+  // The apex session IS visible on oyster.to/api/publish/... because the
+  // cookie is host-scoped to oyster.to.
+  const res1 = await call(getReq(
+    `https://oyster.to/api/publish/access-redirect/${token}`,
+    { cookie: `oyster_session=${u.sessionToken}` }));
+  expect(res1.status).toBe(302);
+  const loc = new URL(res1.headers.get("location")!);
+  expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+  const nonce = loc.searchParams.get("key");
+  expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+  // share.oyster.to/p/<token>?key=<nonce> succeeds even with no cookie.
+  const res2 = await call(getReq(loc.toString()));  // no cookie
+  expect(res2.status).toBe(302);
+  expect(res2.headers.get("location")).toBe(`/p/${token}`);
+  expect(res2.headers.get("set-cookie")).toContain(`oyster_view_${token}=`);
+  expect(res2.headers.get("referrer-policy")).toBe("no-referrer");
+});
+```
+
+The first test will pass today (and continues to pass after the change — the access-redirect endpoint is opt-in via the gate page link). The second test fails today and passes after the change.
+
+### Return-path allowlist — `infra/auth-worker/test/return-path.test.ts`
+
+- `/api/publish/access-redirect/<token>` → accepted.
+- `/api/publish/access-redirect/<token>/extra` → rejected.
+- `/api/publish/access-redirect/<token>?evil=…` → rejected (no query allowed by current regex anchoring).
+
+### Seed fixture
+
+`infra/oyster-publish/test/fixtures/seed.ts` adds `viewer_access_nonces` to the in-memory schema so the new tests can mint/consume in isolation.
+
+## Migration / rollout
+
+- Migration file: `infra/auth-worker/migrations/0011_viewer_access_nonces.sql` (next ordinal after `0010_device_label.sql`). Pure additive; no down-migration needed.
+- Worker deploys: both workers (well, the one `oyster-publish` worker that handles both hosts) ship together. No staged rollout needed because the endpoint and the pre-check are independent — old browsers without the gate-page link continue to use password POST normally; new gate pages can use either path.
+- No local-server changes; no surface UI changes; no MCP changes.
+- CHANGELOG.md under `Added`: one user-visible bullet, e.g. **"Sign in to view your own password-protected shares"**. No mention of nonces, workers, or D1.
+
+## Out of scope (foreseen extensions)
+
+- **ACL widening.** When sharing-to-specific-user lands, the predicate in `handleAccessRedirect`'s password branch becomes `session.user.id === row.owner_user_id || isInShareAcl(env, shareToken, session.user.id)`. Everything else (nonce machinery, viewer pre-check, gate-page link) is unchanged.
+- **Auto-bypass for ambient ownership.** A future polish could have the gate-page JS prefetch the access-redirect with `Sec-Fetch-Site` discrimination so that signed-in owners never see the gate. Deferred — explicit click is acceptable for v1 and avoids the CORS/security trade-off.
+- **Sharing across devices when offline.** The local Oyster server already shows the user their own artefact bytes; the cloud share URL is independent.

--- a/infra/auth-worker/migrations/0011_viewer_access_nonces.sql
+++ b/infra/auth-worker/migrations/0011_viewer_access_nonces.sql
@@ -1,0 +1,23 @@
+-- 0011_viewer_access_nonces.sql — single-use access nonces for the viewer access redirect.
+--
+-- Used by /api/publish/access-redirect/<token> to mint a short-lived, opaque
+-- handoff token that share.oyster.to consumes. The viewer worker enforces
+-- single-use via an atomic UPDATE ... WHERE consumed_at IS NULL, with
+-- share_token in the WHERE clause so a nonce minted for share A cannot be
+-- burned against share B's URL. user_id is for audit only; it is never
+-- surfaced in any response.
+--
+-- TTL is 60s (enforced in application code). Mint is opportunistic and
+-- deletes expired rows on each insert, so the table stays small.
+
+CREATE TABLE viewer_access_nonces (
+  nonce        TEXT    PRIMARY KEY,
+  share_token  TEXT    NOT NULL,
+  user_id      TEXT    NOT NULL,
+  expires_at   INTEGER NOT NULL,
+  consumed_at  INTEGER,
+  created_at   INTEGER NOT NULL
+);
+
+CREATE INDEX idx_viewer_access_nonces_expires
+  ON viewer_access_nonces(expires_at);

--- a/infra/auth-worker/src/return-path.ts
+++ b/infra/auth-worker/src/return-path.ts
@@ -1,12 +1,15 @@
-// Generic post-sign-in redirect target validation for #316.
-// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Auth-worker change).
+// Generic post-sign-in redirect target validation for #316 and the
+// viewer access redirect (2026-05-18 spec).
 //
-// The allowlist matches the share-viewer route AND ONLY that route.
-// We reject /p/<token>/raw because that's the iframe-content endpoint —
-// landing a user there would strand them with no navigation.
+// Allowlist matches the share-viewer route AND the access-redirect route,
+// and nothing else. We reject /p/<token>/raw because that's the iframe-
+// content endpoint — landing a user there would strand them with no
+// navigation. We reject query strings and fragments so attackers cannot
+// smuggle params through the validator.
 
-const SHARE_VIEWER_PATH = /^\/p\/[A-Za-z0-9_-]+$/;
-const MAX_PATH_LEN = 256;  // share_token is 32 chars; this is generous.
+const SHARE_VIEWER_PATH    = /^\/p\/[A-Za-z0-9_-]+$/;
+const ACCESS_REDIRECT_PATH = /^\/api\/publish\/access-redirect\/[A-Za-z0-9_-]+$/;
+const MAX_PATH_LEN = 256;
 
 export function validateReturnPath(raw: string | null | undefined): string | null {
   if (raw == null) return null;
@@ -15,6 +18,6 @@ export function validateReturnPath(raw: string | null | undefined): string | nul
   // JS regex `$` matches before a trailing newline; reject any control
   // chars (especially CR/LF) explicitly so they never reach a Location header.
   if (/[\x00-\x1f\x7f]/.test(raw)) return null;
-  if (!SHARE_VIEWER_PATH.test(raw)) return null;
-  return raw;
+  if (SHARE_VIEWER_PATH.test(raw) || ACCESS_REDIRECT_PATH.test(raw)) return raw;
+  return null;
 }

--- a/infra/auth-worker/test/return-path.test.ts
+++ b/infra/auth-worker/test/return-path.test.ts
@@ -69,3 +69,27 @@ describe("validateReturnPath — rejects everything else", () => {
     expect(validateReturnPath("/p/ab\x00c")).toBeNull();
   });
 });
+
+describe("validateReturnPath — accepts access-redirect path", () => {
+  it("accepts /api/publish/access-redirect/<token>", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/abc123"))
+      .toBe("/api/publish/access-redirect/abc123");
+  });
+
+  it("accepts /api/publish/access-redirect/<token> with - and _ in the token", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/AaBb_-_-9"))
+      .toBe("/api/publish/access-redirect/AaBb_-_-9");
+  });
+
+  it("rejects /api/publish/access-redirect/ with no token", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/")).toBeNull();
+  });
+
+  it("rejects /api/publish/access-redirect/<token>/extra", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/abc123/raw")).toBeNull();
+  });
+
+  it("rejects /api/publish/access-redirect/<token>?evil=1", () => {
+    expect(validateReturnPath("/api/publish/access-redirect/abc?x=1")).toBeNull();
+  });
+});

--- a/infra/oyster-publish/src/access-nonce.ts
+++ b/infra/oyster-publish/src/access-nonce.ts
@@ -1,0 +1,69 @@
+// Short-lived, single-use access nonces for the viewer access redirect.
+// Spec: docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+//
+// Mint: oyster.to/api/publish/access-redirect/<token> after the access
+// predicate passes. Consume: share.oyster.to/p/<token>?key=<nonce> on the
+// viewer pre-check. The atomic UPDATE pins share_token in the WHERE clause
+// so a nonce minted for one share cannot consume against another.
+
+import type { Env } from "./types";
+
+const TTL_MS = 60_000;
+
+/**
+ * Mint a fresh nonce bound to (share_token, user_id). Also opportunistically
+ * deletes expired rows. Returns the nonce — 22 base64url chars, 128 bits of
+ * entropy.
+ */
+export async function mintAccessNonce(
+  env: Env,
+  shareToken: string,
+  userId: string,
+): Promise<string> {
+  const now = Date.now();
+
+  // Opportunistic cleanup. The expires_at index makes this a range scan;
+  // the table is small (60s TTL bounds the steady-state size).
+  await env.DB.prepare(
+    "DELETE FROM viewer_access_nonces WHERE expires_at < ?",
+  ).bind(now).run();
+
+  const nonce = base64urlRandom(16);  // 16 bytes → 22 chars
+  await env.DB.prepare(
+    `INSERT INTO viewer_access_nonces
+       (nonce, share_token, user_id, expires_at, consumed_at, created_at)
+     VALUES (?, ?, ?, ?, NULL, ?)`,
+  ).bind(nonce, shareToken, userId, now + TTL_MS, now).run();
+  return nonce;
+}
+
+/**
+ * Returns true iff this call atomically transitioned the nonce for THIS
+ * share_token from unconsumed-and-live to consumed. Wrong share_token,
+ * wrong nonce, expired, or already-consumed all return false WITHOUT any
+ * side effect on the row.
+ */
+export async function consumeAccessNonce(
+  env: Env,
+  nonce: string,
+  shareToken: string,
+): Promise<boolean> {
+  const now = Date.now();
+  const res = await env.DB.prepare(
+    `UPDATE viewer_access_nonces
+        SET consumed_at = ?
+      WHERE nonce       = ?
+        AND share_token = ?
+        AND consumed_at IS NULL
+        AND expires_at  > ?`,
+  ).bind(now, nonce, shareToken, now).run();
+  return (res.meta?.changes ?? 0) === 1;
+}
+
+function base64urlRandom(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  let bin = "";
+  for (const b of buf) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/infra/oyster-publish/src/viewer-access.ts
+++ b/infra/oyster-publish/src/viewer-access.ts
@@ -5,25 +5,43 @@
 // `oyster_view_<token>` is treated as a generic recent-access proof for
 // the artefact: any successful gate-clearing path (password POST,
 // owner-via-nonce, signin-via-nonce) mints it, and both password and
-// signin modes accept it. Without that semantics, the post-nonce
-// clean-URL follow-up GET in signin mode would loop back to access-
-// redirect because the apex session is not visible on share.oyster.to.
+// signin modes accept it.
+//
+// The `consumeNonce` option on resolveViewerAccess is REQUIRED on every
+// call site so that /raw cannot accidentally start consuming nonces
+// without a deliberate edit. /p passes true, /raw and the password POST
+// pass false.
 
 import { resolveSession } from "./worker";
 import { verifyViewerCookie } from "./viewer-cookie";
+import { consumeAccessNonce } from "./access-nonce";
 import type { Env, PublicationRow } from "./types";
 
 export type ViewerAccess =
   | { kind: "ok"; row: PublicationRow }
+  | { kind: "ok_via_nonce"; row: PublicationRow }
   | { kind: "gate"; row: PublicationRow; error?: "wrong_password" }
   | { kind: "redirect"; location: string }
   | { kind: "gone"; row: PublicationRow }
   | { kind: "not_found" };
 
+export interface ResolveOptions {
+  /**
+   * When true, a valid `?key=<nonce>` consumes the nonce and yields
+   * `ok_via_nonce`. When false, the `?key=` parameter is ignored entirely
+   * (the caller is responsible for any cookie-based check). /p MUST pass
+   * true; /raw and the password POST handler MUST pass false. Making the
+   * flag required prevents a future regression from silently turning the
+   * iframe endpoint into a nonce-consuming endpoint.
+   */
+  consumeNonce: boolean;
+}
+
 export async function resolveViewerAccess(
   req: Request,
   env: Env,
   shareToken: string,
+  opts: ResolveOptions,
 ): Promise<ViewerAccess> {
   // Step 1: row lookup.
   const row = await env.DB.prepare(
@@ -36,7 +54,17 @@ export async function resolveViewerAccess(
     return { kind: "gone", row };
   }
 
-  // Step 3: mode dispatch.
+  // Step 3: nonce pre-check (caller opt-in). Open mode never needs a
+  // nonce — the viewer would serve content anyway. Invalid / expired /
+  // wrong-share nonces fall through silently — no oracle.
+  if (opts.consumeNonce && (row.mode === "password" || row.mode === "signin")) {
+    const key = new URL(req.url).searchParams.get("key");
+    if (key && await consumeAccessNonce(env, key, shareToken)) {
+      return { kind: "ok_via_nonce", row };
+    }
+  }
+
+  // Step 4: mode dispatch.
   switch (row.mode) {
     case "open":
       return { kind: "ok", row };
@@ -49,11 +77,6 @@ export async function resolveViewerAccess(
     }
 
     case "signin": {
-      // Honour the viewer cookie as a generic recent-access proof. The
-      // apex `oyster_session` is host-only on oyster.to and is NOT
-      // visible on share.oyster.to in production (auth-worker #397), so
-      // resolveSession() returns null in the cross-host case — the
-      // cookie is the only access proof we'll see on this host.
       if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
         return { kind: "ok", row };
       }
@@ -68,7 +91,6 @@ export async function resolveViewerAccess(
     }
 
     default:
-      // Unreachable per the D1 CHECK constraint, but typescript-safe.
       return { kind: "not_found" };
   }
 }

--- a/infra/oyster-publish/src/viewer-access.ts
+++ b/infra/oyster-publish/src/viewer-access.ts
@@ -57,7 +57,17 @@ export async function resolveViewerAccess(
   // Step 3: nonce pre-check (caller opt-in). Open mode never needs a
   // nonce — the viewer would serve content anyway. Invalid / expired /
   // wrong-share nonces fall through silently — no oracle.
-  if (opts.consumeNonce && (row.mode === "password" || row.mode === "signin")) {
+  //
+  // Skipped when the visitor already has a valid recent-access cookie,
+  // since burning a single-use nonce in that case grants no new access
+  // (the visitor would have been admitted by the mode dispatch below
+  // anyway). This guards against back/forward navigation, bookmarks,
+  // and cached pages that still carry ?key=<nonce>.
+  if (
+    opts.consumeNonce &&
+    (row.mode === "password" || row.mode === "signin") &&
+    !(await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET))
+  ) {
     const key = new URL(req.url).searchParams.get("key");
     if (key && await consumeAccessNonce(env, key, shareToken)) {
       return { kind: "ok_via_nonce", row };

--- a/infra/oyster-publish/src/viewer-access.ts
+++ b/infra/oyster-publish/src/viewer-access.ts
@@ -1,5 +1,13 @@
 // Access dispatch for the public viewer.
-// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Access dispatch).
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Access dispatch)
+//       docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
+//
+// `oyster_view_<token>` is treated as a generic recent-access proof for
+// the artefact: any successful gate-clearing path (password POST,
+// owner-via-nonce, signin-via-nonce) mints it, and both password and
+// signin modes accept it. Without that semantics, the post-nonce
+// clean-URL follow-up GET in signin mode would loop back to access-
+// redirect because the apex session is not visible on share.oyster.to.
 
 import { resolveSession } from "./worker";
 import { verifyViewerCookie } from "./viewer-cookie";
@@ -34,17 +42,27 @@ export async function resolveViewerAccess(
       return { kind: "ok", row };
 
     case "password": {
-      const cookieValue = readCookie(req, `oyster_view_${shareToken}`);
-      if (!cookieValue) return { kind: "gate", row };
-      const ok = await verifyViewerCookie(cookieValue, shareToken, env.VIEWER_COOKIE_SECRET);
-      if (!ok) return { kind: "gate", row };
-      return { kind: "ok", row };
+      if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
+      return { kind: "gate", row };
     }
 
     case "signin": {
+      // Honour the viewer cookie as a generic recent-access proof. The
+      // apex `oyster_session` is host-only on oyster.to and is NOT
+      // visible on share.oyster.to in production (auth-worker #397), so
+      // resolveSession() returns null in the cross-host case — the
+      // cookie is the only access proof we'll see on this host.
+      if (await hasValidViewerCookie(req, shareToken, env.VIEWER_COOKIE_SECRET)) {
+        return { kind: "ok", row };
+      }
       const session = await resolveSession(req, env);
       if (!session) {
-        return { kind: "redirect", location: `https://oyster.to/auth/sign-in?return=/p/${shareToken}` };
+        return {
+          kind: "redirect",
+          location: `https://oyster.to/api/publish/access-redirect/${shareToken}`,
+        };
       }
       return { kind: "ok", row };
     }
@@ -61,4 +79,14 @@ export function readCookie(req: Request, name: string): string | null {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const m = cookie.match(new RegExp(`(?:^|;\\s*)${escaped}=([^;]+)`));
   return m && m[1] ? m[1] : null;
+}
+
+async function hasValidViewerCookie(
+  req: Request,
+  shareToken: string,
+  secret: string,
+): Promise<boolean> {
+  const value = readCookie(req, `oyster_view_${shareToken}`);
+  if (!value) return false;
+  return await verifyViewerCookie(value, shareToken, secret);
 }

--- a/infra/oyster-publish/src/viewer-cookie.ts
+++ b/infra/oyster-publish/src/viewer-cookie.ts
@@ -1,5 +1,11 @@
-// HMAC-SHA256 signed cookie for password-mode unlock.
-// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Cookie scheme).
+// HMAC-SHA256 signed cookie — generic recent-access proof for a share.
+// The cookie certifies "this visitor cleared an access check for
+// <share_token> at time T". It is minted by any successful gate-clearing
+// path (password POST, owner-via-nonce, signin-via-nonce) and is honoured
+// by both password and signin modes (see viewer-access.ts).
+//
+// Spec: docs/superpowers/specs/2026-05-03-r5-viewer-design.md (Cookie scheme)
+//       docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md
 // Format: <token>.<unix_seconds>.<hmac_b64url>
 //   - token is the share_token (asserted on verify; the cookie path also scopes it)
 //   - hmac is over `${token}.${unix_seconds}` keyed by VIEWER_COOKIE_SECRET

--- a/infra/oyster-publish/src/viewer-pages.ts
+++ b/infra/oyster-publish/src/viewer-pages.ts
@@ -40,6 +40,15 @@ export function notFoundPage(): string {
   `);
 }
 
+export function noAccessPage(shareToken: string): string {
+  return basePage("No access", `
+    <div class="icon">🔒</div>
+    <h1>You don't have access to this share</h1>
+    <p class="hint">This publication belongs to a different account.</p>
+    <p><a href="/p/${escapeHtml(shareToken)}">Enter the password instead</a></p>
+  `);
+}
+
 export function internalErrorPage(): string {
   return basePage("Error", `
     <div class="icon">⚠️</div>

--- a/infra/oyster-publish/src/viewer-pages.ts
+++ b/infra/oyster-publish/src/viewer-pages.ts
@@ -12,15 +12,17 @@ export function passwordGatePage(shareToken: string, opts?: { error?: "wrong_pas
   const errorBlock = opts?.error === "wrong_password"
     ? `<p class="err">Incorrect password.</p>`
     : "";
+  const tokenSafe = escapeHtml(shareToken);
   return basePage("Password required", `
     <div class="icon">🔒</div>
     <h1>Password required</h1>
     <p class="hint">This share is password-protected.</p>
     ${errorBlock}
-    <form method="POST" action="/p/${escapeHtml(shareToken)}">
+    <form method="POST" action="/p/${tokenSafe}">
       <input type="password" name="password" placeholder="Password" autofocus required>
       <button type="submit">Unlock</button>
     </form>
+    <p class="hint-link">Have access? <a href="https://oyster.to/api/publish/access-redirect/${tokenSafe}">Sign in to view</a></p>
   `);
 }
 
@@ -85,6 +87,8 @@ function basePage(title: string, bodyHtml: string): string {
   input[type=password] { padding: 0.55rem 0.7rem; font-size: 0.95rem; border: 1px solid var(--bd); border-radius: 0.35rem; background: transparent; color: inherit; text-align: center; }
   button { padding: 0.55rem 0.7rem; font-size: 0.95rem; font-weight: 500; border: 0; border-radius: 0.35rem; background: var(--fg); color: var(--bg); cursor: pointer; }
   .tag { font-size: 0.7rem; color: var(--muted); margin-top: 4rem; opacity: 0.6; }
+  .hint-link { font-size: 0.85rem; color: var(--muted); margin-top: 1.25rem; }
+  .hint-link a { color: inherit; text-decoration: underline; }
 </style>
 </head><body>
 ${bodyHtml}

--- a/infra/oyster-publish/src/viewer-pages.ts
+++ b/infra/oyster-publish/src/viewer-pages.ts
@@ -47,7 +47,7 @@ export function noAccessPage(shareToken: string): string {
     <div class="icon">🔒</div>
     <h1>You don't have access to this share</h1>
     <p class="hint">This publication belongs to a different account.</p>
-    <p><a href="/p/${escapeHtml(shareToken)}">Enter the password instead</a></p>
+    <p><a href="https://share.oyster.to/p/${escapeHtml(shareToken)}">Enter the password instead</a></p>
   `);
 }
 

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -44,6 +44,11 @@ export function cacheHeaders(row: PublicationRow, contentType: string): HeadersI
   }
   // Block content-type sniffing across all responses.
   headers["x-content-type-options"] = "nosniff";
+  // Defence in depth: don't surface URL info on subresource fetches or
+  // onward navigation from the rendered page. Consistent with the
+  // nonce-consumption 302; matters most if a future change introduces
+  // any URL-shaped sensitive parameter on the viewer URL.
+  headers["referrer-policy"] = "no-referrer";
   return headers;
 }
 

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -711,15 +711,25 @@ async function handleViewerGet(req: Request, env: Env, shareToken: string): Prom
       return htmlPage(200, passwordGatePage(shareToken));
     case "ok":
       return renderForRow(env, access.row, req);
-    case "ok_via_nonce":
-      // Placeholder — real handling lands in Task 6. Returning 500 instead
-      // of throwing means the test for Task 6's transition can pin the
-      // current behaviour (`status === 500`) and Task 6 turns it into the
-      // expected 302 with a visible edit.
-      return new Response("ok_via_nonce: handler not yet implemented (Task 6)", {
-        status: 500,
-        headers: { "content-type": "text/plain" },
+    case "ok_via_nonce": {
+      // The visitor proved they have access (owner of a password share,
+      // or any signed-in user for a signin share) via
+      // /api/publish/access-redirect. Mint the standard recent-access
+      // cookie and 302 to the clean URL so that ?key=<nonce> does not
+      // linger in the address bar / Referer.
+      const cookieValue = await signViewerCookie(access.row.share_token, env.VIEWER_COOKIE_SECRET);
+      const host = new URL(req.url).host;
+      const secureFlag = isLoopback(host) ? "" : " Secure;";
+      return new Response(null, {
+        status: 302,
+        headers: {
+          "set-cookie": `oyster_view_${access.row.share_token}=${cookieValue}; HttpOnly;${secureFlag} SameSite=Lax; Path=/p/${access.row.share_token}; Max-Age=86400`,
+          "location": `/p/${access.row.share_token}`,
+          "cache-control": "private, no-store",
+          "referrer-policy": "no-referrer",
+        },
       });
+    }
   }
 }
 

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -857,6 +857,7 @@ function redirectNoStore(location: string): Response {
     headers: {
       location,
       "cache-control": "private, no-store",
+      "referrer-policy": "no-referrer",
     },
   });
 }

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -696,7 +696,7 @@ async function collectWithSizeCap(
 // ─── Viewer handlers (#316) ────────────────────────────────────────────────
 
 async function handleViewerGet(req: Request, env: Env, shareToken: string): Promise<Response> {
-  const access = await resolveViewerAccess(req, env, shareToken);
+  const access = await resolveViewerAccess(req, env, shareToken, { consumeNonce: true });
   switch (access.kind) {
     case "not_found":
       return htmlPage(404, notFoundPage());
@@ -711,11 +711,14 @@ async function handleViewerGet(req: Request, env: Env, shareToken: string): Prom
       return htmlPage(200, passwordGatePage(shareToken));
     case "ok":
       return renderForRow(env, access.row, req);
+    case "ok_via_nonce":
+      // Placeholder — real handling lands in Task 6.
+      throw new Error("ok_via_nonce: handler not yet implemented (Task 6)");
   }
 }
 
 async function handleViewerRaw(req: Request, env: Env, shareToken: string): Promise<Response> {
-  const access = await resolveViewerAccess(req, env, shareToken);
+  const access = await resolveViewerAccess(req, env, shareToken, { consumeNonce: false });
   if (access.kind === "not_found") return htmlPage(404, notFoundPage());
   if (access.kind === "gone") return htmlPage(410, gonePage());
   if (access.kind === "redirect") {
@@ -736,7 +739,7 @@ async function handleViewerRaw(req: Request, env: Env, shareToken: string): Prom
 }
 
 async function handleViewerPost(req: Request, env: Env, shareToken: string): Promise<Response> {
-  const access = await resolveViewerAccess(req, env, shareToken);
+  const access = await resolveViewerAccess(req, env, shareToken, { consumeNonce: false });
   if (access.kind === "not_found") return htmlPage(404, notFoundPage());
   if (access.kind === "gone") return htmlPage(410, gonePage());
   if (access.kind === "redirect") {

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -712,8 +712,14 @@ async function handleViewerGet(req: Request, env: Env, shareToken: string): Prom
     case "ok":
       return renderForRow(env, access.row, req);
     case "ok_via_nonce":
-      // Placeholder — real handling lands in Task 6.
-      throw new Error("ok_via_nonce: handler not yet implemented (Task 6)");
+      // Placeholder — real handling lands in Task 6. Returning 500 instead
+      // of throwing means the test for Task 6's transition can pin the
+      // current behaviour (`status === 500`) and Task 6 turns it into the
+      // expected 302 with a visible edit.
+      return new Response("ok_via_nonce: handler not yet implemented (Task 6)", {
+        status: 500,
+        headers: { "content-type": "text/plain" },
+      });
   }
 }
 

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -26,6 +26,19 @@ export default {
     }
 
     if (url.pathname.startsWith("/api/publish/access-redirect/") && req.method === "GET") {
+      // Canonical host is oyster.to (where the apex session cookie lives).
+      // www. and share. get a 308 mirroring the /p/* legacy-origin pattern;
+      // without this the handler on a non-apex host fails session checks and
+      // burns an extra hop through sign-in.
+      if (url.hostname === "www.oyster.to" || url.hostname === "share.oyster.to") {
+        return new Response(null, {
+          status: 308,
+          headers: {
+            location: `https://oyster.to${url.pathname}${url.search}`,
+            "cache-control": "public, max-age=3600",
+          },
+        });
+      }
       const token = url.pathname.slice("/api/publish/access-redirect/".length);
       if (!token || token.includes("/")) {
         return new Response("Not Found", { status: 404 });

--- a/infra/oyster-publish/src/worker.ts
+++ b/infra/oyster-publish/src/worker.ts
@@ -6,11 +6,12 @@ import { CAPS, generateShareToken, IFRAME_KINDS, parseMetadataHeader, parseShare
 import { resolveViewerAccess } from "./viewer-access";
 import { signViewerCookie } from "./viewer-cookie";
 import {
-  passwordGatePage, gonePage, notFoundPage, internalErrorPage, rateLimitedPage,
+  passwordGatePage, gonePage, notFoundPage, noAccessPage, internalErrorPage, rateLimitedPage,
 } from "./viewer-pages";
 import {
   renderMarkdownPage, renderMermaidPage, renderChromeWithIframe, renderRawHtmlBody, renderImageInline,
 } from "./viewer-render";
+import { mintAccessNonce } from "./access-nonce";
 
 export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -22,6 +23,14 @@ export default {
 
     if (url.pathname === "/api/publish/mine" && req.method === "GET") {
       return handlePublishMine(req, env);
+    }
+
+    if (url.pathname.startsWith("/api/publish/access-redirect/") && req.method === "GET") {
+      const token = url.pathname.slice("/api/publish/access-redirect/".length);
+      if (!token || token.includes("/")) {
+        return new Response("Not Found", { status: 404 });
+      }
+      return handleAccessRedirect(req, env, token);
     }
 
     if (url.pathname.startsWith("/api/publish/") && req.method === "DELETE") {
@@ -803,6 +812,50 @@ async function handleViewerPost(req: Request, env: Env, shareToken: string): Pro
     headers: {
       "set-cookie": `oyster_view_${shareToken}=${cookieValue}; HttpOnly;${secureFlag} SameSite=Lax; Path=/p/${shareToken}; Max-Age=86400`,
       "location": `/p/${shareToken}`,
+      "cache-control": "private, no-store",
+    },
+  });
+}
+
+async function handleAccessRedirect(req: Request, env: Env, shareToken: string): Promise<Response> {
+  type Row = { mode: "open" | "password" | "signin"; owner_user_id: string; unpublished_at: number | null };
+  const row = await env.DB.prepare(
+    "SELECT mode, owner_user_id, unpublished_at FROM published_artifacts WHERE share_token = ?",
+  ).bind(shareToken).first<Row>();
+
+  if (!row) return htmlPage(404, notFoundPage());
+  if (row.unpublished_at !== null) return htmlPage(410, gonePage());
+
+  // Open mode: no gate to clear, no nonce to mint.
+  if (row.mode === "open") {
+    return redirectNoStore(`https://share.oyster.to/p/${shareToken}`);
+  }
+
+  const session = await resolveSession(req, env);
+  if (!session) {
+    return redirectNoStore(
+      `https://oyster.to/auth/sign-in?return=${encodeURIComponent(`/api/publish/access-redirect/${shareToken}`)}`,
+    );
+  }
+
+  // Access predicates — widen the password case to an ACL when sharing-
+  // to-specific-user lands. resolveSession() in this worker returns flat
+  // { id, email, tier } (see the existing resolveSession declaration).
+  let mayAccess = false;
+  if (row.mode === "signin")   mayAccess = true;
+  if (row.mode === "password") mayAccess = session.id === row.owner_user_id;
+
+  if (!mayAccess) return htmlPage(403, noAccessPage(shareToken));
+
+  const nonce = await mintAccessNonce(env, shareToken, session.id);
+  return redirectNoStore(`https://share.oyster.to/p/${shareToken}?key=${nonce}`);
+}
+
+function redirectNoStore(location: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location,
       "cache-control": "private, no-store",
     },
   });

--- a/infra/oyster-publish/test/access-nonce.test.ts
+++ b/infra/oyster-publish/test/access-nonce.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { applySchema } from "./fixtures/seed";
+import { mintAccessNonce, consumeAccessNonce } from "../src/access-nonce";
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+describe("access-nonce — mint + consume", () => {
+  it("a freshly minted nonce consumes once and only once", async () => {
+    const nonce = await mintAccessNonce(env, "tok_a", "user_1");
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(true);
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(false);
+  });
+
+  it("consume with a wrong share_token returns false AND leaves the row unconsumed", async () => {
+    // Regression for the atomic-share_token-in-WHERE invariant. If consume
+    // updates before asserting the share_token, the row is burned and the
+    // legitimate consumption against tok_a would then fail.
+    const nonce = await mintAccessNonce(env, "tok_a", "user_1");
+    expect(await consumeAccessNonce(env, nonce, "tok_b")).toBe(false);
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(true);
+  });
+
+  it("an expired nonce cannot be consumed", async () => {
+    const nonce = await mintAccessNonce(env, "tok_a", "user_1");
+    // Force-expire the row.
+    await env.DB.prepare(
+      "UPDATE viewer_access_nonces SET expires_at = ? WHERE nonce = ?",
+    ).bind(Date.now() - 1, nonce).run();
+    expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(false);
+  });
+
+  it("a never-minted nonce cannot be consumed", async () => {
+    expect(await consumeAccessNonce(env, "no-such-nonce-1234567x", "tok_a")).toBe(false);
+  });
+
+  it("mint opportunistically deletes expired rows", async () => {
+    const stale = await mintAccessNonce(env, "tok_a", "user_1");
+    await env.DB.prepare(
+      "UPDATE viewer_access_nonces SET expires_at = ? WHERE nonce = ?",
+    ).bind(Date.now() - 1, stale).run();
+
+    await mintAccessNonce(env, "tok_b", "user_2");  // triggers cleanup
+
+    const stillThere = await env.DB.prepare(
+      "SELECT 1 AS x FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(stale).first<{ x: number }>();
+    expect(stillThere).toBeNull();
+  });
+});

--- a/infra/oyster-publish/test/access-nonce.test.ts
+++ b/infra/oyster-publish/test/access-nonce.test.ts
@@ -8,11 +8,21 @@ beforeEach(async () => {
 });
 
 describe("access-nonce — mint + consume", () => {
-  it("a freshly minted nonce consumes once and only once", async () => {
+  it("a freshly minted nonce consumes once and only once, and sets consumed_at", async () => {
     const nonce = await mintAccessNonce(env, "tok_a", "user_1");
     expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
 
     expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(true);
+
+    // Verify the row-level invariant: consumed_at must be populated after
+    // the first successful consume. Without this, a hypothetical regression
+    // that returns true once then resets consumed_at to null (allowing a
+    // replay) would still pass the boolean-only checks below.
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).not.toBeNull();
+
     expect(await consumeAccessNonce(env, nonce, "tok_a")).toBe(false);
   });
 

--- a/infra/oyster-publish/test/access-redirect-handler.test.ts
+++ b/infra/oyster-publish/test/access-redirect-handler.test.ts
@@ -50,6 +50,7 @@ describe("GET /api/publish/access-redirect/:token", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe(`https://share.oyster.to/p/${token}`);
     expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
     expect(new URL(res.headers.get("location")!).searchParams.get("key")).toBeNull();
   });
 
@@ -70,6 +71,7 @@ describe("GET /api/publish/access-redirect/:token", () => {
     expect(res.status).toBe(302);
     const loc = new URL(res.headers.get("location")!);
     expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
     const key = loc.searchParams.get("key");
     expect(key).toMatch(/^[A-Za-z0-9_-]{22}$/);
 
@@ -99,6 +101,7 @@ describe("GET /api/publish/access-redirect/:token", () => {
     expect(res.status).toBe(302);
     const loc = new URL(res.headers.get("location")!);
     expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
     expect(loc.searchParams.get("key")).toMatch(/^[A-Za-z0-9_-]{22}$/);
   });
 

--- a/infra/oyster-publish/test/access-redirect-handler.test.ts
+++ b/infra/oyster-publish/test/access-redirect-handler.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import {
+  applySchema, seedUser, seedActivePublication, retirePublication,
+} from "./fixtures/seed";
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (env as any).VIEWER_PASSWORD_LIMIT = { limit: async () => ({ success: true }) };
+});
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function getReq(path: string, opts: { cookie?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  return new Request(`https://oyster.to${path}`, { method: "GET", headers });
+}
+
+async function call(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+const PATH = (t: string) => `/api/publish/access-redirect/${t}`;
+
+describe("GET /api/publish/access-redirect/:token", () => {
+  it("returns 404 for an unknown token", async () => {
+    const res = await call(getReq(PATH("no-such")));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 410 for a retired publication", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art1", mode: "open" });
+    await retirePublication(token);
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(410);
+  });
+
+  it("open mode → 302 straight to viewer with no key", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art1", mode: "open" });
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`https://share.oyster.to/p/${token}`);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(new URL(res.headers.get("location")!).searchParams.get("key")).toBeNull();
+  });
+
+  it("signin mode + no session → 302 to sign-in with return target", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art2", mode: "signin" });
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.origin + loc.pathname).toBe("https://oyster.to/auth/sign-in");
+    expect(loc.searchParams.get("return")).toBe(PATH(token));
+  });
+
+  it("signin mode + session → 302 to viewer with a fresh ?key= and a row in viewer_access_nonces", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art2", mode: "signin" });
+    const res = await call(getReq(PATH(token), { cookie: `oyster_session=${u.sessionToken}` }));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+    const key = loc.searchParams.get("key");
+    expect(key).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+    const row = await env.DB.prepare(
+      "SELECT share_token, user_id, consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(key).first<{ share_token: string; user_id: string; consumed_at: number | null }>();
+    expect(row?.share_token).toBe(token);
+    expect(row?.user_id).toBe(u.id);
+    expect(row?.consumed_at).toBeNull();
+  });
+
+  it("password mode + no session → 302 to sign-in with return target", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art3", mode: "password" });
+    const res = await call(getReq(PATH(token)));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.searchParams.get("return")).toBe(PATH(token));
+  });
+
+  it("password mode + owner session → 302 to viewer with a fresh ?key=", async () => {
+    const owner = await seedUser();
+    const token = await seedActivePublication({
+      ownerUserId: owner.id, artifactId: "art4", mode: "password",
+    });
+    const res = await call(getReq(PATH(token), { cookie: `oyster_session=${owner.sessionToken}` }));
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.origin + loc.pathname).toBe(`https://share.oyster.to/p/${token}`);
+    expect(loc.searchParams.get("key")).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  });
+
+  it("password mode + non-owner session → 403 page (no nonce minted)", async () => {
+    const owner = await seedUser({ id: "user_owner" });
+    const other = await seedUser({ id: "user_other" });
+    const token = await seedActivePublication({
+      ownerUserId: owner.id, artifactId: "art5", mode: "password",
+    });
+    const res = await call(getReq(PATH(token), { cookie: `oyster_session=${other.sessionToken}` }));
+    expect(res.status).toBe(403);
+    expect(res.headers.get("content-type")).toMatch(/^text\/html/);
+    // Body should give them a way back to the public gate.
+    expect(await res.text()).toContain(`/p/${token}`);
+
+    // No nonce minted.
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM viewer_access_nonces WHERE share_token = ?",
+    ).bind(token).first<{ n: number }>();
+    expect(count?.n).toBe(0);
+  });
+});

--- a/infra/oyster-publish/test/access-redirect-handler.test.ts
+++ b/infra/oyster-publish/test/access-redirect-handler.test.ts
@@ -114,13 +114,37 @@ describe("GET /api/publish/access-redirect/:token", () => {
     const res = await call(getReq(PATH(token), { cookie: `oyster_session=${other.sessionToken}` }));
     expect(res.status).toBe(403);
     expect(res.headers.get("content-type")).toMatch(/^text\/html/);
-    // Body should give them a way back to the public gate.
-    expect(await res.text()).toContain(`/p/${token}`);
+    // Body should give them an absolute way back to the public gate on
+    // share.oyster.to (avoiding a 308 hop from the oyster.to apex).
+    expect(await res.text()).toContain(`https://share.oyster.to/p/${token}`);
 
     // No nonce minted.
     const count = await env.DB.prepare(
       "SELECT COUNT(*) AS n FROM viewer_access_nonces WHERE share_token = ?",
     ).bind(token).first<{ n: number }>();
     expect(count?.n).toBe(0);
+  });
+
+  describe("legacy-origin 308", () => {
+    function reqWithHost(host: string, path: string): Request {
+      return new Request(`https://${host}${path}`, { method: "GET" });
+    }
+
+    it("share.oyster.to/api/publish/access-redirect/<token> → 308 to oyster.to", async () => {
+      const res = await call(reqWithHost("share.oyster.to", PATH("any-token")));
+      expect(res.status).toBe(308);
+      expect(res.headers.get("location")).toBe(`https://oyster.to${PATH("any-token")}`);
+    });
+
+    it("www.oyster.to/api/publish/access-redirect/<token> → 308 to oyster.to", async () => {
+      const res = await call(reqWithHost("www.oyster.to", PATH("any-token")));
+      expect(res.status).toBe(308);
+      expect(res.headers.get("location")).toBe(`https://oyster.to${PATH("any-token")}`);
+    });
+
+    it("oyster.to host bypasses 308 and runs the handler (404 for unknown token)", async () => {
+      const res = await call(reqWithHost("oyster.to", PATH("no-such")));
+      expect(res.status).toBe(404);
+    });
   });
 });

--- a/infra/oyster-publish/test/fixtures/seed.ts
+++ b/infra/oyster-publish/test/fixtures/seed.ts
@@ -8,6 +8,7 @@ const SCHEMA_SQL = `
 --   infra/auth-worker/migrations/0001_init.sql  (users, sessions)
 --   infra/auth-worker/migrations/0003_publish.sql (users.tier, published_artifacts)
 --   infra/auth-worker/migrations/0006_synced_spaces.sql (synced_spaces)
+--   infra/auth-worker/migrations/0011_viewer_access_nonces.sql (viewer_access_nonces)
 CREATE TABLE users (
   id            TEXT PRIMARY KEY,
   email         TEXT NOT NULL UNIQUE,
@@ -61,6 +62,16 @@ CREATE TABLE synced_spaces (
 );
 CREATE INDEX idx_synced_spaces_owner_updated
   ON synced_spaces (owner_id, updated_at DESC);
+CREATE TABLE viewer_access_nonces (
+  nonce        TEXT    PRIMARY KEY,
+  share_token  TEXT    NOT NULL,
+  user_id      TEXT    NOT NULL,
+  expires_at   INTEGER NOT NULL,
+  consumed_at  INTEGER,
+  created_at   INTEGER NOT NULL
+);
+CREATE INDEX idx_viewer_access_nonces_expires
+  ON viewer_access_nonces(expires_at);
 `;
 
 export async function applySchema(): Promise<void> {

--- a/infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts
+++ b/infra/oyster-publish/test/signin-mode-cookie-boundary.test.ts
@@ -1,0 +1,114 @@
+// Regression: signin-mode handoff across the oyster.to / share.oyster.to
+// cookie boundary.
+//
+// Production reality: the auth-worker sets `oyster_session` host-only on
+// oyster.to (no Domain=), so browsers DO NOT send it to share.oyster.to.
+// Tests in viewer-handler.test.ts that forge the cookie onto a
+// share.oyster.to request hide this — they bypass the host-scoping the
+// browser would enforce.
+//
+// This file models the real behaviour: cookies on oyster.to vs not on
+// share.oyster.to, and asserts:
+//   (a) without the access-redirect, signin mode is a closed loop, and
+//   (b) with the access-redirect, the visitor can reach content.
+
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import worker from "../src/worker";
+import { applySchema, seedUser, seedActiveOpenWithBody } from "./fixtures/seed";
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (env as any).VIEWER_PASSWORD_LIMIT = { limit: async () => ({ success: true }) };
+});
+
+beforeEach(async () => {
+  await applySchema();
+});
+
+function req(absUrl: string, opts: { cookie?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.cookie) headers.set("Cookie", opts.cookie);
+  return new Request(absUrl, { method: "GET", headers });
+}
+
+async function call(r: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(r, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("signin mode across the oyster.to / share.oyster.to cookie boundary", () => {
+  it("direct signin-mode visit to share.oyster.to without apex cookie → redirect to access-redirect", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_loop1", body: "# private",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    // Real browser: would NOT send oyster.to-host-only cookie to share.oyster.to.
+    const res = await call(req(`https://share.oyster.to/p/${shareToken}`));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location"))
+      .toBe(`https://oyster.to/api/publish/access-redirect/${shareToken}`);
+  });
+
+  it("oyster.to/p/<token> 308s to share.oyster.to even with an apex session — loop is real", async () => {
+    // Demonstrates that the cookie boundary is enforced by the worker's
+    // own legacy-origin 308: even though oyster.to/p sees the cookie,
+    // the redirect strips the host and the next hop is share.oyster.to,
+    // where the cookie cannot follow. Combined with the previous test,
+    // this is the closed loop that existed before access-redirect.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_loop2", body: "# private",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const res = await call(req(`https://oyster.to/p/${shareToken}`, {
+      cookie: `oyster_session=${u.sessionToken}`,
+    }));
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe(`https://share.oyster.to/p/${shareToken}`);
+  });
+
+  it("access-redirect on oyster.to sees the apex session and produces a working cross-host handoff", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_loop3", body: "# private content",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    // Step 1: oyster.to sees the apex cookie (host-only on oyster.to).
+    const step1 = await call(req(
+      `https://oyster.to/api/publish/access-redirect/${shareToken}`,
+      { cookie: `oyster_session=${u.sessionToken}` },
+    ));
+    expect(step1.status).toBe(302);
+    const handoff = new URL(step1.headers.get("location")!);
+    expect(handoff.origin + handoff.pathname).toBe(`https://share.oyster.to/p/${shareToken}`);
+    const nonce = handoff.searchParams.get("key");
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+    // Step 2: share.oyster.to consumes the nonce — NO apex cookie sent
+    // here, matching real browser cookie scoping.
+    const step2 = await call(req(handoff.toString()));
+    expect(step2.status).toBe(302);
+    expect(step2.headers.get("location")).toBe(`/p/${shareToken}`);
+    const setCookie = step2.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oyster_view_${shareToken}=`);
+    const cookieValue = setCookie.match(/oyster_view_[^=]+=([^;]+)/)?.[1] ?? "";
+
+    // Step 3: clean URL follow-up — still no apex cookie, only the
+    // recent-access proof — must serve content.
+    const step3 = await call(req(`https://share.oyster.to/p/${shareToken}`, {
+      cookie: `oyster_view_${shareToken}=${cookieValue}`,
+    }));
+    expect(step3.status).toBe(200);
+    expect(await step3.text()).toContain("private content");
+  });
+});

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -452,7 +452,7 @@ describe("GET /p/:token — footer copy is mode-invariant", () => {
 });
 
 describe("nonce pre-check — consumeNonce flag", () => {
-  it("/p/<token>?key=<valid_nonce> consumes the nonce", async () => {
+  it("/p/<token>?key=<valid_nonce> sets viewer cookie, 302s to clean URL, no-referrer", async () => {
     const u = await seedUser();
     const { shareToken } = await seedActiveOpenWithBody({
       ownerUserId: u.id, artifactId: "art_n1", body: "# nonce content",
@@ -462,10 +462,28 @@ describe("nonce pre-check — consumeNonce flag", () => {
 
     const nonce = await mintAccessNonce(env, shareToken, u.id);
     const res = await call(getReq(`/p/${shareToken}?key=${nonce}`));
-    // ok_via_nonce has no handler yet (Task 6); the placeholder throws,
-    // surfacing as a 500. TODO Task 6: assert 302 + cookie + clean URL.
-    expect(res.status).toBe(500);
 
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`/p/${shareToken}`);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oyster_view_${shareToken}=`);
+    expect(setCookie).toContain(`Path=/p/${shareToken}`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+
+    // Follow-up GET with the cookie returns content. We pass NO oyster_session
+    // here on purpose — the cookie is the only proof on share.oyster.to.
+    const cookieValue = setCookie.match(/oyster_view_[^=]+=([^;]+)/)?.[1] ?? "";
+    const follow = await call(getReq(`/p/${shareToken}`, {
+      cookie: `oyster_view_${shareToken}=${cookieValue}`,
+    }));
+    expect(follow.status).toBe(200);
+    expect(await follow.text()).toContain("nonce content");
+
+    // The nonce is consumed.
     const row = await env.DB.prepare(
       "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
     ).bind(nonce).first<{ consumed_at: number | null }>();
@@ -538,5 +556,23 @@ describe("nonce pre-check — consumeNonce flag", () => {
       "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
     ).bind(nonce).first<{ consumed_at: number | null }>();
     expect(row?.consumed_at).toBeNull();
+  });
+
+  it("a replayed key falls through to the standard mode dispatch", async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_replay", mode: "signin" });
+    const nonce = await mintAccessNonce(env, token, u.id);
+
+    // First call consumes.
+    const first = await call(getReq(`/p/${token}?key=${nonce}`));
+    expect(first.status).toBe(302);
+    expect(first.headers.get("location")).toBe(`/p/${token}`);
+
+    // Second call with the same (now-consumed) key behaves identically to
+    // a no-key request: signin mode, no cookie → 302 to access-redirect.
+    const second = await call(getReq(`/p/${token}?key=${nonce}`));
+    expect(second.status).toBe(302);
+    expect(second.headers.get("location"))
+      .toBe(`https://oyster.to/api/publish/access-redirect/${token}`);
   });
 });

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -575,6 +575,31 @@ describe("nonce pre-check — consumeNonce flag", () => {
     expect(second.headers.get("location"))
       .toBe(`https://oyster.to/api/publish/access-redirect/${token}`);
   });
+
+  it("does NOT consume the nonce when the visitor already has a valid viewer cookie", async () => {
+    // Models a visitor who clicked the access-redirect link earlier (got
+    // the cookie), then re-lands on the ?key= URL via back-button /
+    // bookmark / cached page. The nonce must NOT be burned.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_n_cookie", body: "# content",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const nonce = await mintAccessNonce(env, shareToken, u.id);
+    const viewerCookie = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+
+    const res = await call(getReq(`/p/${shareToken}?key=${nonce}`, {
+      cookie: `oyster_view_${shareToken}=${viewerCookie}`,
+    }));
+    expect(res.status).toBe(200);  // standard mode dispatch admits via cookie
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+  });
 });
 
 describe("password gate — sign-in link", () => {

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -461,11 +461,10 @@ describe("nonce pre-check — consumeNonce flag", () => {
       .bind(shareToken).run();
 
     const nonce = await mintAccessNonce(env, shareToken, u.id);
-    // Pre-Task-6 there is no ok_via_nonce render handler, so we expect
-    // the handler to throw and the request to surface as 500 (placeholder
-    // is added in this task). What we assert here is the SIDE EFFECT:
-    // the nonce was consumed.
-    await call(getReq(`/p/${shareToken}?key=${nonce}`));
+    const res = await call(getReq(`/p/${shareToken}?key=${nonce}`));
+    // ok_via_nonce has no handler yet (Task 6); the placeholder throws,
+    // surfacing as a 500. TODO Task 6: assert 302 + cookie + clean URL.
+    expect(res.status).toBe(500);
 
     const row = await env.DB.prepare(
       "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
@@ -493,6 +492,31 @@ describe("nonce pre-check — consumeNonce flag", () => {
     expect(row?.consumed_at).toBeNull();
 
     // The nonce remains usable on the proper /p endpoint.
+    expect(await consumeAccessNonce(env, nonce, shareToken)).toBe(true);
+  });
+
+  it("/p/<token>/raw?key=<valid_nonce> does NOT consume — password mode", async () => {
+    // Password mode is the higher-stakes case for the /raw non-consume
+    // invariant: it has an owner-bound password and the most surface area.
+    // A future regression that started consuming on /raw in password mode
+    // would burn the nonce before the outer /p page could use it.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_n_raw_pw", body: "<h1>iframe</h1>",
+      artifactKind: "app", contentType: "text/html",
+    });
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET mode = 'password', password_hash = 'pbkdf2$100000$AAAA$BBBB' WHERE share_token = ?",
+    ).bind(shareToken).run();
+
+    const nonce = await mintAccessNonce(env, shareToken, u.id);
+    await call(getReq(`/p/${shareToken}/raw?key=${nonce}`));
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+
     expect(await consumeAccessNonce(env, nonce, shareToken)).toBe(true);
   });
 

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -6,6 +6,7 @@ import {
   putR2Object, seedActiveOpenWithBody,
 } from "./fixtures/seed";
 import { signViewerCookie } from "../src/viewer-cookie";
+import { mintAccessNonce, consumeAccessNonce } from "../src/access-nonce";
 
 beforeAll(() => {
   // VIEWER_PASSWORD_LIMIT is an unsafe ratelimit binding; miniflare doesn't auto-mock it.
@@ -447,5 +448,71 @@ describe("GET /p/:token — footer copy is mode-invariant", () => {
     const res = await call(getReq(`/p/${shareToken}`, { cookie }));
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("Published with");
+  });
+});
+
+describe("nonce pre-check — consumeNonce flag", () => {
+  it("/p/<token>?key=<valid_nonce> consumes the nonce", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_n1", body: "# nonce content",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const nonce = await mintAccessNonce(env, shareToken, u.id);
+    // Pre-Task-6 there is no ok_via_nonce render handler, so we expect
+    // the handler to throw and the request to surface as 500 (placeholder
+    // is added in this task). What we assert here is the SIDE EFFECT:
+    // the nonce was consumed.
+    await call(getReq(`/p/${shareToken}?key=${nonce}`));
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).not.toBeNull();
+  });
+
+  it("/p/<token>/raw?key=<valid_nonce> does NOT consume the nonce", async () => {
+    // Regression for the explicit consumeNonce: false on /raw. If a future
+    // change drops the flag, this test fails.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_n_raw", body: "<h1>iframe</h1>",
+      artifactKind: "app", contentType: "text/html",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const nonce = await mintAccessNonce(env, shareToken, u.id);
+    await call(getReq(`/p/${shareToken}/raw?key=${nonce}`));
+
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
+
+    // The nonce remains usable on the proper /p endpoint.
+    expect(await consumeAccessNonce(env, nonce, shareToken)).toBe(true);
+  });
+
+  it("/p/<token>?key=<nonce_for_other_share> falls through silently AND leaves the nonce unconsumed", async () => {
+    const u = await seedUser();
+    const tokA = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_A", mode: "signin" });
+    const tokB = await seedActivePublication({ ownerUserId: u.id, artifactId: "art_B", mode: "signin" });
+
+    const nonce = await mintAccessNonce(env, tokA, u.id);
+    const res = await call(getReq(`/p/${tokB}?key=${nonce}`));
+    // signin mode, no cookie/session → 302 to access-redirect (silent fall-through).
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `https://oyster.to/api/publish/access-redirect/${tokB}`,
+    );
+
+    // Nonce is still alive for its real share.
+    const row = await env.DB.prepare(
+      "SELECT consumed_at FROM viewer_access_nonces WHERE nonce = ?",
+    ).bind(nonce).first<{ consumed_at: number | null }>();
+    expect(row?.consumed_at).toBeNull();
   });
 });

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -605,3 +605,33 @@ describe("password gate — sign-in link", () => {
     expect(body).toContain("Have access?");
   });
 });
+
+describe("rendered viewer responses — Referrer-Policy", () => {
+  it("open-mode markdown render carries referrer-policy: no-referrer", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_rp_open", body: "# hi",
+    });
+    const res = await call(getReq(`/p/${shareToken}`));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+
+  it("password-mode (post-unlock) render carries referrer-policy: no-referrer", async () => {
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art_rp_pw", body: "# secret",
+    });
+    await env.DB.prepare(
+      "UPDATE published_artifacts SET mode = 'password', password_hash = 'pbkdf2$100000$AAAA$BBBB' WHERE share_token = ?",
+    ).bind(shareToken).run();
+
+    // Hand-mint a valid viewer cookie so we exercise the rendered response path.
+    const cookieValue = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+    const res = await call(getReq(`/p/${shareToken}`, {
+      cookie: `oyster_view_${shareToken}=${cookieValue}`,
+    }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+});

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -379,7 +379,7 @@ describe("GET /p/:token — unknown artifact_kind", () => {
 });
 
 describe("GET /p/:token — signin mode", () => {
-  it("unsigned visitor → 302 to /auth/sign-in?return=/p/<token>", async () => {
+  it("unsigned visitor → 302 to /api/publish/access-redirect/<token>", async () => {
     const u = await seedUser();
     const token = await seedActivePublication({
       ownerUserId: u.id, artifactId: "art3", mode: "signin",
@@ -387,7 +387,7 @@ describe("GET /p/:token — signin mode", () => {
     const res = await call(getReq(`/p/${token}`));
     expect(res.status).toBe(302);
     const location = res.headers.get("location") ?? "";
-    expect(location).toBe(`https://oyster.to/auth/sign-in?return=/p/${token}`);
+    expect(location).toBe(`https://oyster.to/api/publish/access-redirect/${token}`);
   });
 
   it("signed-in visitor → content", async () => {
@@ -404,6 +404,25 @@ describe("GET /p/:token — signin mode", () => {
     expect(await res.text()).toContain("private");
   });
 
+  it("signed-in cookie-only visitor (no apex session) → content", async () => {
+    // Models the post-nonce-consumption follow-up GET: the viewer cookie
+    // was minted by the consume handler, but the apex session cookie was
+    // NEVER on share.oyster.to in the first place. Without the signin-mode
+    // cookie acceptance change, this would loop back to access-redirect.
+    const u = await seedUser();
+    const { shareToken } = await seedActiveOpenWithBody({
+      ownerUserId: u.id, artifactId: "art3cookie", body: "# private",
+    });
+    await env.DB.prepare("UPDATE published_artifacts SET mode = 'signin' WHERE share_token = ?")
+      .bind(shareToken).run();
+
+    const viewerCookie = await signViewerCookie(shareToken, env.VIEWER_COOKIE_SECRET);
+    const res = await call(getReq(`/p/${shareToken}`, {
+      cookie: `oyster_view_${shareToken}=${viewerCookie}`,  // no oyster_session
+    }));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("private");
+  });
 });
 
 describe("GET /p/:token — footer copy is mode-invariant", () => {

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -576,3 +576,32 @@ describe("nonce pre-check — consumeNonce flag", () => {
       .toBe(`https://oyster.to/api/publish/access-redirect/${token}`);
   });
 });
+
+describe("password gate — sign-in link", () => {
+  it('shows "Have access? Sign in to view" link pointing at access-redirect', async () => {
+    const u = await seedUser();
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art_gate", mode: "password",
+    });
+    const res = await call(getReq(`/p/${token}`));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Have access?");
+    expect(body).toContain(`https://oyster.to/api/publish/access-redirect/${token}`);
+  });
+
+  it("link is present on the wrong-password error state too", async () => {
+    const u = await seedUser();
+    // Use a stub PBKDF2 hash that verifyPbkdf2 will reject for any input
+    // (well-formed but not derivable). Submitting "wrong" produces the error block.
+    const token = await seedActivePublication({
+      ownerUserId: u.id, artifactId: "art_gate2", mode: "password",
+      passwordHash: "pbkdf2$100000$AAAA$BBBB",
+    });
+    const res = await call(postReq(`/p/${token}`, { password: "wrong" }));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Incorrect password.");
+    expect(body).toContain("Have access?");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET oyster.to/api/publish/access-redirect/:token` — owners of password-protected shares (and any signed-in visitor for signin-mode shares) get a single-click bypass instead of typing the password.
- D1 `viewer_access_nonces` table with atomic single-use semantics. `share_token` is in the consume `WHERE` clause so a nonce minted for one share cannot be burned against another.
- **Fixes a production bug in `signin` mode**: the apex `oyster_session` cookie is host-only on `oyster.to` (issue #397) and never reaches `share.oyster.to`, so the previous signin-handoff was a closed loop. `oyster_view_<token>` is now a generic recent-access proof honoured by both password and signin modes.
- `resolveViewerAccess` takes a required `{ consumeNonce }` option so `/raw` cannot accidentally start consuming nonces in a future change.
- New "Have access? Sign in to view" link on the password gate page.
- `Referrer-Policy: no-referrer` on the nonce-consumption 302, on every access-redirect 302, AND on rendered viewer responses (defence in depth across the whole viewer flow).

**Spec:** [`docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md`](docs/superpowers/specs/2026-05-18-viewer-access-redirect-design.md)
**Plan:** [`docs/superpowers/plans/2026-05-18-viewer-access-redirect.md`](docs/superpowers/plans/2026-05-18-viewer-access-redirect.md)

## Test plan

- [x] `infra/oyster-publish` test suite green (158 tests — incl. new `access-nonce`, `access-redirect-handler`, `signin-mode-cookie-boundary`, and additions to `viewer-handler`).
- [x] `infra/auth-worker` test suite green (36 tests — incl. new `return-path` cases for the access-redirect path).
- [x] Full root TypeScript build clean (`npm run build`).
- [ ] Manual: publish a password share locally; visit `share.oyster.to/p/<token>` while signed in to Oyster; click "Sign in to view"; confirm content with no password prompt.
- [ ] Manual: same flow while signed out → land on sign-in → return → bypass.
- [ ] Manual: non-owner clicks "Sign in to view" → 403 page with link back to the public gate.
- [ ] **Audit Cloudflare Logpush / Workers Analytics / `wrangler tail` for query-string capture on viewer URLs; disable or scrub `?key=` capture before deploying.** (Operational pre-merge item from the spec.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)