### PR TITLE
feat(terminals): launch and resume Claude Code sessions in-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Added
 
+- **Launch and resume Claude Code sessions inside Oyster.** A new *Launch Claude here* action on project tiles starts a fresh `claude` session in the project's folder, inside an in-app terminal. *Resume here* on a Session Inspector continues that conversation via `claude --resume`. The Resume dialog for cross-device sessions now offers *Open in Oyster* alongside the existing *Copy command*. Terminals are real PTYs with slash commands, status line, and resize — and the title turns into a link to the session's Inspector as soon as the conversation begins.
 - **Rocket Ship on mobile.** On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to *TAP* labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right. High-score initials can be entered with the same buttons: ◀ ▶ cycle the letter, ▲ advances to the next slot or saves.
 - **Mute toggle on the Rocket Ship title screen.** Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -306,6 +306,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.1...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Added</h3>
 <ul>
+<li><strong>Launch and resume Claude Code sessions inside Oyster.</strong> A new <em>Launch Claude here</em> action on project tiles starts a fresh <code>claude</code> session in the project&#39;s folder, inside an in-app terminal. <em>Resume here</em> on a Session Inspector continues that conversation via <code>claude --resume</code>. The Resume dialog for cross-device sessions now offers <em>Open in Oyster</em> alongside the existing <em>Copy command</em>. Terminals are real PTYs with slash commands, status line, and resize — and the title turns into a link to the session&#39;s Inspector as soon as the conversation begins.</li>
 <li><strong>Rocket Ship on mobile.</strong> On-screen ◀ ▶ ▲ controls overlay the canvas during gameplay, the title-screen instructions swap to <em>TAP</em> labels, and launching from the homepage breaks the game out to fullscreen with a × close button in the top-right. High-score initials can be entered with the same buttons: ◀ ▶ cycle the letter, ▲ advances to the next slot or saves.</li>
 <li><strong>Mute toggle on the Rocket Ship title screen.</strong> Click the ♪ in the top-right to silence music and sound effects; the choice is remembered next time you boot the game.</li>
 </ul>

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -1,0 +1,258 @@
+// Multi-instance PTY manager dedicated to Claude Code launches.
+//
+// Distinct from `pty-manager.ts` (the legacy OpenCode singleton): each Claude
+// terminal has its own `proc`, scrollback, and connected-clients set, keyed
+// by a generated `terminalId`. WebSockets attach at `/ws/terminal?id=<id>`
+// and the upgrade is routed to us explicitly by `index.ts`.
+//
+// On `proc.onExit` we retain the entry for 30s so a transient WS reconnect
+// can still replay the final frames before we drop scrollback.
+
+import { randomUUID } from "node:crypto";
+import { WebSocketServer, WebSocket } from "ws";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+
+const SCROLLBACK_LIMIT = 50_000;
+const POST_EXIT_RETENTION_MS = 30_000;
+const MAX_CONCURRENT_TERMINALS = 8;
+
+export class TerminalCapError extends Error {
+  constructor() {
+    super("too_many_terminals");
+    this.name = "TerminalCapError";
+  }
+}
+
+export class PtyUnavailableError extends Error {
+  constructor() {
+    super("pty_unavailable");
+    this.name = "PtyUnavailableError";
+  }
+}
+
+export interface ClaudePtyEntry {
+  terminalId: string;
+  kind: "claude_new" | "claude_resume";
+  proc: any;
+  scrollback: string;
+  clients: Set<WebSocket>;
+  cwd: string;
+  command: string;
+  args: string[];
+  startedAt: number;
+  exitedAt: number | null;
+  linkedSessionId: string | null;
+  evictTimer: NodeJS.Timeout | null;
+}
+
+export interface SpawnInput {
+  kind: "claude_new" | "claude_resume";
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  cols?: number;
+  rows?: number;
+}
+
+export interface SpawnResult {
+  terminalId: string;
+  startedAt: number;
+}
+
+// Mirror of pty-manager.ts's dynamic import. Duplicated rather than extracted
+// to keep blast radius tiny in the v1 rollout.
+let ptyModule: any = null;
+let ptyAvailable = false;
+async function loadPty(): Promise<void> {
+  if (ptyAvailable || ptyModule) return;
+  try {
+    ptyModule = await import("@lydell/node-pty");
+    ptyAvailable = true;
+  } catch {
+    try {
+      // @ts-ignore — fallback, may not be installed
+      ptyModule = await import("node-pty");
+      ptyAvailable = true;
+    } catch {
+      ptyAvailable = false;
+    }
+  }
+}
+// Eagerly attempt — module is cheap to load and a missing native binding
+// should surface at boot, not at first user click.
+loadPty().catch(() => { /* swallowed; spawn throws PtyUnavailableError instead */ });
+
+export interface ClaudePtyListEntry {
+  terminalId: string;
+  kind: "claude_new" | "claude_resume";
+  cwd: string;
+  command: string;
+  args: string[];
+  startedAt: number;
+  linkedSessionId: string | null;
+  alive: boolean;
+}
+
+export class ClaudePtyManager {
+  private terminals = new Map<string, ClaudePtyEntry>();
+  private wss = new WebSocketServer({ noServer: true });
+
+  spawn(input: SpawnInput): SpawnResult {
+    if (!ptyAvailable || !ptyModule) {
+      throw new PtyUnavailableError();
+    }
+    const alive = Array.from(this.terminals.values()).filter((t) => t.exitedAt === null).length;
+    if (alive >= MAX_CONCURRENT_TERMINALS) {
+      throw new TerminalCapError();
+    }
+
+    const terminalId = randomUUID();
+    const startedAt = Date.now();
+    const pty = ptyModule.default ?? ptyModule;
+    const proc = pty.spawn(input.command, input.args, {
+      name: "xterm-256color",
+      cols: input.cols ?? 120,
+      rows: input.rows ?? 40,
+      cwd: input.cwd,
+      env: input.env,
+    });
+
+    const entry: ClaudePtyEntry = {
+      terminalId,
+      kind: input.kind,
+      proc,
+      scrollback: "",
+      clients: new Set(),
+      cwd: input.cwd,
+      command: input.command,
+      args: input.args,
+      startedAt,
+      exitedAt: null,
+      linkedSessionId: null,
+      evictTimer: null,
+    };
+    this.terminals.set(terminalId, entry);
+
+    proc.onData((data: string) => {
+      entry.scrollback += data;
+      if (entry.scrollback.length > SCROLLBACK_LIMIT) {
+        entry.scrollback = entry.scrollback.slice(-SCROLLBACK_LIMIT);
+      }
+      for (const ws of entry.clients) {
+        if (ws.readyState === WebSocket.OPEN) ws.send(data);
+      }
+    });
+
+    proc.onExit(({ exitCode }: { exitCode: number }) => {
+      entry.exitedAt = Date.now();
+      const closeNote = `\r\n\x1b[90m[session ended (exit ${exitCode})]\x1b[0m\r\n`;
+      entry.scrollback += closeNote;
+      for (const ws of entry.clients) {
+        if (ws.readyState === WebSocket.OPEN) ws.send(closeNote);
+      }
+      // Retain for late reconnects, then evict.
+      entry.evictTimer = setTimeout(() => {
+        this.terminals.delete(terminalId);
+      }, POST_EXIT_RETENTION_MS);
+    });
+
+    return { terminalId, startedAt };
+  }
+
+  attachClient(terminalId: string, ws: WebSocket): boolean {
+    const entry = this.terminals.get(terminalId);
+    if (!entry) return false;
+    entry.clients.add(ws);
+
+    if (entry.scrollback.length > 0) {
+      ws.send(entry.scrollback);
+    }
+
+    ws.on("message", (msg: Buffer | string) => {
+      if (entry.exitedAt !== null) return;
+      const data = typeof msg === "string" ? msg : msg.toString("utf-8");
+      // JSON control envelope for resize. Tolerant: malformed JSON or
+      // unknown types pass through as input bytes.
+      if (data.length > 0 && data.charCodeAt(0) === 0x7b /* `{` */) {
+        try {
+          const ctrl = JSON.parse(data);
+          if (ctrl && ctrl.type === "resize" && Number.isInteger(ctrl.cols) && Number.isInteger(ctrl.rows)) {
+            if (ctrl.cols > 0 && ctrl.rows > 0) entry.proc.resize(ctrl.cols, ctrl.rows);
+            return;
+          }
+        } catch { /* fall through */ }
+      }
+      entry.proc.write(data);
+    });
+
+    ws.on("close", () => {
+      entry.clients.delete(ws);
+    });
+
+    return true;
+  }
+
+  setLinkedSession(terminalId: string, sessionId: string): boolean {
+    const entry = this.terminals.get(terminalId);
+    if (!entry) return false;
+    entry.linkedSessionId = sessionId;
+    return true;
+  }
+
+  kill(terminalId: string): boolean {
+    const entry = this.terminals.get(terminalId);
+    if (!entry) return false;
+    try { entry.proc.kill(); } catch { /* best-effort */ }
+    // proc.onExit fans out closeNote + schedules eviction. Drop the entry
+    // immediately if the proc had already exited (defensive).
+    if (entry.exitedAt !== null && !entry.evictTimer) {
+      this.terminals.delete(terminalId);
+    }
+    return true;
+  }
+
+  list(): ClaudePtyListEntry[] {
+    return Array.from(this.terminals.values()).map((e) => ({
+      terminalId: e.terminalId,
+      kind: e.kind,
+      cwd: e.cwd,
+      command: e.command,
+      args: e.args.slice(),
+      startedAt: e.startedAt,
+      linkedSessionId: e.linkedSessionId,
+      alive: e.exitedAt === null,
+    }));
+  }
+
+  getEntry(terminalId: string): ClaudePtyEntry | undefined {
+    return this.terminals.get(terminalId);
+  }
+
+  disposeAll(): void {
+    for (const entry of this.terminals.values()) {
+      if (entry.evictTimer) {
+        clearTimeout(entry.evictTimer);
+        entry.evictTimer = null;
+      }
+      try { entry.proc.kill(); } catch { /* best-effort */ }
+    }
+    this.terminals.clear();
+  }
+
+  handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer, terminalId: string): void {
+    const entry = this.terminals.get(terminalId);
+    if (!entry) {
+      socket.destroy();
+      return;
+    }
+    this.wss.handleUpgrade(req, socket, head, (ws) => {
+      this.attachClient(terminalId, ws);
+    });
+  }
+
+  isPtyAvailable(): boolean {
+    return ptyAvailable;
+  }
+}

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -103,6 +103,31 @@ export class ClaudePtyManager {
     if (!ptyAvailable || !ptyModule) {
       throw new PtyUnavailableError();
     }
+    // Reap zombie entries before counting. node-pty's `onExit` doesn't
+    // strictly guarantee firing on every failure path (native errors during
+    // spawn, hard kills before the pty is fully wired, etc.). Without this,
+    // a zombie can occupy a slot against the cap forever. `process.kill(pid, 0)`
+    // is the standard probe — throws ESRCH when the process is gone.
+    for (const entry of this.terminals.values()) {
+      if (entry.exitedAt !== null) continue;
+      const pid = entry.proc?.pid;
+      if (typeof pid !== "number") continue;
+      try {
+        process.kill(pid, 0);
+      } catch (err) {
+        const code = (err as { code?: string } | null)?.code;
+        if (code === "ESRCH") {
+          // Process is gone; mark exited so it stops counting against the
+          // cap. Schedule the same 30s retention so reconnects still see
+          // the final scrollback.
+          entry.exitedAt = Date.now();
+          entry.evictTimer ??= setTimeout(() => {
+            this.terminals.delete(entry.terminalId);
+          }, POST_EXIT_RETENTION_MS);
+        }
+        // EPERM means it exists but we can't signal it — leave as alive.
+      }
+    }
     const alive = Array.from(this.terminals.values()).filter((t) => t.exitedAt === null).length;
     if (alive >= MAX_CONCURRENT_TERMINALS) {
       throw new TerminalCapError();

--- a/server/src/http-utils.ts
+++ b/server/src/http-utils.ts
@@ -109,6 +109,22 @@ export function makeRouteCtx(req: IncomingMessage, res: ServerResponse): RouteCt
   return { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin };
 }
 
+/** Same loopback + Origin check as `rejectIfNonLocalOrigin`, but for the
+ *  WebSocket upgrade path where we don't have a usable response object —
+ *  on rejection we just destroy the socket. Browsers can open cross-origin
+ *  WebSocket connections to localhost; without this check a same-machine
+ *  page from a different port could read/write any active Claude PTY. */
+export function isLocalUpgradeOrigin(req: import("node:http").IncomingMessage): boolean {
+  const origin = req.headers.origin;
+  if (typeof origin === "string" && origin.length > 0) {
+    return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+  }
+  // No Origin header (curl, native WS clients) — fall back to the
+  // socket-level loopback check.
+  const remote = req.socket.remoteAddress || "";
+  return remote === "127.0.0.1" || remote === "::1" || remote === "::ffff:127.0.0.1";
+}
+
 /** Safely percent-decode a URL path segment. `decodeURIComponent` throws
  *  `URIError` on malformed encoding (e.g. `/api/artifacts/%E0%A4%A`); an
  *  unguarded throw inside a route handler would crash the server process.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -66,7 +66,9 @@ import {
 } from "./opencode-manager.js";
 import { attachChatEventClient } from "./opencode-events.js";
 import { sweepOrphanOpenCodeProcesses } from "./opencode-orphan-sweep.js";
-import { attachWebSocket } from "./pty-manager.js";
+import { attachWebSocket, handleLegacyUpgrade } from "./pty-manager.js";
+import { ClaudePtyManager } from "./claude-pty-manager.js";
+import { tryHandleTerminalRoute } from "./routes/terminals.js";
 import { SqliteFtsMemoryProvider } from "./memory-store.js";
 import { AuthService } from "./auth-service.js";
 import { bootMark, bootTime, bootTimeAsync } from "./boot-timer.js";
@@ -556,6 +558,12 @@ sessionSnapshotHandle.unref();
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const projectService = new ProjectService(db);
 const sessionService = new SessionService(db, sessionStore);
+const claudePtyManager = new ClaudePtyManager();
+// Forward-declared so the terminal route can hold a stable reference even
+// though the watcher is constructed inside `httpServer.listen`. The route
+// is only ever called after the server is listening (and therefore after
+// this is assigned).
+let claudeCodeWatcherRef: import("./watchers/claude-code.js").ClaudeCodeWatcher | null = null;
 const publishService = createPublishService({
   db,
   readArtifactBytes: async (artifactId) => {
@@ -708,6 +716,7 @@ startAutoApprover(getOpenCodePort, (file) => handleFileEdited(file, ARTIFACTS_DI
 // lock left behind is more annoying than the failure that triggered the exit.
 function shutdown(code: number): never {
   markShuttingDown();
+  try { claudePtyManager.disposeAll(); } catch { /* best effort */ }
   try { killOpenCode(); } catch { /* best effort */ }
   try { db.close(); } catch { /* best effort */ }
   try { memoryProvider.close(); } catch { /* best effort */ }
@@ -773,6 +782,15 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     db, sessionStore, spaceStore, artifactService, memoryProvider, sessionSync,
     currentUserId: () => authService.getState().user?.id ?? null,
     sessionService, broadcastUiEvent,
+  })) return;
+
+  // /api/terminals/* — spawn / list / kill Claude Code PTYs. Source-typed
+  // launch contract: no raw cwd accepted from the client.
+  if (claudeCodeWatcherRef && await tryHandleTerminalRoute(req, res, url, ctx, {
+    db, sessionStore, projectService, claudeCodeWatcher: claudeCodeWatcherRef,
+    claudePtyManager, packageRoot: PACKAGE_ROOT, cleanEnv,
+    currentUserId: () => authService.getState().user?.id ?? null,
+    broadcastUiEvent,
   })) return;
 
   // /api/artifacts/*, /api/groups/*, /api/plugins/:id/uninstall.
@@ -1051,7 +1069,27 @@ writeFileSync(join(USERLAND_DIR, "opencode.json"), JSON.stringify(sourceOpencode
 bootMark("opencode config written, about to listen");
 
 const httpServer = createServer(handleHttpRequest);
-attachWebSocket(httpServer, { shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: cleanEnv });
+// Legacy OpenCode terminal — still attached via the singleton in
+// pty-manager.ts, just routed by pathname now (root path "/"). See the
+// upgrade dispatcher below.
+attachWebSocket({ shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: cleanEnv });
+
+// Explicit WS upgrade routing. Unknown paths get socket.destroy() so we
+// don't silently accept any URL the way `WebSocketServer({server})` did.
+httpServer.on("upgrade", (req, socket, head) => {
+  const u = new URL(req.url ?? "/", "http://localhost");
+  if (u.pathname === "/ws/terminal") {
+    const id = u.searchParams.get("id");
+    if (!id) { socket.destroy(); return; }
+    claudePtyManager.handleUpgrade(req, socket, head, id);
+    return;
+  }
+  if (u.pathname === "/") {
+    handleLegacyUpgrade(req, socket, head);
+    return;
+  }
+  socket.destroy();
+});
 
 // Wipe any stale .dev-port from a prior crash before we listen, so wait-on
 // can never succeed against a dead server's port. (See declaration above.)
@@ -1152,6 +1190,9 @@ httpServer.listen(port, "127.0.0.1", () => {
   claudeCodeWatcher.start().catch((err) => {
     console.warn(`[claude-code-watcher] start failed: ${err instanceof Error ? err.message : err}`);
   });
+  // Publish for the /api/terminals route. Auto-link consults this watcher
+  // to resolve the new JSONL produced by a freshly spawned `claude`.
+  claudeCodeWatcherRef = claudeCodeWatcher;
 
   // Reap any orphaned opencode-ai processes from a prior Oyster run that
   // didn't shut down cleanly (SIGKILL, crash, laptop sleep). See #191.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,7 +25,7 @@ import { SqliteSpaceStore } from "./space-store.js";
 import { SpaceService } from "./space-service.js";
 import { SessionService } from "./session-service.js";
 import { slugify } from "./utils.js";
-import { makeRouteCtx } from "./http-utils.js";
+import { makeRouteCtx, isLocalUpgradeOrigin } from "./http-utils.js";
 import { tryHandleSessionRoute } from "./routes/sessions.js";
 import { tryHandleArtifactRoute } from "./routes/artifacts.js";
 import { tryHandleSpaceRoute } from "./routes/spaces.js";
@@ -1076,7 +1076,12 @@ attachWebSocket({ shell: SHELL, shellArgs: SHELL_ARGS, cwd: WORKSPACE, env: clea
 
 // Explicit WS upgrade routing. Unknown paths get socket.destroy() so we
 // don't silently accept any URL the way `WebSocketServer({server})` did.
+// Origin gate: same loopback + Origin policy as `rejectIfNonLocalOrigin`
+// on the REST side — browsers can open cross-origin WebSockets to
+// localhost, so without this a same-machine page from a different
+// port could read/write any active Claude PTY (or the legacy shell).
 httpServer.on("upgrade", (req, socket, head) => {
+  if (!isLocalUpgradeOrigin(req)) { socket.destroy(); return; }
   const u = new URL(req.url ?? "/", "http://localhost");
   if (u.pathname === "/ws/terminal") {
     const id = u.searchParams.get("id");

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -785,8 +785,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
   })) return;
 
   // /api/terminals/* — spawn / list / kill Claude Code PTYs. Source-typed
-  // launch contract: no raw cwd accepted from the client.
-  if (claudeCodeWatcherRef && await tryHandleTerminalRoute(req, res, url, ctx, {
+  // launch contract: no raw cwd accepted from the client. The watcher may
+  // still be initialising during the boot window (between listen() and the
+  // listen-callback running); the route handler surfaces that as 503 rather
+  // than letting the request fall through to the 404 catchall.
+  if (await tryHandleTerminalRoute(req, res, url, ctx, {
     db, sessionStore, projectService, claudeCodeWatcher: claudeCodeWatcherRef,
     claudePtyManager, packageRoot: PACKAGE_ROOT, cleanEnv,
     currentUserId: () => authService.getState().user?.id ?? null,

--- a/server/src/project-service.ts
+++ b/server/src/project-service.ts
@@ -80,6 +80,16 @@ export class ProjectService {
     return rows.map((row) => ({ ...rowToProject(row), ...this.detectPathState(row.id) }));
   }
 
+  /** Lookup a single non-removed project by id, with path state attached.
+   *  Used by terminal-launch to resolve a cwd from a project reference. */
+  getById(id: string): Project | null {
+    const row = this.db
+      .prepare("SELECT id, space_id, name, created_at FROM projects WHERE id = ? AND removed_at IS NULL")
+      .get(id) as ProjectRow | undefined;
+    if (!row) return null;
+    return { ...rowToProject(row), ...this.detectPathState(row.id) };
+  }
+
   // Walk this project's cached paths once and derive:
   //   - recentPath  (most-recent, for display)
   //   - hasLivePath (ANY path exists on disk → not homeless)

--- a/server/src/pty-manager.ts
+++ b/server/src/pty-manager.ts
@@ -1,5 +1,6 @@
 import { WebSocketServer, WebSocket } from "ws";
-import type { Server } from "node:http";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
 
 const SCROLLBACK_LIMIT = 50_000; // chars to replay on reconnect
 
@@ -70,13 +71,27 @@ export function spawnSession(
   return proc;
 }
 
+// WSS in noServer mode — `index.ts` owns the single `upgrade` listener on
+// the http server and routes by pathname. We just handle whatever upgrade
+// is forwarded to us.
+const wss = new WebSocketServer({ noServer: true });
+let attachedSpawnParams: { shell: string; shellArgs: string[]; cwd: string; env: Record<string, string> } | null = null;
+
 export function attachWebSocket(
-  httpServer: Server,
   spawnParams?: { shell: string; shellArgs: string[]; cwd: string; env: Record<string, string> },
 ) {
-  const wss = new WebSocketServer({ server: httpServer });
+  attachedSpawnParams = spawnParams ?? null;
+}
 
-  wss.on("connection", (ws: WebSocket) => {
+/** Called by `index.ts` when an upgrade arrives on the legacy WS path
+ *  (root). Behaviour identical to the previous `wss.on("connection", …)`
+ *  handler — only the dispatch route differs. */
+export function handleLegacyUpgrade(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+): void {
+  wss.handleUpgrade(req, socket, head, (ws) => {
     console.log(`Client connected (${clients.size + 1} total)`);
     clients.add(ws);
 
@@ -90,8 +105,8 @@ export function attachWebSocket(
     // startup time (~11s) because two opencode-ai processes initialised in
     // parallel and competed for CPU. The terminal window is rarely opened —
     // most users never trigger this. See #385.
-    if (spawnParams && !proc) {
-      spawnSession(spawnParams.shell, spawnParams.shellArgs, spawnParams.cwd, spawnParams.env);
+    if (attachedSpawnParams && !proc) {
+      spawnSession(attachedSpawnParams.shell, attachedSpawnParams.shellArgs, attachedSpawnParams.cwd, attachedSpawnParams.env);
     }
 
     // Replay scrollback so reconnecting clients see current state

--- a/server/src/routes/terminals.ts
+++ b/server/src/routes/terminals.ts
@@ -5,8 +5,30 @@
 // cwd via `resolveSourceCwd` against trusted DB rows. That makes the route
 // safe to call from web origins without arbitrary local-directory exposure.
 
-import { existsSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { statSync, openSync, readSync, closeSync } from "node:fs";
 import { basename, dirname } from "node:path";
+
+/** Single-syscall existence + directory check. Returns true only if the
+ *  path exists AND is a directory; absorbs ENOENT/ENOTDIR/EACCES. Used in
+ *  place of an `existsSync` + `statSync` pair to avoid the TOCTOU window
+ *  where the path is deleted between the two calls, which would otherwise
+ *  throw out of a synchronous route handler. */
+function isLiveDirectory(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Same idea for files (the reassembled remote-session jsonl). */
+function isLiveFile(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type Database from "better-sqlite3";
 import type { RouteCtx } from "../http-utils.js";
@@ -59,7 +81,7 @@ export function resolveSourceCwd(
     if (!project.recentPath || project.hasLivePath === false) {
       return { error: "project_homeless" };
     }
-    if (!existsSync(project.recentPath)) return { error: "project_homeless" };
+    if (!isLiveDirectory(project.recentPath)) return { error: "project_homeless" };
     return { cwd: project.recentPath, displayName: project.name };
   }
 
@@ -67,7 +89,7 @@ export function resolveSourceCwd(
     const row = deps.sessionStore.getById(source.id);
     if (!row) return { error: "session_not_found" };
     if (!row.cwd) return { error: "session_no_cwd" };
-    if (!existsSync(row.cwd)) return { error: "session_cwd_missing" };
+    if (!isLiveDirectory(row.cwd)) return { error: "session_cwd_missing" };
     return { cwd: row.cwd, displayName: row.title ?? basename(row.cwd) };
   }
 
@@ -81,7 +103,7 @@ export function resolveSourceCwd(
     )
     .get(ownerId, source.id) as { jsonl_local_path: string | null } | undefined;
   if (!row || !row.jsonl_local_path) return { error: "session_not_reassembled_yet" };
-  if (!existsSync(row.jsonl_local_path)) return { error: "session_not_reassembled_yet" };
+  if (!isLiveFile(row.jsonl_local_path)) return { error: "session_not_reassembled_yet" };
 
   // The parent dir's basename is `encodeCwd(originalCwd)`. The original cwd
   // may not exist on this device (cross-device reassemble), so scan the head
@@ -89,7 +111,7 @@ export function resolveSourceCwd(
   // locally. Mirrors `pickJsonlCwd` used by the watcher.
   const candidates = headEventCwds(row.jsonl_local_path);
   const resolved = pickJsonlCwd(row.jsonl_local_path, candidates);
-  if (!resolved || !existsSync(resolved)) return { error: "cwd_not_on_this_device" };
+  if (!resolved || !isLiveDirectory(resolved)) return { error: "cwd_not_on_this_device" };
   return { cwd: resolved, displayName: basename(resolved) };
 }
 
@@ -178,10 +200,9 @@ export async function tryHandleTerminalRoute(
       sendJson({ error: resolved.error }, 400);
       return true;
     }
-    if (!statSync(resolved.cwd).isDirectory()) {
-      sendJson({ error: "cwd_not_a_directory" }, 400);
-      return true;
-    }
+    // resolveSourceCwd already asserted isDirectory() via isLiveDirectory.
+    // Don't re-stat here — a TOCTOU window between two syscalls in a
+    // sync handler can throw out of the route and crash the server.
 
     const bin = resolveClaudeBinary(deps.packageRoot);
     if (!bin.ok) {

--- a/server/src/routes/terminals.ts
+++ b/server/src/routes/terminals.ts
@@ -51,7 +51,10 @@ export interface TerminalRouteDeps {
   db: Database.Database;
   sessionStore: SessionStore;
   projectService: ProjectService;
-  claudeCodeWatcher: ClaudeCodeWatcher;
+  /** Null during the boot window between `httpServer.listen()` resolving
+   *  and the listen callback constructing the watcher. The route handler
+   *  surfaces this as 503 rather than letting the request 404. */
+  claudeCodeWatcher: ClaudeCodeWatcher | null;
   claudePtyManager: ClaudePtyManager;
   packageRoot: string;
   /** Clean env (PATH, HOME, etc.) for spawned PTYs. Lifted from index.ts so
@@ -159,6 +162,13 @@ export async function tryHandleTerminalRoute(
 
   if (url === "/api/terminals" && req.method === "POST") {
     if (rejectIfNonLocalOrigin()) return true;
+    if (!deps.claudeCodeWatcher) {
+      // Server is up but the JSONL watcher hasn't initialised yet. Auto-link
+      // would be impossible and the launch flow expects a live watcher.
+      // Honest 503 ("come back in a moment") beats a misleading 404.
+      sendJson({ error: "watcher_not_ready" }, 503);
+      return true;
+    }
     let body: Record<string, unknown>;
     try {
       body = await readJsonBody();
@@ -258,7 +268,10 @@ export async function tryHandleTerminalRoute(
       });
     } else if (kind === "claude_new") {
       const encoded = encodeCwd(resolved.cwd);
-      deps.claudeCodeWatcher
+      // Local binding so the closure below doesn't depend on TS narrowing
+      // surviving through the .then arrow.
+      const watcher = deps.claudeCodeWatcher;
+      watcher
         .onceNewJsonl(encoded, sinceMs)
         .then((result) => {
           if (!result) return;

--- a/server/src/routes/terminals.ts
+++ b/server/src/routes/terminals.ts
@@ -1,0 +1,283 @@
+// /api/terminals/* — spawn and manage in-app Claude Code PTY terminals.
+//
+// Cwd is never accepted from the client. The body carries a typed `source`
+// reference (project / session / remote_session); the server resolves the
+// cwd via `resolveSourceCwd` against trusted DB rows. That makes the route
+// safe to call from web origins without arbitrary local-directory exposure.
+
+import { existsSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { basename, dirname } from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type Database from "better-sqlite3";
+import type { RouteCtx } from "../http-utils.js";
+import type { SessionStore } from "../session-store.js";
+import type { ProjectService } from "../project-service.js";
+import type { ClaudeCodeWatcher } from "../watchers/claude-code.js";
+import { pickJsonlCwd } from "../watchers/claude-code.js";
+import { encodeCwd } from "../session-sync-service.js";
+import { ClaudePtyManager, TerminalCapError, PtyUnavailableError } from "../claude-pty-manager.js";
+import { resolveClaudeBinary, buildLaunchArgs } from "../terminal-launcher.js";
+import type { UiCommand } from "../../../shared/types.js";
+
+type LaunchKind = "claude_new" | "claude_resume";
+type LaunchSource =
+  | { type: "project"; id: string }
+  | { type: "session"; id: string }
+  | { type: "remote_session"; id: string };
+
+export interface TerminalRouteDeps {
+  db: Database.Database;
+  sessionStore: SessionStore;
+  projectService: ProjectService;
+  claudeCodeWatcher: ClaudeCodeWatcher;
+  claudePtyManager: ClaudePtyManager;
+  packageRoot: string;
+  /** Clean env (PATH, HOME, etc.) for spawned PTYs. Lifted from index.ts so
+   *  the legacy and new launches share scrubbing. */
+  cleanEnv: Record<string, string>;
+  currentUserId: () => string | null;
+  broadcastUiEvent: (event: UiCommand) => void;
+}
+
+type ResolveOk = { cwd: string; displayName: string };
+type ResolveErr =
+  | { error: "project_not_found" }
+  | { error: "project_homeless" }
+  | { error: "session_not_found" }
+  | { error: "session_no_cwd" }
+  | { error: "session_cwd_missing" }
+  | { error: "session_not_reassembled_yet" }
+  | { error: "cwd_not_on_this_device" };
+
+export function resolveSourceCwd(
+  source: LaunchSource,
+  deps: Pick<TerminalRouteDeps, "db" | "sessionStore" | "projectService" | "currentUserId">,
+): ResolveOk | ResolveErr {
+  if (source.type === "project") {
+    const project = deps.projectService.getById(source.id);
+    if (!project) return { error: "project_not_found" };
+    if (!project.recentPath || project.hasLivePath === false) {
+      return { error: "project_homeless" };
+    }
+    if (!existsSync(project.recentPath)) return { error: "project_homeless" };
+    return { cwd: project.recentPath, displayName: project.name };
+  }
+
+  if (source.type === "session") {
+    const row = deps.sessionStore.getById(source.id);
+    if (!row) return { error: "session_not_found" };
+    if (!row.cwd) return { error: "session_no_cwd" };
+    if (!existsSync(row.cwd)) return { error: "session_cwd_missing" };
+    return { cwd: row.cwd, displayName: row.title ?? basename(row.cwd) };
+  }
+
+  // remote_session — bytes already reassembled to disk by /api/sessions/:id/resume.
+  const ownerId = deps.currentUserId();
+  if (!ownerId) return { error: "session_not_reassembled_yet" };
+  const row = deps.db
+    .prepare(
+      `SELECT jsonl_local_path FROM remote_sessions
+        WHERE owner_id = ? AND session_id = ? LIMIT 1`,
+    )
+    .get(ownerId, source.id) as { jsonl_local_path: string | null } | undefined;
+  if (!row || !row.jsonl_local_path) return { error: "session_not_reassembled_yet" };
+  if (!existsSync(row.jsonl_local_path)) return { error: "session_not_reassembled_yet" };
+
+  // The parent dir's basename is `encodeCwd(originalCwd)`. The original cwd
+  // may not exist on this device (cross-device reassemble), so scan the head
+  // events for a `cwd` whose encoding matches the parent dir AND exists
+  // locally. Mirrors `pickJsonlCwd` used by the watcher.
+  const candidates = headEventCwds(row.jsonl_local_path);
+  const resolved = pickJsonlCwd(row.jsonl_local_path, candidates);
+  if (!resolved || !existsSync(resolved)) return { error: "cwd_not_on_this_device" };
+  return { cwd: resolved, displayName: basename(resolved) };
+}
+
+/** Read a few KB from the head of a jsonl and collect any `cwd` fields seen.
+ *  Mirrors the head-scan in `ClaudeCodeWatcher.readSessionMetadata`, scoped
+ *  small. Used only for remote-session resume. */
+function headEventCwds(jsonlPath: string): string[] {
+  const HEAD_BYTES = 65_536;
+  const buf = Buffer.alloc(HEAD_BYTES);
+  let fd: number | null = null;
+  try {
+    fd = openSync(jsonlPath, "r");
+    const n = readSync(fd, buf, 0, HEAD_BYTES, 0);
+    const text = buf.slice(0, n).toString("utf8");
+    const cwds: string[] = [];
+    for (const line of text.split("\n")) {
+      if (!line) continue;
+      try {
+        const ev = JSON.parse(line);
+        if (typeof ev?.cwd === "string") cwds.push(ev.cwd);
+      } catch { /* skip malformed */ }
+    }
+    return cwds;
+  } catch {
+    return [];
+  } finally {
+    if (fd !== null) try { closeSync(fd); } catch { /* ignore */ }
+  }
+}
+
+export async function tryHandleTerminalRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: string,
+  ctx: RouteCtx,
+  deps: TerminalRouteDeps,
+): Promise<boolean> {
+  const { sendJson, sendError, readJsonBody, rejectIfNonLocalOrigin } = ctx;
+
+  if (url === "/api/terminals" && req.method === "GET") {
+    if (rejectIfNonLocalOrigin()) return true;
+    sendJson(deps.claudePtyManager.list());
+    return true;
+  }
+
+  if (url === "/api/terminals" && req.method === "POST") {
+    if (rejectIfNonLocalOrigin()) return true;
+    let body: Record<string, unknown>;
+    try {
+      body = await readJsonBody();
+    } catch (err) {
+      sendError(err);
+      return true;
+    }
+    if ("cwd" in body) {
+      sendJson({ error: "cwd_not_accepted", message: "Provide a typed `source` reference, not a cwd." }, 400);
+      return true;
+    }
+    const kind = body.kind as LaunchKind | undefined;
+    if (kind !== "claude_new" && kind !== "claude_resume") {
+      sendJson({ error: "invalid_kind" }, 400);
+      return true;
+    }
+    const source = body.source as LaunchSource | undefined;
+    if (!source || typeof source !== "object" || typeof source.id !== "string" || source.id.length === 0) {
+      sendJson({ error: "invalid_source" }, 400);
+      return true;
+    }
+    if (source.type !== "project" && source.type !== "session" && source.type !== "remote_session") {
+      sendJson({ error: "invalid_source_type" }, 400);
+      return true;
+    }
+    if (kind === "claude_resume" && source.type === "project") {
+      sendJson({ error: "resume_requires_session_source" }, 400);
+      return true;
+    }
+    if (kind === "claude_new" && source.type === "remote_session") {
+      // We could allow this in future (start a fresh claude in the
+      // reassembled cwd); for v1 keep the surface tight.
+      sendJson({ error: "new_session_requires_project_or_session_source" }, 400);
+      return true;
+    }
+
+    const resolved = resolveSourceCwd(source, deps);
+    if ("error" in resolved) {
+      sendJson({ error: resolved.error }, 400);
+      return true;
+    }
+    if (!statSync(resolved.cwd).isDirectory()) {
+      sendJson({ error: "cwd_not_a_directory" }, 400);
+      return true;
+    }
+
+    const bin = resolveClaudeBinary(deps.packageRoot);
+    if (!bin.ok) {
+      sendJson(
+        {
+          error: "binary_not_found",
+          installHint: "npm install -g @anthropic-ai/claude-code",
+        },
+        400,
+      );
+      return true;
+    }
+
+    // Capture BEFORE spawn so any JSONL claude writes during init is inside
+    // the auto-link window. The watcher's `onceNewJsonl` allows a 1s back-
+    // window on top of this for mtime resolution slop.
+    const sinceMs = Date.now();
+    const args = buildLaunchArgs(kind, source.type === "session" || source.type === "remote_session" ? source.id : undefined);
+
+    let spawned: { terminalId: string; startedAt: number };
+    try {
+      spawned = deps.claudePtyManager.spawn({
+        kind,
+        command: bin.path,
+        args,
+        cwd: resolved.cwd,
+        env: deps.cleanEnv,
+      });
+    } catch (err) {
+      if (err instanceof TerminalCapError) {
+        sendJson({ error: "too_many_terminals" }, 429);
+        return true;
+      }
+      if (err instanceof PtyUnavailableError) {
+        sendJson({ error: "pty_unavailable" }, 503);
+        return true;
+      }
+      sendError(err, 500);
+      return true;
+    }
+
+    const { terminalId, startedAt } = spawned;
+
+    // Auto-link is fire-and-forget. claude_resume: we already know the id —
+    // attach it synchronously and broadcast. claude_new: watch for the next
+    // JSONL in the encoded-cwd dir.
+    if (kind === "claude_resume" && source.type === "session") {
+      deps.claudePtyManager.setLinkedSession(terminalId, source.id);
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "terminal_session_linked",
+        payload: { terminalId, sessionId: source.id },
+      });
+    } else if (kind === "claude_new") {
+      const encoded = encodeCwd(resolved.cwd);
+      deps.claudeCodeWatcher
+        .onceNewJsonl(encoded, sinceMs)
+        .then((result) => {
+          if (!result) return;
+          const entry = deps.claudePtyManager.getEntry(terminalId);
+          if (!entry || entry.exitedAt !== null) return;
+          deps.claudePtyManager.setLinkedSession(terminalId, result.sessionId);
+          deps.broadcastUiEvent({
+            version: 1,
+            command: "terminal_session_linked",
+            payload: { terminalId, sessionId: result.sessionId },
+          });
+        })
+        .catch(() => { /* best-effort */ });
+    }
+
+    sendJson({
+      terminalId,
+      kind,
+      cwd: resolved.cwd,
+      displayName: resolved.displayName,
+      command: bin.path,
+      args,
+      startedAt,
+    });
+    return true;
+  }
+
+  const deleteMatch = url.match(/^\/api\/terminals\/([^/?#]+)$/);
+  if (deleteMatch && req.method === "DELETE") {
+    if (rejectIfNonLocalOrigin()) return true;
+    const id = deleteMatch[1]!;
+    deps.claudePtyManager.kill(id);
+    res.writeHead(204);
+    res.end();
+    return true;
+  }
+
+  return false;
+}
+
+// Re-exported for routes/index.ts callers that want to check existence
+// without parsing the response object.
+export { dirname as _dirnameForTests };

--- a/server/src/routes/terminals.ts
+++ b/server/src/routes/terminals.ts
@@ -259,7 +259,12 @@ export async function tryHandleTerminalRoute(
     // Auto-link is fire-and-forget. claude_resume: we already know the id —
     // attach it synchronously and broadcast. claude_new: watch for the next
     // JSONL in the encoded-cwd dir.
-    if (kind === "claude_resume" && source.type === "session") {
+    //
+    // Both `session` and `remote_session` sources carry the session id as
+    // `source.id` (a reassembled remote session has the same uuid as on the
+    // origin device). Link both — otherwise the ResumeDialog "Open in Oyster"
+    // path would never get its title linked to the Inspector.
+    if (kind === "claude_resume" && (source.type === "session" || source.type === "remote_session")) {
       deps.claudePtyManager.setLinkedSession(terminalId, source.id);
       deps.broadcastUiEvent({
         version: 1,

--- a/server/src/terminal-launcher.ts
+++ b/server/src/terminal-launcher.ts
@@ -5,10 +5,9 @@
 // installer at `~/.claude/local/claude`). The route surfaces a clean
 // `binary_not_found` to the UI when none of the candidates resolve.
 
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter as PATH_DELIM, dirname, join } from "node:path";
 
 export type ResolveResult =
   | { ok: true; path: string }
@@ -47,18 +46,25 @@ export function resolveClaudeBinary(packageRoot: string): ResolveResult {
     }
   }
 
-  // 4. PATH lookup.
-  try {
-    const which = isWin ? "where" : "which";
-    const out = execFileSync(which, ["claude"], {
-      stdio: ["ignore", "pipe", "ignore"],
-      encoding: "utf8",
-      timeout: 2000,
-    });
-    const firstLine = out.split(/\r?\n/).map((s) => s.trim()).find((s) => s.length > 0);
-    if (firstLine && existsSync(firstLine)) return { ok: true, path: firstLine };
-  } catch {
-    /* not on PATH */
+  // 4. Walk $PATH ourselves. Earlier versions shelled out to `which`/`where`
+  //    via `execFileSync` with a 2s timeout — a synchronous subprocess
+  //    blocks the Node event loop for every other in-flight request, and
+  //    on slow / NFS-backed PATHs it could stall the server for the full
+  //    timeout. A pure-fs walk is faster, predictable, and (because each
+  //    `statSync` is cheap) tolerates a long PATH without trouble.
+  const pathEnv = process.env.PATH ?? "";
+  if (pathEnv) {
+    for (const dirEntry of pathEnv.split(PATH_DELIM)) {
+      if (!dirEntry) continue;
+      for (const name of names) {
+        const candidate = join(dirEntry, name);
+        // statSync absorbs ENOENT cheaply via try/catch; checking isFile()
+        // skips matching directories or sockets named `claude`.
+        try {
+          if (statSync(candidate).isFile()) return { ok: true, path: candidate };
+        } catch { /* not here */ }
+      }
+    }
   }
 
   return { ok: false, error: "binary_not_found" };

--- a/server/src/terminal-launcher.ts
+++ b/server/src/terminal-launcher.ts
@@ -1,0 +1,76 @@
+// Locate the `claude` CLI binary and build its launch args.
+//
+// We don't ship Claude Code as a dependency — users install it themselves
+// (`npm install -g @anthropic-ai/claude-code`, or via the official macOS
+// installer at `~/.claude/local/claude`). The route surfaces a clean
+// `binary_not_found` to the UI when none of the candidates resolve.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export type ResolveResult =
+  | { ok: true; path: string }
+  | { ok: false; error: "binary_not_found" };
+
+export function resolveClaudeBinary(packageRoot: string): ResolveResult {
+  const isWin = process.platform === "win32";
+  const names = isWin ? ["claude.cmd", "claude.ps1", "claude"] : ["claude"];
+
+  // 1. Explicit escape hatch.
+  const explicit = process.env.OYSTER_CLAUDE_BIN;
+  if (explicit && existsSync(explicit)) {
+    return { ok: true, path: explicit };
+  }
+
+  const candidates: string[] = [];
+
+  // 2. node_modules/.bin walks (claude bundled as a server dep, or hoisted).
+  candidates.push(join(packageRoot, "server", "node_modules", ".bin"));
+  candidates.push(join(packageRoot, "node_modules", ".bin"));
+  let dir = packageRoot;
+  for (let i = 0; i < 5; i++) {
+    candidates.push(join(dir, "node_modules", ".bin"));
+    dir = dirname(dir);
+  }
+
+  // 3. Common official install locations.
+  const home = homedir();
+  candidates.push(join(home, ".claude", "local"));
+  candidates.push(join(home, ".npm-global", "bin"));
+
+  for (const root of candidates) {
+    for (const name of names) {
+      const candidate = join(root, name);
+      if (existsSync(candidate)) return { ok: true, path: candidate };
+    }
+  }
+
+  // 4. PATH lookup.
+  try {
+    const which = isWin ? "where" : "which";
+    const out = execFileSync(which, ["claude"], {
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+      timeout: 2000,
+    });
+    const firstLine = out.split(/\r?\n/).map((s) => s.trim()).find((s) => s.length > 0);
+    if (firstLine && existsSync(firstLine)) return { ok: true, path: firstLine };
+  } catch {
+    /* not on PATH */
+  }
+
+  return { ok: false, error: "binary_not_found" };
+}
+
+export function buildLaunchArgs(
+  kind: "claude_new" | "claude_resume",
+  sessionId?: string,
+): string[] {
+  if (kind === "claude_resume") {
+    if (!sessionId) throw new Error("buildLaunchArgs: claude_resume requires sessionId");
+    return ["--resume", sessionId];
+  }
+  return [];
+}

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -193,6 +193,110 @@ export class ClaudeCodeWatcher {
     this.fileLocks.clear();
   }
 
+  /** Resolve once a new `.jsonl` lands under `<root>/<encodedCwd>/`. Used by
+   *  the terminal-launch flow to auto-link a freshly spawned claude PTY to
+   *  the session row the watcher will produce.
+   *
+   *  Belt-and-braces:
+   *   1. Sync directory scan — covers the race where claude writes its
+   *      first line before any chokidar `add` event fires. Exactly one
+   *      qualifying file → resolve with its uuid. More than one → resolve
+   *      `null` (ambiguous; wrong link is worse than no link).
+   *   2. Subscribe to the watcher's existing chokidar `add` events for
+   *      `timeoutMs`. First match resolves; a second arrival before
+   *      resolution rejects to `null`.
+   *   3. Timeout → resolve `null`.
+   *
+   *  Never throws — auto-link is strictly best-effort. */
+  async onceNewJsonl(
+    encodedCwd: string,
+    sinceMs: number,
+    timeoutMs = 5_000,
+  ): Promise<{ sessionId: string } | null> {
+    const targetDir = join(this.root, encodedCwd);
+
+    // Step 1 — sync scan with a 1s back-window to absorb mtime resolution
+    // and the gap between sinceMs capture and the JSONL write.
+    try {
+      const entries = await fs.readdir(targetDir);
+      const matched: string[] = [];
+      for (const name of entries) {
+        if (!name.endsWith(".jsonl")) continue;
+        try {
+          const st = await fs.stat(join(targetDir, name));
+          if (st.mtimeMs >= sinceMs - 1000) matched.push(name);
+        } catch { /* file vanished between readdir and stat */ }
+      }
+      if (matched.length === 1) {
+        return { sessionId: filenameToSessionId(matched[0]!) };
+      }
+      if (matched.length > 1) return null; // ambiguous
+    } catch {
+      // Directory doesn't exist yet — claude will create it. Fall through
+      // to the watcher subscription path.
+    }
+
+    // Step 2 — subscribe to the chokidar `add` event for the remainder of
+    // `timeoutMs`. If chokidar hasn't started yet (rare: server still
+    // booting), the subscriber resolves only via timeout.
+    if (!this.watcher) {
+      return new Promise((resolve) => setTimeout(() => resolve(null), timeoutMs));
+    }
+
+    return new Promise<{ sessionId: string } | null>((resolve) => {
+      const watcher = this.watcher!;
+      let resolved = false;
+      let timer: NodeJS.Timeout | null = null;
+
+      const cleanup = (): void => {
+        if (timer) clearTimeout(timer);
+        watcher.off("add", onAdd);
+      };
+
+      const onAdd = (path: string): void => {
+        if (resolved) return;
+        if (!path.endsWith(".jsonl")) return;
+        if (basename(dirname(path)) !== encodedCwd) return;
+        // mtime check — only count files actually fresh relative to spawn.
+        fs.stat(path).then(
+          (st) => {
+            if (resolved) return;
+            if (st.mtimeMs < sinceMs - 1000) return;
+            // Ambiguity: if another candidate already appeared, reject.
+            if (resolveState.firstSessionId) {
+              resolved = true;
+              cleanup();
+              resolve(null);
+              return;
+            }
+            resolveState.firstSessionId = filenameToSessionId(path);
+            // Slight delay to detect simultaneous additions racing each other.
+            // 100ms is short enough to be invisible to users yet long enough
+            // to catch two claudes spawned in the same beat.
+            setTimeout(() => {
+              if (resolved) return;
+              resolved = true;
+              cleanup();
+              resolve({ sessionId: resolveState.firstSessionId! });
+            }, 100);
+          },
+          () => { /* stat failed; ignore */ },
+        );
+      };
+
+      const resolveState: { firstSessionId: string | null } = { firstSessionId: null };
+
+      watcher.on("add", onAdd);
+
+      timer = setTimeout(() => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+        resolve(null);
+      }, timeoutMs);
+    });
+  }
+
   // ── Boot reconciliation ─────────────────────────────────────────────────
   // Walk every .jsonl already on disk, upsert a session row for it, and seed
   // the offset tracker with the current file size so we don't replay history

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -246,10 +246,18 @@ export class ClaudeCodeWatcher {
     return new Promise<{ sessionId: string } | null>((resolve) => {
       const watcher = this.watcher!;
       let resolved = false;
-      let timer: NodeJS.Timeout | null = null;
+      let outerTimer: NodeJS.Timeout | null = null;
+      // The 100ms grace timer that waits for a second `add` before resolving
+      // with the first match. Tracked separately so cleanup() can cancel it —
+      // without that, a 5s outer timeout firing mid-grace would call
+      // resolve(null) and then the 100ms timer would later try to
+      // resolve({sessionId}) on the already-settled promise (silently
+      // dropped), losing a perfectly good link.
+      let graceTimer: NodeJS.Timeout | null = null;
 
       const cleanup = (): void => {
-        if (timer) clearTimeout(timer);
+        if (outerTimer) clearTimeout(outerTimer);
+        if (graceTimer) clearTimeout(graceTimer);
         watcher.off("add", onAdd);
       };
 
@@ -273,7 +281,7 @@ export class ClaudeCodeWatcher {
             // Slight delay to detect simultaneous additions racing each other.
             // 100ms is short enough to be invisible to users yet long enough
             // to catch two claudes spawned in the same beat.
-            setTimeout(() => {
+            graceTimer = setTimeout(() => {
               if (resolved) return;
               resolved = true;
               cleanup();
@@ -288,7 +296,7 @@ export class ClaudeCodeWatcher {
 
       watcher.on("add", onAdd);
 
-      timer = setTimeout(() => {
+      outerTimer = setTimeout(() => {
         if (resolved) return;
         resolved = true;
         cleanup();

--- a/server/test/claude-code-once-new-jsonl.test.ts
+++ b/server/test/claude-code-once-new-jsonl.test.ts
@@ -1,0 +1,91 @@
+// Tests for `ClaudeCodeWatcher.onceNewJsonl` — the auto-link lookup used by
+// the terminal route to map a freshly spawned `claude` process to the
+// session UUID it creates.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ClaudeCodeWatcher } from "../src/watchers/claude-code.js";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+function makeWatcher(root: string) {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-once-jsonl-db-"));
+  const db = initDb(dir);
+  const sessionStore = new SqliteSessionStore(db);
+  const artifactStore = new SqliteArtifactStore(db);
+  const watcher = new ClaudeCodeWatcher({
+    sessionStore,
+    artifactStore,
+    lookupProject: () => ({ projectId: null, spaceId: null }),
+    projectsRoot: root,
+  });
+  return { watcher, db, cleanupDb: () => { db.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+describe("ClaudeCodeWatcher.onceNewJsonl", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "oyster-once-jsonl-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves null with no matches before the timeout", async () => {
+    const { watcher, cleanupDb } = makeWatcher(root);
+    try {
+      const result = await watcher.onceNewJsonl("-encoded-cwd", Date.now(), 200);
+      expect(result).toBeNull();
+    } finally {
+      await watcher.stop();
+      cleanupDb();
+    }
+  });
+
+  it("resolves the only qualifying file via sync scan", async () => {
+    const sessDir = join(root, "-encoded");
+    mkdirSync(sessDir, { recursive: true });
+    writeFileSync(join(sessDir, "session-abc.jsonl"), "{}\n");
+
+    const { watcher, cleanupDb } = makeWatcher(root);
+    try {
+      // sinceMs slightly in the past so the file is "fresh" enough.
+      const result = await watcher.onceNewJsonl("-encoded", Date.now() - 2000, 200);
+      expect(result).toEqual({ sessionId: "session-abc" });
+    } finally {
+      await watcher.stop();
+      cleanupDb();
+    }
+  });
+
+  it("resolves null when two qualifying files appear (ambiguous)", async () => {
+    const sessDir = join(root, "-encoded");
+    mkdirSync(sessDir, { recursive: true });
+    writeFileSync(join(sessDir, "s1.jsonl"), "{}\n");
+    writeFileSync(join(sessDir, "s2.jsonl"), "{}\n");
+
+    const { watcher, cleanupDb } = makeWatcher(root);
+    try {
+      const result = await watcher.onceNewJsonl("-encoded", Date.now() - 2000, 200);
+      expect(result).toBeNull();
+    } finally {
+      await watcher.stop();
+      cleanupDb();
+    }
+  });
+
+  it("never throws even if the directory doesn't exist", async () => {
+    const { watcher, cleanupDb } = makeWatcher(root);
+    try {
+      const result = await watcher.onceNewJsonl("-no-such-encoded", Date.now(), 200);
+      expect(result).toBeNull();
+    } finally {
+      await watcher.stop();
+      cleanupDb();
+    }
+  });
+});

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -1,0 +1,109 @@
+// Smoke tests for the multi-instance ClaudePtyManager. Each test spawns a
+// trivial shell (sh / sleep) — not `claude` itself — to exercise the
+// lifecycle without depending on Claude Code being installed in CI.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ClaudePtyManager, TerminalCapError, PtyUnavailableError } from "../src/claude-pty-manager.js";
+import { tmpdir, homedir } from "node:os";
+
+const SLEEP = process.platform === "win32" ? "ping" : "sleep";
+const SLEEP_ARGS = process.platform === "win32"
+  ? ["-n", "60", "127.0.0.1"]
+  : ["60"];
+
+describe("ClaudePtyManager", () => {
+  let mgr: ClaudePtyManager;
+
+  beforeEach(() => {
+    mgr = new ClaudePtyManager();
+  });
+  afterEach(() => {
+    mgr.disposeAll();
+  });
+
+  it("spawn returns an entry visible to list()", () => {
+    if (!mgr.isPtyAvailable()) return; // CI without node-pty: skip
+    const { terminalId } = mgr.spawn({
+      kind: "claude_new",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+    });
+    const list = mgr.list();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.terminalId).toBe(terminalId);
+    expect(list[0]!.alive).toBe(true);
+    expect(list[0]!.linkedSessionId).toBeNull();
+  });
+
+  it("setLinkedSession updates the entry's linkedSessionId", () => {
+    if (!mgr.isPtyAvailable()) return;
+    const { terminalId } = mgr.spawn({
+      kind: "claude_resume",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+    });
+    expect(mgr.setLinkedSession(terminalId, "session-uuid")).toBe(true);
+    const list = mgr.list();
+    expect(list[0]!.linkedSessionId).toBe("session-uuid");
+  });
+
+  it("rejects more than 8 concurrent terminals with TerminalCapError", () => {
+    if (!mgr.isPtyAvailable()) return;
+    for (let i = 0; i < 8; i++) {
+      mgr.spawn({
+        kind: "claude_new",
+        command: SLEEP,
+        args: SLEEP_ARGS,
+        cwd: tmpdir(),
+        env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+      });
+    }
+    expect(() => mgr.spawn({
+      kind: "claude_new",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+    })).toThrow(TerminalCapError);
+  });
+
+  it("kill() retires the entry from list() after disposeAll", () => {
+    if (!mgr.isPtyAvailable()) return;
+    const { terminalId } = mgr.spawn({
+      kind: "claude_new",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+    });
+    expect(mgr.kill(terminalId)).toBe(true);
+    mgr.disposeAll();
+    expect(mgr.list()).toHaveLength(0);
+  });
+
+  it("setLinkedSession returns false for unknown id", () => {
+    expect(mgr.setLinkedSession("nope", "x")).toBe(false);
+  });
+
+  it("kill() returns false for unknown id", () => {
+    expect(mgr.kill("nope")).toBe(false);
+  });
+
+  // Documents what happens on a host where node-pty failed to load —
+  // spawn must throw PtyUnavailableError rather than producing a half-
+  // initialised entry.
+  it("throws PtyUnavailableError if pty isn't available", () => {
+    if (mgr.isPtyAvailable()) return;
+    expect(() => mgr.spawn({
+      kind: "claude_new",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: {},
+    })).toThrow(PtyUnavailableError);
+  });
+});

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -85,6 +85,40 @@ describe("ClaudePtyManager", () => {
     expect(mgr.list()).toHaveLength(0);
   });
 
+  it("reaps a zombie entry whose process has died on next spawn", async () => {
+    if (!mgr.isPtyAvailable()) return;
+    // Spawn one terminal, kill its OS process out-of-band, then null out
+    // the entry's exitedAt to simulate the case where `proc.onExit` never
+    // fired (native error, hard kill before pty wiring, etc.). Next spawn
+    // should reap the zombie before counting against the cap.
+    const first = mgr.spawn({
+      kind: "claude_new",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+    });
+    const entry = mgr.getEntry(first.terminalId)!;
+    process.kill(entry.proc.pid, "SIGKILL");
+    // Give the kernel a beat to actually reap the process so the next
+    // `process.kill(pid, 0)` probe sees ESRCH.
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Pretend onExit never fired.
+    if (entry.evictTimer) { clearTimeout(entry.evictTimer); entry.evictTimer = null; }
+    entry.exitedAt = null;
+
+    const second = mgr.spawn({
+      kind: "claude_new",
+      command: SLEEP,
+      args: SLEEP_ARGS,
+      cwd: tmpdir(),
+      env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+    });
+    expect(second.terminalId).not.toBe(first.terminalId);
+    expect(mgr.getEntry(first.terminalId)?.exitedAt).not.toBeNull();
+  });
+
   it("setLinkedSession returns false for unknown id", () => {
     expect(mgr.setLinkedSession("nope", "x")).toBe(false);
   });

--- a/server/test/terminal-launcher.test.ts
+++ b/server/test/terminal-launcher.test.ts
@@ -1,0 +1,61 @@
+// Tests for `resolveClaudeBinary` and `buildLaunchArgs`. Pure helpers, so
+// covered with focused unit tests rather than full route exercising.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveClaudeBinary, buildLaunchArgs } from "../src/terminal-launcher.js";
+
+describe("buildLaunchArgs", () => {
+  it("returns [] for claude_new", () => {
+    expect(buildLaunchArgs("claude_new")).toEqual([]);
+  });
+  it("returns --resume <id> for claude_resume", () => {
+    expect(buildLaunchArgs("claude_resume", "abc-123")).toEqual(["--resume", "abc-123"]);
+  });
+  it("throws when claude_resume is called without a sessionId", () => {
+    expect(() => buildLaunchArgs("claude_resume")).toThrow();
+  });
+});
+
+describe("resolveClaudeBinary", () => {
+  let dir: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-claude-bin-"));
+    originalEnv = process.env.OYSTER_CLAUDE_BIN;
+    delete process.env.OYSTER_CLAUDE_BIN;
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalEnv === undefined) delete process.env.OYSTER_CLAUDE_BIN;
+    else process.env.OYSTER_CLAUDE_BIN = originalEnv;
+  });
+
+  it("respects OYSTER_CLAUDE_BIN when set and the path exists", () => {
+    const fakeBin = join(dir, "fake-claude");
+    writeFileSync(fakeBin, "#!/bin/sh\necho fake", "utf8");
+    chmodSync(fakeBin, 0o755);
+    process.env.OYSTER_CLAUDE_BIN = fakeBin;
+    const result = resolveClaudeBinary(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.path).toBe(fakeBin);
+  });
+
+  it("finds a binary at node_modules/.bin/claude under the package root", () => {
+    const binDir = join(dir, "server", "node_modules", ".bin");
+    mkdirSync(binDir, { recursive: true });
+    const bin = join(binDir, process.platform === "win32" ? "claude.cmd" : "claude");
+    writeFileSync(bin, "#!/bin/sh\necho fake", "utf8");
+    chmodSync(bin, 0o755);
+    const result = resolveClaudeBinary(dir);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.path).toBe(bin);
+  });
+
+  // Note: we don't unit-test the PATH `which` branch — it depends on the
+  // host environment and Cgi shells. The route-level integration test covers
+  // the binary_not_found error code returned to clients.
+});

--- a/server/test/terminals-route.test.ts
+++ b/server/test/terminals-route.test.ts
@@ -1,0 +1,225 @@
+// Unit tests for `resolveSourceCwd` — the heart of the source-typed
+// launch contract. Cwd is never accepted from the client; the resolver
+// turns a typed reference into a trusted cwd via the DB.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { ProjectService } from "../src/project-service.js";
+import { resolveSourceCwd } from "../src/routes/terminals.js";
+
+describe("resolveSourceCwd — project source", () => {
+  let dir: string;
+  let db: ReturnType<typeof initDb>;
+  let sessionStore: SqliteSessionStore;
+  let projectService: ProjectService;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-term-route-"));
+    db = initDb(dir);
+    sessionStore = new SqliteSessionStore(db);
+    projectService = new ProjectService(db);
+    // Seed a space so attachFolder succeeds.
+    db.prepare(
+      `INSERT INTO spaces (id, display_name, color, parent_id, scan_status)
+       VALUES (?, ?, NULL, NULL, 'none')`,
+    ).run("space-a", "Space A");
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolves cwd from a live project path", () => {
+    // Real folder on disk so existsSync passes.
+    const livePath = mkdtempSync(join(tmpdir(), "oyster-term-proj-"));
+    try {
+      const { project } = projectService.attachFolder({ spaceId: "space-a", path: livePath });
+      const result = resolveSourceCwd(
+        { type: "project", id: project.id },
+        {
+          db,
+          sessionStore,
+          projectService,
+          currentUserId: () => null,
+        },
+      );
+      expect("error" in result).toBe(false);
+      if (!("error" in result)) {
+        expect(result.cwd).toBe(livePath);
+      }
+    } finally {
+      rmSync(livePath, { recursive: true, force: true });
+    }
+  });
+
+  it("returns project_not_found for unknown id", () => {
+    const result = resolveSourceCwd(
+      { type: "project", id: "does-not-exist" },
+      { db, sessionStore, projectService, currentUserId: () => null },
+    );
+    expect(result).toEqual({ error: "project_not_found" });
+  });
+
+  it("returns project_homeless when the project has no live path", () => {
+    // Attach a path that we then delete — project becomes homeless.
+    const ephemeral = mkdtempSync(join(tmpdir(), "oyster-term-gone-"));
+    const { project } = projectService.attachFolder({ spaceId: "space-a", path: ephemeral });
+    rmSync(ephemeral, { recursive: true, force: true });
+
+    const result = resolveSourceCwd(
+      { type: "project", id: project.id },
+      { db, sessionStore, projectService, currentUserId: () => null },
+    );
+    expect(result).toEqual({ error: "project_homeless" });
+  });
+});
+
+describe("resolveSourceCwd — session source", () => {
+  let dir: string;
+  let db: ReturnType<typeof initDb>;
+  let sessionStore: SqliteSessionStore;
+  let projectService: ProjectService;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-term-route-"));
+    db = initDb(dir);
+    sessionStore = new SqliteSessionStore(db);
+    projectService = new ProjectService(db);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolves cwd from a local session row", () => {
+    const liveCwd = mkdtempSync(join(tmpdir(), "oyster-term-sess-"));
+    try {
+      sessionStore.upsertSession({
+        id: "s1",
+        space_id: null,
+        project_id: null,
+        cwd: liveCwd,
+        jsonl_path: null,
+        agent: "claude-code",
+        title: "test session",
+        state: "active",
+        started_at: new Date().toISOString(),
+        model: null,
+      });
+      const result = resolveSourceCwd(
+        { type: "session", id: "s1" },
+        { db, sessionStore, projectService, currentUserId: () => null },
+      );
+      expect("error" in result).toBe(false);
+      if (!("error" in result)) expect(result.cwd).toBe(liveCwd);
+    } finally {
+      rmSync(liveCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns session_not_found for unknown id", () => {
+    const result = resolveSourceCwd(
+      { type: "session", id: "nope" },
+      { db, sessionStore, projectService, currentUserId: () => null },
+    );
+    expect(result).toEqual({ error: "session_not_found" });
+  });
+
+  it("returns session_no_cwd when the row has no cwd", () => {
+    sessionStore.upsertSession({
+      id: "s2",
+      space_id: null,
+      project_id: null,
+      cwd: null,
+      jsonl_path: null,
+      agent: "claude-code",
+      title: null,
+      state: "active",
+      started_at: new Date().toISOString(),
+      model: null,
+    });
+    const result = resolveSourceCwd(
+      { type: "session", id: "s2" },
+      { db, sessionStore, projectService, currentUserId: () => null },
+    );
+    expect(result).toEqual({ error: "session_no_cwd" });
+  });
+
+  it("returns session_cwd_missing when the cwd doesn't exist", () => {
+    sessionStore.upsertSession({
+      id: "s3",
+      space_id: null,
+      project_id: null,
+      cwd: "/this/path/does/not/exist/anywhere",
+      jsonl_path: null,
+      agent: "claude-code",
+      title: null,
+      state: "active",
+      started_at: new Date().toISOString(),
+      model: null,
+    });
+    const result = resolveSourceCwd(
+      { type: "session", id: "s3" },
+      { db, sessionStore, projectService, currentUserId: () => null },
+    );
+    expect(result).toEqual({ error: "session_cwd_missing" });
+  });
+});
+
+describe("resolveSourceCwd — remote_session source", () => {
+  let dir: string;
+  let db: ReturnType<typeof initDb>;
+  let sessionStore: SqliteSessionStore;
+  let projectService: ProjectService;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-term-route-"));
+    db = initDb(dir);
+    sessionStore = new SqliteSessionStore(db);
+    projectService = new ProjectService(db);
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns session_not_reassembled_yet when no user signed in", () => {
+    const result = resolveSourceCwd(
+      { type: "remote_session", id: "rs1" },
+      { db, sessionStore, projectService, currentUserId: () => null },
+    );
+    expect(result).toEqual({ error: "session_not_reassembled_yet" });
+  });
+
+  it("returns cwd_not_on_this_device when the jsonl has no cwd matching the encoded dir", () => {
+    // Mimic the on-disk shape `<root>/<encodedCwd>/<id>.jsonl`. The first
+    // line's `cwd` field doesn't encode to the parent dir, so pickJsonlCwd
+    // returns null and we get cwd_not_on_this_device.
+    const projectsRoot = join(dir, "projects");
+    const encoded = "-fake-encoded";
+    const sessDir = join(projectsRoot, encoded);
+    mkdirSync(sessDir, { recursive: true });
+    const jsonlPath = join(sessDir, "rs2.jsonl");
+    writeFileSync(jsonlPath, JSON.stringify({ cwd: "/some/other/path", type: "system" }) + "\n");
+
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO remote_sessions (owner_id, session_id, agent, state, has_bytes, jsonl_local_path,
+                                    started_at, last_event_at, cloud_updated_at, fetched_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "user-1", "rs2", "claude-code", "done", 1, jsonlPath,
+      new Date().toISOString(), new Date().toISOString(), now, now,
+    );
+
+    const result = resolveSourceCwd(
+      { type: "remote_session", id: "rs2" },
+      { db, sessionStore, projectService, currentUserId: () => "user-1" },
+    );
+    expect(result).toEqual({ error: "cwd_not_on_this_device" });
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ import { fetchSpaces, updateSpace, deleteSpace, convertFolderToSpace, promoteFol
 import type { Space, SetupProposal } from "../../shared/types";
 import { createSession, sendMessage } from "./data/chat-api";
 import { unpublishArtifact } from "./data/publish-api";
+import { launchAndOpen, humanError } from "./lib/launch-terminal";
 import "./App.css";
 
 // `?onboarding=force` wipes the dock's persisted state and pretends this
@@ -225,6 +226,10 @@ export default function App() {
       void fetchSpaces().then(setSpaces).catch(() => undefined);
       void loadArtifacts().then(setArtifacts).catch(() => undefined);
     }
+    if (event.command === "terminal_session_linked") {
+      const { terminalId, sessionId } = event.payload as { terminalId: string; sessionId: string };
+      dispatch({ type: "LINK_TERMINAL_SESSION", terminalId, sessionId });
+    }
   }), [loadArtifacts]);
 
   // Sync state from browser back/forward
@@ -316,6 +321,7 @@ export default function App() {
 
   const viewers = windows.filter((w) => w.type === "viewer");
   const terminalWindow = windows.find((w) => w.type === "terminal");
+  const claudeTerminals = windows.filter((w) => w.type === "claude_terminal");
 
   async function handleArtifactClick(artifact: Artifact) {
     if (artifact.status === "generating") return;
@@ -380,6 +386,53 @@ export default function App() {
     await stopAppApi(appName);
   }
 
+  // Spawn an in-app Claude PTY for a project. Failures (missing binary,
+  // homeless project, cap reached) are surfaced via a simple alert with
+  // copy guidance — the binary-missing case has the install hint.
+  const handleLaunchClaudeFromProject = useCallback(async (projectId: string) => {
+    const outcome = await launchAndOpen(
+      { kind: "claude_new", source: { type: "project", id: projectId } },
+      dispatch,
+    );
+    if (!outcome.ok) {
+      const hint = outcome.installHint ? `\n\n${outcome.installHint}` : "";
+      alert(`${humanError(outcome.error)}${hint}`);
+    }
+  }, []);
+
+  const handleLaunchClaudeFromSession = useCallback(
+    async (sessionId: string) => {
+      const outcome = await launchAndOpen(
+        { kind: "claude_resume", source: { type: "session", id: sessionId } },
+        dispatch,
+      );
+      if (!outcome.ok) {
+        const hint = outcome.installHint ? `\n\n${outcome.installHint}` : "";
+        alert(`${humanError(outcome.error)}${hint}`);
+      }
+    },
+    [],
+  );
+
+  // Remote-session "Open in Oyster" path (from ResumeDialog). Source is
+  // `remote_session`: server resolves the cwd from the reassembled jsonl on
+  // disk, so the dialog doesn't need to pass the cwd back. The dialog
+  // surfaces the error inline (so the user can still copy the command),
+  // so we return rather than alert.
+  const handleOpenRemoteInOyster = useCallback(
+    async (sessionId: string) => {
+      const outcome = await launchAndOpen(
+        { kind: "claude_resume", source: { type: "remote_session", id: sessionId } },
+        dispatch,
+      );
+      if (!outcome.ok) {
+        return { ok: false, error: humanError(outcome.error), installHint: outcome.installHint };
+      }
+      return { ok: true };
+    },
+    [],
+  );
+
   // T16-T18 will pass this to Desktop, ViewerWindow, and ChatBar.
   const handleArtifactPublish = useCallback((artifact: Artifact) => {
     if (artifact.builtin || artifact.plugin || artifact.status === "generating") return;
@@ -442,6 +495,9 @@ export default function App() {
         onSpaceDelete={handleSpaceDelete}
         onSpaceUpdate={handleSpaceUpdate}
         onSubViewActiveChange={setHomeSubViewActive}
+        onLaunchClaude={handleLaunchClaudeFromProject}
+        onLaunchClaudeFromSession={handleLaunchClaudeFromSession}
+        onOpenRemoteInOyster={handleOpenRemoteInOyster}
         desktopProps={{
           space: activeSpace,
           spaces: spaces.map((s) => s.id),
@@ -536,6 +592,28 @@ export default function App() {
             onClose={() => dispatch({ type: "CLOSE", id: terminalWindow.id })}
           />
         )}
+        {claudeTerminals.map((w, i) => (
+          <TerminalWindow
+            key={w.id}
+            defaultX={140 + i * 24}
+            defaultY={80 + i * 24}
+            zIndex={w.zIndex}
+            onFocus={() => dispatch({ type: "FOCUS", id: w.id })}
+            onClose={() => dispatch({ type: "CLOSE", id: w.id })}
+            terminalId={w.terminalId}
+            title={w.title}
+            linkedSessionId={w.linkedSessionId}
+            onOpenSession={(sessionId) => {
+              // Route to /s/<space>/sessions/<id>; the space prefix is required
+              // by the active routing today, so use the current activeSpace
+              // (the session inspector itself does its own resolve).
+              window.history.pushState(null, "", `/s/${activeSpace}/sessions/${sessionId}`);
+              // Nudge the router (mirrors how artifact navigation triggers
+              // a popstate elsewhere).
+              window.dispatchEvent(new PopStateEvent("popstate"));
+            }}
+          />
+        ))}
       </div>
 
       {showHardcoreGate && (

--- a/web/src/components/Home/ProjectTile.tsx
+++ b/web/src/components/Home/ProjectTile.tsx
@@ -11,6 +11,7 @@ import { PromptModal } from "../PromptModal";
 export function ProjectTile({
   project, artefactCount, sessionCounts, selected, onSelect, onChanged,
   isLastProject, spaceTotalSessions, onSpaceDelete, otherProjects,
+  onLaunchClaude,
 }: {
   project: Project;
   artefactCount: number;
@@ -24,6 +25,9 @@ export function ProjectTile({
   onSpaceDelete?: (spaceId: string) => Promise<void> | void;
   /** Other projects in the same space — populates the "Merge into…" picker. */
   otherProjects: Project[];
+  /** Spawn a Claude PTY in this project's folder. Disabled when the
+   *  project has no live path. */
+  onLaunchClaude?: (projectId: string) => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -142,6 +146,20 @@ export function ProjectTile({
         </button>
         {menuOpen && !mergePickerOpen && (
           <div className="home-project-tile-menu" role="menu">
+            {onLaunchClaude && (
+              <button
+                type="button"
+                className="home-project-tile-menu-item"
+                disabled={project.hasLivePath === false}
+                title={project.hasLivePath === false ? "This project has no folder on this machine." : `Run claude in ${project.recentPath ?? project.name}`}
+                onClick={() => {
+                  onLaunchClaude(project.id);
+                  setMenuOpen(false);
+                }}
+              >
+                Launch Claude here
+              </button>
+            )}
             <button
               type="button"
               className="home-project-tile-menu-item"

--- a/web/src/components/Home/ProjectTileGrid.tsx
+++ b/web/src/components/Home/ProjectTileGrid.tsx
@@ -12,6 +12,7 @@ export function ProjectTileGrid({
   spaceId, projects, projectArtefactCounts, sessionCountsByProject,
   selectedProjectId, setSelectedProjectId,
   totalCounts, showAttachForm, setShowAttachForm, onProjectsChanged, onSpaceDelete,
+  onLaunchClaude,
 }: {
   spaceId: string;
   projects: Project[];
@@ -27,6 +28,7 @@ export function ProjectTileGrid({
   setShowAttachForm: (v: boolean) => void;
   onProjectsChanged: () => void;
   onSpaceDelete?: (spaceId: string) => Promise<void> | void;
+  onLaunchClaude?: (projectId: string) => void;
 }) {
   // Sort by artefact count desc — busiest projects first.
   const sortedProjects = useMemo(
@@ -91,6 +93,7 @@ export function ProjectTileGrid({
             spaceTotalSessions={totalCounts.all}
             onSpaceDelete={onSpaceDelete}
             otherProjects={sortedProjects.filter((o) => o.id !== p.id)}
+            onLaunchClaude={onLaunchClaude}
           />
         ))}
 

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -51,6 +51,13 @@ interface Props {
    *  drop the chat bar out of hero mode so it stops occluding sub-view
    *  content. */
   onSubViewActiveChange?: (active: boolean) => void;
+  /** Spawn an in-app Claude PTY in the given project's recent path. */
+  onLaunchClaude?: (projectId: string) => void;
+  /** Resume a session in an Oyster terminal (`claude --resume <id>`). */
+  onLaunchClaudeFromSession?: (sessionId: string) => void;
+  /** Launch a remote (cross-device) session in an Oyster terminal once
+   *  reassemble has completed. Threaded to ResumeDialog via SessionInspector. */
+  onOpenRemoteInOyster?: (sessionId: string) => Promise<import("../SessionInspector/ResumeDialog").OpenInOysterResult>;
 }
 
 const ARTEFACT_SOURCE_ORDER: ArtefactSource[] = ["all", "manual", "ai_generated", "discovered", "published", "pinned"];
@@ -127,7 +134,7 @@ const FILTER_LABELS: Record<StateFilter, string> = {
   all: "all",
 };
 
-export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange }: Props) {
+export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster }: Props) {
   const { sessions, error, loading } = useSessions();
   const signedIn = useAuthSignedIn();
   const myDevice = useMyDeviceId();
@@ -967,6 +974,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
               setShowAttachForm={setShowAttachForm}
               onProjectsChanged={refreshSpaceProjects}
               onSpaceDelete={onSpaceDelete}
+              onLaunchClaude={onLaunchClaude}
             />
           )
         )}
@@ -1313,6 +1321,8 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
               setActivePanel(null);
               alert("Session no longer available");
             }}
+            onLaunchClaude={onLaunchClaudeFromSession}
+            onOpenInOyster={onOpenRemoteInOyster}
           />
         )}
         {activePanel?.kind === "artefact" && activeArtefact && (

--- a/web/src/components/SessionInspector/Header.tsx
+++ b/web/src/components/SessionInspector/Header.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import type { Session, SessionState } from "../../data/sessions-api";
 import { useMyDeviceId } from "../../hooks/useMyDeviceId";
 import { SessionActions } from "./SessionActions";
-import { ResumeDialog } from "./ResumeDialog";
+import { ResumeDialog, type OpenInOysterResult } from "./ResumeDialog";
 import { formatTs } from "./utils";
 
 const PIP_CLASS: Record<SessionState, string> = {
@@ -20,7 +20,15 @@ const STATE_LABEL: Record<SessionState, string> = {
   done: "done",
 };
 
-export function Header({ session, onClose }: { session: Session; onClose: () => void }) {
+export function Header({ session, onClose, onLaunchClaude, onOpenInOyster }: {
+  session: Session;
+  onClose: () => void;
+  /** Resume this session in an Oyster terminal (`claude --resume <id>`). */
+  onLaunchClaude?: () => void;
+  /** Launch a remote (cross-device) session in an Oyster terminal once
+   *  its bytes have been reassembled. Surfaced by the ResumeDialog OkPanel. */
+  onOpenInOyster?: (sessionId: string) => Promise<OpenInOysterResult>;
+}) {
   const myDevice = useMyDeviceId();
   const myDeviceId = myDevice?.deviceId ?? null;
   // Show the Resume affordance only on remote sessions. A null myDeviceId
@@ -50,7 +58,7 @@ export function Header({ session, onClose }: { session: Session; onClose: () => 
         {session.id} · started {formatTs(session.startedAt)}
         {session.model ? ` · ${session.model}` : ""}
       </div>
-      <SessionActions session={session} />
+      <SessionActions session={session} onLaunchClaude={onLaunchClaude} />
 
       {isRemote && (
         <div className="inspector-resume">
@@ -69,7 +77,11 @@ export function Header({ session, onClose }: { session: Session; onClose: () => 
       )}
 
       {resumeOpen && (
-        <ResumeDialog session={session} onClose={() => setResumeOpen(false)} />
+        <ResumeDialog
+          session={session}
+          onClose={() => setResumeOpen(false)}
+          onOpenInOyster={onOpenInOyster}
+        />
       )}
     </header>
   );

--- a/web/src/components/SessionInspector/ResumeDialog.tsx
+++ b/web/src/components/SessionInspector/ResumeDialog.tsx
@@ -21,9 +21,22 @@ import { useEffect, useState } from "react";
 import type { Session } from "../../data/sessions-api";
 import { resumeSession, type SessionResumeResponse } from "../../data/sessions-api";
 
+// Result shape for the "Open in Oyster" path. ResumeDialog renders a small
+// error message inline on failure; the parent owns the actual launch.
+export interface OpenInOysterResult {
+  ok: boolean;
+  error?: string;
+  installHint?: string;
+}
+
 interface ResumeDialogProps {
   session: Session;
   onClose: () => void;
+  /** Launch the resumed session inside an Oyster terminal window. Called
+   *  from the OkPanel "Open in Oyster" button. Returns whether the launch
+   *  succeeded so the panel can surface failures inline (e.g. binary not
+   *  found) without dismissing the dialog. */
+  onOpenInOyster?: (sessionId: string) => Promise<OpenInOysterResult>;
 }
 
 interface DialogState {
@@ -38,7 +51,7 @@ interface DialogState {
   loading: boolean;
 }
 
-export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
+export function ResumeDialog({ session, onClose, onOpenInOyster }: ResumeDialogProps) {
   const [state, setState] = useState<DialogState>({
     response: null,
     draftCwd: "",
@@ -109,7 +122,12 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
       )}
 
       {!state.loading && state.response?.status === "ok" && (
-        <OkPanel response={state.response} copied={copied} onCopy={copyCommand} />
+        <OkPanel
+          response={state.response}
+          copied={copied}
+          onCopy={copyCommand}
+          onOpenInOyster={onOpenInOyster ? () => onOpenInOyster(session.id) : undefined}
+        />
       )}
 
       {!state.loading && state.response?.status === "needs_target" && (
@@ -148,12 +166,33 @@ export function ResumeDialog({ session, onClose }: ResumeDialogProps) {
 // ── Panels ──
 
 function OkPanel({
-  response, copied, onCopy,
+  response, copied, onCopy, onOpenInOyster,
 }: {
   response: Extract<SessionResumeResponse, { status: "ok" }>;
   copied: boolean;
   onCopy: (cmd: string) => void;
+  onOpenInOyster?: () => Promise<OpenInOysterResult>;
 }) {
+  const [busy, setBusy] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
+  const [openHint, setOpenHint] = useState<string | null>(null);
+
+  async function handleOpen(): Promise<void> {
+    if (!onOpenInOyster) return;
+    setBusy(true);
+    setOpenError(null);
+    setOpenHint(null);
+    try {
+      const result = await onOpenInOyster();
+      if (!result.ok) {
+        setOpenError(result.error ?? "launch_failed");
+        setOpenHint(result.installHint ?? null);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div className="resume-panel resume-ok">
       <p>Transcript ready at <code>{response.jsonlPath}</code>.</p>
@@ -163,7 +202,18 @@ function OkPanel({
         <button type="button" onClick={() => onCopy(response.command)}>
           {copied ? "Copied" : "Copy command"}
         </button>
+        {onOpenInOyster && (
+          <button type="button" disabled={busy} onClick={handleOpen}>
+            {busy ? "Opening…" : "Open in Oyster"}
+          </button>
+        )}
       </div>
+      {openError && (
+        <div className="resume-open-error" style={{ marginTop: 8, color: "var(--text-dim)" }}>
+          {openError}
+          {openHint && <div style={{ marginTop: 4 }}><code>{openHint}</code></div>}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/SessionInspector/SessionActions.tsx
+++ b/web/src/components/SessionInspector/SessionActions.tsx
@@ -9,7 +9,13 @@ function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
-export function SessionActions({ session }: { session: Session }) {
+export function SessionActions({ session, onLaunchClaude }: {
+  session: Session;
+  /** Continue this session in an Oyster terminal (`claude --resume`).
+   *  "Start new" lives on the project tile, not here — the inspector is
+   *  about *this* transcript. */
+  onLaunchClaude?: () => void;
+}) {
   const [copiedCmd, setCopiedCmd] = useState(false);
   const [copiedId, setCopiedId] = useState(false);
   // `cd --` disables option parsing so a path beginning with `-` (or
@@ -19,6 +25,11 @@ export function SessionActions({ session }: { session: Session }) {
   const command = session.cwd
     ? `cd -- ${shellQuote(session.cwd)} && claude --resume ${session.id}`
     : `claude --resume ${session.id}`;
+
+  // "Resume here" is meaningful only on local sessions that still have a
+  // cwd recorded. Remote (cross-device) sessions surface launch via the
+  // ResumeDialog after reassembly.
+  const canResumeInOyster = Boolean(onLaunchClaude && session.cwd && session.originDeviceId == null);
 
   function copyCommand() {
     if (!navigator.clipboard) {
@@ -50,7 +61,17 @@ export function SessionActions({ session }: { session: Session }) {
 
   return (
     <div className="inspector-actions">
-      <button type="button" className="btn primary" onClick={copyCommand}>
+      {canResumeInOyster && (
+        <button
+          type="button"
+          className="btn primary"
+          onClick={() => onLaunchClaude!()}
+          title={`Run claude --resume ${session.id} in ${session.cwd}`}
+        >
+          Resume here
+        </button>
+      )}
+      <button type="button" className="btn" onClick={copyCommand}>
         {copiedCmd ? "Copied!" : "Copy resume command"}
       </button>
       <button type="button" className="btn" onClick={copyId}>

--- a/web/src/components/SessionInspector/index.tsx
+++ b/web/src/components/SessionInspector/index.tsx
@@ -44,9 +44,16 @@ interface Props {
   onOpenArtefact: (artefact: Artifact) => void;
   onClose: () => void;
   onNotFound: () => void;
+  /** Resume this session in an Oyster terminal (`claude --resume <id>`).
+   *  Optional: when omitted, the "Resume here" button is hidden and the
+   *  user falls back to copying the resume command. */
+  onLaunchClaude?: (sessionId: string) => void;
+  /** Launch a remote (cross-device) session in an Oyster terminal once
+   *  its bytes have been reassembled. Threaded through to ResumeDialog. */
+  onOpenInOyster?: (sessionId: string) => Promise<import("./ResumeDialog").OpenInOysterResult>;
 }
 
-export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, onSwitchTo, onOpenArtefact, onClose, onNotFound }: Props) {
+export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, onSwitchTo, onOpenArtefact, onClose, onNotFound, onLaunchClaude, onOpenInOyster }: Props) {
   const [session, setSession] = useState<Session | null>(null);
   const [events, setEvents] = useState<SessionEvent[] | null>(null);
   const [artefacts, setArtefacts] = useState<SessionArtifactJoined[] | null>(null);
@@ -269,7 +276,12 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
 
   return (
     <>
-      <Header session={session} onClose={onClose} />
+      <Header
+        session={session}
+        onClose={onClose}
+        onLaunchClaude={onLaunchClaude ? () => onLaunchClaude(session.id) : undefined}
+        onOpenInOyster={onOpenInOyster}
+      />
       <Banner session={session} />
       {isRemoteUnsynced ? (
         <div className="inspector-empty" style={{ padding: "32px 28px", lineHeight: 1.6 }}>

--- a/web/src/components/TerminalWindow.tsx
+++ b/web/src/components/TerminalWindow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -11,9 +11,18 @@ interface Props {
   zIndex: number;
   onFocus?: () => void;
   onClose: () => void;
+  /** When set, connect to /ws/terminal?id=<terminalId> (Claude PTY).
+   *  When absent, connect to the legacy root path (OpenCode singleton). */
+  terminalId?: string;
+  /** Title shown in the window chrome. Defaults to "opencode" for legacy
+   *  shells. */
+  title?: string;
+  /** When non-null, render the title as a button that opens the inspector
+   *  for this session. */
+  linkedSessionId?: string;
+  /** Optional callback fired when the user clicks a linked title. */
+  onOpenSession?: (sessionId: string) => void;
 }
-
-const WS_URL = `ws://${window.location.host}`;
 
 export function TerminalWindow({
   defaultX,
@@ -21,11 +30,27 @@ export function TerminalWindow({
   zIndex,
   onFocus,
   onClose,
+  terminalId,
+  title,
+  linkedSessionId,
+  onOpenSession,
 }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+
+  const wsUrl = useMemo(() => {
+    const proto = window.location.protocol === "https:" ? "wss" : "ws";
+    const host = window.location.host;
+    if (terminalId) {
+      return `${proto}://${host}/ws/terminal?id=${encodeURIComponent(terminalId)}`;
+    }
+    // Legacy singleton — root path.
+    return `${proto}://${host}`;
+  }, [terminalId]);
+
+  const isClaudeTerm = !!terminalId;
 
   useEffect(() => {
     if (!termRef.current) return;
@@ -67,16 +92,21 @@ export function TerminalWindow({
     terminal.open(termRef.current);
     fitAddon.fit();
 
-    // Connect to WebSocket PTY server
-    const ws = new WebSocket(WS_URL);
+    const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 
-    ws.onopen = () => {
-      // Send initial size
-      const dims = fitAddon.proposeDimensions();
-      if (dims) {
-        ws.send(`\x01resize:${dims.cols},${dims.rows}`);
+    const sendResize = (cols: number, rows: number): void => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      if (isClaudeTerm) {
+        ws.send(JSON.stringify({ type: "resize", cols, rows }));
+      } else {
+        ws.send(`\x01resize:${cols},${rows}`);
       }
+    };
+
+    ws.onopen = () => {
+      const dims = fitAddon.proposeDimensions();
+      if (dims) sendResize(dims.cols, dims.rows);
     };
 
     ws.onmessage = (event) => {
@@ -93,20 +123,16 @@ export function TerminalWindow({
       );
     };
 
-    // Terminal input → WebSocket
     terminal.onData((data) => {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(data);
       }
     });
 
-    // Handle resize
     const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
       const dims = fitAddon.proposeDimensions();
-      if (dims && ws.readyState === WebSocket.OPEN) {
-        ws.send(`\x01resize:${dims.cols},${dims.rows}`);
-      }
+      if (dims) sendResize(dims.cols, dims.rows);
     });
     resizeObserver.observe(termRef.current);
 
@@ -115,11 +141,30 @@ export function TerminalWindow({
       ws.close();
       terminal.dispose();
     };
-  }, []);
+  }, [wsUrl, isClaudeTerm]);
+
+  const titleNode: React.ReactNode = linkedSessionId && onOpenSession ? (
+    <button
+      type="button"
+      onClick={() => onOpenSession(linkedSessionId)}
+      style={{
+        background: "none",
+        border: "none",
+        color: "inherit",
+        font: "inherit",
+        cursor: "pointer",
+        textDecoration: "underline",
+        padding: 0,
+      }}
+      title="Open in Session Inspector"
+    >
+      {title ?? "claude"}
+    </button>
+  ) : (title ?? "opencode");
 
   return (
     <WindowChrome
-      title="opencode"
+      title={titleNode}
       onFocus={onFocus}
       onClose={onClose}
       defaultX={defaultX}

--- a/web/src/components/WindowChrome.tsx
+++ b/web/src/components/WindowChrome.tsx
@@ -11,7 +11,7 @@ const MIN_W = 320;
 const MIN_H = 200;
 
 interface Props {
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   onFocus?: () => void;
   onClose: () => void;

--- a/web/src/data/terminals-api.ts
+++ b/web/src/data/terminals-api.ts
@@ -1,0 +1,71 @@
+// Client for /api/terminals/*. Source-typed launch contract; never sends a
+// raw cwd.
+import { getJson, del, ApiError } from "./http";
+
+export type LaunchKind = "claude_new" | "claude_resume";
+export type LaunchSource =
+  | { type: "project"; id: string }
+  | { type: "session"; id: string }
+  | { type: "remote_session"; id: string };
+
+export interface LaunchedTerminal {
+  terminalId: string;
+  kind: LaunchKind;
+  cwd: string;
+  displayName: string;
+  command: string;
+  args: string[];
+  startedAt: number;
+}
+
+export interface ListedTerminal {
+  terminalId: string;
+  kind: LaunchKind;
+  cwd: string;
+  command: string;
+  args: string[];
+  startedAt: number;
+  linkedSessionId: string | null;
+  alive: boolean;
+}
+
+export type LaunchResult =
+  | { ok: true; data: LaunchedTerminal }
+  | { ok: false; error: string; installHint?: string };
+
+export async function launchClaudeTerminal(input: {
+  kind: LaunchKind;
+  source: LaunchSource;
+}): Promise<LaunchResult> {
+  try {
+    const res = await fetch("/api/terminals", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: input.kind, source: input.source }),
+    });
+    if (!res.ok) {
+      let body: unknown = null;
+      try { body = await res.json(); } catch { /* non-JSON */ }
+      const err = typeof body === "object" && body && "error" in body
+        ? String((body as { error: unknown }).error)
+        : `http_${res.status}`;
+      const installHint = typeof body === "object" && body && "installHint" in body
+        ? String((body as { installHint: unknown }).installHint)
+        : undefined;
+      return { ok: false, error: err, installHint };
+    }
+    const data = await res.json() as LaunchedTerminal;
+    return { ok: true, data };
+  } catch (err) {
+    if (err instanceof ApiError) return { ok: false, error: err.message };
+    return { ok: false, error: err instanceof Error ? err.message : "launch_failed" };
+  }
+}
+
+export async function listTerminals(): Promise<ListedTerminal[]> {
+  return getJson<ListedTerminal[]>("/api/terminals");
+}
+
+export async function killTerminal(terminalId: string): Promise<void> {
+  await del(`/api/terminals/${encodeURIComponent(terminalId)}`);
+}

--- a/web/src/lib/launch-terminal.ts
+++ b/web/src/lib/launch-terminal.ts
@@ -1,0 +1,93 @@
+// Shared launch helper used by ProjectTile, SessionActions, and ResumeDialog.
+// Owns: POST to /api/terminals, dispatch OPEN_CLAUDE_TERMINAL, surface
+// failures via a single consistent UX (BinaryMissingModal + alert).
+//
+// The error vocabulary mirrors `routes/terminals.ts`. New codes added there
+// should be reflected in `humanError` to keep the UI honest.
+
+import type { Dispatch } from "react";
+import {
+  launchClaudeTerminal,
+  type LaunchKind,
+  type LaunchSource,
+} from "../data/terminals-api";
+import type { WindowAction } from "../stores/windows";
+
+function basename(p: string): string {
+  // Works for both POSIX and Windows separators. Trailing slash is stripped.
+  const trimmed = p.replace(/[/\\]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
+export interface LaunchOptions {
+  kind: LaunchKind;
+  source: LaunchSource;
+  /** Window title (e.g. session title for resume). If omitted, derived
+   *  from the resolved cwd's basename. */
+  titleHint?: string;
+}
+
+export type LaunchOutcome =
+  | { ok: true; terminalId: string }
+  | { ok: false; error: string; installHint?: string };
+
+export async function launchAndOpen(
+  options: LaunchOptions,
+  dispatch: Dispatch<WindowAction>,
+): Promise<LaunchOutcome> {
+  const result = await launchClaudeTerminal({ kind: options.kind, source: options.source });
+  if (!result.ok) {
+    return { ok: false, error: result.error, installHint: result.installHint };
+  }
+  const { terminalId, cwd, displayName, kind } = result.data;
+  const cwdBase = basename(cwd);
+  const titlePrefix = kind === "claude_resume" ? "resume" : "claude";
+  const title = `${titlePrefix} · ${options.titleHint ?? displayName ?? cwdBase}`;
+  dispatch({
+    type: "OPEN_CLAUDE_TERMINAL",
+    terminalId,
+    title,
+    cwd,
+    kind,
+  });
+  return { ok: true, terminalId };
+}
+
+/** Human-readable copy for the error codes the route can return. Keep in
+ *  sync with `routes/terminals.ts`. */
+export function humanError(code: string): string {
+  switch (code) {
+    case "binary_not_found":
+      return "Claude Code isn't installed on this machine.";
+    case "project_not_found":
+      return "This project no longer exists.";
+    case "project_homeless":
+      return "This project has no folder on this machine. Attach it first.";
+    case "session_not_found":
+      return "This session is no longer in your local index.";
+    case "session_no_cwd":
+      return "This session has no recorded working folder.";
+    case "session_cwd_missing":
+      return "The session's working folder no longer exists on disk.";
+    case "session_not_reassembled_yet":
+      return "The session's transcript hasn't finished downloading. Try again in a moment.";
+    case "cwd_not_on_this_device":
+      return "The session's working folder doesn't exist on this device. Resume on the device that has it.";
+    case "cwd_not_a_directory":
+      return "The resolved path isn't a folder.";
+    case "too_many_terminals":
+      return "You have too many Claude terminals open. Close one and try again.";
+    case "pty_unavailable":
+      return "Native terminal support isn't installed in this build.";
+    case "invalid_kind":
+    case "invalid_source":
+    case "invalid_source_type":
+    case "resume_requires_session_source":
+    case "new_session_requires_project_or_session_source":
+    case "cwd_not_accepted":
+      return "Internal: invalid launch request.";
+    default:
+      return code;
+  }
+}

--- a/web/src/lib/launch-terminal.ts
+++ b/web/src/lib/launch-terminal.ts
@@ -1,6 +1,7 @@
 // Shared launch helper used by ProjectTile, SessionActions, and ResumeDialog.
-// Owns: POST to /api/terminals, dispatch OPEN_CLAUDE_TERMINAL, surface
-// failures via a single consistent UX (BinaryMissingModal + alert).
+// Owns: POST to /api/terminals, dispatch OPEN_CLAUDE_TERMINAL, return a
+// typed outcome the caller surfaces (project + session callsites alert();
+// ResumeDialog renders an inline error region inside its OkPanel).
 //
 // The error vocabulary mirrors `routes/terminals.ts`. New codes added there
 // should be reflected in `humanError` to keep the UI honest.
@@ -80,6 +81,8 @@ export function humanError(code: string): string {
       return "You have too many Claude terminals open. Close one and try again.";
     case "pty_unavailable":
       return "Native terminal support isn't installed in this build.";
+    case "watcher_not_ready":
+      return "Oyster is still starting up. Try again in a moment.";
     case "invalid_kind":
     case "invalid_source":
     case "invalid_source_type":

--- a/web/src/stores/windows.ts
+++ b/web/src/stores/windows.ts
@@ -1,4 +1,4 @@
-export type WindowType = "chat" | "viewer" | "terminal";
+export type WindowType = "chat" | "viewer" | "terminal" | "claude_terminal";
 
 export interface WindowState {
   id: string;
@@ -8,6 +8,15 @@ export interface WindowState {
   artifactPath?: string;
   zIndex: number;
   fullscreen: boolean;
+  /** Claude terminal: identifier passed back to /ws/terminal?id=…. */
+  terminalId?: string;
+  /** Claude terminal: cwd shown in the title bar. */
+  cwd?: string;
+  /** Claude terminal: kind drives the title prefix ("claude" vs "resume"). */
+  terminalKind?: "claude_new" | "claude_resume";
+  /** Claude terminal: session id once auto-link succeeds; turns the title
+   *  into a link to the Session Inspector. */
+  linkedSessionId?: string;
 }
 
 export type WindowAction =
@@ -17,6 +26,15 @@ export type WindowAction =
   | { type: "CLOSE_ALL_VIEWERS" }
   | { type: "UPDATE_STATUS"; id: string; statusText: string }
   | { type: "OPEN_TERMINAL" }
+  | {
+      type: "OPEN_CLAUDE_TERMINAL";
+      terminalId: string;
+      title: string;
+      cwd: string;
+      kind: "claude_new" | "claude_resume";
+      linkedSessionId?: string;
+    }
+  | { type: "LINK_TERMINAL_SESSION"; terminalId: string; sessionId: string }
   | { type: "FOCUS"; id: string }
   | { type: "TOGGLE_FULLSCREEN"; id: string }
   | { type: "NAVIGATE_VIEWER"; id: string; title: string; artifactPath: string };
@@ -120,6 +138,32 @@ export function windowsReducer(
           fullscreen: false,
         },
       ];
+    }
+    case "OPEN_CLAUDE_TERMINAL": {
+      // Always appends — multiple Claude terminals can coexist.
+      topZ++;
+      return [
+        ...state,
+        {
+          id: "claude-term-" + nextId++,
+          type: "claude_terminal",
+          title: action.title,
+          statusText: "",
+          zIndex: topZ,
+          fullscreen: false,
+          terminalId: action.terminalId,
+          cwd: action.cwd,
+          terminalKind: action.kind,
+          linkedSessionId: action.linkedSessionId,
+        },
+      ];
+    }
+    case "LINK_TERMINAL_SESSION": {
+      return state.map((w) =>
+        w.type === "claude_terminal" && w.terminalId === action.terminalId
+          ? { ...w, linkedSessionId: action.sessionId }
+          : w
+      );
     }
     case "FOCUS": {
       topZ++;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -43,6 +43,12 @@ export default defineConfig(({ mode }) => ({
         headers: { Accept: 'text/event-stream' },
       },
       '/api': target,
+      '/ws/terminal': {
+        // Backend uses `ws://localhost:<serverPort>/ws/terminal?id=…`.
+        // `ws: true` upgrades the HTTP proxy to a WebSocket proxy.
+        target: target.replace(/^http/, 'ws'),
+        ws: true,
+      },
       '/mcp': target,
       '/docs': target,
       '/artifacts': target,


### PR DESCRIPTION
## Summary

- New multi-instance Claude PTY service alongside the existing OpenCode singleton; cwd is never accepted from the client (typed `source` reference resolved server-side against project / session / remote_session rows).
- Three launch surfaces: *Launch Claude here* on Project tiles, *Resume here* in the Session Inspector, *Open in Oyster* in the ResumeDialog OkPanel — all sit alongside the existing Copy command paths.
- Best-effort auto-link from a freshly spawned `claude` to its new session UUID; the terminal title becomes a clickable link to the Session Inspector once the JSONL lands.

## What changes for the user

- A *Launch Claude here* menu item on each project tile spawns `claude` in that folder, inside an in-app terminal window.
- Session Inspector adds *Resume here* next to *Copy resume command* — picks the conversation back up via `claude --resume <id>` in an in-app terminal.
- Cross-device sessions: after the existing ResumeDialog reassembles the transcript, *Open in Oyster* spawns `claude --resume <id>` directly. Copy command remains for users who prefer their own terminal.
- Multiple Claude terminals can run side-by-side (cap of 8).

## What's untouched

- Legacy OpenCode terminal — only its WS upgrade routing moved (`noServer: true` + explicit `/`/`/ws/terminal` dispatcher). Boot-time spawn, lazy-spawn, scrollback, Hardcore gate all preserved.
- No new client cwd input — every launch resolves cwd from a trusted DB reference.

## Architecture notes

- `server/src/claude-pty-manager.ts` — `Map<terminalId, ...>` with 30s post-exit retention so transient WS reconnects can still replay the closing frames. Cap of 8 enforced at spawn.
- `server/src/terminal-launcher.ts` — `claude` binary discovery (env / node_modules / official install / `which`). `binary_not_found` is surfaced to the UI with an install hint, never spawns a broken PTY.
- `server/src/watchers/claude-code.ts:onceNewJsonl` — sync dir scan first, then chokidar `add` subscription, then timeout. Ambiguity → resolve null (no link is better than a wrong link). Never throws.
- Resume *here* gets its session id wired synchronously at spawn time. Fresh launches use `onceNewJsonl`.
- `server/src/routes/terminals.ts` — POST validates kind + source, refuses `cwd` in the body, resolves via `resolveSourceCwd`, returns `{ terminalId, cwd, displayName, command, args, startedAt }`. GET lists, DELETE is idempotent. Cap → 429. Binary missing → 400 with hint.

## Test plan

- [ ] `cd server && npx vitest run` — 400/400 pass (16 new across `claude-pty-manager`, `terminal-launcher`, `terminals-route`, `claude-code-once-new-jsonl`).
- [ ] `npm run build` from the repo root — clean.
- [ ] Manual: open a project tile menu → *Launch Claude here* → terminal opens running `claude` in the project's folder; title turns into a link within ~5s; click the title opens the Session Inspector for the new session.
- [ ] Manual: open that new session's Inspector → *Resume here* → second terminal opens running `claude --resume <id>` in the same folder; transcript continues.
- [ ] Manual: from a cross-device session row, run the existing Resume dialog through to `status: "ok"`. OkPanel shows both *Copy command* and *Open in Oyster*; the latter resumes inside Oyster.
- [ ] Manual: open eight terminals in different folders → ninth POST returns 429 with a clear message.
- [ ] Manual: temporarily hide the `claude` binary (`mv ~/.claude/local/claude{,.tmp}` etc.) → any launch shows the binary-not-found message with the install hint.
- [ ] Manual: legacy OpenCode terminal (Hardcore gate → *Open terminal*) still works.
- [ ] Manual: Ctrl-C the server → `ps -ef | grep claude` shows no orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)