### PR TITLE
Spotlight cmd+K: group transcript hits by session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Launch and resume Claude Code sessions inside Oyster.** *Launch Claude here* on a project tile starts a fresh `claude` session in the folder, inside an in-app terminal. *Resume here* on a Session Inspector continues that conversation via `claude --resume`. The cross-device Resume dialog now offers *Open in Oyster* alongside *Copy command*.
 - **Sign in to view your own protected shares.** A password-protected share now offers a "Have access? Sign in to view" option alongside the password field; if you're signed in to Oyster as the owner, you skip the password.
 
+### Changed
+
+- **Cmd+K results group by session.** Searching transcripts now returns one row per matching session — title, snippet preview, date, and space — instead of one row per matching line. A `+N` badge on the title shows how many more matches the session contains; opening still scrolls the inspector to the best match.
+
 ## [0.9.1] - 2026-05-16
 
 ### Added

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -267,8 +267,13 @@ export async function tryHandleSessionRoute(
   }
 
   // GET /api/sessions/search?q=…&session_id=…&space_id=…&limit=…
-  // R2 verbatim recall (#311). FTS5 over session_events.text. Mirrors the
-  // MCP `recall_transcripts` tool surface for the web UI.
+  // R2 verbatim recall (#311). FTS5 over session_events.text. Powers the
+  // Spotlight UI — results are grouped by session (one row per session
+  // with the best-ranked snippet) so a single chat with many matches
+  // doesn't flood the result list. When `session_id` is supplied (scoping
+  // to a single session) we drop back to event-level results since the
+  // collapse would always produce exactly one row.
+  // The MCP `recall_transcripts` tool keeps event-level results.
   // Local-origin only — transcripts are private user content.
   {
     const searchPath = url.split("?")[0];
@@ -290,17 +295,21 @@ export async function tryHandleSessionRoute(
         }
       }
       try {
-        const hits = sessionStore.searchEvents(q, { sessionId: scopeSession, spaceId: scopeSpace, limit });
-        // Rename `id` → `event_id` for the wire format (the web UI's
-        // ambient `id` is artefact id; explicit naming avoids confusion).
-        sendJson(hits.map((h) => ({
-          event_id: h.id,
-          session_id: h.session_id,
-          session_title: h.session_title,
-          role: h.role,
-          ts: h.ts,
-          snippet: h.snippet,
-        })));
+        if (scopeSession) {
+          const hits = sessionStore.searchEvents(q, { sessionId: scopeSession, spaceId: scopeSpace, limit });
+          sendJson(hits.map((h) => ({
+            event_id: h.id,
+            session_id: h.session_id,
+            session_title: h.session_title,
+            space_id: null,
+            last_event_at: h.ts,
+            role: h.role,
+            snippet: h.snippet,
+            match_count: 1,
+          })));
+        } else {
+          sendJson(sessionStore.searchSessions(q, { spaceId: scopeSpace, limit }));
+        }
       } catch (err) {
         sendError(err, 500);
       }

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -75,6 +75,25 @@ export interface SessionEventSearchHit {
   snippet: string;
 }
 
+/** A session-grouped search hit. One row per session, picking the
+ *  best-ranked matching event as the representative snippet. Used by
+ *  the Spotlight UI so a single session with many matches collapses
+ *  to a single row instead of flooding the result list. */
+export interface SessionSearchHit {
+  session_id: string;
+  session_title: string | null;
+  space_id: string | null;
+  /** Best-ranked matching event id, for click-through deep-linking. */
+  event_id: number;
+  role: SessionEventRole;
+  /** Timestamp of the *session* (last_event_at), for date display. */
+  last_event_at: string | null;
+  /** Highlighted excerpt of the best-ranked match. */
+  snippet: string;
+  /** Number of distinct matching events in this session. */
+  match_count: number;
+}
+
 // ── Insert shapes (let SQLite supply timestamps + auto-id) ──
 
 export interface InsertSession {
@@ -145,6 +164,10 @@ export interface SessionStore {
    *  `query` is natural language; tokenised to OR-joined terms inside the
    *  implementation. `sessionId` optionally scopes to one session. */
   searchEvents(query: string, opts?: { limit?: number; sessionId?: string; spaceId?: string }): SessionEventSearchHit[];
+  /** Same FTS5 search, but grouped by session — returns one row per
+   *  matching session with the best-ranked event as the representative
+   *  snippet plus a match_count. Used by the Spotlight UI. */
+  searchSessions(query: string, opts?: { limit?: number; spaceId?: string }): SessionSearchHit[];
 }
 
 // ── SQLite implementation ──
@@ -476,5 +499,62 @@ export class SqliteSessionStore implements SessionStore {
                  LIMIT ?`;
     params.push(limit);
     return this.db.prepare(sql).all(...params) as SessionEventSearchHit[];
+  }
+
+  searchSessions(
+    query: string,
+    opts: { limit?: number; spaceId?: string } = {},
+  ): SessionSearchHit[] {
+    // Same query-shape logic as searchEvents — keep them in sync.
+    const trimmed = query.trim();
+    if (trimmed.length === 0) return [];
+    if (!/[A-Za-z0-9]/.test(trimmed)) return [];
+    const isPlainWord = /^[A-Za-z0-9]+$/.test(trimmed);
+    let ftsQuery: string;
+    if (isPlainWord) {
+      if (trimmed.length < 2) return [];
+      ftsQuery = `${trimmed}*`;
+    } else {
+      ftsQuery = `"${trimmed.replace(/"/g, '""')}"`;
+    }
+    const limit = opts.limit ?? 20;
+
+    // FTS5's snippet() auxiliary can't be used in a SELECT that also wraps
+    // window functions ("unable to use function snippet in the requested
+    // context") — it needs to live in a query that directly scans the FTS
+    // virtual table under MATCH. So we materialize the snippet + raw rank
+    // in an inner CTE and let the outer CTE handle ROW_NUMBER / COUNT over
+    // those plain columns.
+    const innerWhere: string[] = ["session_events_fts MATCH ?"];
+    const innerParams: unknown[] = [ftsQuery];
+    if (opts.spaceId) { innerWhere.push("s.space_id = ?"); innerParams.push(opts.spaceId); }
+
+    const sql = `WITH matches AS (
+                   SELECT e.id, e.session_id, e.role,
+                          fts.rank AS m_rank,
+                          snippet(session_events_fts, 0, '[', ']', '…', 12) AS snippet
+                   FROM session_events e
+                   JOIN session_events_fts fts ON e.id = fts.rowid
+                   JOIN sessions s             ON s.id = e.session_id
+                   WHERE ${innerWhere.join(" AND ")}
+                 ),
+                 ranked AS (
+                   SELECT id, session_id, role, m_rank, snippet,
+                          ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY m_rank) AS rn,
+                          COUNT(*)     OVER (PARTITION BY session_id)                 AS match_count
+                   FROM matches
+                 )
+                 SELECT r.id AS event_id, r.session_id, r.role,
+                        r.snippet, r.match_count,
+                        s.title         AS session_title,
+                        s.space_id      AS space_id,
+                        s.last_event_at AS last_event_at
+                 FROM ranked r
+                 JOIN sessions s ON s.id = r.session_id
+                 WHERE r.rn = 1
+                 ORDER BY r.m_rank ASC
+                 LIMIT ?`;
+    innerParams.push(limit);
+    return this.db.prepare(sql).all(...innerParams) as SessionSearchHit[];
   }
 }

--- a/server/test/session-search-grouping.test.ts
+++ b/server/test/session-search-grouping.test.ts
@@ -71,21 +71,43 @@ describe("SqliteSessionStore.searchSessions", () => {
     expect(hits[0].snippet).toContain("[deposit]");
   });
 
-  it("returns one row per matching session, ordered by best rank", () => {
+  it("returns one row per matching session and excludes non-matching ones", () => {
     seedSpace(env.db, "ws");
     seedSession(env.db, { id: "a", title: "A", space_id: "ws" });
     seedSession(env.db, { id: "b", title: "B", space_id: "ws" });
     seedSession(env.db, { id: "c", title: "C", space_id: "ws" });
-    // Same word, distributed across three sessions
     env.store.insertEvent({ session_id: "a", role: "user", text: "talk about deposit cards" });
     env.store.insertEvent({ session_id: "b", role: "user", text: "no match here" });
     env.store.insertEvent({ session_id: "c", role: "user", text: "another deposit mention" });
 
     const hits = env.store.searchSessions("deposit");
+    // Two matching sessions returned, the non-matching `b` is excluded.
+    // Relative ordering between `a` and `c` is not asserted — their FTS
+    // ranks are equivalent here and BM25 tie-break order is fragile to
+    // assert on. A dedicated rank-ordering test below uses asymmetric
+    // inputs to lock that in deterministically.
     expect(hits).toHaveLength(2);
-    const ids = hits.map(h => h.session_id).sort();
-    expect(ids).toEqual(["a", "c"]);
+    const ids = new Set(hits.map(h => h.session_id));
+    expect(ids).toEqual(new Set(["a", "c"]));
     for (const h of hits) expect(h.match_count).toBe(1);
+  });
+
+  it("orders sessions by best FTS rank (stronger match first)", () => {
+    seedSpace(env.db, "ws");
+    seedSession(env.db, { id: "strong", title: "S", space_id: "ws" });
+    seedSession(env.db, { id: "weak", title: "W", space_id: "ws" });
+    // BM25 favours higher term frequency relative to doc length. A short
+    // event that's just the query token outranks a long event where the
+    // token appears once amongst many.
+    env.store.insertEvent({ session_id: "strong", role: "user", text: "deposit" });
+    env.store.insertEvent({
+      session_id: "weak",
+      role: "user",
+      text: "lorem ipsum dolor sit amet consectetur adipiscing elit deposit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+    });
+
+    const hits = env.store.searchSessions("deposit");
+    expect(hits.map(h => h.session_id)).toEqual(["strong", "weak"]);
   });
 
   it("scopes by space_id when given", () => {

--- a/server/test/session-search-grouping.test.ts
+++ b/server/test/session-search-grouping.test.ts
@@ -1,0 +1,123 @@
+// Spotlight session-grouped search: verifies that searchSessions collapses
+// multiple matching events into one row per session, picks the best-ranked
+// event as the representative, and returns match_count.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import type Database from "better-sqlite3";
+
+function seedSpace(db: Database.Database, id: string) {
+  db.prepare(
+    `INSERT INTO spaces (id, display_name, color, scan_status)
+     VALUES (?, ?, ?, 'none')`,
+  ).run(id, id, "#000");
+}
+
+function seedSession(
+  db: Database.Database,
+  fields: { id: string; title: string; space_id: string; last_event_at?: string },
+) {
+  db.prepare(
+    `INSERT INTO sessions
+       (id, space_id, cwd, agent, title, state,
+        started_at, last_event_at)
+     VALUES (?, ?, NULL, 'claude-code', ?, 'done',
+             '2026-05-15T10:00:00Z', ?)`,
+  ).run(fields.id, fields.space_id, fields.title, fields.last_event_at ?? "2026-05-15T10:30:00Z");
+}
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-sess-search-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  return {
+    dir,
+    db,
+    store,
+    dispose: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("SqliteSessionStore.searchSessions", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("collapses many matches in one session into a single row", () => {
+    seedSpace(env.db, "ws");
+    seedSession(env.db, { id: "s1", title: "Big session", space_id: "ws" });
+    // 5 events in the same session, all matching "deposit"
+    for (let i = 0; i < 5; i++) {
+      env.store.insertEvent({
+        session_id: "s1",
+        role: "assistant",
+        text: `something about deposit number ${i}`,
+      });
+    }
+
+    const hits = env.store.searchSessions("deposit");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].session_id).toBe("s1");
+    expect(hits[0].session_title).toBe("Big session");
+    expect(hits[0].space_id).toBe("ws");
+    expect(hits[0].match_count).toBe(5);
+    expect(hits[0].snippet).toContain("[deposit]");
+  });
+
+  it("returns one row per matching session, ordered by best rank", () => {
+    seedSpace(env.db, "ws");
+    seedSession(env.db, { id: "a", title: "A", space_id: "ws" });
+    seedSession(env.db, { id: "b", title: "B", space_id: "ws" });
+    seedSession(env.db, { id: "c", title: "C", space_id: "ws" });
+    // Same word, distributed across three sessions
+    env.store.insertEvent({ session_id: "a", role: "user", text: "talk about deposit cards" });
+    env.store.insertEvent({ session_id: "b", role: "user", text: "no match here" });
+    env.store.insertEvent({ session_id: "c", role: "user", text: "another deposit mention" });
+
+    const hits = env.store.searchSessions("deposit");
+    expect(hits).toHaveLength(2);
+    const ids = hits.map(h => h.session_id).sort();
+    expect(ids).toEqual(["a", "c"]);
+    for (const h of hits) expect(h.match_count).toBe(1);
+  });
+
+  it("scopes by space_id when given", () => {
+    seedSpace(env.db, "ws1");
+    seedSpace(env.db, "ws2");
+    seedSession(env.db, { id: "s1", title: "in ws1", space_id: "ws1" });
+    seedSession(env.db, { id: "s2", title: "in ws2", space_id: "ws2" });
+    env.store.insertEvent({ session_id: "s1", role: "user", text: "deposit one" });
+    env.store.insertEvent({ session_id: "s2", role: "user", text: "deposit two" });
+
+    const hits = env.store.searchSessions("deposit", { spaceId: "ws2" });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].session_id).toBe("s2");
+  });
+
+  it("returns empty for queries with no alphanumeric chars", () => {
+    seedSpace(env.db, "ws");
+    seedSession(env.db, { id: "s1", title: "T", space_id: "ws" });
+    env.store.insertEvent({ session_id: "s1", role: "user", text: "anything" });
+    expect(env.store.searchSessions("???")).toEqual([]);
+    expect(env.store.searchSessions("")).toEqual([]);
+  });
+
+  it("supports multi-word phrase queries", () => {
+    seedSpace(env.db, "ws");
+    seedSession(env.db, { id: "s1", title: "T", space_id: "ws" });
+    env.store.insertEvent({ session_id: "s1", role: "user", text: "we need deposit cards now" });
+    env.store.insertEvent({ session_id: "s1", role: "user", text: "deposit alone, no cards" });
+
+    const hits = env.store.searchSessions("deposit cards");
+    expect(hits).toHaveLength(1);
+    // match_count counts events that match the phrase, not just events mentioning either word
+    expect(hits[0].match_count).toBe(1);
+  });
+});

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1707,41 +1707,71 @@ body {
   font-size: 0.78rem;
   color: rgba(232, 233, 240, 0.35);
 }
-.spotlight-result--transcript {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 16px;
-}
-.spotlight-result-snippet {
-  font-size: 0.82rem;
-  color: rgba(232, 233, 240, 0.78);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 .spotlight-snippet-mark {
   background: rgba(124, 107, 255, 0.22);
   color: #c8bfff;
   padding: 0 2px;
   border-radius: 3px;
 }
-.spotlight-result-session {
-  font-size: 0.7rem;
-  color: rgba(232, 233, 240, 0.5);
-  font-family: var(--font-mono);
-  max-width: 140px;
+/* ── Session-grouped hits: title + snippet stacked, date/space on right ── */
+.spotlight-result--session {
+  display: grid;
+  grid-template-columns: 14px 1fr max-content;
+  align-items: center;
+  column-gap: 12px;
+  padding: 10px 16px;
+}
+.spotlight-result-session-icon {
+  color: rgba(232, 233, 240, 0.4);
+  justify-self: center;
+}
+.spotlight-result-session-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.spotlight-result-session-line1 {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.spotlight-result-session-title {
+  font-size: 0.9rem;
+  color: #e8e9f0;
+  font-weight: 500;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
 }
-.spotlight-result-role {
-  font-size: 0.62rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(232, 233, 240, 0.35);
-  font-family: var(--font-mono);
+.spotlight-result-session-count {
+  font-size: 0.65rem;
+  color: rgba(232, 233, 240, 0.4);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.spotlight-result-session-snippet {
+  font-size: 0.78rem;
+  color: rgba(232, 233, 240, 0.55);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.spotlight-result-session-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.spotlight-result-session-date {
+  font-size: 0.7rem;
+  color: rgba(232, 233, 240, 0.45);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .spotlight-token-chip {

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -525,9 +525,12 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
   );
 }
 
-/** ChatGPT-style compact relative date: "Today", "Yesterday", "8 May",
- *  or "8 May 2024" if older than the current year. Full ISO timestamp
- *  shown on hover via title attr at the row level. */
+/** ChatGPT-style compact relative date: "Today", "Yesterday", or a
+ *  short locale-formatted date — e.g. "8 May" / "May 8" — adding the
+ *  year only when older than the current calendar year. Day/month
+ *  ordering follows the user's locale (passing `undefined` lets the
+ *  runtime decide). The hover title at the row level shows the full
+ *  locale-formatted timestamp. */
 function formatHitDate(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "";

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -423,26 +423,45 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
             })}
 
             {(transcriptHits.length > 0 || transcriptsLoading) && (
-              <div className="spotlight-section-label">Transcripts</div>
+              <div className="spotlight-section-label">Sessions</div>
             )}
             {transcriptsLoading && transcriptHits.length === 0 && (
-              <div className="spotlight-section-loading">Searching transcripts…</div>
+              <div className="spotlight-section-loading">Searching sessions…</div>
             )}
             {transcriptHits.map((h, j) => {
               const flatIndex = artefactHits.length + j;
               const isSelected = flatIndex === selected;
+              const title = h.session_title ?? h.session_id.slice(0, 8);
               return (
                 <div
-                  key={`t-${h.event_id}`}
-                  className={`spotlight-result spotlight-result--transcript${isSelected ? " spotlight-result--selected" : ""}`}
+                  key={`t-${h.session_id}`}
+                  className={`spotlight-result spotlight-result--session${isSelected ? " spotlight-result--selected" : ""}`}
                   onMouseEnter={() => setSelected(flatIndex)}
                   onClick={() => activate({ kind: "transcript", hit: h })}
+                  title={h.last_event_at ? new Date(h.last_event_at).toLocaleString() : undefined}
                 >
-                  <span className="spotlight-result-snippet">
-                    <SnippetMarks text={h.snippet} />
-                  </span>
-                  <span className="spotlight-result-session">{h.session_title ?? h.session_id.slice(0, 8)}</span>
-                  <span className="spotlight-result-role">{h.role}</span>
+                  <svg className="spotlight-result-session-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+                  </svg>
+                  <div className="spotlight-result-session-body">
+                    <div className="spotlight-result-session-line1">
+                      <span className="spotlight-result-session-title">{title}</span>
+                      {h.match_count > 1 && (
+                        <span className="spotlight-result-session-count">+{h.match_count - 1}</span>
+                      )}
+                    </div>
+                    <div className="spotlight-result-session-snippet">
+                      <SnippetMarks text={h.snippet} />
+                    </div>
+                  </div>
+                  <div className="spotlight-result-session-meta">
+                    {h.last_event_at && (
+                      <span className="spotlight-result-session-date">{formatHitDate(h.last_event_at)}</span>
+                    )}
+                    {h.space_id && (
+                      <span className="spotlight-result-space" style={{ color: spaceColor(h.space_id), background: `${spaceColor(h.space_id)}18` }}>{h.space_id}</span>
+                    )}
+                  </div>
                 </div>
               );
             })}
@@ -504,6 +523,23 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       </div>
     </div>
   );
+}
+
+/** ChatGPT-style compact relative date: "Today", "Yesterday", "8 May",
+ *  or "8 May 2024" if older than the current year. Full ISO timestamp
+ *  shown on hover via title attr at the row level. */
+function formatHitDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const now = new Date();
+  const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const dayDiff = Math.round((startOf(now) - startOf(d)) / 86_400_000);
+  if (dayDiff === 0) return "Today";
+  if (dayDiff === 1) return "Yesterday";
+  const sameYear = d.getFullYear() === now.getFullYear();
+  return d.toLocaleDateString(undefined, sameYear
+    ? { day: "numeric", month: "short" }
+    : { day: "numeric", month: "short", year: "numeric" });
 }
 
 /** Renders FTS5 snippet text, turning the [bracketed] match markers

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -109,15 +109,20 @@ export async function fetchSessionMemory(id: string, signal?: AbortSignal): Prom
 }
 
 /** A transcript-search hit returned by GET /api/sessions/search.
- *  Slim by design — snippet already covers what the UI renders, and
- *  click-through loads the full event from the inspector. */
+ *  Grouped by session — one row per matching session, with the
+ *  best-ranked event as the representative snippet. `event_id` deep-
+ *  links to that event in the inspector. */
 export interface TranscriptHit {
   event_id: number;
   session_id: string;
   session_title: string | null;
+  space_id: string | null;
+  /** Session's last_event_at — used for the date column in the UI. */
+  last_event_at: string | null;
   role: string;
-  ts: string;
   snippet: string;
+  /** Total matches in this session (≥1). Surfaces "+N more" affordance. */
+  match_count: number;
 }
 
 export async function searchTranscripts(


### PR DESCRIPTION
## Summary

- Searching transcripts in cmd+K used to return one row per matching event, so a single session with many hits flooded the list (the *"R5 hardening"* / *"deposit cards"* case in the screenshots). Hits are now grouped server-side by session — one row per matching session with the best-ranked event as the representative snippet.
- Spotlight row redesign: chat-bubble icon · **session title** (with `+N` badge if more matches in the session) over a small snippet preview, with date and space chip stacked on the right. Date shows *Today / Yesterday / 8 May / 8 May 2024*; full ISO timestamp on row hover.
- MCP `recall_transcripts` keeps event-level results — that surface is for agents pulling verbatim transcripts.

## Implementation

- New `SqliteSessionStore.searchSessions` uses FTS5 → window functions (`ROW_NUMBER` per session + `COUNT(*)`) to collapse hits and pick the best-ranked event per session. `snippet()` is materialised in an inner CTE because FTS5 can't combine it with window functions in the same SELECT.
- `/api/sessions/search` calls `searchSessions` by default; falls back to event-level when scoped to a single session (`?session_id=…`).
- Wire shape: `TranscriptHit` gained `space_id`, `last_event_at`, `match_count`.

## Test plan

- [x] New unit tests in `server/test/session-search-grouping.test.ts` cover: multiple matches collapsing to one row with correct `match_count`; one row per matching session ordered by best rank; space scoping; punctuation-only query guard; phrase queries.
- [x] Full server suite still passes (406 tests).
- [x] Server + web typecheck clean; `npm run build` succeeds.
- [ ] Manual browser check: open cmd+K, search a term that hits many events in one session (e.g. "deposit"), confirm one row per session with snippet + date + space chip; opening a result still scrolls the inspector to the best match and highlights the term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)