### PR TITLE
fix(publish): allow popups in share.oyster.to iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **Links inside shared artefacts now click through.** External links in published prototypes (`target="_blank"`, `window.open`) open as expected instead of silently failing — the share.oyster.to iframe now permits popups, matching CodePen/JSFiddle/StackBlitz.
+
 ## [0.9.3] - 2026-05-19
 
 ### Added

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -289,6 +289,7 @@
   </section>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-9-3">0.9</a>
       <a class="version-pill" href="#v-0-8-2">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
@@ -302,6 +303,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.3...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong>Links inside shared artefacts now click through.</strong> External links in published prototypes (<code>target=&quot;_blank&quot;</code>, <code>window.open</code>) open as expected instead of silently failing — the share.oyster.to iframe now permits popups, matching CodePen/JSFiddle/StackBlitz.</li>
+</ul>
 <h2 id="v-0-9-3"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.1...v0.9.3" rel="noopener noreferrer"><span class="release-version">0.9.3</span></a><span class="release-date"> — 2026-05-19</span></h2>
 <h3>Added</h3>
 <ul>

--- a/infra/oyster-publish/src/viewer-render.ts
+++ b/infra/oyster-publish/src/viewer-render.ts
@@ -115,9 +115,12 @@ export function renderChromeWithIframe(row: PublicationRow): Response {
   // served from share.oyster.to, separate from the main app's cookies and
   // storage. allow-same-origin is now safe — apps can use real localStorage
   // / sessionStorage / IndexedDB, scoped to share.oyster.to. Sandbox stays
-  // as defense-in-depth (no plugins, no top-nav, no popups).
+  // as defense-in-depth (no plugins, no top-nav). allow-popups +
+  // allow-popups-to-escape-sandbox match the CodePen/JSFiddle/StackBlitz
+  // baseline so artifacts can link to external resources; popups open as
+  // fresh browsing contexts and do not inherit oyster privileges.
   const iframe = `
-<iframe sandbox="allow-scripts allow-same-origin" src="/p/${escapeAttr(row.share_token)}/raw"
+<iframe sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" src="/p/${escapeAttr(row.share_token)}/raw"
         style="border:0;width:100%;flex:1;display:block;"></iframe>`;
   // Iframe view: main fills remaining flex space and stretches the iframe to it.
   // Avoids vh-math that would drift when header height changes at responsive breakpoints.

--- a/infra/oyster-publish/test/viewer-handler.test.ts
+++ b/infra/oyster-publish/test/viewer-handler.test.ts
@@ -140,7 +140,7 @@ describe("GET /p/:token — open mode", () => {
     expect(res.headers.get("content-type")).toMatch(/^text\/html/);
     const body = await res.text();
     expect(body).toContain(`src="/p/${shareToken}/raw"`);
-    expect(body).toContain('sandbox="allow-scripts allow-same-origin"');
+    expect(body).toContain('sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"');
   });
 });
 

--- a/infra/oyster-publish/test/viewer-render.test.ts
+++ b/infra/oyster-publish/test/viewer-render.test.ts
@@ -141,8 +141,15 @@ describe("renderChromeWithIframe", () => {
   it("contains a sandboxed iframe pointing at /p/<token>/raw", async () => {
     const res = renderChromeWithIframe(ROW);
     const body = await res.text();
-    expect(body).toContain('sandbox="allow-scripts allow-same-origin"');
+    expect(body).toContain('sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"');
     expect(body).toContain('src="/p/app1/raw"');
+  });
+
+  it("permits popups so artifacts can link to external resources (CodePen/StackBlitz baseline)", async () => {
+    const res = renderChromeWithIframe(ROW);
+    const body = await res.text();
+    expect(body).toMatch(/sandbox="[^"]*allow-popups[^"]*"/);
+    expect(body).toMatch(/sandbox="[^"]*allow-popups-to-escape-sandbox[^"]*"/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `allow-popups allow-popups-to-escape-sandbox` to the `share.oyster.to/p/*` iframe sandbox. Links inside published artefacts (`target="_blank"`, `window.open`) were silently blocked on left-click — only ⌘-click worked.
- Matches the CodePen / JSFiddle / StackBlitz / Replit baseline for user-uploaded HTML previews. Popups open as fresh browsing contexts and do not inherit oyster-domain privileges.
- Update the explanatory comment in `viewer-render.ts` (it previously claimed "no popups" — now inaccurate).
- Tests: update the two existing sandbox assertions; add an explicit popup-permission test so the security intent is captured in tests, not just code comments.

## Background

See `docs/2026-05-19-iframe-sandbox-blocks-popups-bug.md` for the full bug write-up — repro, root cause, security analysis, and alternatives considered. Surfaced while reviewing a Tokinvest prototype whose Jira ticket chips didn't click through.

## Deploy status

Already deployed to production via `wrangler deploy` (version `4d40432c-3922-43e3-912d-b961606e2472`). This PR catches `main` up to what's already running.

## Test plan

- [x] `vitest run` in `infra/oyster-publish` — 163 passed (was 162, +1 new test documenting popup behaviour)
- [x] `tsc --noEmit` — clean
- [x] Manual: left-click an external link inside a published artefact on `share.oyster.to` opens a new tab (verified by Matt against the deployed worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)