### PR TITLE
Terminal × minimises; running pill + popover; Stop, fork warnings, polish

### DIFF
--- a/docs/superpowers/handovers/2026-05-19-new-session-handover.md
+++ b/docs/superpowers/handovers/2026-05-19-new-session-handover.md
@@ -1,0 +1,145 @@
+# Handover: New Session affordance
+
+**For the next agent — read this end-to-end before doing anything.**
+
+## What you're picking up
+
+The user wants a "Start a fresh Claude session" affordance that's reachable from anywhere in Oyster. Today, the only way to start a fresh session is via *Launch Claude here* on a project tile — which means you have to be on Home, in the right space, and you have to know which tile maps to the folder you want.
+
+Their stated requirements (verbatim):
+
+> Also need to be able to start a new fresh session, if we are on home it should ask which space / project to start in (it will start in the current active cwd).
+
+So the new affordance needs to:
+
+1. Be reachable from any view (Home, Inspector, anywhere the topbar shows).
+2. When the user is *already inside a space*, start the new session in the active space's project (whichever cwd is current).
+3. When the user is on Home (no space active), open a picker to choose space → project, then start there.
+
+They want this **brainstormed properly before building** — same flow as the previous feature: brainstorm → spec → plan → subagent-driven implementation → finish-a-branch.
+
+## Branching
+
+Branch off the `terminal-minimise-ux` branch (NOT `main`). That branch carries the entire minimise/running-pill feature this work depends on:
+
+```bash
+git fetch origin
+git worktree add ~/Dev/oyster.worktrees/new-session -b new-session origin/terminal-minimise-ux
+ln -s ~/Dev/oyster-dev/.env ~/Dev/oyster.worktrees/new-session/.env
+cd ~/Dev/oyster.worktrees/new-session/server && npm install --no-audit --no-fund
+cd ~/Dev/oyster.worktrees/new-session/web && npm install --no-audit --no-fund
+```
+
+PR target = the merged `terminal-minimise-ux` branch (or `main` if it's been merged by then — check first with `gh pr view 531`).
+
+The user's preferences (from prior memory):
+- Non-trivial work in `~/Dev/oyster.worktrees/<branch>` worktrees, never the main checkout.
+- When pointing the user at a file, run `open <path>` via Bash — printing the path alone needs cmd+click which is annoying.
+
+## What already exists (relevant context)
+
+### Launch Claude infrastructure (PR #527)
+
+The plumbing for spawning Claude in an in-app terminal already exists. You'll reuse it; don't reinvent.
+
+- **Project tile**: `web/src/components/Home/ProjectTile.tsx` has a *Launch Claude here* button. It calls `onLaunchClaude` which dispatches `OPEN_CLAUDE_TERMINAL` after first spawning a PTY on the server.
+- **Server endpoint**: `POST /api/terminals` (in `server/src/routes/terminals.ts`) spawns a new `claude` process via `ClaudePtyManager.spawn`. Takes `{ cwd, command, args, kind }`.
+- **Dispatch action**: `OPEN_CLAUDE_TERMINAL` in `web/src/stores/windows.ts` — opens a `TerminalWindow` pointed at the new terminalId.
+- **Resume flow**: `web/src/components/SessionInspector/SessionActions.tsx` has `Resume here` which calls `onLaunchClaude` from `App.tsx`. Look at how that callback is wired — it's the reference for what you need to call.
+
+### State you can lean on
+
+- `activeSpace` is in `App.tsx` — the currently-visible space (`"home"` or a real space id).
+- `spaces`, `projects` (per-space, fetched lazily) — see `web/src/data/projects-api.ts`.
+- `windows` store + dispatch.
+- `useSessions()` for the live sessions list.
+- `useTerminalPresence` if you need to check live PTY state.
+
+### The Running pill (you're working alongside it)
+
+The `terminal-minimise-ux` branch added a topbar `● N running ▾` pill that lists every live terminal. The New Session affordance should feel like its sibling — discoverable from anywhere in the topbar. Whether it lives as a button next to the running pill, inside the popover, on the avatar menu, or as its own pill is one of the design questions.
+
+## Questions worth exploring (don't decide unilaterally — brainstorm)
+
+1. **Where does the affordance live?**
+   - A `+ New session` button in the topbar (next to the running pill)
+   - A *New session* option inside the running pill's popover
+   - A cmd+K command (`/new` or similar)
+   - An overlay/dock button
+   - Multiple of the above
+
+2. **When the user is in a space, do they get a picker, or does it just start?**
+   - The user said "current active cwd" — but if there are multiple projects in the space, which one is "the active cwd"?
+   - The current `activeSpace` doesn't have a notion of "active project" beyond what the user is looking at.
+   - Options: (a) start in the first/most-recent project's cwd silently, (b) always ask which project even inside a space, (c) inherit from the most recently used project for that space.
+
+3. **What's the picker UI?**
+   - Modal? Popover? Tile-style grid?
+   - List spaces, then expand to show projects? Or flat list of all projects across spaces?
+   - Recently-used at the top?
+   - Should it support typing to filter (cmd+K-style search)?
+
+4. **Agent choice**
+   - Today it's always `claude` (via `claude` binary). Are we forward-compatible with `opencode` / future agents? Probably not v1 — leave a hook but don't UI it.
+   - First spec-level call: lock to Claude, note future agents as out-of-scope.
+
+5. **What happens after spawn?**
+   - The new terminal panel opens, populated and ready for input
+   - The session row appears in the Sessions list as soon as the first JSONL event lands
+   - Linked correctly via the existing auto-link path
+   - Should it pre-fill anything? Probably not.
+
+6. **What happens if you try to start a new session in a folder that has another live session?**
+   - That's fine — two `claude` processes in the same cwd are allowed, they'll have separate session ids.
+   - But do we surface that ("There's already 1 running terminal here — start another?")? Probably overkill for v1.
+
+7. **What about no-projects-yet?**
+   - If user is on Home with zero spaces, the picker has nothing to show.
+   - Either: (a) the affordance is hidden until they set up a space, (b) it offers to create a space first ("Add a project to get started"), (c) it falls back to a free-form path picker.
+
+## Suggested workflow
+
+1. `Skill: superpowers:brainstorming` — work the user through the questions above. Use the visual companion for picker UI mockups.
+2. Write the spec to `docs/superpowers/specs/2026-05-19-new-session-design.md`.
+3. `Skill: superpowers:writing-plans` — break into bite-sized tasks.
+4. `Skill: superpowers:subagent-driven-development` — execute the plan.
+5. `Skill: superpowers:finishing-a-development-branch` — PR or merge.
+
+## Repo conventions to follow
+
+- Branch + commit on `~/Dev/oyster.worktrees/new-session`, never the main checkout.
+- Server: vitest. Web: tsc only (no test runner).
+- Commit message style: `feat(scope): short imperative`. See `git log --oneline -20` for examples.
+- Pre-commit hooks aren't bypassed; if a hook fails, fix the root cause, don't `--no-verify`.
+- CHANGELOG entry in the same PR for user-visible changes; style per `CLAUDE.md`.
+- Add `co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` to commits.
+
+## Pointers to read first
+
+- `docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md` — the parent feature's spec (sets the design vocabulary).
+- `web/src/App.tsx` around lines 600-650 — the TerminalWindow render site, where `OPEN_CLAUDE_TERMINAL` is dispatched.
+- `web/src/stores/windows.ts` — `OPEN_CLAUDE_TERMINAL` action shape.
+- `server/src/routes/terminals.ts` — `POST /api/terminals` handler.
+- `web/src/components/Home/ProjectTile.tsx` — existing *Launch Claude here* call site.
+- `web/src/components/Topbar/RunningTerminalsPill.tsx` — the visual sibling.
+
+## What NOT to touch
+
+- The terminal-minimise UX itself. Bug fixes are fine, but redesign requests should be raised separately.
+- The session state model (`active / waiting / done`). Renames were discussed and explicitly deferred.
+- The `Inspect` chip, the fork warning, the `running` pill positioning — settled.
+
+## How to start
+
+After cloning into the worktree and confirming `git log --oneline -5` shows the terminal-minimise-ux commits at HEAD:
+
+```
+Skill: superpowers:brainstorming
+
+I'm picking up the New Session affordance work per the handover at
+docs/superpowers/handovers/2026-05-19-new-session-handover.md.
+Working in the worktree on branch `new-session` based on
+`terminal-minimise-ux`. Let's brainstorm.
+```
+
+That's it. Good luck.

--- a/docs/superpowers/plans/2026-05-19-terminal-minimise-ux.md
+++ b/docs/superpowers/plans/2026-05-19-terminal-minimise-ux.md
@@ -1,0 +1,1508 @@
+# Terminal minimise UX implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Click × on the embedded Claude Code terminal panel minimises (keeps the PTY alive) and surfaces it via a new topbar **Running N** pill + popover plus *Open* / *Minimised* states in the Sessions list.
+
+**Architecture:** PTY lifecycle stays in `ClaudePtyManager` (in-memory). Two denormalised columns on the `sessions` table (`terminal_id`, `terminal_attached_clients`) project that state for fast Sessions-list reads. SSE pushes `terminal:attached` / `terminal:detached` / `terminal:exited` events. A new `useTerminalPresence` hook fuses the windows store + sessions feed into one source of truth, consumed by the new `RunningTerminalsPill` + the existing Sessions list rows.
+
+**Tech Stack:** TypeScript everywhere. Server: Node + better-sqlite3 + node-pty + ws + vitest. Web: React 19 + vite + xterm.js. No test framework in `web/` — client-side tasks use `tsc --noEmit` + browser smoke.
+
+**Spec:** [`docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md`](../specs/2026-05-19-terminal-minimise-ux-design.md)
+
+---
+
+## File structure
+
+### Server — created
+
+- `server/test/sessions-table-terminal-columns.test.ts` — migration + boot reset
+- `server/test/session-store-terminal-link.test.ts` — link / clear / attached-clients store methods
+- `server/test/claude-pty-manager-link.test.ts` — manager writes / clears the columns through link / exit / attach / detach
+- `server/test/pty-retention-cap.test.ts` — POST_EXIT_RETENTION_MS bump + 50-retained cap
+
+### Server — modified
+
+- `server/src/db.ts` — two additive ALTERs + boot-reset query
+- `server/src/session-store.ts` — `SessionRow` adds two fields; add `linkTerminal` / `clearTerminal` / `setAttachedClients` methods
+- `server/src/claude-pty-manager.ts` — accept `sessionStore` + `broadcastUiEvent` deps; call store methods on link / attach / detach / exit; emit SSE; bump retention; add eviction cap
+- `server/src/index.ts` — wire the new deps when constructing `ClaudePtyManager`
+- `server/src/routes/sessions.ts` — include `terminalId` / `terminalAttachedClients` in `GET /api/sessions` payload
+- `shared/types.ts` — `Session` interface gains the two fields; new `UiCommand` shapes for terminal events documented inline
+
+### Web — created
+
+- `web/src/hooks/useTerminalPresence.ts` — fuses `windows` store + sessions feed
+- `web/src/components/Topbar/RunningTerminalsPill.tsx` — pill + popover
+- `web/src/components/Topbar/RunningTerminalsPill.css` *(or extend `App.css`)* — pill + popover styles
+
+### Web — modified
+
+- `web/src/data/sessions-api.ts` — re-exported `Session` type picks up new fields automatically once shared types update
+- `web/src/stores/windows.ts` — new `MINIMISE` action; reducer case
+- `web/src/components/TerminalWindow.tsx` — × dispatches `MINIMISE`; tooltip *"Minimise terminal"*
+- `web/src/components/Topbar.tsx` *(or wherever the topbar is composed)* — mount `RunningTerminalsPill`
+- `web/src/components/Home/index.tsx` — new **Live** filter pill; row-level Open/Minimised state; live-rows pin-to-top sort
+- `web/src/App.css` — `.row-dot--attached`, `.row-dot--running`, `.sr--attached`, `.sr--running`, `.sl-chip--restore`
+
+---
+
+## Task 1: Schema migration + boot reset
+
+**Files:**
+- Create: `server/test/sessions-table-terminal-columns.test.ts`
+- Modify: `server/src/db.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/test/sessions-table-terminal-columns.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-term-cols-"));
+  return {
+    dir,
+    dispose: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("sessions table — terminal columns", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("adds terminal_id and terminal_attached_clients columns idempotently", () => {
+    const db1 = initDb(env.dir);
+    const cols = db1.prepare("PRAGMA table_info(sessions)").all() as { name: string }[];
+    const names = cols.map(c => c.name);
+    expect(names).toContain("terminal_id");
+    expect(names).toContain("terminal_attached_clients");
+    db1.close();
+
+    // Re-init — must not throw on duplicate-column ALTER.
+    const db2 = initDb(env.dir);
+    db2.close();
+  });
+
+  it("boot reset clears stale terminal_id and zeros attached clients", () => {
+    const db1 = initDb(env.dir);
+    db1.prepare(
+      `INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('s','s','#000','none')`,
+    ).run();
+    db1.prepare(
+      `INSERT INTO sessions
+         (id, space_id, cwd, agent, title, state, started_at, last_event_at,
+          terminal_id, terminal_attached_clients)
+       VALUES
+         ('a', 's', NULL, 'claude-code', 't', 'done',
+          '2026-05-19T10:00:00Z', '2026-05-19T10:30:00Z',
+          'stale-term-id', 3)`,
+    ).run();
+    db1.close();
+
+    // Re-init — boot reset should fire.
+    const db2 = initDb(env.dir);
+    const row = db2.prepare(
+      "SELECT terminal_id, terminal_attached_clients FROM sessions WHERE id = 'a'",
+    ).get() as { terminal_id: string | null; terminal_attached_clients: number };
+    expect(row.terminal_id).toBeNull();
+    expect(row.terminal_attached_clients).toBe(0);
+    db2.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/Matthew.Slight/Dev/oyster.worktrees/terminal-minimise-ux/server && npx vitest run test/sessions-table-terminal-columns.test.ts`
+Expected: FAIL — columns don't exist yet.
+
+- [ ] **Step 3: Add the migrations and boot reset**
+
+Edit `server/src/db.ts`. Find the `initDb` function and locate the existing migration list (around line 47). Append the two ALTERs to the existing pattern:
+
+```ts
+// Existing migrations block (around line 47-56):
+const additiveMigrations = [
+  // … existing ALTERs …
+  "ALTER TABLE sessions ADD COLUMN terminal_id TEXT",
+  "ALTER TABLE sessions ADD COLUMN terminal_attached_clients INTEGER NOT NULL DEFAULT 0",
+];
+```
+
+(If the existing list isn't named `additiveMigrations`, mirror the local convention — the file has a clear pattern of try/catch around each ALTER for idempotency.)
+
+Then add the boot reset *after* all migrations run but *before* `initDb` returns:
+
+```ts
+// Stale-indicator reset. PTYs live in-memory only — they don't survive a
+// server restart, so any non-null terminal_id or non-zero attached count
+// from the previous boot is meaningless.
+db.prepare(
+  `UPDATE sessions
+     SET terminal_id = NULL, terminal_attached_clients = 0
+   WHERE terminal_id IS NOT NULL OR terminal_attached_clients > 0`,
+).run();
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /Users/Matthew.Slight/Dev/oyster.worktrees/terminal-minimise-ux/server && npx vitest run test/sessions-table-terminal-columns.test.ts`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/Matthew.Slight/Dev/oyster.worktrees/terminal-minimise-ux
+git add server/src/db.ts server/test/sessions-table-terminal-columns.test.ts
+git commit -m "feat(sessions): add terminal_id + attached_clients columns with boot reset"
+```
+
+---
+
+## Task 2: SessionStore terminal-link methods
+
+**Files:**
+- Create: `server/test/session-store-terminal-link.test.ts`
+- Modify: `server/src/session-store.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/test/session-store-terminal-link.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function seed(store: SqliteSessionStore, id: string) {
+  // Use the existing seedSpace pattern from other tests if needed.
+  store.insertSession({
+    id, space_id: null, agent: "claude-code", state: "done",
+  });
+}
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-term-link-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  return {
+    db, store,
+    dispose: () => { db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("SqliteSessionStore terminal link", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("linkTerminal writes terminal_id, clearTerminal nulls it and resets clients", () => {
+    seed(env.store, "s1");
+    env.store.linkTerminal("s1", "term-1");
+    env.store.setAttachedClients("s1", 2);
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBe("term-1");
+    expect(row.terminal_attached_clients).toBe(2);
+
+    env.store.clearTerminal("s1");
+    const cleared = env.store.getById("s1")!;
+    expect(cleared.terminal_id).toBeNull();
+    expect(cleared.terminal_attached_clients).toBe(0);
+  });
+
+  it("setAttachedClients on an unknown session is a no-op (does not throw)", () => {
+    expect(() => env.store.setAttachedClients("missing", 1)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run test/session-store-terminal-link.test.ts` (from `server/`)
+Expected: FAIL — methods don't exist.
+
+- [ ] **Step 3: Extend SessionRow and add the methods**
+
+Edit `server/src/session-store.ts`:
+
+1. Add the two fields to `SessionRow` (next to the other columns, around line 43):
+
+```ts
+export interface SessionRow {
+  // … existing fields …
+  assignment_mode: AssignmentMode;
+  /** ClaudePtyManager terminal id this session is linked to, or null. */
+  terminal_id: string | null;
+  /** Count of currently-attached WS clients on the linked terminal. 0 + non-null terminal_id = Minimised. */
+  terminal_attached_clients: number;
+}
+```
+
+2. Add the methods to the `SessionStore` interface (after `searchEvents`):
+
+```ts
+  /** Mark a session as linked to a running PTY. Idempotent. */
+  linkTerminal(sessionId: string, terminalId: string): void;
+  /** Clear the link and zero the attached-clients counter. Idempotent. */
+  clearTerminal(sessionId: string): void;
+  /** Update the attached-clients counter on the linked session. No-op if the session row is missing. */
+  setAttachedClients(sessionId: string, count: number): void;
+```
+
+3. Implement on `SqliteSessionStore` (after `searchEvents`):
+
+```ts
+  linkTerminal(sessionId: string, terminalId: string): void {
+    this.db.prepare(
+      "UPDATE sessions SET terminal_id = ? WHERE id = ?",
+    ).run(terminalId, sessionId);
+  }
+
+  clearTerminal(sessionId: string): void {
+    this.db.prepare(
+      "UPDATE sessions SET terminal_id = NULL, terminal_attached_clients = 0 WHERE id = ?",
+    ).run(sessionId);
+  }
+
+  setAttachedClients(sessionId: string, count: number): void {
+    this.db.prepare(
+      "UPDATE sessions SET terminal_attached_clients = ? WHERE id = ?",
+    ).run(Math.max(0, count | 0), sessionId);
+  }
+```
+
+4. Update `getAll`, `getById` and any other SELECT in the file that materialises a `SessionRow` to include the two new columns — better-sqlite3 returns `null` for absent columns but the type guard will fail. Easiest path: change `SELECT *` queries (they pick up new columns automatically) — confirm via `git grep "SELECT.*FROM sessions" server/src` and adjust any column-listed SELECTs to add `terminal_id, terminal_attached_clients`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run test/session-store-terminal-link.test.ts`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Run the full server suite to catch regressions**
+
+Run: `npx vitest run` (from `server/`)
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/session-store.ts server/test/session-store-terminal-link.test.ts
+git commit -m "feat(sessions): add linkTerminal/clearTerminal/setAttachedClients store methods"
+```
+
+---
+
+## Task 3: ClaudePtyManager writes terminal_id on link / exit
+
+**Files:**
+- Create: `server/test/claude-pty-manager-link.test.ts`
+- Modify: `server/src/claude-pty-manager.ts`, `server/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/test/claude-pty-manager-link.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { ClaudePtyManager } from "../src/claude-pty-manager.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-pty-link-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  const events: { command: string; payload: unknown }[] = [];
+  const broadcast = (cmd: { command: string; payload: unknown }) => { events.push(cmd); };
+  const mgr = new ClaudePtyManager({ sessionStore: store, broadcastUiEvent: broadcast });
+  store.insertSession({ id: "s1", space_id: null, agent: "claude-code", state: "done" });
+  return {
+    db, store, mgr, events,
+    dispose: () => { mgr.disposeAll(); db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("ClaudePtyManager DB link", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("setLinkedSession writes terminal_id to the linked session row", () => {
+    // Fake spawn — bypass node-pty by injecting an entry directly via test seam.
+    // Add a test-only `_seedEntry` method on the manager (or accept a stub
+    // proc) — see step 3 below for the helper.
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+
+    env.mgr.setLinkedSession("t1", "s1");
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBe("t1");
+  });
+
+  it("calling kill() clears terminal_id on the linked session row", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t2", linkedSessionId: null });
+    env.mgr.setLinkedSession("t2", "s1");
+    env.mgr.kill("t2");
+    // proc.onExit is what actually clears the row; the test seed wires a
+    // synchronous fake proc that fires onExit during kill().
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBeNull();
+    expect(row.terminal_attached_clients).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run test/claude-pty-manager-link.test.ts`
+Expected: FAIL — `_seedEntryForTest` doesn't exist; constructor doesn't accept deps.
+
+- [ ] **Step 3: Refactor ClaudePtyManager to accept dependencies**
+
+Edit `server/src/claude-pty-manager.ts`:
+
+1. Add dependency types at top (after existing imports):
+
+```ts
+import type { SessionStore } from "./session-store.js";
+import type { UiCommand } from "../../shared/types.js";
+
+export interface ClaudePtyManagerDeps {
+  sessionStore: SessionStore;
+  broadcastUiEvent: (cmd: UiCommand) => void;
+}
+```
+
+2. Change the constructor signature:
+
+```ts
+export class ClaudePtyManager {
+  private terminals = new Map<string, ClaudePtyEntry>();
+  private wss = new WebSocketServer({ noServer: true });
+  private sessionStore: SessionStore;
+  private broadcastUiEvent: (cmd: UiCommand) => void;
+
+  constructor(deps: ClaudePtyManagerDeps) {
+    this.sessionStore = deps.sessionStore;
+    this.broadcastUiEvent = deps.broadcastUiEvent;
+  }
+  // …
+}
+```
+
+3. In `setLinkedSession`, call the store:
+
+```ts
+  setLinkedSession(terminalId: string, sessionId: string): boolean {
+    const entry = this.terminals.get(terminalId);
+    if (!entry) return false;
+    entry.linkedSessionId = sessionId;
+    this.sessionStore.linkTerminal(sessionId, terminalId);
+    return true;
+  }
+```
+
+4. In `proc.onExit` (around line 175), after the existing `closeNote` / eviction-timer block, add:
+
+```ts
+      if (entry.linkedSessionId) {
+        this.sessionStore.clearTerminal(entry.linkedSessionId);
+      }
+```
+
+5. Add a test-only seam at the bottom of the class (guarded so we don't ship a foot-gun):
+
+```ts
+  /** Test-only: inject a fake entry with a stub proc whose onExit fires
+   *  immediately on kill(). Production code never calls this. */
+  _seedEntryForTest(input: { terminalId: string; linkedSessionId: string | null }): void {
+    let exitCb: (e: { exitCode: number }) => void = () => {};
+    const fakeProc: any = {
+      pid: -1,
+      onData: () => {},
+      onExit: (cb: typeof exitCb) => { exitCb = cb; },
+      write: () => {},
+      resize: () => {},
+      kill: () => { /* fire onExit synchronously like a real signal would */ exitCb({ exitCode: 0 }); },
+    };
+    const entry: ClaudePtyEntry = {
+      terminalId: input.terminalId,
+      kind: "claude_new",
+      proc: fakeProc,
+      scrollback: "",
+      clients: new Set(),
+      cwd: "/tmp",
+      command: "/bin/echo",
+      args: [],
+      startedAt: Date.now(),
+      exitedAt: null,
+      linkedSessionId: input.linkedSessionId,
+      evictTimer: null,
+    };
+    // Wire the onExit listener the same way spawn() does.
+    fakeProc.onExit((event: { exitCode: number }) => {
+      entry.exitedAt = Date.now();
+      if (entry.linkedSessionId) {
+        this.sessionStore.clearTerminal(entry.linkedSessionId);
+      }
+      // Emit terminal:exited; production code does the same in Task 5.
+    });
+    this.terminals.set(input.terminalId, entry);
+  }
+```
+
+- [ ] **Step 4: Wire the new deps in `server/src/index.ts`**
+
+Find where `ClaudePtyManager` is constructed (grep for `new ClaudePtyManager`) and pass the deps:
+
+```ts
+const claudePtyManager = new ClaudePtyManager({
+  sessionStore,
+  broadcastUiEvent,
+});
+```
+
+`broadcastUiEvent` is already in scope at that point in `index.ts` (line 307 shows existing use).
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run test/claude-pty-manager-link.test.ts`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 6: Run the full server suite**
+
+Run: `npx vitest run`
+Expected: all pass; the constructor-signature change may break call sites — fix any that surface.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/claude-pty-manager.ts server/src/index.ts server/test/claude-pty-manager-link.test.ts
+git commit -m "feat(pty): persist terminal link on session row via store"
+```
+
+---
+
+## Task 4: ClaudePtyManager tracks attached clients
+
+**Files:**
+- Modify: `server/src/claude-pty-manager.ts`, `server/test/claude-pty-manager-link.test.ts`
+
+- [ ] **Step 1: Extend the test with attached-clients cases**
+
+Append to `server/test/claude-pty-manager-link.test.ts`:
+
+```ts
+import { WebSocket } from "ws";
+
+describe("ClaudePtyManager attached clients", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("attach/detach updates terminal_attached_clients on the linked row", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: "s1" });
+    env.mgr.linkTerminalForTest("t1", "s1");
+
+    const fakeWs1 = makeFakeWs();
+    const fakeWs2 = makeFakeWs();
+
+    env.mgr.attachClient("t1", fakeWs1 as unknown as WebSocket);
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(1);
+
+    env.mgr.attachClient("t1", fakeWs2 as unknown as WebSocket);
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(2);
+
+    fakeWs1.fireClose();
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(1);
+
+    fakeWs2.fireClose();
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
+  });
+});
+
+function makeFakeWs() {
+  const handlers: Record<string, ((arg?: unknown) => void)[]> = { message: [], close: [] };
+  return {
+    readyState: 1, // OPEN
+    send: () => {},
+    on(event: string, cb: (arg?: unknown) => void) { handlers[event] ??= []; handlers[event].push(cb); },
+    fireClose() { handlers.close?.forEach(cb => cb()); },
+  };
+}
+```
+
+Also add a tiny test-only helper on the manager since the WS-attach path needs the entry to already know its linked session:
+
+```ts
+  /** Test-only: pair `_seedEntryForTest` with a link write in one step. */
+  linkTerminalForTest(terminalId: string, sessionId: string): void { this.setLinkedSession(terminalId, sessionId); }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run test/claude-pty-manager-link.test.ts -t "attached clients"`
+Expected: FAIL — counter not updated by attach/detach.
+
+- [ ] **Step 3: Update `attachClient` and the WS close handler**
+
+In `server/src/claude-pty-manager.ts`, inside `attachClient`, after `entry.clients.add(ws)`:
+
+```ts
+    entry.clients.add(ws);
+    if (entry.linkedSessionId) {
+      this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+    }
+```
+
+And inside the existing `ws.on("close", …)` handler:
+
+```ts
+    ws.on("close", () => {
+      entry.clients.delete(ws);
+      if (entry.linkedSessionId) {
+        this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+      }
+    });
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run test/claude-pty-manager-link.test.ts -t "attached clients"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/claude-pty-manager.ts server/test/claude-pty-manager-link.test.ts
+git commit -m "feat(pty): track attached WS clients on linked session row"
+```
+
+---
+
+## Task 5: SSE events on attach / detach / exit
+
+**Files:**
+- Modify: `server/src/claude-pty-manager.ts`, `server/test/claude-pty-manager-link.test.ts`, `shared/types.ts`
+
+- [ ] **Step 1: Document the three new SSE commands in `shared/types.ts`**
+
+Find the `UiCommand` interface (around line 208). Add a JSDoc note above it listing the new commands, and define the three payload shapes:
+
+```ts
+/** Payload for the `terminal:attached` / `terminal:detached` / `terminal:exited`
+ *  UiCommand variants. SessionId is null when the PTY was not yet linked. */
+export interface TerminalPresenceEventPayload {
+  terminalId: string;
+  sessionId: string | null;
+  attachedClients: number;
+}
+```
+
+- [ ] **Step 2: Extend the test with an SSE assertion**
+
+In `server/test/claude-pty-manager-link.test.ts`, add:
+
+```ts
+  it("emits terminal:attached / terminal:detached / terminal:exited", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+    env.mgr.linkTerminalForTest("t1", "s1");
+    env.events.length = 0;
+
+    const ws = makeFakeWs();
+    env.mgr.attachClient("t1", ws as unknown as WebSocket);
+    ws.fireClose();
+    env.mgr.kill("t1");
+
+    const commands = env.events.map(e => e.command);
+    expect(commands).toContain("terminal:attached");
+    expect(commands).toContain("terminal:detached");
+    expect(commands).toContain("terminal:exited");
+
+    const attachedEvent = env.events.find(e => e.command === "terminal:attached")!;
+    const payload = attachedEvent.payload as { terminalId: string; sessionId: string | null; attachedClients: number };
+    expect(payload.terminalId).toBe("t1");
+    expect(payload.sessionId).toBe("s1");
+    expect(payload.attachedClients).toBe(1);
+  });
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run test/claude-pty-manager-link.test.ts -t "emits terminal"`
+Expected: FAIL.
+
+- [ ] **Step 4: Emit the events from the manager**
+
+In `attachClient`, after the `setAttachedClients` call:
+
+```ts
+    this.broadcastUiEvent({
+      version: 1,
+      command: "terminal:attached",
+      payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size },
+    });
+```
+
+In the WS `close` handler, after `setAttachedClients`:
+
+```ts
+      this.broadcastUiEvent({
+        version: 1,
+        command: "terminal:detached",
+        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size },
+      });
+```
+
+In `proc.onExit` (and inside `_seedEntryForTest`'s onExit), after the `clearTerminal` call:
+
+```ts
+      this.broadcastUiEvent({
+        version: 1,
+        command: "terminal:exited",
+        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 },
+      });
+```
+
+**Then piggy-back a `session_changed` emission after each of the three terminal events.** The web's `useSessions` hook (`web/src/hooks/useSessions.ts:21`) already refetches on `session_changed`, so this avoids any changes to `web/src/data/ui-events.ts` — the topbar pill + Sessions list pick up the new state via the normal refresh. Add this once at the end of each terminal-event emission (attach, detach, exit):
+
+```ts
+      if (entry.linkedSessionId) {
+        this.broadcastUiEvent({
+          version: 1,
+          command: "session_changed",
+          payload: { id: entry.linkedSessionId },
+        });
+      }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run test/claude-pty-manager-link.test.ts -t "emits terminal"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/claude-pty-manager.ts server/test/claude-pty-manager-link.test.ts shared/types.ts
+git commit -m "feat(pty): emit terminal:attached/detached/exited SSE events"
+```
+
+---
+
+## Task 6: Extend `GET /api/sessions` payload + shared types
+
+**Files:**
+- Modify: `server/src/routes/sessions.ts`, `shared/types.ts`
+
+- [ ] **Step 1: Extend the existing route test (or add one) for the new fields**
+
+Find a sessions-route test (likely `server/test/sessions-resume-route.test.ts` or similar). If there isn't a direct "GET /api/sessions" test, add one as `server/test/sessions-route-terminal-fields.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-sess-route-term-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  return { db, store, dispose: () => { db.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+describe("GET /api/sessions payload — terminal fields", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("payload mapping projects terminal_id and terminal_attached_clients", () => {
+    // Direct unit test the mapping function rather than spinning up a server.
+    // Find the local helper in routes/sessions.ts (the `MergedSessionPayload`
+    // mapper) and export it (or extract it) so this test can import it.
+    // Then:
+    env.store.insertSession({ id: "s1", space_id: null, agent: "claude-code", state: "done" });
+    env.store.linkTerminal("s1", "term-1");
+    env.store.setAttachedClients("s1", 2);
+
+    const row = env.store.getById("s1")!;
+    // mapSessionRow is the extracted mapper.
+    const payload = mapSessionRow(row, /* myDeviceId */ null, /* myDeviceLabel */ null);
+    expect(payload.terminalId).toBe("term-1");
+    expect(payload.terminalAttachedClients).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Expected: FAIL — `mapSessionRow` is not exported / fields not on payload.
+
+- [ ] **Step 3: Extend the payload + map**
+
+In `server/src/routes/sessions.ts`, locate `interface MergedSessionPayload` (around line 133). Add:
+
+```ts
+interface MergedSessionPayload {
+  // … existing fields …
+  assignmentMode?: "auto" | "manual";
+  /** Linked PTY terminal id, or null when no live terminal. */
+  terminalId: string | null;
+  /** Count of currently-attached WS clients on the linked terminal. */
+  terminalAttachedClients: number;
+}
+```
+
+In the row-to-payload mapping (around line 164), add the two fields:
+
+```ts
+const localPayload: MergedSessionPayload[] = rows.map((row) => {
+  return {
+    // … existing fields …
+    activeDeviceLabel: resolveActiveLabel(/* … */),
+    terminalId: row.terminal_id,
+    terminalAttachedClients: row.terminal_attached_clients,
+  };
+});
+```
+
+Extract the per-row mapping into a top-level `mapSessionRow(row, myDeviceId, myDeviceLabel)` helper and export it so the unit test in step 1 can import it. This keeps the route handler thin and the mapper independently testable.
+
+In `shared/types.ts`, extend the `Session` interface (find it via `git grep "interface Session\b"`):
+
+```ts
+export interface Session {
+  // … existing fields …
+  /** Linked PTY terminal id, or null when no live terminal. */
+  terminalId: string | null;
+  /** Count of currently-attached WS clients on the linked terminal. */
+  terminalAttachedClients: number;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run test/sessions-route-terminal-fields.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full server suite + typecheck**
+
+```bash
+npx vitest run
+npx tsc --noEmit
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/routes/sessions.ts shared/types.ts server/test/sessions-route-terminal-fields.test.ts
+git commit -m "feat(sessions): expose terminalId + terminalAttachedClients on GET /api/sessions"
+```
+
+---
+
+## Task 7: Retention bump + 50-retained eviction cap
+
+**Files:**
+- Create: `server/test/pty-retention-cap.test.ts`
+- Modify: `server/src/claude-pty-manager.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// server/test/pty-retention-cap.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { ClaudePtyManager, POST_EXIT_RETENTION_MS, MAX_RETAINED_EXITED } from "../src/claude-pty-manager.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-pty-cap-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  const mgr = new ClaudePtyManager({ sessionStore: store, broadcastUiEvent: () => {} });
+  return { db, store, mgr, dispose: () => { mgr.disposeAll(); db.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+describe("ClaudePtyManager retention", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("POST_EXIT_RETENTION_MS is 15 minutes", () => {
+    expect(POST_EXIT_RETENTION_MS).toBe(15 * 60 * 1000);
+  });
+
+  it("MAX_RETAINED_EXITED is 50", () => {
+    expect(MAX_RETAINED_EXITED).toBe(50);
+  });
+
+  it("evicts the oldest exited entry when the cap is exceeded", () => {
+    // Seed MAX_RETAINED_EXITED + 1 exited entries, oldest first.
+    for (let i = 0; i < MAX_RETAINED_EXITED + 1; i++) {
+      env.mgr._seedEntryForTest({ terminalId: `t${i}`, linkedSessionId: null });
+      env.mgr.kill(`t${i}`); // marks exited via the fake proc's onExit
+    }
+    expect(env.mgr.list().length).toBe(MAX_RETAINED_EXITED);
+    expect(env.mgr.getEntry("t0")).toBeUndefined(); // oldest evicted
+    expect(env.mgr.getEntry(`t${MAX_RETAINED_EXITED}`)).toBeDefined(); // newest kept
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run test/pty-retention-cap.test.ts`
+Expected: FAIL — `MAX_RETAINED_EXITED` not exported; retention is 30_000.
+
+- [ ] **Step 3: Bump retention + add the cap**
+
+In `server/src/claude-pty-manager.ts`:
+
+```ts
+export const POST_EXIT_RETENTION_MS = 15 * 60 * 1000;  // was 30_000
+export const MAX_RETAINED_EXITED = 50;
+```
+
+Add a private helper that enforces the cap by evicting oldest-exited-first:
+
+```ts
+  private enforceRetentionCap(): void {
+    const exited = Array.from(this.terminals.values())
+      .filter(e => e.exitedAt !== null)
+      .sort((a, b) => (a.exitedAt ?? 0) - (b.exitedAt ?? 0));
+    while (exited.length > MAX_RETAINED_EXITED) {
+      const victim = exited.shift()!;
+      if (victim.evictTimer) { clearTimeout(victim.evictTimer); victim.evictTimer = null; }
+      this.terminals.delete(victim.terminalId);
+    }
+  }
+```
+
+Call it inside `proc.onExit` (after the `setTimeout` line) and inside the fake `_seedEntryForTest` onExit handler.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run test/pty-retention-cap.test.ts`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/claude-pty-manager.ts server/test/pty-retention-cap.test.ts
+git commit -m "feat(pty): bump retention to 15min, cap at 50 exited entries"
+```
+
+---
+
+## Task 8: Client `useTerminalPresence` hook
+
+**Files:**
+- Create: `web/src/hooks/useTerminalPresence.ts`
+- Modify: `web/src/data/sessions-api.ts` (no edits required — types regen from shared)
+
+- [ ] **Step 1: Verify the shared type already exposes the fields**
+
+Run: `cd /Users/Matthew.Slight/Dev/oyster.worktrees/terminal-minimise-ux/web && npx tsc --noEmit 2>&1 | grep -i "terminalId\|terminalAttachedClients" | head -5`
+Expected: silent (no errors), meaning Session already has the fields from Task 6.
+
+- [ ] **Step 2: Write the hook**
+
+```ts
+// web/src/hooks/useTerminalPresence.ts
+import { useMemo } from "react";
+import type { Session } from "../data/sessions-api";
+import type { WindowState } from "../stores/windows";
+
+export type PresenceState = "attached" | "running";
+
+export interface PresenceInfo {
+  sessionId: string;
+  terminalId: string;
+  state: PresenceState;
+  attachedClients: number;
+}
+
+export interface TerminalPresence {
+  /** Sessions whose linked PTY currently has at least one attached window. */
+  attached: PresenceInfo[];
+  /** Sessions whose linked PTY is alive but no window is attached. */
+  running: PresenceInfo[];
+  byId: Record<string, PresenceInfo>;
+  /** Convenience: attached.length + running.length. */
+  totalLive: number;
+}
+
+/** Fuses two sources of truth:
+ *
+ *  - `sessions` carries `terminalId` + `terminalAttachedClients` from the
+ *    server (DB-projected, SSE-refreshed by the parent's subscriber).
+ *  - `windows` is the client-side list of open panels. A terminal id is
+ *    "attached" iff a window in the store references that terminalId.
+ *
+ *  The DB column tells us if a PTY *exists*; the windows store tells us
+ *  whether *this client* is currently looking at it. They are NOT
+ *  redundant — the server counts every WS connection (including other
+ *  tabs); the local store reflects only this tab's panels. */
+export function useTerminalPresence(
+  sessions: Session[],
+  windows: WindowState[],
+): TerminalPresence {
+  return useMemo(() => {
+    const localTerminalIds = new Set(
+      windows.filter(w => w.type === "claude_terminal" && w.terminalId).map(w => w.terminalId!),
+    );
+    const attached: PresenceInfo[] = [];
+    const running: PresenceInfo[] = [];
+    const byId: Record<string, PresenceInfo> = {};
+    for (const s of sessions) {
+      if (!s.terminalId) continue;
+      const isAttached = localTerminalIds.has(s.terminalId);
+      const info: PresenceInfo = {
+        sessionId: s.id,
+        terminalId: s.terminalId,
+        state: isAttached ? "attached" : "running",
+        attachedClients: s.terminalAttachedClients,
+      };
+      byId[s.id] = info;
+      (isAttached ? attached : running).push(info);
+    }
+    return { attached, running, byId, totalLive: attached.length + running.length };
+  }, [sessions, windows]);
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd /Users/Matthew.Slight/Dev/oyster.worktrees/terminal-minimise-ux/web && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/hooks/useTerminalPresence.ts
+git commit -m "feat(web): add useTerminalPresence hook fusing sessions + windows"
+```
+
+---
+
+## Task 9: `MINIMISE` action in windows store
+
+**Files:**
+- Modify: `web/src/stores/windows.ts`
+
+- [ ] **Step 1: Add the action variant and reducer case**
+
+Edit `web/src/stores/windows.ts`. In the `WindowAction` union:
+
+```ts
+export type WindowAction =
+  // … existing variants …
+  | { type: "CLOSE"; id: string }
+  | { type: "MINIMISE"; id: string }
+  // … rest …
+```
+
+In `windowsReducer`, add a case directly after `CLOSE`:
+
+```ts
+    case "MINIMISE":
+      // Same state change as CLOSE for the windows array (drop the window).
+      // Behavioural difference lives at the call site: terminal panels do
+      // NOT call DELETE /api/terminals/:id — the PTY survives.
+      return state.filter((w) => w.id !== action.id);
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/stores/windows.ts
+git commit -m "feat(web): add MINIMISE window action (behavioural distinct from CLOSE)"
+```
+
+---
+
+## Task 10: TerminalWindow × dispatches MINIMISE
+
+**Files:**
+- Modify: `web/src/components/TerminalWindow.tsx`, `web/src/App.tsx`
+
+- [ ] **Step 1: Change the close handler**
+
+In `web/src/App.tsx`, find the `<TerminalWindow … onClose={…} />` invocation (around line 602 per the spec's `Current state` citation). Change the dispatched action:
+
+```tsx
+onClose={() => dispatch({ type: "MINIMISE", id: w.id })}
+```
+
+In `web/src/components/TerminalWindow.tsx`, update the tooltip on the × button (find the `onClose` button — should be passed to `WindowChrome` at line ~169). Pass a new prop or set the `title` attribute directly:
+
+```tsx
+<WindowChrome
+  /* … existing props … */
+  onClose={onClose}
+  closeButtonTooltip="Minimise terminal"
+/>
+```
+
+If `WindowChrome` doesn't accept a tooltip prop, add it (single line change there):
+
+```tsx
+// In WindowChrome.tsx
+interface WindowChromeProps {
+  // …
+  onClose: () => void;
+  closeButtonTooltip?: string;
+}
+// In the JSX:
+<button onClick={onClose} title={closeButtonTooltip ?? "Close"}>×</button>
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/components/TerminalWindow.tsx web/src/components/WindowChrome.tsx web/src/App.tsx
+git commit -m "feat(web): terminal × minimises (keeps PTY alive); tooltip 'Minimise terminal'"
+```
+
+---
+
+## Task 11: `RunningTerminalsPill` component (pill + popover)
+
+**Files:**
+- Create: `web/src/components/Topbar/RunningTerminalsPill.tsx`
+- Modify: `web/src/App.css`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+// web/src/components/Topbar/RunningTerminalsPill.tsx
+import { useState, useRef, useEffect } from "react";
+import type { TerminalPresence, PresenceInfo } from "../../hooks/useTerminalPresence";
+import type { Session } from "../../data/sessions-api";
+
+interface Props {
+  presence: TerminalPresence;
+  sessions: Session[];
+  onFocus: (terminalId: string) => void;
+  onRestore: (sessionId: string, terminalId: string) => void;
+  onStop: (terminalId: string) => Promise<void>;
+}
+
+export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, onStop }: Props) {
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Close popover when count drops to 0 — the pill disappears too.
+  useEffect(() => {
+    if (presence.totalLive === 0) setOpen(false);
+  }, [presence.totalLive]);
+
+  // Click-outside closes the popover.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (presence.totalLive === 0) return null;
+
+  const rows: { info: PresenceInfo; session: Session | undefined }[] =
+    [...presence.attached, ...presence.running].map(info => ({
+      info,
+      session: sessions.find(s => s.id === info.sessionId),
+    }));
+
+  return (
+    <div className="rtp-wrap">
+      <button
+        className={`rtp-pill${open ? " rtp-pill--open" : ""}`}
+        onClick={() => setOpen(o => !o)}
+        title={`${presence.totalLive} running terminal${presence.totalLive === 1 ? "" : "s"}`}
+      >
+        <span className="rtp-pulse" />
+        Running {presence.totalLive} ▾
+      </button>
+      {open && (
+        <div className="rtp-popover" ref={popoverRef}>
+          <div className="rtp-popover-arrow" />
+          <div className="rtp-popover-head">
+            <span>Running terminals</span>
+            <span>{presence.totalLive}</span>
+          </div>
+          {rows.map(({ info, session }) => {
+            const title = session?.title ?? info.sessionId.slice(0, 8);
+            const space = session?.spaceId ?? "—";
+            const isAttached = info.state === "attached";
+            return (
+              <div
+                key={info.terminalId}
+                className="rtp-row"
+                onClick={() => isAttached ? onFocus(info.terminalId) : onRestore(info.sessionId, info.terminalId)}
+              >
+                <span className={isAttached ? "rtp-dot rtp-dot--attached" : "rtp-dot rtp-dot--running"} />
+                <div className="rtp-body">
+                  <span className="rtp-title">{title}</span>
+                  <span className="rtp-meta">
+                    <span className="rtp-space">{space}</span> · claude-code · {isAttached ? "open" : "minimised"}
+                  </span>
+                </div>
+                {!isAttached && <span className="rtp-chip rtp-chip--restore">Restore</span>}
+                <button
+                  className="rtp-stop"
+                  title="Stop terminal"
+                  onClick={(e) => { e.stopPropagation(); void onStop(info.terminalId); }}
+                >■</button>
+              </div>
+            );
+          })}
+          <div className="rtp-popover-foot">Click row to focus · Stop ends the session</div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add the CSS**
+
+Append to `web/src/App.css`:
+
+```css
+/* ── Topbar Running terminals pill + popover ─────────────────────── */
+.rtp-wrap { position: relative; display: inline-flex; }
+.rtp-pill {
+  padding: 4px 10px; border-radius: 14px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid transparent;
+  color: rgba(232,233,240,0.75);
+  font-size: 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+  cursor: pointer;
+}
+.rtp-pill--open { background: rgba(94,234,212,0.12); border-color: rgba(94,234,212,0.35); color: #5eead4; }
+.rtp-pulse {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #5eead4; box-shadow: 0 0 8px rgba(94,234,212,0.7);
+  animation: rtp-pulse 1.6s infinite;
+}
+@keyframes rtp-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.45 } }
+
+.rtp-popover {
+  position: absolute; top: calc(100% + 8px); right: 0; z-index: 60;
+  background: #1d1f29; border: 1px solid rgba(94,234,212,0.3);
+  border-radius: 10px; padding: 6px; min-width: 340px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.6);
+}
+.rtp-popover-arrow {
+  position: absolute; top: -6px; right: 24px; width: 12px; height: 12px;
+  background: #1d1f29;
+  border-left: 1px solid rgba(94,234,212,0.3);
+  border-top: 1px solid rgba(94,234,212,0.3);
+  transform: rotate(45deg);
+}
+.rtp-popover-head {
+  padding: 8px 10px 6px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em;
+  color: rgba(232,233,240,0.4); display: flex; justify-content: space-between;
+}
+.rtp-row {
+  display: grid; grid-template-columns: 14px 1fr auto auto;
+  gap: 10px; align-items: center; padding: 8px 10px; border-radius: 6px; cursor: pointer;
+}
+.rtp-row + .rtp-row { margin-top: 2px; }
+.rtp-row:hover { background: rgba(255,255,255,0.04); }
+.rtp-dot { width: 9px; height: 9px; border-radius: 50%; }
+.rtp-dot--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
+.rtp-dot--running { background: transparent; border: 2px solid #a78bfa; box-shadow: 0 0 6px rgba(167,139,250,0.4); }
+.rtp-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.rtp-title { font-size: 12px; color: #e8e9f0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rtp-meta { font-size: 10px; color: rgba(232,233,240,0.45); }
+.rtp-meta .rtp-space { color: #b39dff; }
+.rtp-chip {
+  font-size: 9px; padding: 2px 7px; border-radius: 4px;
+  letter-spacing: 0.05em; text-transform: uppercase; font-weight: 600;
+}
+.rtp-chip--restore { background: rgba(167,139,250,0.18); color: #a78bfa; }
+.rtp-stop {
+  background: transparent; border: none; cursor: pointer;
+  color: rgba(232,233,240,0.4); font-size: 12px; padding: 4px 6px;
+  border-radius: 4px;
+}
+.rtp-stop:hover { color: #ff7777; background: rgba(255,119,119,0.08); }
+.rtp-popover-foot {
+  padding: 8px 10px 6px; font-size: 10px;
+  color: rgba(232,233,240,0.35);
+  border-top: 1px solid rgba(255,255,255,0.05); margin-top: 4px;
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Topbar/RunningTerminalsPill.tsx web/src/App.css
+git commit -m "feat(web): add RunningTerminalsPill component (pill + popover)"
+```
+
+---
+
+## Task 12: Mount the pill in the topbar
+
+**Files:**
+- Modify: `web/src/App.tsx`
+
+No SSE wiring needed — Task 5 piggy-backs `session_changed` on each terminal event, and `useSessions` (`web/src/hooks/useSessions.ts:21`) already refetches on it. The pill receives fresh presence via the sessions feed.
+
+- [ ] **Step 1: Mount `RunningTerminalsPill` in the topbar**
+
+In `App.tsx`, import the pill and the presence hook and wire it inside the topbar JSX (alongside the existing avatar / space switcher — grep for `<AuthBadge` or similar to find the topbar region):
+
+```tsx
+import { useTerminalPresence } from "./hooks/useTerminalPresence";
+import { RunningTerminalsPill } from "./components/Topbar/RunningTerminalsPill";
+
+// In the component render, alongside the existing topbar elements:
+const presence = useTerminalPresence(sessions, windows);
+
+<RunningTerminalsPill
+  presence={presence}
+  sessions={sessions}
+  onFocus={(terminalId) => {
+    const w = windows.find(w => w.terminalId === terminalId);
+    if (w) dispatch({ type: "FOCUS", id: w.id });
+  }}
+  onRestore={(sessionId, terminalId) => {
+    const session = sessions.find(s => s.id === sessionId);
+    dispatch({
+      type: "OPEN_CLAUDE_TERMINAL",
+      terminalId,
+      title: session?.title ?? "Claude",
+      cwd: session?.cwd ?? "/",
+      kind: "claude_resume",
+      linkedSessionId: sessionId,
+    });
+  }}
+  onStop={async (terminalId) => {
+    await fetch(`/api/terminals/${encodeURIComponent(terminalId)}`, { method: "DELETE" });
+    // SSE event will trigger refetch.
+  }}
+/>
+```
+
+- [ ] **Step 2: Typecheck + dev server smoke**
+
+```bash
+cd web && npx tsc --noEmit
+```
+
+Then start the dev server and verify the pill appears when you launch a Claude terminal, the popover opens, click row focuses or restores, and Stop ends the session.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/App.tsx
+git commit -m "feat(web): mount RunningTerminalsPill in topbar"
+```
+
+---
+
+## Task 13: Sessions list — `Live` filter + row treatment
+
+**Files:**
+- Modify: `web/src/components/Home/index.tsx`, `web/src/App.css`
+
+- [ ] **Step 1: Extend the filter pills list**
+
+In `web/src/components/Home/index.tsx`, find `LIVE_STATES` and the filter-pill render block (around lines 107-135 per spec citation). Add a new "Live" filter that derives from `useTerminalPresence`:
+
+```tsx
+const presence = useTerminalPresence(sessions, windows);
+const liveCount = presence.totalLive;
+// In the pills render, insert before the existing "waiting" pill:
+{liveCount > 0 && (
+  <button
+    className={`hp-pill hp-pill--live${filter === "live-terminals" ? " is-active" : ""}`}
+    onClick={() => setFilter("live-terminals")}
+  >
+    {liveCount} Live
+  </button>
+)}
+```
+
+Extend the existing filter switch / `useMemo` that produces `visibleSessions` to handle `"live-terminals"` by filtering to sessions where `presence.byId[s.id]` exists.
+
+- [ ] **Step 2: Add per-row Open/Minimised treatment**
+
+In the row render, derive the class:
+
+```tsx
+const live = presence.byId[s.id];
+const rowClass = live
+  ? (live.state === "attached" ? "sr--attached" : "sr--running")
+  : "";
+// …
+<div className={`sr ${rowClass}`}>
+  <span className="sr-space">{s.spaceId}</span>
+  <span className="sr-title">
+    {live
+      ? <span className={live.state === "attached" ? "rd rd--attached" : "rd rd--running"} />
+      : <span className={`rd rd--${s.state}`} />}
+    {s.title ?? "(no title)"}
+  </span>
+  {live?.state === "running" && (
+    <button
+      className="sl-chip sl-chip--restore"
+      onClick={() => onRestore(s.id, live.terminalId)}
+    >Restore</button>
+  )}
+  {/* … existing right-side meta … */}
+</div>
+```
+
+- [ ] **Step 3: Pin live rows to the top in the sort**
+
+Where `visibleSessions` is sorted (look for the existing `.sort(...)` on the rows array), wrap the comparator:
+
+```tsx
+const sorted = visibleSessions.slice().sort((a, b) => {
+  const aLive = presence.byId[a.id] ? 0 : 1;
+  const bLive = presence.byId[b.id] ? 0 : 1;
+  if (aLive !== bLive) return aLive - bLive; // live first
+  // Fall through to existing comparison (last_event_at desc, etc.)
+  return (b.lastEventAt ?? "").localeCompare(a.lastEventAt ?? "");
+});
+```
+
+- [ ] **Step 4: Add the row CSS**
+
+Append to `web/src/App.css`:
+
+```css
+.sr--attached {
+  background: linear-gradient(90deg, rgba(94,234,212,0.06), transparent 70%);
+  border-left: 2px solid #5eead4;
+  padding-left: 12px;
+}
+.sr--running {
+  background: linear-gradient(90deg, rgba(167,139,250,0.05), transparent 70%);
+  border-left: 2px solid #a78bfa;
+  padding-left: 12px;
+}
+.rd--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.5); }
+.rd--running { background: transparent; border: 2px solid #a78bfa; }
+.sl-chip--restore {
+  background: rgba(167,139,250,0.18); color: #a78bfa;
+  font-size: 9px; padding: 2px 7px; border-radius: 4px;
+  letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600;
+  border: none; cursor: pointer;
+}
+.hp-pill--live { background: rgba(94,234,212,0.18); color: #5eead4; }
+```
+
+- [ ] **Step 5: Typecheck + dev server smoke**
+
+```bash
+cd web && npx tsc --noEmit
+```
+
+Run the dev server. Launch a Claude terminal, click ×; confirm the Sessions list row shows the purple outlined dot, the Restore chip, and pinned to top.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/Home/index.tsx web/src/App.css
+git commit -m "feat(web): Sessions list shows Open/Minimised state and Live filter pill"
+```
+
+---
+
+## Task 14: Manual acceptance smoke test
+
+Spec acceptance tests, walked through in a real browser against a real PTY.
+
+- [ ] **Step 1: Start dev server in the worktree**
+
+```bash
+cd /Users/Matthew.Slight/Dev/oyster.worktrees/terminal-minimise-ux
+# If the production Oyster on 4444 is running, kill it first (single-instance lock).
+# Then:
+npm run dev
+```
+
+Open `http://localhost:7337`.
+
+- [ ] **Step 2: Walk the acceptance tests**
+
+Verify each item from `docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md#acceptance-tests`:
+
+- **Minimise keeps PTY alive.** Open a Claude terminal in any space. Send a `pwd` keystroke; see output. Click × on the panel. Confirm: panel gone, topbar pill shows `Running 1 ▾`.
+- **Running pill appears after minimise.** Confirmed in the step above. Also confirm: pill disappears entirely if you Stop the only terminal.
+- **Restore re-attaches the same PTY.** Click the pill → popover → click the row. Panel re-opens. Type `echo OK` — output goes through the same shell history (you should see the earlier `pwd` output in scrollback).
+- **Stop kills the PTY.** Click the Stop button (■) in the popover. The row disappears from the popover. In the Sessions list the row reverts to its underlying state (no dot/stripe).
+- **Boot reset clears stale indicators.** Stop the dev server. Open `~/Oyster/db/oyster.db` (`sqlite3 ~/Oyster/db/oyster.db`) and run `UPDATE sessions SET terminal_id = 'fake', terminal_attached_clients = 3 WHERE id = (SELECT id FROM sessions LIMIT 1);`. Restart the dev server. Refresh the page. Confirm the Sessions list shows no Live / Open / Minimised indicators (the boot reset zeroed them).
+- **Live rows pin to top.** With one Live row in the Sessions list, scroll to the bottom of "done" rows; confirm the Live row is still at the top regardless of last activity.
+
+- [ ] **Step 3: If anything fails, file specific follow-up commits**
+
+Each follow-up gets its own commit so the failure → fix is reviewable in isolation.
+
+---
+
+## Wrap-up
+
+After all tasks pass, push the branch and open the PR.
+
+```bash
+git push -u origin terminal-minimise-ux
+gh pr create --title "Terminal × minimises (keeps PTY alive); Running pill + Sessions list states" --body "$(cat <<'EOF'
+## Summary
+
+Click × on the embedded Claude Code terminal panel now means *minimise* — the PTY stays alive on the server. A new topbar **Running N** pill (with a popover listing every live terminal) gives one-click restore from anywhere. The Sessions list grows an **Open** / **Minimised** state visualisation and a single **Live** filter pill.
+
+Design: [docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md](docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md)
+Plan: [docs/superpowers/plans/2026-05-19-terminal-minimise-ux.md](docs/superpowers/plans/2026-05-19-terminal-minimise-ux.md)
+
+## Test plan
+
+- [x] Server: vitest covers schema migration + boot reset, store link/clear/attached-clients methods, manager link/exit/attach/detach DB writes, SSE event emission, retention bump + 50-retained cap.
+- [x] Web: tsc --noEmit clean.
+- [ ] Manual smoke checklist from the spec's Acceptance Tests (see plan Task 14).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -207,6 +207,9 @@ export class ClaudePtyManager {
     const entry = this.terminals.get(terminalId);
     if (!entry) return false;
     entry.clients.add(ws);
+    if (entry.linkedSessionId) {
+      this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+    }
 
     if (entry.scrollback.length > 0) {
       ws.send(entry.scrollback);
@@ -231,6 +234,9 @@ export class ClaudePtyManager {
 
     ws.on("close", () => {
       entry.clients.delete(ws);
+      if (entry.linkedSessionId) {
+        this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+      }
     });
 
     return true;
@@ -298,6 +304,9 @@ export class ClaudePtyManager {
   isPtyAvailable(): boolean {
     return ptyAvailable;
   }
+
+  /** Test-only: pair `_seedEntryForTest` with a link write in one step. */
+  linkTerminalForTest(terminalId: string, sessionId: string): void { this.setLinkedSession(terminalId, sessionId); }
 
   /** Test-only: inject a fake entry with a stub proc whose onExit fires
    *  immediately on kill(). Production code never calls this. */

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -12,6 +12,13 @@ import { randomUUID } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
+import type { SessionStore } from "./session-store.js";
+import type { UiCommand } from "../../shared/types.js";
+
+export interface ClaudePtyManagerDeps {
+  sessionStore: SessionStore;
+  broadcastUiEvent: (cmd: UiCommand) => void;
+}
 
 const SCROLLBACK_LIMIT = 50_000;
 const POST_EXIT_RETENTION_MS = 30_000;
@@ -98,6 +105,13 @@ export interface ClaudePtyListEntry {
 export class ClaudePtyManager {
   private terminals = new Map<string, ClaudePtyEntry>();
   private wss = new WebSocketServer({ noServer: true });
+  private sessionStore: SessionStore;
+  private broadcastUiEvent: (cmd: UiCommand) => void;
+
+  constructor(deps: ClaudePtyManagerDeps) {
+    this.sessionStore = deps.sessionStore;
+    this.broadcastUiEvent = deps.broadcastUiEvent;
+  }
 
   spawn(input: SpawnInput): SpawnResult {
     if (!ptyAvailable || !ptyModule) {
@@ -177,6 +191,9 @@ export class ClaudePtyManager {
       for (const ws of entry.clients) {
         if (ws.readyState === WebSocket.OPEN) ws.send(closeNote);
       }
+      if (entry.linkedSessionId) {
+        this.sessionStore.clearTerminal(entry.linkedSessionId);
+      }
       // Retain for late reconnects, then evict.
       entry.evictTimer = setTimeout(() => {
         this.terminals.delete(terminalId);
@@ -223,6 +240,7 @@ export class ClaudePtyManager {
     const entry = this.terminals.get(terminalId);
     if (!entry) return false;
     entry.linkedSessionId = sessionId;
+    this.sessionStore.linkTerminal(sessionId, terminalId);
     return true;
   }
 
@@ -279,5 +297,41 @@ export class ClaudePtyManager {
 
   isPtyAvailable(): boolean {
     return ptyAvailable;
+  }
+
+  /** Test-only: inject a fake entry with a stub proc whose onExit fires
+   *  immediately on kill(). Production code never calls this. */
+  _seedEntryForTest(input: { terminalId: string; linkedSessionId: string | null }): void {
+    let exitCb: (e: { exitCode: number }) => void = () => {};
+    const fakeProc: any = {
+      pid: -1,
+      onData: () => {},
+      onExit: (cb: typeof exitCb) => { exitCb = cb; },
+      write: () => {},
+      resize: () => {},
+      kill: () => { exitCb({ exitCode: 0 }); },
+    };
+    const entry: ClaudePtyEntry = {
+      terminalId: input.terminalId,
+      kind: "claude_new",
+      proc: fakeProc,
+      scrollback: "",
+      clients: new Set(),
+      cwd: "/tmp",
+      command: "/bin/echo",
+      args: [],
+      startedAt: Date.now(),
+      exitedAt: null,
+      linkedSessionId: input.linkedSessionId,
+      evictTimer: null,
+    };
+    // Wire the onExit listener the same way spawn() does.
+    fakeProc.onExit((event: { exitCode: number }) => {
+      entry.exitedAt = Date.now();
+      if (entry.linkedSessionId) {
+        this.sessionStore.clearTerminal(entry.linkedSessionId);
+      }
+    });
+    this.terminals.set(input.terminalId, entry);
   }
 }

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -194,15 +194,15 @@ export class ClaudePtyManager {
     const entry = this.terminals.get(terminalId);
     if (!entry) return false;
     entry.clients.add(ws);
-    if (entry.linkedSessionId) {
+    if (entry.exitedAt === null && entry.linkedSessionId) {
       this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+      this.broadcastUiEvent({
+        version: 1,
+        command: "terminal:attached",
+        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size } satisfies TerminalPresenceEventPayload,
+      });
+      this.notifySessionChanged(entry.linkedSessionId);
     }
-    this.broadcastUiEvent({
-      version: 1,
-      command: "terminal:attached",
-      payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size } satisfies TerminalPresenceEventPayload,
-    });
-    this.notifySessionChanged(entry.linkedSessionId);
 
     if (entry.scrollback.length > 0) {
       ws.send(entry.scrollback);
@@ -227,15 +227,15 @@ export class ClaudePtyManager {
 
     ws.on("close", () => {
       entry.clients.delete(ws);
-      if (entry.linkedSessionId) {
+      if (entry.exitedAt === null && entry.linkedSessionId) {
         this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+        this.broadcastUiEvent({
+          version: 1,
+          command: "terminal:detached",
+          payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size } satisfies TerminalPresenceEventPayload,
+        });
+        this.notifySessionChanged(entry.linkedSessionId);
       }
-      this.broadcastUiEvent({
-        version: 1,
-        command: "terminal:detached",
-        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size } satisfies TerminalPresenceEventPayload,
-      });
-      this.notifySessionChanged(entry.linkedSessionId);
     });
 
     return true;
@@ -327,15 +327,17 @@ export class ClaudePtyManager {
     for (const ws of entry.clients) {
       if (ws.readyState === WebSocket.OPEN) ws.send(closeNote);
     }
-    if (entry.linkedSessionId) {
-      this.sessionStore.clearTerminal(entry.linkedSessionId);
+    const exitedSessionId = entry.linkedSessionId;
+    if (exitedSessionId) {
+      this.sessionStore.clearTerminal(exitedSessionId);
+      entry.linkedSessionId = null;
     }
     this.broadcastUiEvent({
       version: 1,
       command: "terminal:exited",
-      payload: { terminalId: entry.terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 } satisfies TerminalPresenceEventPayload,
+      payload: { terminalId: entry.terminalId, sessionId: exitedSessionId, attachedClients: 0 } satisfies TerminalPresenceEventPayload,
     });
-    this.notifySessionChanged(entry.linkedSessionId);
+    this.notifySessionChanged(exitedSessionId);
     // Retain for late reconnects, then evict.
     entry.evictTimer = setTimeout(() => {
       this.terminals.delete(entry.terminalId);

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -194,6 +194,18 @@ export class ClaudePtyManager {
       if (entry.linkedSessionId) {
         this.sessionStore.clearTerminal(entry.linkedSessionId);
       }
+      this.broadcastUiEvent({
+        version: 1,
+        command: "terminal:exited",
+        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 },
+      });
+      if (entry.linkedSessionId) {
+        this.broadcastUiEvent({
+          version: 1,
+          command: "session_changed",
+          payload: { id: entry.linkedSessionId },
+        });
+      }
       // Retain for late reconnects, then evict.
       entry.evictTimer = setTimeout(() => {
         this.terminals.delete(terminalId);
@@ -209,6 +221,18 @@ export class ClaudePtyManager {
     entry.clients.add(ws);
     if (entry.linkedSessionId) {
       this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+    }
+    this.broadcastUiEvent({
+      version: 1,
+      command: "terminal:attached",
+      payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size },
+    });
+    if (entry.linkedSessionId) {
+      this.broadcastUiEvent({
+        version: 1,
+        command: "session_changed",
+        payload: { id: entry.linkedSessionId },
+      });
     }
 
     if (entry.scrollback.length > 0) {
@@ -236,6 +260,18 @@ export class ClaudePtyManager {
       entry.clients.delete(ws);
       if (entry.linkedSessionId) {
         this.sessionStore.setAttachedClients(entry.linkedSessionId, entry.clients.size);
+      }
+      this.broadcastUiEvent({
+        version: 1,
+        command: "terminal:detached",
+        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size },
+      });
+      if (entry.linkedSessionId) {
+        this.broadcastUiEvent({
+          version: 1,
+          command: "session_changed",
+          payload: { id: entry.linkedSessionId },
+        });
       }
     });
 
@@ -339,6 +375,18 @@ export class ClaudePtyManager {
       entry.exitedAt = Date.now();
       if (entry.linkedSessionId) {
         this.sessionStore.clearTerminal(entry.linkedSessionId);
+      }
+      this.broadcastUiEvent({
+        version: 1,
+        command: "terminal:exited",
+        payload: { terminalId: input.terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 },
+      });
+      if (entry.linkedSessionId) {
+        this.broadcastUiEvent({
+          version: 1,
+          command: "session_changed",
+          payload: { id: entry.linkedSessionId },
+        });
       }
     });
     this.terminals.set(input.terminalId, entry);

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -13,7 +13,7 @@ import { WebSocketServer, WebSocket } from "ws";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import type { SessionStore } from "./session-store.js";
-import type { UiCommand } from "../../shared/types.js";
+import type { UiCommand, TerminalPresenceEventPayload } from "../../shared/types.js";
 
 export interface ClaudePtyManagerDeps {
   sessionStore: SessionStore;
@@ -184,33 +184,7 @@ export class ClaudePtyManager {
       }
     });
 
-    proc.onExit(({ exitCode }: { exitCode: number }) => {
-      entry.exitedAt = Date.now();
-      const closeNote = `\r\n\x1b[90m[session ended (exit ${exitCode})]\x1b[0m\r\n`;
-      entry.scrollback += closeNote;
-      for (const ws of entry.clients) {
-        if (ws.readyState === WebSocket.OPEN) ws.send(closeNote);
-      }
-      if (entry.linkedSessionId) {
-        this.sessionStore.clearTerminal(entry.linkedSessionId);
-      }
-      this.broadcastUiEvent({
-        version: 1,
-        command: "terminal:exited",
-        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 },
-      });
-      if (entry.linkedSessionId) {
-        this.broadcastUiEvent({
-          version: 1,
-          command: "session_changed",
-          payload: { id: entry.linkedSessionId },
-        });
-      }
-      // Retain for late reconnects, then evict.
-      entry.evictTimer = setTimeout(() => {
-        this.terminals.delete(terminalId);
-      }, POST_EXIT_RETENTION_MS);
-    });
+    proc.onExit(({ exitCode }: { exitCode: number }) => this._handleExit(entry, exitCode));
 
     return { terminalId, startedAt };
   }
@@ -225,15 +199,9 @@ export class ClaudePtyManager {
     this.broadcastUiEvent({
       version: 1,
       command: "terminal:attached",
-      payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size },
+      payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size } satisfies TerminalPresenceEventPayload,
     });
-    if (entry.linkedSessionId) {
-      this.broadcastUiEvent({
-        version: 1,
-        command: "session_changed",
-        payload: { id: entry.linkedSessionId },
-      });
-    }
+    this.notifySessionChanged(entry.linkedSessionId);
 
     if (entry.scrollback.length > 0) {
       ws.send(entry.scrollback);
@@ -264,15 +232,9 @@ export class ClaudePtyManager {
       this.broadcastUiEvent({
         version: 1,
         command: "terminal:detached",
-        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size },
+        payload: { terminalId, sessionId: entry.linkedSessionId, attachedClients: entry.clients.size } satisfies TerminalPresenceEventPayload,
       });
-      if (entry.linkedSessionId) {
-        this.broadcastUiEvent({
-          version: 1,
-          command: "session_changed",
-          payload: { id: entry.linkedSessionId },
-        });
-      }
+      this.notifySessionChanged(entry.linkedSessionId);
     });
 
     return true;
@@ -341,6 +303,33 @@ export class ClaudePtyManager {
     return ptyAvailable;
   }
 
+  private notifySessionChanged(sessionId: string | null): void {
+    if (!sessionId) return;
+    this.broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: sessionId } });
+  }
+
+  private _handleExit(entry: ClaudePtyEntry, exitCode: number): void {
+    entry.exitedAt = Date.now();
+    const closeNote = `\r\n\x1b[90m[session ended (exit ${exitCode})]\x1b[0m\r\n`;
+    entry.scrollback += closeNote;
+    for (const ws of entry.clients) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(closeNote);
+    }
+    if (entry.linkedSessionId) {
+      this.sessionStore.clearTerminal(entry.linkedSessionId);
+    }
+    this.broadcastUiEvent({
+      version: 1,
+      command: "terminal:exited",
+      payload: { terminalId: entry.terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 } satisfies TerminalPresenceEventPayload,
+    });
+    this.notifySessionChanged(entry.linkedSessionId);
+    // Retain for late reconnects, then evict.
+    entry.evictTimer = setTimeout(() => {
+      this.terminals.delete(entry.terminalId);
+    }, POST_EXIT_RETENTION_MS);
+  }
+
   /** Test-only: pair `_seedEntryForTest` with a link write in one step. */
   linkTerminalForTest(terminalId: string, sessionId: string): void { this.setLinkedSession(terminalId, sessionId); }
 
@@ -371,24 +360,7 @@ export class ClaudePtyManager {
       evictTimer: null,
     };
     // Wire the onExit listener the same way spawn() does.
-    fakeProc.onExit((event: { exitCode: number }) => {
-      entry.exitedAt = Date.now();
-      if (entry.linkedSessionId) {
-        this.sessionStore.clearTerminal(entry.linkedSessionId);
-      }
-      this.broadcastUiEvent({
-        version: 1,
-        command: "terminal:exited",
-        payload: { terminalId: input.terminalId, sessionId: entry.linkedSessionId, attachedClients: 0 },
-      });
-      if (entry.linkedSessionId) {
-        this.broadcastUiEvent({
-          version: 1,
-          command: "session_changed",
-          payload: { id: entry.linkedSessionId },
-        });
-      }
-    });
+    fakeProc.onExit(({ exitCode }: { exitCode: number }) => this._handleExit(entry, exitCode));
     this.terminals.set(input.terminalId, entry);
   }
 }

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -21,7 +21,8 @@ export interface ClaudePtyManagerDeps {
 }
 
 const SCROLLBACK_LIMIT = 50_000;
-const POST_EXIT_RETENTION_MS = 30_000;
+export const POST_EXIT_RETENTION_MS = 15 * 60 * 1000;
+export const MAX_RETAINED_EXITED = 50;
 const MAX_CONCURRENT_TERMINALS = 8;
 
 export class TerminalCapError extends Error {
@@ -308,6 +309,17 @@ export class ClaudePtyManager {
     this.broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: sessionId } });
   }
 
+  private enforceRetentionCap(): void {
+    const exited = Array.from(this.terminals.values())
+      .filter(e => e.exitedAt !== null)
+      .sort((a, b) => (a.exitedAt ?? 0) - (b.exitedAt ?? 0));
+    while (exited.length > MAX_RETAINED_EXITED) {
+      const victim = exited.shift()!;
+      if (victim.evictTimer) { clearTimeout(victim.evictTimer); victim.evictTimer = null; }
+      this.terminals.delete(victim.terminalId);
+    }
+  }
+
   private _handleExit(entry: ClaudePtyEntry, exitCode: number): void {
     entry.exitedAt = Date.now();
     const closeNote = `\r\n\x1b[90m[session ended (exit ${exitCode})]\x1b[0m\r\n`;
@@ -328,6 +340,8 @@ export class ClaudePtyManager {
     entry.evictTimer = setTimeout(() => {
       this.terminals.delete(entry.terminalId);
     }, POST_EXIT_RETENTION_MS);
+    // Eagerly enforce the hard cap, evicting oldest-exited-first.
+    this.enforceRetentionCap();
   }
 
   /** Test-only: pair `_seedEntryForTest` with a link write in one step. */

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -676,6 +676,13 @@ export function initDb(userlandDir: string): Database.Database {
     // the origin device's cwd (e.g. "C:\\Users\\matth" on a Mac-resumed
     // Windows session). Storing the real path is the only ground truth.
     "ALTER TABLE sessions ADD COLUMN jsonl_path TEXT",
+    // Terminal UX: in-memory PTY identity. terminal_id is the UUID of the
+    // live PTY (null between boots); terminal_attached_clients is the count
+    // of WebSocket connections currently tailing the output. Both are reset
+    // to null/0 on boot (see boot reset below) because PTYs are in-memory
+    // only and don't survive a server restart.
+    "ALTER TABLE sessions ADD COLUMN terminal_id TEXT",
+    "ALTER TABLE sessions ADD COLUMN terminal_attached_clients INTEGER NOT NULL DEFAULT 0",
   ]) {
     try { db.exec(sql); } catch { /* already exists */ }
   }
@@ -752,6 +759,15 @@ export function initDb(userlandDir: string): Database.Database {
         AND removed_at IS NULL
     `);
   }
+
+  // Stale-indicator reset. PTYs live in-memory only — they don't survive a
+  // server restart, so any non-null terminal_id or non-zero attached count
+  // from the previous boot is meaningless.
+  db.prepare(
+    `UPDATE sessions
+       SET terminal_id = NULL, terminal_attached_clients = 0
+     WHERE terminal_id IS NOT NULL OR terminal_attached_clients > 0`,
+  ).run();
 
   return db;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -558,7 +558,7 @@ sessionSnapshotHandle.unref();
 const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
 const projectService = new ProjectService(db);
 const sessionService = new SessionService(db, sessionStore);
-const claudePtyManager = new ClaudePtyManager();
+const claudePtyManager = new ClaudePtyManager({ sessionStore, broadcastUiEvent });
 // Forward-declared so the terminal route can hold a stable reference even
 // though the watcher is constructed inside `httpServer.listen`. The route
 // is only ever called after the server is listening (and therefore after

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -151,8 +151,6 @@ export interface MergedSessionPayload {
  *  Exported so unit tests can exercise the mapping without spinning up HTTP. */
 export function mapSessionRow(
   row: SessionRow,
-  myDeviceId: string | null,
-  myDeviceLabel: string | null,
 ): MergedSessionPayload {
   return {
     id: row.id,
@@ -206,7 +204,7 @@ export async function tryHandleSessionRoute(
     const { myDeviceId, myDeviceLabel } = readMyDeviceIdentity(db);
     const resolveActiveLabel = makeActiveLabelResolver(myDeviceId, myDeviceLabel);
     const localPayload: MergedSessionPayload[] = rows.map((row) =>
-      mapSessionRow(row, myDeviceId, myDeviceLabel),
+      mapSessionRow(row),
     );
 
     // Merge cross-device sessions from remote_sessions. Pulled by
@@ -353,27 +351,7 @@ export async function tryHandleSessionRoute(
       const id = m[1]!;
       const row = sessionStore.getById(id);
       if (row) {
-        sendJson({
-          id: row.id,
-          spaceId: row.space_id,
-          projectId: row.project_id ?? null,
-          cwd: row.cwd,
-          agent: row.agent,
-          title: row.title,
-          state: row.state,
-          startedAt: row.started_at,
-          endedAt: row.ended_at,
-          model: row.model,
-          lastEventAt: row.last_event_at,
-          // Local sessions are by definition local — null/true.
-          originDeviceId: null,
-          originDeviceLabel: null,
-          jsonlAvailableLocally: true,
-          hasBytes: true,
-          activeDeviceId: null,
-          activeDeviceLabel: null,
-          assignmentMode: row.assignment_mode,
-        });
+        sendJson(mapSessionRow(row));
         return true;
       }
 
@@ -417,6 +395,9 @@ export async function tryHandleSessionRoute(
             activeDeviceLabel: resolve(
               remoteRow.active_device_id, remoteRow.device_id, remoteRow.device_label,
             ),
+            // Remote sessions have no local PTY terminal.
+            terminalId: null,
+            terminalAttachedClients: 0,
           });
           return true;
         }
@@ -450,26 +431,7 @@ export async function tryHandleSessionRoute(
         }
         const updated = sessionService.moveSession(input);
         broadcastUiEvent({ version: 1, command: "session_changed", payload: { id } });
-        sendJson({
-          id: updated.id,
-          spaceId: updated.space_id,
-          projectId: updated.project_id ?? null,
-          cwd: updated.cwd,
-          agent: updated.agent,
-          title: updated.title,
-          state: updated.state,
-          startedAt: updated.started_at,
-          endedAt: updated.ended_at,
-          model: updated.model,
-          lastEventAt: updated.last_event_at,
-          assignmentMode: updated.assignment_mode,
-          originDeviceId: null,
-          originDeviceLabel: null,
-          jsonlAvailableLocally: true,
-          hasBytes: true,
-          activeDeviceId: null,
-          activeDeviceLabel: null,
-        });
+        sendJson(mapSessionRow(updated));
       } catch (err) {
         if (err instanceof SessionNotFoundError || err instanceof ProjectNotFoundError) {
           sendJson({ error: err.message }, 404);

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -10,7 +10,7 @@ import { basename, join } from "node:path";
 import { existsSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import type Database from "better-sqlite3";
-import type { SessionStore } from "../session-store.js";
+import type { SessionStore, SessionRow } from "../session-store.js";
 import type { SqliteSpaceStore } from "../space-store.js";
 import type { ArtifactService } from "../artifact-service.js";
 import type { MemoryProvider } from "../memory-store.js";
@@ -114,6 +114,76 @@ function validateOverrideTarget(targetCwd: string, remoteCwd: string | null): Va
   return { ok: reasons.length === 0, reasons };
 }
 
+// ── Local-session payload types + mapper ───────────────────────────────────
+
+export interface MergedSessionPayload {
+  id: string;
+  spaceId: string | null;
+  projectId: string | null;
+  cwd: string | null;
+  agent: string;
+  title: string | null;
+  state: string;
+  startedAt: string;
+  endedAt: string | null;
+  model: string | null;
+  lastEventAt: string;
+  originDeviceId: string | null;
+  originDeviceLabel: string | null;
+  jsonlAvailableLocally: boolean;
+  hasBytes: boolean;
+  activeDeviceId: string | null;
+  /** Human-readable label of whichever device most recently wrote a
+   *  chunk for this session. Resolved server-side from one of:
+   *  - this device's device_identity.label (when active is us)
+   *  - remote_sessions.device_label (when active is the origin device)
+   *  - null (when active is some third device we don't yet know about).
+   *  Drives the "Now active on Mac" chip in the UI. */
+  activeDeviceLabel: string | null;
+  assignmentMode?: "auto" | "manual";
+  /** Linked PTY terminal id, or null when no live terminal. */
+  terminalId: string | null;
+  /** Count of currently-attached WS clients on the linked terminal. */
+  terminalAttachedClients: number;
+}
+
+/** Map a local sessions row to the wire payload shape.
+ *  Exported so unit tests can exercise the mapping without spinning up HTTP. */
+export function mapSessionRow(
+  row: SessionRow,
+  myDeviceId: string | null,
+  myDeviceLabel: string | null,
+): MergedSessionPayload {
+  return {
+    id: row.id,
+    spaceId: row.space_id,
+    projectId: row.project_id ?? null,
+    cwd: row.cwd,
+    agent: row.agent,
+    title: row.title,
+    state: row.state,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    model: row.model,
+    lastEventAt: row.last_event_at,
+    // Local sessions are by definition available on this device.
+    originDeviceId: null,
+    originDeviceLabel: null,
+    jsonlAvailableLocally: true,
+    // We don't track "is there a cloud chunk for this local session" here
+    // — that requires a cloud round-trip. For the UI, the
+    // jsonlAvailableLocally flag is the right gate. hasBytes mirrors that
+    // (the file is on disk, so there are bytes to read).
+    hasBytes: true,
+    // Local sessions are always actively written by this device.
+    activeDeviceId: null,
+    activeDeviceLabel: null,
+    assignmentMode: row.assignment_mode,
+    terminalId: row.terminal_id,
+    terminalAttachedClients: row.terminal_attached_clients,
+  };
+}
+
 export async function tryHandleSessionRoute(
   req: IncomingMessage,
   res: ServerResponse,
@@ -130,65 +200,14 @@ export async function tryHandleSessionRoute(
   if (url === "/api/sessions" && req.method === "GET") {
     if (rejectIfNonLocalOrigin()) return true;
     const rows = sessionStore.getAll();
-    interface MergedSessionPayload {
-      id: string;
-      spaceId: string | null;
-      projectId: string | null;
-      cwd: string | null;
-      agent: string;
-      title: string | null;
-      state: string;
-      startedAt: string;
-      endedAt: string | null;
-      model: string | null;
-      lastEventAt: string;
-      originDeviceId: string | null;
-      originDeviceLabel: string | null;
-      jsonlAvailableLocally: boolean;
-      hasBytes: boolean;
-      activeDeviceId: string | null;
-      /** Human-readable label of whichever device most recently wrote a
-       *  chunk for this session. Resolved server-side from one of:
-       *  - this device's device_identity.label (when active is us)
-       *  - remote_sessions.device_label (when active is the origin device)
-       *  - null (when active is some third device we don't yet know about).
-       *  Drives the "Now active on Mac" chip in the UI. */
-      activeDeviceLabel: string | null;
-      assignmentMode?: "auto" | "manual";
-    }
     // Cache the current device identity once — used to resolve "active is us"
     // for both local and remote payload entries. NULL when device_identity
     // hasn't been seeded yet; the chip silently skips in that case.
     const { myDeviceId, myDeviceLabel } = readMyDeviceIdentity(db);
     const resolveActiveLabel = makeActiveLabelResolver(myDeviceId, myDeviceLabel);
-    const localPayload: MergedSessionPayload[] = rows.map((row) => {
-      return {
-        id: row.id,
-        spaceId: row.space_id,
-        projectId: row.project_id ?? null,
-        cwd: row.cwd,
-        agent: row.agent,
-        title: row.title,
-        state: row.state,
-        startedAt: row.started_at,
-        endedAt: row.ended_at,
-        model: row.model,
-        lastEventAt: row.last_event_at,
-        // Local sessions are by definition available on this device.
-        originDeviceId: null,
-        originDeviceLabel: null,
-        jsonlAvailableLocally: true,
-        // We don't track "is there a cloud chunk for this local session" here
-        // — that requires a cloud round-trip. For the UI, the
-        // jsonlAvailableLocally flag is the right gate. hasBytes mirrors that
-        // (the file is on disk, so there are bytes to read).
-        hasBytes: true,
-        // Local sessions are always actively written by this device.
-        activeDeviceId: null,
-        activeDeviceLabel: null,
-        assignmentMode: row.assignment_mode,
-      };
-    });
+    const localPayload: MergedSessionPayload[] = rows.map((row) =>
+      mapSessionRow(row, myDeviceId, myDeviceLabel),
+    );
 
     // Merge cross-device sessions from remote_sessions. Pulled by
     // SessionSyncService from the cloud's GET /api/sessions/metadata.
@@ -255,6 +274,9 @@ export async function tryHandleSessionRoute(
           hasBytes: r.has_bytes === 1,
           activeDeviceId: r.active_device_id,
           activeDeviceLabel: resolveActiveLabel(r.active_device_id, r.device_id, r.device_label),
+          // Remote sessions have no local PTY terminal.
+          terminalId: null,
+          terminalAttachedClients: 0,
         }));
     }
 

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -570,7 +570,7 @@ export class SqliteSessionStore implements SessionStore {
 
   linkTerminal(sessionId: string, terminalId: string): void {
     this.db.prepare(
-      "UPDATE sessions SET terminal_id = ? WHERE id = ?",
+      "UPDATE sessions SET terminal_id = ?, terminal_attached_clients = 0 WHERE id = ?",
     ).run(terminalId, sessionId);
   }
 

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -41,6 +41,10 @@ export interface SessionRow {
    *  watcher refresh on each ingest; `'manual'` is pinned by the user (or
    *  an MCP-driven move_session) and is never overwritten by the watcher. */
   assignment_mode: AssignmentMode;
+  /** ClaudePtyManager terminal id this session is linked to, or null. */
+  terminal_id: string | null;
+  /** Count of currently-attached WS clients on the linked terminal. 0 + non-null terminal_id = Minimised. */
+  terminal_attached_clients: number;
 }
 
 export interface SessionEventRow {
@@ -168,6 +172,12 @@ export interface SessionStore {
    *  matching session with the best-ranked event as the representative
    *  snippet plus a match_count. Used by the Spotlight UI. */
   searchSessions(query: string, opts?: { limit?: number; spaceId?: string }): SessionSearchHit[];
+  /** Mark a session as linked to a running PTY. Idempotent. */
+  linkTerminal(sessionId: string, terminalId: string): void;
+  /** Clear the link and zero the attached-clients counter. Idempotent. */
+  clearTerminal(sessionId: string): void;
+  /** Update the attached-clients counter on the linked session. No-op if the session row is missing. */
+  setAttachedClients(sessionId: string, count: number): void;
 }
 
 // ── SQLite implementation ──
@@ -556,5 +566,23 @@ export class SqliteSessionStore implements SessionStore {
                  LIMIT ?`;
     innerParams.push(limit);
     return this.db.prepare(sql).all(...innerParams) as SessionSearchHit[];
+  }
+
+  linkTerminal(sessionId: string, terminalId: string): void {
+    this.db.prepare(
+      "UPDATE sessions SET terminal_id = ? WHERE id = ?",
+    ).run(terminalId, sessionId);
+  }
+
+  clearTerminal(sessionId: string): void {
+    this.db.prepare(
+      "UPDATE sessions SET terminal_id = NULL, terminal_attached_clients = 0 WHERE id = ?",
+    ).run(sessionId);
+  }
+
+  setAttachedClients(sessionId: string, count: number): void {
+    this.db.prepare(
+      "UPDATE sessions SET terminal_attached_clients = ? WHERE id = ?",
+    ).run(Math.max(0, count | 0), sessionId);
   }
 }

--- a/server/test/claude-pty-manager-link.test.ts
+++ b/server/test/claude-pty-manager-link.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { initDb } from "../src/db.js";
 import { SqliteSessionStore } from "../src/session-store.js";
 import { ClaudePtyManager } from "../src/claude-pty-manager.js";
+import { WebSocket } from "ws";
 
 function makeEnv() {
   const dir = mkdtempSync(join(tmpdir(), "oyster-pty-link-"));
@@ -17,6 +18,42 @@ function makeEnv() {
   return {
     db, store, mgr, events,
     dispose: () => { mgr.disposeAll(); db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("ClaudePtyManager attached clients", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("attach/detach updates terminal_attached_clients on the linked row", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: "s1" });
+    env.mgr.linkTerminalForTest("t1", "s1");
+
+    const fakeWs1 = makeFakeWs();
+    const fakeWs2 = makeFakeWs();
+
+    env.mgr.attachClient("t1", fakeWs1 as unknown as WebSocket);
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(1);
+
+    env.mgr.attachClient("t1", fakeWs2 as unknown as WebSocket);
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(2);
+
+    fakeWs1.fireClose();
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(1);
+
+    fakeWs2.fireClose();
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
+  });
+});
+
+function makeFakeWs() {
+  const handlers: Record<string, ((arg?: unknown) => void)[]> = { message: [], close: [] };
+  return {
+    readyState: 1, // OPEN
+    send: () => {},
+    on(event: string, cb: (arg?: unknown) => void) { handlers[event] ??= []; handlers[event].push(cb); },
+    fireClose() { handlers.close?.forEach(cb => cb()); },
   };
 }
 

--- a/server/test/claude-pty-manager-link.test.ts
+++ b/server/test/claude-pty-manager-link.test.ts
@@ -67,6 +67,49 @@ describe("ClaudePtyManager attached clients", () => {
     fakeWs2.fireClose();
     expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
   });
+
+  it("attach after PTY exit does NOT update terminal_attached_clients", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+    env.mgr.linkTerminalForTest("t1", "s1");
+    // Kill the PTY — fires _handleExit synchronously via the fake proc.
+    env.mgr.kill("t1");
+    // terminal_attached_clients should be 0 after exit (clearTerminal resets it).
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
+    env.events.length = 0;
+
+    // Now attach a new WS to the retained (exited) entry.
+    const ws = makeFakeWs();
+    env.mgr.attachClient("t1", ws as unknown as WebSocket);
+
+    // DB count must remain 0 — no write for an exited terminal.
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
+    // No terminal:attached event should be emitted.
+    expect(env.events.map(e => e.command)).not.toContain("terminal:attached");
+  });
+
+  it("ws close after PTY exit does NOT update terminal_attached_clients", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+    env.mgr.linkTerminalForTest("t1", "s1");
+
+    // Attach a WS while the PTY is still alive.
+    const ws = makeFakeWs();
+    env.mgr.attachClient("t1", ws as unknown as WebSocket);
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(1);
+
+    // Kill the PTY — fires _handleExit synchronously.
+    env.mgr.kill("t1");
+    // clearTerminal resets attached_clients to 0.
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
+    env.events.length = 0;
+
+    // Now close the WS — the close handler should be gated on exitedAt.
+    ws.fireClose();
+
+    // DB count must remain 0 — no write after exit.
+    expect(env.store.getById("s1")!.terminal_attached_clients).toBe(0);
+    // No terminal:detached event should be emitted.
+    expect(env.events.map(e => e.command)).not.toContain("terminal:detached");
+  });
 });
 
 function makeFakeWs() {

--- a/server/test/claude-pty-manager-link.test.ts
+++ b/server/test/claude-pty-manager-link.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { ClaudePtyManager } from "../src/claude-pty-manager.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-pty-link-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  const events: { command: string; payload: unknown }[] = [];
+  const broadcast = (cmd: { command: string; payload: unknown }) => { events.push(cmd); };
+  const mgr = new ClaudePtyManager({ sessionStore: store, broadcastUiEvent: broadcast });
+  store.insertSession({ id: "s1", space_id: null, agent: "claude-code", state: "done" });
+  return {
+    db, store, mgr, events,
+    dispose: () => { mgr.disposeAll(); db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("ClaudePtyManager DB link", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("setLinkedSession writes terminal_id to the linked session row", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+    env.mgr.setLinkedSession("t1", "s1");
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBe("t1");
+  });
+
+  it("calling kill() clears terminal_id on the linked session row", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t2", linkedSessionId: null });
+    env.mgr.setLinkedSession("t2", "s1");
+    env.mgr.kill("t2");
+    // proc.onExit is what actually clears the row; the test seed wires a
+    // synchronous fake proc that fires onExit during kill().
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBeNull();
+    expect(row.terminal_attached_clients).toBe(0);
+  });
+});

--- a/server/test/claude-pty-manager-link.test.ts
+++ b/server/test/claude-pty-manager-link.test.ts
@@ -26,6 +26,28 @@ describe("ClaudePtyManager attached clients", () => {
   beforeEach(() => { env = makeEnv(); });
   afterEach(() => { env.dispose(); });
 
+  it("emits terminal:attached / terminal:detached / terminal:exited", () => {
+    env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+    env.mgr.linkTerminalForTest("t1", "s1");
+    env.events.length = 0;
+
+    const ws = makeFakeWs();
+    env.mgr.attachClient("t1", ws as unknown as WebSocket);
+    ws.fireClose();
+    env.mgr.kill("t1");
+
+    const commands = env.events.map(e => e.command);
+    expect(commands).toContain("terminal:attached");
+    expect(commands).toContain("terminal:detached");
+    expect(commands).toContain("terminal:exited");
+
+    const attachedEvent = env.events.find(e => e.command === "terminal:attached")!;
+    const payload = attachedEvent.payload as { terminalId: string; sessionId: string | null; attachedClients: number };
+    expect(payload.terminalId).toBe("t1");
+    expect(payload.sessionId).toBe("s1");
+    expect(payload.attachedClients).toBe(1);
+  });
+
   it("attach/detach updates terminal_attached_clients on the linked row", () => {
     env.mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: "s1" });
     env.mgr.linkTerminalForTest("t1", "s1");

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -6,6 +6,35 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ClaudePtyManager, TerminalCapError, PtyUnavailableError } from "../src/claude-pty-manager.js";
 import { tmpdir, homedir } from "node:os";
 
+const stubDeps = {
+  sessionStore: {
+    getAll: () => [],
+    getById: () => undefined,
+    getMostRecentActiveByAgent: () => undefined,
+    insertSession: () => {},
+    upsertSession: () => {},
+    updateSessionState: () => {},
+    updateSession: () => {},
+    insertEvent: () => 0,
+    insertEvents: () => {},
+    getEventsBySession: () => [],
+    getEventsBeforeBySession: () => [],
+    getEventsAfterBySession: () => [],
+    getEventById: () => undefined,
+    insertArtifactTouch: () => {},
+    getArtifactsBySession: () => [],
+    getSessionsByArtifact: () => [],
+    getLastOffset: () => 0,
+    setLastOffset: () => {},
+    searchEvents: () => [],
+    searchSessions: () => [],
+    linkTerminal: () => {},
+    clearTerminal: () => {},
+    setAttachedClients: () => {},
+  } as any,
+  broadcastUiEvent: () => {},
+};
+
 const SLEEP = process.platform === "win32" ? "ping" : "sleep";
 const SLEEP_ARGS = process.platform === "win32"
   ? ["-n", "60", "127.0.0.1"]
@@ -15,7 +44,7 @@ describe("ClaudePtyManager", () => {
   let mgr: ClaudePtyManager;
 
   beforeEach(() => {
-    mgr = new ClaudePtyManager();
+    mgr = new ClaudePtyManager(stubDeps);
   });
   afterEach(() => {
     mgr.disposeAll();

--- a/server/test/pty-retention-cap.test.ts
+++ b/server/test/pty-retention-cap.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { ClaudePtyManager, POST_EXIT_RETENTION_MS, MAX_RETAINED_EXITED } from "../src/claude-pty-manager.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-pty-cap-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  const mgr = new ClaudePtyManager({ sessionStore: store, broadcastUiEvent: () => {} });
+  return { db, store, mgr, dispose: () => { mgr.disposeAll(); db.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+describe("ClaudePtyManager retention", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("POST_EXIT_RETENTION_MS is 15 minutes", () => {
+    expect(POST_EXIT_RETENTION_MS).toBe(15 * 60 * 1000);
+  });
+
+  it("MAX_RETAINED_EXITED is 50", () => {
+    expect(MAX_RETAINED_EXITED).toBe(50);
+  });
+
+  it("evicts the oldest exited entry when the cap is exceeded", () => {
+    // Seed MAX_RETAINED_EXITED + 1 exited entries, oldest first.
+    for (let i = 0; i < MAX_RETAINED_EXITED + 1; i++) {
+      env.mgr._seedEntryForTest({ terminalId: `t${i}`, linkedSessionId: null });
+      env.mgr.kill(`t${i}`); // marks exited via the fake proc's onExit
+    }
+    expect(env.mgr.list().length).toBe(MAX_RETAINED_EXITED);
+    expect(env.mgr.getEntry("t0")).toBeUndefined(); // oldest evicted
+    expect(env.mgr.getEntry(`t${MAX_RETAINED_EXITED}`)).toBeDefined(); // newest kept
+  });
+});

--- a/server/test/session-store-terminal-link.test.ts
+++ b/server/test/session-store-terminal-link.test.ts
@@ -40,6 +40,17 @@ describe("SqliteSessionStore terminal link", () => {
     expect(cleared.terminal_attached_clients).toBe(0);
   });
 
+  it("linkTerminal resets stale attached_clients to 0", () => {
+    seed(env.store, "s1");
+    env.store.linkTerminal("s1", "term-1");
+    env.store.setAttachedClients("s1", 5);
+    // Simulate stale state: re-link to a different terminal id without going through clearTerminal.
+    env.store.linkTerminal("s1", "term-2");
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBe("term-2");
+    expect(row.terminal_attached_clients).toBe(0);
+  });
+
   it("setAttachedClients on an unknown session is a no-op (does not throw)", () => {
     expect(() => env.store.setAttachedClients("missing", 1)).not.toThrow();
   });

--- a/server/test/session-store-terminal-link.test.ts
+++ b/server/test/session-store-terminal-link.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function seed(store: SqliteSessionStore, id: string) {
+  store.insertSession({
+    id, space_id: null, agent: "claude-code", state: "done",
+  });
+}
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-term-link-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  return {
+    db, store,
+    dispose: () => { db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("SqliteSessionStore terminal link", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("linkTerminal writes terminal_id, clearTerminal nulls it and resets clients", () => {
+    seed(env.store, "s1");
+    env.store.linkTerminal("s1", "term-1");
+    env.store.setAttachedClients("s1", 2);
+    const row = env.store.getById("s1")!;
+    expect(row.terminal_id).toBe("term-1");
+    expect(row.terminal_attached_clients).toBe(2);
+
+    env.store.clearTerminal("s1");
+    const cleared = env.store.getById("s1")!;
+    expect(cleared.terminal_id).toBeNull();
+    expect(cleared.terminal_attached_clients).toBe(0);
+  });
+
+  it("setAttachedClients on an unknown session is a no-op (does not throw)", () => {
+    expect(() => env.store.setAttachedClients("missing", 1)).not.toThrow();
+  });
+});

--- a/server/test/sessions-route-terminal-fields.test.ts
+++ b/server/test/sessions-route-terminal-fields.test.ts
@@ -24,7 +24,7 @@ describe("GET /api/sessions payload — terminal fields", () => {
     env.store.setAttachedClients("s1", 2);
 
     const row = env.store.getById("s1")!;
-    const payload = mapSessionRow(row, /* myDeviceId */ null, /* myDeviceLabel */ null);
+    const payload = mapSessionRow(row);
     expect(payload.terminalId).toBe("term-1");
     expect(payload.terminalAttachedClients).toBe(2);
   });
@@ -32,7 +32,7 @@ describe("GET /api/sessions payload — terminal fields", () => {
   it("payload mapping projects null/0 when no terminal linked", () => {
     env.store.insertSession({ id: "s2", space_id: null, agent: "claude-code", state: "done" });
     const row = env.store.getById("s2")!;
-    const payload = mapSessionRow(row, null, null);
+    const payload = mapSessionRow(row);
     expect(payload.terminalId).toBeNull();
     expect(payload.terminalAttachedClients).toBe(0);
   });

--- a/server/test/sessions-route-terminal-fields.test.ts
+++ b/server/test/sessions-route-terminal-fields.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { mapSessionRow } from "../src/routes/sessions.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-sess-route-term-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  return { db, store, dispose: () => { db.close(); rmSync(dir, { recursive: true, force: true }); } };
+}
+
+describe("GET /api/sessions payload — terminal fields", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("payload mapping projects terminal_id and terminal_attached_clients", () => {
+    env.store.insertSession({ id: "s1", space_id: null, agent: "claude-code", state: "done" });
+    env.store.linkTerminal("s1", "term-1");
+    env.store.setAttachedClients("s1", 2);
+
+    const row = env.store.getById("s1")!;
+    const payload = mapSessionRow(row, /* myDeviceId */ null, /* myDeviceLabel */ null);
+    expect(payload.terminalId).toBe("term-1");
+    expect(payload.terminalAttachedClients).toBe(2);
+  });
+
+  it("payload mapping projects null/0 when no terminal linked", () => {
+    env.store.insertSession({ id: "s2", space_id: null, agent: "claude-code", state: "done" });
+    const row = env.store.getById("s2")!;
+    const payload = mapSessionRow(row, null, null);
+    expect(payload.terminalId).toBeNull();
+    expect(payload.terminalAttachedClients).toBe(0);
+  });
+});

--- a/server/test/sessions-table-terminal-columns.test.ts
+++ b/server/test/sessions-table-terminal-columns.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-term-cols-"));
+  return {
+    dir,
+    dispose: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("sessions table — terminal columns", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("adds terminal_id and terminal_attached_clients columns idempotently", () => {
+    const db1 = initDb(env.dir);
+    const cols = db1.prepare("PRAGMA table_info(sessions)").all() as { name: string }[];
+    const names = cols.map(c => c.name);
+    expect(names).toContain("terminal_id");
+    expect(names).toContain("terminal_attached_clients");
+    db1.close();
+
+    // Re-init — must not throw on duplicate-column ALTER.
+    const db2 = initDb(env.dir);
+    db2.close();
+  });
+
+  it("boot reset clears stale terminal_id and zeros attached clients", () => {
+    const db1 = initDb(env.dir);
+    db1.prepare(
+      `INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('s','s','#000','none')`,
+    ).run();
+    db1.prepare(
+      `INSERT INTO sessions
+         (id, space_id, cwd, agent, title, state, started_at, last_event_at,
+          terminal_id, terminal_attached_clients)
+       VALUES
+         ('a', 's', NULL, 'claude-code', 't', 'done',
+          '2026-05-19T10:00:00Z', '2026-05-19T10:30:00Z',
+          'stale-term-id', 3)`,
+    ).run();
+    db1.close();
+
+    // Re-init — boot reset should fire.
+    const db2 = initDb(env.dir);
+    const row = db2.prepare(
+      "SELECT terminal_id, terminal_attached_clients FROM sessions WHERE id = 'a'",
+    ).get() as { terminal_id: string | null; terminal_attached_clients: number };
+    expect(row.terminal_id).toBeNull();
+    expect(row.terminal_attached_clients).toBe(0);
+    db2.close();
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -200,6 +200,14 @@ export interface Space {
   updatedAt: string;
 }
 
+/** Payload for the `terminal:attached` / `terminal:detached` / `terminal:exited`
+ *  UiCommand variants. SessionId is null when the PTY was not yet linked. */
+export interface TerminalPresenceEventPayload {
+  terminalId: string;
+  sessionId: string | null;
+  attachedClients: number;
+}
+
 /** SSE message broadcast on /api/ui/events. The web app subscribes via
  *  subscribeUiEvents and routes by `command`. The `version` field is
  *  reserved for future envelope evolution — today's client (ui-events.ts)

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -133,6 +133,10 @@ export interface Session {
    *  it. Returned by GET /api/sessions/:id and PATCH; absent on older
    *  rows from before this column existed, which the UI treats as 'auto'. */
   assignmentMode?: "auto" | "manual";
+  /** Linked PTY terminal id, or null when no live terminal. */
+  terminalId: string | null;
+  /** Count of currently-attached WS clients on the linked terminal. */
+  terminalAttachedClients: number;
 }
 
 /** POST /api/sessions/:id/resume response shapes. */

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2484,3 +2484,69 @@ body {
   position: relative;
   z-index: 1;
 }
+
+/* ── Topbar Running terminals pill + popover ─────────────────────── */
+.rtp-wrap { position: relative; display: inline-flex; }
+.rtp-pill {
+  padding: 4px 10px; border-radius: 14px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid transparent;
+  color: rgba(232,233,240,0.75);
+  font-size: 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+  cursor: pointer;
+}
+.rtp-pill--open { background: rgba(94,234,212,0.12); border-color: rgba(94,234,212,0.35); color: #5eead4; }
+.rtp-pulse {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: #5eead4; box-shadow: 0 0 8px rgba(94,234,212,0.7);
+  animation: rtp-pulse 1.6s infinite;
+}
+@keyframes rtp-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.45 } }
+
+.rtp-popover {
+  position: absolute; top: calc(100% + 8px); right: 0; z-index: 60;
+  background: #1d1f29; border: 1px solid rgba(94,234,212,0.3);
+  border-radius: 10px; padding: 6px; min-width: 340px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.6);
+}
+.rtp-popover-arrow {
+  position: absolute; top: -6px; right: 24px; width: 12px; height: 12px;
+  background: #1d1f29;
+  border-left: 1px solid rgba(94,234,212,0.3);
+  border-top: 1px solid rgba(94,234,212,0.3);
+  transform: rotate(45deg);
+}
+.rtp-popover-head {
+  padding: 8px 10px 6px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em;
+  color: rgba(232,233,240,0.4); display: flex; justify-content: space-between;
+}
+.rtp-row {
+  display: grid; grid-template-columns: 14px 1fr auto auto;
+  gap: 10px; align-items: center; padding: 8px 10px; border-radius: 6px; cursor: pointer;
+}
+.rtp-row + .rtp-row { margin-top: 2px; }
+.rtp-row:hover { background: rgba(255,255,255,0.04); }
+.rtp-dot { width: 9px; height: 9px; border-radius: 50%; }
+.rtp-dot--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
+.rtp-dot--running { background: transparent; border: 2px solid #a78bfa; box-shadow: 0 0 6px rgba(167,139,250,0.4); }
+.rtp-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.rtp-title { font-size: 12px; color: #e8e9f0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rtp-meta { font-size: 10px; color: rgba(232,233,240,0.45); }
+.rtp-meta .rtp-space { color: #b39dff; }
+.rtp-chip {
+  font-size: 9px; padding: 2px 7px; border-radius: 4px;
+  letter-spacing: 0.05em; text-transform: uppercase; font-weight: 600;
+}
+.rtp-chip--restore { background: rgba(167,139,250,0.18); color: #a78bfa; }
+.rtp-stop {
+  background: transparent; border: none; cursor: pointer;
+  color: rgba(232,233,240,0.4); font-size: 12px; padding: 4px 6px;
+  border-radius: 4px;
+}
+.rtp-stop:hover { color: #ff7777; background: rgba(255,119,119,0.08); }
+.rtp-popover-foot {
+  padding: 8px 10px 6px; font-size: 10px;
+  color: rgba(232,233,240,0.35);
+  border-top: 1px solid rgba(255,255,255,0.05); margin-top: 4px;
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2493,7 +2493,9 @@ body {
   border: 1px solid transparent;
   color: rgba(232,233,240,0.75);
   font-size: 12px;
-  display: inline-flex; align-items: center; gap: 6px;
+  /* No flex gap — .home-breadcrumb-badges (used for the count) carries
+   * its own margin-right, so a gap here would compound. */
+  display: inline-flex; align-items: center;
   cursor: pointer;
 }
 .rtp-pill--open { background: rgba(94,234,212,0.12); border-color: rgba(94,234,212,0.35); color: #5eead4; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2539,6 +2539,7 @@ body {
   letter-spacing: 0.05em; text-transform: uppercase; font-weight: 600;
 }
 .rtp-chip--restore { background: rgba(167,139,250,0.18); color: #a78bfa; }
+.rtp-chip-placeholder { display: inline-block; width: 0; }
 .rtp-stop {
   background: transparent; border: none; cursor: pointer;
   color: rgba(232,233,240,0.4); font-size: 12px; padding: 4px 6px;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2551,3 +2551,26 @@ body {
   color: rgba(232,233,240,0.35);
   border-top: 1px solid rgba(255,255,255,0.05); margin-top: 4px;
 }
+
+/* ── Sessions list: live terminal row treatment (Task 13) ── */
+.sr--attached {
+  background: linear-gradient(90deg, rgba(94,234,212,0.06), transparent 70%);
+  border-left: 2px solid #5eead4;
+  padding-left: 12px;
+}
+.sr--running {
+  background: linear-gradient(90deg, rgba(167,139,250,0.05), transparent 70%);
+  border-left: 2px solid #a78bfa;
+  padding-left: 12px;
+}
+.home-row-status.rd--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.5); }
+.home-row-status.rd--running { background: transparent; border: 2px solid #a78bfa; }
+.sl-chip--restore {
+  background: rgba(167,139,250,0.18); color: #a78bfa;
+  font-size: 9px; padding: 2px 7px; border-radius: 4px;
+  letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600;
+  border: none; cursor: pointer; margin-right: 4px;
+}
+.sl-chip--restore:hover { background: rgba(167,139,250,0.28); }
+.stat-btn--live-terminals { color: #5eead4; }
+.stat-btn--live-terminals.active { background: rgba(94,234,212,0.15); color: #5eead4; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1224,6 +1224,12 @@ body {
   background: rgba(255, 80, 80, 0.3);
   color: #ff6b6b;
 }
+/* Stop button on terminal panel headers — mirrors the popover Stop. */
+.window-btn--stop { color: rgba(232, 233, 240, 0.55); }
+.window-btn--stop:hover {
+  background: rgba(255, 80, 80, 0.18);
+  color: #ff6b6b;
+}
 
 .window-body {
   flex: 1;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2553,15 +2553,21 @@ body {
 }
 
 /* ── Sessions list: live terminal row treatment (Task 13) ── */
-.sr--attached {
+.home-row.sr--attached {
   background: linear-gradient(90deg, rgba(94,234,212,0.06), transparent 70%);
   border-left: 2px solid #5eead4;
   padding-left: 12px;
 }
-.sr--running {
+.home-row.sr--attached:hover {
+  background: linear-gradient(90deg, rgba(94,234,212,0.10), rgba(124,107,255,0.05) 70%);
+}
+.home-row.sr--running {
   background: linear-gradient(90deg, rgba(167,139,250,0.05), transparent 70%);
   border-left: 2px solid #a78bfa;
   padding-left: 12px;
+}
+.home-row.sr--running:hover {
+  background: linear-gradient(90deg, rgba(167,139,250,0.09), rgba(124,107,255,0.05) 70%);
 }
 .home-row-status.rd--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.5); }
 .home-row-status.rd--running { background: transparent; border: 2px solid #a78bfa; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2542,11 +2542,17 @@ body {
   border-radius: 4px;
 }
 .rtp-stop:hover { color: #ff7777; background: rgba(255,119,119,0.08); }
-.rtp-popover-foot {
-  padding: 8px 10px 6px; font-size: 10px;
-  color: rgba(232,233,240,0.35);
-  border-top: 1px solid rgba(255,255,255,0.05); margin-top: 4px;
+.rtp-divider {
+  width: 1px; height: 16px;
+  background: rgba(255,255,255,0.08);
+  margin: 0 8px;
 }
+.rtp-confirm-checkbox {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; color: rgba(232,233,240,0.6);
+  margin-top: 8px; cursor: pointer;
+}
+.rtp-confirm-checkbox input { accent-color: #5eead4; }
 
 /* ── Sessions list: live terminal row treatment (Task 13) ── */
 .home-row.sr--attached {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2518,14 +2518,16 @@ body {
   transform: rotate(45deg);
 }
 .rtp-row {
-  display: grid; grid-template-columns: 14px 1fr auto auto;
+  display: grid; grid-template-columns: 14px 1fr auto;
   gap: 10px; align-items: center; padding: 8px 10px; border-radius: 6px; cursor: pointer;
 }
 .rtp-row + .rtp-row { margin-top: 2px; }
 .rtp-row:hover { background: rgba(255,255,255,0.04); }
-.rtp-dot { width: 9px; height: 9px; border-radius: 50%; }
-.rtp-dot--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
-.rtp-dot--running { background: transparent; border: 2px solid #a78bfa; box-shadow: 0 0 6px rgba(167,139,250,0.4); }
+/* Both Open and Minimised terminals are "running" — share the teal dot.
+ * The Restore chip on Minimised rows is the only state-distinguishing
+ * signal in the popover. */
+.rtp-dot { width: 9px; height: 9px; border-radius: 50%; background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
+.rtp-dot--attached, .rtp-dot--running { /* same — kept as separate classes for any future per-state styling */ }
 .rtp-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .rtp-title { font-size: 12px; color: #e8e9f0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .rtp-meta { font-size: 10px; color: rgba(232,233,240,0.45); }
@@ -2554,32 +2556,28 @@ body {
 }
 .rtp-confirm-checkbox input { accent-color: #5eead4; }
 
-/* ── Sessions list: live terminal row treatment (Task 13) ── */
-.home-row.sr--attached {
+/* ── Sessions list: live terminal row treatment ──
+ * Both Open and Minimised are "running" — same teal stripe + dot.
+ * Clicking the row focuses (Open) or restores (Minimised) — no chip needed. */
+.home-row.sr--attached,
+.home-row.sr--running {
   background: linear-gradient(90deg, rgba(94,234,212,0.06), transparent 70%);
   border-left: 2px solid #5eead4;
   padding-left: 12px;
 }
-.home-row.sr--attached:hover {
+.home-row.sr--attached:hover,
+.home-row.sr--running:hover {
   background: linear-gradient(90deg, rgba(94,234,212,0.10), rgba(124,107,255,0.05) 70%);
 }
-.home-row.sr--running {
-  background: linear-gradient(90deg, rgba(167,139,250,0.05), transparent 70%);
-  border-left: 2px solid #a78bfa;
-  padding-left: 12px;
-}
-.home-row.sr--running:hover {
-  background: linear-gradient(90deg, rgba(167,139,250,0.09), rgba(124,107,255,0.05) 70%);
-}
-.home-row-status.rd--attached { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.5); }
-.home-row-status.rd--running { background: transparent; border: 2px solid #a78bfa; }
-.sl-chip--restore {
-  background: rgba(167,139,250,0.18); color: #a78bfa;
+.home-row-status.rd--attached,
+.home-row-status.rd--running { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.5); }
+.sl-chip--inspect {
+  background: rgba(255,255,255,0.06); color: rgba(232,233,240,0.7);
   font-size: 9px; padding: 2px 7px; border-radius: 4px;
   letter-spacing: 0.04em; text-transform: uppercase; font-weight: 600;
   border: none; cursor: pointer; margin-right: 4px;
 }
-.sl-chip--restore:hover { background: rgba(167,139,250,0.28); }
+.sl-chip--inspect:hover { background: rgba(255,255,255,0.12); color: #e8e9f0; }
 .stat-btn--live-terminals { color: #5eead4; }
 .stat-btn--live-terminals.active { background: rgba(94,234,212,0.15); color: #5eead4; }
 
@@ -2602,6 +2600,6 @@ body {
   height: 7px;
   border-radius: 50%;
 }
-.tile-presence-dot.tpd--attached::before { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
-.tile-presence-dot.tpd--running { background: var(--desktop-bg, #1e1f36); }
-.tile-presence-dot.tpd--running::before { background: transparent; border: 1.5px solid #a78bfa; width: 6px; height: 6px; }
+/* Both Open and Minimised tiles get the same teal dot — they're both running. */
+.tile-presence-dot.tpd--attached::before,
+.tile-presence-dot.tpd--running::before { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2517,10 +2517,6 @@ body {
   border-top: 1px solid rgba(94,234,212,0.3);
   transform: rotate(45deg);
 }
-.rtp-popover-head {
-  padding: 8px 10px 6px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em;
-  color: rgba(232,233,240,0.4); display: flex; justify-content: space-between;
-}
 .rtp-row {
   display: grid; grid-template-columns: 14px 1fr auto auto;
   gap: 10px; align-items: center; padding: 8px 10px; border-radius: 6px; cursor: pointer;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2542,11 +2542,6 @@ body {
   border-radius: 4px;
 }
 .rtp-stop:hover { color: #ff7777; background: rgba(255,119,119,0.08); }
-.rtp-divider {
-  width: 1px; height: 16px;
-  background: rgba(255,255,255,0.08);
-  margin: 0 8px;
-}
 .rtp-confirm-checkbox {
   display: inline-flex; align-items: center; gap: 6px;
   font-size: 12px; color: rgba(232,233,240,0.6);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2574,3 +2574,26 @@ body {
 .sl-chip--restore:hover { background: rgba(167,139,250,0.28); }
 .stat-btn--live-terminals { color: #5eead4; }
 .stat-btn--live-terminals.active { background: rgba(94,234,212,0.15); color: #5eead4; }
+
+/* ── Sessions icon-view: live terminal tile dot ── */
+.tile-presence-dot {
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--desktop-bg, #1e1f36);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.tile-presence-dot::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.tile-presence-dot.tpd--attached::before { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
+.tile-presence-dot.tpd--running { background: var(--desktop-bg, #1e1f36); }
+.tile-presence-dot.tpd--running::before { background: transparent; border: 1.5px solid #a78bfa; width: 6px; height: 6px; }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2497,11 +2497,9 @@ body {
   cursor: pointer;
 }
 .rtp-pill--open { background: rgba(94,234,212,0.12); border-color: rgba(94,234,212,0.35); color: #5eead4; }
-.rtp-pulse {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: #5eead4; box-shadow: 0 0 8px rgba(94,234,212,0.7);
-  animation: rtp-pulse 1.6s infinite;
-}
+/* Pulse animation applied to a standard .pip element so the dot+count
+ * uses the same .pip-count layout as the space-pill badges. */
+.rtp-pulse-anim { animation: rtp-pulse 1.6s infinite; }
 @keyframes rtp-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.45 } }
 
 .rtp-popover {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -324,7 +324,7 @@ export default function App() {
   const terminalWindow = windows.find((w) => w.type === "terminal");
   const claudeTerminals = windows.filter((w) => w.type === "claude_terminal");
 
-  const { sessions: allSessions } = useSessions();
+  const { sessions: allSessions, loading: sessionsLoading, error: sessionsError } = useSessions();
 
   async function handleArtifactClick(artifact: Artifact) {
     if (artifact.status === "generating") return;
@@ -501,6 +501,9 @@ export default function App() {
         onLaunchClaude={handleLaunchClaudeFromProject}
         onLaunchClaudeFromSession={handleLaunchClaudeFromSession}
         onOpenRemoteInOyster={handleOpenRemoteInOyster}
+        sessions={allSessions}
+        sessionsLoading={sessionsLoading}
+        sessionsError={sessionsError}
         terminalWindows={claudeTerminals}
         onTerminalFocus={(terminalId) => {
           const w = windows.find(w => w.terminalId === terminalId);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -634,6 +634,11 @@ export default function App() {
               title={w.title}
               linkedSessionId={w.linkedSessionId}
               ptyAlive={ptyAlive}
+              onStop={ptyAlive && w.terminalId ? async () => {
+                await fetch(`/api/terminals/${encodeURIComponent(w.terminalId!)}`, { method: "DELETE" });
+                // SSE event will refresh sessions feed; the window's
+                // ptyAlive flag flips to false on next render.
+              } : undefined}
               onOpenSession={(sessionId) => {
                 // Route to /s/<space>/sessions/<id>; the space prefix is required
                 // by the active routing today, so use the current activeSpace

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -615,28 +615,37 @@ export default function App() {
             onClose={() => dispatch({ type: "MINIMISE", id: terminalWindow.id })}
           />
         )}
-        {claudeTerminals.map((w, i) => (
-          <TerminalWindow
-            key={w.id}
-            defaultX={140 + i * 24}
-            defaultY={80 + i * 24}
-            zIndex={w.zIndex}
-            onFocus={() => dispatch({ type: "FOCUS", id: w.id })}
-            onClose={() => dispatch({ type: "MINIMISE", id: w.id })}
-            terminalId={w.terminalId}
-            title={w.title}
-            linkedSessionId={w.linkedSessionId}
-            onOpenSession={(sessionId) => {
-              // Route to /s/<space>/sessions/<id>; the space prefix is required
-              // by the active routing today, so use the current activeSpace
-              // (the session inspector itself does its own resolve).
-              window.history.pushState(null, "", `/s/${activeSpace}/sessions/${sessionId}`);
-              // Nudge the router (mirrors how artifact navigation triggers
-              // a popstate elsewhere).
-              window.dispatchEvent(new PopStateEvent("popstate"));
-            }}
-          />
-        ))}
+        {claudeTerminals.map((w, i) => {
+          // PTY alive iff some session row reports this terminalId as live.
+          // After Stop / natural exit / cross-tab kill, the server clears
+          // session.terminalId on the linked row, so this flips to false.
+          const ptyAlive = w.terminalId
+            ? allSessions.some((s) => s.terminalId === w.terminalId)
+            : true; // legacy non-Claude terminals always treat × as minimise
+          return (
+            <TerminalWindow
+              key={w.id}
+              defaultX={140 + i * 24}
+              defaultY={80 + i * 24}
+              zIndex={w.zIndex}
+              onFocus={() => dispatch({ type: "FOCUS", id: w.id })}
+              onClose={() => dispatch({ type: ptyAlive ? "MINIMISE" : "CLOSE", id: w.id })}
+              terminalId={w.terminalId}
+              title={w.title}
+              linkedSessionId={w.linkedSessionId}
+              ptyAlive={ptyAlive}
+              onOpenSession={(sessionId) => {
+                // Route to /s/<space>/sessions/<id>; the space prefix is required
+                // by the active routing today, so use the current activeSpace
+                // (the session inspector itself does its own resolve).
+                window.history.pushState(null, "", `/s/${activeSpace}/sessions/${sessionId}`);
+                // Nudge the router (mirrors how artifact navigation triggers
+                // a popstate elsewhere).
+                window.dispatchEvent(new PopStateEvent("popstate"));
+              }}
+            />
+          );
+        })}
       </div>
 
       {showHardcoreGate && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -519,7 +519,10 @@ export default function App() {
         }}
         onTerminalStop={async (terminalId) => {
           await fetch(`/api/terminals/${encodeURIComponent(terminalId)}`, { method: "DELETE" });
-          // SSE event will trigger refetch.
+          // Also close any open panel for this terminal — Stop is a finish
+          // action; the user doesn't need the dead panel hanging around.
+          const w = windows.find((x) => x.terminalId === terminalId);
+          if (w) dispatch({ type: "CLOSE", id: w.id });
         }}
         desktopProps={{
           space: activeSpace,
@@ -636,8 +639,8 @@ export default function App() {
               ptyAlive={ptyAlive}
               onStop={ptyAlive && w.terminalId ? async () => {
                 await fetch(`/api/terminals/${encodeURIComponent(w.terminalId!)}`, { method: "DELETE" });
-                // SSE event will refresh sessions feed; the window's
-                // ptyAlive flag flips to false on next render.
+                // Close the panel too — Stop is a finish action, not a pause.
+                dispatch({ type: "CLOSE", id: w.id });
               } : undefined}
               onOpenSession={(sessionId) => {
                 // Route to /s/<space>/sessions/<id>; the space prefix is required

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,8 @@ import type { Space, SetupProposal } from "../../shared/types";
 import { createSession, sendMessage } from "./data/chat-api";
 import { unpublishArtifact } from "./data/publish-api";
 import { launchAndOpen, humanError } from "./lib/launch-terminal";
+import { useSessions } from "./hooks/useSessions";
+import { useTerminalPresence } from "./hooks/useTerminalPresence";
 import "./App.css";
 
 // `?onboarding=force` wipes the dock's persisted state and pretends this
@@ -323,6 +325,9 @@ export default function App() {
   const terminalWindow = windows.find((w) => w.type === "terminal");
   const claudeTerminals = windows.filter((w) => w.type === "claude_terminal");
 
+  const { sessions: allSessions } = useSessions();
+  const presence = useTerminalPresence(allSessions, windows);
+
   async function handleArtifactClick(artifact: Artifact) {
     if (artifact.status === "generating") return;
 
@@ -498,6 +503,26 @@ export default function App() {
         onLaunchClaude={handleLaunchClaudeFromProject}
         onLaunchClaudeFromSession={handleLaunchClaudeFromSession}
         onOpenRemoteInOyster={handleOpenRemoteInOyster}
+        terminalWindows={claudeTerminals}
+        onTerminalFocus={(terminalId) => {
+          const w = windows.find(w => w.terminalId === terminalId);
+          if (w) dispatch({ type: "FOCUS", id: w.id });
+        }}
+        onTerminalRestore={(sessionId, terminalId) => {
+          const session = allSessions.find(s => s.id === sessionId);
+          dispatch({
+            type: "OPEN_CLAUDE_TERMINAL",
+            terminalId,
+            title: session?.title ?? "Claude",
+            cwd: session?.cwd ?? "/",
+            kind: "claude_resume",
+            linkedSessionId: sessionId,
+          });
+        }}
+        onTerminalStop={async (terminalId) => {
+          await fetch(`/api/terminals/${encodeURIComponent(terminalId)}`, { method: "DELETE" });
+          // SSE event will trigger refetch.
+        }}
         desktopProps={{
           space: activeSpace,
           spaces: spaces.map((s) => s.id),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,7 +25,6 @@ import { createSession, sendMessage } from "./data/chat-api";
 import { unpublishArtifact } from "./data/publish-api";
 import { launchAndOpen, humanError } from "./lib/launch-terminal";
 import { useSessions } from "./hooks/useSessions";
-import { useTerminalPresence } from "./hooks/useTerminalPresence";
 import "./App.css";
 
 // `?onboarding=force` wipes the dock's persisted state and pretends this
@@ -326,7 +325,6 @@ export default function App() {
   const claudeTerminals = windows.filter((w) => w.type === "claude_terminal");
 
   const { sessions: allSessions } = useSessions();
-  const presence = useTerminalPresence(allSessions, windows);
 
   async function handleArtifactClick(artifact: Artifact) {
     if (artifact.status === "generating") return;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -589,7 +589,7 @@ export default function App() {
             defaultY={60}
             zIndex={terminalWindow.zIndex}
             onFocus={() => dispatch({ type: "FOCUS", id: terminalWindow.id })}
-            onClose={() => dispatch({ type: "CLOSE", id: terminalWindow.id })}
+            onClose={() => dispatch({ type: "MINIMISE", id: terminalWindow.id })}
           />
         )}
         {claudeTerminals.map((w, i) => (
@@ -599,7 +599,7 @@ export default function App() {
             defaultY={80 + i * 24}
             zIndex={w.zIndex}
             onFocus={() => dispatch({ type: "FOCUS", id: w.id })}
-            onClose={() => dispatch({ type: "CLOSE", id: w.id })}
+            onClose={() => dispatch({ type: "MINIMISE", id: w.id })}
             terminalId={w.terminalId}
             title={w.title}
             linkedSessionId={w.linkedSessionId}

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -660,6 +660,15 @@
 .home-row-title {
   font-size: 13px;
   color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+.home-row-title-inner {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -238,6 +238,7 @@
 .pip-amber { background: var(--home-amber); box-shadow: 0 0 6px var(--home-amber); }
 .pip-red   { background: var(--home-red);   box-shadow: 0 0 6px var(--home-red); }
 .pip-dim   { background: var(--home-text-muted); }
+.pip-teal  { background: #5eead4; box-shadow: 0 0 6px rgba(94,234,212,0.6); }
 .pip-published { background: #a78bfa; }
 .pip-pinned    { background: #fbbf24; }
 

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1453,6 +1453,9 @@
   padding: 16px 32px 12px;
   display: flex;
   align-items: center;
+  /* Visible gap between the spaces cluster and the optional running pill
+   * cluster — they are two separate pill bars, not one continuous strip. */
+  gap: 10px;
 }
 .home-breadcrumb-inner {
   display: inline-flex;

--- a/web/src/components/Home/ProjectTile.tsx
+++ b/web/src/components/Home/ProjectTile.tsx
@@ -15,7 +15,7 @@ export function ProjectTile({
 }: {
   project: Project;
   artefactCount: number;
-  sessionCounts?: { active: number; waiting: number; disconnected: number };
+  sessionCounts?: { running: number; active: number; waiting: number; disconnected: number };
   selected: boolean;
   onSelect: () => void;
   onChanged: () => void;
@@ -119,6 +119,7 @@ export function ProjectTile({
             <span style={{ minWidth: 0, wordBreak: "break-word" }}>{project.name}</span>
           </div>
           <div className="home-space-card-counts">
+            {sessionCounts && sessionCounts.running > 0 && <span className="signal"><span className="pip pip-teal" />{sessionCounts.running} running</span>}
             {sessionCounts && sessionCounts.active > 0 && <span className="signal"><span className="pip pip-green" />{sessionCounts.active} active</span>}
             {sessionCounts && sessionCounts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{sessionCounts.waiting} waiting</span>}
             <span className="signal"><span className="pip pip-dim" />{artefactCount} {artefactCount === 1 ? "artefact" : "artefacts"}</span>

--- a/web/src/components/Home/ProjectTile.tsx
+++ b/web/src/components/Home/ProjectTile.tsx
@@ -121,7 +121,6 @@ export function ProjectTile({
           <div className="home-space-card-counts">
             {sessionCounts && sessionCounts.active > 0 && <span className="signal"><span className="pip pip-green" />{sessionCounts.active} active</span>}
             {sessionCounts && sessionCounts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{sessionCounts.waiting} waiting</span>}
-            {sessionCounts && sessionCounts.disconnected > 0 && <span className="signal"><span className="pip pip-red" />{sessionCounts.disconnected} disconnected</span>}
             <span className="signal"><span className="pip pip-dim" />{artefactCount} {artefactCount === 1 ? "artefact" : "artefacts"}</span>
             {project.hasLivePath === false && (
               <span

--- a/web/src/components/Home/ProjectTileGrid.tsx
+++ b/web/src/components/Home/ProjectTileGrid.tsx
@@ -20,7 +20,7 @@ export function ProjectTileGrid({
   // entry. Callsites use `?? 0` and pass the lookup into ProjectTile's
   // optional `sessionCounts?` prop.
   projectArtefactCounts: Partial<Record<string, number>>;
-  sessionCountsByProject: Partial<Record<string, { active: number; waiting: number; disconnected: number }>>;
+  sessionCountsByProject: Partial<Record<string, { running: number; active: number; waiting: number; disconnected: number }>>;
   selectedProjectId: string | null;
   setSelectedProjectId: (next: string | null) => void;
   totalCounts: Record<StateFilter, number>;
@@ -54,6 +54,7 @@ export function ProjectTileGrid({
         >
           <div className="home-space-card-name">All</div>
           <div className="home-space-card-counts">
+            {totalCounts["live-terminals"] > 0 && <span className="signal"><span className="pip pip-teal" />{totalCounts["live-terminals"]} running</span>}
             {totalCounts.active > 0 && <span className="signal"><span className="pip pip-green" />{totalCounts.active} active</span>}
             {totalCounts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{totalCounts.waiting} waiting</span>}
             {totalCounts.done > 0 && <span className="signal"><span className="pip pip-dim" />{totalCounts.done} done</span>}

--- a/web/src/components/Home/ProjectTileGrid.tsx
+++ b/web/src/components/Home/ProjectTileGrid.tsx
@@ -56,7 +56,6 @@ export function ProjectTileGrid({
           <div className="home-space-card-counts">
             {totalCounts.active > 0 && <span className="signal"><span className="pip pip-green" />{totalCounts.active} active</span>}
             {totalCounts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{totalCounts.waiting} waiting</span>}
-            {totalCounts.disconnected > 0 && <span className="signal"><span className="pip pip-red" />{totalCounts.disconnected} disconnected</span>}
             {totalCounts.done > 0 && <span className="signal"><span className="pip pip-dim" />{totalCounts.done} done</span>}
             {totalCounts.all === 0 && <span className="signal signal-muted">no sessions yet</span>}
           </div>

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -123,22 +123,25 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
     >
       <span className={`home-row-status ${statusDotClass}`} />
       <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
-      <span className="home-row-title" title={title}>
-        {remoteChip && (
-          <span className="home-remote-chip" title={remoteChip.titleTooltip}>
-            <span aria-hidden="true">↗</span> {remoteChip.label}
-          </span>
-        )}
-        {activeChip && (
-          <span className="home-active-chip" title={activeChip.titleTooltip}>
-            {activeChip.label}
-          </span>
-        )}
-        {isManual && (
-          <span className="home-manual-chip" title="Pinned manually — Oyster's heuristic won't reassign this.">
-            pinned
-          </span>
-        )}
+      <span className="home-row-title">
+        <span className="home-row-title-inner" title={title}>
+          {remoteChip && (
+            <span className="home-remote-chip" title={remoteChip.titleTooltip}>
+              <span aria-hidden="true">↗</span> {remoteChip.label}
+            </span>
+          )}
+          {activeChip && (
+            <span className="home-active-chip" title={activeChip.titleTooltip}>
+              {activeChip.label}
+            </span>
+          )}
+          {isManual && (
+            <span className="home-manual-chip" title="Pinned manually — Oyster's heuristic won't reassign this.">
+              pinned
+            </span>
+          )}
+          {title}
+        </span>
         {livePresence?.state === "running" && onTerminalRestore && (
           <button
             type="button"
@@ -149,7 +152,6 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
             Restore
           </button>
         )}
-        {title}
       </span>
       <span className={`home-row-agent ${AGENT_PIP_CLASS[session.agent]}`}>
         <span className="home-agent-pip" />

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -8,16 +8,21 @@ import {
   AGENT_PIP_CLASS, activeWriterChipFor, formatRelative,
   originDeviceChipFor, spaceLabelFor,
 } from "./utils";
+import type { PresenceInfo } from "../../hooks/useTerminalPresence";
 
 interface SessionRowProps {
   session: Session;
   spaces: Space[];
   /** Local device id; drives the cross-device chip. See SessionTile. */
   myDeviceId: string | null;
+  /** Presence info from useTerminalPresence; undefined when no live terminal. */
+  livePresence?: PresenceInfo;
   onOpen?: (id: string) => void;
+  /** Restore a minimised terminal window for this session. */
+  onTerminalRestore?: (sessionId: string, terminalId: string) => void;
 }
 
-export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowProps) {
+export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, onTerminalRestore }: SessionRowProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
   const rel = formatRelative(session.lastEventAt) ?? "—";
   const time = session.state === "waiting" ? `waiting ${rel}`
@@ -32,6 +37,12 @@ export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowPr
   const remoteChip = originDeviceChipFor(session, myDeviceId);
   const activeChip = activeWriterChipFor(session, myDeviceId);
   const isManual = session.assignmentMode === "manual";
+  const rowExtraClass = livePresence
+    ? (livePresence.state === "attached" ? " sr--attached" : " sr--running")
+    : "";
+  const statusDotClass = livePresence
+    ? (livePresence.state === "attached" ? "rd--attached" : "rd--running")
+    : session.state;
 
   const [menuOpen, setMenuOpen] = useState(false);
   // Cache keyed by the spaceId we loaded for, so an empty result (or a
@@ -102,7 +113,7 @@ export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowPr
 
   return (
     <div
-      className="home-row"
+      className={`home-row${rowExtraClass}`}
       onClick={() => onOpen?.(session.id)}
       onKeyDown={onOpen ? (e) => {
         if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpen(session.id); }
@@ -110,7 +121,7 @@ export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowPr
       role={onOpen ? "button" : undefined}
       tabIndex={onOpen ? 0 : undefined}
     >
-      <span className={`home-row-status ${session.state}`} />
+      <span className={`home-row-status ${statusDotClass}`} />
       <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
       <span className="home-row-title" title={title}>
         {remoteChip && (
@@ -127,6 +138,16 @@ export function SessionRow({ session, spaces, myDeviceId, onOpen }: SessionRowPr
           <span className="home-manual-chip" title="Pinned manually — Oyster's heuristic won't reassign this.">
             pinned
           </span>
+        )}
+        {livePresence?.state === "running" && onTerminalRestore && (
+          <button
+            type="button"
+            className="sl-chip--restore"
+            onClick={(e) => { e.stopPropagation(); onTerminalRestore(session.id, livePresence.terminalId); }}
+            title="Restore terminal"
+          >
+            Restore
+          </button>
         )}
         {title}
       </span>

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -18,11 +18,13 @@ interface SessionRowProps {
   /** Presence info from useTerminalPresence; undefined when no live terminal. */
   livePresence?: PresenceInfo;
   onOpen?: (id: string) => void;
+  /** Focus an already-open terminal window for this session. */
+  onTerminalFocus?: (terminalId: string) => void;
   /** Restore a minimised terminal window for this session. */
   onTerminalRestore?: (sessionId: string, terminalId: string) => void;
 }
 
-export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, onTerminalRestore }: SessionRowProps) {
+export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, onTerminalFocus, onTerminalRestore }: SessionRowProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
   const rel = formatRelative(session.lastEventAt) ?? "—";
   const time = session.state === "waiting" ? `waiting ${rel}`
@@ -111,15 +113,29 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
     }
   }
 
+  // Row click priority: if this row has a live terminal, focus it (Open) or
+  // restore it (Minimised) — bringing the panel to the user is the most
+  // likely intent. Falls through to onOpen (Session Inspector) otherwise.
+  // The Inspect chip below gives a deliberate path to the inspector when the
+  // row is live.
+  const handleRowActivate = () => {
+    if (livePresence?.state === "attached" && onTerminalFocus) {
+      onTerminalFocus(livePresence.terminalId);
+    } else if (livePresence?.state === "running" && onTerminalRestore) {
+      onTerminalRestore(session.id, livePresence.terminalId);
+    } else if (onOpen) {
+      onOpen(session.id);
+    }
+  };
   return (
     <div
       className={`home-row${rowExtraClass}`}
-      onClick={() => onOpen?.(session.id)}
-      onKeyDown={onOpen ? (e) => {
-        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpen(session.id); }
+      onClick={handleRowActivate}
+      onKeyDown={onOpen || livePresence ? (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleRowActivate(); }
       } : undefined}
-      role={onOpen ? "button" : undefined}
-      tabIndex={onOpen ? 0 : undefined}
+      role={onOpen || livePresence ? "button" : undefined}
+      tabIndex={onOpen || livePresence ? 0 : undefined}
     >
       <span className={`home-row-status ${statusDotClass}`} />
       <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
@@ -142,14 +158,14 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
           )}
           {title}
         </span>
-        {livePresence?.state === "running" && onTerminalRestore && (
+        {livePresence && onOpen && (
           <button
             type="button"
-            className="sl-chip--restore"
-            onClick={(e) => { e.stopPropagation(); onTerminalRestore(session.id, livePresence.terminalId); }}
-            title="Restore terminal"
+            className="sl-chip--inspect"
+            onClick={(e) => { e.stopPropagation(); onOpen(session.id); }}
+            title="Open the Session Inspector for this conversation"
           >
-            Restore
+            Inspect
           </button>
         )}
       </span>

--- a/web/src/components/Home/SessionTile.tsx
+++ b/web/src/components/Home/SessionTile.tsx
@@ -1,6 +1,7 @@
 // Session tile (icons-view card). Extracted from Home/index.tsx.
 import type { Session } from "../../data/sessions-api";
 import type { Space } from "../../../../shared/types";
+import type { PresenceInfo } from "../../hooks/useTerminalPresence";
 import {
   AGENT_CLASS, AGENT_LETTERS,
   activeWriterChipFor, metaForSession, originDeviceChipFor, spaceLabelFor,
@@ -14,10 +15,11 @@ interface SessionTileProps {
    *  during the brief window before useMyDeviceId resolves — chip is
    *  suppressed during that window. */
   myDeviceId: string | null;
+  livePresence?: PresenceInfo | undefined;
   onOpen?: (id: string) => void;
 }
 
-export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, onOpen }: SessionTileProps) {
+export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, livePresence, onOpen }: SessionTileProps) {
   const spaceLabel = spaceLabelFor(session.spaceId, spaces);
   const title = session.title ?? "(no title yet)";
   const remoteChip = originDeviceChipFor(session, myDeviceId);
@@ -54,6 +56,12 @@ export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, onOpen
         )}
         <span className="home-agent-mark">{AGENT_LETTERS[session.agent]}</span>
         <span className={`home-status ${session.state}`} />
+        {livePresence && (
+          <span
+            className={`tile-presence-dot${livePresence.state === "attached" ? " tpd--attached" : " tpd--running"}`}
+            title={livePresence.state === "attached" ? "Open in terminal" : "Minimised"}
+          />
+        )}
       </div>
       <div className="home-tile-label" title={title}>{title}</div>
       <div className="home-tile-meta">{metaForSession(session)}</div>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1118,6 +1118,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                         myDeviceId={myDeviceId}
                         livePresence={presence.byId[session.id]}
                         onOpen={(id) => setActivePanel({ kind: "session", id })}
+                        onTerminalFocus={onTerminalFocus}
                         onTerminalRestore={onTerminalRestore}
                       />
                     ))}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -758,7 +758,6 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                 counts.running > 0 && `${counts.running} running`,
                 counts.active > 0 && `${counts.active} active`,
                 counts.waiting > 0 && `${counts.waiting} waiting`,
-                counts.disconnected > 0 && `${counts.disconnected} disconnected`,
                 counts.done > 0 && `${counts.done} done`,
               ].filter(Boolean).join(" · ") || "no sessions yet";
               const isSelected = scopedSpace === space.id;
@@ -781,7 +780,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       transition={{ type: "spring", stiffness: 400, damping: 35 }}
                     />
                   )}
-                  {(counts.running > 0 || counts.active > 0 || counts.waiting > 0 || counts.disconnected > 0) && (
+                  {(counts.running > 0 || counts.active > 0 || counts.waiting > 0) && (
                     <span className="home-breadcrumb-badges">
                       {renderPipCounts(counts)}
                     </span>
@@ -800,7 +799,6 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                   orphanCounts.running > 0 && `${orphanCounts.running} running`,
                   orphanCounts.active > 0 && `${orphanCounts.active} active`,
                   orphanCounts.waiting > 0 && `${orphanCounts.waiting} waiting`,
-                  orphanCounts.disconnected > 0 && `${orphanCounts.disconnected} disconnected`,
                   orphanCounts.done > 0 && `${orphanCounts.done} done`,
                 ].filter(Boolean).join(" · ") || "Sessions outside any registered space"}
               >
@@ -811,7 +809,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                     transition={{ type: "spring", stiffness: 400, damping: 35 }}
                   />
                 )}
-                {(orphanCounts.running > 0 || orphanCounts.active > 0 || orphanCounts.waiting > 0 || orphanCounts.disconnected > 0) && (
+                {(orphanCounts.running > 0 || orphanCounts.active > 0 || orphanCounts.waiting > 0) && (
                   <span className="home-breadcrumb-badges">
                     {renderPipCounts(orphanCounts)}
                   </span>
@@ -889,7 +887,6 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       <div className="home-active-project-counts">
                         {p.counts.active > 0 && <span className="signal"><span className="pip pip-green" />{p.counts.active} active</span>}
                         {p.counts.waiting > 0 && <span className="signal"><span className="pip pip-amber" />{p.counts.waiting} waiting</span>}
-                        {p.counts.disconnected > 0 && <span className="signal"><span className="pip pip-red" />{p.counts.disconnected} disconnected</span>}
                       </div>
                     </button>
                     <button

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -273,6 +273,16 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     setSelectedOrphanCwd(null);
   }, [scopedSpace, showElsewhere, isHomeView]);
 
+  // Auto-reset the live-terminals filter if there are no live terminals
+  // (e.g. the last terminal was stopped, or the user switched to a space
+  // with none). Without this the pill disappears but the filter sticks,
+  // leaving a silently empty session list.
+  useEffect(() => {
+    if (stateFilter === "live-terminals" && presence.totalLive === 0) {
+      setStateFilter("all");
+    }
+  }, [stateFilter, presence.totalLive]);
+
   const scopedSessions = useMemo(() => {
     if (showElsewhere && isHomeView) return sessions.filter((s) => s.spaceId === null);
     return scopedSpace ? sessions.filter((s) => s.spaceId === scopedSpace) : sessions;

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1097,6 +1097,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       spaces={spaces}
                       showSpaceChip={isMetaView}
                       myDeviceId={myDeviceId}
+                      livePresence={presence.byId[session.id]}
                       onOpen={(id) => setActivePanel({ kind: "session", id })}
                     />
                   ))}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -31,6 +31,9 @@ import { VAULT, type ArtefactSource, type StateFilter, type ViewMode } from "./t
 import { attachFolder } from "../../data/projects-api";
 import { deleteMemory, type Memory } from "../../data/memories-api";
 import { ApiError } from "../../data/http";
+import { useTerminalPresence } from "../../hooks/useTerminalPresence";
+import type { WindowState } from "../../stores/windows";
+import { RunningTerminalsPill } from "../Topbar/RunningTerminalsPill";
 import "./Home.css";
 
 interface Props {
@@ -58,6 +61,14 @@ interface Props {
   /** Launch a remote (cross-device) session in an Oyster terminal once
    *  reassemble has completed. Threaded to ResumeDialog via SessionInspector. */
   onOpenRemoteInOyster?: (sessionId: string) => Promise<import("../SessionInspector/ResumeDialog").OpenInOysterResult>;
+  /** Running-terminals pill: client-side window list for presence fusion. */
+  terminalWindows?: WindowState[];
+  /** Running-terminals pill: focus an already-open terminal window. */
+  onTerminalFocus?: (terminalId: string) => void;
+  /** Running-terminals pill: restore a minimised terminal. */
+  onTerminalRestore?: (sessionId: string, terminalId: string) => void;
+  /** Running-terminals pill: stop (DELETE) a running terminal. */
+  onTerminalStop?: (terminalId: string) => Promise<void>;
 }
 
 const ARTEFACT_SOURCE_ORDER: ArtefactSource[] = ["all", "manual", "ai_generated", "discovered", "published", "pinned"];
@@ -134,8 +145,9 @@ const FILTER_LABELS: Record<StateFilter, string> = {
   all: "all",
 };
 
-export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster }: Props) {
+export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop }: Props) {
   const { sessions, error, loading } = useSessions();
+  const presence = useTerminalPresence(sessions, terminalWindows ?? []);
   const signedIn = useAuthSignedIn();
   const myDevice = useMyDeviceId();
   const myDeviceId = myDevice?.deviceId ?? null;
@@ -771,6 +783,15 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                 )}
                 <span className="home-breadcrumb-pill-label">Unsorted</span>
               </button>
+            )}
+            {onTerminalFocus && onTerminalRestore && onTerminalStop && (
+              <RunningTerminalsPill
+                presence={presence}
+                sessions={sessions}
+                onFocus={onTerminalFocus}
+                onRestore={onTerminalRestore}
+                onStop={onTerminalStop}
+              />
             )}
             </div>
             </LayoutGroup>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -138,6 +138,7 @@ const MEMORIES_PREVIEW = 5;
 
 const FILTER_LABELS: Record<StateFilter, string> = {
   live: "live",
+  "live-terminals": "live terminals",
   active: "active",
   waiting: "waiting",
   disconnected: "disconnected",
@@ -282,7 +283,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // when a folder is selected. Everything below this point (chips,
   // list) does narrow.
   const spaceCounts = useMemo(() => {
-    const counts: Record<StateFilter, number> = { live: 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
+    const counts: Record<StateFilter, number> = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
     for (const s of scopedSessions) counts[s.state]++;
     counts.live = counts.active + counts.waiting + counts.disconnected;
     return counts;
@@ -301,17 +302,28 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   }, [scopedSessions, selectedProjectId, selectedOrphanCwd, showElsewhere, isHomeView]);
 
   const stateCounts = useMemo(() => {
-    const counts: Record<StateFilter, number> = { live: 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: folderScopedSessions.length };
+    const counts: Record<StateFilter, number> = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: folderScopedSessions.length };
     for (const s of folderScopedSessions) counts[s.state]++;
     counts.live = counts.active + counts.waiting + counts.disconnected;
+    counts["live-terminals"] = presence.totalLive;
     return counts;
-  }, [folderScopedSessions]);
+  }, [folderScopedSessions, presence.totalLive]);
 
   const visibleSessions = useMemo(() => {
-    if (stateFilter === "all") return folderScopedSessions;
-    if (stateFilter === "live") return folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state));
-    return folderScopedSessions.filter((s) => s.state === stateFilter);
-  }, [folderScopedSessions, stateFilter]);
+    let list: typeof folderScopedSessions;
+    if (stateFilter === "all") list = folderScopedSessions;
+    else if (stateFilter === "live") list = folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state));
+    else if (stateFilter === "live-terminals") list = folderScopedSessions.filter((s) => presence.byId[s.id] != null);
+    else list = folderScopedSessions.filter((s) => s.state === stateFilter);
+    // Pin live (open terminal) rows to the top; within each group preserve
+    // descending last-activity order.
+    return list.slice().sort((a, b) => {
+      const aLive = presence.byId[a.id] ? 0 : 1;
+      const bLive = presence.byId[b.id] ? 0 : 1;
+      if (aLive !== bLive) return aLive - bLive;
+      return (b.lastEventAt ?? "").localeCompare(a.lastEventAt ?? "");
+    });
+  }, [folderScopedSessions, stateFilter, presence.byId]);
 
   // Per-space session counts + a separate orphan tally (sessions with
   // spaceId === null) + a grand total for the Home card.
@@ -1021,6 +1033,14 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                   </span>
                 );
               })}
+              {presence.totalLive > 0 && (
+                <button
+                  className={`stat-btn stat-btn--live-terminals${stateFilter === "live-terminals" ? " active" : ""}`}
+                  onClick={() => setStateFilter("live-terminals")}
+                >
+                  {presence.totalLive} Live
+                </button>
+              )}
             </span>
             <span className="home-section-rule" />
             <div className="home-view-toggle">
@@ -1080,7 +1100,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                         session={session}
                         spaces={spaces}
                         myDeviceId={myDeviceId}
+                        livePresence={presence.byId[session.id]}
                         onOpen={(id) => setActivePanel({ kind: "session", id })}
+                        onTerminalRestore={onTerminalRestore}
                       />
                     ))}
                   </div>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
 import { ArrowUpRight, Folder, FolderPlus, Shield } from "lucide-react";
-import type { SessionState } from "../../data/sessions-api";
+import type { Session, SessionState } from "../../data/sessions-api";
 import type { Artifact, Space } from "../../../../shared/types";
-import { useSessions } from "../../hooks/useSessions";
 import { useMemories } from "../../hooks/useMemories";
 import { useAuthSignedIn } from "../../hooks/useAuthSignedIn";
 import { useMyDeviceId } from "../../hooks/useMyDeviceId";
@@ -69,6 +68,10 @@ interface Props {
   onTerminalRestore?: (sessionId: string, terminalId: string) => void;
   /** Running-terminals pill: stop (DELETE) a running terminal. */
   onTerminalStop?: (terminalId: string) => Promise<void>;
+  /** Sessions feed — hoisted to App to avoid duplicate SSE-triggered refetches. */
+  sessions: Session[];
+  sessionsLoading?: boolean;
+  sessionsError?: Error | null;
 }
 
 const ARTEFACT_SOURCE_ORDER: ArtefactSource[] = ["all", "manual", "ai_generated", "discovered", "published", "pinned"];
@@ -146,8 +149,7 @@ const FILTER_LABELS: Record<StateFilter, string> = {
   all: "all",
 };
 
-export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop }: Props) {
-  const { sessions, error, loading } = useSessions();
+export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onSubViewActiveChange, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop, sessions, sessionsLoading: loading, sessionsError: error }: Props) {
   const presence = useTerminalPresence(sessions, terminalWindows ?? []);
   const signedIn = useAuthSignedIn();
   const myDevice = useMyDeviceId();

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1048,7 +1048,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                   className={`stat-btn stat-btn--live-terminals${stateFilter === "live-terminals" ? " active" : ""}`}
                   onClick={() => setStateFilter("live-terminals")}
                 >
-                  {presence.totalLive} Live
+                  {presence.totalLive} Running
                 </button>
               )}
             </span>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -806,14 +806,17 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                 <span className="home-breadcrumb-pill-label">Unsorted</span>
               </button>
             )}
-            {onTerminalFocus && onTerminalRestore && onTerminalStop && (
-              <RunningTerminalsPill
-                presence={presence}
-                sessions={sessions}
-                onFocus={onTerminalFocus}
-                onRestore={onTerminalRestore}
-                onStop={onTerminalStop}
-              />
+            {onTerminalFocus && onTerminalRestore && onTerminalStop && presence.totalLive > 0 && (
+              <>
+                <span className="rtp-divider" aria-hidden="true" />
+                <RunningTerminalsPill
+                  presence={presence}
+                  sessions={sessions}
+                  onFocus={onTerminalFocus}
+                  onRestore={onTerminalRestore}
+                  onStop={onTerminalStop}
+                />
+              </>
             )}
             </div>
             </LayoutGroup>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -819,9 +819,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                 <span className="home-breadcrumb-pill-label">Unsorted</span>
               </button>
             )}
+            </div>
             {onTerminalFocus && onTerminalRestore && onTerminalStop && presence.totalLive > 0 && (
-              <>
-                <span className="rtp-divider" aria-hidden="true" />
+              <div className="home-breadcrumb-inner home-breadcrumb-inner--running">
                 <RunningTerminalsPill
                   presence={presence}
                   sessions={sessions}
@@ -829,9 +829,8 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                   onRestore={onTerminalRestore}
                   onStop={onTerminalStop}
                 />
-              </>
+              </div>
             )}
-            </div>
             </LayoutGroup>
           </nav>
 

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -123,7 +123,7 @@ function useStickyView(key: string, defaultValue: ViewMode): [ViewMode, (v: View
 const FILTER_ORDER: StateFilter[] = ["live-terminals", "live", "active", "waiting", "done", "all"];
 const LIVE_STATES: SessionState[] = ["active", "waiting"];
 
-const EMPTY_COUNTS = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+const EMPTY_COUNTS = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
 
 // Sessions list cap. Busy spaces can run dozens of concurrent sessions
 // and previously pushed Artefacts below the fold; ten keeps the section
@@ -319,9 +319,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     counts.done += counts.disconnected;
     counts.disconnected = 0;
     counts.live = counts.active + counts.waiting;
-    counts["live-terminals"] = presence.totalLive;
+    counts["live-terminals"] = folderScopedSessions.filter((s) => presence.byId[s.id] != null).length;
     return counts;
-  }, [folderScopedSessions, presence.totalLive]);
+  }, [folderScopedSessions, presence.byId]);
 
   const visibleSessions = useMemo(() => {
     let list: typeof folderScopedSessions;
@@ -343,24 +343,27 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // Per-space session counts + a separate orphan tally (sessions with
   // spaceId === null) + a grand total for the Home card.
   const { sessionCountsBySpace, orphanCounts, totalCounts } = useMemo(() => {
-    const bySpace: Record<string, { total: number; active: number; waiting: number; disconnected: number; done: number }> = {};
-    const orphans = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
-    const total = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+    const bySpace: Record<string, { total: number; running: number; active: number; waiting: number; disconnected: number; done: number }> = {};
+    const orphans = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+    const total = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     for (const s of sessions) {
       total.total++;
       total[s.state]++;
+      if (presence.byId[s.id]) total.running++;
       if (s.spaceId) {
-        const c = bySpace[s.spaceId] ?? { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+        const c = bySpace[s.spaceId] ?? { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
         c.total++;
         c[s.state]++;
+        if (presence.byId[s.id]) c.running++;
         bySpace[s.spaceId] = c;
       } else {
         orphans.total++;
         orphans[s.state]++;
+        if (presence.byId[s.id]) orphans.running++;
       }
     }
     return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total };
-  }, [sessions]);
+  }, [sessions, presence.byId]);
 
   // Active projects on Home: collapse sessions by projectId, count
   // non-done states, drop projects with no live activity. Each entry
@@ -402,17 +405,20 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // ProjectTileGrid so a project tile can show "1 active · 1 waiting"
   // when sessions are running for that project.
   const sessionCountsByProject = useMemo(() => {
-    const out: Record<string, { active: number; waiting: number; disconnected: number }> = {};
+    const out: Record<string, { running: number; active: number; waiting: number; disconnected: number }> = {};
     for (const s of sessions) {
-      if (!s.projectId || s.state === "done") continue;
-      const c = out[s.projectId] ?? { active: 0, waiting: 0, disconnected: 0 };
+      if (!s.projectId) continue;
+      const isRunning = presence.byId[s.id] != null;
+      if (s.state === "done" && !isRunning) continue;
+      const c = out[s.projectId] ?? { running: 0, active: 0, waiting: 0, disconnected: 0 };
+      if (isRunning) c.running++;
       if (s.state === "active") c.active++;
       else if (s.state === "waiting") c.waiting++;
       else if (s.state === "disconnected") c.disconnected++;
       out[s.projectId] = c;
     }
     return out;
-  }, [sessions]);
+  }, [sessions, presence.byId]);
 
   // Orphan-cwd "projects" on Elsewhere — sessions whose cwd doesn't
   // match any registered source still came from somewhere. Group by
@@ -749,6 +755,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
             {realSpaces.map((space) => {
               const counts = sessionCountsBySpace[space.id] ?? EMPTY_COUNTS;
               const tip = [
+                counts.running > 0 && `${counts.running} running`,
                 counts.active > 0 && `${counts.active} active`,
                 counts.waiting > 0 && `${counts.waiting} waiting`,
                 counts.disconnected > 0 && `${counts.disconnected} disconnected`,
@@ -774,7 +781,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       transition={{ type: "spring", stiffness: 400, damping: 35 }}
                     />
                   )}
-                  {(counts.active > 0 || counts.waiting > 0 || counts.disconnected > 0) && (
+                  {(counts.running > 0 || counts.active > 0 || counts.waiting > 0 || counts.disconnected > 0) && (
                     <span className="home-breadcrumb-badges">
                       {renderPipCounts(counts)}
                     </span>
@@ -790,6 +797,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                 onClick={() => { onSpaceChange("home"); setShowElsewhere(true); setShowVault(false); }}
                 onContextMenu={(e) => e.preventDefault()}
                 title={[
+                  orphanCounts.running > 0 && `${orphanCounts.running} running`,
                   orphanCounts.active > 0 && `${orphanCounts.active} active`,
                   orphanCounts.waiting > 0 && `${orphanCounts.waiting} waiting`,
                   orphanCounts.disconnected > 0 && `${orphanCounts.disconnected} disconnected`,
@@ -803,7 +811,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                     transition={{ type: "spring", stiffness: 400, damping: 35 }}
                   />
                 )}
-                {(orphanCounts.active > 0 || orphanCounts.waiting > 0 || orphanCounts.disconnected > 0) && (
+                {(orphanCounts.running > 0 || orphanCounts.active > 0 || orphanCounts.waiting > 0 || orphanCounts.disconnected > 0) && (
                   <span className="home-breadcrumb-badges">
                     {renderPipCounts(orphanCounts)}
                   </span>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -120,8 +120,8 @@ function useStickyView(key: string, defaultValue: ViewMode): [ViewMode, (v: View
 // is review/history, not active inventory. The dot after "live" indicates
 // the live cluster ends; the per-state chips after it are for fine-grained
 // filtering.
-const FILTER_ORDER: StateFilter[] = ["live", "active", "waiting", "disconnected", "done", "all"];
-const LIVE_STATES: SessionState[] = ["active", "waiting", "disconnected"];
+const FILTER_ORDER: StateFilter[] = ["live-terminals", "live", "active", "waiting", "done", "all"];
+const LIVE_STATES: SessionState[] = ["active", "waiting"];
 
 const EMPTY_COUNTS = { total: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
 
@@ -138,7 +138,7 @@ const MEMORIES_PREVIEW = 5;
 
 const FILTER_LABELS: Record<StateFilter, string> = {
   live: "live",
-  "live-terminals": "live terminals",
+  "live-terminals": "running",
   active: "active",
   waiting: "waiting",
   disconnected: "disconnected",
@@ -295,7 +295,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   const spaceCounts = useMemo(() => {
     const counts: Record<StateFilter, number> = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
     for (const s of scopedSessions) counts[s.state]++;
-    counts.live = counts.active + counts.waiting + counts.disconnected;
+    counts.done += counts.disconnected;
+    counts.disconnected = 0;
+    counts.live = counts.active + counts.waiting;
     return counts;
   }, [scopedSessions]);
 
@@ -314,7 +316,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   const stateCounts = useMemo(() => {
     const counts: Record<StateFilter, number> = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: folderScopedSessions.length };
     for (const s of folderScopedSessions) counts[s.state]++;
-    counts.live = counts.active + counts.waiting + counts.disconnected;
+    counts.done += counts.disconnected;
+    counts.disconnected = 0;
+    counts.live = counts.active + counts.waiting;
     counts["live-terminals"] = presence.totalLive;
     return counts;
   }, [folderScopedSessions, presence.totalLive]);
@@ -324,6 +328,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     if (stateFilter === "all") list = folderScopedSessions;
     else if (stateFilter === "live") list = folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state));
     else if (stateFilter === "live-terminals") list = folderScopedSessions.filter((s) => presence.byId[s.id] != null);
+    else if (stateFilter === "done") list = folderScopedSessions.filter((s) => s.state === "done" || s.state === "disconnected");
     else list = folderScopedSessions.filter((s) => s.state === stateFilter);
     // Pin live (open terminal) rows to the top; within each group preserve
     // descending last-activity order.
@@ -1032,6 +1037,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
               {FILTER_ORDER.map((f) => {
                 const count = stateCounts[f];
                 if (count === 0 && f !== "all" && f !== "live") return null;
+                const isLiveTerminals = f === "live-terminals";
                 const showPip = f !== "all" && f !== "live";
                 return (
                   <span key={f} style={{ display: "contents" }}>
@@ -1039,21 +1045,17 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       className={`stat-btn${stateFilter === f ? " active" : ""}`}
                       onClick={() => setStateFilter(f)}
                     >
-                      {showPip && <span className={`pip pip-${stateColor(f as SessionState)}`} />}
+                      {showPip && (
+                        isLiveTerminals
+                          ? <span className="pip pip-teal" />
+                          : <span className={`pip pip-${stateColor(f as SessionState)}`} />
+                      )}
                       {count} {FILTER_LABELS[f]}
                     </button>
                     {f === "live" && <span className="stat-divider" aria-hidden="true" />}
                   </span>
                 );
               })}
-              {presence.totalLive > 0 && (
-                <button
-                  className={`stat-btn stat-btn--live-terminals${stateFilter === "live-terminals" ? " active" : ""}`}
-                  onClick={() => setStateFilter("live-terminals")}
-                >
-                  {presence.totalLive} Running
-                </button>
-              )}
             </span>
             <span className="home-section-rule" />
             <div className="home-view-toggle">

--- a/web/src/components/Home/types.ts
+++ b/web/src/components/Home/types.ts
@@ -3,7 +3,7 @@
 import type { SessionState } from "../../data/sessions-api";
 
 export type ViewMode = "icons" | "table";
-export type StateFilter = SessionState | "live" | "all";
+export type StateFilter = SessionState | "live" | "live-terminals" | "all";
 // "published" and "pinned" are *statuses*, not origins — but they join the same radio
 // group on Home so users only deal with one filter dimension. The coloured pips in the
 // JSX are the visual cue that acknowledges the semantic mismatch; both pills stay visible

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -34,13 +34,15 @@ export function homeRelative(p: string): string {
 // the Active-projects tile signals use, just without the trailing
 // state word — fits in a breadcrumb pill while keeping counts exact
 // and the visual language consistent with the tiles.
-export function renderPipCounts(counts: { active?: number; waiting?: number; disconnected?: number }) {
+export function renderPipCounts(counts: { running?: number; active?: number; waiting?: number; disconnected?: number }) {
+  const r = counts.running ?? 0;
   const a = counts.active ?? 0;
   const w = counts.waiting ?? 0;
   const d = counts.disconnected ?? 0;
-  if (a + w + d === 0) return null;
+  if (r + a + w + d === 0) return null;
   return (
     <>
+      {r > 0 && <span className="pip-count"><span className="pip pip-teal" />{r}</span>}
       {a > 0 && <span className="pip-count"><span className="pip pip-green" />{a}</span>}
       {w > 0 && <span className="pip-count"><span className="pip pip-amber" />{w}</span>}
       {d > 0 && <span className="pip-count"><span className="pip pip-red" />{d}</span>}

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -34,18 +34,19 @@ export function homeRelative(p: string): string {
 // the Active-projects tile signals use, just without the trailing
 // state word — fits in a breadcrumb pill while keeping counts exact
 // and the visual language consistent with the tiles.
-export function renderPipCounts(counts: { running?: number; active?: number; waiting?: number; disconnected?: number }) {
+// Disconnected sessions are folded into Done in the UI vocabulary —
+// don't render a red disconnected pip on space pills or tiles. The data
+// column still exists on the count objects, it's just not displayed.
+export function renderPipCounts(counts: { running?: number; active?: number; waiting?: number }) {
   const r = counts.running ?? 0;
   const a = counts.active ?? 0;
   const w = counts.waiting ?? 0;
-  const d = counts.disconnected ?? 0;
-  if (r + a + w + d === 0) return null;
+  if (r + a + w === 0) return null;
   return (
     <>
       {r > 0 && <span className="pip-count"><span className="pip pip-teal" />{r}</span>}
       {a > 0 && <span className="pip-count"><span className="pip pip-green" />{a}</span>}
       {w > 0 && <span className="pip-count"><span className="pip pip-amber" />{w}</span>}
-      {d > 0 && <span className="pip-count"><span className="pip pip-red" />{d}</span>}
     </>
   );
 }

--- a/web/src/components/SessionInspector/Banner.tsx
+++ b/web/src/components/SessionInspector/Banner.tsx
@@ -12,14 +12,8 @@ export function Banner({ session }: { session: Session }) {
       </div>
     );
   }
-  if (session.state === "waiting") {
-    return (
-      <div className="inspector-banner waiting">
-        <div>
-          The agent is waiting on you — usually for tool approval. Open the terminal where it's running to respond.
-        </div>
-      </div>
-    );
-  }
+  // "Waiting" banner removed — the Resume actions cover the recovery
+  // path, and the Resume button shows a fork warning when the session is
+  // active/waiting outside Oyster.
   return null;
 }

--- a/web/src/components/SessionInspector/SessionActions.tsx
+++ b/web/src/components/SessionInspector/SessionActions.tsx
@@ -1,6 +1,7 @@
 // SessionActions — extracted from SessionInspector for navigability.
 import { useState } from "react";
 import type { Session } from "../../data/sessions-api";
+import { ConfirmModal } from "../ConfirmModal";
 
 // POSIX single-quote: wrap in 's, replace embedded ' with '\''. Keeps
 // paths with spaces, $, backticks, etc. literal so resume can be pasted
@@ -18,6 +19,14 @@ export function SessionActions({ session, onLaunchClaude }: {
 }) {
   const [copiedCmd, setCopiedCmd] = useState(false);
   const [copiedId, setCopiedId] = useState(false);
+  const [forkWarningOpen, setForkWarningOpen] = useState(false);
+
+  // A session that's active or waiting AND not currently running in Oyster
+  // is alive somewhere else (the user's own claude CLI, another device,
+  // another tab). Resuming it here would attach a second claude process
+  // to the same session id and fork the conversation.
+  const forkRisk = (session.state === "active" || session.state === "waiting")
+    && session.terminalId == null;
   // `cd --` disables option parsing so a path beginning with `-` (or
   // the literal `-`, which would otherwise mean "previous dir") is
   // taken as a positional path argument. Single-quoting handles
@@ -65,7 +74,7 @@ export function SessionActions({ session, onLaunchClaude }: {
         <button
           type="button"
           className="btn primary"
-          onClick={() => onLaunchClaude!()}
+          onClick={() => forkRisk ? setForkWarningOpen(true) : onLaunchClaude!()}
           title={`Run claude --resume ${session.id} in ${session.cwd}`}
         >
           Resume here
@@ -77,6 +86,26 @@ export function SessionActions({ session, onLaunchClaude }: {
       <button type="button" className="btn" onClick={copyId}>
         {copiedId ? "Copied!" : "Copy session ID"}
       </button>
+      <ConfirmModal
+        open={forkWarningOpen}
+        title="This session is active outside Oyster"
+        body={
+          <p>
+            Resuming here will start a second Claude process on the same session id and
+            <strong> fork the conversation</strong>. The original copy will keep running where it is.
+            <br /><br />
+            To avoid forks, launch sessions from inside Oyster.
+          </p>
+        }
+        confirmLabel="Resume anyway"
+        cancelLabel="Cancel"
+        destructive
+        onCancel={() => setForkWarningOpen(false)}
+        onConfirm={() => {
+          setForkWarningOpen(false);
+          onLaunchClaude!();
+        }}
+      />
     </div>
   );
 }

--- a/web/src/components/TerminalWindow.tsx
+++ b/web/src/components/TerminalWindow.tsx
@@ -173,6 +173,7 @@ export function TerminalWindow({
       defaultH={480}
       zIndex={zIndex}
       closeButtonTooltip="Minimise terminal"
+      closeButtonGlyph="−"
     >
       <div
         ref={termRef}

--- a/web/src/components/TerminalWindow.tsx
+++ b/web/src/components/TerminalWindow.tsx
@@ -172,6 +172,7 @@ export function TerminalWindow({
       defaultW={720}
       defaultH={480}
       zIndex={zIndex}
+      closeButtonTooltip="Minimise terminal"
     >
       <div
         ref={termRef}

--- a/web/src/components/TerminalWindow.tsx
+++ b/web/src/components/TerminalWindow.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { WindowChrome } from "./WindowChrome";
+import { ConfirmModal } from "./ConfirmModal";
 
 interface Props {
   defaultX: number;
@@ -26,6 +27,9 @@ interface Props {
    *  the close button means "minimise" (alive — glyph −) or "close" (dead,
    *  PTY was stopped or exited — glyph ×). Defaults to true. */
   ptyAlive?: boolean;
+  /** Optional handler to kill the PTY. When provided AND `ptyAlive`, a Stop
+   *  (■) button is rendered in the header. Mirrors the popover Stop. */
+  onStop?: () => void | Promise<void>;
 }
 
 export function TerminalWindow({
@@ -39,7 +43,23 @@ export function TerminalWindow({
   linkedSessionId,
   onOpenSession,
   ptyAlive = true,
+  onStop,
 }: Props) {
+  const [stopConfirmOpen, setStopConfirmOpen] = useState(false);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
+
+  // Stop button click — same fork in behaviour as the popover's Stop
+  // button (shared localStorage flag, so the user only needs to ack once
+  // across both surfaces).
+  function requestStop() {
+    if (!onStop) return;
+    if (localStorage.getItem("oyster-skip-stop-confirm") === "1") {
+      void onStop();
+    } else {
+      setDontAskAgain(false);
+      setStopConfirmOpen(true);
+    }
+  }
   const termRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -168,22 +188,54 @@ export function TerminalWindow({
   ) : (title ?? "opencode");
 
   return (
-    <WindowChrome
-      title={titleNode}
-      onFocus={onFocus}
-      onClose={onClose}
-      defaultX={defaultX}
-      defaultY={defaultY}
-      defaultW={720}
-      defaultH={480}
-      zIndex={zIndex}
-      closeButtonTooltip={ptyAlive ? "Minimise terminal" : "Close window"}
-      closeButtonGlyph={ptyAlive ? "−" : "×"}
-    >
-      <div
-        ref={termRef}
-        style={{ width: "100%", height: "100%", padding: "4px" }}
+    <>
+      <WindowChrome
+        title={titleNode}
+        onFocus={onFocus}
+        onClose={onClose}
+        defaultX={defaultX}
+        defaultY={defaultY}
+        defaultW={720}
+        defaultH={480}
+        zIndex={zIndex}
+        closeButtonTooltip={ptyAlive ? "Minimise terminal" : "Close window"}
+        closeButtonGlyph={ptyAlive ? "−" : "×"}
+        extraHeader={ptyAlive && onStop ? (
+          <button
+            type="button"
+            className="window-btn window-btn--stop"
+            onClick={requestStop}
+            title="Stop terminal"
+          >■</button>
+        ) : undefined}
+      >
+        <div
+          ref={termRef}
+          style={{ width: "100%", height: "100%", padding: "4px" }}
+        />
+      </WindowChrome>
+      <ConfirmModal
+        open={stopConfirmOpen}
+        title="Stop this terminal?"
+        body={
+          <>
+            <p>Ending the session kills the Claude process and discards any in-progress work. The conversation history stays in the Sessions list.</p>
+            <label className="rtp-confirm-checkbox">
+              <input type="checkbox" checked={dontAskAgain} onChange={(e) => setDontAskAgain(e.target.checked)} />
+              Don't ask me again
+            </label>
+          </>
+        }
+        confirmLabel="Stop terminal"
+        cancelLabel="Cancel"
+        destructive
+        onCancel={() => setStopConfirmOpen(false)}
+        onConfirm={() => {
+          if (dontAskAgain) localStorage.setItem("oyster-skip-stop-confirm", "1");
+          setStopConfirmOpen(false);
+          void onStop?.();
+        }}
       />
-    </WindowChrome>
+    </>
   );
 }

--- a/web/src/components/TerminalWindow.tsx
+++ b/web/src/components/TerminalWindow.tsx
@@ -22,6 +22,10 @@ interface Props {
   linkedSessionId?: string;
   /** Optional callback fired when the user clicks a linked title. */
   onOpenSession?: (sessionId: string) => void;
+  /** True when the underlying PTY is alive on the server. Controls whether
+   *  the close button means "minimise" (alive — glyph −) or "close" (dead,
+   *  PTY was stopped or exited — glyph ×). Defaults to true. */
+  ptyAlive?: boolean;
 }
 
 export function TerminalWindow({
@@ -34,6 +38,7 @@ export function TerminalWindow({
   title,
   linkedSessionId,
   onOpenSession,
+  ptyAlive = true,
 }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -172,8 +177,8 @@ export function TerminalWindow({
       defaultW={720}
       defaultH={480}
       zIndex={zIndex}
-      closeButtonTooltip="Minimise terminal"
-      closeButtonGlyph="−"
+      closeButtonTooltip={ptyAlive ? "Minimise terminal" : "Close window"}
+      closeButtonGlyph={ptyAlive ? "−" : "×"}
     >
       <div
         ref={termRef}

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -50,10 +50,6 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
       {open && (
         <div className="rtp-popover" ref={popoverRef}>
           <div className="rtp-popover-arrow" />
-          <div className="rtp-popover-head">
-            <span>Running terminals</span>
-            <span>{presence.totalLive}</span>
-          </div>
           {rows.map(({ info, session }) => {
             const title = session?.title ?? info.sessionId.slice(0, 8);
             const space = session?.spaceId ?? "—";

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import type { TerminalPresence, PresenceInfo } from "../../hooks/useTerminalPresence";
 import type { Session } from "../../data/sessions-api";
+import { ConfirmModal } from "../ConfirmModal";
 
 interface Props {
   presence: TerminalPresence;
@@ -12,6 +13,8 @@ interface Props {
 
 export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, onStop }: Props) {
   const [open, setOpen] = useState(false);
+  const [pendingStopId, setPendingStopId] = useState<string | null>(null);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
 
   // Close popover when count drops to 0 — the pill disappears too.
@@ -45,7 +48,7 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
         title={`${presence.totalLive} running terminal${presence.totalLive === 1 ? "" : "s"}`}
       >
         <span className="rtp-pulse" />
-        Running {presence.totalLive} ▾
+        running ({presence.totalLive})
       </button>
       {open && (
         <div className="rtp-popover" ref={popoverRef}>
@@ -74,14 +77,44 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
                 <button
                   className="rtp-stop"
                   title="Stop terminal"
-                  onClick={(e) => { e.stopPropagation(); void onStop(info.terminalId); }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (localStorage.getItem("oyster-skip-stop-confirm") === "1") {
+                      void onStop(info.terminalId);
+                    } else {
+                      setDontAskAgain(false);
+                      setPendingStopId(info.terminalId);
+                    }
+                  }}
                 >■</button>
               </div>
             );
           })}
-          <div className="rtp-popover-foot">Click row to focus · Stop ends the session</div>
         </div>
       )}
+      <ConfirmModal
+        open={pendingStopId !== null}
+        title="Stop this terminal?"
+        body={
+          <>
+            <p>Ending the session kills the Claude process and discards any in-progress work. The conversation history stays in the Sessions list.</p>
+            <label className="rtp-confirm-checkbox">
+              <input type="checkbox" checked={dontAskAgain} onChange={e => setDontAskAgain(e.target.checked)} />
+              Don't ask me again
+            </label>
+          </>
+        }
+        confirmLabel="Stop terminal"
+        cancelLabel="Cancel"
+        destructive
+        onCancel={() => setPendingStopId(null)}
+        onConfirm={() => {
+          if (dontAskAgain) localStorage.setItem("oyster-skip-stop-confirm", "1");
+          const id = pendingStopId!;
+          setPendingStopId(null);
+          void onStop(id);
+        }}
+      />
     </div>
   );
 }

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -47,8 +47,8 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
         onClick={() => setOpen(o => !o)}
         title={`${presence.totalLive} running terminal${presence.totalLive === 1 ? "" : "s"}`}
       >
-        <span className="rtp-pulse" />
-        {presence.totalLive} running
+        <span className="pip-count"><span className="pip pip-teal rtp-pulse-anim" />{presence.totalLive}</span>
+        running
       </button>
       {open && (
         <div className="rtp-popover" ref={popoverRef}>

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -71,7 +71,10 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
                     <span className="rtp-space">{space}</span> · claude-code · {isAttached ? "open" : "minimised"}
                   </span>
                 </div>
-                {!isAttached && <span className="rtp-chip rtp-chip--restore">Restore</span>}
+                {/* Always render the chip slot to keep stop-button column aligned. */}
+                {!isAttached
+                  ? <span className="rtp-chip rtp-chip--restore">Restore</span>
+                  : <span className="rtp-chip-placeholder" />}
                 <button
                   className="rtp-stop"
                   title="Stop terminal"

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -63,17 +63,13 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
                 className="rtp-row"
                 onClick={() => isAttached ? onFocus(info.terminalId) : onRestore(info.sessionId, info.terminalId)}
               >
-                <span className={isAttached ? "rtp-dot rtp-dot--attached" : "rtp-dot rtp-dot--running"} />
+                <span className="rtp-dot" />
                 <div className="rtp-body">
                   <span className="rtp-title">{title}</span>
                   <span className="rtp-meta">
                     <span className="rtp-space">{space}</span> · claude-code · {isAttached ? "open" : "minimised"}
                   </span>
                 </div>
-                {/* Always render the chip slot to keep stop-button column aligned. */}
-                {!isAttached
-                  ? <span className="rtp-chip rtp-chip--restore">Restore</span>
-                  : <span className="rtp-chip-placeholder" />}
                 <button
                   className="rtp-stop"
                   title="Stop terminal"

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -47,7 +47,9 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
         onClick={() => setOpen(o => !o)}
         title={`${presence.totalLive} running terminal${presence.totalLive === 1 ? "" : "s"}`}
       >
-        <span className="pip-count"><span className="pip pip-teal rtp-pulse-anim" />{presence.totalLive}</span>
+        <span className="home-breadcrumb-badges">
+          <span className="pip-count"><span className="pip pip-teal rtp-pulse-anim" />{presence.totalLive}</span>
+        </span>
         running
       </button>
       {open && (

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -1,0 +1,88 @@
+import { useState, useRef, useEffect } from "react";
+import type { TerminalPresence, PresenceInfo } from "../../hooks/useTerminalPresence";
+import type { Session } from "../../data/sessions-api";
+
+interface Props {
+  presence: TerminalPresence;
+  sessions: Session[];
+  onFocus: (terminalId: string) => void;
+  onRestore: (sessionId: string, terminalId: string) => void;
+  onStop: (terminalId: string) => Promise<void>;
+}
+
+export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, onStop }: Props) {
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Close popover when count drops to 0 — the pill disappears too.
+  useEffect(() => {
+    if (presence.totalLive === 0) setOpen(false);
+  }, [presence.totalLive]);
+
+  // Click-outside closes the popover.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (presence.totalLive === 0) return null;
+
+  const rows: { info: PresenceInfo; session: Session | undefined }[] =
+    [...presence.attached, ...presence.running].map(info => ({
+      info,
+      session: sessions.find(s => s.id === info.sessionId),
+    }));
+
+  return (
+    <div className="rtp-wrap">
+      <button
+        className={`rtp-pill${open ? " rtp-pill--open" : ""}`}
+        onClick={() => setOpen(o => !o)}
+        title={`${presence.totalLive} running terminal${presence.totalLive === 1 ? "" : "s"}`}
+      >
+        <span className="rtp-pulse" />
+        Running {presence.totalLive} ▾
+      </button>
+      {open && (
+        <div className="rtp-popover" ref={popoverRef}>
+          <div className="rtp-popover-arrow" />
+          <div className="rtp-popover-head">
+            <span>Running terminals</span>
+            <span>{presence.totalLive}</span>
+          </div>
+          {rows.map(({ info, session }) => {
+            const title = session?.title ?? info.sessionId.slice(0, 8);
+            const space = session?.spaceId ?? "—";
+            const isAttached = info.state === "attached";
+            return (
+              <div
+                key={info.terminalId}
+                className="rtp-row"
+                onClick={() => isAttached ? onFocus(info.terminalId) : onRestore(info.sessionId, info.terminalId)}
+              >
+                <span className={isAttached ? "rtp-dot rtp-dot--attached" : "rtp-dot rtp-dot--running"} />
+                <div className="rtp-body">
+                  <span className="rtp-title">{title}</span>
+                  <span className="rtp-meta">
+                    <span className="rtp-space">{space}</span> · claude-code · {isAttached ? "open" : "minimised"}
+                  </span>
+                </div>
+                {!isAttached && <span className="rtp-chip rtp-chip--restore">Restore</span>}
+                <button
+                  className="rtp-stop"
+                  title="Stop terminal"
+                  onClick={(e) => { e.stopPropagation(); void onStop(info.terminalId); }}
+                >■</button>
+              </div>
+            );
+          })}
+          <div className="rtp-popover-foot">Click row to focus · Stop ends the session</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -48,7 +48,7 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
         title={`${presence.totalLive} running terminal${presence.totalLive === 1 ? "" : "s"}`}
       >
         <span className="rtp-pulse" />
-        running ({presence.totalLive})
+        {presence.totalLive} running
       </button>
       {open && (
         <div className="rtp-popover" ref={popoverRef}>

--- a/web/src/components/Topbar/RunningTerminalsPill.tsx
+++ b/web/src/components/Topbar/RunningTerminalsPill.tsx
@@ -15,18 +15,20 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
   const [open, setOpen] = useState(false);
   const [pendingStopId, setPendingStopId] = useState<string | null>(null);
   const [dontAskAgain, setDontAskAgain] = useState(false);
-  const popoverRef = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
 
   // Close popover when count drops to 0 — the pill disappears too.
   useEffect(() => {
     if (presence.totalLive === 0) setOpen(false);
   }, [presence.totalLive]);
 
-  // Click-outside closes the popover.
+  // Click-outside closes the popover. The ref covers both the pill button
+  // and the popover so clicking the pill itself doesn't re-open it after
+  // the mousedown handler closes it.
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) setOpen(false);
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
@@ -41,7 +43,7 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
     }));
 
   return (
-    <div className="rtp-wrap">
+    <div className="rtp-wrap" ref={wrapRef}>
       <button
         className={`rtp-pill${open ? " rtp-pill--open" : ""}`}
         onClick={() => setOpen(o => !o)}
@@ -53,7 +55,7 @@ export function RunningTerminalsPill({ presence, sessions, onFocus, onRestore, o
         running
       </button>
       {open && (
-        <div className="rtp-popover" ref={popoverRef}>
+        <div className="rtp-popover">
           <div className="rtp-popover-arrow" />
           {rows.map(({ info, session }) => {
             const title = session?.title ?? info.sessionId.slice(0, 8);

--- a/web/src/components/WindowChrome.tsx
+++ b/web/src/components/WindowChrome.tsx
@@ -24,6 +24,9 @@ interface Props {
   onToggleFullscreen?: () => void;
   extraHeader?: ReactNode;
   closeButtonTooltip?: string;
+  /** Glyph shown inside the close button. Defaults to ×; pass "−" for
+   *  windows where close means "minimise" (the action is non-destructive). */
+  closeButtonGlyph?: string;
 }
 
 export function WindowChrome({
@@ -40,6 +43,7 @@ export function WindowChrome({
   onToggleFullscreen,
   extraHeader,
   closeButtonTooltip = "Close",
+  closeButtonGlyph = "×",
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const offset = useRef({ x: 0, y: 0 });
@@ -212,7 +216,7 @@ export function WindowChrome({
             </button>
           )}
           <button className="window-btn close" onClick={onClose} title={closeButtonTooltip}>
-            ×
+            {closeButtonGlyph}
           </button>
         </div>
       </div>

--- a/web/src/components/WindowChrome.tsx
+++ b/web/src/components/WindowChrome.tsx
@@ -23,6 +23,7 @@ interface Props {
   fullscreen?: boolean;
   onToggleFullscreen?: () => void;
   extraHeader?: ReactNode;
+  closeButtonTooltip?: string;
 }
 
 export function WindowChrome({
@@ -38,6 +39,7 @@ export function WindowChrome({
   fullscreen = false,
   onToggleFullscreen,
   extraHeader,
+  closeButtonTooltip = "Close",
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const offset = useRef({ x: 0, y: 0 });
@@ -209,7 +211,7 @@ export function WindowChrome({
               )}
             </button>
           )}
-          <button className="window-btn close" onClick={onClose}>
+          <button className="window-btn close" onClick={onClose} title={closeButtonTooltip}>
             ×
           </button>
         </div>

--- a/web/src/hooks/useTerminalPresence.ts
+++ b/web/src/hooks/useTerminalPresence.ts
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import type { Session } from "../data/sessions-api";
+import type { WindowState } from "../stores/windows";
+
+export type PresenceState = "attached" | "running";
+
+export interface PresenceInfo {
+  sessionId: string;
+  terminalId: string;
+  state: PresenceState;
+  attachedClients: number;
+}
+
+export interface TerminalPresence {
+  /** Sessions whose linked PTY currently has at least one attached window. */
+  attached: PresenceInfo[];
+  /** Sessions whose linked PTY is alive but no window is attached. */
+  running: PresenceInfo[];
+  byId: Record<string, PresenceInfo>;
+  /** Convenience: attached.length + running.length. */
+  totalLive: number;
+}
+
+/** Fuses two sources of truth:
+ *
+ *  - `sessions` carries `terminalId` + `terminalAttachedClients` from the
+ *    server (DB-projected, SSE-refreshed by the parent's subscriber).
+ *  - `windows` is the client-side list of open panels. A terminal id is
+ *    "attached" iff a window in the store references that terminalId.
+ *
+ *  The DB column tells us if a PTY *exists*; the windows store tells us
+ *  whether *this client* is currently looking at it. They are NOT
+ *  redundant — the server counts every WS connection (including other
+ *  tabs); the local store reflects only this tab's panels. */
+export function useTerminalPresence(
+  sessions: Session[],
+  windows: WindowState[],
+): TerminalPresence {
+  return useMemo(() => {
+    const localTerminalIds = new Set(
+      windows.filter(w => w.type === "claude_terminal" && w.terminalId).map(w => w.terminalId!),
+    );
+    const attached: PresenceInfo[] = [];
+    const running: PresenceInfo[] = [];
+    const byId: Record<string, PresenceInfo> = {};
+    for (const s of sessions) {
+      if (!s.terminalId) continue;
+      const isAttached = localTerminalIds.has(s.terminalId);
+      const info: PresenceInfo = {
+        sessionId: s.id,
+        terminalId: s.terminalId,
+        state: isAttached ? "attached" : "running",
+        attachedClients: s.terminalAttachedClients,
+      };
+      byId[s.id] = info;
+      (isAttached ? attached : running).push(info);
+    }
+    return { attached, running, byId, totalLive: attached.length + running.length };
+  }, [sessions, windows]);
+}

--- a/web/src/hooks/useTerminalPresence.ts
+++ b/web/src/hooks/useTerminalPresence.ts
@@ -38,7 +38,11 @@ export function useTerminalPresence(
 ): TerminalPresence {
   return useMemo(() => {
     const localTerminalIds = new Set(
-      windows.filter(w => w.type === "claude_terminal" && w.terminalId).map(w => w.terminalId!),
+      windows
+        .filter((w): w is WindowState & { terminalId: string } =>
+          w.type === "claude_terminal" && w.terminalId != null
+        )
+        .map(w => w.terminalId),
     );
     const attached: PresenceInfo[] = [];
     const running: PresenceInfo[] = [];

--- a/web/src/stores/windows.ts
+++ b/web/src/stores/windows.ts
@@ -23,6 +23,7 @@ export type WindowAction =
   | { type: "OPEN_CHAT" }
   | { type: "OPEN_VIEWER"; title: string; path: string; fullscreen?: boolean }
   | { type: "CLOSE"; id: string }
+  | { type: "MINIMISE"; id: string }
   | { type: "CLOSE_ALL_VIEWERS" }
   | { type: "UPDATE_STATUS"; id: string; statusText: string }
   | { type: "OPEN_TERMINAL" }
@@ -111,6 +112,11 @@ export function windowsReducer(
       ];
     }
     case "CLOSE":
+      return state.filter((w) => w.id !== action.id);
+    case "MINIMISE":
+      // Same state change as CLOSE for the windows array (drop the window).
+      // Behavioural difference lives at the call site: terminal panels do
+      // NOT call DELETE /api/terminals/:id — the PTY survives.
       return state.filter((w) => w.id !== action.id);
     case "CLOSE_ALL_VIEWERS":
       return state.filter((w) => w.type !== "viewer");


### PR DESCRIPTION
## Summary

Closing × on an embedded Claude Code terminal panel now **minimises** instead of silently killing the PTY. A new **`● N running`** pill in the topbar (with a popover) surfaces every live terminal so you can find, focus, stop, or restore any of them from anywhere.

Spec: [`docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md`](docs/superpowers/specs/2026-05-19-terminal-minimise-ux-design.md)
Plan: [`docs/superpowers/plans/2026-05-19-terminal-minimise-ux.md`](docs/superpowers/plans/2026-05-19-terminal-minimise-ux.md)

## What's in it

- **× → −**: terminal panel header. `−` minimises (PTY stays alive); flips to `×` only after the PTY actually exits (Stopped, natural exit, killed elsewhere).
- **`● N running` pill** (topbar, right of the space cluster, its own pill bar). Hidden when no PTYs are live.
- **Popover** lists every live terminal: title · space · agent · activity. Click row to view (focus or restore). `■` Stop kills, with a first-time confirmation modal (with *Don't ask again*).
- **Stop button on terminal panels too** — same confirmation modal, shares the *Don't ask again* preference via localStorage.
- **Sessions list** rows for live terminals get a teal stripe + dot; an *Inspect* chip provides the alternate path to the transcript. Click the row → open the panel.
- **Space pills + project tiles** get a `●N running` count badge, first (teal). The `done` chip and the red `disconnected` pip were dropped from project cards to reduce clutter.
- **Sessions list filter** gets a `running` pill, first, scoped to the current space.
- **Inspector** shows a **fork warning** on `Resume here` when the session is active/waiting outside Oyster (resuming would start a second `claude` process and fork the conversation).
- **Inspector** drops the *"agent is waiting on you"* banner — Resume + the fork warning cover that path now.
- **Disconnected** state folded into **Done** for display purposes (no DB / state-model change).
- **Server**: new `terminal_id` / `terminal_attached_clients` columns on `sessions`, written by `ClaudePtyManager` on link / attach / detach / exit. Boot-time reset clears stale indicators after a restart. `terminal:attached / :detached / :exited` SSE events (with `session_changed` piggyback so the existing `useSessions` hook refreshes). `POST_EXIT_RETENTION_MS` bumped from 30s to 15min; 50-retained eviction cap added.

## Test plan

- [x] Server: vitest covers schema migration + boot reset, store link/clear/attached-clients methods, manager link/exit/attach/detach DB writes, SSE event emission, retention bump + 50-retained cap. **421/421 tests pass.**
- [x] Web: `tsc --noEmit` clean.
- [ ] Manual smoke checklist from the spec's Acceptance Tests (see plan Task 14):
  - [ ] Minimise keeps the PTY alive; running pill appears
  - [ ] Click popover row restores / focuses
  - [ ] Stop in popover kills (with confirm)
  - [ ] Stop on panel header kills (with same confirm; preference shared)
  - [ ] Resume here on an active/waiting outside-Oyster session shows fork warning
  - [ ] Once PTY dies, terminal panel button flips `−` → `×`
  - [ ] Boot reset clears stale indicators after a server restart
  - [ ] Live rows pin to top of Sessions list

## Known follow-ups (separate PRs)

- **New Session affordance** — "Start fresh Claude session" from anywhere, with a space/project picker when on Home. Brainstorm pending.
- **In-Oyster "waiting for input" detection** — today *running* doesn't distinguish cooking from awaiting input. Will use a richer signal from the PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)