### PR TITLE
fix(transcript): hide claude-code slash-command machinery (#530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Slash-command machinery no longer clutters the session transcript.** Claude Code's internal wrapper tags (`<command-name>`, `<system-reminder>`, `<local-command-stdout>`) are now hidden from the Session Inspector and excluded from Spotlight transcript search. Existing sessions clean up on next start.
 - **Links inside shared artefacts now click through.** External links in published prototypes (`target="_blank"`, `window.open`) open as expected instead of silently failing — the share.oyster.to iframe now permits popups, matching CodePen/JSFiddle/StackBlitz.
 
 ## [0.9.3] - 2026-05-19

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -306,6 +306,7 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.3...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Fixed</h3>
 <ul>
+<li><strong>Slash-command machinery no longer clutters the session transcript.</strong> Claude Code&#39;s internal wrapper tags (<code>&lt;command-name&gt;</code>, <code>&lt;system-reminder&gt;</code>, <code>&lt;local-command-stdout&gt;</code>) are now hidden from the Session Inspector and excluded from Spotlight transcript search. Existing sessions clean up on next start.</li>
 <li><strong>Links inside shared artefacts now click through.</strong> External links in published prototypes (<code>target=&quot;_blank&quot;</code>, <code>window.open</code>) open as expected instead of silently failing — the share.oyster.to iframe now permits popups, matching CodePen/JSFiddle/StackBlitz.</li>
 </ul>
 <h2 id="v-0-9-3"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.1...v0.9.3" rel="noopener noreferrer"><span class="release-version">0.9.3</span></a><span class="release-date"> — 2026-05-19</span></h2>

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -743,24 +743,35 @@ export function initDb(userlandDir: string): Database.Database {
   // that pre-date this migration. The UPDATE fires session_events_au_del
   // for each (old artifact=0 → indexed in FTS), pulling those rows out of
   // the inverted index; session_events_au_ins skips the re-insert because
-  // new.is_protocol_artifact = 1. Re-running matches zero rows so it's a
-  // no-op on subsequent boots.
+  // new.is_protocol_artifact = 1.
+  //
+  // Gated via app_state so the full-table predicate scan doesn't run on
+  // every boot — session_events grows roughly linearly with usage and
+  // there's no useful index for the leading-whitespace + prefix check.
   //
   // Predicate mirrors isClaudeProtocolArtifact: strip leading whitespace
   // (space/tab/LF/CR) and check the three wrapper prefixes. Only USER
   // events qualify — assistant slash-command echoes (e.g. `/rename …`)
   // stay visible.
-  db.exec(`
-    UPDATE session_events
-       SET is_protocol_artifact = 1
-     WHERE is_protocol_artifact = 0
-       AND role = 'user'
-       AND (
-         ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<local-command-%'
-         OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<command-%'
-         OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<system-reminder>%'
-       );
-  `);
+  {
+    const flag = db.prepare(
+      `INSERT OR IGNORE INTO app_state (key, value, applied_at)
+       VALUES ('protocol_artifact_backfill_done', '1', ?)`,
+    ).run(Date.now());
+    if (flag.changes > 0) {
+      db.exec(`
+        UPDATE session_events
+           SET is_protocol_artifact = 1
+         WHERE is_protocol_artifact = 0
+           AND role = 'user'
+           AND (
+             ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<local-command-%'
+             OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<command-%'
+             OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<system-reminder>%'
+           );
+      `);
+    }
+  }
 
   // Backfill the FTS index if it's stale relative to the content table.
   //
@@ -790,18 +801,16 @@ export function initDb(userlandDir: string): Database.Database {
       if (sampleHits * 4 < indexableCount) {
         // rebuild reads from the content table directly, bypassing our
         // gated triggers — so it re-indexes protocol artefacts too.
-        // Sweep them back out afterwards so the post-rebuild state
-        // matches the trigger-maintained invariant.
-        db.exec("INSERT INTO session_events_fts(session_events_fts) VALUES('rebuild')");
-        const artefacts = db.prepare(
-          "SELECT id, text FROM session_events WHERE is_protocol_artifact = 1"
-        ).all() as Array<{ id: number; text: string }>;
-        const del = db.prepare(
-          "INSERT INTO session_events_fts(session_events_fts, rowid, text) VALUES('delete', ?, ?)"
-        );
-        for (const r of artefacts) {
-          try { del.run(r.id, r.text); } catch { /* already absent */ }
-        }
+        // Sweep them back out in a single INSERT...SELECT so the cost
+        // scales with row count, not round-trips, and any unexpected
+        // FTS5 error surfaces instead of being swallowed per-row.
+        db.exec(`
+          INSERT INTO session_events_fts(session_events_fts) VALUES('rebuild');
+          INSERT INTO session_events_fts(session_events_fts, rowid, text)
+            SELECT 'delete', id, text
+              FROM session_events
+             WHERE is_protocol_artifact = 1;
+        `);
       }
     }
   }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -686,12 +686,28 @@ export function initDb(userlandDir: string): Database.Database {
        ON sessions(sync_dirty_at) WHERE sync_dirty_at IS NOT NULL`,
   );
 
+  // Classify slash-command machinery (`<command-…>`, `<local-command-…>`,
+  // `<system-reminder>`) at ingest so the transcript reader and the FTS
+  // search index can both ignore it while the raw row stays on disk for
+  // audit. See #530 + server/src/utils/claude-protocol-artifacts.ts.
+  try {
+    db.exec("ALTER TABLE session_events ADD COLUMN is_protocol_artifact INTEGER NOT NULL DEFAULT 0");
+  } catch { /* already exists */ }
+
   // ── R2 verbatim recall (#311): FTS5 over session_events.text ──
   // Lives after the state-rename rebuild block (which DROPs and rebuilds
   // session_events) so the virtual table + triggers always end up
   // attached to the final concrete table. We index `text` only — `raw`
   // is the original JSONL with metadata + JSON syntax, which would
   // bloat the index and pollute matches.
+  //
+  // Triggers are gated on `is_protocol_artifact`:
+  //   - AI re-indexes only non-artifact rows.
+  //   - AD / AU's delete-half only fires when the row WAS indexed
+  //     (old.is_protocol_artifact = 0); FTS5 'delete' is unsafe to call
+  //     for a rowid that isn't in the inverted index (#530).
+  // Drop-then-create keeps existing installs in sync after the trigger
+  // shape changed in this migration.
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS session_events_fts USING fts5(
       text,
@@ -699,16 +715,51 @@ export function initDb(userlandDir: string): Database.Database {
       content_rowid=id
     );
 
-    CREATE TRIGGER IF NOT EXISTS session_events_ai AFTER INSERT ON session_events BEGIN
+    DROP TRIGGER IF EXISTS session_events_ai;
+    DROP TRIGGER IF EXISTS session_events_ad;
+    DROP TRIGGER IF EXISTS session_events_au;
+    DROP TRIGGER IF EXISTS session_events_au_del;
+    DROP TRIGGER IF EXISTS session_events_au_ins;
+
+    CREATE TRIGGER session_events_ai AFTER INSERT ON session_events
+    WHEN new.is_protocol_artifact = 0 BEGIN
       INSERT INTO session_events_fts(rowid, text) VALUES (new.id, new.text);
     END;
-    CREATE TRIGGER IF NOT EXISTS session_events_ad AFTER DELETE ON session_events BEGIN
+    CREATE TRIGGER session_events_ad AFTER DELETE ON session_events
+    WHEN old.is_protocol_artifact = 0 BEGIN
       INSERT INTO session_events_fts(session_events_fts, rowid, text) VALUES('delete', old.id, old.text);
     END;
-    CREATE TRIGGER IF NOT EXISTS session_events_au AFTER UPDATE ON session_events BEGIN
+    CREATE TRIGGER session_events_au_del AFTER UPDATE ON session_events
+    WHEN old.is_protocol_artifact = 0 BEGIN
       INSERT INTO session_events_fts(session_events_fts, rowid, text) VALUES('delete', old.id, old.text);
+    END;
+    CREATE TRIGGER session_events_au_ins AFTER UPDATE ON session_events
+    WHEN new.is_protocol_artifact = 0 BEGIN
       INSERT INTO session_events_fts(rowid, text) VALUES (new.id, new.text);
     END;
+  `);
+
+  // One-time backfill: mark existing protocol-artifact rows on installs
+  // that pre-date this migration. The UPDATE fires session_events_au_del
+  // for each (old artifact=0 → indexed in FTS), pulling those rows out of
+  // the inverted index; session_events_au_ins skips the re-insert because
+  // new.is_protocol_artifact = 1. Re-running matches zero rows so it's a
+  // no-op on subsequent boots.
+  //
+  // Predicate mirrors isClaudeProtocolArtifact: strip leading whitespace
+  // (space/tab/LF/CR) and check the three wrapper prefixes. Only USER
+  // events qualify — assistant slash-command echoes (e.g. `/rename …`)
+  // stay visible.
+  db.exec(`
+    UPDATE session_events
+       SET is_protocol_artifact = 1
+     WHERE is_protocol_artifact = 0
+       AND role = 'user'
+       AND (
+         ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<local-command-%'
+         OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<command-%'
+         OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<system-reminder>%'
+       );
   `);
 
   // Backfill the FTS index if it's stale relative to the content table.
@@ -727,15 +778,30 @@ export function initDb(userlandDir: string): Database.Database {
   // 'rebuild' is idempotent — clears + re-populates from content — so
   // it's safe to run.
   {
-    const eventCount = (db.prepare("SELECT COUNT(*) as n FROM session_events").get() as { n: number }).n;
-    if (eventCount > 0) {
+    const indexableCount = (db.prepare(
+      "SELECT COUNT(*) as n FROM session_events WHERE is_protocol_artifact = 0"
+    ).get() as { n: number }).n;
+    if (indexableCount > 0) {
       const sampleHits = (db.prepare(
         "SELECT count(*) as n FROM session_events_fts WHERE session_events_fts MATCH 'a'"
       ).get() as { n: number }).n;
       // Threshold is generous — even pathological transcripts will have
       // 'a' in well over 50% of events. < 25% indicates a broken index.
-      if (sampleHits * 4 < eventCount) {
+      if (sampleHits * 4 < indexableCount) {
+        // rebuild reads from the content table directly, bypassing our
+        // gated triggers — so it re-indexes protocol artefacts too.
+        // Sweep them back out afterwards so the post-rebuild state
+        // matches the trigger-maintained invariant.
         db.exec("INSERT INTO session_events_fts(session_events_fts) VALUES('rebuild')");
+        const artefacts = db.prepare(
+          "SELECT id, text FROM session_events WHERE is_protocol_artifact = 1"
+        ).all() as Array<{ id: number; text: string }>;
+        const del = db.prepare(
+          "INSERT INTO session_events_fts(session_events_fts, rowid, text) VALUES('delete', ?, ?)"
+        );
+        for (const r of artefacts) {
+          try { del.run(r.id, r.text); } catch { /* already absent */ }
+        }
       }
     }
   }

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -50,6 +50,11 @@ export interface SessionEventRow {
   text: string;
   ts: string;
   raw: string | null;
+  /** 1 when this row is slash-command machinery from claude-code (e.g.
+   *  `<command-name>/exit</command-name>`, `<system-reminder>…`). Such
+   *  rows are kept on disk for audit but hidden from the transcript
+   *  reader and excluded from the FTS index. See #530. */
+  is_protocol_artifact: 0 | 1;
 }
 
 export interface SessionArtifactRow {
@@ -125,6 +130,10 @@ export interface InsertSessionEvent {
   text: string;
   ts?: string;
   raw?: string | null;
+  /** Defaults to 0 when omitted. Set to 1 for claude-code slash-command
+   *  machinery so the row is excluded from the transcript and the FTS
+   *  index. See server/src/utils/claude-protocol-artifacts.ts. */
+  is_protocol_artifact?: 0 | 1;
 }
 
 export interface InsertSessionArtifact {
@@ -277,20 +286,25 @@ export class SqliteSessionStore implements SessionStore {
         "UPDATE sessions SET state = ?, last_event_at = ? WHERE id = ?"
       ),
       insertEvent: db.prepare(`
-        INSERT INTO session_events (session_id, role, text, ts, raw)
-        VALUES (@session_id, @role, @text, COALESCE(@ts, datetime('now')), @raw)
+        INSERT INTO session_events (session_id, role, text, ts, raw, is_protocol_artifact)
+        VALUES (@session_id, @role, @text, COALESCE(@ts, datetime('now')), @raw, @is_protocol_artifact)
       `),
+      // Transcript reads filter out protocol artefacts (#530). The FTS
+      // search path filters implicitly via the JOIN (artefacts are never
+      // indexed). getEventById stays unfiltered — it's a primitive "fetch
+      // by id" used by the inspector to lazy-load the raw JSONL for tool
+      // turns; future "show hidden" toggles can lean on it.
       getEventsBySession: db.prepare(
-        "SELECT * FROM session_events WHERE session_id = ? ORDER BY id"
+        "SELECT * FROM session_events WHERE session_id = ? AND is_protocol_artifact = 0 ORDER BY id"
       ),
       getEventsBySessionLimit: db.prepare(
-        "SELECT * FROM session_events WHERE session_id = ? ORDER BY id DESC LIMIT ?"
+        "SELECT * FROM session_events WHERE session_id = ? AND is_protocol_artifact = 0 ORDER BY id DESC LIMIT ?"
       ),
       getEventsBefore: db.prepare(
-        "SELECT * FROM session_events WHERE session_id = ? AND id < ? ORDER BY id DESC LIMIT ?"
+        "SELECT * FROM session_events WHERE session_id = ? AND id < ? AND is_protocol_artifact = 0 ORDER BY id DESC LIMIT ?"
       ),
       getEventsAfter: db.prepare(
-        "SELECT * FROM session_events WHERE session_id = ? AND id > ? ORDER BY id ASC LIMIT ?"
+        "SELECT * FROM session_events WHERE session_id = ? AND id > ? AND is_protocol_artifact = 0 ORDER BY id ASC LIMIT ?"
       ),
       getEventById: db.prepare(
         "SELECT * FROM session_events WHERE session_id = ? AND id = ? LIMIT 1"
@@ -318,7 +332,7 @@ export class SqliteSessionStore implements SessionStore {
     const insertOne = this.stmts.insertEvent;
     this.insertEventsTxn = db.transaction((rows: InsertSessionEvent[]) => {
       for (const r of rows) {
-        insertOne.run({ ts: null, raw: null, ...r });
+        insertOne.run({ ts: null, raw: null, is_protocol_artifact: 0, ...r });
       }
     });
   }
@@ -387,7 +401,7 @@ export class SqliteSessionStore implements SessionStore {
   }
 
   insertEvent(row: InsertSessionEvent): number {
-    const info = this.stmts.insertEvent.run({ ts: null, raw: null, ...row });
+    const info = this.stmts.insertEvent.run({ ts: null, raw: null, is_protocol_artifact: 0, ...row });
     return Number(info.lastInsertRowid);
   }
 

--- a/server/src/utils/claude-protocol-artifacts.ts
+++ b/server/src/utils/claude-protocol-artifacts.ts
@@ -1,0 +1,22 @@
+// Claude Code wraps slash-command machinery in pseudo-user messages — e.g.
+// `<command-name>/exit</command-name>`, `<local-command-stdout>Goodbye!`,
+// `<system-reminder>The user named this session "…"</system-reminder>`. They
+// were never typed by the user and were never said by the assistant; they're
+// protocol artefacts. We classify them at ingest so the transcript reader and
+// search index can ignore them while the raw rows stay on disk.
+//
+// Match is intentionally prefix-only: a real message that happens to *contain*
+// these strings (e.g. someone pasting a snippet about slash-commands) should
+// still render. Only events whose leading non-whitespace token is one of these
+// wrappers get classified out.
+//
+// Caller is expected to gate this on `role === "user"`. Assistant messages can
+// legitimately echo a slash command (`/rename ...`) and we want those visible.
+export function isClaudeProtocolArtifact(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith("<local-command-")
+    || trimmed.startsWith("<command-")
+    || trimmed.startsWith("<system-reminder>")
+  );
+}

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -11,6 +11,7 @@ import type {
   SessionStore,
 } from "../session-store.js";
 import { encodeCwd } from "../session-sync-service.js";
+import { isClaudeProtocolArtifact } from "../utils/claude-protocol-artifacts.js";
 import { activeClaudeCwdCounts } from "./claude-process-probe.js";
 
 // claude-code session log watcher (Sprint 2 of the 0.5.0 sessions arc).
@@ -456,12 +457,15 @@ export class ClaudeCodeWatcher {
 
       const rendered = renderEvent(ev);
       if (rendered) {
+        const text = rendered.text.slice(0, TEXT_PREVIEW_MAX);
         events.push({
           session_id: sessionId,
           role: rendered.role,
-          text: rendered.text.slice(0, TEXT_PREVIEW_MAX),
+          text,
           ts: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
           raw: line,
+          is_protocol_artifact:
+            rendered.role === "user" && isClaudeProtocolArtifact(text) ? 1 : 0,
         });
       }
 
@@ -786,12 +790,15 @@ export class ClaudeCodeWatcher {
 
       const rendered = renderEvent(ev);
       if (rendered && tracker.sessionId) {
+        const text = rendered.text.slice(0, TEXT_PREVIEW_MAX);
         events.push({
           session_id: tracker.sessionId,
           role: rendered.role,
-          text: rendered.text.slice(0, TEXT_PREVIEW_MAX),
+          text,
           ts: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
           raw: line,
+          is_protocol_artifact:
+            rendered.role === "user" && isClaudeProtocolArtifact(text) ? 1 : 0,
         });
         if (typeof ev.timestamp === "string") latestTimestamp = ev.timestamp;
       }
@@ -920,22 +927,14 @@ export function deriveState(ageMs: number, signal: ProbeSignal): SessionState {
 
 // Pull a usable title out of a `type:"user"` event's content, or return null.
 // claude-code wraps slash-command machinery (/compact, /clear, etc.) in
-// pseudo-user messages prefixed with <local-command-caveat>, <command-name>,
-// or <command-message>. Those are noise — keep scanning until we find a
-// real prompt the user actually typed.
+// pseudo-user messages — skip those and keep scanning for a real prompt.
 export function userMessageTitleCandidate(ev: Record<string, any>): string | null {
   if (ev?.type !== "user") return null;
   const content = ev.message?.content;
   if (typeof content !== "string") return null;
   const trimmed = content.trim();
   if (!trimmed) return null;
-  // Slash-command machinery shows up under several tag prefixes — current
-  // ones are <local-command-caveat>, <local-command-stdout>, and the older
-  // <command-name>/<command-message>. Catch the family with a single check
-  // so future variants don't slip through.
-  if (trimmed.startsWith("<local-command-") || trimmed.startsWith("<command-")) {
-    return null;
-  }
+  if (isClaudeProtocolArtifact(trimmed)) return null;
   return trimmed;
 }
 

--- a/server/test/claude-protocol-artifacts.test.ts
+++ b/server/test/claude-protocol-artifacts.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isClaudeProtocolArtifact } from "../src/utils/claude-protocol-artifacts.js";
+
+describe("isClaudeProtocolArtifact", () => {
+  it("matches the three wrapper families", () => {
+    expect(isClaudeProtocolArtifact("<command-name>/exit</command-name>")).toBe(true);
+    expect(isClaudeProtocolArtifact("<command-message>name</command-message>")).toBe(true);
+    expect(isClaudeProtocolArtifact("<command-args></command-args>")).toBe(true);
+    expect(isClaudeProtocolArtifact("<local-command-stdout>Goodbye!</local-command-stdout>")).toBe(true);
+    expect(isClaudeProtocolArtifact("<local-command-caveat>Caveat: ...</local-command-caveat>")).toBe(true);
+    expect(isClaudeProtocolArtifact("<system-reminder>\nThe user named this session ...\n</system-reminder>")).toBe(true);
+  });
+
+  it("tolerates leading whitespace (real claude-code indents some variants)", () => {
+    expect(isClaudeProtocolArtifact("  \n\t<command-name>/exit</command-name>")).toBe(true);
+  });
+
+  it("does not match normal user text", () => {
+    expect(isClaudeProtocolArtifact("hello")).toBe(false);
+    expect(isClaudeProtocolArtifact("")).toBe(false);
+    expect(isClaudeProtocolArtifact("can you fix the bug in src/foo.ts?")).toBe(false);
+  });
+
+  it("does not match messages that merely mention the tags inside their body", () => {
+    expect(isClaudeProtocolArtifact("here's an example: <command-name>")).toBe(false);
+    expect(isClaudeProtocolArtifact("the <system-reminder> tag was confusing")).toBe(false);
+  });
+
+  it("does not match assistant slash-command echoes", () => {
+    expect(isClaudeProtocolArtifact("/rename OYSTER: fix share iframe popups")).toBe(false);
+  });
+});

--- a/server/test/session-protocol-artifacts.test.ts
+++ b/server/test/session-protocol-artifacts.test.ts
@@ -165,4 +165,28 @@ describe("protocol-artifact classification", () => {
     });
     expect(env.store.getEventsBySession("s1")).toHaveLength(1);
   });
+
+  it("backfill is gated so it doesn't rescan session_events on every boot", () => {
+    // First boot has already happened via makeEnv → flag is now set.
+    const flag = env.db
+      .prepare("SELECT value FROM app_state WHERE key = 'protocol_artifact_backfill_done'")
+      .get() as { value: string } | undefined;
+    expect(flag?.value).toBe("1");
+
+    // Insert a pre-migration-style row (unmarked artifact). If the backfill
+    // re-fired on the next boot, this row would flip to artifact=1.
+    env.db.prepare(
+      `INSERT INTO session_events (session_id, role, text, is_protocol_artifact)
+       VALUES ('s1', 'user', ?, 0)`,
+    ).run("<command-name>/exit</command-name>");
+
+    // Simulate a second boot on the same userland dir.
+    env.db.close();
+    const db2 = initDb(env.dir);
+    const row = db2
+      .prepare("SELECT is_protocol_artifact FROM session_events WHERE text LIKE ? LIMIT 1")
+      .get("<command-name>/exit%") as { is_protocol_artifact: number } | undefined;
+    db2.close();
+    expect(row?.is_protocol_artifact).toBe(0);
+  });
 });

--- a/server/test/session-protocol-artifacts.test.ts
+++ b/server/test/session-protocol-artifacts.test.ts
@@ -1,0 +1,168 @@
+// Coverage for #530: protocol-artifact classification keeps slash-command
+// machinery (`<command-…>`, `<local-command-…>`, `<system-reminder>`) out of
+// the rendered transcript and FTS index while preserving the raw row.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function seedSpace(db: Database.Database, id: string) {
+  db.prepare(
+    `INSERT INTO spaces (id, display_name, color, scan_status)
+     VALUES (?, ?, ?, 'none')`,
+  ).run(id, id, "#000");
+}
+
+function seedSession(db: Database.Database, id: string, spaceId: string) {
+  db.prepare(
+    `INSERT INTO sessions
+       (id, space_id, cwd, agent, title, state,
+        started_at, last_event_at)
+     VALUES (?, ?, NULL, 'claude-code', ?, 'done',
+             '2026-05-19T10:00:00Z', '2026-05-19T10:30:00Z')`,
+  ).run(id, spaceId, id);
+}
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-protocol-artifacts-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  seedSpace(db, "ws");
+  seedSession(db, "s1", "ws");
+  return {
+    dir,
+    db,
+    store,
+    dispose: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("protocol-artifact classification", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("transcript reads exclude marked rows but preserve them on disk", () => {
+    env.store.insertEvent({ session_id: "s1", role: "user", text: "first real question" });
+    env.store.insertEvent({
+      session_id: "s1",
+      role: "user",
+      text: "<command-name>/exit</command-name>",
+      is_protocol_artifact: 1,
+    });
+    env.store.insertEvent({ session_id: "s1", role: "assistant", text: "the reply" });
+    env.store.insertEvent({
+      session_id: "s1",
+      role: "user",
+      text: "<system-reminder>noise</system-reminder>",
+      is_protocol_artifact: 1,
+    });
+
+    // Transcript reads hide artefacts.
+    expect(env.store.getEventsBySession("s1").map((e) => e.text))
+      .toEqual(["first real question", "the reply"]);
+    expect(env.store.getEventsBySession("s1", { limit: 10 }).map((e) => e.text))
+      .toEqual(["first real question", "the reply"]);
+
+    // Cursor pagination also hides them.
+    const all = env.store.getEventsBySession("s1");
+    const first = all[0]!;
+    const last = all[all.length - 1]!;
+    expect(env.store.getEventsAfterBySession("s1", first.id, 10).map((e) => e.text))
+      .toEqual(["the reply"]);
+    expect(env.store.getEventsBeforeBySession("s1", last.id, 10).map((e) => e.text))
+      .toEqual(["first real question"]);
+
+    // Raw rows are still on disk for audit.
+    const allOnDisk = env.db
+      .prepare("SELECT role, text, is_protocol_artifact FROM session_events WHERE session_id = ? ORDER BY id")
+      .all("s1") as Array<{ role: string; text: string; is_protocol_artifact: number }>;
+    expect(allOnDisk).toHaveLength(4);
+    expect(allOnDisk.filter((r) => r.is_protocol_artifact === 1)).toHaveLength(2);
+  });
+
+  it("FTS search excludes artefacts via the gated trigger", () => {
+    env.store.insertEvent({
+      session_id: "s1",
+      role: "user",
+      text: "<command-name>/rename special-phrase-uniquetoken</command-name>",
+      is_protocol_artifact: 1,
+    });
+    env.store.insertEvent({
+      session_id: "s1",
+      role: "user",
+      text: "real prompt with special-phrase-uniquetoken in it",
+    });
+
+    const hits = env.store.searchEvents("special");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].snippet).toContain("real");
+  });
+
+  it("backfill marks pre-migration rows and pulls them out of FTS", () => {
+    // Simulate pre-migration state: artefact rows inserted with the flag
+    // still 0, so the (gated) AI trigger DID index them in FTS. The new
+    // migration UPDATE flips the flag, which fires the AU triggers and
+    // removes them from the inverted index.
+    env.db.prepare(
+      `INSERT INTO session_events (session_id, role, text, is_protocol_artifact)
+       VALUES ('s1', 'user', ?, 0)`,
+    ).run("<command-name>/exit needle-token</command-name>");
+    env.db.prepare(
+      `INSERT INTO session_events (session_id, role, text, is_protocol_artifact)
+       VALUES ('s1', 'user', ?, 0)`,
+    ).run("genuine question needle-token");
+
+    // Sanity: pre-backfill, both rows match.
+    expect(env.store.searchEvents("needle").map((h) => h.snippet).join("\n")).toContain("needle");
+    expect(env.store.searchEvents("needle")).toHaveLength(2);
+
+    // Re-run the backfill UPDATE (mirrors db.ts).
+    env.db.exec(`
+      UPDATE session_events
+         SET is_protocol_artifact = 1
+       WHERE is_protocol_artifact = 0
+         AND role = 'user'
+         AND (
+           ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<local-command-%'
+           OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<command-%'
+           OR ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE '<system-reminder>%'
+         );
+    `);
+
+    // Artefact gone from FTS; genuine row still matches.
+    const hits = env.store.searchEvents("needle");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].snippet).toContain("genuine");
+
+    // Transcript reads also exclude it now.
+    expect(env.store.getEventsBySession("s1").map((e) => e.text))
+      .toEqual(["genuine question needle-token"]);
+  });
+
+  it("assistant slash-command echoes are NOT classified as artefacts", () => {
+    // The watcher gates classification on role === 'user', so an
+    // assistant echo like `/rename …` stays visible and searchable.
+    env.store.insertEvent({ session_id: "s1", role: "assistant", text: "/rename foo" });
+    expect(env.store.getEventsBySession("s1").map((e) => e.text)).toEqual(["/rename foo"]);
+    expect(env.store.searchEvents("rename")).toHaveLength(1);
+  });
+
+  it("messages that merely mention wrapper tags are not classified", () => {
+    // Prefix-only match: a legit user message that happens to contain
+    // `<command-` in its body stays visible.
+    env.store.insertEvent({
+      session_id: "s1",
+      role: "user",
+      text: "here's an example: <command-name> — what does that tag mean?",
+    });
+    expect(env.store.getEventsBySession("s1")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Classify claude-code's wrapper tags (`<command-name>`, `<system-reminder>`, `<local-command-*>`) at ingest with a new `is_protocol_artifact` column on `session_events`.
- Transcript reads filter `is_protocol_artifact = 0` (keeps pagination honest); FTS triggers are gated on the flag so search never returns artefacts; raw rows stay on disk for audit.
- Shared `isClaudeProtocolArtifact` helper in `server/src/utils/`; the watcher's existing title heuristic now reuses it instead of duplicating the predicate.
- Migration backfill marks pre-existing rows on first start; the gated `AU` trigger sweeps them out of FTS on the same write.
- Assistant slash-command echoes (e.g. `/rename …`) stay visible — only `role = 'user'` events are classified.

Fixes #530.

## Test plan

- [x] Helper unit tests (5 cases): three wrapper families match; leading whitespace tolerated; normal text + mid-body tag mentions + assistant echoes don't match.
- [x] Integration tests (5 cases): transcript reads + cursor pagination exclude artefacts; raw rows still on disk; FTS search excludes artefacts; backfill correctly migrates pre-existing rows and pulls them from FTS; assistant `/rename` stays visible; messages mentioning tags mid-body stay visible.
- [x] Full server suite: 417/417 passing.
- [ ] Manual: run a session with `/rename` and `/exit`, open the Session Inspector — verify no wrapper tags visible; Spotlight for `exit` doesn't return the slash-command turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)