### PR TITLE
feat(docs): running-terminals demo on the landing prototype

### DIFF
--- a/docs/assets/hero-mock.css
+++ b/docs/assets/hero-mock.css
@@ -159,6 +159,16 @@
 .hm-status-a { background: #fbbf24; box-shadow: 0 0 8px rgba(251, 191, 36, 0.6); }
 .hm-status-r { background: #f87171; box-shadow: 0 0 8px rgba(248, 113, 113, 0.5); }
 .hm-status-d { background: rgba(255, 255, 255, 0.22); }
+.hm-status-running { background: #5eead4; box-shadow: 0 0 8px rgba(94, 234, 212, 0.6); animation: hmRtpPulse 2.4s ease-out infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .hm-status-running { animation: none; }
+}
+.hm-tile-running {
+  position: relative;
+  border-left: 2px solid #5eead4;
+  background: rgba(94, 234, 212, 0.05);
+}
+.hm-tile-running:hover { background: rgba(94, 234, 212, 0.1); }
 .hm-tile-body { flex: 1; min-width: 0; }
 .hm-tile-title {
   font-size: 12px;
@@ -460,7 +470,7 @@
   box-shadow: -16px 0 40px rgba(0, 0, 0, 0.4);
   overflow-y: auto;
 }
-.hero-mock:has(.hm-tile:hover) .hm-side,
+.hero-mock:has(.hm-tile:not(.hm-tile-running):hover) .hm-side,
 .hero-mock:has(.hm-mem:hover) .hm-side,
 .hero-mock.is-side-open .hm-side { transform: translateX(0); pointer-events: auto; }
 /* Back button — pill-shaped, accent-coloured so it reads as the primary action when the drawer is pinned */
@@ -635,4 +645,281 @@
   .pv-list ul { grid-template-columns: 1fr; gap: 2px; }
   .pv-list li { padding: 9px 8px; font-size: 12px; }
   .pv-chk { width: 16px; height: 16px; font-size: 11px; }
+}
+
+/* ------------------------------------------------------------------ */
+/* Running-terminals demo — pill, popover, simulated terminal panel.  */
+/* Mirrors the in-app RunningTerminalsPill + TerminalWindow surface   */
+/* shipped in PR #531.                                                */
+/* ------------------------------------------------------------------ */
+
+.hm-rtp-wrap { position: relative; display: inline-flex; }
+
+.hm-rtp-pill {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 6px 12px;
+  border-radius: 9999px;
+  background: rgba(94, 234, 212, 0.08);
+  border: 1px solid rgba(94, 234, 212, 0.28);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+  color: rgba(167, 243, 224, 0.92);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  appearance: none;
+}
+.hm-rtp-pill:hover,
+.hm-rtp-pill[aria-expanded="true"] {
+  background: rgba(94, 234, 212, 0.16);
+  border-color: rgba(94, 234, 212, 0.5);
+  color: #ccfbf1;
+}
+.hm-rtp-pill .hm-rtp-count {
+  color: #5eead4;
+  font-variant-numeric: tabular-nums;
+}
+.hm-rtp-pip {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #5eead4;
+  box-shadow: 0 0 0 0 rgba(94, 234, 212, 0.6);
+  animation: hmRtpPulse 2.4s ease-out infinite;
+}
+@keyframes hmRtpPulse {
+  0%   { box-shadow: 0 0 0 0   rgba(94, 234, 212, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(94, 234, 212, 0); }
+  100% { box-shadow: 0 0 0 0   rgba(94, 234, 212, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hm-rtp-pip { animation: none; box-shadow: 0 0 6px rgba(94, 234, 212, 0.55); }
+}
+
+.hm-rtp-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  min-width: 280px;
+  max-width: min(340px, 92vw);
+  background: rgba(14, 15, 30, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+  padding: 6px;
+  z-index: 7;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity 0.14s ease, transform 0.14s ease;
+}
+/* Invisible bridge so the cursor can cross the gap to the popover without
+   triggering mouseleave on the wrap. */
+.hm-rtp-popover::before {
+  content: '';
+  position: absolute;
+  left: 0; right: 0;
+  top: -10px;
+  height: 10px;
+}
+.hm-rtp-wrap:hover .hm-rtp-popover,
+.hm-rtp-wrap:focus-within .hm-rtp-popover,
+.hm-rtp-popover.is-pinned {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.hm-rtp-arrow {
+  position: absolute;
+  top: -5px; left: 24px;
+  width: 10px; height: 10px;
+  background: rgba(14, 15, 30, 0.98);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  transform: rotate(45deg);
+}
+
+.hm-rtp-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 8px 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  border-left: 2px solid #5eead4;
+  background: rgba(94, 234, 212, 0.05);
+  transition: background 0.15s;
+  outline: none;
+}
+.hm-rtp-row:hover,
+.hm-rtp-row:focus-visible { background: rgba(94, 234, 212, 0.12); }
+
+.hm-rtp-dot {
+  width: 9px; height: 9px; border-radius: 50%;
+  background: #5eead4;
+  box-shadow: 0 0 6px rgba(94, 234, 212, 0.6);
+  flex-shrink: 0;
+}
+
+.hm-rtp-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.hm-rtp-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.hm-rtp-meta {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Simulated terminal panel — same footprint family as .hm-preview */
+.hm-terminal {
+  position: absolute;
+  left: 24px; right: 24px;
+  bottom: 110px;
+  height: 200px;
+  background: #0a0c12;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.22s ease, transform 0.22s ease;
+  pointer-events: none;
+  z-index: 6;
+  overflow: hidden;
+}
+.hero-mock.is-terminal-open .hm-terminal {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.hm-terminal-chrome {
+  display: flex; align-items: center; gap: 6px;
+  padding: 7px 12px;
+  background: #1d1f27;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+}
+.hm-term-dot {
+  width: 12px; height: 12px; border-radius: 50%;
+  appearance: none;
+  border: 0.5px solid rgba(0, 0, 0, 0.25);
+  padding: 0;
+  display: inline-block;
+}
+.hm-term-dot-r { background: #ff5f57; }
+.hm-term-dot-y { background: #febc2e; }
+.hm-term-dot-g { background: #28c840; }
+.hm-term-dot-r {
+  cursor: pointer;
+  position: relative;
+  transition: filter 0.15s;
+}
+.hm-term-dot-r:hover { filter: brightness(1.15); }
+.hm-term-dot-r:hover::after {
+  content: '×';
+  position: absolute;
+  inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.65);
+  line-height: 1;
+}
+.hm-terminal-title {
+  flex: 1;
+  min-width: 0;
+  padding: 0 10px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.62);
+  text-align: center;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  letter-spacing: 0.02em;
+}
+.hm-terminal-tag {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 9.5px;
+  color: rgba(167, 139, 250, 0.72);
+  background: rgba(167, 139, 250, 0.1);
+  border: 1px solid rgba(167, 139, 250, 0.2);
+  border-radius: 4px;
+  padding: 2px 6px;
+  letter-spacing: 0.04em;
+}
+
+.hm-terminal-body {
+  padding: 14px 16px 12px;
+  height: calc(100% - 33px);
+  overflow: hidden;
+  font-family: 'IBM Plex Mono', 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #cfe3e1;
+  background:
+    radial-gradient(ellipse at top, rgba(94, 234, 212, 0.025), transparent 60%),
+    #0a0c12;
+}
+.hm-term-banner {
+  color: rgba(94, 234, 212, 0.55);
+  font-size: 11px;
+  margin-bottom: 6px;
+  letter-spacing: 0.02em;
+}
+.hm-term-banner .accent { color: #5eead4; }
+.hm-term-line {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0;
+  transform: translateY(2px);
+  animation: hmTermAppear 0.18s ease-out forwards;
+}
+.hm-term-line.user    { color: #ffffff; }
+.hm-term-line.tool    { color: #c4b5fd; }
+.hm-term-line.dim     { color: rgba(207, 227, 225, 0.55); padding-left: 18px; }
+.hm-term-line.exit    { color: #5eead4; margin-top: 6px; }
+.hm-term-line .pfx-user { color: #5eead4; margin-right: 8px; font-weight: 600; }
+.hm-term-line .pfx-tool { color: #a78bfa; margin-right: 8px; }
+.hm-term-line .pfx-dim  { color: rgba(207, 227, 225, 0.35); margin-right: 6px; margin-left: -18px; }
+.hm-term-cursor {
+  display: inline-block;
+  width: 8px; height: 14px;
+  vertical-align: -3px;
+  background: #5eead4;
+  margin-left: 2px;
+  animation: hmTermBlink 1.05s steps(2) infinite;
+}
+@keyframes hmTermAppear { to { opacity: 1; transform: translateY(0); } }
+@keyframes hmTermBlink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .hm-term-line { animation: none; opacity: 1; transform: none; }
+  .hm-term-cursor { animation: none; }
+}
+
+@media (max-width: 700px) {
+  .hm-rtp-pill { font-size: 11px; padding: 5px 10px; gap: 6px; }
+  .hm-rtp-popover {
+    position: fixed;
+    top: auto;
+    left: 12px; right: 12px;
+    bottom: 12px;
+    max-width: none;
+  }
+  .hm-rtp-arrow { display: none; }
+  /* Terminal fills the bottom on mobile, matching .hm-preview's mobile treatment */
+  .hero-mock.is-terminal-open .hm-terminal {
+    left: 0; right: 0; bottom: 0;
+    height: 62%;
+    border-radius: 10px 10px 0 0;
+  }
+}
+@media (max-width: 420px) {
+  /* Drop "running" label and the activity counter; keep the count + dot.
+     The popover still works on tap to reveal the rest. */
+  .hm-rtp-pill { padding: 5px 9px; font-size: 0; gap: 0; }
+  .hm-rtp-pill .hm-rtp-pip { margin-right: 5px; }
+  .hm-rtp-pill .hm-rtp-count { font-size: 11px; }
 }

--- a/docs/assets/hero-mock.js
+++ b/docs/assets/hero-mock.js
@@ -192,6 +192,10 @@
   // Hover is the transient "peek" — but stop swapping content once the user has pinned a panel,
   // otherwise the active highlight on one tile would mismatch the content showing for another.
   document.querySelectorAll('.hm-tile').forEach(tile => {
+    // Tiles marked .hm-tile-running are the demo entry point for the running
+    // terminal — handled in the running-terminals block further down. Skip the
+    // generic side-panel wiring so hovering doesn't pop the side panel.
+    if (tile.classList.contains('hm-tile-running')) return;
     tile.addEventListener('mouseenter', () => {
       if (mock.classList.contains('is-side-open')) return;
       renderSession(tile.dataset.session);
@@ -373,4 +377,241 @@
       }
     });
   });
+
+  // ----------------------------------------------------------------
+  // Running-terminals demo: pill, popover, simulated terminal panel.
+  // Inspired by the in-app RunningTerminalsPill + TerminalWindow.
+  // ----------------------------------------------------------------
+  const pill = document.getElementById('hm-rtp-pill');
+  const popover = document.getElementById('hm-rtp-popover');
+  const row = document.getElementById('hm-rtp-row');
+  const activity = document.getElementById('hm-rtp-activity');
+  const term = document.getElementById('hm-terminal');
+  const termBody = document.getElementById('hm-terminal-body');
+  const termClose = document.getElementById('hm-terminal-close');
+
+  if (!pill || !popover || !row || !term || !termBody) return;
+
+  const reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Canned scrollback — short, believable Claude Code session. The last entry
+  // is the session-ended marker that ends the run; demo loops after a pause.
+  const SCRIPT = [
+    { delay: 0,    kind: 'user', text: 'refactor billing module to handle multi-currency' },
+    { delay: 700,  kind: 'tool', text: 'Read(src/checkout/cart.ts)' },
+    { delay: 1300, kind: 'tool', text: 'Read(src/checkout/payment.ts)' },
+    { delay: 2100, kind: 'tool', text: 'Edit(src/checkout/cart.ts)',     result: '24 lines changed' },
+    { delay: 3000, kind: 'tool', text: 'Edit(src/checkout/payment.ts)',  result: '18 lines changed' },
+    { delay: 3900, kind: 'tool', text: 'Bash(npm test)',                 result: '9 passed in 1.2s' },
+    { delay: 5000, kind: 'tool', text: 'Bash(gh pr create)',             result: 'opened PR #218' },
+    { delay: 6100, kind: 'text', text: 'Ready for review — handing back to you.' },
+    { delay: 7000, kind: 'exit', text: '[session ended (exit 0)]' },
+  ];
+  const LOOP_PAUSE_MS = 2400;
+  const ACTIVITY_TICK_MS = 1000;
+
+  let popoverPinned = false;
+  let terminalOpen = false;
+  let playTimers = [];
+  let loopTimer = null;
+  let activityTimer = null;
+  let activitySeconds = 4;
+  let closeGraceTimer = null;
+  const CLOSE_GRACE_MS = 220;   // forgive cursor crossings between hover zones
+
+  function esc(s) { return String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c])); }
+
+  function setActivity(text) { if (activity) activity.textContent = text; }
+
+  function startActivityTicker() {
+    stopActivityTicker();
+    activityTimer = setInterval(() => {
+      activitySeconds += 1;
+      setActivity('cooking ' + activitySeconds + 's');
+    }, ACTIVITY_TICK_MS);
+  }
+  function stopActivityTicker() {
+    if (activityTimer) { clearInterval(activityTimer); activityTimer = null; }
+  }
+
+  function pinPopover() {
+    popoverPinned = true;
+    popover.classList.add('is-pinned');
+    pill.setAttribute('aria-expanded', 'true');
+  }
+  function unpinPopover() {
+    popoverPinned = false;
+    popover.classList.remove('is-pinned');
+    pill.setAttribute('aria-expanded', 'false');
+  }
+
+  function clearPlayTimers() {
+    playTimers.forEach(t => clearTimeout(t));
+    playTimers = [];
+    if (loopTimer) { clearTimeout(loopTimer); loopTimer = null; }
+  }
+
+  function renderBanner() {
+    const banner = document.createElement('div');
+    banner.className = 'hm-term-banner';
+    banner.innerHTML = '<span class="accent">✻ Welcome to Claude Code</span>  <span style="color: rgba(207,227,225,0.35)">/Users/you/acme-app</span>';
+    termBody.appendChild(banner);
+  }
+
+  function appendLine(step) {
+    const line = document.createElement('div');
+    line.className = 'hm-term-line ' + step.kind;
+    if (step.kind === 'user') {
+      line.innerHTML = '<span class="pfx-user">&gt;</span>' + esc(step.text);
+    } else if (step.kind === 'tool') {
+      const result = step.result ? '  <span class="pfx-dim">⎿</span><span style="color: rgba(207,227,225,0.55)">' + esc(step.result) + '</span>' : '';
+      line.innerHTML = '<span class="pfx-tool">⏺</span>' + esc(step.text) + result;
+    } else if (step.kind === 'text') {
+      line.innerHTML = '<span class="pfx-tool">⏺</span><span style="color: #cfe3e1">' + esc(step.text) + '</span>';
+    } else if (step.kind === 'exit') {
+      line.textContent = step.text;
+    }
+    termBody.appendChild(line);
+  }
+
+  function appendCursor() {
+    if (termBody.querySelector('.hm-term-cursor')) return;
+    const last = termBody.querySelector('.hm-term-line:last-child');
+    if (!last) return;
+    const c = document.createElement('span');
+    c.className = 'hm-term-cursor';
+    last.appendChild(c);
+  }
+  function removeCursor() {
+    const c = termBody.querySelector('.hm-term-cursor');
+    if (c) c.remove();
+  }
+
+  function playOnce() {
+    clearPlayTimers();
+    termBody.innerHTML = '';
+    renderBanner();
+
+    if (reducedMotion) {
+      SCRIPT.forEach(s => appendLine(s));
+      return;
+    }
+
+    SCRIPT.forEach((step, idx) => {
+      const t = setTimeout(() => {
+        removeCursor();
+        appendLine(step);
+        if (step.kind === 'exit') {
+          loopTimer = setTimeout(() => {
+            if (terminalOpen) playOnce();
+          }, LOOP_PAUSE_MS);
+        } else if (idx < SCRIPT.length - 1) {
+          appendCursor();
+        }
+      }, step.delay);
+      playTimers.push(t);
+    });
+  }
+
+  function openTerminal() {
+    if (terminalOpen) return;
+    terminalOpen = true;
+    activitySeconds = 1;
+    setActivity('cooking 1s');
+    term.setAttribute('aria-hidden', 'false');
+    mock.classList.remove('is-side-open', 'is-preview-open');
+    mock.classList.add('is-terminal-open');
+    unpinPopover();
+    playOnce();
+  }
+
+  function closeTerminal() {
+    if (!terminalOpen) return;
+    terminalOpen = false;
+    activitySeconds = 1;
+    setActivity('cooking 1s');
+    term.setAttribute('aria-hidden', 'true');
+    mock.classList.remove('is-terminal-open');
+    clearPlayTimers();
+  }
+
+  // --- Wire interactions ---
+  // CSS :hover and :focus-within reveal the popover on desktop. Tap on touch
+  // pins it open via .is-pinned.
+  pill.addEventListener('click', e => {
+    e.stopPropagation();
+    if (popoverPinned) unpinPopover(); else pinPopover();
+  });
+  pill.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && popoverPinned) { unpinPopover(); pill.blur(); }
+  });
+
+  // Hover-driven open/close across three zones — the popover row, the
+  // "running" top session tile, and the terminal panel itself. Cursor crossing
+  // between zones is forgiven by CLOSE_GRACE_MS so the panel doesn't flicker.
+  function cancelGraceClose() {
+    if (closeGraceTimer) { clearTimeout(closeGraceTimer); closeGraceTimer = null; }
+  }
+  function scheduleGraceClose() {
+    cancelGraceClose();
+    closeGraceTimer = setTimeout(() => {
+      closeGraceTimer = null;
+      closeTerminal();
+    }, CLOSE_GRACE_MS);
+  }
+
+  row.addEventListener('mouseenter', () => { cancelGraceClose(); if (!terminalOpen) openTerminal(); });
+  row.addEventListener('mouseleave', scheduleGraceClose);
+  row.addEventListener('click', e => {
+    e.stopPropagation();
+    cancelGraceClose();
+    if (!terminalOpen) openTerminal();
+  });
+  row.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); cancelGraceClose(); openTerminal(); }
+  });
+
+  // Top session tile — same trigger as the popover row.
+  const runningTile = mock.querySelector('.hm-tile-running');
+  if (runningTile) {
+    runningTile.addEventListener('mouseenter', () => { cancelGraceClose(); if (!terminalOpen) openTerminal(); });
+    runningTile.addEventListener('mouseleave', scheduleGraceClose);
+    runningTile.addEventListener('click', e => {
+      e.stopPropagation();
+      cancelGraceClose();
+      if (!terminalOpen) openTerminal();
+    });
+    runningTile.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); cancelGraceClose(); openTerminal(); }
+    });
+  }
+
+  // Hovering the terminal itself keeps it open.
+  term.addEventListener('mouseenter', cancelGraceClose);
+  term.addEventListener('mouseleave', scheduleGraceClose);
+
+  termClose.addEventListener('click', e => { e.stopPropagation(); cancelGraceClose(); closeTerminal(); });
+
+  // Click-outside unpins the popover. Only matters for touch tap-pin.
+  document.addEventListener('mousedown', e => {
+    if (!popoverPinned) return;
+    if (e.target.closest('.hm-rtp-wrap')) return;
+    unpinPopover();
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && popoverPinned) unpinPopover();
+  });
+
+  // The terminal panel shares its bottom footprint with the side and preview
+  // panels — close the terminal when another overlay opens. The running tile
+  // is excluded since clicking it is *how* you open the terminal.
+  document.querySelectorAll('.hm-tile:not(.hm-tile-running), .hm-mem[data-memory], .hm-art-cell[data-artefact]').forEach(el => {
+    el.addEventListener('click', () => {
+      unpinPopover();
+      if (terminalOpen) closeTerminal();
+    });
+  });
+
+  // Kick the demo into life — the activity counter ticks even before any hover.
+  startActivityTicker();
 })();

--- a/docs/assets/hero-mock.js
+++ b/docs/assets/hero-mock.js
@@ -390,7 +390,7 @@
   const termBody = document.getElementById('hm-terminal-body');
   const termClose = document.getElementById('hm-terminal-close');
 
-  if (!pill || !popover || !row || !term || !termBody) return;
+  if (!pill || !popover || !row || !term || !termBody || !termClose) return;
 
   const reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -519,7 +519,10 @@
     activitySeconds = 1;
     setActivity('cooking 1s');
     term.setAttribute('aria-hidden', 'false');
-    mock.classList.remove('is-side-open', 'is-preview-open');
+    // Use the existing helpers so aria-hidden / active state / focus are
+    // properly restored on whatever overlay was previously open.
+    if (mock.classList.contains('is-side-open')) closeSide();
+    if (mock.classList.contains('is-preview-open')) closePreview();
     mock.classList.add('is-terminal-open');
     unpinPopover();
     playOnce();
@@ -545,6 +548,23 @@
   pill.addEventListener('keydown', e => {
     if (e.key === 'Escape' && popoverPinned) { unpinPopover(); pill.blur(); }
   });
+
+  // Sync aria-expanded with the popover's actual visibility — CSS reveals it
+  // on hover and focus, so aria-expanded must mirror those states too, not
+  // just the tap-pinned click path.
+  const wrap = pill.closest('.hm-rtp-wrap');
+  if (wrap) {
+    const setExpanded = (v) => pill.setAttribute('aria-expanded', v ? 'true' : 'false');
+    wrap.addEventListener('pointerenter', () => setExpanded(true));
+    wrap.addEventListener('pointerleave', () => { if (!popoverPinned) setExpanded(false); });
+    wrap.addEventListener('focusin', () => setExpanded(true));
+    wrap.addEventListener('focusout', () => {
+      // focusout fires before the new activeElement settles; defer one tick.
+      setTimeout(() => {
+        if (!wrap.contains(document.activeElement) && !popoverPinned) setExpanded(false);
+      }, 0);
+    });
+  }
 
   // Hover-driven open/close across three zones — the popover row, the
   // "running" top session tile, and the terminal panel itself. Cursor crossing

--- a/docs/index.html
+++ b/docs/index.html
@@ -1455,7 +1455,7 @@
             <span class="hm-terminal-title" id="hm-terminal-title">Refactor checkout flow — acme-app</span>
             <span class="hm-terminal-tag" aria-hidden="true">claude-code</span>
           </div>
-          <div class="hm-terminal-body" id="hm-terminal-body" aria-live="polite"></div>
+          <div class="hm-terminal-body" id="hm-terminal-body"></div>
         </div>
 
         <div class="hero-mock-body">
@@ -1471,9 +1471,9 @@
               <button type="button" class="hm-rtp-pill" id="hm-rtp-pill" aria-expanded="false" aria-controls="hm-rtp-popover" aria-label="1 running terminal">
                 <span class="hm-rtp-pip" aria-hidden="true"></span><span class="hm-rtp-count">1</span> running
               </button>
-              <div class="hm-rtp-popover" id="hm-rtp-popover" role="menu">
+              <div class="hm-rtp-popover" id="hm-rtp-popover">
                 <div class="hm-rtp-arrow" aria-hidden="true"></div>
-                <div class="hm-rtp-row" id="hm-rtp-row" role="menuitem" tabindex="0">
+                <div class="hm-rtp-row" id="hm-rtp-row" tabindex="0" role="button" aria-label="Open running terminal: Refactor checkout flow">
                   <span class="hm-rtp-dot" aria-hidden="true"></span>
                   <div class="hm-rtp-body">
                     <span class="hm-rtp-title">Refactor checkout flow</span>
@@ -1494,7 +1494,7 @@
               </span>
             </div>
             <div class="hm-tiles">
-              <div class="hm-tile hm-tile-running" data-space="acme-app" data-session="s1" role="button" tabindex="0" aria-label="Refactor checkout flow — running, hover to peek at the terminal">
+              <div class="hm-tile hm-tile-running" data-space="acme-app" data-session="s1" role="button" tabindex="0" aria-label="Open running terminal: Refactor checkout flow">
                 <span class="hm-status hm-status-running"></span>
                 <div class="hm-tile-body">
                   <div class="hm-tile-title">Refactor checkout flow</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1447,6 +1447,17 @@
           <div id="hm-side-body"></div>
         </div>
 
+        <div class="hm-terminal" id="hm-terminal" aria-hidden="true">
+          <div class="hm-terminal-chrome">
+            <button type="button" class="hm-term-dot hm-term-dot-r" id="hm-terminal-close" aria-label="Close terminal" title="Close terminal"></button>
+            <span class="hm-term-dot hm-term-dot-y" aria-hidden="true"></span>
+            <span class="hm-term-dot hm-term-dot-g" aria-hidden="true"></span>
+            <span class="hm-terminal-title" id="hm-terminal-title">Refactor checkout flow — acme-app</span>
+            <span class="hm-terminal-tag" aria-hidden="true">claude-code</span>
+          </div>
+          <div class="hm-terminal-body" id="hm-terminal-body" aria-live="polite"></div>
+        </div>
+
         <div class="hero-mock-body">
           <div class="hero-mock-breadcrumb">
             <span class="hm-pill hm-pill-icon hm-pill-active" aria-label="Home">
@@ -1455,6 +1466,22 @@
             <span class="hm-pill" data-space="acme-app"><span class="pip pip-g"></span>acme-app</span>
             <span class="hm-pill" data-space="pitch-deck"><span class="pip pip-a"></span>pitch-deck</span>
             <span class="hm-pill" data-space="field-notes"><span class="pip pip-r"></span>field-notes</span>
+
+            <div class="hm-rtp-wrap">
+              <button type="button" class="hm-rtp-pill" id="hm-rtp-pill" aria-expanded="false" aria-controls="hm-rtp-popover" aria-label="1 running terminal">
+                <span class="hm-rtp-pip" aria-hidden="true"></span><span class="hm-rtp-count">1</span> running
+              </button>
+              <div class="hm-rtp-popover" id="hm-rtp-popover" role="menu">
+                <div class="hm-rtp-arrow" aria-hidden="true"></div>
+                <div class="hm-rtp-row" id="hm-rtp-row" role="menuitem" tabindex="0">
+                  <span class="hm-rtp-dot" aria-hidden="true"></span>
+                  <div class="hm-rtp-body">
+                    <span class="hm-rtp-title">Refactor checkout flow</span>
+                    <span class="hm-rtp-meta">acme-app · claude-code · <span id="hm-rtp-activity">cooking 4s</span></span>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div>
@@ -1467,13 +1494,13 @@
               </span>
             </div>
             <div class="hm-tiles">
-              <div class="hm-tile" data-space="acme-app" data-session="s1" role="button" tabindex="0" aria-label="Open session: Refactor checkout flow">
-                <span class="hm-status hm-status-g"></span>
+              <div class="hm-tile hm-tile-running" data-space="acme-app" data-session="s1" role="button" tabindex="0" aria-label="Refactor checkout flow — running, hover to peek at the terminal">
+                <span class="hm-status hm-status-running"></span>
                 <div class="hm-tile-body">
                   <div class="hm-tile-title">Refactor checkout flow</div>
-                  <div class="hm-tile-meta">claude-code · acme-app</div>
+                  <div class="hm-tile-meta">claude-code · acme-app · running</div>
                 </div>
-                <span class="hm-tile-time">2m ago</span>
+                <span class="hm-tile-time">just now</span>
               </div>
               <div class="hm-tile" data-space="pitch-deck" data-session="s2" role="button" tabindex="0" aria-label="Open session: Stakeholder pitch v3">
                 <span class="hm-status hm-status-a"></span>


### PR DESCRIPTION
## Summary

- Adds the in-app **RunningTerminalsPill** + **TerminalWindow** surface (PR #531) to the marketing prototype on oyster.to, so visitors can see the live-terminal experience without installing.
- Teal pulsing pill in the simulated topbar, hover-reveal popover, and a simulated Claude Code terminal that mocks the real CLI look (welcome banner, `⏺` action prefix, `⎿` result prefix, blinking caret, mac-style chrome with the red dot as close).
- Hovering the top session tile ("Refactor checkout flow") opens the terminal; hovering off closes it after a ~220ms grace so cursor crossings don't flicker.

Scope is confined to `docs/index.html` + `docs/assets/hero-mock.{css,js}`. No real network/WebSocket calls; canned scrollback plays in ~7s and loops automatically. `prefers-reduced-motion` renders the full transcript statically.

Closes #533

## Test plan

- [ ] Open `docs/index.html` (`python3 -m http.server 8765 -d docs`) — pill is visible in the hero-mock topbar with a teal pulsing dot
- [ ] Hover the running pill — popover slides in below; hover off closes it
- [ ] Hover the top "Refactor checkout flow" tile — terminal opens at the bottom (no side panel)
- [ ] Hover off the tile — terminal closes after a beat; moving cursor onto the terminal keeps it open
- [ ] Watch the canned scrollback play through and loop after `[session ended (exit 0)]`
- [ ] Click the red mac dot — terminal closes
- [ ] Other session tiles still open the side panel as before
- [ ] On mobile width: popover collapses to a bottom sheet; terminal fills 62% of the surface
- [ ] `prefers-reduced-motion` (toggle in macOS Settings) — animations skipped, full transcript rendered statically

🤖 Generated with [Claude Code](https://claude.com/claude-code)