### PR TITLE
fix(transcript): hide `local_command` SYSTEM rows (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/rename` and other slash-command machinery no longer leak into the transcript.** A second path for Claude Code's internal wrapper tags — emitted as `SYSTEM` rows under the `local_command` subtype — is now hidden from the Session Inspector and excluded from Spotlight transcript search. Existing sessions clean up on next start.
+
 ## [0.9.5] - 2026-05-20
 
 ### Added

--- a/docs/bugs/transcript-system-local-command.md
+++ b/docs/bugs/transcript-system-local-command.md
@@ -1,0 +1,47 @@
+# Transcript: `system` events with subtype `local_command` leak slash-command machinery into inspector
+
+## Summary
+
+Session Inspector renders raw `<command-name>` / `<command-args>` / `<local-command-stdout>` blocks under a **SYSTEM** badge. These are claude-code slash-command machinery (e.g. `/rename`) that should be hidden from the transcript, the same way #530/#532 hides the `role === "user"` variant.
+
+PR #530/#532 (shipped in 0.9.4) is working as written — this is **not** a regression of that work. It is a new uncovered ingest path: claude-code emits the same machinery as `type: "system", subtype: "local_command"` JSONL events, which the existing classifier never sees.
+
+## Reproduce
+
+1. In a claude-code session, run `/rename "Some new title"`.
+2. Open the session in the Oyster Inspector.
+3. Two SYSTEM rows appear, e.g.:
+
+   ```
+   SYSTEM
+   local_command: <command-name>/rename</command-name>
+       <command-message>rename</command-message>
+       <command-args>TOKINVEST: review SEO PR #40</command-args>
+
+   SYSTEM
+   local_command: <local-command-stdout>Session renamed to: TOKINVEST: review SEO PR #40</local-command-stdout>
+   ```
+
+## Root cause
+
+Two compounding gaps in the #530 classifier:
+
+1. `is_protocol_artifact` is only set when `rendered.role === "user"` (see `server/src/watchers/claude-code.ts:467-468` and the duplicate at `:800-801`). System-role events are never classified.
+2. `renderEvent`'s `system` case at `server/src/watchers/claude-code.ts:1041-1045` emits text as `` `${subtype}: ${content}` `` → produces `local_command: <command-name>…`. Even if the role gate were removed, `isClaudeProtocolArtifact` checks `startsWith("<local-command-")` / `<command-` / `<system-reminder>` and returns false for text that starts with the `local_command: ` subtype prefix.
+
+## Suggested fix (sketch)
+
+- Drop the `role === "user"` gate in `claude-code.ts:467-468` and `:800-801` so system rows get classified too.
+- Either: teach `isClaudeProtocolArtifact` to also match the `local_command: <...>` shape, **or** classify directly in the `system` case of `renderEvent` when `subtype === "local_command"`.
+- Backfill predicate at `server/src/db.ts:759-772` needs the same `local_command: ` prefix so existing rows on disk get cleaned up on the next boot. Will need a new `app_state` gate flag (mirror the existing `device_label_backfill_done` pattern) so it only runs once.
+- Add a regression test in `server/test/session-protocol-artifacts.test.ts` covering a `type: "system", subtype: "local_command"` event end-to-end.
+
+## Scope / risk
+
+- Self-contained server-side change, additive backfill, mirrors the shape of #530.
+- No user-visible CHANGELOG entry needed beyond "hides slash-command machinery from SYSTEM rows too" if filed under Fixed.
+
+## Related
+
+- PR #530 / #532 — original hide-slash-command-machinery work (0.9.4)
+- `server/src/utils/claude-protocol-artifacts.ts` — classifier helper

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -289,6 +289,7 @@
   </section>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-9-5">0.9</a>
       <a class="version-pill" href="#v-0-8-2">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
@@ -302,6 +303,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.5...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Fixed</h3>
+<ul>
+<li><strong><code>/rename</code> and other slash-command machinery no longer leak into the transcript.</strong> A second path for Claude Code&#39;s internal wrapper tags — emitted as <code>SYSTEM</code> rows under the <code>local_command</code> subtype — is now hidden from the Session Inspector and excluded from Spotlight transcript search. Existing sessions clean up on next start.</li>
+</ul>
 <h2 id="v-0-9-5"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.4...v0.9.5" rel="noopener noreferrer"><span class="release-version">0.9.5</span></a><span class="release-date"> — 2026-05-20</span></h2>
 <h3>Added</h3>
 <ul>

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -780,6 +780,26 @@ export function initDb(userlandDir: string): Database.Database {
     }
   }
 
+  // v2 backfill (#536): the original predicate above missed SYSTEM-role
+  // rows carrying slash-command machinery as the `local_command` subtype
+  // (rendered as `local_command: <command-name>…`). Gated on its own
+  // app_state key so it runs exactly once per userland, not on every boot.
+  {
+    const flag = db.prepare(
+      `INSERT OR IGNORE INTO app_state (key, value, applied_at)
+       VALUES ('protocol_artifact_backfill_v2_done', '1', ?)`,
+    ).run(Date.now());
+    if (flag.changes > 0) {
+      db.exec(`
+        UPDATE session_events
+           SET is_protocol_artifact = 1
+         WHERE is_protocol_artifact = 0
+           AND role = 'system'
+           AND ltrim(text, ' ' || char(9) || char(10) || char(13)) LIKE 'local_command:%';
+      `);
+    }
+  }
+
   // Backfill the FTS index if it's stale relative to the content table.
   //
   // The naive "rebuild only when ftsCount === 0" check is wrong: a hot-

--- a/server/src/utils/claude-protocol-artifacts.ts
+++ b/server/src/utils/claude-protocol-artifacts.ts
@@ -1,22 +1,32 @@
-// Claude Code wraps slash-command machinery in pseudo-user messages — e.g.
-// `<command-name>/exit</command-name>`, `<local-command-stdout>Goodbye!`,
-// `<system-reminder>The user named this session "…"</system-reminder>`. They
-// were never typed by the user and were never said by the assistant; they're
-// protocol artefacts. We classify them at ingest so the transcript reader and
-// search index can ignore them while the raw rows stay on disk.
+// Claude Code wraps slash-command machinery in two shapes:
+//
+//   1. Pseudo-`user` messages — `<command-name>/exit</command-name>`,
+//      `<local-command-stdout>Goodbye!`, `<system-reminder>The user named
+//      this session "…"</system-reminder>`.
+//   2. `system` events with `subtype = "local_command"` — renderEvent
+//      stringifies these as `local_command: <command-name>…` (the wrapper
+//      tag is no longer the leading token, so the prefix checks above miss
+//      them). See #536.
+//
+// They were never typed by the user and were never said by the assistant;
+// they're protocol artefacts. We classify them at ingest so the transcript
+// reader and search index can ignore them while the raw rows stay on disk.
 //
 // Match is intentionally prefix-only: a real message that happens to *contain*
 // these strings (e.g. someone pasting a snippet about slash-commands) should
 // still render. Only events whose leading non-whitespace token is one of these
-// wrappers get classified out.
+// wrappers, or whose text begins with the `local_command:` subtype label,
+// get classified out.
 //
-// Caller is expected to gate this on `role === "user"`. Assistant messages can
-// legitimately echo a slash command (`/rename ...`) and we want those visible.
+// Assistant messages can legitimately echo a slash command (`/rename ...`).
+// Those start with `/`, never match any of the prefixes below, and stay
+// visible regardless of the caller's role gate.
 export function isClaudeProtocolArtifact(text: string): boolean {
   const trimmed = text.trimStart();
   return (
     trimmed.startsWith("<local-command-")
     || trimmed.startsWith("<command-")
     || trimmed.startsWith("<system-reminder>")
+    || trimmed.startsWith("local_command:")
   );
 }

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -464,8 +464,7 @@ export class ClaudeCodeWatcher {
           text,
           ts: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
           raw: line,
-          is_protocol_artifact:
-            rendered.role === "user" && isClaudeProtocolArtifact(text) ? 1 : 0,
+          is_protocol_artifact: isClaudeProtocolArtifact(text) ? 1 : 0,
         });
       }
 
@@ -797,8 +796,7 @@ export class ClaudeCodeWatcher {
           text,
           ts: typeof ev.timestamp === "string" ? ev.timestamp : undefined,
           raw: line,
-          is_protocol_artifact:
-            rendered.role === "user" && isClaudeProtocolArtifact(text) ? 1 : 0,
+          is_protocol_artifact: isClaudeProtocolArtifact(text) ? 1 : 0,
         });
         if (typeof ev.timestamp === "string") latestTimestamp = ev.timestamp;
       }

--- a/server/test/claude-protocol-artifacts.test.ts
+++ b/server/test/claude-protocol-artifacts.test.ts
@@ -11,6 +11,21 @@ describe("isClaudeProtocolArtifact", () => {
     expect(isClaudeProtocolArtifact("<system-reminder>\nThe user named this session ...\n</system-reminder>")).toBe(true);
   });
 
+  it("matches the `system`-event `local_command:` subtype prefix (#536)", () => {
+    // claude-code also emits slash-command machinery as
+    // `{ type: "system", subtype: "local_command", content: "<command-name>…" }`,
+    // which renderEvent stringifies as `local_command: <command-name>…`. The
+    // rendered text never starts with one of the wrapper tags, so we need an
+    // additional prefix check for the subtype label itself.
+    expect(isClaudeProtocolArtifact("local_command: <command-name>/rename</command-name>")).toBe(true);
+    expect(isClaudeProtocolArtifact("local_command: <local-command-stdout>Session renamed</local-command-stdout>")).toBe(true);
+  });
+
+  it("does not match messages that merely mention `local_command:` inside their body", () => {
+    expect(isClaudeProtocolArtifact("we should rename the local_command: handler")).toBe(false);
+    expect(isClaudeProtocolArtifact("local commander reporting in")).toBe(false);
+  });
+
   it("tolerates leading whitespace (real claude-code indents some variants)", () => {
     expect(isClaudeProtocolArtifact("  \n\t<command-name>/exit</command-name>")).toBe(true);
   });

--- a/server/test/session-protocol-artifacts.test.ts
+++ b/server/test/session-protocol-artifacts.test.ts
@@ -148,8 +148,9 @@ describe("protocol-artifact classification", () => {
   });
 
   it("assistant slash-command echoes are NOT classified as artefacts", () => {
-    // The watcher gates classification on role === 'user', so an
-    // assistant echo like `/rename …` stays visible and searchable.
+    // After #536 the watcher classifies every role through the same prefix
+    // check. Assistant echoes like `/rename …` start with `/`, never match
+    // any wrapper prefix, and stay visible + searchable.
     env.store.insertEvent({ session_id: "s1", role: "assistant", text: "/rename foo" });
     expect(env.store.getEventsBySession("s1").map((e) => e.text)).toEqual(["/rename foo"]);
     expect(env.store.searchEvents("rename")).toHaveLength(1);
@@ -164,6 +165,77 @@ describe("protocol-artifact classification", () => {
       text: "here's an example: <command-name> — what does that tag mean?",
     });
     expect(env.store.getEventsBySession("s1")).toHaveLength(1);
+  });
+
+  it("v2 backfill marks role='system' local_command rows on first boot (#536)", () => {
+    // Simulate a userland that booted before the v2 backfill: a SYSTEM-role
+    // row carrying claude-code slash-command machinery as the `local_command`
+    // subtype has been ingested with the artifact flag still at 0.
+    //
+    // To exercise the migration we need to drop the v2 done flag so a second
+    // boot re-runs it. (makeEnv has already set both v1 and v2 flags.)
+    env.db.prepare("DELETE FROM app_state WHERE key = 'protocol_artifact_backfill_v2_done'").run();
+    env.db.prepare(
+      `INSERT INTO session_events (session_id, role, text, is_protocol_artifact)
+       VALUES ('s1', 'system', ?, 0)`,
+    ).run("local_command: <command-name>/rename needle-token</command-name>");
+    env.db.prepare(
+      `INSERT INTO session_events (session_id, role, text, is_protocol_artifact)
+       VALUES ('s1', 'user', ?, 0)`,
+    ).run("genuine question needle-token");
+
+    // Pre-backfill sanity: both rows are in FTS.
+    expect(env.store.searchEvents("needle")).toHaveLength(2);
+
+    // Second boot on the same userland dir runs the v2 backfill.
+    env.db.close();
+    const db2 = initDb(env.dir);
+    const store2 = new SqliteSessionStore(db2);
+
+    // Artefact row is now classified and out of FTS.
+    expect(store2.searchEvents("needle")).toHaveLength(1);
+    expect(store2.searchEvents("needle")[0].snippet).toContain("genuine");
+
+    // Transcript reads also exclude the SYSTEM row.
+    expect(store2.getEventsBySession("s1").map((e) => e.text))
+      .toEqual(["genuine question needle-token"]);
+
+    // Raw row is still on disk for audit.
+    const onDisk = db2
+      .prepare(
+        `SELECT role, text, is_protocol_artifact FROM session_events
+         WHERE session_id = 's1' AND text LIKE 'local_command:%'`,
+      )
+      .all() as Array<{ role: string; is_protocol_artifact: number }>;
+    expect(onDisk).toHaveLength(1);
+    expect(onDisk[0].role).toBe("system");
+    expect(onDisk[0].is_protocol_artifact).toBe(1);
+
+    db2.close();
+  });
+
+  it("v2 backfill is gated so it doesn't rescan on every boot (#536)", () => {
+    const flag = env.db
+      .prepare("SELECT value FROM app_state WHERE key = 'protocol_artifact_backfill_v2_done'")
+      .get() as { value: string } | undefined;
+    expect(flag?.value).toBe("1");
+
+    // Pre-migration-style unmarked row inserted after the v2 gate is set.
+    env.db.prepare(
+      `INSERT INTO session_events (session_id, role, text, is_protocol_artifact)
+       VALUES ('s1', 'system', ?, 0)`,
+    ).run("local_command: <command-name>/rename</command-name>");
+
+    // Second boot must NOT re-run the backfill UPDATE.
+    env.db.close();
+    const db2 = initDb(env.dir);
+    const row = db2
+      .prepare(
+        "SELECT is_protocol_artifact FROM session_events WHERE role = 'system' AND text LIKE 'local_command:%' LIMIT 1",
+      )
+      .get() as { is_protocol_artifact: number } | undefined;
+    db2.close();
+    expect(row?.is_protocol_artifact).toBe(0);
   });
 
   it("backfill is gated so it doesn't rescan session_events on every boot", () => {


### PR DESCRIPTION
## Summary

- `/rename` and other Claude Code slash-command machinery were still leaking into the Session Inspector as SYSTEM rows (#536). Root cause: the #530 classifier was gated on `role === "user"` and its prefix checks (`<command-`, `<local-command-`, `<system-reminder>`) didn't see the `local_command: <command-…>` shape that `renderEvent` produces for `{ type: "system", subtype: "local_command" }` events.
- Drops the role gate at both watcher callsites — the classifier is now the sole gatekeeper — and teaches `isClaudeProtocolArtifact` a fourth prefix (`local_command:`). Adds a `protocol_artifact_backfill_v2_done` gate so existing sessions clean up on next start without rescanning `session_events` on every boot.
- Assistant `/rename …` echoes stay visible because they start with `/` and never match any prefix.

## Test plan

- [x] `npm test` in `server/` — 438 passed (15 in the two protocol-artifact files, up from 12).
- [x] `npm run build` in `server/` — clean `tsc`.
- [x] `npm run build:changelog` — `docs/changelog.html` regenerated.
- [ ] On a userland with pre-fix `local_command:` rows, restart Oyster and confirm the rows disappear from the Inspector and stop matching in Spotlight.
- [ ] In a live Claude Code session, run `/rename …` and confirm no SYSTEM row appears.

Closes #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)