### PR TITLE
feat(arcade): Space Jumper — LEVELS[] + jetpack; Rocket Ship → shared modules

### DIFF
--- a/docs/arcade/shared/audio.js
+++ b/docs/arcade/shared/audio.js
@@ -11,10 +11,11 @@
 // for the short window between page load and first decode completing.
 // They MUST share their `id` with the keys passed to init({ sfx }).
 //
-// Usage (use the arcade-wide mute key so MUSIC / SFX state is shared
-// across every cabinet game — see shared/pause.js):
+// Usage (volumeKey is preferred — gives players a slider in the pause
+// overlay; mutedKey is the legacy on/off variant, still accepted for
+// back-compat with older cabinet games):
 //   Arcade.Audio.init({ sfx: { 'sfx-coin': 'sfx-coin.mp3', ... },
-//                       mutedKey: 'oyster-arcade-sfx-muted' });
+//                       volumeKey: 'oyster-arcade-sfx-volume' });
 //   // ...on first user gesture (e.g. splash dismiss):
 //   Arcade.Audio.ensureCtx();
 //   // ...in-game:
@@ -27,20 +28,35 @@
 
 (function () {
   let sfxFiles = {};
-  let mutedKey = null;
+  let volumeKey = null;
+  let mutedKey = null;          // legacy
   let audioCtx = null;
   let masterGain = null;
   let buffers = {};
-  let muted = false;
+  let masterVolume = 1;          // 0..1 — multiplied into each play()'s per-clip volume
+
+  function readInitialVolume() {
+    // Prefer the volume key (number 0..1). Fall back to the legacy mute key.
+    if (volumeKey) {
+      try {
+        const raw = localStorage.getItem(volumeKey);
+        if (raw != null) {
+          const n = parseFloat(raw);
+          if (Number.isFinite(n)) return Math.max(0, Math.min(1, n));
+        }
+      } catch (_) {}
+    }
+    if (mutedKey) {
+      try { if (localStorage.getItem(mutedKey) === '1') return 0; } catch (_) {}
+    }
+    return 1;
+  }
 
   function init(opts) {
     sfxFiles = (opts && opts.sfx) || {};
-    mutedKey = (opts && opts.mutedKey) || null;
-    let initialMuted = false;
-    if (mutedKey) {
-      try { initialMuted = localStorage.getItem(mutedKey) === '1'; } catch (_) {}
-    }
-    setMuted(initialMuted);
+    volumeKey = (opts && opts.volumeKey) || null;
+    mutedKey  = (opts && opts.mutedKey)  || null;
+    setVolume(readInitialVolume(), { persist: false });
   }
 
   function ensureCtx() {
@@ -50,7 +66,7 @@
         if (!Ctx) return null;
         audioCtx = new Ctx();
         masterGain = audioCtx.createGain();
-        masterGain.gain.value = muted ? 0 : 1;
+        masterGain.gain.value = masterVolume;
         masterGain.connect(audioCtx.destination);
         Object.entries(sfxFiles).forEach(async ([id, src]) => {
           try {
@@ -65,18 +81,25 @@
     return audioCtx;
   }
 
-  function setMuted(m) {
-    muted = !!m;
-    if (masterGain) masterGain.gain.value = muted ? 0 : 1;
-    // Mirror onto every <audio> element (used for the fallback path AND any
-    // background-music track the page declares).
-    document.querySelectorAll('audio').forEach(a => { a.muted = muted; });
-    if (mutedKey) {
-      try { localStorage.setItem(mutedKey, muted ? '1' : '0'); } catch (_) {}
+  function setVolume(v, opts) {
+    masterVolume = Math.max(0, Math.min(1, Number.isFinite(v) ? v : 0));
+    if (masterGain) masterGain.gain.value = masterVolume;
+    // Mirror onto every <audio> element so the fallback path matches the
+    // Web Audio master. Note: this also touches BGM tracks — pause.js
+    // re-applies the music volume right after if both keys are managed.
+    document.querySelectorAll('audio').forEach(a => { a.volume = masterVolume; });
+    if (volumeKey && (!opts || opts.persist !== false)) {
+      try { localStorage.setItem(volumeKey, String(masterVolume)); } catch (_) {}
     }
   }
 
-  function isMuted() { return muted; }
+  function getVolume() { return masterVolume; }
+
+  // Legacy boolean API — keeps older callers working. Mute = volume 0;
+  // unmute restores to 1 (the legacy default). For nuanced control, use
+  // setVolume directly.
+  function setMuted(m) { setVolume(m ? 0 : 1); }
+  function isMuted() { return masterVolume === 0; }
 
   function play(id, volume) {
     if (volume == null) volume = 0.6;
@@ -87,7 +110,7 @@
       // finishes decoding, which is usually well before any in-game shot.
       const el = document.getElementById(id);
       if (!el) return;
-      el.volume = muted ? 0 : volume;
+      el.volume = masterVolume * volume;
       try { el.currentTime = 0; el.play().catch(() => {}); } catch (_) {}
       return;
     }
@@ -100,5 +123,5 @@
   }
 
   window.Arcade = window.Arcade || {};
-  window.Arcade.Audio = { init, ensureCtx, setMuted, isMuted, play };
+  window.Arcade.Audio = { init, ensureCtx, setVolume, getVolume, setMuted, isMuted, play };
 })();

--- a/docs/arcade/shared/pause.js
+++ b/docs/arcade/shared/pause.js
@@ -1,76 +1,109 @@
-// Shared pause overlay + global mute toggles for all arcade games.
+// Shared pause overlay + global volume sliders for all arcade games.
 //
 // Usage (in a game's HTML):
 //   <script src="../shared/pause.js"></script>
 //   // … then in the game's update loop:
 //   if (Arcade.Pause.isPaused()) return;
 //
-// Pressing P or ESC toggles the pause overlay. The overlay holds the
-// MUSIC and SFX toggles and shares mute state across every game in the
-// arcade via localStorage keys:
+// Pressing P or ESC toggles the pause overlay. The overlay holds two
+// 5-step volume bars (MUSIC + SFX) and shares state across every game in
+// the arcade via localStorage keys:
 //
-//   oyster-arcade-music-muted  — controls every <audio id^="bgm"> on the page
-//   oyster-arcade-sfx-muted    — controls Arcade.Audio (sfx buffers)
+//   oyster-arcade-music-volume  — 0..1, controls every <audio id^="bgm">
+//   oyster-arcade-sfx-volume    — 0..1, threaded into Arcade.Audio master gain
 //
-// `Arcade.Audio.init({ mutedKey: 'oyster-arcade-sfx-muted', … })` makes
-// the SFX toggle persistent across reloads / games. Music is handled
-// here directly via the <audio> element's `muted` property.
+// Legacy *-muted keys are still read on first boot so existing players
+// don't get reset when they upgrade. They're discarded once a volume key
+// is written. `Arcade.Audio.init({ volumeKey: 'oyster-arcade-sfx-volume', … })`
+// gives Arcade.Audio its own persistence; pause.js mirrors on user changes.
 //
 // API exposed on window.Arcade.Pause:
-//   isPaused()              — bool, true while overlay is visible
+//   isPaused()                     — bool, true while overlay is visible
 //   pause() / resume() / toggle()
-//   isMusicMuted() / setMusicMuted(bool)
-//   isSfxMuted()   / setSfxMuted(bool)
-//   onToggle(cb)            — fires whenever music/sfx state flips
-//   canPause = fn() | null  — optional gate; pause/resume are no-ops if it returns false
+//   getMusicVolume() / setMusicVolume(0..1)
+//   getSfxVolume()   / setSfxVolume(0..1)
+//   isMusicMuted() / setMusicMuted(bool)  — kept for back-compat (vol 0/1)
+//   isSfxMuted()   / setSfxMuted(bool)    — kept for back-compat (vol 0/1)
+//   onToggle(cb)                   — fires whenever music/sfx state changes
+//   canPause = fn() | null         — optional gate; pause/resume are no-ops if it returns false
 
 (function () {
-  const MUSIC_KEY = 'oyster-arcade-music-muted';
-  const SFX_KEY   = 'oyster-arcade-sfx-muted';
+  const MUSIC_VOL_KEY  = 'oyster-arcade-music-volume';
+  const SFX_VOL_KEY    = 'oyster-arcade-sfx-volume';
+  const MUSIC_MUTE_KEY = 'oyster-arcade-music-muted';   // legacy
+  const SFX_MUTE_KEY   = 'oyster-arcade-sfx-muted';     // legacy
+
+  const STEPS = 5;            // 0/1/2/3/4 → 0, 25%, 50%, 75%, 100%
+  const DEFAULT_VOLUME = 1;
 
   let paused = false;
   let pauseEl = null;
   const onToggleCbs = [];
 
-  function readBool(key) {
-    try { return localStorage.getItem(key) === '1'; } catch (_) { return false; }
+  function readVolume(volKey, muteKey) {
+    try {
+      const raw = localStorage.getItem(volKey);
+      if (raw != null) {
+        const n = parseFloat(raw);
+        if (Number.isFinite(n)) return Math.max(0, Math.min(1, n));
+      }
+    } catch (_) {}
+    // Legacy fallback — boolean mute → volume 0 (muted) or 1 (unmuted).
+    try { if (localStorage.getItem(muteKey) === '1') return 0; } catch (_) {}
+    return DEFAULT_VOLUME;
   }
-  function writeBool(key, v) {
-    try { localStorage.setItem(key, v ? '1' : '0'); } catch (_) {}
-  }
-
-  function getMusicMuted() { return readBool(MUSIC_KEY); }
-  function getSfxMuted()   {
-    return (window.Arcade && Arcade.Audio && Arcade.Audio.isMuted)
-      ? Arcade.Audio.isMuted()
-      : readBool(SFX_KEY);
-  }
-
-  function applyMusicMute() {
-    const m = getMusicMuted();
-    document.querySelectorAll('audio[id^="bgm"]').forEach(a => { a.muted = m; });
+  function writeVolume(key, v) {
+    try { localStorage.setItem(key, String(v)); } catch (_) {}
   }
 
-  function setMusicMuted(m) {
-    writeBool(MUSIC_KEY, m);
-    applyMusicMute();
+  // Step ↔ continuous helpers. The slider is discrete (STEPS levels), but
+  // the underlying audio APIs are 0..1 continuous — round to the nearest
+  // step for display so the bar always matches the saved value.
+  function stepFromVolume(v) { return Math.round(Math.max(0, Math.min(1, v)) * (STEPS - 1)); }
+  function volumeFromStep(s) { return Math.max(0, Math.min(STEPS - 1, s)) / (STEPS - 1); }
+
+  function getMusicVolume() { return readVolume(MUSIC_VOL_KEY, MUSIC_MUTE_KEY); }
+  function getSfxVolume()   {
+    if (window.Arcade && Arcade.Audio && Arcade.Audio.getVolume) return Arcade.Audio.getVolume();
+    return readVolume(SFX_VOL_KEY, SFX_MUTE_KEY);
+  }
+
+  function applyMusicVolume() {
+    const v = getMusicVolume();
+    document.querySelectorAll('audio[id^="bgm"]').forEach(a => {
+      a.volume = v;
+      a.muted = v === 0;
+    });
+  }
+
+  function setMusicVolume(v) {
+    const clamped = Math.max(0, Math.min(1, v));
+    writeVolume(MUSIC_VOL_KEY, clamped);
+    applyMusicVolume();
     paint();
     onToggleCbs.forEach(cb => { try { cb(); } catch (_) {} });
   }
 
-  function setSfxMuted(m) {
-    if (window.Arcade && Arcade.Audio && Arcade.Audio.setMuted) {
-      Arcade.Audio.setMuted(m);
-      // Arcade.Audio.setMuted mirrors muted=true onto every <audio>
-      // including the bgm tracks — restore the (independent) music state
-      // so the two toggles don't bleed into each other.
-      applyMusicMute();
+  function setSfxVolume(v) {
+    const clamped = Math.max(0, Math.min(1, v));
+    if (window.Arcade && Arcade.Audio && Arcade.Audio.setVolume) {
+      Arcade.Audio.setVolume(clamped);
+      // setVolume mirrors onto every <audio> element including bgm tracks
+      // — restore the (independent) music state so the two sliders don't
+      // bleed into each other.
+      applyMusicVolume();
     } else {
-      writeBool(SFX_KEY, m);
+      writeVolume(SFX_VOL_KEY, clamped);
     }
     paint();
     onToggleCbs.forEach(cb => { try { cb(); } catch (_) {} });
   }
+
+  // Boolean aliases for the legacy callers — mute = 0, unmute = full.
+  function getMusicMuted() { return getMusicVolume() === 0; }
+  function getSfxMuted()   { return getSfxVolume()   === 0; }
+  function setMusicMuted(m) { setMusicVolume(m ? 0 : 1); }
+  function setSfxMuted(m)   { setSfxVolume(m   ? 0 : 1); }
 
   function ensureOverlay() {
     if (pauseEl) return;
@@ -100,30 +133,41 @@
           color: #ffd84a; letter-spacing: 0.18em;
           text-shadow: 3px 3px 0 #ff3aa1, 6px 6px 0 #2dd4ff;
         }
-        .arcade-pause-toggle {
-          background: transparent;
+        .arcade-pause-row {
+          display: flex; align-items: center;
+          gap: clamp(8px, 1.6vw, 14px);
+          padding: 8px 12px;
           border: 2px solid #2dd4ff;
-          color: #2dd4ff;
-          padding: 10px 14px;
           font-family: inherit;
           font-size: clamp(10px, 1.8vw, 14px);
           letter-spacing: 0.14em;
-          cursor: pointer;
-          -webkit-tap-highlight-color: transparent;
-          transition: color 0.12s, border-color 0.12s, background 0.12s;
+          color: #2dd4ff;
         }
-        .arcade-pause-toggle:hover,
-        .arcade-pause-toggle:focus-visible {
-          color: #fff; border-color: #fff;
-          background: rgba(255, 255, 255, 0.06);
-          outline: none;
-        }
-        .arcade-pause-toggle.is-muted {
+        .arcade-pause-row.is-muted .arcade-pause-row-label {
           color: rgba(255, 255, 255, 0.4);
           text-decoration: line-through;
           text-decoration-thickness: 0.12em;
-          border-color: rgba(255, 255, 255, 0.25);
         }
+        .arcade-pause-row.is-muted { border-color: rgba(255, 255, 255, 0.25); }
+        .arcade-pause-row-label {
+          flex: 1; text-align: left; min-width: 80px;
+        }
+        .arcade-pause-bar {
+          display: flex; gap: 3px;
+        }
+        .arcade-pause-seg {
+          width: clamp(14px, 2.6vw, 22px);
+          height: clamp(14px, 2.6vw, 22px);
+          border: 2px solid #2dd4ff;
+          background: transparent;
+          cursor: pointer;
+          padding: 0;
+          -webkit-tap-highlight-color: transparent;
+          transition: background 0.1s;
+        }
+        .arcade-pause-seg.is-on { background: #2dd4ff; }
+        .arcade-pause-seg:hover { border-color: #fff; }
+        .arcade-pause-seg.is-on:hover { background: #fff; }
         .arcade-pause-hint {
           font-size: clamp(8px, 1.3vw, 10px);
           letter-spacing: 0.24em;
@@ -134,34 +178,61 @@
       `;
       document.head.appendChild(s);
     }
+    function rowHtml(label, kind, glyph) {
+      let segs = '';
+      for (let i = 0; i < STEPS; i++) {
+        segs += `<button class="arcade-pause-seg" type="button" data-kind="${kind}" data-step="${i}" aria-label="${label} level ${i + 1}"></button>`;
+      }
+      return `
+        <div class="arcade-pause-row" data-row="${kind}">
+          <span class="arcade-pause-row-label">${glyph} ${label}</span>
+          <span class="arcade-pause-bar">${segs}</span>
+        </div>
+      `;
+    }
     pauseEl = document.createElement('div');
     pauseEl.className = 'arcade-pause';
     pauseEl.setAttribute('aria-hidden', 'true');
     pauseEl.innerHTML = `
       <div class="arcade-pause-card" role="dialog" aria-label="Paused">
         <div class="arcade-pause-title">PAUSED</div>
-        <button class="arcade-pause-toggle" data-toggle="music" type="button">♫ MUSIC</button>
-        <button class="arcade-pause-toggle" data-toggle="sfx"   type="button">♪ SFX</button>
+        ${rowHtml('MUSIC', 'music', '♫')}
+        ${rowHtml('SFX',   'sfx',   '♪')}
         <div class="arcade-pause-hint">P or ESC to resume</div>
       </div>
     `;
     document.body.appendChild(pauseEl);
-    pauseEl.querySelector('[data-toggle="music"]').addEventListener('click', e => {
-      e.stopPropagation();
-      setMusicMuted(!getMusicMuted());
-    });
-    pauseEl.querySelector('[data-toggle="sfx"]').addEventListener('click', e => {
-      e.stopPropagation();
-      setSfxMuted(!getSfxMuted());
+    // Segment clicks set the volume to (step+1)/STEPS, EXCEPT: clicking the
+    // segment that's already the last-lit one toggles down to mute (step 0).
+    // That gives a single-tap mute path without sacrificing the "click any
+    // segment to set" affordance.
+    pauseEl.querySelectorAll('.arcade-pause-seg').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        const kind = btn.dataset.kind;
+        const step = parseInt(btn.dataset.step, 10);
+        const cur  = stepFromVolume(kind === 'music' ? getMusicVolume() : getSfxVolume());
+        const targetStep = (step + 1 === cur) ? 0 : step + 1;
+        const v = volumeFromStep(targetStep);
+        if (kind === 'music') setMusicVolume(v); else setSfxVolume(v);
+      });
     });
   }
 
   function paint() {
     if (!pauseEl) return;
-    const m = pauseEl.querySelector('[data-toggle="music"]');
-    const s = pauseEl.querySelector('[data-toggle="sfx"]');
-    if (m) m.classList.toggle('is-muted', getMusicMuted());
-    if (s) s.classList.toggle('is-muted', getSfxMuted());
+    function paintRow(kind, value) {
+      const row = pauseEl.querySelector(`[data-row="${kind}"]`);
+      if (!row) return;
+      row.classList.toggle('is-muted', value === 0);
+      const cur = stepFromVolume(value);
+      row.querySelectorAll('.arcade-pause-seg').forEach(seg => {
+        const step = parseInt(seg.dataset.step, 10);
+        seg.classList.toggle('is-on', step < cur);
+      });
+    }
+    paintRow('music', getMusicVolume());
+    paintRow('sfx',   getSfxVolume());
   }
 
   function pause() {
@@ -194,10 +265,10 @@
     }
   });
 
-  // Apply persisted music mute to every bgm-prefixed <audio> on the page
+  // Apply persisted music volume to every bgm-prefixed <audio> on the page
   // once the DOM is ready (handles late audio elements too).
   function init() {
-    applyMusicMute();
+    applyMusicVolume();
   }
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init, { once: true });
@@ -209,7 +280,9 @@
   window.Arcade.Pause = {
     isPaused: () => paused,
     pause, resume, toggle,
-    isMusicMuted: getMusicMuted,
+    getMusicVolume, setMusicVolume,
+    getSfxVolume,   setSfxVolume,
+    isMusicMuted: getMusicMuted,        // legacy aliases
     isSfxMuted:   getSfxMuted,
     setMusicMuted,
     setSfxMuted,

--- a/docs/arcade/shared/pause.js
+++ b/docs/arcade/shared/pause.js
@@ -33,7 +33,9 @@
   const MUSIC_MUTE_KEY = 'oyster-arcade-music-muted';   // legacy
   const SFX_MUTE_KEY   = 'oyster-arcade-sfx-muted';     // legacy
 
-  const STEPS = 5;            // 0/1/2/3/4 → 0, 25%, 50%, 75%, 100%
+  // STEPS = number of segments rendered in the bar AND number of non-zero
+  // volume levels. Volume 0 lights no segments; volume 1 lights all STEPS.
+  const STEPS = 5;
   const DEFAULT_VOLUME = 1;
 
   let paused = false;
@@ -56,11 +58,12 @@
     try { localStorage.setItem(key, String(v)); } catch (_) {}
   }
 
-  // Step ↔ continuous helpers. The slider is discrete (STEPS levels), but
-  // the underlying audio APIs are 0..1 continuous — round to the nearest
-  // step for display so the bar always matches the saved value.
-  function stepFromVolume(v) { return Math.round(Math.max(0, Math.min(1, v)) * (STEPS - 1)); }
-  function volumeFromStep(s) { return Math.max(0, Math.min(STEPS - 1, s)) / (STEPS - 1); }
+  // Step ↔ continuous helpers. The slider is discrete (0..STEPS = 6 distinct
+  // levels: mute + STEPS lit-segment levels), but the underlying audio APIs
+  // are 0..1 continuous — round to the nearest level for display so the bar
+  // always matches the saved value.
+  function levelFromVolume(v) { return Math.round(Math.max(0, Math.min(1, v)) * STEPS); }
+  function volumeFromLevel(L) { return Math.max(0, Math.min(STEPS, L)) / STEPS; }
 
   function getMusicVolume() { return readVolume(MUSIC_VOL_KEY, MUSIC_MUTE_KEY); }
   function getSfxVolume()   {
@@ -151,7 +154,10 @@
         .arcade-pause-row.is-muted { border-color: rgba(255, 255, 255, 0.25); }
         .arcade-pause-row-label {
           flex: 1; text-align: left; min-width: 80px;
+          cursor: pointer;
+          -webkit-tap-highlight-color: transparent;
         }
+        .arcade-pause-row-label:hover { color: #fff; }
         .arcade-pause-bar {
           display: flex; gap: 3px;
         }
@@ -202,20 +208,78 @@
       </div>
     `;
     document.body.appendChild(pauseEl);
-    // Segment clicks set the volume to (step+1)/STEPS, EXCEPT: clicking the
-    // segment that's already the last-lit one toggles down to mute (step 0).
-    // That gives a single-tap mute path without sacrificing the "click any
-    // segment to set" affordance.
-    pauseEl.querySelectorAll('.arcade-pause-seg').forEach(btn => {
-      btn.addEventListener('click', e => {
+
+    // Label click toggles mute, remembering the previous volume so unmuting
+    // restores it. This is the obvious desktop gesture — "click the label
+    // to silence this channel" — and saves a multi-tap dance on the bar.
+    const prev = { music: 1, sfx: 1 };
+    pauseEl.querySelectorAll('.arcade-pause-row-label').forEach(lbl => {
+      const kind = lbl.parentElement.dataset.row;
+      lbl.setAttribute('role', 'button');
+      lbl.setAttribute('title', 'Click to toggle mute');
+      lbl.addEventListener('click', e => {
         e.stopPropagation();
-        const kind = btn.dataset.kind;
-        const step = parseInt(btn.dataset.step, 10);
-        const cur  = stepFromVolume(kind === 'music' ? getMusicVolume() : getSfxVolume());
-        const targetStep = (step + 1 === cur) ? 0 : step + 1;
-        const v = volumeFromStep(targetStep);
-        if (kind === 'music') setMusicVolume(v); else setSfxVolume(v);
+        const cur = kind === 'music' ? getMusicVolume() : getSfxVolume();
+        if (cur > 0) {
+          prev[kind] = cur;
+          if (kind === 'music') setMusicVolume(0); else setSfxVolume(0);
+        } else {
+          const restore = prev[kind] > 0 ? prev[kind] : 1;
+          if (kind === 'music') setMusicVolume(restore); else setSfxVolume(restore);
+        }
       });
+    });
+
+    // Bar-level pointer handling: covers BOTH tap (set this level) and
+    // drag/swipe (continuously update level as the finger moves across the
+    // bar). Per-segment click handlers are deliberately avoided — they'd
+    // race with the drag and create flicker.
+    pauseEl.querySelectorAll('.arcade-pause-bar').forEach(bar => {
+      const kind = bar.parentElement.dataset.row; // 'music' | 'sfx'
+      let dragging = false;
+      let levelOnDragStart = 0;
+      let movedDuringDrag = false;
+
+      function levelFromX(clientX) {
+        const rect = bar.getBoundingClientRect();
+        const x = clientX - rect.left;
+        if (x < 0) return 0;
+        if (x >= rect.width) return STEPS;
+        // STEPS segments evenly spaced — segment N covers [N*w/STEPS, (N+1)*w/STEPS),
+        // and pointing into segment N means "I want level N+1".
+        return Math.min(STEPS, Math.floor(x / (rect.width / STEPS)) + 1);
+      }
+      function applyLevel(L) {
+        const v = volumeFromLevel(L);
+        if (kind === 'music') setMusicVolume(v); else setSfxVolume(v);
+      }
+
+      bar.addEventListener('pointerdown', e => {
+        e.stopPropagation();
+        dragging = true;
+        movedDuringDrag = false;
+        levelOnDragStart = levelFromVolume(kind === 'music' ? getMusicVolume() : getSfxVolume());
+        try { bar.setPointerCapture(e.pointerId); } catch (_) {}
+        applyLevel(levelFromX(e.clientX));
+      });
+      bar.addEventListener('pointermove', e => {
+        if (!dragging) return;
+        const newLevel = levelFromX(e.clientX);
+        if (newLevel !== levelOnDragStart) movedDuringDrag = true;
+        applyLevel(newLevel);
+      });
+      function endDrag(e) {
+        if (!dragging) return;
+        dragging = false;
+        // Mute-toggle path: a TAP (no movement) on the segment that's already
+        // the top-lit one drops to 0. A drag never toggles — it just sets.
+        if (!movedDuringDrag) {
+          const endLevel = levelFromX(e.clientX);
+          if (endLevel === levelOnDragStart && endLevel > 0) applyLevel(0);
+        }
+      }
+      bar.addEventListener('pointerup', endDrag);
+      bar.addEventListener('pointercancel', endDrag);
     });
   }
 
@@ -225,10 +289,10 @@
       const row = pauseEl.querySelector(`[data-row="${kind}"]`);
       if (!row) return;
       row.classList.toggle('is-muted', value === 0);
-      const cur = stepFromVolume(value);
+      const lit = levelFromVolume(value);
       row.querySelectorAll('.arcade-pause-seg').forEach(seg => {
         const step = parseInt(seg.dataset.step, 10);
-        seg.classList.toggle('is-on', step < cur);
+        seg.classList.toggle('is-on', step < lit);
       });
     }
     paintRow('music', getMusicVolume());

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -233,6 +233,7 @@
 <audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
 <audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
 <audio id="sfx-glitch"    src="../shared/sfx-glitch.mp3"    preload="auto"></audio>
+<audio id="sfx-thruster"  src="../shared/sfx-thruster.mp3"  preload="auto"></audio>
 <audio id="sfx-win"       src="sfx-win.mp3"             preload="auto"></audio>
 <audio id="sfx-jump"      src="sfx-jump.mp3"            preload="auto"></audio>
 <audio id="bgm"           src="bgm.mp3?v=2"             preload="auto" loop></audio>
@@ -263,7 +264,10 @@
           <span class="go-slot" data-slot="1">A</span>
           <span class="go-slot" data-slot="2">A</span>
         </div>
-        <div class="go-initials-hint"><span class="key-only">↑↓ CHANGE · ←→ MOVE · ENTER SAVE</span><span class="touch-only">◀ ▶ LETTER · ▲ NEXT</span></div>
+        <div class="go-initials-hint">
+          <span class="key-only">↑↓ LETTER · ←→ SLOT · ENTER SAVE</span>
+          <span class="touch-only">TAP SLOT · SWIPE LETTER · SELECT SAVES</span>
+        </div>
       </div>
     </div>
     <div class="splash" id="splash">
@@ -312,6 +316,17 @@ window.addEventListener('keydown', e => {
 });
 window.addEventListener('keyup', e => keys[e.key] = false);
 
+// Debug overlay — press H to toggle hitbox visualisation (player, enemies,
+// solid tiles, pickups, goal). Ignored while a text input is focused so
+// initials entry isn't blocked.
+let debugHitboxes = false;
+window.addEventListener('keydown', e => {
+  if (e.key !== 'h' && e.key !== 'H') return;
+  const t = e.target;
+  if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+  debugHitboxes = !debugHitboxes;
+});
+
 // Forward-declared so the touch closures can route to initials entry when
 // it's active. Defined fully further down (after the leaderboard module).
 let initialsActive = false;
@@ -344,15 +359,17 @@ Arcade.Audio.init({
     'sfx-explosion': '../shared/sfx-explosion.mp3',
     'sfx-lose':      '../shared/sfx-lose.mp3',
     'sfx-glitch':    '../shared/sfx-glitch.mp3',
+    'sfx-thruster': '../shared/sfx-thruster.mp3',
     'sfx-win':       'sfx-win.mp3',
     'sfx-jump':      'sfx-jump.mp3',
   },
   mutedKey: 'oyster-arcade-sfx-muted',  // global across all arcade games
 });
-function playCoin() { Arcade.Audio.play('sfx-powerup', 0.5); }
-function playHurt() { Arcade.Audio.play('sfx-lose',    0.5); }
-function playWin()  { Arcade.Audio.play('sfx-win',     0.55); }
-function playJump() { Arcade.Audio.play('sfx-jump',    0.4); }
+function playCoin()    { Arcade.Audio.play('sfx-powerup',  0.5); }
+function playHurt()    { Arcade.Audio.play('sfx-lose',     0.5); }
+function playWin()     { Arcade.Audio.play('sfx-win',      0.55); }
+function playJump()    { Arcade.Audio.play('sfx-jump',     0.4); }
+function playThrust()  { Arcade.Audio.play('sfx-thruster', 0.45); }
 // BGM controls — paused at end-of-run (win or final death) so the
 // jingle plays cleanly, resumed on restart.
 function pauseBgm()  { const a = document.getElementById('bgm'); if (a) a.pause(); }
@@ -461,12 +478,83 @@ window.addEventListener('keydown', e => {
   else if (e.key === 'ArrowLeft')   action = 'slot-prev';
   else if (e.key === 'ArrowRight')  action = 'slot-next';
   else if (e.key === 'Enter' || e.key === ' ') action = 'advance';
+  // Single-letter typed input: jump to that letter at the active slot and
+  // auto-advance — fastest path on a real keyboard.
+  else if (e.key.length === 1) {
+    const c = e.key.toUpperCase();
+    const idx = LETTERS.indexOf(c);
+    if (idx >= 0) {
+      initialsLetters[initialsSlot] = idx;
+      if (initialsSlot < 2) {
+        initialsSlot++;
+        paintInitials();
+      } else {
+        paintInitials();
+        finishInitialsEntry();
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+  }
   if (action) {
     initialsAction(action);
     e.preventDefault();
     e.stopPropagation();
   }
 });
+
+// Touch UX during initials entry — three affordances on top of the existing
+// ◀/▶/SELECT buttons, so a player who tapped the wrong letter isn't stuck:
+//   1. Tap a slot directly → jump to that slot (fixes typos cheaply)
+//   2. Horizontal swipe across the overlay → cycle letters quickly (~40px/letter)
+//   3. (Existing buttons unchanged: ◀/▶ = letter prev/next, SELECT = advance)
+(function wireInitialsTouch() {
+  // Slots tappable. Each carries data-slot="N" — clicking sets initialsSlot.
+  const slots = document.querySelectorAll('#go-initials .go-slot');
+  slots.forEach(s => {
+    s.style.cursor = 'pointer';
+    s.addEventListener('click', e => {
+      if (!initialsActive) return;
+      const idx = parseInt(s.dataset.slot, 10);
+      if (Number.isInteger(idx) && idx >= 0 && idx <= 2) {
+        initialsSlot = idx;
+        paintInitials();
+      }
+      e.stopPropagation();
+    });
+  });
+
+  // Horizontal-drag → letter cycling on the overlay (not on slots themselves,
+  // so taps still land on the slots). 40px per letter — a fast swipe scrolls
+  // ~5 letters in one gesture.
+  const container = document.getElementById('go-initials');
+  if (!container) return;
+  let dragStartX = 0;
+  let dragStartLetter = 0;
+  let dragging = false;
+  container.addEventListener('pointerdown', e => {
+    if (!initialsActive) return;
+    if (e.target && e.target.classList && e.target.classList.contains('go-slot')) return;
+    dragStartX = e.clientX;
+    dragStartLetter = initialsLetters[initialsSlot];
+    dragging = true;
+    try { container.setPointerCapture(e.pointerId); } catch (_) {}
+  });
+  container.addEventListener('pointermove', e => {
+    if (!dragging || !initialsActive) return;
+    const dx = e.clientX - dragStartX;
+    const step = Math.round(dx / 40);
+    const newLetter = ((dragStartLetter + step) % LETTERS.length + LETTERS.length) % LETTERS.length;
+    if (newLetter !== initialsLetters[initialsSlot]) {
+      initialsLetters[initialsSlot] = newLetter;
+      paintInitials();
+    }
+  });
+  function endDrag() { dragging = false; }
+  container.addEventListener('pointerup', endDrag);
+  container.addEventListener('pointercancel', endDrag);
+})();
 
 // ============================================
 // END-OF-RUN OVERLAY (HTML). One panel for both win and loss states,
@@ -602,63 +690,85 @@ splash.addEventListener('pointerdown', e => {
 });
 
 // ============================================
-// LEVEL — tile grid. '.' = empty, '#' = solid, 'S' = spawn marker (treated
-// as empty at runtime; only used to derive spawn coords if not given).
-// Designed in a string for easy editing; will move to JSON when there are
-// multiple levels.
-// ============================================
-// Test level: 7 step-up platforms — each 3 tiles wide, 3-tile horizontal
-// gaps between them, each one row higher than the previous. Tests how
-// far the player can reliably jump diagonally up onto the next ledge.
+// LEVELS — world-stage progression (Mario-style: 1-1, 1-2, 1-3 boss, then
+// 2-1 moon, 2-2, 2-3 boss). Each entry is self-describing so the renderer,
+// physics, and audio all key off it.
 //
-// P1 row 11 (1 above ground)  P2 row 10  P3 row 9  P4 row 8
-// P5 row 7  P6 row 6  P7 row 5
-const LEVEL = {
-  width: 60,
-  height: 14,
-  spawn: { col: 2, row: 12 },
-  tiles: [
-    '............................................................',
-    '............................................................',
-    '............................................................',
-    '............................................................',
-    '............................................................',
-    '..........................................###...............',
-    '....................................###.....................',
-    '..............................###...........................',
-    '........................###.................................',
-    '..................###.......................................',
-    '............###.............................................',
-    '......###...................................................',
-    '############################################################',
-    '############################################################',
-  ],
-  // One coin centred above each platform (rows are the row immediately
-  // above the platform top, so the player picks them up as they land).
-  coins: [
-    { col:  7, row: 10 },
-    { col: 13, row:  9 },
-    { col: 19, row:  8 },
-    { col: 25, row:  7 },
-    { col: 31, row:  6 },
-    { col: 37, row:  5 },
-  ],
-  // Goal flag sits on top of the last platform (row 5, cols 42-44).
-  // The flag visual extends ~2 tiles above this anchor.
-  goal: { col: 43, row: 5 },
-  // Walker enemies pace back and forth on their starting platform. The
-  // col/row anchors place the enemy's feet at the top-left of the tile.
-  enemies: [
-    { col: 13, row: 10, type: 'walker' },
-    { col: 25, row:  8, type: 'walker' },
-  ],
-};
+// Required fields:
+//   id, world, stage   — display + progression
+//   type               — 'platformer' (reach goal) or 'boss' (defeat boss)
+//   width, height      — tile grid
+//   spawn              — { col, row } player start
+//   tiles              — array of row strings; '.' empty, '#' solid
+//   coins, enemies     — { col, row, … }[]
+//   goal               — { col, row } (platformer only; bosses use boss.x)
+//   jetpacks           — { col, row }[] (0 or more pickups in the stage)
+//   bgm                — background music src (relative to this HTML)
+//   gravityScale       — multiplier on GRAVITY (1 = earth, 0.55 = moon)
+//   hasTorch           — true → darkness overlay + radial light on player
+//   boss               — { type, hp, … } for type:'boss', else null
+const LEVELS = [
+  // 1-1 — the existing tutorial step-ladder. 7 platforms ascending right.
+  {
+    id: '1-1', world: 1, stage: 1, type: 'platformer',
+    width: 60, height: 14,
+    spawn: { col: 2, row: 12 },
+    tiles: [
+      '............................................................',
+      '............................................................',
+      '............................................................',
+      '............................................................',
+      '............................................................',
+      '..........................................###...............',
+      '....................................###.....................',
+      '..............................###...........................',
+      '........................###.................................',
+      '..................###.......................................',
+      '............###.............................................',
+      '......###...................................................',
+      '############################################################',
+      '############################################################',
+    ],
+    coins: [
+      { col:  7, row: 10 },
+      { col: 13, row:  9 },
+      { col: 19, row:  8 },
+      { col: 25, row:  7 },
+      { col: 31, row:  6 },
+      { col: 37, row:  5 },
+    ],
+    goal: { col: 43, row: 5 },
+    enemies: [
+      { col: 13, row: 10, type: 'walker' },
+      { col: 25, row:  8, type: 'walker' },
+    ],
+    // Floating on the lane between platforms — players can grab it with a
+    // ground-launched jump while running through 1-1. Once they have it the
+    // remaining diagonal jumps are trivially skippable with thrust.
+    jetpacks: [
+      { col: 21, row: 11 },
+    ],
+    bgm: 'bgm.mp3?v=2',
+    gravityScale: 1,
+    hasTorch: false,
+    boss: null,
+  },
+];
+
+let currentLevelIndex = 0;
+let level = LEVELS[currentLevelIndex];
+function loadLevel(idx) {
+  currentLevelIndex = Math.max(0, Math.min(idx, LEVELS.length - 1));
+  level = LEVELS[currentLevelIndex];
+  if (typeof recomputeScale === 'function') recomputeScale();
+}
+
 function tileAt(col, row) {
-  if (col < 0 || row < 0 || col >= LEVEL.width || row >= LEVEL.height) {
+  if (col < 0 || row < 0 || col >= level.width || row >= level.height) {
     // Treat horizontal out-of-bounds as solid wall; below as void (death).
-    return (col < 0 || col >= LEVEL.width) ? '#' : '.';
+    return (col < 0 || col >= level.width) ? '#' : '.';
   }
-  return LEVEL.tiles[row][col];
+  return level.tiles[row][col];
 }
 function isSolid(col, row) { return tileAt(col, row) === '#'; }
 
@@ -673,15 +783,19 @@ let PLAYER_H = 40;
 let ENEMY_W = 28;
 let ENEMY_H = 28;
 const PLAYER_W_FRAC = 0.85;
-const PLAYER_H_FRAC = 1.25;
-// Goombas are shorter than Steve on purpose — mooks should feel
-// mookable, not boss-like. Steve is 0.85w × 1.25h tiles; enemies are
-// 0.85w × 0.65h, so the player towers roughly 2× the enemy.
+// Hitbox kept just under one tile so the player can walk under any 1-tile
+// vertical gap (e.g. under the row-10 platforms in 1-1). The visual sprite
+// is taller — see the render block in draw(); it offsets so the bottom of
+// the sprite aligns with the hitbox bottom and the head pokes ABOVE the
+// hitbox top. Without this split, players bonk on every low overhang.
+const PLAYER_H_FRAC = 0.95;
+// Goombas are shorter than Rogers on purpose — mooks should feel
+// mookable, not boss-like. Enemies are 0.85w × 0.65h.
 const ENEMY_W_FRAC = 0.85;
 const ENEMY_H_FRAC = 0.65;
 
 function recomputeScale() {
-  TILE_PX = Math.max(16, Math.floor(H / LEVEL.height));
+  TILE_PX = Math.max(16, Math.floor(H / level.height));
   PLAYER_W = Math.round(TILE_PX * PLAYER_W_FRAC);
   PLAYER_H = Math.round(TILE_PX * PLAYER_H_FRAC);
   ENEMY_W = Math.round(TILE_PX * ENEMY_W_FRAC);
@@ -690,16 +804,25 @@ function recomputeScale() {
 recomputeScale();
 
 // Movement tuning (in screen px / frame at 60fps).
-// Peak jump = JUMP_VEL^2 / (2 * GRAVITY) ≈ 141 px ≈ 2.35 tiles at typical
-// scale, so the player can comfortably land on 2-tile-high platforms.
+// Peak jump = JUMP_VEL^2 / (2 * GRAVITY) ≈ 163 px ≈ 2.7 tiles at typical
+// scale, so the player can comfortably clear the step-up platforms in 1-1
+// from a running start without needing the jetpack.
 const MOVE_ACCEL = 0.75;
 const MOVE_MAX = 5.0;
 const FRICTION = 0.82;
 const GRAVITY = 0.6;
-const JUMP_VEL = -13;
+const JUMP_VEL = -14;
 const JUMP_CUT = 0.4;
 const COYOTE_MS = 100;
 const JUMP_BUFFER_MS = 130;
+
+// Jetpack — once picked up (one per level), holding JUMP in mid-air burns
+// fuel for upward thrust. Fuel refills on landing. Numbers tuned for 60fps:
+// FUEL_MAX = ~1.0s of burn; THRUST is stronger than gravity so net rise is
+// gentle (~0.45 px/f²); MAX_VY caps how fast a thrust burst can fling you.
+const JETPACK_FUEL_MAX     = 60;
+const JETPACK_THRUST_ACCEL = -1.05;
+const JETPACK_MAX_VY       = -7;
 
 const player = {
   x: 0, y: 0,            // world pixels, top-left
@@ -710,6 +833,9 @@ const player = {
   jumpPressedAt: -Infinity,
   jumpHeld: false,
   invulnAt: -Infinity,   // last time a hit was taken
+  hasJetpack: false,
+  fuel: 0,
+  thrusting: false,
 };
 
 const cam = { x: 0 };
@@ -724,6 +850,7 @@ const ENEMY_SPEED_FRAC = 0.04;     // per-tile / frame; ENEMY_SPEED computed bel
 let score = 0;
 let lives = MAX_LIVES;
 const coinsCollected = new Set();
+const jetpacksTaken = new Set();
 let levelComplete = false;
 let levelCompleteAt = 0;
 let gameOver = false;
@@ -737,7 +864,7 @@ function aabbOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
 function initEnemies() {
   enemies.length = 0;
   const speed = Math.max(1.2, TILE_PX * ENEMY_SPEED_FRAC * 60 / 60);
-  for (const e of LEVEL.enemies) {
+  for (const e of level.enemies) {
     enemies.push({
       x: e.col * TILE_PX + (TILE_PX - ENEMY_W) / 2,
       y: e.row * TILE_PX - ENEMY_H,
@@ -754,6 +881,7 @@ function resetRun() {
   score = 0;
   lives = MAX_LIVES;
   coinsCollected.clear();
+  jetpacksTaken.clear();
   levelComplete = false; levelCompleteAt = 0;
   gameOver = false; gameOverAt = 0;
   dying = false; livesScreen = false;
@@ -822,8 +950,8 @@ function stepDeathSequence(now) {
     if (now - livesScreenAt < LIVES_MS) return true;
     // Lives screen done — restart the level.
     livesScreen = false;
-    player.x = LEVEL.spawn.col * TILE_PX + (TILE_PX - PLAYER_W) / 2;
-    player.y = LEVEL.spawn.row * TILE_PX - PLAYER_H;
+    player.x = level.spawn.col * TILE_PX + (TILE_PX - PLAYER_W) / 2;
+    player.y = level.spawn.row * TILE_PX - PLAYER_H;
     player.vx = 0; player.vy = 0;
     player.facing = 1;
     player.invulnAt = now;
@@ -836,8 +964,8 @@ function stepDeathSequence(now) {
 }
 
 function resetPlayer() {
-  player.x = LEVEL.spawn.col * TILE_PX + (TILE_PX - PLAYER_W) / 2;
-  player.y = LEVEL.spawn.row * TILE_PX - PLAYER_H;
+  player.x = level.spawn.col * TILE_PX + (TILE_PX - PLAYER_W) / 2;
+  player.y = level.spawn.row * TILE_PX - PLAYER_H;
   player.vx = 0;
   player.vy = 0;
   player.facing = 1;
@@ -845,6 +973,9 @@ function resetPlayer() {
   player.lastGroundedAt = performance.now();
   player.jumpPressedAt = -Infinity;
   player.jumpHeld = false;
+  player.hasJetpack = false;
+  player.fuel = 0;
+  player.thrusting = false;
   cam.x = 0;
 }
 resetRun();
@@ -906,6 +1037,7 @@ function resolveY(dy) {
         player.vy = 0;
         player.grounded = true;
         player.lastGroundedAt = performance.now();
+        player.fuel = JETPACK_FUEL_MAX;
         return;
       }
     }
@@ -979,6 +1111,22 @@ function update() {
   // takes over normally afterward.
   if (jumpJustReleased && player.vy < 0) player.vy *= JUMP_CUT;
 
+  // Jetpack thrust — held JUMP in mid-air burns fuel for an upward burst.
+  // Doesn't replace the initial jump (that still launches at JUMP_VEL); it
+  // kicks in *after* the player is airborne and offsets gravity for as long
+  // as fuel + held-input both hold. Capped at JETPACK_MAX_VY so chained
+  // taps don't launch the player off the screen. Sound plays on rising
+  // edge — the thruster clip is short, replays each fresh burst.
+  const wasThrusting = player.thrusting;
+  player.thrusting = false;
+  if (player.hasJetpack && jumpDown && !player.grounded && player.fuel > 0) {
+    player.vy += JETPACK_THRUST_ACCEL;
+    if (player.vy < JETPACK_MAX_VY) player.vy = JETPACK_MAX_VY;
+    player.fuel--;
+    player.thrusting = true;
+  }
+  if (player.thrusting && !wasThrusting) playThrust();
+
   // Gravity
   player.vy += GRAVITY;
   if (player.vy > 16) player.vy = 16;
@@ -988,7 +1136,7 @@ function update() {
   resolveY(player.vy);
 
   // Death by falling below the level → lose a life (keep score + coins).
-  if (player.y > LEVEL.height * TILE_PX + 200) {
+  if (player.y > level.height * TILE_PX + 200) {
     hurtPlayer();
     return;
   }
@@ -1042,9 +1190,9 @@ function update() {
   }
 
   // Coin pickups — small AABB centred on the coin tile.
-  for (let i = 0; i < LEVEL.coins.length; i++) {
+  for (let i = 0; i < level.coins.length; i++) {
     if (coinsCollected.has(i)) continue;
-    const c = LEVEL.coins[i];
+    const c = level.coins[i];
     const cw = TILE_PX * 0.6;
     const cx = c.col * TILE_PX + (TILE_PX - cw) / 2;
     const cy = c.row * TILE_PX + (TILE_PX - cw) / 2;
@@ -1055,10 +1203,28 @@ function update() {
     }
   }
 
+  // Jetpack pickups — one-shot per pickup; flips hasJetpack on and fills
+  // fuel. The pickup stays in level.jetpacks so the renderer just consults
+  // jetpacksTaken to hide it.
+  for (let i = 0; i < level.jetpacks.length; i++) {
+    if (jetpacksTaken.has(i)) continue;
+    const jp = level.jetpacks[i];
+    const jw = TILE_PX * 0.7;
+    const jx = jp.col * TILE_PX + (TILE_PX - jw) / 2;
+    const jy = jp.row * TILE_PX + (TILE_PX - jw) / 2;
+    if (aabbOverlap(player.x, player.y, PLAYER_W, PLAYER_H, jx, jy, jw, jw)) {
+      jetpacksTaken.add(i);
+      player.hasJetpack = true;
+      player.fuel = JETPACK_FUEL_MAX;
+      score += 25;
+      Arcade.Audio.play('sfx-powerup', 0.85);
+    }
+  }
+
   // Goal flag — collision box covers the pole + flag (2 tiles tall, anchored
   // at the goal column on row 5 = top of the last platform).
   {
-    const g = LEVEL.goal;
+    const g = level.goal;
     const gx = g.col * TILE_PX;
     const gy = (g.row - 2) * TILE_PX;
     const gw = TILE_PX * 0.8;
@@ -1076,7 +1242,7 @@ function update() {
   // 40% from the left edge once at speed. Clamp to level bounds.
   const targetX = player.x - W * 0.4;
   cam.x += (targetX - cam.x) * 0.15;
-  const maxCamX = Math.max(0, LEVEL.width * TILE_PX - W);
+  const maxCamX = Math.max(0, level.width * TILE_PX - W);
   if (cam.x < 0) cam.x = 0;
   if (cam.x > maxCamX) cam.x = maxCamX;
 }
@@ -1193,8 +1359,52 @@ function drawCoin(col, row, t) {
   ctx.fillRect(cx - 1, cy - r * 0.5, 2, r);
 }
 
+// Jetpack pickup — TWIN cylindrical fuel tanks joined by a hazard band.
+// Two distinct tanks side-by-side, each with its own flame below, makes the
+// silhouette read as machinery (NOT a mushroom). 8×10 pixel-art grid scaled
+// by PXL so it stays crisp at any tile size.
+function drawJetpack(col, row, t) {
+  // Pickup sits at roughly half a tile wide so it reads as a collectible
+  // rather than crowding the platform it floats over.
+  const PXL = Math.max(2, Math.floor(TILE_PX / 16));
+  const bob = Math.round(Math.sin(t * 0.005 + col) * 2);
+  const ox = Math.round(col * TILE_PX - cam.x + (TILE_PX - 8 * PXL) / 2);
+  const oy = Math.round(row * TILE_PX + bob + (TILE_PX - 10 * PXL) / 2);
+  if (ox + 8 * PXL < 0 || ox > W) return;
+
+  // Tank bodies — two cylinders, cols 0-1 (left) and cols 6-7 (right).
+  function tank(colStart) {
+    ctx.fillStyle = '#67e8f9';                                                  // light cap
+    ctx.fillRect(ox + colStart * PXL, oy,           2 * PXL, 1 * PXL);
+    ctx.fillStyle = '#2dd4ff';                                                  // body
+    ctx.fillRect(ox + colStart * PXL, oy + 1 * PXL, 2 * PXL, 6 * PXL);
+    ctx.fillStyle = '#0891b2';                                                  // shaded bottom
+    ctx.fillRect(ox + colStart * PXL, oy + 6 * PXL, 2 * PXL, 1 * PXL);
+    ctx.fillStyle = '#475569';                                                  // nozzle
+    ctx.fillRect(ox + colStart * PXL, oy + 7 * PXL, 2 * PXL, 1 * PXL);
+  }
+  tank(0);
+  tank(6);
+
+  // Hazard band linking the tanks — yellow stripes top/bottom, gray harness mid.
+  ctx.fillStyle = '#ffd84a';
+  ctx.fillRect(ox + 2 * PXL, oy + 3 * PXL, 4 * PXL, 1 * PXL);
+  ctx.fillRect(ox + 2 * PXL, oy + 5 * PXL, 4 * PXL, 1 * PXL);
+  ctx.fillStyle = '#94a3b8';
+  ctx.fillRect(ox + 2 * PXL, oy + 4 * PXL, 4 * PXL, 1 * PXL);
+
+  // Twin flickering flames below each nozzle.
+  const flicker = Math.floor(t / 80) % 2 === 0;
+  ctx.fillStyle = flicker ? '#ffd84a' : '#ff8800';
+  ctx.fillRect(ox + 0 * PXL, oy + 8 * PXL, 2 * PXL, 1 * PXL);
+  ctx.fillRect(ox + 6 * PXL, oy + 8 * PXL, 2 * PXL, 1 * PXL);
+  ctx.fillStyle = flicker ? '#ff8800' : '#ff3aa1';
+  ctx.fillRect(ox + 0 * PXL, oy + 9 * PXL, 2 * PXL, 1 * PXL);
+  ctx.fillRect(ox + 6 * PXL, oy + 9 * PXL, 2 * PXL, 1 * PXL);
+}
+
 function drawGoal(t) {
-  const g = LEVEL.goal;
+  const g = level.goal;
   const poleX = g.col * TILE_PX + TILE_PX / 2 - cam.x;
   const poleTop = (g.row - 2) * TILE_PX;
   const poleBot = g.row * TILE_PX;
@@ -1239,6 +1449,27 @@ function drawHUD() {
     const ix = iconStartX + i * (iconSize + 5);
     ctx.fillStyle = i < lives ? '#ff3aa1' : 'rgba(255,58,161,0.22)';
     ctx.fillRect(ix, iconY, iconSize, iconSize);
+  }
+
+  // Fuel bar — only shown after picking up a jetpack. Sits under the
+  // score, sized relative to the score text so it scales with the HUD.
+  if (player.hasJetpack) {
+    const barW = Math.max(80, Math.floor(TILE_PX * 2.2));
+    const barH = Math.max(6, Math.floor(size * 0.45));
+    const barX = pad;
+    const barY = pad + size + 10;
+    const ratio = Math.max(0, Math.min(1, player.fuel / JETPACK_FUEL_MAX));
+    ctx.fillStyle = 'rgba(0,0,0,0.55)';
+    ctx.fillRect(barX - 1, barY - 1, barW + 2, barH + 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.16)';
+    ctx.fillRect(barX, barY, barW, barH);
+    ctx.fillStyle = ratio > 0.3 ? '#2dd4ff' : '#ff8800';
+    ctx.fillRect(barX, barY, Math.round(barW * ratio), barH);
+    // Compact 'FUEL' label tucked to the right of the bar.
+    const labelSize = Math.max(8, Math.floor(size * 0.6));
+    ctx.font = `${labelSize}px 'Press Start 2P', ui-monospace, monospace`;
+    ctx.fillStyle = '#94a3b8';
+    ctx.fillText('FUEL', barX + barW + 8, barY + Math.floor((barH - labelSize) / 2));
   }
 }
 
@@ -1501,14 +1732,14 @@ function draw() {
 
   // ---- Moon — cached offscreen canvas, blitted via drawImage. ----
   const moonImg = getMoonCanvas();
-  const moonCx  = LEVEL.width * TILE_PX - 110 - cam.x * 0.05;
+  const moonCx  = level.width * TILE_PX - 110 - cam.x * 0.05;
   const moonCy  = Math.round(H * 0.16);
   ctx.drawImage(moonImg, Math.round(moonCx - moonImg.width / 2), Math.round(moonCy - moonImg.height / 2));
 
   // ---- Distant star field — small static dots far away. ----
   ctx.fillStyle = 'rgba(255,255,255,0.45)';
   for (let i = 0; i < 70; i++) {
-    const baseX = (i * 53) % (LEVEL.width * TILE_PX);
+    const baseX = (i * 53) % (level.width * TILE_PX);
     const baseY = (i * 91) % Math.max(1, Math.round(H * 0.7));
     const sx = baseX - cam.x * 0.15;
     const wrapped = ((sx % W) + W) % W;
@@ -1522,7 +1753,7 @@ function draw() {
   ctx.fillStyle = 'rgba(255,255,255,0.9)';
   for (let i = 0; i < nearTotal; i++) {
     if (i % 5 === 0) continue;
-    const baseX = (i * 73) % (LEVEL.width * TILE_PX);
+    const baseX = (i * 73) % (level.width * TILE_PX);
     const baseY = (i * 137) % Math.max(1, Math.round(H * 0.65));
     const sx = baseX - cam.x * 0.32;
     const wrapped = ((sx % W) + W) % W;
@@ -1531,7 +1762,7 @@ function draw() {
   for (let i = 0; i < nearTotal; i += 5) {
     const a = 0.45 + (Math.sin(t * 0.003 + i) * 0.5 + 0.5) * 0.45;
     ctx.fillStyle = 'rgba(255,255,255,' + a.toFixed(2) + ')';
-    const baseX = (i * 73) % (LEVEL.width * TILE_PX);
+    const baseX = (i * 73) % (level.width * TILE_PX);
     const baseY = (i * 137) % Math.max(1, Math.round(H * 0.65));
     const sx = baseX - cam.x * 0.32;
     const wrapped = ((sx % W) + W) % W;
@@ -1581,17 +1812,23 @@ function draw() {
 
   // Visible tile range
   const c0 = Math.max(0, Math.floor(cam.x / TILE_PX));
-  const c1 = Math.min(LEVEL.width - 1, Math.ceil((cam.x + W) / TILE_PX));
-  for (let row = 0; row < LEVEL.height; row++) {
+  const c1 = Math.min(level.width - 1, Math.ceil((cam.x + W) / TILE_PX));
+  for (let row = 0; row < level.height; row++) {
     for (let col = c0; col <= c1; col++) {
       if (isSolid(col, row)) drawTile(col, row);
     }
   }
 
   // Coins (skip collected)
-  for (let i = 0; i < LEVEL.coins.length; i++) {
+  for (let i = 0; i < level.coins.length; i++) {
     if (coinsCollected.has(i)) continue;
-    drawCoin(LEVEL.coins[i].col, LEVEL.coins[i].row, t);
+    drawCoin(level.coins[i].col, level.coins[i].row, t);
+  }
+
+  // Jetpack pickups (skip collected)
+  for (let i = 0; i < level.jetpacks.length; i++) {
+    if (jetpacksTaken.has(i)) continue;
+    drawJetpack(level.jetpacks[i].col, level.jetpacks[i].row, t);
   }
 
   // Goal flag
@@ -1605,15 +1842,18 @@ function draw() {
     if (enemies[i].alive) drawEnemy(enemies[i], t);
   }
 
-  // Player — Steve. Rendered as a literal scaled-up version of the
+  // Player — Rogers. Rendered as a literal scaled-up version of the
   // preview-platformer SVG thumbnail so the in-game character reads the
-  // same way (chunky 3-game-pixel "preview units" per cell). Walk-cycle
-  // alternates leg height every ~150ms; jump tucks both legs up. The
-  // sprite mirrors horizontally based on facing.
+  // same way (chunky pixel-units per cell). Walk-cycle alternates leg
+  // height every ~150ms; jump tucks both legs up. The sprite mirrors
+  // horizontally based on facing.
   const invulnLeft = player.invulnAt + INVULN_MS - t;
   const flashOff = invulnLeft > 0 && Math.floor(t / 80) % 2 === 0;
   if (!flashOff) {
-    const PXL = 3;     // game pixels per preview unit
+    // Scale the sprite with TILE_PX so it stays proportional to the
+    // hitbox on larger viewports. Divisor tuned so Rogers sits at roughly
+    // ~70% tile width — small enough that he doesn't tower over the level.
+    const PXL = Math.max(2, Math.round(TILE_PX / 14));
     const SW  = 10;    // sprite width in preview units (incl. arms)
     const SH  = 13;    // sprite height in preview units
     const sw  = SW * PXL;
@@ -1667,21 +1907,149 @@ function draw() {
     // Feet (dark) — slightly wider than the leg, anchored to its bottom
     block(1, 10 + lLen - 1, 3, 1, '#0a0a0a');
     block(6, 10 + rLen - 1, 3, 1, '#0a0a0a');
+
+    // Jetpack tank — when equipped, sits on the back. `block` mirrors with
+    // facing so col 0 maps to "back side" automatically. A yellow hazard
+    // stripe + visible nozzle keeps it readable as a piece of hardware.
+    if (player.hasJetpack) {
+      block(0, 5, 2, 5, '#2dd4ff');     // tank cylinder
+      block(0, 5, 2, 1, '#67e8f9');     // cap highlight
+      block(0, 7, 2, 1, '#ffd84a');     // yellow hazard stripe
+      block(0, 9, 2, 1, '#0891b2');     // shaded bottom
+      block(0, 10, 2, 1, '#475569');    // nozzle (full-width)
+    }
+
+    // Thrust effect — only while burning fuel. Three-layer flame (outer
+    // yellow → mid orange → magenta/white hot core) plus a few drifting
+    // ember particles for motion. Compact size; intent is "I can see I'm
+    // boosting" rather than a full vfx spectacle.
+    if (player.thrusting) {
+      const fW = Math.max(6, Math.floor(PLAYER_W * 0.4));
+      const fH = Math.max(8, Math.floor(PLAYER_H * 0.3));
+      const fX = Math.round(player.x - cam.x) + Math.floor((PLAYER_W - fW) / 2);
+      const fY = Math.round(player.y) + PLAYER_H;
+      const flicker = Math.floor(t / 60) % 2 === 0;
+      // Outer flame — yellow/orange flicker.
+      ctx.fillStyle = flicker ? '#ffd84a' : '#ff8800';
+      ctx.fillRect(fX, fY, fW, fH);
+      // Mid flame — narrower, brighter.
+      const mW = Math.floor(fW * 0.65);
+      const mH = Math.floor(fH * 0.85);
+      ctx.fillStyle = flicker ? '#ff8800' : '#ffd84a';
+      ctx.fillRect(fX + Math.floor((fW - mW) / 2), fY, mW, mH);
+      // Hot core — narrow magenta/white core, alternating.
+      const iW = Math.max(2, Math.floor(fW * 0.35));
+      const iH = Math.floor(fH * 0.55);
+      ctx.fillStyle = flicker ? '#ff3aa1' : '#ffffff';
+      ctx.fillRect(fX + Math.floor((fW - iW) / 2), fY, iW, iH);
+      // Drift particles — small ember dots fanning out left/right/down.
+      const epx = Math.max(2, Math.floor(TILE_PX / 16));
+      const driftPhase = (t / 90) % 1;
+      ctx.fillStyle = '#ffd84a';
+      ctx.fillRect(fX - epx * 2, fY + Math.floor(fH * driftPhase),       epx, epx);
+      ctx.fillRect(fX + fW + epx, fY + Math.floor(fH * (1 - driftPhase)), epx, epx);
+      ctx.fillStyle = '#ff8800';
+      ctx.fillRect(fX + Math.floor(fW / 2) - epx, fY + fH + epx, epx * 2, epx);
+    }
   }
 
   // HUD on top
   drawHUD();
+
+  // Debug hitbox overlay — sits between HUD and lives screen so it's
+  // visible during gameplay but doesn't obscure end-of-run UI.
+  if (debugHitboxes) drawDebugHitboxes();
 
   // Mario-style lives screen — sprite + "× N" on a dim overlay between
   // dying and the level restart.
   if (livesScreen) drawLivesScreen();
 }
 
-// Steve — static sprite at (originX, originY) using the same 10×13
+// Press H in-game to toggle. Renders every collision rectangle the
+// physics actually checks against: tile cells, player, enemies, pickups,
+// goal — colour-coded so it's obvious which hitbox is blocking you.
+function drawDebugHitboxes() {
+  ctx.save();
+  ctx.lineWidth = 1;
+  // Solid tiles — translucent red fill + thin border on each cell.
+  const c0 = Math.max(0, Math.floor(cam.x / TILE_PX));
+  const c1 = Math.min(level.width - 1, Math.ceil((cam.x + W) / TILE_PX));
+  ctx.fillStyle = 'rgba(255, 0, 0, 0.18)';
+  ctx.strokeStyle = 'rgba(255, 80, 80, 0.5)';
+  for (let row = 0; row < level.height; row++) {
+    for (let col = c0; col <= c1; col++) {
+      if (!isSolid(col, row)) continue;
+      const x = Math.round(col * TILE_PX - cam.x);
+      const y = Math.round(row * TILE_PX);
+      ctx.fillRect(x, y, TILE_PX, TILE_PX);
+      ctx.strokeRect(x + 0.5, y + 0.5, TILE_PX - 1, TILE_PX - 1);
+    }
+  }
+  // Player hitbox — bright green so it stands out against everything.
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = '#00ff66';
+  ctx.strokeRect(
+    Math.round(player.x - cam.x) + 0.5,
+    Math.round(player.y) + 0.5,
+    PLAYER_W - 1,
+    PLAYER_H - 1,
+  );
+  // Enemies — yellow for alive, dim grey for squashed.
+  for (const e of enemies) {
+    ctx.strokeStyle = e.alive ? '#ffd84a' : 'rgba(140,60,30,0.5)';
+    ctx.strokeRect(
+      Math.round(e.x - cam.x) + 0.5,
+      Math.round(e.y) + 0.5,
+      ENEMY_W - 1,
+      ENEMY_H - 1,
+    );
+  }
+  // Coin pickups (uncollected) — cyan.
+  ctx.strokeStyle = '#2dd4ff';
+  for (let i = 0; i < level.coins.length; i++) {
+    if (coinsCollected.has(i)) continue;
+    const c = level.coins[i];
+    const cw = TILE_PX * 0.6;
+    const cx = c.col * TILE_PX + (TILE_PX - cw) / 2 - cam.x;
+    const cy = c.row * TILE_PX + (TILE_PX - cw) / 2;
+    ctx.strokeRect(Math.round(cx) + 0.5, Math.round(cy) + 0.5, cw - 1, cw - 1);
+  }
+  // Jetpack pickups (uncollected) — magenta.
+  ctx.strokeStyle = '#ff3aa1';
+  for (let i = 0; i < level.jetpacks.length; i++) {
+    if (jetpacksTaken.has(i)) continue;
+    const jp = level.jetpacks[i];
+    const jw = TILE_PX * 0.7;
+    const jx = jp.col * TILE_PX + (TILE_PX - jw) / 2 - cam.x;
+    const jy = jp.row * TILE_PX + (TILE_PX - jw) / 2;
+    ctx.strokeRect(Math.round(jx) + 0.5, Math.round(jy) + 0.5, jw - 1, jw - 1);
+  }
+  // Goal — white.
+  ctx.strokeStyle = '#ffffff';
+  const g = level.goal;
+  const gx = g.col * TILE_PX - cam.x;
+  const gy = (g.row - 2) * TILE_PX;
+  const gw = TILE_PX * 0.8;
+  const gh = TILE_PX * 2;
+  ctx.strokeRect(Math.round(gx) + 0.5, Math.round(gy) + 0.5, gw - 1, gh - 1);
+  // Legend in the bottom-left corner.
+  const legendY = H - 14;
+  ctx.font = `10px ui-monospace, monospace`;
+  ctx.textBaseline = 'bottom';
+  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillRect(6, legendY - 12, 280, 18);
+  ctx.fillStyle = '#00ff66';
+  ctx.fillText('HITBOX DEBUG — H to toggle  ', 10, legendY);
+  ctx.fillStyle = '#ffd84a';
+  ctx.fillText(`pos ${Math.round(player.x)},${Math.round(player.y)}  v ${player.vx.toFixed(1)},${player.vy.toFixed(1)}  ${player.grounded ? 'GND' : 'AIR'}`, 10, legendY - 12);
+  ctx.restore();
+}
+
+// Rogers — static sprite at (originX, originY) using the same 10×13
 // preview-unit grid as the in-game render. Same colours, same shapes,
 // just no walk cycle. PXL is the size of one preview unit in canvas
 // pixels (use a bigger value for splash/lives-screen displays).
-function drawSteveSprite(originX, originY, PXL, facingR) {
+function drawRogersSprite(originX, originY, PXL, facingR) {
   const SW = 10;
   function block(col, row, w, h, color) {
     const c = facingR ? col : SW - col - w;
@@ -1726,7 +2094,7 @@ function drawLivesScreen() {
   const elapsed = performance.now() - livesScreenAt;
   const display = elapsed < LIVES_MS / 2 ? lives + 1 : lives;
 
-  // Steve sprite — scale up the 10×13 grid for a chunky display
+  // Rogers sprite — scale up the 10×13 grid for a chunky display
   const PXL = 6;
   const sw  = 10 * PXL;
   const sh  = 13 * PXL;
@@ -1740,7 +2108,7 @@ function drawLivesScreen() {
   const sx = Math.round((W - totalW) / 2);
   const sy = Math.round((H - sh) / 2);
 
-  drawSteveSprite(sx, sy, PXL, true);
+  drawRogersSprite(sx, sy, PXL, true);
 
   // "× N"
   ctx.fillStyle = '#fff';

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -363,7 +363,8 @@ Arcade.Audio.init({
     'sfx-win':       'sfx-win.mp3',
     'sfx-jump':      'sfx-jump.mp3',
   },
-  mutedKey: 'oyster-arcade-sfx-muted',  // global across all arcade games
+  volumeKey: 'oyster-arcade-sfx-volume',  // global across all arcade games
+  mutedKey:  'oyster-arcade-sfx-muted',   // legacy fallback
 });
 function playCoin()    { Arcade.Audio.play('sfx-powerup',  0.5); }
 function playHurt()    { Arcade.Audio.play('sfx-lose',     0.5); }
@@ -692,9 +693,9 @@ splash.addEventListener('pointerdown', e => {
 // ============================================
 // LEVELS — world-stage progression (Mario-style: 1-1, 1-2, 1-3 boss, then
 // 2-1 moon, 2-2, 2-3 boss). Each entry is self-describing so the renderer,
-// physics, and audio all key off it.
+// physics, and audio key off it.
 //
-// Required fields:
+// Required at runtime (currently consulted by the engine):
 //   id, world, stage   — display + progression
 //   type               — 'platformer' (reach goal) or 'boss' (defeat boss)
 //   width, height      — tile grid
@@ -703,8 +704,11 @@ splash.addEventListener('pointerdown', e => {
 //   coins, enemies     — { col, row, … }[]
 //   goal               — { col, row } (platformer only; bosses use boss.x)
 //   jetpacks           — { col, row }[] (0 or more pickups in the stage)
-//   bgm                — background music src (relative to this HTML)
+//   bgm                — background music src (loaded into <audio id="bgm">)
 //   gravityScale       — multiplier on GRAVITY (1 = earth, 0.55 = moon)
+//
+// Declared for forward compatibility (read by upcoming work, not consulted
+// by the engine yet — see milestone 2-1 moon level, 1-3 / 2-3 bosses):
 //   hasTorch           — true → darkness overlay + radial light on player
 //   boss               — { type, hp, … } for type:'boss', else null
 const LEVELS = [
@@ -761,6 +765,14 @@ function loadLevel(idx) {
   currentLevelIndex = Math.max(0, Math.min(idx, LEVELS.length - 1));
   level = LEVELS[currentLevelIndex];
   if (typeof recomputeScale === 'function') recomputeScale();
+  // Swap the BGM track to whatever the level declares. Guarded so a first
+  // load before the <audio> element is parsed (script-init order) just no-ops
+  // — the inline src in HTML serves the same file for 1-1 in that window.
+  const bgmEl = document.getElementById('bgm');
+  if (bgmEl && level.bgm && bgmEl.dataset.src !== level.bgm) {
+    bgmEl.dataset.src = level.bgm;
+    bgmEl.src = level.bgm;
+  }
 }
 
 function tileAt(col, row) {
@@ -1127,8 +1139,9 @@ function update() {
   }
   if (player.thrusting && !wasThrusting) playThrust();
 
-  // Gravity
-  player.vy += GRAVITY;
+  // Gravity — level can scale it (moon = ~0.55) for different feel.
+  const gScale = (typeof level.gravityScale === 'number') ? level.gravityScale : 1;
+  player.vy += GRAVITY * gScale;
   if (player.vy > 16) player.vy = 16;
 
   // Integrate with tile collision (X then Y)

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -723,6 +723,13 @@
 <audio id="sfx-lose"      src="arcade/shared/sfx-lose.mp3"      preload="auto"></audio>
 <audio id="sfx-thruster"  src="arcade/shared/sfx-thruster.mp3"  preload="auto"></audio>
 <audio id="sfx-glitch"    src="arcade/shared/sfx-glitch.mp3"    preload="auto"></audio>
+<!-- Shared arcade modules. pause.js is intentionally NOT loaded here so
+     ESC remains a close-the-easter-egg gesture (handled by iframe-host
+     when embedded in oyster.to's home page). -->
+<script src="arcade/shared/audio.js"></script>
+<script src="arcade/shared/touch.js"></script>
+<script src="arcade/shared/leaderboard.js"></script>
+<script src="arcade/shared/iframe-host.js"></script>
 <div class="screen">
   <div class="tube">
     <canvas id="c"></canvas>
@@ -950,25 +957,9 @@ window.addEventListener('keyup', e => keys[e.key] = false);
 // Touch controls — driven by the on-screen buttons (◀ ▶ ▲) overlaid on the
 // tube. Buttons set the same flags the keyboard does so the rest of the game
 // loop doesn't need to know where the input came from.
-const isTouchDevice = window.matchMedia && matchMedia('(pointer: coarse)').matches;
+const isTouchDevice = Arcade.Touch.isCoarse();
 let touchThrust = false;
 (function bindTouchButtons() {
-  const left   = document.getElementById('tc-left');
-  const right  = document.getElementById('tc-right');
-  const thrust = document.getElementById('tc-thrust');
-  function bind(btn, onDown, onUp) {
-    if (!btn) return;
-    const down = e => { e.preventDefault(); btn.classList.add('is-pressed'); onDown(); };
-    const up   = e => { if (e) e.preventDefault(); btn.classList.remove('is-pressed'); onUp(); };
-    btn.addEventListener('pointerdown', down);
-    btn.addEventListener('pointerup', up);
-    btn.addEventListener('pointercancel', up);
-    btn.addEventListener('pointerleave', up);
-    // Stop pointer events from bubbling to the splash's global dismiss listener.
-    ['pointerdown', 'mousedown', 'touchstart'].forEach(ev => {
-      btn.addEventListener(ev, e => e.stopPropagation(), { passive: false });
-    });
-  }
   // While the game-over overlay is up, the on-screen buttons drive initials
   // entry instead of game motion: ◀/▶ cycle the active letter, ▲ advances
   // slots (and saves on the last one). The game-over IIFE returns true if
@@ -977,12 +968,15 @@ let touchThrust = false;
     const handler = window.__rocketGameOverTouch;
     return !!(handler && handler(action));
   }
-  bind(left,   () => { if (!goConsumed('letter-prev')) keys['ArrowLeft']  = true; },
-                () => keys['ArrowLeft']  = false);
-  bind(right,  () => { if (!goConsumed('letter-next')) keys['ArrowRight'] = true; },
-                () => keys['ArrowRight'] = false);
-  bind(thrust, () => { if (!goConsumed('advance'))     touchThrust        = true; },
-                () => touchThrust = false);
+  Arcade.Touch.bind(document.getElementById('tc-left'),
+    () => { if (!goConsumed('letter-prev')) keys['ArrowLeft']  = true; },
+    () => keys['ArrowLeft']  = false);
+  Arcade.Touch.bind(document.getElementById('tc-right'),
+    () => { if (!goConsumed('letter-next')) keys['ArrowRight'] = true; },
+    () => keys['ArrowRight'] = false);
+  Arcade.Touch.bind(document.getElementById('tc-thrust'),
+    () => { if (!goConsumed('advance'))     touchThrust        = true; },
+    () => touchThrust = false);
 })();
 
 // Mouse control — release tracked on window (and window blur) so a drag
@@ -1479,26 +1473,51 @@ loop();
   bgm.volume = 0.45;
 })();
 
-// Mark the body when embedded so the host can target embedded-only styles
-// if needed. The close button lives on the host page now (see index.html).
-if (window.self !== window.top) document.body.classList.add('is-embedded');
+// SFX setup. Audio engine lives in arcade/shared/audio.js; per-game wrappers
+// here just keep call sites readable. mutedKey is the arcade-wide one so
+// SFX mute state syncs with the cabinet games.
+Arcade.Audio.init({
+  sfx: {
+    'sfx-powerup':   'arcade/shared/sfx-powerup.mp3',
+    'sfx-explosion': 'arcade/shared/sfx-explosion.mp3',
+    'sfx-lose':      'arcade/shared/sfx-lose.mp3',
+    'sfx-thruster':  'arcade/shared/sfx-thruster.mp3',
+    'sfx-glitch':    'arcade/shared/sfx-glitch.mp3',
+  },
+  mutedKey: 'oyster-arcade-sfx-muted',
+});
+function ensureAudioCtx() { return Arcade.Audio.ensureCtx(); }
+function playCoin()  { Arcade.Audio.play('sfx-powerup',   0.55); }
+function playCrash() { Arcade.Audio.play('sfx-explosion', 0.75); }
+function playLose()  { Arcade.Audio.play('sfx-lose',      0.55); }
+function playGlitch(vol = 0.4) { Arcade.Audio.play('sfx-glitch', vol); }
+// Thruster: fires on every fresh press (no debounce). Gated to post-splash gameplay.
+function playThruster() {
+  if (!document.querySelector('.tube.is-ready')) return;
+  Arcade.Audio.play('sfx-thruster', 0.4);
+}
 
-// Sound toggle on the splash. Persists muted state to localStorage and
-// mirrors it onto every <audio> element so both BGM and SFX go silent.
+// Sound toggle on the splash. Mutes EVERYTHING (BGM + SFX) by flipping both
+// arcade-wide mute keys so the state is shared across rocket-ship and the
+// arcade cabinet games.
 (function () {
-  const SOUND_KEY = 'oyster-rocket-muted';
+  const MUSIC_KEY = 'oyster-arcade-music-muted';
+  const SFX_KEY   = 'oyster-arcade-sfx-muted';
   const btn = document.getElementById('sound-toggle');
   if (!btn) return;
+  function readBool(k) { try { return localStorage.getItem(k) === '1'; } catch (_) { return false; } }
+  function writeBool(k, v) { try { localStorage.setItem(k, v ? '1' : '0'); } catch (_) {} }
+  function applyMusic(m) { document.querySelectorAll('audio[id^="bgm"]').forEach(a => { a.muted = m; }); }
   function setMuted(m) {
-    document.querySelectorAll('audio').forEach(a => { a.muted = m; });
-    if (typeof setSfxMuted === 'function') setSfxMuted(m);
+    writeBool(MUSIC_KEY, m);
+    applyMusic(m);
+    Arcade.Audio.setMuted(m);
     btn.classList.toggle('is-muted', m);
     btn.setAttribute('aria-pressed', String(m));
-    try { localStorage.setItem(SOUND_KEY, m ? '1' : '0'); } catch (_) {}
   }
-  let muted = false;
-  try { muted = localStorage.getItem(SOUND_KEY) === '1'; } catch (_) {}
-  setMuted(muted);
+  // Both flags must be consistent — if a sister cabinet game set only one,
+  // treat the splash button as muted (safer) and re-sync.
+  setMuted(readBool(MUSIC_KEY) || readBool(SFX_KEY));
   // Stop pointer events from bubbling to the splash's global dismiss listener.
   ['mousedown', 'touchstart', 'pointerdown'].forEach(ev => {
     btn.addEventListener(ev, e => e.stopPropagation(), { passive: true });
@@ -1508,96 +1527,6 @@ if (window.self !== window.top) document.body.classList.add('is-embedded');
     setMuted(!btn.classList.contains('is-muted'));
   });
 })();
-
-// 8-bit SFX via Web Audio. The previous <audio>-element approach hitched
-// on every shot because setting currentTime=0 to retrigger an MP3 forces
-// the browser to tear down and reinit its decoder on the main thread,
-// dropping a frame. Web Audio decodes each clip once into an AudioBuffer
-// and plays disposable BufferSources for each shot — no seek, no decode,
-// runs on the audio thread so it can't block paint.
-//
-// The <audio> elements in HTML stay as a fallback for the short window
-// between page load and first decode completing.
-const SFX_FILES = {
-  'sfx-powerup':   'arcade/shared/sfx-powerup.mp3',
-  'sfx-explosion': 'arcade/shared/sfx-explosion.mp3',
-  'sfx-lose':      'arcade/shared/sfx-lose.mp3',
-  'sfx-thruster':  'arcade/shared/sfx-thruster.mp3',
-  'sfx-glitch':    'arcade/shared/sfx-glitch.mp3',
-};
-// `var` (not `let`) is deliberate: the sound-toggle IIFE above runs at
-// module init and calls setSfxMuted to apply the persisted muted state.
-// That call lands here before this line would have executed under `let`,
-// which would throw a TDZ ReferenceError, halt the script, and prevent
-// the splash IIFE further down from registering its click handlers.
-// `sfxMuted` has no initializer for the same reason: the IIFE has
-// already written the persisted value, and re-initializing here to
-// `false` would clobber it.
-var audioCtx = null;
-var sfxMasterGain = null;
-var sfxBuffers = {};
-var sfxMuted;
-
-// Called from the first user gesture (see Splash IIFE). Idempotent —
-// creates the context, kicks off all decodes in parallel, and resumes
-// the context if iOS auto-suspended it. Fully try/catched: a throw here
-// would otherwise blow up the click handler that just unlocks audio and
-// dismisses the splash, leaving the player stuck on the title screen.
-function ensureAudioCtx() {
-  try {
-    if (!audioCtx) {
-      const Ctx = window.AudioContext || window.webkitAudioContext;
-      if (!Ctx) return null;
-      audioCtx = new Ctx();
-      sfxMasterGain = audioCtx.createGain();
-      sfxMasterGain.gain.value = sfxMuted ? 0 : 1;
-      sfxMasterGain.connect(audioCtx.destination);
-      Object.entries(SFX_FILES).forEach(async ([id, src]) => {
-        try {
-          const resp = await fetch(src);
-          const arr = await resp.arrayBuffer();
-          sfxBuffers[id] = await audioCtx.decodeAudioData(arr);
-        } catch (_) {}
-      });
-    }
-    if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
-  } catch (_) {}
-  return audioCtx;
-}
-
-function setSfxMuted(m) {
-  sfxMuted = m;
-  if (sfxMasterGain) sfxMasterGain.gain.value = m ? 0 : 1;
-}
-
-function playSfx(id, volume = 0.6) {
-  const ctx = audioCtx;
-  const buf = ctx && sfxBuffers[id];
-  if (!ctx || !buf) {
-    // Fallback path: <audio> element. Used only until the matching buffer
-    // finishes decoding, which is usually well before any in-game shot.
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.volume = sfxMuted ? 0 : volume;
-    try { el.currentTime = 0; el.play().catch(() => {}); } catch (_) {}
-    return;
-  }
-  const src = ctx.createBufferSource();
-  src.buffer = buf;
-  const gain = ctx.createGain();
-  gain.gain.value = volume;
-  src.connect(gain).connect(sfxMasterGain);
-  try { src.start(0); } catch (_) {}
-}
-function playCoin()  { playSfx('sfx-powerup', 0.55); }
-function playCrash() { playSfx('sfx-explosion', 0.75); }
-function playLose()  { playSfx('sfx-lose', 0.55); }
-function playGlitch(vol = 0.4) { playSfx('sfx-glitch', vol); }
-// Thruster: fires on every fresh press (no debounce). Gated to post-splash gameplay.
-function playThruster() {
-  if (!document.querySelector('.tube.is-ready')) return;
-  playSfx('sfx-thruster', 0.4);
-}
 
 // ============================================
 // CELEBRATION — pixel flag on #1 high score
@@ -1632,109 +1561,31 @@ function showCelebration(onAdvance) {
 }
 
 // ============================================
-// LEADERBOARD — top 10, ranked by score DESC then created_at ASC (oldest wins ties).
-// Local mirror in localStorage; cloud source-of-truth via Cloudflare Worker.
-// Score POSTs require a short-lived HMAC token minted from /api/leaderboard/start.
+// LEADERBOARD — Cloudflare-Worker-backed, shared client lives at
+// arcade/shared/leaderboard.js. Top 10 per game; cloud is the source of
+// truth, localStorage mirrors for fast paints.
 // ============================================
-const LB_KEY = 'oyster-rocket-leaderboard';
 const LB_SIZE = 10;
-const LB_API = '/api/leaderboard';
-const LB_API_START = '/api/leaderboard/start';
+Arcade.Leaderboard.init({ game: 'rocket-ship', max: LB_SIZE });
+// Pull fresh scores from the cloud on load — repaints if the local mirror
+// changed. Synchronous reads (readLeaderboard / getHighScore) keep working
+// against whatever the mirror holds today.
+Arcade.Leaderboard.refresh().then(() => {
+  paintSplashHighScore();
+  paintLeaderboard();
+});
 
-// One token per session, refreshed on game start and when the previous expires.
-// TTL is 1h server-side; renew with 60s of headroom so an in-flight POST after
-// a long session never trips on a stale signature.
-let _playToken = null;
-let _playTokenExp = 0;
-async function ensurePlayToken() {
-  if (_playToken && Date.now() < _playTokenExp - 60_000) return _playToken;
-  try {
-    const r = await fetch(LB_API_START, { method: 'GET' });
-    if (!r.ok) return null;
-    const data = await r.json();
-    if (data && typeof data.token === 'string' && typeof data.expires_at === 'number') {
-      _playToken = data.token;
-      _playTokenExp = data.expires_at;
-      return _playToken;
-    }
-  } catch (_) {}
-  return null;
-}
-// Comparator: highest score first; ties broken by who got there first.
-function lbSort(a, b) {
-  if (b.score !== a.score) return b.score - a.score;
-  return (a.created_at || 0) - (b.created_at || 0);
-}
-// Same shape as the server-side guard so we never trust strings we read
-// out of localStorage (or the cloud) any more than we trust user input.
-const INITIALS_OK = /^[A-Z0-9.\-]{1,3}$/;
-function readLeaderboard() {
-  try {
-    const raw = localStorage.getItem(LB_KEY);
-    if (!raw) return [];
-    const v = JSON.parse(raw);
-    if (!Array.isArray(v)) return [];
-    return v
-      .filter(e =>
-        e &&
-        // Keep this aligned with the worker's MAX_SCORE (currently 999) so a
-        // local entry that exceeds the server cap doesn't fool qualifiesForLeaderboard
-        // or sit forever unable to sync.
-        typeof e.score === 'number' && e.score > 0 && e.score <= 999 &&
-        typeof e.initials === 'string' && INITIALS_OK.test(e.initials)
-      )
-      // Back-compat: pre-date entries get the current time so they sort sanely
-      .map(e => ({ score: e.score, initials: e.initials, created_at: e.created_at || Date.now() }))
-      .sort(lbSort)
-      .slice(0, LB_SIZE);
-  } catch (_) { return []; }
-}
-function writeLeaderboard(list) {
-  try { localStorage.setItem(LB_KEY, JSON.stringify(list)); } catch (_) {}
+function readLeaderboard()      { return Arcade.Leaderboard.read(); }
+function qualifiesForLeaderboard(score) { return Arcade.Leaderboard.qualifies(score); }
+function getHighScore() {
+  // Rocket's paint code expects the empty-board fallback shape.
+  return Arcade.Leaderboard.getHighScore() || { score: 0, initials: '---' };
 }
 function addToLeaderboard(score, initials) {
-  const list = readLeaderboard();
-  const entry = { score, initials, created_at: Date.now() };
-  list.push(entry);
-  list.sort(lbSort);
-  const trimmed = list.slice(0, LB_SIZE);
-  writeLeaderboard(trimmed);
-  // Best-effort cloud sync (don't block the UI on it). Server rejects POSTs
-  // without a valid HMAC token + a recent IP — failure here just leaves the
-  // local mirror as-is.
-  (async () => {
-    const token = await ensurePlayToken();
-    if (!token) return;
-    try {
-      const r = await fetch(LB_API, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ score, initials, token }),
-      });
-      if (!r.ok) return;
-      const data = await r.json();
-      if (data && Array.isArray(data.list)) {
-        writeLeaderboard(data.list.slice(0, LB_SIZE));
-        paintSplashHighScore();
-        paintLeaderboard();
-      }
-    } catch (_) {}
-  })();
-  return trimmed.findIndex(e => e === entry || (e.score === score && e.initials === initials && e.created_at === entry.created_at)) + 1;
+  Arcade.Leaderboard.submit(score, initials).then(r => {
+    if (r && r.ok) { paintSplashHighScore(); paintLeaderboard(); }
+  });
 }
-// Refresh from cloud on load — replaces local mirror if server returns a list
-(function refreshFromCloud() {
-  fetch(LB_API, { method: 'GET' })
-    .then(r => r.ok && r.json())
-    .then(data => {
-      if (data && Array.isArray(data.list)) {
-        writeLeaderboard(data.list.slice(0, LB_SIZE));
-        paintSplashHighScore();
-        paintLeaderboard();
-      }
-    })
-    .catch(() => { /* offline / worker not deployed yet — local mirror is fine */ });
-})();
 
 // Humanised "since" — "today", "2d", "3w", "5mo" etc
 function sincePhrase(ts) {
@@ -1746,17 +1597,6 @@ function sincePhrase(ts) {
   if (days < 30) return Math.floor(days / 7) + 'w';
   if (days < 365) return Math.floor(days / 30) + 'mo';
   return Math.floor(days / 365) + 'y';
-}
-function qualifiesForLeaderboard(score) {
-  if (score <= 0) return false;
-  const list = readLeaderboard();
-  // Room on the board: anyone with a positive score gets in (ties OK).
-  // Full board: must STRICTLY beat the lowest existing score — ties don't bump.
-  return list.length < LB_SIZE || score > list[list.length - 1].score;
-}
-function getHighScore() {
-  const list = readLeaderboard();
-  return list[0] || { score: 0, initials: '---' };
 }
 
 function paintSplashHighScore() {
@@ -1892,9 +1732,6 @@ const Splash = (function () {
     startGameMusic();
     if (typeof restartGame === 'function') restartGame();
     gameActive = true; // now the game world is live
-    // Mint a play-token in the background so the eventual score POST has one.
-    // No-op if we already have a fresh one.
-    if (typeof ensurePlayToken === 'function') ensurePlayToken();
   }
 
   // First-load: boot ends → title music starts AND title/leaderboard
@@ -1951,7 +1788,6 @@ const Splash = (function () {
       startGameMusic();
       if (typeof restartGame === 'function') restartGame();
       gameActive = true;
-      if (typeof ensurePlayToken === 'function') ensurePlayToken();
     });
   }
   if (leaderboardEl) {

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -1473,9 +1473,31 @@ loop();
   bgm.volume = 0.45;
 })();
 
+// One-time migration of the legacy single-key mute (`oyster-rocket-muted`)
+// into the arcade-wide music + sfx mute keys, before Arcade.Audio inits.
+// Without this, an existing player who'd muted Rocket Ship pre-port would
+// see the game come back at full volume after the upgrade.
+(function migrateLegacyRocketMute() {
+  try {
+    const LEGACY = 'oyster-rocket-muted';
+    if (localStorage.getItem(LEGACY) !== '1') return;
+    const MUSIC = 'oyster-arcade-music-volume';
+    const SFX   = 'oyster-arcade-sfx-volume';
+    const MUSIC_LEGACY = 'oyster-arcade-music-muted';
+    const SFX_LEGACY   = 'oyster-arcade-sfx-muted';
+    if (localStorage.getItem(MUSIC) == null && localStorage.getItem(MUSIC_LEGACY) == null) {
+      localStorage.setItem(MUSIC, '0');
+    }
+    if (localStorage.getItem(SFX) == null && localStorage.getItem(SFX_LEGACY) == null) {
+      localStorage.setItem(SFX, '0');
+    }
+    localStorage.removeItem(LEGACY);
+  } catch (_) {}
+})();
+
 // SFX setup. Audio engine lives in arcade/shared/audio.js; per-game wrappers
-// here just keep call sites readable. mutedKey is the arcade-wide one so
-// SFX mute state syncs with the cabinet games.
+// here just keep call sites readable. volumeKey is the arcade-wide slider so
+// SFX volume syncs with the cabinet games; mutedKey kept for legacy fallback.
 Arcade.Audio.init({
   sfx: {
     'sfx-powerup':   'arcade/shared/sfx-powerup.mp3',
@@ -1484,7 +1506,8 @@ Arcade.Audio.init({
     'sfx-thruster':  'arcade/shared/sfx-thruster.mp3',
     'sfx-glitch':    'arcade/shared/sfx-glitch.mp3',
   },
-  mutedKey: 'oyster-arcade-sfx-muted',
+  volumeKey: 'oyster-arcade-sfx-volume',
+  mutedKey:  'oyster-arcade-sfx-muted',
 });
 function ensureAudioCtx() { return Arcade.Audio.ensureCtx(); }
 function playCoin()  { Arcade.Audio.play('sfx-powerup',   0.55); }
@@ -1566,6 +1589,21 @@ function showCelebration(onAdvance) {
 // truth, localStorage mirrors for fast paints.
 // ============================================
 const LB_SIZE = 10;
+// One-time migration: the legacy mirror lived at `oyster-rocket-leaderboard`,
+// the shared client expects `oyster-arcade-leaderboard-rocket-ship`. Copy
+// the old list across so an offline player doesn't see an empty board until
+// the next successful cloud refresh.
+(function migrateLegacyRocketLeaderboard() {
+  try {
+    const LEGACY = 'oyster-rocket-leaderboard';
+    const NEW    = 'oyster-arcade-leaderboard-rocket-ship';
+    if (localStorage.getItem(NEW) != null) return;
+    const raw = localStorage.getItem(LEGACY);
+    if (raw == null) return;
+    localStorage.setItem(NEW, raw);
+    localStorage.removeItem(LEGACY);
+  } catch (_) {}
+})();
 Arcade.Leaderboard.init({ game: 'rocket-ship', max: LB_SIZE });
 // Pull fresh scores from the cloud on load — repaints if the local mirror
 // changed. Synchronous reads (readLeaderboard / getHighScore) keep working


### PR DESCRIPTION
## Summary

Two arcade-scope changes that mostly travel together — a refactor that locks in the framework patterns, and the gameplay foundation that the user-facing work will build on top of.

### Rocket Ship → shared modules (refactor commit)
`docs/rocket-ship.html` had ~240 LOC of inline audio engine, leaderboard client, and touch binding that had drifted from the shared implementations the cabinet games already use. Replaced with calls into `docs/arcade/shared/{audio,touch,leaderboard,iframe-host}.js`.

- SFX mute now syncs across the arcade (`oyster-arcade-sfx-muted`)
- Splash sound toggle writes both arcade-wide mute keys (BGM + SFX)
- Leaderboard uses `game: 'rocket-ship'` (already in the worker's GAMES allowlist)
- `pause.js` intentionally NOT loaded — keeps ESC as the easter-egg close gesture via `iframe-host.js`
- Net: **-164 LOC**

### Space Jumper — LEVELS[] foundation + jetpack + polish (feature commit)

**Data model** — `LEVEL` const → `LEVELS[]` array with world/stage IDs (1-1, 1-2, 1-3, 2-1, 2-2, 2-3), per-level `bgm`/`hasTorch`/`gravityScale` fields, `jetpacks` array, `boss` slot. Foundation for moon level (2-1) and bosses (1-3, 2-3) — only 1-1 is populated in this PR.

**Jetpack pickup** — pick up once per level, hold JUMP in mid-air to burn fuel for upward thrust, fuel refills on landing. Twin-cylinder pixel-art (after iterating away from a mushroom silhouette). Fuel meter on the HUD. `sfx-thruster` plays on each fresh burst.

**Hitbox fix** — player was 1.25 tiles tall so couldn't fit under any 1-tile vertical gap (row-10 platforms unreachable from below). `PLAYER_H_FRAC: 1.25 → 0.95`. Sprite stays the same height — head pokes above the hitbox via the existing render offset.

**Tuning** — `JUMP_VEL: -13 → -14` so the step-up platforms in 1-1 are comfortable without the jetpack. Sprite PXL now scales with `TILE_PX` so the player stays proportional on larger viewports.

**Debug overlay** — press `H` in-game to toggle hitbox + solid-tile + entity outlines. Saved me a lot of squinting; might be useful for level design too.

**Initials entry** — tap a slot to jump to it (one-tap typo fix), horizontal swipe cycles letters (~40px/letter), typed-letter shortcut on physical keyboard, hint text spells out controls for both input modes.

**Rename** — Steve → Rogers throughout.

## Test plan
- [x] Both inline `<script>` blocks parse cleanly via `new Function()`
- [x] All shared modules resolve over local HTTP from rocket-ship and from space-jumper
- [x] Manual: complete a 1-1 run without picking up the jetpack
- [x] Manual: pick up jetpack, observe fuel HUD, burn fuel mid-air, refill on landing
- [x] Manual: press H mid-run, verify all hitboxes render
- [ ] Manual: rocket-ship easter egg still loads from oyster.to (deploy)
- [ ] Manual: leaderboard submission round-trips on both games (deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)