### PR TITLE
perf(spotlight): make Cmd+K transcript search fast on large DBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 ### Fixed
 
 - **Boot is fast again on large transcript databases.** Search-index health checks and one-time data migrations no longer block startup — they run after the UI is ready. Users with multi-million-row transcript histories who were seeing 30+ second hangs should boot in well under a second.
+- **Cmd+K search no longer stalls on large session databases.** Spotlight's transcript search now stays responsive (~5× faster on multi-GB DBs with broad queries) by only fetching match snippets for results that actually appear on screen.
 
 ## [0.9.6] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Cmd+K transcript hits are now ordered by recency, and the list goes up to 50.** When scanning Spotlight for "that session I had last week about X", the most-recent matching session sits at the top regardless of FTS rank; within each session the surfaced snippet is still the best match.
+
 ### Fixed
 
 - **Boot is fast again on large transcript databases.** Search-index health checks and one-time data migrations no longer block startup — they run after the UI is ready. Users with multi-million-row transcript histories who were seeing 30+ second hangs should boot in well under a second.
-- **Cmd+K search no longer stalls on large session databases.** Spotlight's transcript search now stays responsive (~5× faster on multi-GB DBs with broad queries) by only fetching match snippets for results that actually appear on screen.
+- **Cmd+K search no longer stalls on large session databases.** Spotlight stays responsive on multi-GB session histories — narrow queries return in tens of milliseconds, and the worst-case 2-char prefixes against hundreds of thousands of matches drop from 15+ seconds to a few. The search input also waits a beat longer before firing so a single fast-typed word doesn't cascade through multiple intermediate queries.
 
 ## [0.9.6] - 2026-05-21
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -307,6 +307,7 @@
 <h3>Fixed</h3>
 <ul>
 <li><strong>Boot is fast again on large transcript databases.</strong> Search-index health checks and one-time data migrations no longer block startup — they run after the UI is ready. Users with multi-million-row transcript histories who were seeing 30+ second hangs should boot in well under a second.</li>
+<li><strong>Cmd+K search no longer stalls on large session databases.</strong> Spotlight&#39;s transcript search now stays responsive (~5× faster on multi-GB DBs with broad queries) by only fetching match snippets for results that actually appear on screen.</li>
 </ul>
 <h2 id="v-0-9-6"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.5...v0.9.6" rel="noopener noreferrer"><span class="release-version">0.9.6</span></a><span class="release-date"> — 2026-05-21</span></h2>
 <h3>Fixed</h3>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -304,10 +304,14 @@
 
   <main class="entries">
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.6...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>Cmd+K transcript hits are now ordered by recency, and the list goes up to 50.</strong> When scanning Spotlight for &quot;that session I had last week about X&quot;, the most-recent matching session sits at the top regardless of FTS rank; within each session the surfaced snippet is still the best match.</li>
+</ul>
 <h3>Fixed</h3>
 <ul>
 <li><strong>Boot is fast again on large transcript databases.</strong> Search-index health checks and one-time data migrations no longer block startup — they run after the UI is ready. Users with multi-million-row transcript histories who were seeing 30+ second hangs should boot in well under a second.</li>
-<li><strong>Cmd+K search no longer stalls on large session databases.</strong> Spotlight&#39;s transcript search now stays responsive (~5× faster on multi-GB DBs with broad queries) by only fetching match snippets for results that actually appear on screen.</li>
+<li><strong>Cmd+K search no longer stalls on large session databases.</strong> Spotlight stays responsive on multi-GB session histories — narrow queries return in tens of milliseconds, and the worst-case 2-char prefixes against hundreds of thousands of matches drop from 15+ seconds to a few. The search input also waits a beat longer before firing so a single fast-typed word doesn&#39;t cascade through multiple intermediate queries.</li>
 </ul>
 <h2 id="v-0-9-6"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.5...v0.9.6" rel="noopener noreferrer"><span class="release-version">0.9.6</span></a><span class="release-date"> — 2026-05-21</span></h2>
 <h3>Fixed</h3>

--- a/server/scripts/bench-spotlight-search.ts
+++ b/server/scripts/bench-spotlight-search.ts
@@ -2,11 +2,11 @@
  * Manual benchmark for SqliteSessionStore.searchSessions — the query that
  * powers Spotlight's transcript hits. Not a CI gate.
  *
- * Usage: cd server && npx tsx scripts/bench-spotlight-search.ts <query> [db-path]
+ * Usage: cd server && npx tsx scripts/bench-spotlight-search.ts <query> [limit] [db-path]
  *
  * Examples:
- *   npx tsx scripts/bench-spotlight-search.ts sp                 # uses ~/Oyster/db/oyster.db
- *   npx tsx scripts/bench-spotlight-search.ts test /tmp/snap.db
+ *   npx tsx scripts/bench-spotlight-search.ts sp                    # limit 50, ~/Oyster/db/oyster.db
+ *   npx tsx scripts/bench-spotlight-search.ts test 50 /tmp/snap.db
  */
 
 import Database from "better-sqlite3";
@@ -15,10 +15,18 @@ import { join } from "node:path";
 import { SqliteSessionStore } from "../src/session-store.js";
 
 const query = process.argv[2];
-const dbPath = process.argv[3] ?? join(homedir(), "Oyster", "db", "oyster.db");
+// Defaults to 50 to match Spotlight's request limit (web/SpotlightSearch
+// TRANSCRIPTS_LIMIT). A numeric second arg overrides; anything else is
+// treated as the db path.
+const arg3 = process.argv[3];
+const arg3IsLimit = arg3 !== undefined && /^\d+$/.test(arg3);
+const limit = arg3IsLimit ? Number(arg3) : 50;
+const dbPath = arg3IsLimit
+  ? (process.argv[4] ?? join(homedir(), "Oyster", "db", "oyster.db"))
+  : (arg3 ?? join(homedir(), "Oyster", "db", "oyster.db"));
 
 if (!query) {
-  console.error("usage: bench-spotlight-search.ts <query> [db-path]");
+  console.error("usage: bench-spotlight-search.ts <query> [limit] [db-path]");
   process.exit(2);
 }
 
@@ -26,10 +34,10 @@ const db = new Database(dbPath, { readonly: true, fileMustExist: true });
 const store = new SqliteSessionStore(db);
 
 const t0 = performance.now();
-const hits = store.searchSessions(query, { limit: 8 });
+const hits = store.searchSessions(query, { limit });
 const ms = performance.now() - t0;
 
 console.log(`db: ${dbPath}`);
-console.log(`q:  ${JSON.stringify(query)}  limit: 8`);
+console.log(`q:  ${JSON.stringify(query)}  limit: ${limit}`);
 console.log(`hits: ${hits.length}  time: ${ms.toFixed(1)}ms`);
 db.close();

--- a/server/scripts/bench-spotlight-search.ts
+++ b/server/scripts/bench-spotlight-search.ts
@@ -1,0 +1,35 @@
+/**
+ * Manual benchmark for SqliteSessionStore.searchSessions — the query that
+ * powers Spotlight's transcript hits. Not a CI gate.
+ *
+ * Usage: cd server && npx tsx scripts/bench-spotlight-search.ts <query> [db-path]
+ *
+ * Examples:
+ *   npx tsx scripts/bench-spotlight-search.ts sp                 # uses ~/Oyster/db/oyster.db
+ *   npx tsx scripts/bench-spotlight-search.ts test /tmp/snap.db
+ */
+
+import Database from "better-sqlite3";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+const query = process.argv[2];
+const dbPath = process.argv[3] ?? join(homedir(), "Oyster", "db", "oyster.db");
+
+if (!query) {
+  console.error("usage: bench-spotlight-search.ts <query> [db-path]");
+  process.exit(2);
+}
+
+const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+const store = new SqliteSessionStore(db);
+
+const t0 = performance.now();
+const hits = store.searchSessions(query, { limit: 8 });
+const ms = performance.now() - t0;
+
+console.log(`db: ${dbPath}`);
+console.log(`q:  ${JSON.stringify(query)}  limit: 8`);
+console.log(`hits: ${hits.length}  time: ${ms.toFixed(1)}ms`);
+db.close();

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -99,7 +99,13 @@ export interface SessionSearchHit {
   last_event_at: string | null;
   /** Highlighted excerpt of the best-ranked match. */
   snippet: string;
-  /** Number of distinct matching events in this session. */
+  /** Matching events in this session — counted within the
+   *  candidate pool that drives the surfaced results. Exact when the
+   *  session has at most as many matches as the pool size; truncated
+   *  (a lower bound) on hyper-broad prefix queries against very large
+   *  histories where a single session's matches exceed the pool. The
+   *  Spotlight "+N more" affordance treats this as a hint, not a
+   *  precise total. */
   match_count: number;
 }
 

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -548,42 +548,66 @@ export class SqliteSessionStore implements SessionStore {
     }
     const limit = opts.limit ?? 20;
 
-    // FTS5's snippet() auxiliary can't be used in a SELECT that also wraps
-    // window functions ("unable to use function snippet in the requested
-    // context") — it needs to live in a query that directly scans the FTS
-    // virtual table under MATCH. So we materialize the snippet + raw rank
-    // in an inner CTE and let the outer CTE handle ROW_NUMBER / COUNT over
-    // those plain columns.
+    // Two-stage query so snippet() runs only for the rows that survive
+    // the per-session winner pick + LIMIT, not for the full match set.
+    // The naive shape — snippet() inside the inner CTE — pays the cost of
+    // computing a contextual snippet (which requires reading the original
+    // `text` column from the external-content base table, i.e. a random
+    // rowid lookup) for every matched row, then throws all but `limit`
+    // away. On broad prefix matches against a multi-GB DB that means
+    // ~60k+ lookups per query and Spotlight feels broken.
+    //
+    // Instead the inner CTE carries only (id, session_id, rank), the
+    // window functions pick the top match per session, the outer query
+    // takes the LIMIT, and snippet() runs in a correlated subquery
+    // bound to that handful of winners — same FTS MATCH so snippet()
+    // sees the matched tokens for that rowid.
+    //
+    // The `sessions` table is only joined inside the inner CTE when
+    // we need it for the space_id filter; otherwise the join is done
+    // after LIMIT for the metadata columns.
     const innerWhere: string[] = ["session_events_fts MATCH ?"];
     const innerParams: unknown[] = [ftsQuery];
-    if (opts.spaceId) { innerWhere.push("s.space_id = ?"); innerParams.push(opts.spaceId); }
+    let innerJoinSessions = "";
+    if (opts.spaceId) {
+      innerJoinSessions = "JOIN sessions s ON s.id = e.session_id";
+      innerWhere.push("s.space_id = ?");
+      innerParams.push(opts.spaceId);
+    }
 
     const sql = `WITH matches AS (
-                   SELECT e.id, e.session_id, e.role,
-                          fts.rank AS m_rank,
-                          snippet(session_events_fts, 0, '[', ']', '…', 12) AS snippet
+                   SELECT e.id, e.session_id, fts.rank AS m_rank
                    FROM session_events e
                    JOIN session_events_fts fts ON e.id = fts.rowid
-                   JOIN sessions s             ON s.id = e.session_id
+                   ${innerJoinSessions}
                    WHERE ${innerWhere.join(" AND ")}
                  ),
                  ranked AS (
-                   SELECT id, session_id, role, m_rank, snippet,
+                   SELECT id, session_id, m_rank,
                           ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY m_rank) AS rn,
                           COUNT(*)     OVER (PARTITION BY session_id)                 AS match_count
                    FROM matches
+                 ),
+                 winners AS (
+                   SELECT id, session_id, m_rank, match_count
+                   FROM ranked
+                   WHERE rn = 1
+                   ORDER BY m_rank ASC
+                   LIMIT ?
                  )
-                 SELECT r.id AS event_id, r.session_id, r.role,
-                        r.snippet, r.match_count,
+                 SELECT w.id AS event_id, w.session_id, e.role,
+                        (SELECT snippet(session_events_fts, 0, '[', ']', '…', 12)
+                           FROM session_events_fts
+                           WHERE session_events_fts MATCH ? AND rowid = w.id) AS snippet,
+                        w.match_count,
                         s.title         AS session_title,
                         s.space_id      AS space_id,
                         s.last_event_at AS last_event_at
-                 FROM ranked r
-                 JOIN sessions s ON s.id = r.session_id
-                 WHERE r.rn = 1
-                 ORDER BY r.m_rank ASC
-                 LIMIT ?`;
-    innerParams.push(limit);
+                 FROM winners w
+                 JOIN sessions s        ON s.id = w.session_id
+                 JOIN session_events e  ON e.id = w.id
+                 ORDER BY w.m_rank ASC`;
+    innerParams.push(limit, ftsQuery);
     return this.db.prepare(sql).all(...innerParams) as SessionSearchHit[];
   }
 

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -546,26 +546,40 @@ export class SqliteSessionStore implements SessionStore {
     } else {
       ftsQuery = `"${trimmed.replace(/"/g, '""')}"`;
     }
-    const limit = opts.limit ?? 20;
+    const limit = opts.limit ?? 50;
 
-    // Two-stage query so snippet() runs only for the rows that survive
-    // the per-session winner pick + LIMIT, not for the full match set.
-    // The naive shape — snippet() inside the inner CTE — pays the cost of
-    // computing a contextual snippet (which requires reading the original
-    // `text` column from the external-content base table, i.e. a random
-    // rowid lookup) for every matched row, then throws all but `limit`
-    // away. On broad prefix matches against a multi-GB DB that means
-    // ~60k+ lookups per query and Spotlight feels broken.
+    // Three structural choices, all driven by perf against multi-GB DBs
+    // where broad prefix queries match hundreds of thousands of events:
     //
-    // Instead the inner CTE carries only (id, session_id, rank), the
-    // window functions pick the top match per session, the outer query
-    // takes the LIMIT, and snippet() runs in a correlated subquery
-    // bound to that handful of winners — same FTS MATCH so snippet()
-    // sees the matched tokens for that rowid.
+    // 1. Inner CTE caps the FTS scan at the top CANDIDATE_POOL events by
+    //    BM25 rank. FTS5's planner pushes ORDER BY rank LIMIT down into
+    //    the index scan, so the candidate-pool size — not the total
+    //    match count — bounds the work. A pool large enough to almost
+    //    always contain each session's best-ranked event for the top 50
+    //    surfaced sessions; sessions whose best match ranks beyond the
+    //    pool fall off (acceptable in the Cmd+K context).
     //
-    // The `sessions` table is only joined inside the inner CTE when
-    // we need it for the space_id filter; otherwise the join is done
-    // after LIMIT for the metadata columns.
+    // 2. Window functions pick one row per session (the best-ranked
+    //    representative) and compute match_count over the pool. The
+    //    count is "matches within the candidate pool", which drives
+    //    the "+N more" UI affordance — exact when the session has at
+    //    most CANDIDATE_POOL matches, conservative otherwise.
+    //
+    // 3. snippet() runs in a correlated subquery bound to the final
+    //    survivors only — not the full pool — because computing it on
+    //    every candidate would require reading the `text` column from
+    //    the external-content base table for every row.
+    //
+    // Result ordering is by session recency (s.last_event_at DESC) not
+    // FTS rank — when scanning a long list the user looks for "the
+    // recent session I was working in", not "the session with the most
+    // term-frequency-weighted hits". Within a session, the surfaced
+    // event_id (and its snippet) is still the best-ranked match.
+    //
+    // The `sessions` table is only joined inside the inner CTE when we
+    // need it for the space_id filter; otherwise the join is done after
+    // LIMIT for the metadata columns.
+    const CANDIDATE_POOL = 500;
     const innerWhere: string[] = ["session_events_fts MATCH ?"];
     const innerParams: unknown[] = [ftsQuery];
     let innerJoinSessions = "";
@@ -581,6 +595,8 @@ export class SqliteSessionStore implements SessionStore {
                    JOIN session_events_fts fts ON e.id = fts.rowid
                    ${innerJoinSessions}
                    WHERE ${innerWhere.join(" AND ")}
+                   ORDER BY fts.rank
+                   LIMIT ${CANDIDATE_POOL}
                  ),
                  ranked AS (
                    SELECT id, session_id, m_rank,
@@ -592,8 +608,6 @@ export class SqliteSessionStore implements SessionStore {
                    SELECT id, session_id, m_rank, match_count
                    FROM ranked
                    WHERE rn = 1
-                   ORDER BY m_rank ASC
-                   LIMIT ?
                  )
                  SELECT w.id AS event_id, w.session_id, e.role,
                         (SELECT snippet(session_events_fts, 0, '[', ']', '…', 12)
@@ -606,8 +620,9 @@ export class SqliteSessionStore implements SessionStore {
                  FROM winners w
                  JOIN sessions s        ON s.id = w.session_id
                  JOIN session_events e  ON e.id = w.id
-                 ORDER BY w.m_rank ASC`;
-    innerParams.push(limit, ftsQuery);
+                 ORDER BY s.last_event_at DESC
+                 LIMIT ?`;
+    innerParams.push(ftsQuery, limit);
     return this.db.prepare(sql).all(...innerParams) as SessionSearchHit[];
   }
 

--- a/server/test/session-search-grouping.test.ts
+++ b/server/test/session-search-grouping.test.ts
@@ -92,22 +92,17 @@ describe("SqliteSessionStore.searchSessions", () => {
     for (const h of hits) expect(h.match_count).toBe(1);
   });
 
-  it("orders sessions by best FTS rank (stronger match first)", () => {
+  it("orders sessions by recency (most recently active first)", () => {
     seedSpace(env.db, "ws");
-    seedSession(env.db, { id: "strong", title: "S", space_id: "ws" });
-    seedSession(env.db, { id: "weak", title: "W", space_id: "ws" });
-    // BM25 favours higher term frequency relative to doc length. A short
-    // event that's just the query token outranks a long event where the
-    // token appears once amongst many.
-    env.store.insertEvent({ session_id: "strong", role: "user", text: "deposit" });
-    env.store.insertEvent({
-      session_id: "weak",
-      role: "user",
-      text: "lorem ipsum dolor sit amet consectetur adipiscing elit deposit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
-    });
+    seedSession(env.db, { id: "old",    title: "O", space_id: "ws", last_event_at: "2026-05-01T10:00:00Z" });
+    seedSession(env.db, { id: "newer",  title: "N", space_id: "ws", last_event_at: "2026-05-10T10:00:00Z" });
+    seedSession(env.db, { id: "newest", title: "X", space_id: "ws", last_event_at: "2026-05-20T10:00:00Z" });
+    env.store.insertEvent({ session_id: "newer",  role: "user", text: "deposit one" });
+    env.store.insertEvent({ session_id: "newest", role: "user", text: "deposit two" });
+    env.store.insertEvent({ session_id: "old",    role: "user", text: "deposit three" });
 
     const hits = env.store.searchSessions("deposit");
-    expect(hits.map(h => h.session_id)).toEqual(["strong", "weak"]);
+    expect(hits.map(h => h.session_id)).toEqual(["newest", "newer", "old"]);
   });
 
   it("scopes by space_id when given", () => {

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -16,9 +16,20 @@ interface Props {
 }
 
 const ARTEFACTS_LIMIT = 8;
-const TRANSCRIPTS_LIMIT = 8;
+// Capped at 50: a longer list isn't useful — nobody scrolls past 50
+// transcript hits, and broad prefix queries on multi-GB DBs are
+// fundamentally floor-bound by FTS5 ranking cost. Sessions surface
+// ordered by recency (server-side), so the most-likely target sits
+// near the top.
+const TRANSCRIPTS_LIMIT = 50;
 const MEMORIES_LIMIT = 8;
-const DEBOUNCE_MS = 180;
+// 350ms not 180: better-sqlite3 is synchronous, so a slow query
+// blocks the Node event loop until it completes. Short debounces
+// cause incremental keystrokes to queue up SQL behind each other,
+// and the final query (the one the user actually waits on) lands
+// at the back of a multi-second cascade. 350ms covers fast typing
+// without making the search feel laggy.
+const DEBOUNCE_MS = 350;
 
 type FilterType = "session" | "artefact" | "memory" | null;
 type SpotlightFilter = { type: FilterType; spaceId: string | null };

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -105,7 +105,10 @@ export interface TranscriptHit {
   last_event_at: string | null;
   role: string;
   snippet: string;
-  /** Total matches in this session (≥1). Surfaces "+N more" affordance. */
+  /** Matches in this session (≥1) counted within the server's
+   *  candidate pool. Exact for narrow queries; a lower bound on
+   *  hyper-broad prefix queries. Drives the "+N more" affordance,
+   *  which treats it as a hint. */
   match_count: number;
 }
 


### PR DESCRIPTION
## Summary

Cmd+K's transcript search was unusable on multi-GB session histories — typing "deposit" against a 4.8 GB / 1.3M-row DB took 15+ seconds. Three changes, all in `searchSessions` and Spotlight:

- **Defer `snippet()` to result winners.** The old CTE computed snippets across every matched row (60k+ for broad prefixes), then threw all but 8 away. The inner CTE now carries only `(id, session_id, rank)`; `snippet()` runs in a correlated subquery bound to the final survivors.
- **Cap the inner CTE at top-500 events by FTS rank.** The FTS5 planner pushes the limit down, so the work is bounded by candidate-pool size rather than total match count. Sessions whose best match ranks beyond the pool fall off — acceptable for an 8-50 row UI surface, exact for narrower queries.
- **Order by recency, limit to 50.** When scanning a list, *"the recent session I worked in"* beats *"the session with the BM25-best match"*. Within each session the surfaced event (and its snippet) is still the best-ranked representative. Transcript-hit cap raised from 8 to 50, and the client-side debounce from 180ms to 350ms so a fast-typed word doesn't fire intermediate queries that pile up behind the final one (better-sqlite3 is synchronous — slow SQL blocks the Node event loop).

Live UAT on a 4.8 GB DB (single curl, before → after):
- `de` (295k matches): 14.5s → **2.3s**
- `ba` (382k matches): 16.3s → **0.86s**
- `deposit` (909 matches): ~6s → **80ms**
- `wise` (46 matches): **8ms**
- `banana` (0 matches): ~15s → **2ms**

The 2-3s floor on ultra-broad 2-char prefixes is BM25 ranking against 300k postings — addressing it further would need a schema change (session-level aggregate FTS) and isn't worth it for this UI surface. The longer debounce makes that floor very hard to trigger in real typing.

Adds `server/scripts/bench-spotlight-search.ts` for ad-hoc timing against a real DB.

## Test plan

- [x] Existing 9 `session-search-grouping` + `sessions-search-space` tests still pass (parity contract: session_id, match_count, snippet markers, space scoping, multi-word phrase, empty / punctuation-only queries). The one rank-ordering case is updated to assert the new recency ordering.
- [x] Full server suite — 450/450 passing.
- [x] Server + web typecheck clean.
- [x] Manual: Cmd+K on a 4.8 GB userland DB. `wise`, `deposit`, `banana`, `de` all return in expected time; results land in the inspector when clicked.
- [ ] Reviewer: try a few of your own queries in Cmd+K against your largest userland to confirm it feels usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)