### PR TITLE
Session status palette — evidence-first state machine + dot redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Changed
+
+- **Clearer session status dots.** Oyster-owned sessions stay purple when active; the dot picks up an amber centre when the agent is awaiting your input. Externally observed sessions show green when active and amber when idle. Red means the session appears disconnected or ended badly; grey "dormant" means it has been quiet long enough that the urgency has decayed. A session is only marked truly "done" when a clean `/exit` (or a clean PTY shutdown) is observed.
+
 ## [0.9.7] - 2026-05-21
 
 ### Changed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -289,6 +289,7 @@
   </section>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-9-7">0.9</a>
       <a class="version-pill" href="#v-0-8-2">0.8</a>
       <a class="version-pill" href="#v-0-7-1-beta-0">0.7</a>
@@ -302,6 +303,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.7...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Changed</h3>
+<ul>
+<li><strong>Clearer session status dots.</strong> Oyster-owned sessions stay purple when active; the dot picks up an amber centre when the agent is awaiting your input. Externally observed sessions show green when active and amber when idle. Red means the session appears disconnected or ended badly; grey &quot;dormant&quot; means it has been quiet long enough that the urgency has decayed. A session is only marked truly &quot;done&quot; when a clean <code>/exit</code> (or a clean PTY shutdown) is observed.</li>
+</ul>
 <h2 id="v-0-9-7"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.6...v0.9.7" rel="noopener noreferrer"><span class="release-version">0.9.7</span></a><span class="release-date"> — 2026-05-21</span></h2>
 <h3>Changed</h3>
 <ul>

--- a/docs/superpowers/plans/2026-05-21-session-status-palette.md
+++ b/docs/superpowers/plans/2026-05-21-session-status-palette.md
@@ -1,0 +1,994 @@
+# Session Status Palette Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the time-based `done` state with evidence-based clean-exit detection, add `dormant` for 8h+ idle sessions, and split the managed-vs-unmanaged dot palette so colour reflects what we actually know.
+
+**Architecture:** Evidence-first storage with derived display state. New nullable fact columns (`exit_code`, `exit_signal`, `explicit_exit_seen`, `clean_process_exit`, `last_assistant_stop_reason`) capture what we observe; `deriveState()` becomes a pure function over those facts plus age + probe. The two clean-exit signals are kept separate so the decision rule is auditable: `done = explicit_exit_seen || clean_process_exit`, and bad exit evidence (non-zero exit code or a signal) beats either of them.
+
+**`dormant` is a display-only state, never persisted.** The DB `state` enum stays as `active | waiting | disconnected | done` (no schema CHECK change, no risky table rebuild). The wire format gains a second field, `displayState`, computed server-side as `state === 'disconnected' && now - lastEventAt > 8h ? 'dormant' : state`. The UI consumes `displayState` for the dot. This keeps the persisted state honest about what we actually know and avoids the migration footgun where widening the `state` CHECK triggers a table rebuild that silently drops every later-ALTER'd column.
+
+UI splits dot colour by managed presence (purple-themed for Oyster-owned PTYs, green-themed for externally observed JSONL sessions). Single composite glyph (amber fill + purple ring) for the only state that needs two facts at once: managed + waiting.
+
+**Tech Stack:** TypeScript (server + web), better-sqlite3, React, Vitest.
+
+---
+
+## Pre-work: confirm we're in the right worktree
+
+- [ ] **Step 0.1: Verify worktree**
+
+Run: `pwd && git branch --show-current`
+Expected: `/Users/Matthew.Slight/Dev/oyster.worktrees/session-status-investigation` on branch `session-status-investigation`.
+
+If not, see `docs/plans/roadmap.md` and re-create the worktree per the project convention (`~/Dev/oyster.worktrees/<branch>`).
+
+---
+
+## Task 1: Schema — add fact columns via additive ALTER (no CHECK change, no rebuild)
+
+Goal: persist the new facts the watcher and PTY manager will write. **`dormant` is NOT added to the persisted enum** — it's purely a display-time concept (see Task 6). This task only adds nullable fact columns via the well-trodden additive-ALTER path.
+
+> **Why no CHECK widening.** Widening the `state` CHECK requires a SQLite table rebuild (CHECK can't be ALTERed in place). The existing rebuild block in `db.ts` was written long ago when the `sessions` table had ~10 columns; since then many `ALTER TABLE sessions ADD COLUMN ...` statements have been appended below it (`cwd`, `assignment_mode`, `project_id`, terminal columns, all the cloud-sync columns). The rebuild's `INSERT INTO _sessions_new ... SELECT` projection only knows about its original column list. Widening the rebuild trigger to fire on every upgrade would silently drop every later-ALTER'd column's data. The right move is to skip the rebuild entirely.
+
+**Files:**
+- Modify: `server/src/db.ts` — CREATE TABLE (around `:255-298`) and the post-rebuild additive ALTER section.
+- Test: new `server/test/sessions-table-status-columns.test.ts` and new `server/test/sessions-migration-regression.test.ts` (the guardrail).
+
+- [ ] **Step 1.1: Write the status-columns test (failing)**
+
+```ts
+// server/test/sessions-table-status-columns.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+describe("sessions table — status-evidence columns", () => {
+  it("has exit_code, exit_signal, explicit_exit_seen, clean_process_exit, last_assistant_stop_reason", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    const db = initDb(dir);
+    const cols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{
+      name: string; notnull: number; dflt_value: unknown;
+    }>;
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.has("exit_code")).toBe(true);
+    expect(byName.has("exit_signal")).toBe(true);
+    expect(byName.has("explicit_exit_seen")).toBe(true);
+    expect(byName.has("clean_process_exit")).toBe(true);
+    expect(byName.has("last_assistant_stop_reason")).toBe(true);
+
+    // Lock in the structural shape — typos like DEAFULT or NULL slip through column-name-only checks.
+    expect(byName.get("explicit_exit_seen")).toMatchObject({ notnull: 1, dflt_value: "0" });
+    expect(byName.get("clean_process_exit")).toMatchObject({ notnull: 1, dflt_value: "0" });
+  });
+
+  it("still rejects 'dormant' as a stored state value (dormant is display-only)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    const db = initDb(dir);
+    expect(() =>
+      db.prepare(`
+        INSERT INTO sessions (id, agent, title, state)
+        VALUES ('s1', 'claude-code', 't', 'dormant')
+      `).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+});
+```
+
+Confirm the actual exported function name from `server/src/db.ts` — it may be `initDb`, `initSchema`, or similar. Adjust the import if needed.
+
+- [ ] **Step 1.2: Write the migration regression test (failing initially because columns don't exist yet)**
+
+This is the guardrail that would have caught the data-loss bug. It seeds a sessions row using the *current legacy schema shape* (CHECK with four states, columns that have been added by `ALTER` over time), runs `initDb`, and asserts that NO data is lost.
+
+```ts
+// server/test/sessions-migration-regression.test.ts
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+// Guard against the migration ever silently dropping ALTER-added columns
+// from existing-install rows. Seed a sessions row with values in every
+// column that's been added via ALTER in the project history, run initDb,
+// and assert the values survive.
+describe("sessions migration — ALTER-added column preservation", () => {
+  it("preserves cwd/assignment_mode/project_id and other ALTER-added column values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    mkdirSync(join(dir, "db"), { recursive: true });
+    const dbPath = join(dir, "db", "oyster.db");
+
+    // Hand-build a sessions table matching what an existing install looks
+    // like RIGHT BEFORE the migration runs (post-rename, pre-this-change):
+    //   - state CHECK has four values (no 'dormant')
+    //   - all the ALTER-added columns exist with their declared types
+    {
+      const raw = new Database(dbPath);
+      raw.exec(`
+        CREATE TABLE sessions (
+          id            TEXT PRIMARY KEY,
+          space_id      TEXT,
+          agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
+          title         TEXT,
+          state         TEXT NOT NULL CHECK (state IN ('active','waiting','disconnected','done')),
+          started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+          ended_at      TEXT,
+          model         TEXT,
+          last_event_at TEXT NOT NULL DEFAULT (datetime('now')),
+          last_offset   INTEGER NOT NULL DEFAULT 0
+        );
+      `);
+      // Replay every ALTER currently in db.ts that adds a column to sessions.
+      // If db.ts grows more ALTERs in future, add them here too.
+      const alters = [
+        "ALTER TABLE sessions ADD COLUMN cwd TEXT",
+        "ALTER TABLE sessions ADD COLUMN assignment_mode TEXT NOT NULL DEFAULT 'auto'",
+        "ALTER TABLE sessions ADD COLUMN project_id TEXT",
+        "ALTER TABLE sessions ADD COLUMN jsonl_path TEXT",
+        "ALTER TABLE sessions ADD COLUMN terminal_id TEXT",
+        "ALTER TABLE sessions ADD COLUMN terminal_attached_clients INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sessions ADD COLUMN sync_dirty_at TEXT",
+        "ALTER TABLE sessions ADD COLUMN cloud_synced_at TEXT",
+        "ALTER TABLE sessions ADD COLUMN cloud_owner_id TEXT",
+        "ALTER TABLE sessions ADD COLUMN jsonl_synced_at TEXT",
+        "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER",
+        "ALTER TABLE sessions ADD COLUMN jsonl_chunk_count INTEGER",
+        "ALTER TABLE sessions ADD COLUMN bytes_generation INTEGER",
+      ];
+      for (const sql of alters) {
+        try { raw.exec(sql); } catch { /* column already exists or table didn't need it */ }
+      }
+      raw.prepare(`
+        INSERT INTO sessions (
+          id, agent, title, state, last_event_at,
+          cwd, assignment_mode, project_id, jsonl_path, terminal_id
+        ) VALUES (
+          's1', 'claude-code', 'test', 'active', datetime('now'),
+          '/some/cwd', 'manual', 'proj-abc', '/tmp/abc.jsonl', 'term-xyz'
+        )
+      `).run();
+      raw.close();
+    }
+
+    // Run real init.
+    const db = initDb(dir);
+    const row = db.prepare("SELECT * FROM sessions WHERE id = 's1'").get() as Record<string, unknown>;
+
+    expect(row).toBeDefined();
+    expect(row.cwd).toBe("/some/cwd");
+    expect(row.assignment_mode).toBe("manual");
+    expect(row.project_id).toBe("proj-abc");
+    expect(row.jsonl_path).toBe("/tmp/abc.jsonl");
+    expect(row.terminal_id).toBe("term-xyz");
+  });
+});
+```
+
+(The point of this test isn't to pass on day one — once the new fact columns are added below, it will pass because nothing rebuilds the table. Its real job is to fail loudly the next time someone tries to widen a CHECK or rebuild the sessions table without preserving every ALTER-added column.)
+
+- [ ] **Step 1.3: Run both tests — verify they fail**
+
+Run: `cd server && npx vitest run test/sessions-table-status-columns.test.ts test/sessions-migration-regression.test.ts`
+Expected: status-columns test FAILS (columns missing). Migration regression test may pass or fail depending on whether the current db.ts already preserves these columns — record the result. Either way it becomes a permanent guardrail.
+
+- [ ] **Step 1.4: Add the 5 columns to the CREATE TABLE in `server/src/db.ts` (around line 260)**
+
+**Do NOT change the `state` CHECK.** It stays as:
+```sql
+state         TEXT NOT NULL CHECK (state IN ('active','waiting','disconnected','done')),
+```
+
+Add 5 columns inside the CREATE TABLE block, after `last_offset INTEGER NOT NULL DEFAULT 0`:
+```sql
+exit_code                  INTEGER,
+exit_signal                TEXT,
+explicit_exit_seen         INTEGER NOT NULL DEFAULT 0,
+clean_process_exit         INTEGER NOT NULL DEFAULT 0,
+last_assistant_stop_reason TEXT,
+```
+
+- [ ] **Step 1.5: Add additive ALTERs (idempotent) for existing installs**
+
+Below the existing `try { db.exec("ALTER TABLE sessions ADD COLUMN last_offset ..."); } catch {}` block (around `:312`), add five more in the same try/catch style:
+```ts
+try { db.exec("ALTER TABLE sessions ADD COLUMN exit_code INTEGER"); } catch {}
+try { db.exec("ALTER TABLE sessions ADD COLUMN exit_signal TEXT"); } catch {}
+try { db.exec("ALTER TABLE sessions ADD COLUMN explicit_exit_seen INTEGER NOT NULL DEFAULT 0"); } catch {}
+try { db.exec("ALTER TABLE sessions ADD COLUMN clean_process_exit INTEGER NOT NULL DEFAULT 0"); } catch {}
+try { db.exec("ALTER TABLE sessions ADD COLUMN last_assistant_stop_reason TEXT"); } catch {}
+```
+
+**Do NOT touch the existing `needsMigrate` block or `_sessions_new` rebuild.** Leave it exactly as-is.
+
+- [ ] **Step 1.6: Run both tests — verify they pass**
+
+Run: `cd server && npx vitest run test/sessions-table-status-columns.test.ts test/sessions-migration-regression.test.ts`
+Expected: PASS for both.
+
+Also run the full suite to confirm no regressions:
+Run: `cd server && npx vitest run`
+Expected: all pre-existing tests still pass.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add server/src/db.ts server/test/sessions-table-status-columns.test.ts server/test/sessions-migration-regression.test.ts
+git commit -m "feat(sessions): add fact columns (exit_code, exit_signal, explicit_exit_seen, clean_process_exit, last_assistant_stop_reason) via additive ALTER + migration regression guard"
+```
+
+---
+
+## Task 2: SessionStore — methods to write the new facts
+
+Goal: typed write paths for the columns added in Task 1, so the watcher and PTY manager don't poke the DB directly. Keep the two clean-exit signals on separate methods so each callsite states exactly which evidence it has.
+
+**Files:**
+- Modify: `server/src/session-store.ts` (interface around `:159`, prepared statements around `:204` and `:299`, implementation around `:395`).
+- Test: `server/test/session-store-exit-info.test.ts` (new).
+
+- [ ] **Step 2.1: Write failing test**
+
+```ts
+// server/test/session-store-exit-info.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { initSchema } from "../src/db.js";
+import { SessionStore } from "../src/session-store.js";
+
+describe("SessionStore — exit info + last_assistant_stop_reason", () => {
+  let db: Database.Database;
+  let store: SessionStore;
+  beforeEach(() => {
+    db = new Database(":memory:");
+    initSchema(db);
+    store = new SessionStore(db);
+    store.insertSession({
+      id: "s1", space_id: null, project_id: null, cwd: null, jsonl_path: null,
+      agent: "claude-code", title: "t", state: "active",
+      started_at: null, model: null, last_event_at: null, assignment_mode: "auto",
+    } as any);
+  });
+
+  it("recordExit writes exit_code, exit_signal, clean_process_exit", () => {
+    store.recordExit("s1", { exitCode: 0, exitSignal: null, cleanProcessExit: true });
+    const row = db.prepare("SELECT exit_code, exit_signal, clean_process_exit FROM sessions WHERE id=?").get("s1");
+    expect(row).toEqual({ exit_code: 0, exit_signal: null, clean_process_exit: 1 });
+  });
+
+  it("recordExit on bad exit does not set clean_process_exit", () => {
+    store.recordExit("s1", { exitCode: 137, exitSignal: "SIGKILL", cleanProcessExit: false });
+    const row = db.prepare("SELECT exit_code, exit_signal, clean_process_exit FROM sessions WHERE id=?").get("s1");
+    expect(row).toEqual({ exit_code: 137, exit_signal: "SIGKILL", clean_process_exit: 0 });
+  });
+
+  it("setLastAssistantStopReason updates only that column", () => {
+    store.setLastAssistantStopReason("s1", "end_turn");
+    const row = db.prepare("SELECT last_assistant_stop_reason FROM sessions WHERE id=?").get("s1");
+    expect(row).toEqual({ last_assistant_stop_reason: "end_turn" });
+  });
+
+  it("markExplicitExitSeen flips the flag without touching process-exit fields", () => {
+    store.markExplicitExitSeen("s1");
+    const row = db.prepare("SELECT explicit_exit_seen, exit_code, exit_signal, clean_process_exit FROM sessions WHERE id=?").get("s1");
+    expect(row).toEqual({ explicit_exit_seen: 1, exit_code: null, exit_signal: null, clean_process_exit: 0 });
+  });
+});
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/session-store-exit-info.test.ts`
+Expected: FAIL — `recordExit`, `setLastAssistantStopReason`, `markExplicitExitSeen` undefined.
+
+- [ ] **Step 2.3: Extend the SessionStore interface**
+
+In `server/src/session-store.ts` near `:159`, add three method signatures:
+```ts
+recordExit(id: string, info: { exitCode: number | null; exitSignal: string | null; cleanProcessExit: boolean }): void;
+setLastAssistantStopReason(id: string, reason: string | null): void;
+markExplicitExitSeen(id: string): void;
+```
+
+Also extend the `SessionRow` / `Session` types (search file for `SessionRow`) with the five new optional fields:
+```ts
+exit_code: number | null;
+exit_signal: string | null;
+explicit_exit_seen: number; // 0 | 1, sqlite-style
+clean_process_exit: number; // 0 | 1, sqlite-style
+last_assistant_stop_reason: string | null;
+```
+
+- [ ] **Step 2.4: Add prepared statements and implementations**
+
+In the constructor's `this.stmts = { ... }` (around `:204` and `:299`):
+```ts
+recordExit: db.prepare(`
+  UPDATE sessions
+  SET exit_code = @exit_code,
+      exit_signal = @exit_signal,
+      clean_process_exit = @clean_process_exit
+  WHERE id = @id
+`),
+setLastAssistantStopReason: db.prepare(`
+  UPDATE sessions SET last_assistant_stop_reason = ? WHERE id = ?
+`),
+markExplicitExitSeen: db.prepare(`
+  UPDATE sessions SET explicit_exit_seen = 1 WHERE id = ?
+`),
+```
+
+And in the methods section near `:395`:
+```ts
+recordExit(id: string, info: { exitCode: number | null; exitSignal: string | null; cleanProcessExit: boolean }): void {
+  this.stmts.recordExit.run({
+    id,
+    exit_code: info.exitCode,
+    exit_signal: info.exitSignal,
+    clean_process_exit: info.cleanProcessExit ? 1 : 0,
+  });
+}
+setLastAssistantStopReason(id: string, reason: string | null): void {
+  this.stmts.setLastAssistantStopReason.run(reason, id);
+}
+markExplicitExitSeen(id: string): void {
+  this.stmts.markExplicitExitSeen.run(id);
+}
+```
+
+- [ ] **Step 2.5: Run test to verify it passes**
+
+Run: `cd server && npx vitest run test/session-store-exit-info.test.ts`
+Expected: PASS.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add server/src/session-store.ts server/test/session-store-exit-info.test.ts
+git commit -m "feat(session-store): add recordExit/setLastAssistantStopReason/markExplicitExitSeen"
+```
+
+---
+
+## Task 3: PTY exit handler — capture exit code/signal as evidence
+
+Goal: when a managed PTY ends, record the exit code/signal as facts. Clean process exit (`exit=0` and no signal) sets `clean_process_exit = 1`; that's an independent signal from `explicit_exit_seen` (which only the watcher sets when it sees a `/exit` event in the JSONL). The handler stops hard-coding `"disconnected"`.
+
+**Files:**
+- Modify: `server/src/claude-pty-manager.ts:_handleExit` (around `:328-360`) — and the upstream `pty.onExit` wiring so we receive the signal too. Search for `_handleExit(entry, exitCode` and the `pty.onExit(` call that invokes it.
+- Test: `server/test/claude-pty-manager.test.ts` (extend).
+
+- [ ] **Step 3.1: Write failing test**
+
+Open `server/test/claude-pty-manager.test.ts` and add:
+```ts
+it("records exit code/signal and marks clean_process_exit on exit=0", async () => {
+  const { manager, store, sessionId } = setupManagedSession(); // existing test helper pattern
+  manager._handleExit(entryForSession(sessionId), { exitCode: 0, signal: null });
+  const row = store.getById(sessionId)!;
+  expect(row.exit_code).toBe(0);
+  expect(row.exit_signal).toBeNull();
+  expect(row.clean_process_exit).toBe(1);
+});
+
+it("records non-zero exit without setting clean_process_exit", async () => {
+  const { manager, store, sessionId } = setupManagedSession();
+  manager._handleExit(entryForSession(sessionId), { exitCode: 137, signal: "SIGKILL" });
+  const row = store.getById(sessionId)!;
+  expect(row.exit_code).toBe(137);
+  expect(row.exit_signal).toBe("SIGKILL");
+  expect(row.clean_process_exit).toBe(0);
+});
+```
+
+(Use existing fixture helpers in the test file — match the existing style.)
+
+- [ ] **Step 3.2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/claude-pty-manager.test.ts`
+Expected: FAIL — `_handleExit` signature doesn't accept `{ exitCode, signal }`; `exit_code` column not populated.
+
+- [ ] **Step 3.3: Update `_handleExit` signature and body**
+
+In `server/src/claude-pty-manager.ts:_handleExit`:
+
+Change the signature from:
+```ts
+private _handleExit(entry: ClaudePtyEntry, exitCode: number): void {
+```
+to:
+```ts
+private _handleExit(entry: ClaudePtyEntry, exit: { exitCode: number; signal: string | null }): void {
+```
+
+Update the body so:
+1. The existing `closeNote` keeps using `exit.exitCode` for the visible message.
+2. Replace the hard-coded `updateSessionState(..., "disconnected", ...)` call with:
+   ```ts
+   const cleanProcessExit = exit.exitCode === 0 && !exit.signal;
+   this.sessionStore.recordExit(exitedSessionId, {
+     exitCode: exit.exitCode,
+     exitSignal: exit.signal ?? null,
+     cleanProcessExit,
+   });
+   // Derived state: the next heartbeat sweep will pick the right label
+   // from the new facts, but write an immediate value so SSE clients
+   // don't flicker through "active".
+   this.sessionStore.updateSessionState(
+     exitedSessionId,
+     cleanProcessExit ? "done" : "disconnected",
+     new Date().toISOString(),
+   );
+   ```
+
+- [ ] **Step 3.4: Update the `pty.onExit` callsite**
+
+Search for the place that wires up `pty.onExit(...)` in this file. node-pty's `onExit` callback receives `{ exitCode, signal }`. Update the callback to pass that object straight through to `_handleExit`. Example:
+```ts
+pty.onExit(({ exitCode, signal }) => {
+  this._handleExit(entry, { exitCode, signal: signal ? String(signal) : null });
+});
+```
+
+- [ ] **Step 3.5: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run test/claude-pty-manager.test.ts test/claude-pty-manager-link.test.ts`
+Expected: PASS for the new tests; existing link/exit tests still pass.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add server/src/claude-pty-manager.ts server/test/claude-pty-manager.test.ts
+git commit -m "feat(pty): record exit_code/exit_signal and clean_process_exit on PTY exit"
+```
+
+---
+
+## Task 4: Watcher — detect `/exit` event and track `last_assistant_stop_reason`
+
+Goal: for unmanaged sessions, scan incoming events for the slash-command that closes the session (sets `explicit_exit_seen = 1`), and persist the `stop_reason` of the most recent assistant message so the UI can distinguish "agent is thinking" from "agent is awaiting input".
+
+**Files:**
+- Modify: `server/src/watchers/claude-code.ts` event-ingest path (search for where assistant events get written and where slash-command-style user events are filtered, around the `userMessageTitleCandidate` / `isClaudeProtocolArtifact` helpers).
+- Test: `server/test/claude-code-once-new-jsonl.test.ts` (extend) or new `server/test/claude-code-watcher-evidence.test.ts`.
+
+> **Wire format note:** Claude Code templates slash commands into a `<command-name>/exit</command-name>` wrapper inside the user message `content` before persisting — the wrapper IS the invocation event, not a follow-up render artefact. Match the wrapper; don't expect a raw `/exit`. (Verified empirically against `~/.claude/projects/*/*.jsonl`: 0 raw `/exit` user events vs 73 wrapped ones in the local corpus.)
+
+- [ ] **Step 4.1: Write failing test**
+
+```ts
+// server/test/claude-code-watcher-evidence.test.ts
+import { describe, it, expect } from "vitest";
+// Set up the watcher with a temp dir and a hand-rolled JSONL file.
+// See claude-code-once-new-jsonl.test.ts for the existing fixture style — match it.
+
+const EXIT_WRAPPED =
+  "<command-name>/exit</command-name>\n            <command-message>exit</command-message>\n            <command-args></command-args>";
+
+describe("claude-code watcher — evidence capture", () => {
+  it("sets explicit_exit_seen when the JSONL tail has a wrapped /exit user event", async () => {
+    const { sessionId, store } = await runWatcherOnce([
+      { type: "user", message: { content: "first" } },
+      { type: "assistant", message: { stop_reason: "end_turn" } },
+      { type: "user", message: { role: "user", content: EXIT_WRAPPED } },
+    ]);
+    expect(store.getById(sessionId)!.explicit_exit_seen).toBe(1);
+  });
+
+  it("stores last assistant stop_reason in last_assistant_stop_reason", async () => {
+    const { sessionId, store } = await runWatcherOnce([
+      { type: "user", message: { content: "do it" } },
+      { type: "assistant", message: { stop_reason: "tool_use" } },
+    ]);
+    expect(store.getById(sessionId)!.last_assistant_stop_reason).toBe("tool_use");
+  });
+
+  it("end_turn updates last_assistant_stop_reason from a prior tool_use", async () => {
+    const { sessionId, store } = await runWatcherOnce([
+      { type: "assistant", message: { stop_reason: "tool_use" } },
+      { type: "tool_result", message: {} },
+      { type: "assistant", message: { stop_reason: "end_turn" } },
+    ]);
+    expect(store.getById(sessionId)!.last_assistant_stop_reason).toBe("end_turn");
+  });
+});
+```
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/claude-code-watcher-evidence.test.ts`
+Expected: FAIL — neither `explicit_exit_seen` nor `last_assistant_stop_reason` are written by the watcher today.
+
+- [ ] **Step 4.3: Hook the event handler to update `last_assistant_stop_reason`**
+
+Locate the function in `claude-code.ts` that processes each parsed event and writes session_events / updates session state (search for `updateSessionState(tracker.sessionId, "active", ts)` near `:854`). At the point where an event is committed, add:
+
+```ts
+if (ev.type === "assistant") {
+  const stopReason = ev?.message?.stop_reason;
+  if (typeof stopReason === "string") {
+    this.deps.sessionStore.setLastAssistantStopReason(tracker.sessionId, stopReason);
+  }
+}
+```
+
+- [ ] **Step 4.4: Hook the event handler to detect `/exit`**
+
+In the same loop, when processing a `type: "user"` event:
+```ts
+if (ev.type === "user") {
+  const content = ev?.message?.content;
+  if (typeof content === "string") {
+    // Claude Code templates slash commands into a wrapper *before* writing to
+    // JSONL — the wrapper IS the invocation event, not a follow-up render
+    // artefact. Match the wrapper; don't expect a raw `/exit`.
+    if (content.trimStart().startsWith("<command-name>/exit</command-name>")) {
+      this.deps.sessionStore.markExplicitExitSeen(tracker.sessionId);
+    }
+  }
+}
+```
+
+Place this BEFORE the existing `isClaudeProtocolArtifact` filter so `/exit` is recognised even though it's a protocol artifact for title purposes.
+
+- [ ] **Step 4.5: Run tests to verify they pass**
+
+Run: `cd server && npx vitest run test/claude-code-watcher-evidence.test.ts`
+Expected: PASS.
+
+Also re-run: `cd server && npx vitest run test/claude-code-once-new-jsonl.test.ts`
+Expected: still passes (no regression).
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add server/src/watchers/claude-code.ts server/test/claude-code-watcher-evidence.test.ts
+git commit -m "feat(watcher): set explicit_exit_seen on /exit and persist last_assistant_stop_reason"
+```
+
+---
+
+## Task 5: Rewrite `deriveState()` as a pure evidence-first function
+
+Goal: collapse the rules from the proposed table into one pure function. Replace the existing time-only `deriveState(ageMs, signal)` with a richer input. The heartbeat sweep calls it; tests live alongside it.
+
+**Files:**
+- Modify: `server/src/watchers/claude-code.ts:921` (`deriveState`) and the heartbeat sweep around `:877` (`runHeartbeatSweep`) which currently calls it.
+- Test: new `server/test/derive-state.test.ts`.
+
+- [ ] **Step 5.1: Write failing test**
+
+```ts
+// server/test/derive-state.test.ts
+import { describe, it, expect } from "vitest";
+import { deriveState } from "../src/watchers/claude-code.js";
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+const base = {
+  terminalId: null as string | null,
+  ageMs: 0,
+  probeSignal: "unknown" as const,
+  exitCode: null as number | null,
+  exitSignal: null as string | null,
+  explicitExitSeen: false,
+  cleanProcessExit: false,
+  lastAssistantStopReason: null as string | null,
+};
+
+describe("deriveState — evidence-first", () => {
+  it("managed + recent activity → active", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000 })).toBe("active");
+  });
+
+  it("managed + last stop_reason end_turn → waiting", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000, lastAssistantStopReason: "end_turn" })).toBe("waiting");
+  });
+
+  it("managed + last stop_reason tool_use → active (still thinking)", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 90_000, lastAssistantStopReason: "tool_use" })).toBe("active");
+  });
+
+  it("explicit /exit observed → done regardless of age", () => {
+    expect(deriveState({ ...base, explicitExitSeen: true, ageMs: 10 * HOUR })).toBe("done");
+  });
+
+  it("clean PTY exit observed → done regardless of age", () => {
+    expect(deriveState({ ...base, cleanProcessExit: true, ageMs: 10 * HOUR })).toBe("done");
+  });
+
+  // Precedence: bad exit evidence beats clean exit evidence. A session that
+  // ran /exit but then got SIGKILLed mid-shutdown should read as disconnected.
+  it("bad exit beats explicit /exit", () => {
+    expect(deriveState({ ...base, explicitExitSeen: true, exitSignal: "SIGKILL" })).toBe("disconnected");
+  });
+
+  it("bad exit beats clean process exit", () => {
+    expect(deriveState({ ...base, cleanProcessExit: true, exitCode: 1 })).toBe("disconnected");
+  });
+
+  it("PTY exit with non-zero code → disconnected", () => {
+    expect(deriveState({ ...base, exitCode: 1, ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  it("PTY exit with signal → disconnected", () => {
+    expect(deriveState({ ...base, exitSignal: "SIGKILL", ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  it("unmanaged, <60s → active", () => {
+    expect(deriveState({ ...base, ageMs: 30_000 })).toBe("active");
+  });
+
+  it("unmanaged, 60s–30min, probe alive → waiting", () => {
+    expect(deriveState({ ...base, ageMs: 5 * MIN, probeSignal: "alive" })).toBe("waiting");
+  });
+
+  it("unmanaged, 60s–30min, probe absent → disconnected", () => {
+    expect(deriveState({ ...base, ageMs: 5 * MIN, probeSignal: "absent" })).toBe("disconnected");
+  });
+
+  it("unmanaged, 30min–8h → disconnected", () => {
+    expect(deriveState({ ...base, ageMs: 4 * HOUR })).toBe("disconnected");
+  });
+
+  // 8h+ idle still returns 'disconnected' from deriveState; 'dormant' is
+  // computed at the presentation layer (see Task 6) and never persisted.
+  it("unmanaged, >8h, no exit evidence → disconnected (dormant happens at display time)", () => {
+    expect(deriveState({ ...base, ageMs: 12 * HOUR })).toBe("disconnected");
+  });
+});
+```
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/derive-state.test.ts`
+Expected: FAIL — current `deriveState` signature is `(ageMs, signal)` and lacks the new branches.
+
+- [ ] **Step 5.3: Rewrite `deriveState` and update callers**
+
+Replace the existing `deriveState` in `server/src/watchers/claude-code.ts:921`:
+
+```ts
+export interface DeriveStateInput {
+  terminalId: string | null;
+  ageMs: number;
+  probeSignal: ProbeSignal;
+  exitCode: number | null;
+  exitSignal: string | null;
+  explicitExitSeen: boolean;
+  cleanProcessExit: boolean;
+  lastAssistantStopReason: string | null;
+}
+
+const ACTIVE_WINDOW_MS = 60_000;
+const WAITING_WINDOW_MS = 30 * 60 * 1000;
+const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+
+export function deriveState(input: DeriveStateInput): SessionState {
+  // Precedence: bad exit evidence beats any "clean" claim. A session that
+  // typed /exit and then got SIGKILLed mid-shutdown should read disconnected,
+  // not done.
+  if (input.exitSignal || (input.exitCode != null && input.exitCode !== 0)) {
+    return "disconnected";
+  }
+  if (input.explicitExitSeen || input.cleanProcessExit) return "done";
+  if (input.terminalId) {
+    return input.lastAssistantStopReason === "end_turn" ? "waiting" : "active";
+  }
+  if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
+  if (input.ageMs < WAITING_WINDOW_MS) {
+    return input.probeSignal === "absent" ? "disconnected" : "waiting";
+  }
+  // 8h+ idle is still 'disconnected' in the persisted enum. The presentation
+  // layer (sessions API) maps disconnected + age > 8h into 'dormant' for the
+  // wire-format displayState field. See Task 6.
+  return "disconnected";
+}
+```
+
+The old `DONE_THRESHOLD_MS = 24 * 60 * 60 * 1000` constant goes away. Delete it. The `DORMANT_THRESHOLD_MS` constant is no longer needed inside `deriveState` either (it moves to the presentation layer in Task 6) — but if you keep the time-bucket constants near `deriveState` for documentation, leave it as an export.
+
+- [ ] **Step 5.4: Update `runHeartbeatSweep` to pass the new shape**
+
+In `runHeartbeatSweep` around `:877`, replace:
+```ts
+const next = deriveState(ageMs, signal);
+```
+with:
+```ts
+const next = deriveState({
+  terminalId: session.terminal_id ?? null,
+  ageMs,
+  probeSignal: signal,
+  exitCode: session.exit_code ?? null,
+  exitSignal: session.exit_signal ?? null,
+  explicitExitSeen: !!session.explicit_exit_seen,
+  cleanProcessExit: !!session.clean_process_exit,
+  lastAssistantStopReason: session.last_assistant_stop_reason ?? null,
+});
+```
+
+- [ ] **Step 5.5: Run tests**
+
+Run: `cd server && npx vitest run test/derive-state.test.ts`
+Expected: PASS.
+
+Run the broader suite to catch any caller breakage:
+Run: `cd server && npx vitest run`
+Expected: all green.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add server/src/watchers/claude-code.ts server/test/derive-state.test.ts
+git commit -m "feat(watcher): evidence-first deriveState with dormant + done-on-evidence"
+```
+
+---
+
+## Task 6: Wire format — add `displayState` field with server-side derivation
+
+Goal: expose a second state field on `Session` that the UI can consume for the dot. The DB-backed `state` stays as the 4-state enum (and matches what's persisted). `displayState` is computed server-side from `state + last_event_at` and adds the `'dormant'` value.
+
+**Why two fields:** keeps the persisted state honest about what we know, and keeps the UI dumb (no client-side age math). Either field can be inspected when debugging.
+
+**Files:**
+- Modify: `shared/types.ts` — add `displayState` to the `Session` interface; introduce a `DisplayState` union including `'dormant'`.
+- Modify: the server-side place where `SessionRow` → `Session` (wire) conversion happens. Most likely an exported function in `server/src/session-store.ts` (search for `rowToSession`, `toWire`, or similar). If conversion is inline in route handlers, add a centralised converter. Routes touched: list (`/api/sessions`), single (`/api/sessions/:id`), and SSE session-changed events.
+- Test: new `server/test/display-state.test.ts` covering the derivation rule.
+
+- [ ] **Step 6.1: Write failing test**
+
+```ts
+// server/test/display-state.test.ts
+import { describe, it, expect } from "vitest";
+import { computeDisplayState } from "../src/session-display-state.js";
+
+const HOUR = 60 * 60 * 1000;
+
+describe("computeDisplayState", () => {
+  const now = new Date("2026-05-21T12:00:00Z").getTime();
+
+  it("active stays active", () => {
+    expect(computeDisplayState("active", new Date(now - 30_000).toISOString(), now)).toBe("active");
+  });
+
+  it("disconnected within 8h stays disconnected", () => {
+    expect(computeDisplayState("disconnected", new Date(now - 4 * HOUR).toISOString(), now)).toBe("disconnected");
+  });
+
+  it("disconnected past 8h becomes dormant", () => {
+    expect(computeDisplayState("disconnected", new Date(now - 9 * HOUR).toISOString(), now)).toBe("dormant");
+  });
+
+  it("done past 8h stays done (not dormant — dormant only widens disconnected)", () => {
+    expect(computeDisplayState("done", new Date(now - 100 * HOUR).toISOString(), now)).toBe("done");
+  });
+
+  it("waiting past 8h stays waiting (heartbeat would have flipped it to disconnected first if process is gone)", () => {
+    expect(computeDisplayState("waiting", new Date(now - 9 * HOUR).toISOString(), now)).toBe("waiting");
+  });
+});
+```
+
+- [ ] **Step 6.2: Run test to verify it fails**
+
+Run: `cd server && npx vitest run test/display-state.test.ts`
+Expected: FAIL — `computeDisplayState` and the module don't exist yet.
+
+- [ ] **Step 6.3: Add the `DisplayState` union and `Session` field in `shared/types.ts`**
+
+In `shared/types.ts`:
+```ts
+export type SessionState = "active" | "waiting" | "disconnected" | "done";
+export type DisplayState = SessionState | "dormant";
+```
+
+Add `displayState: DisplayState;` to the `Session` interface (the wire-format type, not `SessionRow`).
+
+Keep `server/src/session-store.ts:11` `SessionState` aligned with `shared/types.ts`. **Do NOT add `'dormant'` to the persisted/DB union.**
+
+- [ ] **Step 6.4: Create `server/src/session-display-state.ts`**
+
+```ts
+// server/src/session-display-state.ts
+import type { SessionState, DisplayState } from "@oyster/shared/types.js"; // use whatever the project's import path for shared types is
+
+const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * Maps the persisted state to the wire-format displayState. The only
+ * difference is that 'disconnected' rows older than 8h are presented as
+ * 'dormant' to dim the urgency. Other states pass through unchanged.
+ */
+export function computeDisplayState(
+  state: SessionState,
+  lastEventAt: string,
+  now: number = Date.now(),
+): DisplayState {
+  if (state !== "disconnected") return state;
+  const ts = Date.parse(lastEventAt);
+  if (!Number.isFinite(ts)) return "disconnected";
+  return now - ts > DORMANT_THRESHOLD_MS ? "dormant" : "disconnected";
+}
+```
+
+Adjust the shared-types import path to match the project's actual layout (e.g. `../../shared/types.js`).
+
+- [ ] **Step 6.5: Apply `displayState` in the row→wire conversion**
+
+Find the function that builds a wire-format `Session` from a `SessionRow`. Common spots:
+- `server/src/session-store.ts` — if there's a `rowToSession` helper, use it.
+- Route handlers in `server/src/index.ts` or `server/src/routes/*.ts` — if they map rows inline, factor out a helper or inline the `computeDisplayState` call.
+- SSE broadcast paths — wherever a `session-changed` payload gets serialised.
+
+Add `displayState: computeDisplayState(row.state, row.last_event_at)` to the wire object. Make sure every route that returns Session objects gets it (list, get, search, SSE).
+
+- [ ] **Step 6.6: Run the new test + full suite**
+
+Run: `cd server && npx vitest run test/display-state.test.ts`
+Expected: PASS.
+
+Run: `cd server && npx vitest run`
+Expected: all pre-existing tests still pass.
+
+Run: `cd server && npx tsc --noEmit && cd ../web && npx tsc --noEmit`
+Expected: type-clean. The web side will get errors only after Task 7 starts consuming `displayState` — pure type errors here mean the union was wired wrong.
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add shared/types.ts server/src/session-display-state.ts server/test/display-state.test.ts server/src/session-store.ts server/src/index.ts
+git commit -m "feat(api): expose displayState (state + 'dormant') derived from state + last_event_at"
+```
+(Adjust the file list to match what you actually touched in 6.5.)
+
+---
+
+## Task 7: Web UI — dot palette per session type + dormant state
+
+Goal: match the agreed palette.
+
+| Session type   | State             | Dot                             |
+| -------------- | ----------------- | ------------------------------- |
+| Oyster-managed | active            | solid purple                    |
+| Oyster-managed | waiting           | amber fill with purple ring     |
+| Unmanaged      | active            | solid green                     |
+| Unmanaged      | waiting           | solid amber                     |
+| Either         | disconnected      | solid red                       |
+| Either         | done              | solid grey                      |
+| Either         | dormant           | solid grey                      |
+
+**Files:**
+- Modify: `web/src/components/Home/utils.tsx:54` (`stateColor`).
+- Modify: `web/src/components/Home/SessionRow.tsx:42-44` (the `statusDotClass` selection).
+- Modify: `web/src/components/Home/index.tsx:311-339` (chip counts).
+- Modify: the stylesheet defining `.rd--*` classes (search `rd--running` to find the file). Add `.rd--managed-waiting`.
+
+- [ ] **Step 7.1: Update `stateColor` to accept `DisplayState`**
+
+In `web/src/components/Home/utils.tsx:54`, extend the function (importing `DisplayState` from shared types):
+```ts
+export function stateColor(state: DisplayState): "green" | "amber" | "red" | "dim" {
+  switch (state) {
+    case "active": return "green";
+    case "waiting": return "amber";
+    case "disconnected": return "red";
+    case "done":
+    case "dormant":
+      return "dim";
+  }
+}
+```
+
+(`dormant` shares the dim/grey colour with `done`.)
+
+- [ ] **Step 7.2: Update `SessionRow` to drive the dot from `displayState`**
+
+In `web/src/components/Home/SessionRow.tsx:42-44`, replace:
+```ts
+const statusDotClass = livePresence
+  ? (livePresence.state === "attached" ? "rd--attached" : "rd--running")
+  : session.state;
+```
+with:
+```ts
+const statusDotClass = livePresence
+  ? (session.displayState === "waiting"
+      ? "rd--managed-waiting"
+      : (livePresence.state === "attached" ? "rd--attached" : "rd--running"))
+  : session.displayState;
+```
+
+This keeps the existing purple-when-managed behaviour, except when `displayState === "waiting"` we use the new composite class. Falling back to `displayState` (which can be `dormant`) gives us the dimmed dot for stale rows automatically.
+
+- [ ] **Step 7.3: Add `.rd--managed-waiting` styles**
+
+Find the stylesheet that defines `.rd--running` (likely `web/src/components/Home/SessionRow.module.css` or a global CSS file — `grep -r "rd--running" web/src`). Add a sibling rule:
+```css
+.rd--managed-waiting {
+  /* amber fill, purple ring */
+  background: var(--rd-waiting-fill, #f59e0b);
+  box-shadow: 0 0 0 2px var(--rd-managed-ring, #a78bfa);
+}
+```
+
+Use the same CSS variables the existing dots use — `grep` for the existing fill/ring tokens to match the project's design tokens.
+
+- [ ] **Step 7.4: Add `dormant` to chip counts (counting `displayState`, not `state`)**
+
+In `web/src/components/Home/index.tsx:311-317`, update the `counts` initialisation:
+```ts
+const counts = { live: 0, active: 0, waiting: 0, disconnected: 0, done: 0, dormant: 0, all: 0 };
+```
+
+Change the iteration to bucket by `s.displayState` (not `s.state`). Remove the `counts.done += counts.disconnected` folding line — `disconnected` is now a first-class state we want to surface.
+
+If the existing UI renders a "done" chip, render it as `done + dormant` (since both are grey and "nothing to do"). Decide based on the existing chip layout — most likely a single grey chip labelled "done" that totals both. Leave the underlying counts separate so we can split later.
+
+- [ ] **Step 7.5: Visual smoke test**
+
+Run the dev server (`npm run dev`), open `http://localhost:7337`, and confirm:
+- A live Oyster-managed session shows a solid purple dot.
+- A live Oyster-managed session whose last event was `end_turn` shows the amber-fill + purple-ring composite dot.
+- An unmanaged session with recent JSONL activity shows a solid green dot.
+- An old session (>8h idle, no clean exit) shows a solid grey dot.
+- A session that exited via `/exit` shows a solid grey dot.
+- A session whose PTY exited non-zero shows a solid red dot.
+
+If you can't surface all six states naturally (some need time to ripen), temporarily UPDATE rows in `~/Oyster/db/oyster.db` to force-set states and reload. Revert manual edits afterwards.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add web/src
+git commit -m "feat(web): managed vs unmanaged dot palette + dormant state"
+```
+
+---
+
+## Task 8: Changelog
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased section).
+
+- [ ] **Step 8.1: Add Changelog entry**
+
+Under `## [Unreleased]` → `### Changed`, add:
+```markdown
+- **Clearer session status dots.** Oyster-owned sessions stay purple when active; the dot picks up an amber centre when the agent is awaiting your input. Externally observed sessions show green when active and amber when idle. Red means the session appears disconnected or ended badly; grey "dormant" means it has been quiet long enough that the urgency has decayed. A session is only marked truly "done" when a clean `/exit` (or a clean PTY shutdown) is observed.
+```
+
+Refresh the docs page:
+Run: `npm run build:changelog`
+Expected: regenerates `docs/changelog.html` with the new entry.
+
+- [ ] **Step 8.2: Commit**
+
+```bash
+git add CHANGELOG.md docs/changelog.html
+git commit -m "docs(changelog): session status palette + dormant state"
+```
+
+---
+
+## Verification gate (before merging)
+
+- [ ] `cd server && npx vitest run` — all green.
+- [ ] `cd web && npx tsc --noEmit` — no type errors.
+- [ ] `npm run build` — completes cleanly.
+- [ ] Manual visual check in the dev server confirms all six dot states.
+- [ ] CHANGELOG.md Unreleased entry present; `docs/changelog.html` regenerated.
+
+---
+
+## What we intentionally did NOT do
+
+- **No PTY-tee tool-permission prompt detection.** `end_turn` is the only "waiting on user" signal for v1. Tool-permission dialogs (Allow Bash? y/n) will still show as `active` while the agent is technically blocked. Acceptable for v1; revisit if it becomes confusing.
+- **No backfill of `exit_code` for historical sessions.** Old rows keep `NULL`; `deriveState` falls through to the time-based path for them, which is the same behaviour they had before.
+- **No new chip layout.** `dormant` counts toward the existing "done" chip for now (both grey). A separate dormant chip is a UX call to make later, not part of this change.
+- **No cross-device fixes.** Cross-device session metadata still depends on whatever the origin device's watcher wrote — unchanged here.

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -17,6 +17,7 @@ import type Database from "better-sqlite3";
 import type { SessionStore } from "./session-store.js";
 import type { UiCommand, TerminalPresenceEventPayload } from "../../shared/types.js";
 import { deleteIfGhostOnExit } from "./ghost-session-cleanup.js";
+import { deriveState } from "./session-state.js";
 
 // node-pty's `onExit` reports `signal` as a number (POSIX signal int) per its
 // type declaration. We translate to the conventional `SIGxxx` name at the
@@ -391,11 +392,37 @@ export class ClaudePtyManager {
           exitSignal: exit.signal ?? null,
           cleanProcessExit,
         });
-        this.sessionStore.updateSessionState(
-          exitedSessionId,
-          cleanProcessExit ? "done" : "disconnected",
-          new Date().toISOString(),
-        );
+        // Compute the new state via the shared deriveState so this branch
+        // stays in sync with the heartbeat sweep. The previous ad-hoc
+        // `cleanProcessExit ? 'done' : 'disconnected'` logic missed
+        // `user_stop_requested_at`, so a UI red-square stop briefly wrote
+        // 'disconnected' (red dot) before the next heartbeat tick re-derived
+        // it to 'done' (grey dot). Pull the freshly-written facts off the
+        // row so we see user_stop_requested_at + the just-recorded exit
+        // columns, and let deriveState pick the final state in one shot.
+        const refreshed = this.sessionStore.getById(exitedSessionId);
+        if (refreshed) {
+          const finalState = deriveState({
+            // PTY just exited and clearTerminal already ran above, so the
+            // session is no longer managed by a live terminal.
+            terminalId: null,
+            // Freshly exited; exit-evidence branches dominate so age
+            // doesn't actually factor in here.
+            ageMs: 0,
+            probeSignal: "unknown",
+            exitCode: refreshed.exit_code ?? null,
+            exitSignal: refreshed.exit_signal ?? null,
+            explicitExitSeen: !!refreshed.explicit_exit_seen,
+            cleanProcessExit: !!refreshed.clean_process_exit,
+            userStopRequested: !!refreshed.user_stop_requested_at,
+            lastAssistantStopReason: refreshed.last_assistant_stop_reason ?? null,
+          });
+          this.sessionStore.updateSessionState(
+            exitedSessionId,
+            finalState,
+            new Date().toISOString(),
+          );
+        }
       }
       entry.linkedSessionId = null;
     }

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -276,9 +276,23 @@ export class ClaudePtyManager {
     return true;
   }
 
-  kill(terminalId: string): boolean {
+  /**
+   * Kill the PTY child. `reason` distinguishes a user-driven stop (UI
+   * red-square click) from system-driven kills (e.g. disposeAll on
+   * server shutdown). When `'user_stop'`, the linked session's
+   * `user_stop_requested_at` is stamped *before* the signal is sent so
+   * the eventual signal-driven exit is classified as a clean
+   * shutdown, not a crash. The flag must precede the signal — once
+   * `proc.kill()` runs, the exit handler can race ahead and call
+   * `recordExit`, and by then `deriveState` must already see the
+   * intent.
+   */
+  kill(terminalId: string, opts: { reason?: "user_stop" | "system" } = {}): boolean {
     const entry = this.terminals.get(terminalId);
     if (!entry) return false;
+    if (opts.reason === "user_stop" && entry.linkedSessionId) {
+      this.sessionStore.markUserStopRequested(entry.linkedSessionId);
+    }
     try { entry.proc.kill(); } catch { /* best-effort */ }
     // proc.onExit fans out closeNote + schedules eviction. Drop the entry
     // immediately if the proc had already exited (defensive).

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -9,6 +9,7 @@
 // can still replay the final frames before we drop scrollback.
 
 import { randomUUID } from "node:crypto";
+import { constants as osConstants } from "node:os";
 import { WebSocketServer, WebSocket } from "ws";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
@@ -16,6 +17,25 @@ import type Database from "better-sqlite3";
 import type { SessionStore } from "./session-store.js";
 import type { UiCommand, TerminalPresenceEventPayload } from "../../shared/types.js";
 import { deleteIfGhostOnExit } from "./ghost-session-cleanup.js";
+
+// node-pty's `onExit` reports `signal` as a number (POSIX signal int) per its
+// type declaration. We translate to the conventional `SIGxxx` name at the
+// capture boundary so `exit_signal` is human-readable in the DB and any UI
+// tooltips downstream. Tests may pass names directly — passthrough is
+// intentional so test fixtures don't need to remember signal numbers.
+const SIGNAL_NUMBER_TO_NAME: ReadonlyMap<number, string> = (() => {
+  const m = new Map<number, string>();
+  for (const [name, num] of Object.entries(osConstants.signals)) {
+    if (typeof num === "number" && !m.has(num)) m.set(num, name);
+  }
+  return m;
+})();
+
+export function signalName(signal: number | string | null | undefined): string | null {
+  if (signal == null) return null;
+  if (typeof signal === "string") return signal;
+  return SIGNAL_NUMBER_TO_NAME.get(signal) ?? `signal-${signal}`;
+}
 
 export interface ClaudePtyManagerDeps {
   sessionStore: SessionStore;
@@ -190,8 +210,8 @@ export class ClaudePtyManager {
       }
     });
 
-    proc.onExit(({ exitCode, signal }: { exitCode: number; signal?: string | number | null }) => {
-      this._handleExit(entry, { exitCode, signal: signal != null ? String(signal) : null });
+    proc.onExit(({ exitCode, signal }: { exitCode: number; signal?: number }) => {
+      this._handleExit(entry, { exitCode, signal: signalName(signal) });
     });
 
     return { terminalId, startedAt };
@@ -343,8 +363,12 @@ export class ClaudePtyManager {
       // file), the stub row inserted at spawn time is a ghost — drop it
       // entirely rather than leaving an un-resumable "Untitled"
       // entry in the list. Otherwise, record the exit facts and write a
-      // transient state so SSE clients don't flicker through "active"
-      // before the next heartbeat sweep re-derives from the new facts.
+      // transient state so SSE clients see the result of this exit
+      // immediately. The next heartbeat sweep will re-derive from facts —
+      // Task 5 will teach deriveState to read exit_code/exit_signal/
+      // clean_process_exit so this value sticks. Until then, an in-flight
+      // session may briefly re-derive to "active" if it exited within the
+      // active-window.
       const deleted = deleteIfGhostOnExit(this.sessionStore, this.db, exitedSessionId, entry.cwd);
       if (!deleted) {
         const cleanProcessExit = exit.exitCode === 0 && !exit.signal;
@@ -380,15 +404,20 @@ export class ClaudePtyManager {
 
   /** Test-only: inject a fake entry with a stub proc whose onExit fires
    *  immediately on kill(). Production code never calls this. */
-  _seedEntryForTest(input: { terminalId: string; linkedSessionId: string | null }): void {
-    let exitCb: (e: { exitCode: number; signal?: string | number | null }) => void = () => {};
+  _seedEntryForTest(input: {
+    terminalId: string;
+    linkedSessionId: string | null;
+    killExit?: { exitCode: number; signal?: number };
+  }): void {
+    let exitCb: (e: { exitCode: number; signal?: number }) => void = () => {};
+    const killExit = input.killExit ?? { exitCode: 0 };
     const fakeProc: any = {
       pid: -1,
       onData: () => {},
       onExit: (cb: typeof exitCb) => { exitCb = cb; },
       write: () => {},
       resize: () => {},
-      kill: () => { exitCb({ exitCode: 0, signal: null }); },
+      kill: () => { exitCb(killExit); },
     };
     const entry: ClaudePtyEntry = {
       terminalId: input.terminalId,
@@ -405,8 +434,8 @@ export class ClaudePtyManager {
       evictTimer: null,
     };
     // Wire the onExit listener the same way spawn() does.
-    fakeProc.onExit(({ exitCode, signal }: { exitCode: number; signal?: string | number | null }) => {
-      this._handleExit(entry, { exitCode, signal: signal != null ? String(signal) : null });
+    fakeProc.onExit(({ exitCode, signal }: { exitCode: number; signal?: number }) => {
+      this._handleExit(entry, { exitCode, signal: signalName(signal) });
     });
     this.terminals.set(input.terminalId, entry);
   }

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -377,13 +377,12 @@ export class ClaudePtyManager {
       // If the session never produced content (no events AND no JSONL
       // file), the stub row inserted at spawn time is a ghost — drop it
       // entirely rather than leaving an un-resumable "Untitled"
-      // entry in the list. Otherwise, record the exit facts and write a
-      // transient state so SSE clients see the result of this exit
-      // immediately. The next heartbeat sweep will re-derive from facts —
-      // Task 5 will teach deriveState to read exit_code/exit_signal/
-      // clean_process_exit so this value sticks. Until then, an in-flight
-      // session may briefly re-derive to "active" if it exited within the
-      // active-window.
+      // entry in the list. Otherwise, record the exit facts (exit_code,
+      // exit_signal, clean_process_exit) and compute the final state via
+      // the shared deriveState so this branch stays in lockstep with the
+      // heartbeat sweep. The state written here is the same the next
+      // heartbeat would compute — no transient wrong value, no SSE
+      // flicker.
       const deleted = deleteIfGhostOnExit(this.sessionStore, this.db, exitedSessionId, entry.cwd);
       if (!deleted) {
         const cleanProcessExit = exit.exitCode === 0 && !exit.signal;

--- a/server/src/claude-pty-manager.ts
+++ b/server/src/claude-pty-manager.ts
@@ -190,7 +190,9 @@ export class ClaudePtyManager {
       }
     });
 
-    proc.onExit(({ exitCode }: { exitCode: number }) => this._handleExit(entry, exitCode));
+    proc.onExit(({ exitCode, signal }: { exitCode: number; signal?: string | number | null }) => {
+      this._handleExit(entry, { exitCode, signal: signal != null ? String(signal) : null });
+    });
 
     return { terminalId, startedAt };
   }
@@ -325,9 +327,9 @@ export class ClaudePtyManager {
     }
   }
 
-  private _handleExit(entry: ClaudePtyEntry, exitCode: number): void {
+  private _handleExit(entry: ClaudePtyEntry, exit: { exitCode: number; signal: string | null }): void {
     entry.exitedAt = Date.now();
-    const closeNote = `\r\n\x1b[90m[session ended (exit ${exitCode})]\x1b[0m\r\n`;
+    const closeNote = `\r\n\x1b[90m[session ended (exit ${exit.exitCode})]\x1b[0m\r\n`;
     entry.scrollback += closeNote;
     for (const ws of entry.clients) {
       if (ws.readyState === WebSocket.OPEN) ws.send(closeNote);
@@ -340,13 +342,20 @@ export class ClaudePtyManager {
       // If the session never produced content (no events AND no JSONL
       // file), the stub row inserted at spawn time is a ghost — drop it
       // entirely rather than leaving an un-resumable "Untitled"
-      // entry in the list. Otherwise, mark disconnected so the UI flips
-      // immediately (see commit 63c64e5).
+      // entry in the list. Otherwise, record the exit facts and write a
+      // transient state so SSE clients don't flicker through "active"
+      // before the next heartbeat sweep re-derives from the new facts.
       const deleted = deleteIfGhostOnExit(this.sessionStore, this.db, exitedSessionId, entry.cwd);
       if (!deleted) {
+        const cleanProcessExit = exit.exitCode === 0 && !exit.signal;
+        this.sessionStore.recordExit(exitedSessionId, {
+          exitCode: exit.exitCode,
+          exitSignal: exit.signal ?? null,
+          cleanProcessExit,
+        });
         this.sessionStore.updateSessionState(
           exitedSessionId,
-          "disconnected",
+          cleanProcessExit ? "done" : "disconnected",
           new Date().toISOString(),
         );
       }
@@ -372,14 +381,14 @@ export class ClaudePtyManager {
   /** Test-only: inject a fake entry with a stub proc whose onExit fires
    *  immediately on kill(). Production code never calls this. */
   _seedEntryForTest(input: { terminalId: string; linkedSessionId: string | null }): void {
-    let exitCb: (e: { exitCode: number }) => void = () => {};
+    let exitCb: (e: { exitCode: number; signal?: string | number | null }) => void = () => {};
     const fakeProc: any = {
       pid: -1,
       onData: () => {},
       onExit: (cb: typeof exitCb) => { exitCb = cb; },
       write: () => {},
       resize: () => {},
-      kill: () => { exitCb({ exitCode: 0 }); },
+      kill: () => { exitCb({ exitCode: 0, signal: null }); },
     };
     const entry: ClaudePtyEntry = {
       terminalId: input.terminalId,
@@ -396,7 +405,9 @@ export class ClaudePtyManager {
       evictTimer: null,
     };
     // Wire the onExit listener the same way spawn() does.
-    fakeProc.onExit(({ exitCode }: { exitCode: number }) => this._handleExit(entry, exitCode));
+    fakeProc.onExit(({ exitCode, signal }: { exitCode: number; signal?: string | number | null }) => {
+      this._handleExit(entry, { exitCode, signal: signal != null ? String(signal) : null });
+    });
     this.terminals.set(input.terminalId, entry);
   }
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -280,12 +280,13 @@ export function initDb(userlandDir: string): Database.Database {
       explicit_exit_seen         INTEGER NOT NULL DEFAULT 0,
       clean_process_exit         INTEGER NOT NULL DEFAULT 0,
       last_assistant_stop_reason TEXT,
-      -- Set when the user clicks the UI stop button, *before* the kill
-      -- signal goes to the PTY. Distinguishes "user intentionally
-      -- stopped this session" from "process died unexpectedly with a
-      -- signal" — both leave the same exit_signal evidence behind, but
-      -- only the former should resolve to 'done'. ISO timestamp for
-      -- audit-trail value vs. an opaque boolean.
+      -- SQLite datetime ('YYYY-MM-DD HH:MM:SS', UTC) set when the user
+      -- clicks the UI stop button, *before* the kill signal goes to
+      -- the PTY. Distinguishes "user intentionally stopped this
+      -- session" from "process died unexpectedly with a signal" —
+      -- both leave the same exit_signal evidence behind, but only
+      -- the former should resolve to 'done'. Stored as a timestamp
+      -- for audit-trail value vs. an opaque boolean.
       user_stop_requested_at     TEXT
     );
     CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -269,7 +269,17 @@ export function initDb(userlandDir: string): Database.Database {
       -- Without this, sessions that finished before the watcher started
       -- (or before a restart) seeded the tracker at EOF and silently lost
       -- their transcript.
-      last_offset   INTEGER NOT NULL DEFAULT 0
+      last_offset   INTEGER NOT NULL DEFAULT 0,
+      -- Status-evidence facts. The watcher and PTY manager write these as
+      -- they observe the session; the API layer derives a display state
+      -- (incl. 'dormant') from them at read time. The stored state enum
+      -- intentionally stays at the original 4 values -- 'dormant' is purely
+      -- a display concept, never persisted here.
+      exit_code                  INTEGER,
+      exit_signal                TEXT,
+      explicit_exit_seen         INTEGER NOT NULL DEFAULT 0,
+      clean_process_exit         INTEGER NOT NULL DEFAULT 0,
+      last_assistant_stop_reason TEXT
     );
     CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);
     CREATE INDEX IF NOT EXISTS sessions_state_last_event
@@ -308,6 +318,16 @@ export function initDb(userlandDir: string): Database.Database {
   try {
     db.exec("ALTER TABLE sessions ADD COLUMN last_offset INTEGER NOT NULL DEFAULT 0");
   } catch { /* already exists */ }
+
+  // Status-evidence facts written by the watcher and PTY manager. Display
+  // state (incl. 'dormant') is derived from these at the API layer; the
+  // stored `state` enum stays at its original 4 values. Each ALTER is
+  // wrapped in try/catch so it's idempotent on existing installs.
+  try { db.exec("ALTER TABLE sessions ADD COLUMN exit_code INTEGER"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN exit_signal TEXT"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN explicit_exit_seen INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN clean_process_exit INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN last_assistant_stop_reason TEXT"); } catch { /* already exists */ }
 
   // ── Sessions state-rename migration (running/awaiting → active/waiting) ──
   // SQLite can't ALTER a CHECK constraint, so we rebuild via temp table.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -319,16 +319,6 @@ export function initDb(userlandDir: string): Database.Database {
     db.exec("ALTER TABLE sessions ADD COLUMN last_offset INTEGER NOT NULL DEFAULT 0");
   } catch { /* already exists */ }
 
-  // Status-evidence facts written by the watcher and PTY manager. Display
-  // state (incl. 'dormant') is derived from these at the API layer; the
-  // stored `state` enum stays at its original 4 values. Each ALTER is
-  // wrapped in try/catch so it's idempotent on existing installs.
-  try { db.exec("ALTER TABLE sessions ADD COLUMN exit_code INTEGER"); } catch { /* already exists */ }
-  try { db.exec("ALTER TABLE sessions ADD COLUMN exit_signal TEXT"); } catch { /* already exists */ }
-  try { db.exec("ALTER TABLE sessions ADD COLUMN explicit_exit_seen INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
-  try { db.exec("ALTER TABLE sessions ADD COLUMN clean_process_exit INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
-  try { db.exec("ALTER TABLE sessions ADD COLUMN last_assistant_stop_reason TEXT"); } catch { /* already exists */ }
-
   // ── Sessions state-rename migration (running/awaiting → active/waiting) ──
   // SQLite can't ALTER a CHECK constraint, so we rebuild via temp table.
   //
@@ -446,6 +436,19 @@ export function initDb(userlandDir: string): Database.Database {
     db.exec("ALTER TABLE sessions ADD COLUMN assignment_mode TEXT NOT NULL DEFAULT 'auto' CHECK (assignment_mode IN ('auto','manual'))");
   } catch { /* already exists */ }
   db.exec("CREATE INDEX IF NOT EXISTS sessions_auto_cwd ON sessions(cwd) WHERE assignment_mode = 'auto'");
+
+  // Status-evidence facts written by the watcher and PTY manager. Display
+  // state (incl. 'dormant') is derived from these at the API layer; the
+  // stored `state` enum stays at its original 4 values -- 'dormant' is
+  // purely a display concept, never persisted here. Each ALTER is wrapped
+  // in try/catch so it's idempotent on existing installs. Positioned
+  // *after* the state-rename rebuild so the rebuild (which recreates the
+  // sessions table from scratch on legacy installs) can't drop them.
+  try { db.exec("ALTER TABLE sessions ADD COLUMN exit_code INTEGER"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN exit_signal TEXT"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN explicit_exit_seen INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN clean_process_exit INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN last_assistant_stop_reason TEXT"); } catch { /* already exists */ }
 
   // ─────────────────────────────────────────────────────────────────────────
   // projects + project_paths — the simplified identity model that supersedes

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -279,7 +279,14 @@ export function initDb(userlandDir: string): Database.Database {
       exit_signal                TEXT,
       explicit_exit_seen         INTEGER NOT NULL DEFAULT 0,
       clean_process_exit         INTEGER NOT NULL DEFAULT 0,
-      last_assistant_stop_reason TEXT
+      last_assistant_stop_reason TEXT,
+      -- Set when the user clicks the UI stop button, *before* the kill
+      -- signal goes to the PTY. Distinguishes "user intentionally
+      -- stopped this session" from "process died unexpectedly with a
+      -- signal" — both leave the same exit_signal evidence behind, but
+      -- only the former should resolve to 'done'. ISO timestamp for
+      -- audit-trail value vs. an opaque boolean.
+      user_stop_requested_at     TEXT
     );
     CREATE INDEX IF NOT EXISTS sessions_space_id ON sessions(space_id);
     CREATE INDEX IF NOT EXISTS sessions_state_last_event
@@ -449,6 +456,7 @@ export function initDb(userlandDir: string): Database.Database {
   try { db.exec("ALTER TABLE sessions ADD COLUMN explicit_exit_seen INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
   try { db.exec("ALTER TABLE sessions ADD COLUMN clean_process_exit INTEGER NOT NULL DEFAULT 0"); } catch { /* already exists */ }
   try { db.exec("ALTER TABLE sessions ADD COLUMN last_assistant_stop_reason TEXT"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE sessions ADD COLUMN user_stop_requested_at TEXT"); } catch { /* already exists */ }
 
   // ─────────────────────────────────────────────────────────────────────────
   // projects + project_paths — the simplified identity model that supersedes

--- a/server/src/routes/artifacts.ts
+++ b/server/src/routes/artifacts.ts
@@ -13,6 +13,7 @@ import type { SessionStore } from "../session-store.js";
 import type { ArtifactService } from "../artifact-service.js";
 import type { RouteCtx } from "../http-utils.js";
 import { safeDecode } from "../http-utils.js";
+import { mapSessionRow } from "./sessions.js";
 
 export interface ArtifactRouteDeps {
   artifactService: ArtifactService;
@@ -68,19 +69,7 @@ export async function tryHandleArtifactRoute(
           artifactId: t.artifact_id,
           role: t.role,
           whenAt: t.when_at,
-          session: {
-            id: s.id,
-            spaceId: s.space_id,
-            projectId: s.project_id,
-            cwd: s.cwd,
-            agent: s.agent,
-            title: s.title,
-            state: s.state,
-            startedAt: s.started_at,
-            endedAt: s.ended_at,
-            model: s.model,
-            lastEventAt: s.last_event_at,
-          },
+          session: mapSessionRow(s),
         }];
       }));
       return true;

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -16,7 +16,8 @@ import type { ArtifactService } from "../artifact-service.js";
 import type { MemoryProvider } from "../memory-store.js";
 import type { RouteCtx } from "../http-utils.js";
 import { SessionService, SessionNotFoundError, ProjectNotFoundError, InvalidMoveSessionInputError } from "../session-service.js";
-import type { UiCommand } from "../../../shared/types.js";
+import type { DisplayState, SessionState, UiCommand } from "../../../shared/types.js";
+import { computeDisplayState } from "../session-display-state.js";
 import {
   encodeCwd,
   LocalDivergedError,
@@ -124,6 +125,10 @@ export interface MergedSessionPayload {
   agent: string;
   title: string | null;
   state: string;
+  /** Derived wire-format state. Same as `state` except `disconnected`
+   *  rows idle for 8h+ are surfaced as `'dormant'`. Computed server-side
+   *  via `computeDisplayState`; never persisted. */
+  displayState: DisplayState;
   startedAt: string;
   endedAt: string | null;
   model: string | null;
@@ -160,6 +165,7 @@ export function mapSessionRow(
     agent: row.agent,
     title: row.title,
     state: row.state,
+    displayState: computeDisplayState(row.state, row.last_event_at),
     startedAt: row.started_at,
     endedAt: row.ended_at,
     model: row.model,
@@ -261,6 +267,7 @@ export async function tryHandleSessionRoute(
           agent: r.agent,
           title: r.title,
           state: r.state,
+          displayState: computeDisplayState(r.state as SessionState, r.last_event_at),
           startedAt: r.started_at,
           endedAt: r.ended_at,
           model: r.model,
@@ -383,6 +390,7 @@ export async function tryHandleSessionRoute(
             agent: remoteRow.agent,
             title: remoteRow.title,
             state: remoteRow.state,
+            displayState: computeDisplayState(remoteRow.state as SessionState, remoteRow.last_event_at),
             startedAt: remoteRow.started_at,
             endedAt: remoteRow.ended_at,
             model: remoteRow.model,

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -186,9 +186,11 @@ export function mapSessionRow(
     displayReason: deriveReason({
       terminalId: row.terminal_id ?? null,
       ageMs,
-      // Wire mapper runs out-of-band of the live process probe. The
-      // tri-state defaults to 'unknown' so deriveReason picks the
-      // benefit-of-doubt copy ("idle") rather than overstating an absence.
+      // Wire mapper runs out-of-band of the live process probe (which only
+      // the heartbeat sweep has access to). With probeSignal: "unknown",
+      // deriveReason suppresses the idle copy entirely — the persisted
+      // state already encodes whatever the heartbeat last saw, and the
+      // dot colour + LAST ACTIVE age carry the same information.
       probeSignal: "unknown",
       exitCode: row.exit_code ?? null,
       exitSignal: row.exit_signal ?? null,

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -18,6 +18,7 @@ import type { RouteCtx } from "../http-utils.js";
 import { SessionService, SessionNotFoundError, ProjectNotFoundError, InvalidMoveSessionInputError } from "../session-service.js";
 import type { DisplayState, SessionState, UiCommand } from "../../../shared/types.js";
 import { computeDisplayState } from "../session-display-state.js";
+import { deriveReason } from "../session-state.js";
 import {
   encodeCwd,
   LocalDivergedError,
@@ -129,6 +130,11 @@ export interface MergedSessionPayload {
    *  rows idle for 8h+ are surfaced as `'dormant'`. Computed server-side
    *  via `computeDisplayState`; never persisted. */
   displayState: DisplayState;
+  /** Short human-readable explanation of the row's current state (e.g.
+   *  "stopped by user", "awaiting input", "killed by SIGKILL"). Pure
+   *  derivation from the same evidence columns deriveState reads; not
+   *  persisted. */
+  displayReason: string;
   startedAt: string;
   endedAt: string | null;
   model: string | null;
@@ -157,6 +163,7 @@ export interface MergedSessionPayload {
 export function mapSessionRow(
   row: SessionRow,
 ): MergedSessionPayload {
+  const ageMs = Math.max(0, Date.now() - Date.parse(row.last_event_at));
   return {
     id: row.id,
     spaceId: row.space_id,
@@ -166,6 +173,20 @@ export function mapSessionRow(
     title: row.title,
     state: row.state,
     displayState: computeDisplayState(row.state, row.last_event_at),
+    displayReason: deriveReason({
+      terminalId: row.terminal_id ?? null,
+      ageMs,
+      // Wire mapper runs out-of-band of the live process probe. The
+      // tri-state defaults to 'unknown' so deriveReason picks the
+      // benefit-of-doubt copy ("idle") rather than overstating an absence.
+      probeSignal: "unknown",
+      exitCode: row.exit_code ?? null,
+      exitSignal: row.exit_signal ?? null,
+      explicitExitSeen: !!row.explicit_exit_seen,
+      cleanProcessExit: !!row.clean_process_exit,
+      userStopRequested: !!row.user_stop_requested_at,
+      lastAssistantStopReason: row.last_assistant_stop_reason ?? null,
+    }),
     startedAt: row.started_at,
     endedAt: row.ended_at,
     model: row.model,
@@ -268,6 +289,19 @@ export async function tryHandleSessionRoute(
           title: r.title,
           state: r.state,
           displayState: computeDisplayState(r.state, r.last_event_at),
+          // Remote rows don't carry exit/stop_reason facts — pass benign
+          // defaults so deriveReason produces a generic time/probe copy.
+          displayReason: deriveReason({
+            terminalId: null,
+            ageMs: Math.max(0, Date.now() - Date.parse(r.last_event_at)),
+            probeSignal: "unknown",
+            exitCode: null,
+            exitSignal: null,
+            explicitExitSeen: false,
+            cleanProcessExit: false,
+            userStopRequested: false,
+            lastAssistantStopReason: null,
+          }),
           startedAt: r.started_at,
           endedAt: r.ended_at,
           model: r.model,
@@ -391,6 +425,17 @@ export async function tryHandleSessionRoute(
             title: remoteRow.title,
             state: remoteRow.state,
             displayState: computeDisplayState(remoteRow.state, remoteRow.last_event_at),
+            displayReason: deriveReason({
+              terminalId: null,
+              ageMs: Math.max(0, Date.now() - Date.parse(remoteRow.last_event_at)),
+              probeSignal: "unknown",
+              exitCode: null,
+              exitSignal: null,
+              explicitExitSeen: false,
+              cleanProcessExit: false,
+              userStopRequested: false,
+              lastAssistantStopReason: null,
+            }),
             startedAt: remoteRow.started_at,
             endedAt: remoteRow.ended_at,
             model: remoteRow.model,

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -39,6 +39,16 @@ export interface SessionRouteDeps {
   broadcastUiEvent: (event: UiCommand) => void;
 }
 
+/** Compute the age-since-last-event in ms, guarding against an unparseable
+ *  `last_event_at` (Date.parse returns NaN → arithmetic propagates NaN →
+ *  every `ageMs < THRESHOLD` comparison in deriveReason is false, producing
+ *  silently-wrong output). When the timestamp can't be parsed we fall back
+ *  to 0 so the row reads as "just active" rather than misclassified. */
+function ageMsFromLastEvent(lastEventAt: string, now: number = Date.now()): number {
+  const ts = Date.parse(lastEventAt);
+  return Number.isFinite(ts) ? Math.max(0, now - ts) : 0;
+}
+
 // ── Resume helpers (#322 PR 2) ──────────────────────────────────────────
 
 interface ValidationOutcome {
@@ -163,7 +173,7 @@ export interface MergedSessionPayload {
 export function mapSessionRow(
   row: SessionRow,
 ): MergedSessionPayload {
-  const ageMs = Math.max(0, Date.now() - Date.parse(row.last_event_at));
+  const ageMs = ageMsFromLastEvent(row.last_event_at);
   return {
     id: row.id,
     spaceId: row.space_id,
@@ -293,7 +303,7 @@ export async function tryHandleSessionRoute(
           // defaults so deriveReason produces a generic time/probe copy.
           displayReason: deriveReason({
             terminalId: null,
-            ageMs: Math.max(0, Date.now() - Date.parse(r.last_event_at)),
+            ageMs: ageMsFromLastEvent(r.last_event_at),
             probeSignal: "unknown",
             exitCode: null,
             exitSignal: null,
@@ -427,7 +437,7 @@ export async function tryHandleSessionRoute(
             displayState: computeDisplayState(remoteRow.state, remoteRow.last_event_at),
             displayReason: deriveReason({
               terminalId: null,
-              ageMs: Math.max(0, Date.now() - Date.parse(remoteRow.last_event_at)),
+              ageMs: ageMsFromLastEvent(remoteRow.last_event_at),
               probeSignal: "unknown",
               exitCode: null,
               exitSignal: null,

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -124,7 +124,7 @@ export interface MergedSessionPayload {
   cwd: string | null;
   agent: string;
   title: string | null;
-  state: string;
+  state: SessionState;
   /** Derived wire-format state. Same as `state` except `disconnected`
    *  rows idle for 8h+ are surfaced as `'dormant'`. Computed server-side
    *  via `computeDisplayState`; never persisted. */
@@ -224,7 +224,7 @@ export async function tryHandleSessionRoute(
       type RemoteRow = {
         session_id: string; device_id: string | null; device_label: string | null;
         agent: string; title: string | null;
-        state: string; cwd: string | null; model: string | null; started_at: string;
+        state: SessionState; cwd: string | null; model: string | null; started_at: string;
         ended_at: string | null; last_event_at: string; has_bytes: number;
         total_bytes: number | null;
         active_device_id: string | null; jsonl_local_path: string | null;
@@ -267,7 +267,7 @@ export async function tryHandleSessionRoute(
           agent: r.agent,
           title: r.title,
           state: r.state,
-          displayState: computeDisplayState(r.state as SessionState, r.last_event_at),
+          displayState: computeDisplayState(r.state, r.last_event_at),
           startedAt: r.started_at,
           endedAt: r.ended_at,
           model: r.model,
@@ -366,7 +366,7 @@ export async function tryHandleSessionRoute(
       if (ownerId) {
         type RemoteRow = {
           device_id: string | null; device_label: string | null;
-          agent: string; title: string | null; state: string;
+          agent: string; title: string | null; state: SessionState;
           cwd: string | null; model: string | null; started_at: string;
           ended_at: string | null; last_event_at: string;
           has_bytes: number; active_device_id: string | null;
@@ -390,7 +390,7 @@ export async function tryHandleSessionRoute(
             agent: remoteRow.agent,
             title: remoteRow.title,
             state: remoteRow.state,
-            displayState: computeDisplayState(remoteRow.state as SessionState, remoteRow.last_event_at),
+            displayState: computeDisplayState(remoteRow.state, remoteRow.last_event_at),
             startedAt: remoteRow.started_at,
             endedAt: remoteRow.ended_at,
             model: remoteRow.model,

--- a/server/src/routes/terminals.ts
+++ b/server/src/routes/terminals.ts
@@ -312,7 +312,7 @@ export async function tryHandleTerminalRoute(
   if (deleteMatch && req.method === "DELETE") {
     if (rejectIfNonLocalOrigin()) return true;
     const id = deleteMatch[1]!;
-    deps.claudePtyManager.kill(id);
+    deps.claudePtyManager.kill(id, { reason: "user_stop" });
     res.writeHead(204);
     res.end();
     return true;

--- a/server/src/session-display-state.ts
+++ b/server/src/session-display-state.ts
@@ -1,6 +1,6 @@
 import type { SessionState, DisplayState } from "../../shared/types.js";
 
-const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+export const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
 /**
  * Maps the persisted state to the wire-format displayState. The only

--- a/server/src/session-display-state.ts
+++ b/server/src/session-display-state.ts
@@ -1,6 +1,10 @@
 import type { SessionState, DisplayState } from "../../shared/types.js";
+import { DORMANT_THRESHOLD_MS } from "./session-state.js";
 
-export const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+// Re-export so callers that already import this module can keep their
+// import paths. The canonical source is session-state.js, alongside the
+// state and reason derivation rules.
+export { DORMANT_THRESHOLD_MS };
 
 /**
  * Maps the persisted state to the wire-format displayState. The only

--- a/server/src/session-display-state.ts
+++ b/server/src/session-display-state.ts
@@ -1,0 +1,19 @@
+import type { SessionState, DisplayState } from "../../shared/types.js";
+
+const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * Maps the persisted state to the wire-format displayState. The only
+ * difference is that 'disconnected' rows older than 8h are presented as
+ * 'dormant' to dim the urgency. Other states pass through unchanged.
+ */
+export function computeDisplayState(
+  state: SessionState,
+  lastEventAt: string,
+  now: number = Date.now(),
+): DisplayState {
+  if (state !== "disconnected") return state;
+  const ts = Date.parse(lastEventAt);
+  if (!Number.isFinite(ts)) return "disconnected";
+  return now - ts > DORMANT_THRESHOLD_MS ? "dormant" : "disconnected";
+}

--- a/server/src/session-state.ts
+++ b/server/src/session-state.ts
@@ -25,9 +25,10 @@ export type ProbeSignal = "alive" | "absent" | "unknown";
 
 export const ACTIVE_WINDOW_MS = 60_000;
 export const WAITING_WINDOW_MS = 30 * 60 * 1000;
-// 8h+ idle "disconnected" rows are presented as `dormant` on the wire
-// (computeDisplayState). Kept here so deriveReason can pick the right
-// copy for the long-idle case.
+// 8h+ idle "disconnected" rows are presented as `dormant` on the wire.
+// Consumed by `computeDisplayState` in `session-display-state.ts` —
+// kept here alongside the other time windows so all the thresholds the
+// state machine cares about live in one place.
 export const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
 export interface DeriveStateInput {

--- a/server/src/session-state.ts
+++ b/server/src/session-state.ts
@@ -1,0 +1,149 @@
+// Single source of truth for deriving a session's `state` and a
+// short human-readable `displayReason` from the evidence columns
+// (exit_code/exit_signal/clean_process_exit/explicit_exit_seen/
+// user_stop_requested_at/last_assistant_stop_reason) plus the live
+// process probe.
+//
+// Why a dedicated module: `_handleExit` (PTY exit handler) and
+// `runHeartbeatSweep` (periodic refresh) used to embed their own
+// state logic. `_handleExit` had a naive `cleanProcessExit ? 'done'
+// : 'disconnected'` branch that didn't know about `userStopRequested`,
+// so a UI red-square stop would briefly write 'disconnected' (red dot)
+// until the next heartbeat tick re-derived to 'done' (grey dot). The
+// fix is to keep deriveState in one place and call it from both.
+
+import type { SessionState } from "../../shared/types.js";
+
+// `signal` is tri-state to handle Windows / probe-unavailable gracefully:
+//   "alive"   — probe ran, found a claude process at this cwd
+//   "absent"  — probe ran, found no claude at this cwd (terminal closed)
+//   "unknown" — probe couldn't run at all (no pgrep). Treat as benefit-
+//               of-doubt: a recent session reads as waiting, not
+//               disconnected. Otherwise Windows would force every idle
+//               session to disconnected, worse than the pre-probe state.
+export type ProbeSignal = "alive" | "absent" | "unknown";
+
+export const ACTIVE_WINDOW_MS = 60_000;
+export const WAITING_WINDOW_MS = 30 * 60 * 1000;
+// 8h+ idle "disconnected" rows are presented as `dormant` on the wire
+// (computeDisplayState). Kept here so deriveReason can pick the right
+// copy for the long-idle case.
+export const DORMANT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+
+export interface DeriveStateInput {
+  terminalId: string | null;
+  ageMs: number;
+  probeSignal: ProbeSignal;
+  exitCode: number | null;
+  exitSignal: string | null;
+  explicitExitSeen: boolean;
+  cleanProcessExit: boolean;
+  /** The user clicked the red-square stop button. Recorded *before* the
+   *  signal is sent so the eventual signal-driven PTY exit isn't
+   *  classified as a crash. Paired with process-exit evidence in
+   *  deriveState so a row can't briefly read 'done' while the PTY is
+   *  still alive (i.e., the intent flag has been written but the
+   *  process hasn't yet exited). */
+  userStopRequested: boolean;
+  lastAssistantStopReason: string | null;
+}
+
+export function deriveState(input: DeriveStateInput): SessionState {
+  // User-initiated stop, once the process has actually exited: the signal
+  // (typically SIGHUP from node-pty's default kill()) IS the shutdown
+  // mechanism, not evidence of a crash. Requires process-exit evidence so
+  // a pre-exit race (flag written, PTY not yet down) doesn't yield 'done'
+  // while the underlying process is still running.
+  const hasProcessExitEvidence =
+    input.exitCode != null || input.exitSignal != null || input.cleanProcessExit;
+  if (input.userStopRequested && hasProcessExitEvidence) return "done";
+
+  // Precedence: bad exit evidence beats any "clean" claim that lacks user
+  // intent. A session that typed /exit and then got SIGKILLed
+  // mid-shutdown should read disconnected, not done.
+  if (input.exitSignal || (input.exitCode != null && input.exitCode !== 0)) {
+    return "disconnected";
+  }
+  if (input.explicitExitSeen || input.cleanProcessExit) return "done";
+  if (input.terminalId) {
+    // Only "computing" stop reasons keep us in active. `null` means we
+    // haven't seen any assistant event yet (user just opened the session
+    // or sent their first prompt — the agent IS computing). `tool_use`
+    // and `pause_turn` are genuine in-flight signals. Every other stop
+    // reason (end_turn, max_tokens, stop_sequence, refusal) means the
+    // model has stopped and the user is the next actor.
+    const computing =
+      input.lastAssistantStopReason === null ||
+      input.lastAssistantStopReason === "tool_use" ||
+      input.lastAssistantStopReason === "pause_turn";
+    return computing ? "active" : "waiting";
+  }
+  if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
+  if (input.ageMs < WAITING_WINDOW_MS) {
+    return input.probeSignal === "absent" ? "disconnected" : "waiting";
+  }
+  // 8h+ idle is still 'disconnected' in the persisted enum. The presentation
+  // layer (sessions API) maps disconnected + age > 8h into 'dormant' for the
+  // wire-format displayState field. See Task 6.
+  return "disconnected";
+}
+
+/** Short, lowercase, human-readable explanation for the row's current
+ *  state. Pure derivation from the same evidence — no DB reads, no
+ *  state argument needed (the priority order below makes the answer
+ *  consistent with deriveState). */
+export function deriveReason(input: DeriveStateInput): string {
+  const userStop = input.userStopRequested;
+  const hasExitEvidence =
+    input.exitCode != null || input.exitSignal != null || input.cleanProcessExit;
+
+  // 1. Bad exit with no user-stop intent → crash / external kill.
+  if (!userStop) {
+    if (input.exitSignal) return `killed by ${input.exitSignal}`;
+    if (input.exitCode != null && input.exitCode !== 0) {
+      return `crashed (exit ${input.exitCode})`;
+    }
+  }
+
+  // 2. User stop, once the process has actually exited.
+  if (userStop && hasExitEvidence) return "stopped by user";
+
+  // 3. Explicit /exit observed in the transcript.
+  if (input.explicitExitSeen) return "ran /exit";
+
+  // 4. Clean process exit (code 0, no signal).
+  if (input.cleanProcessExit) return "exited cleanly";
+
+  // 5. Managed (PTY still linked) — describe the assistant's last stop_reason.
+  if (input.terminalId) {
+    switch (input.lastAssistantStopReason) {
+      case "end_turn": return "awaiting input";
+      case "tool_use": return "running a tool";
+      case "pause_turn": return "thinking";
+      case "max_tokens": return "max tokens — needs continuation";
+      case "refusal": return "refused — needs input";
+      case "stop_sequence": return "stopped at sequence — needs input";
+      case null: return "working";
+      default: return "working";
+    }
+  }
+
+  // 6. Unmanaged — time + probe drives the copy.
+  if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
+  if (input.ageMs < WAITING_WINDOW_MS) {
+    if (input.probeSignal === "alive") return "idle, process detected";
+    if (input.probeSignal === "absent") return "process not found";
+    return "idle";
+  }
+  return `quiet ${humanizeAge(input.ageMs)}`;
+}
+
+/** Short forms: 30m, 2h, 3d. Minutes/hours/days, no smart rounding. */
+function humanizeAge(ageMs: number): string {
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}

--- a/server/src/session-state.ts
+++ b/server/src/session-state.ts
@@ -115,6 +115,9 @@ export function deriveReason(input: DeriveStateInput): string {
   if (input.cleanProcessExit) return "exited cleanly";
 
   // 5. Managed (PTY still linked) — describe the assistant's last stop_reason.
+  // Bare "working" / "active" adds nothing beyond the purple dot + last-active
+  // age, so suppress them (empty string → column renders dark). Only return
+  // copy that actually explains something the colour and age don't.
   if (input.terminalId) {
     switch (input.lastAssistantStopReason) {
       case "end_turn": return "awaiting input";
@@ -123,27 +126,17 @@ export function deriveReason(input: DeriveStateInput): string {
       case "max_tokens": return "max tokens — needs continuation";
       case "refusal": return "refused — needs input";
       case "stop_sequence": return "stopped at sequence — needs input";
-      case null: return "working";
-      default: return "working";
+      default: return "";
     }
   }
 
-  // 6. Unmanaged — time + probe drives the copy.
-  if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
-  if (input.ageMs < WAITING_WINDOW_MS) {
+  // 6. Unmanaged — only surface a reason when it adds info beyond colour + age.
+  // `active` and bare `quiet Xh` echo the dot colour and the LAST ACTIVE
+  // column; suppress them. Keep probe-derived copy because the probe tells
+  // the user something the age doesn't (is the process actually there?).
+  if (input.ageMs < WAITING_WINDOW_MS && input.ageMs >= ACTIVE_WINDOW_MS) {
     if (input.probeSignal === "alive") return "idle, process detected";
     if (input.probeSignal === "absent") return "process not found";
-    return "idle";
   }
-  return `quiet ${humanizeAge(input.ageMs)}`;
-}
-
-/** Short forms: 30m, 2h, 3d. Minutes/hours/days, no smart rounding. */
-function humanizeAge(ageMs: number): string {
-  const minutes = Math.floor(ageMs / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
+  return "";
 }

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -59,6 +59,11 @@ export interface SessionRow {
   /** Last `stop_reason` reported by the assistant (e.g. "end_turn",
    *  "tool_use"). NULL until at least one assistant turn has stopped. */
   last_assistant_stop_reason: string | null;
+  /** ISO timestamp the user clicked the UI stop button (red square).
+   *  Set BEFORE the kill signal goes to the PTY so the eventual
+   *  signal-driven exit isn't misclassified as a crash. NULL when the
+   *  user never explicitly stopped the session. */
+  user_stop_requested_at: string | null;
 }
 
 export interface SessionEventRow {
@@ -189,6 +194,11 @@ export interface SessionStore {
   /** Flip explicit_exit_seen to 1. Idempotent — called by the watcher
    *  when it spots a `/exit` slash-command artefact. */
   markExplicitExitSeen(id: string): void;
+  /** Stamp `user_stop_requested_at` with the current time so the
+   *  imminent PTY signal exit is classified as an intentional shutdown
+   *  rather than a crash. Idempotent: the first stamp wins. Called by
+   *  the PTY manager right before sending the kill signal. */
+  markUserStopRequested(id: string): void;
   // session_events — bulk-friendly
   insertEvent(row: InsertSessionEvent): number;
   insertEvents(rows: InsertSessionEvent[]): void;
@@ -248,6 +258,7 @@ export class SqliteSessionStore implements SessionStore {
     recordExit: Database.Statement;
     setLastAssistantStopReason: Database.Statement;
     markExplicitExitSeen: Database.Statement;
+    markUserStopRequested: Database.Statement;
   };
 
   private insertEventsTxn: (rows: InsertSessionEvent[]) => void;
@@ -374,11 +385,18 @@ export class SqliteSessionStore implements SessionStore {
         "UPDATE sessions SET last_offset = ? WHERE id = ?"
       ),
       deleteSession: db.prepare("DELETE FROM sessions WHERE id = ?"),
+      // recordExit doubles as the canonical "session has ended" writer:
+      // ended_at gets stamped here so the column tracks the actual PTY
+      // exit time (vs. whenever a downstream consumer happens to notice).
+      // COALESCE keeps the original timestamp if recordExit is somehow
+      // re-invoked on the same session (defensive — the PTY exit handler
+      // is the only call site today).
       recordExit: db.prepare(`
         UPDATE sessions
         SET exit_code = @exit_code,
             exit_signal = @exit_signal,
-            clean_process_exit = @clean_process_exit
+            clean_process_exit = @clean_process_exit,
+            ended_at = COALESCE(ended_at, datetime('now'))
         WHERE id = @id
       `),
       setLastAssistantStopReason: db.prepare(
@@ -386,6 +404,11 @@ export class SqliteSessionStore implements SessionStore {
       ),
       markExplicitExitSeen: db.prepare(
         "UPDATE sessions SET explicit_exit_seen = 1 WHERE id = ?"
+      ),
+      // First stamp wins so a double-click on stop doesn't shift the
+      // recorded intent timestamp later than the actual user action.
+      markUserStopRequested: db.prepare(
+        "UPDATE sessions SET user_stop_requested_at = COALESCE(user_stop_requested_at, datetime('now')) WHERE id = ?"
       ),
     };
 
@@ -461,6 +484,10 @@ export class SqliteSessionStore implements SessionStore {
 
   markExplicitExitSeen(id: string): void {
     this.stmts.markExplicitExitSeen.run(id);
+  }
+
+  markUserStopRequested(id: string): void {
+    this.stmts.markUserStopRequested.run(id);
   }
 
   private static readonly UPDATABLE_SESSION_COLUMNS = new Set([

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -59,10 +59,11 @@ export interface SessionRow {
   /** Last `stop_reason` reported by the assistant (e.g. "end_turn",
    *  "tool_use"). NULL until at least one assistant turn has stopped. */
   last_assistant_stop_reason: string | null;
-  /** ISO timestamp the user clicked the UI stop button (red square).
-   *  Set BEFORE the kill signal goes to the PTY so the eventual
-   *  signal-driven exit isn't misclassified as a crash. NULL when the
-   *  user never explicitly stopped the session. */
+  /** SQLite datetime ('YYYY-MM-DD HH:MM:SS', UTC) set when the user
+   *  clicked the UI stop button (red square). Set BEFORE the kill
+   *  signal goes to the PTY so the eventual signal-driven exit isn't
+   *  misclassified as a crash. NULL when the user never explicitly
+   *  stopped the session. */
   user_stop_requested_at: string | null;
 }
 

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -45,6 +45,20 @@ export interface SessionRow {
   terminal_id: string | null;
   /** Count of currently-attached WS clients on the linked terminal. 0 + non-null terminal_id = Minimised. */
   terminal_attached_clients: number;
+  /** Process exit code captured by the PTY manager. NULL until the
+   *  child exits. */
+  exit_code: number | null;
+  /** Process exit signal captured by the PTY manager (e.g. "SIGKILL"). */
+  exit_signal: string | null;
+  /** 1 once the watcher has seen an explicit `/exit` slash-command in the
+   *  transcript. SQLite-style 0/1 boolean. */
+  explicit_exit_seen: number;
+  /** 1 when the PTY manager observed a clean process exit (code 0, no
+   *  signal). SQLite-style 0/1 boolean. */
+  clean_process_exit: number;
+  /** Last `stop_reason` reported by the assistant (e.g. "end_turn",
+   *  "tool_use"). NULL until at least one assistant turn has stopped. */
+  last_assistant_stop_reason: string | null;
 }
 
 export interface SessionEventRow {
@@ -164,6 +178,17 @@ export interface SessionStore {
   upsertSession(row: InsertSession): void;
   updateSessionState(id: string, state: SessionState, lastEventAt: string): void;
   updateSession(id: string, fields: Partial<Omit<SessionRow, "id" | "started_at">>): void;
+  /** Record the PTY child's exit. Called by the ClaudePtyManager once
+   *  when the process exits — `cleanProcessExit` separates a normal exit
+   *  (code 0, no signal) from a crash / kill so the watcher can fold it
+   *  into the displayState derivation without re-reading exit_code. */
+  recordExit(id: string, info: { exitCode: number | null; exitSignal: string | null; cleanProcessExit: boolean }): void;
+  /** Update the assistant's most recent stop_reason. Called by the
+   *  watcher whenever it ingests a new assistant turn that has stopped. */
+  setLastAssistantStopReason(id: string, reason: string | null): void;
+  /** Flip explicit_exit_seen to 1. Idempotent — called by the watcher
+   *  when it spots a `/exit` slash-command artefact. */
+  markExplicitExitSeen(id: string): void;
   // session_events — bulk-friendly
   insertEvent(row: InsertSessionEvent): number;
   insertEvents(rows: InsertSessionEvent[]): void;
@@ -220,6 +245,9 @@ export class SqliteSessionStore implements SessionStore {
     getLastOffset: Database.Statement;
     setLastOffset: Database.Statement;
     deleteSession: Database.Statement;
+    recordExit: Database.Statement;
+    setLastAssistantStopReason: Database.Statement;
+    markExplicitExitSeen: Database.Statement;
   };
 
   private insertEventsTxn: (rows: InsertSessionEvent[]) => void;
@@ -346,6 +374,19 @@ export class SqliteSessionStore implements SessionStore {
         "UPDATE sessions SET last_offset = ? WHERE id = ?"
       ),
       deleteSession: db.prepare("DELETE FROM sessions WHERE id = ?"),
+      recordExit: db.prepare(`
+        UPDATE sessions
+        SET exit_code = @exit_code,
+            exit_signal = @exit_signal,
+            clean_process_exit = @clean_process_exit
+        WHERE id = @id
+      `),
+      setLastAssistantStopReason: db.prepare(
+        "UPDATE sessions SET last_assistant_stop_reason = ? WHERE id = ?"
+      ),
+      markExplicitExitSeen: db.prepare(
+        "UPDATE sessions SET explicit_exit_seen = 1 WHERE id = ?"
+      ),
     };
 
     // Bulk insert helper. Wrap N inserts in a single transaction so a JSONL
@@ -400,6 +441,26 @@ export class SqliteSessionStore implements SessionStore {
 
   updateSessionState(id: string, state: SessionState, lastEventAt: string): void {
     this.stmts.updateSessionState.run(state, lastEventAt, id);
+  }
+
+  recordExit(
+    id: string,
+    info: { exitCode: number | null; exitSignal: string | null; cleanProcessExit: boolean },
+  ): void {
+    this.stmts.recordExit.run({
+      id,
+      exit_code: info.exitCode,
+      exit_signal: info.exitSignal,
+      clean_process_exit: info.cleanProcessExit ? 1 : 0,
+    });
+  }
+
+  setLastAssistantStopReason(id: string, reason: string | null): void {
+    this.stmts.setLastAssistantStopReason.run(reason, id);
+  }
+
+  markExplicitExitSeen(id: string): void {
+    this.stmts.markExplicitExitSeen.run(id);
   }
 
   private static readonly UPDATABLE_SESSION_COLUMNS = new Set([

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -13,6 +13,17 @@ import type {
 import { encodeCwd } from "../session-sync-service.js";
 import { isClaudeProtocolArtifact } from "../utils/claude-protocol-artifacts.js";
 import { activeClaudeCwdCounts } from "./claude-process-probe.js";
+import {
+  deriveState,
+  type DeriveStateInput,
+  type ProbeSignal,
+} from "../session-state.js";
+
+// Re-export so existing watcher consumers can keep their imports stable
+// during the relocation. New callers should import from session-state.js
+// directly.
+export { deriveState };
+export type { DeriveStateInput, ProbeSignal };
 
 // claude-code session log watcher (Sprint 2 of the 0.5.0 sessions arc).
 // See docs/plans/sessions-arc.md.
@@ -26,23 +37,11 @@ import { activeClaudeCwdCounts } from "./claude-process-probe.js";
 
 const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 
-// State derivation: see deriveState() below. Evidence-first — exit columns
-// and (for managed sessions) the last assistant stop_reason short-circuit
-// the time-based fallback. For unmanaged sessions with no exit evidence,
-// JSONL recency + process probe decide between active / waiting /
-// disconnected. The 4-state output never includes `dormant`; that's
-// derived at presentation time from `disconnected + ageMs > 8h` (Task 6).
-//
-// `signal` is tri-state to handle Windows / probe-unavailable gracefully:
-//   "alive"   — probe ran, found a claude process at this cwd
-//   "absent"  — probe ran, found no claude at this cwd (terminal closed)
-//   "unknown" — probe couldn't run at all (no pgrep). Treat as benefit-
-//               of-doubt: a recent session reads as waiting, not
-//               disconnected. Otherwise Windows would force every idle
-//               session to disconnected, worse than the pre-probe state.
-export type ProbeSignal = "alive" | "absent" | "unknown";
-const ACTIVE_WINDOW_MS = 60_000;
-const WAITING_WINDOW_MS = 30 * 60 * 1000;
+// State derivation lives in `../session-state.js` — that module is the
+// single owner of the deriveState / deriveReason rules and is shared by
+// the heartbeat sweep, the boot scan, the PTY exit handler, and the
+// wire-format mapper. See ProbeSignal / DeriveStateInput / deriveState
+// in that file for the full evidence-first semantics.
 
 // How often the heartbeat sweep runs. Each tick probes processes (~40ms on
 // macOS for a few claude PIDs) and recomputes state for every claude-code
@@ -973,64 +972,6 @@ function captureEvidence(
       store.setLastAssistantStopReason(sessionId, stopReason);
     }
   }
-}
-
-export interface DeriveStateInput {
-  terminalId: string | null;
-  ageMs: number;
-  probeSignal: ProbeSignal;
-  exitCode: number | null;
-  exitSignal: string | null;
-  explicitExitSeen: boolean;
-  cleanProcessExit: boolean;
-  /** The user clicked the red-square stop button. Recorded *before* the
-   *  signal is sent so the eventual signal-driven PTY exit isn't
-   *  classified as a crash. Paired with process-exit evidence in
-   *  deriveState so a row can't briefly read 'done' while the PTY is
-   *  still alive (i.e., the intent flag has been written but the
-   *  process hasn't yet exited). */
-  userStopRequested: boolean;
-  lastAssistantStopReason: string | null;
-}
-
-export function deriveState(input: DeriveStateInput): SessionState {
-  // User-initiated stop, once the process has actually exited: the signal
-  // (typically SIGHUP from node-pty's default kill()) IS the shutdown
-  // mechanism, not evidence of a crash. Requires process-exit evidence so
-  // a pre-exit race (flag written, PTY not yet down) doesn't yield 'done'
-  // while the underlying process is still running.
-  const hasProcessExitEvidence =
-    input.exitCode != null || input.exitSignal != null || input.cleanProcessExit;
-  if (input.userStopRequested && hasProcessExitEvidence) return "done";
-
-  // Precedence: bad exit evidence beats any "clean" claim that lacks user
-  // intent. A session that typed /exit and then got SIGKILLed
-  // mid-shutdown should read disconnected, not done.
-  if (input.exitSignal || (input.exitCode != null && input.exitCode !== 0)) {
-    return "disconnected";
-  }
-  if (input.explicitExitSeen || input.cleanProcessExit) return "done";
-  if (input.terminalId) {
-    // Only "computing" stop reasons keep us in active. `null` means we
-    // haven't seen any assistant event yet (user just opened the session
-    // or sent their first prompt — the agent IS computing). `tool_use`
-    // and `pause_turn` are genuine in-flight signals. Every other stop
-    // reason (end_turn, max_tokens, stop_sequence, refusal) means the
-    // model has stopped and the user is the next actor.
-    const computing =
-      input.lastAssistantStopReason === null ||
-      input.lastAssistantStopReason === "tool_use" ||
-      input.lastAssistantStopReason === "pause_turn";
-    return computing ? "active" : "waiting";
-  }
-  if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
-  if (input.ageMs < WAITING_WINDOW_MS) {
-    return input.probeSignal === "absent" ? "disconnected" : "waiting";
-  }
-  // 8h+ idle is still 'disconnected' in the persisted enum. The presentation
-  // layer (sessions API) maps disconnected + age > 8h into 'dormant' for the
-  // wire-format displayState field. See Task 6.
-  return "disconnected";
 }
 
 // Pull a usable title out of a `type:"user"` event's content, or return null.

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -455,6 +455,12 @@ export class ClaudeCodeWatcher {
       const ev = safeParse(line);
       if (!ev) continue;
 
+      // Evidence capture (Task 4 of session-status-palette). Same rules as
+      // consumeOnce: detect `/exit` as a raw user message (the explicit
+      // invocation, not its `<command-name>/exit</command-name>` wrapper),
+      // and persist every assistant `stop_reason` we see.
+      captureEvidence(ev, sessionId, this.deps.sessionStore);
+
       const rendered = renderEvent(ev);
       if (rendered) {
         const text = rendered.text.slice(0, TEXT_PREVIEW_MAX);
@@ -787,6 +793,15 @@ export class ClaudeCodeWatcher {
         sessionEnsured = true;
       }
 
+      // Evidence capture (Task 4 of session-status-palette). Runs after
+      // sessionEnsured so the FK is satisfied. Detect the explicit `/exit`
+      // user command and persist every assistant `stop_reason`. Both feed
+      // deriveState — `end_turn` is the "awaiting user" signal, anything
+      // else means the agent is mid-turn or got cut off.
+      if (tracker.sessionId) {
+        captureEvidence(ev, tracker.sessionId, this.deps.sessionStore);
+      }
+
       const rendered = renderEvent(ev);
       if (rendered && tracker.sessionId) {
         const text = rendered.text.slice(0, TEXT_PREVIEW_MAX);
@@ -913,6 +928,35 @@ export class ClaudeCodeWatcher {
 }
 
 // ── Pure helpers (exported for tests) ─────────────────────────────────────
+
+// Capture the two pieces of evidence Task 5's deriveState reads from the
+// JSONL stream:
+//   1. an explicit `/exit` user message → flips explicit_exit_seen
+//   2. an assistant event's `stop_reason` → updates last_assistant_stop_reason
+//
+// `/exit` is matched on the raw user content (`message.content === "/exit"`),
+// NOT on the `<command-name>/exit</command-name>` wrapper that follows. The
+// wrapper is the prompt shape claude-code uses to render the slash command;
+// only the invocation itself is evidence that the user chose to exit.
+function captureEvidence(
+  ev: Record<string, any>,
+  sessionId: string,
+  store: SessionStore,
+): void {
+  if (ev.type === "user") {
+    const content = ev?.message?.content;
+    if (typeof content === "string" && content.trim() === "/exit") {
+      store.markExplicitExitSeen(sessionId);
+    }
+    return;
+  }
+  if (ev.type === "assistant") {
+    const stopReason = ev?.message?.stop_reason;
+    if (typeof stopReason === "string") {
+      store.setLastAssistantStopReason(sessionId, stopReason);
+    }
+  }
+}
 
 export function deriveState(ageMs: number, signal: ProbeSignal): SessionState {
   if (ageMs < ACTIVE_WINDOW_MS) return "active";

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -993,7 +993,17 @@ export function deriveState(input: DeriveStateInput): SessionState {
   }
   if (input.explicitExitSeen || input.cleanProcessExit) return "done";
   if (input.terminalId) {
-    return input.lastAssistantStopReason === "end_turn" ? "waiting" : "active";
+    // Only "computing" stop reasons keep us in active. `null` means we
+    // haven't seen any assistant event yet (user just opened the session
+    // or sent their first prompt — the agent IS computing). `tool_use`
+    // and `pause_turn` are genuine in-flight signals. Every other stop
+    // reason (end_turn, max_tokens, stop_sequence, refusal) means the
+    // model has stopped and the user is the next actor.
+    const computing =
+      input.lastAssistantStopReason === null ||
+      input.lastAssistantStopReason === "tool_use" ||
+      input.lastAssistantStopReason === "pause_turn";
+    return computing ? "active" : "waiting";
   }
   if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
   if (input.ageMs < WAITING_WINDOW_MS) {

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -455,8 +455,10 @@ export class ClaudeCodeWatcher {
       if (!ev) continue;
 
       // Evidence capture (Task 4 of session-status-palette). Same rules as
-      // consumeOnce: detect `/exit` as a raw user message (the explicit
-      // invocation, not its `<command-name>/exit</command-name>` wrapper),
+      // consumeOnce: detect `/exit` via the `<command-name>/exit</command-name>`
+      // wrapper that claude-code templates into the user content BEFORE
+      // writing to JSONL (verified empirically against ~/.claude/projects/:
+      // 0 raw `/exit` user events vs 73 wrapped ones in the local corpus),
       // and persist every assistant `stop_reason` we see.
       captureEvidence(ev, sessionId, this.deps.sessionStore);
 

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -26,17 +26,12 @@ import { activeClaudeCwdCounts } from "./claude-process-probe.js";
 
 const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 
-// State derivation: JSONL recency is the source of truth, process probe
-// only gates whether a recent-but-not-fresh session reads as `waiting`
-// vs `disconnected`. We can't externally identify *which* claude process
-// is driving *which* session — there's no PID in the JSONL and the file
-// isn't held open between turns. Anything more ambitious than "is there
-// some claude at this cwd?" devolves into heuristics with edge cases.
-//
-//   ageMs < ACTIVE_WINDOW_MS                                → active
-//   ageMs < WAITING_WINDOW_MS    + signal != "absent"       → waiting
-//   ageMs < DONE_THRESHOLD_MS                               → disconnected
-//   otherwise                                               → done
+// State derivation: see deriveState() below. Evidence-first — exit columns
+// and (for managed sessions) the last assistant stop_reason short-circuit
+// the time-based fallback. For unmanaged sessions with no exit evidence,
+// JSONL recency + process probe decide between active / waiting /
+// disconnected. The 4-state output never includes `dormant`; that's
+// derived at presentation time from `disconnected + ageMs > 8h` (Task 6).
 //
 // `signal` is tri-state to handle Windows / probe-unavailable gracefully:
 //   "alive"   — probe ran, found a claude process at this cwd
@@ -45,17 +40,9 @@ const DEFAULT_PROJECTS_ROOT = join(homedir(), ".claude", "projects");
 //               of-doubt: a recent session reads as waiting, not
 //               disconnected. Otherwise Windows would force every idle
 //               session to disconnected, worse than the pre-probe state.
-//
-// The 30-min waiting window is the honest cap: a JSONL untouched for
-// 30 min reads as disconnected regardless of probe. That means an old
-// transcript at a cwd where the user is currently working doesn't get
-// falsely elevated to waiting. False negative: a claude tab idle for
-// >30min on POSIX reads as disconnected even if the process is live —
-// flips back to active the moment the user types.
 export type ProbeSignal = "alive" | "absent" | "unknown";
 const ACTIVE_WINDOW_MS = 60_000;
 const WAITING_WINDOW_MS = 30 * 60 * 1000;
-const DONE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
 // How often the heartbeat sweep runs. Each tick probes processes (~40ms on
 // macOS for a few claude PIDs) and recomputes state for every claude-code
@@ -361,7 +348,19 @@ export class ClaudeCodeWatcher {
     const signal: ProbeSignal = !probe.available
       ? "unknown"
       : meta.cwd && (probe.counts.get(meta.cwd) ?? 0) > 0 ? "alive" : "absent";
-    const state = deriveState(ageMs, signal);
+    // Boot scan runs before any session row exists, so the exit / terminal /
+    // stop_reason facts aren't available yet. Fall through to the time-based
+    // branch; the next heartbeat sweep will refine using the persisted facts.
+    const state = deriveState({
+      terminalId: null,
+      ageMs,
+      probeSignal: signal,
+      exitCode: null,
+      exitSignal: null,
+      explicitExitSeen: false,
+      cleanProcessExit: false,
+      lastAssistantStopReason: null,
+    });
 
     // Always pass ISO-8601 timestamps. If the JSONL didn't have a usable
     // event timestamp in the first 32KB, fall back to the file's birth time
@@ -908,7 +907,16 @@ export class ClaudeCodeWatcher {
       const signal: ProbeSignal = !probe.available
         ? "unknown"
         : cwd && (probe.counts.get(cwd) ?? 0) > 0 ? "alive" : "absent";
-      const next = deriveState(ageMs, signal);
+      const next = deriveState({
+        terminalId: session.terminal_id ?? null,
+        ageMs,
+        probeSignal: signal,
+        exitCode: session.exit_code ?? null,
+        exitSignal: session.exit_signal ?? null,
+        explicitExitSeen: !!session.explicit_exit_seen,
+        cleanProcessExit: !!session.clean_process_exit,
+        lastAssistantStopReason: session.last_assistant_stop_reason ?? null,
+      });
 
       if (next !== session.state) {
         this.deps.sessionStore.updateSessionState(session.id, next, session.last_event_at);
@@ -965,12 +973,35 @@ function captureEvidence(
   }
 }
 
-export function deriveState(ageMs: number, signal: ProbeSignal): SessionState {
-  if (ageMs < ACTIVE_WINDOW_MS) return "active";
-  if (ageMs > DONE_THRESHOLD_MS) return "done";
-  if (ageMs < WAITING_WINDOW_MS) {
-    return signal === "absent" ? "disconnected" : "waiting";
+export interface DeriveStateInput {
+  terminalId: string | null;
+  ageMs: number;
+  probeSignal: ProbeSignal;
+  exitCode: number | null;
+  exitSignal: string | null;
+  explicitExitSeen: boolean;
+  cleanProcessExit: boolean;
+  lastAssistantStopReason: string | null;
+}
+
+export function deriveState(input: DeriveStateInput): SessionState {
+  // Precedence: bad exit evidence beats any "clean" claim. A session that
+  // typed /exit and then got SIGKILLed mid-shutdown should read disconnected,
+  // not done.
+  if (input.exitSignal || (input.exitCode != null && input.exitCode !== 0)) {
+    return "disconnected";
   }
+  if (input.explicitExitSeen || input.cleanProcessExit) return "done";
+  if (input.terminalId) {
+    return input.lastAssistantStopReason === "end_turn" ? "waiting" : "active";
+  }
+  if (input.ageMs < ACTIVE_WINDOW_MS) return "active";
+  if (input.ageMs < WAITING_WINDOW_MS) {
+    return input.probeSignal === "absent" ? "disconnected" : "waiting";
+  }
+  // 8h+ idle is still 'disconnected' in the persisted enum. The presentation
+  // layer (sessions API) maps disconnected + age > 8h into 'dormant' for the
+  // wire-format displayState field. See Task 6.
   return "disconnected";
 }
 

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -359,6 +359,7 @@ export class ClaudeCodeWatcher {
       exitSignal: null,
       explicitExitSeen: false,
       cleanProcessExit: false,
+      userStopRequested: false,
       lastAssistantStopReason: null,
     });
 
@@ -915,6 +916,7 @@ export class ClaudeCodeWatcher {
         exitSignal: session.exit_signal ?? null,
         explicitExitSeen: !!session.explicit_exit_seen,
         cleanProcessExit: !!session.clean_process_exit,
+        userStopRequested: !!session.user_stop_requested_at,
         lastAssistantStopReason: session.last_assistant_stop_reason ?? null,
       });
 
@@ -981,13 +983,29 @@ export interface DeriveStateInput {
   exitSignal: string | null;
   explicitExitSeen: boolean;
   cleanProcessExit: boolean;
+  /** The user clicked the red-square stop button. Recorded *before* the
+   *  signal is sent so the eventual signal-driven PTY exit isn't
+   *  classified as a crash. Paired with process-exit evidence in
+   *  deriveState so a row can't briefly read 'done' while the PTY is
+   *  still alive (i.e., the intent flag has been written but the
+   *  process hasn't yet exited). */
+  userStopRequested: boolean;
   lastAssistantStopReason: string | null;
 }
 
 export function deriveState(input: DeriveStateInput): SessionState {
-  // Precedence: bad exit evidence beats any "clean" claim. A session that
-  // typed /exit and then got SIGKILLed mid-shutdown should read disconnected,
-  // not done.
+  // User-initiated stop, once the process has actually exited: the signal
+  // (typically SIGHUP from node-pty's default kill()) IS the shutdown
+  // mechanism, not evidence of a crash. Requires process-exit evidence so
+  // a pre-exit race (flag written, PTY not yet down) doesn't yield 'done'
+  // while the underlying process is still running.
+  const hasProcessExitEvidence =
+    input.exitCode != null || input.exitSignal != null || input.cleanProcessExit;
+  if (input.userStopRequested && hasProcessExitEvidence) return "done";
+
+  // Precedence: bad exit evidence beats any "clean" claim that lacks user
+  // intent. A session that typed /exit and then got SIGKILLed
+  // mid-shutdown should read disconnected, not done.
   if (input.exitSignal || (input.exitCode != null && input.exitCode !== 0)) {
     return "disconnected";
   }

--- a/server/src/watchers/claude-code.ts
+++ b/server/src/watchers/claude-code.ts
@@ -934,10 +934,11 @@ export class ClaudeCodeWatcher {
 //   1. an explicit `/exit` user message → flips explicit_exit_seen
 //   2. an assistant event's `stop_reason` → updates last_assistant_stop_reason
 //
-// `/exit` is matched on the raw user content (`message.content === "/exit"`),
-// NOT on the `<command-name>/exit</command-name>` wrapper that follows. The
-// wrapper is the prompt shape claude-code uses to render the slash command;
-// only the invocation itself is evidence that the user chose to exit.
+// `/exit` is matched on the `<command-name>/exit</command-name>` wrapper that
+// claude-code templates into the user `content` string BEFORE persisting to
+// JSONL. The wrapper IS the invocation event, not a follow-up render artefact.
+// (Verified empirically against ~/.claude/projects/*/*.jsonl: 0 raw `/exit`
+// user events vs 73 wrapped ones in the local corpus.)
 function captureEvidence(
   ev: Record<string, any>,
   sessionId: string,
@@ -945,8 +946,14 @@ function captureEvidence(
 ): void {
   if (ev.type === "user") {
     const content = ev?.message?.content;
-    if (typeof content === "string" && content.trim() === "/exit") {
-      store.markExplicitExitSeen(sessionId);
+    if (typeof content === "string") {
+      // Claude Code templates slash commands into a wrapper *before* writing to
+      // JSONL — the wrapper IS the invocation, not a follow-up render artefact.
+      // (Verified empirically against ~/.claude/projects/*/*.jsonl: 0 raw /exit
+      // events vs 73 wrapped ones in the local corpus.)
+      if (content.trimStart().startsWith("<command-name>/exit</command-name>")) {
+        store.markExplicitExitSeen(sessionId);
+      }
     }
     return;
   }

--- a/server/test/claude-code-watcher-evidence.test.ts
+++ b/server/test/claude-code-watcher-evidence.test.ts
@@ -6,13 +6,20 @@
 // Both signals feed `deriveState` (Task 5 of the session-status-palette plan).
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ClaudeCodeWatcher } from "../src/watchers/claude-code.js";
 import { initDb } from "../src/db.js";
 import { SqliteSessionStore } from "../src/session-store.js";
 import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+// The exact wire shape Claude Code persists when the user invokes `/exit`:
+// the slash command is templated into a wrapper inside `message.content`
+// BEFORE the line is written to JSONL. Verified empirically against
+// ~/.claude/projects/*/*.jsonl (0 raw `/exit` vs 73 wrapped events).
+const EXIT_WRAPPED =
+  "<command-name>/exit</command-name>\n            <command-message>exit</command-message>\n            <command-args></command-args>";
 
 interface Env {
   watcher: ClaudeCodeWatcher;
@@ -62,11 +69,11 @@ describe("claude-code watcher — evidence capture", () => {
   beforeEach(() => { env = makeEnv(); });
   afterEach(async () => { await env.cleanup(); });
 
-  it("sets explicit_exit_seen when the JSONL has a /exit user event", async () => {
+  it("sets explicit_exit_seen when the JSONL has a wrapped /exit user event", async () => {
     const sessionId = writeJsonl(env.root, [
       { type: "user", message: { content: "first" }, timestamp: new Date().toISOString() },
       { type: "assistant", message: { stop_reason: "end_turn", content: [{ type: "text", text: "ok" }] }, timestamp: new Date().toISOString() },
-      { type: "user", message: { content: "/exit" }, timestamp: new Date().toISOString() },
+      { type: "user", message: { role: "user", content: EXIT_WRAPPED }, timestamp: new Date().toISOString() },
     ]);
 
     await env.watcher.start();
@@ -74,6 +81,46 @@ describe("claude-code watcher — evidence capture", () => {
     const row = env.store.getById(sessionId);
     expect(row).toBeDefined();
     expect(row!.explicit_exit_seen).toBe(1);
+  });
+
+  it("does NOT set explicit_exit_seen on a bare '/exit' user content (not the real wire shape)", async () => {
+    // In production, Claude Code never persists a raw "/exit" — it always
+    // wraps the slash command in <command-name>…</command-name> before write.
+    // A bare "/exit" is paste/echo/test noise, not the invocation, so it must
+    // not flip the flag.
+    const sessionId = writeJsonl(env.root, [
+      { type: "user", message: { role: "user", content: "first" }, timestamp: new Date().toISOString() },
+      { type: "user", message: { role: "user", content: "/exit" }, timestamp: new Date().toISOString() },
+    ]);
+
+    await env.watcher.start();
+
+    const row = env.store.getById(sessionId);
+    expect(row).toBeDefined();
+    expect(row!.explicit_exit_seen).toBe(0);
+  });
+
+  it("does NOT set explicit_exit_seen when an assistant message contains the wrapper substring", async () => {
+    // The user-branch only inspects ev.type === "user" events. An assistant
+    // message that happens to mention the wrapper (e.g. discussing how /exit
+    // is encoded) must not trip the matcher.
+    const sessionId = writeJsonl(env.root, [
+      { type: "user", message: { role: "user", content: "how does /exit get persisted?" }, timestamp: new Date().toISOString() },
+      {
+        type: "assistant",
+        message: {
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: `Claude Code wraps it as ${EXIT_WRAPPED}` }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+
+    await env.watcher.start();
+
+    const row = env.store.getById(sessionId);
+    expect(row).toBeDefined();
+    expect(row!.explicit_exit_seen).toBe(0);
   });
 
   it("stores last assistant stop_reason in last_assistant_stop_reason", async () => {
@@ -114,5 +161,43 @@ describe("claude-code watcher — evidence capture", () => {
     expect(row).toBeDefined();
     expect(row!.explicit_exit_seen).toBe(0);
     expect(row!.last_assistant_stop_reason).toBeNull();
+  });
+
+  it("sets explicit_exit_seen on a wrapped /exit appended AFTER watcher.start (live ingest)", async () => {
+    // Previous tests all write the JSONL first, then call start() — only
+    // exercising the `backfillRange` path. This test exercises the
+    // live-ingest path: start the watcher on a short JSONL, then append the
+    // wrapped /exit line and wait for chokidar's change event to fire.
+    const sessionId = `00000000-0000-0000-0000-${Date.now().toString(16).padStart(12, "0")}`;
+    const projectDir = join(env.root, "-tmp-fixture-cwd");
+    mkdirSync(projectDir, { recursive: true });
+    const filePath = join(projectDir, `${sessionId}.jsonl`);
+    const initial = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "first" },
+      timestamp: new Date().toISOString(),
+    }) + "\n";
+    writeFileSync(filePath, initial);
+
+    await env.watcher.start();
+
+    // Sanity: backfill picked up the initial line but didn't set the flag.
+    expect(env.store.getById(sessionId)!.explicit_exit_seen).toBe(0);
+
+    // Append the wrapped /exit and wait for the watcher tick to ingest it.
+    appendFileSync(filePath, JSON.stringify({
+      type: "user",
+      message: { role: "user", content: EXIT_WRAPPED },
+      timestamp: new Date().toISOString(),
+    }) + "\n");
+
+    // Poll briefly — chokidar's debounce + the file lock can take a moment.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      if (env.store.getById(sessionId)!.explicit_exit_seen === 1) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(env.store.getById(sessionId)!.explicit_exit_seen).toBe(1);
   });
 });

--- a/server/test/claude-code-watcher-evidence.test.ts
+++ b/server/test/claude-code-watcher-evidence.test.ts
@@ -1,0 +1,118 @@
+// Tests for the JSONL-side evidence capture in ClaudeCodeWatcher:
+//   - `/exit` user events flip `explicit_exit_seen` to 1
+//   - every assistant event with a `stop_reason` persists into
+//     `last_assistant_stop_reason`
+//
+// Both signals feed `deriveState` (Task 5 of the session-status-palette plan).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ClaudeCodeWatcher } from "../src/watchers/claude-code.js";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+interface Env {
+  watcher: ClaudeCodeWatcher;
+  store: SqliteSessionStore;
+  root: string;
+  cleanup: () => Promise<void>;
+}
+
+function makeEnv(): Env {
+  const root = mkdtempSync(join(tmpdir(), "oyster-watcher-evidence-"));
+  const dbDir = mkdtempSync(join(tmpdir(), "oyster-watcher-evidence-db-"));
+  const db = initDb(dbDir);
+  const store = new SqliteSessionStore(db);
+  const artifactStore = new SqliteArtifactStore(db);
+  const watcher = new ClaudeCodeWatcher({
+    sessionStore: store,
+    artifactStore,
+    lookupProject: () => ({ projectId: null, spaceId: null }),
+    projectsRoot: root,
+  });
+  return {
+    watcher,
+    store,
+    root,
+    cleanup: async () => {
+      await watcher.stop();
+      db.close();
+      rmSync(root, { recursive: true, force: true });
+      rmSync(dbDir, { recursive: true, force: true });
+    },
+  };
+}
+
+// Write a JSONL file under <root>/<encoded-cwd>/<sessionId>.jsonl and return
+// the chosen sessionId. The boot scan picks it up when start() is called.
+function writeJsonl(root: string, events: Array<Record<string, unknown>>): string {
+  const sessionId = `00000000-0000-0000-0000-${Date.now().toString(16).padStart(12, "0")}`;
+  const projectDir = join(root, "-tmp-fixture-cwd");
+  mkdirSync(projectDir, { recursive: true });
+  const lines = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  writeFileSync(join(projectDir, `${sessionId}.jsonl`), lines);
+  return sessionId;
+}
+
+describe("claude-code watcher — evidence capture", () => {
+  let env: Env;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(async () => { await env.cleanup(); });
+
+  it("sets explicit_exit_seen when the JSONL has a /exit user event", async () => {
+    const sessionId = writeJsonl(env.root, [
+      { type: "user", message: { content: "first" }, timestamp: new Date().toISOString() },
+      { type: "assistant", message: { stop_reason: "end_turn", content: [{ type: "text", text: "ok" }] }, timestamp: new Date().toISOString() },
+      { type: "user", message: { content: "/exit" }, timestamp: new Date().toISOString() },
+    ]);
+
+    await env.watcher.start();
+
+    const row = env.store.getById(sessionId);
+    expect(row).toBeDefined();
+    expect(row!.explicit_exit_seen).toBe(1);
+  });
+
+  it("stores last assistant stop_reason in last_assistant_stop_reason", async () => {
+    const sessionId = writeJsonl(env.root, [
+      { type: "user", message: { content: "do it" }, timestamp: new Date().toISOString() },
+      { type: "assistant", message: { stop_reason: "tool_use", content: [{ type: "tool_use", name: "Bash", input: {} }] }, timestamp: new Date().toISOString() },
+    ]);
+
+    await env.watcher.start();
+
+    const row = env.store.getById(sessionId);
+    expect(row).toBeDefined();
+    expect(row!.last_assistant_stop_reason).toBe("tool_use");
+  });
+
+  it("end_turn updates last_assistant_stop_reason from a prior tool_use", async () => {
+    const sessionId = writeJsonl(env.root, [
+      { type: "assistant", message: { stop_reason: "tool_use", content: [{ type: "tool_use", name: "Bash", input: {} }] }, timestamp: new Date().toISOString() },
+      { type: "user", message: { content: [{ type: "tool_result", content: "ok" }] }, timestamp: new Date().toISOString() },
+      { type: "assistant", message: { stop_reason: "end_turn", content: [{ type: "text", text: "done" }] }, timestamp: new Date().toISOString() },
+    ]);
+
+    await env.watcher.start();
+
+    const row = env.store.getById(sessionId);
+    expect(row).toBeDefined();
+    expect(row!.last_assistant_stop_reason).toBe("end_turn");
+  });
+
+  it("leaves both fields untouched when no /exit and no assistant stop_reason are present", async () => {
+    const sessionId = writeJsonl(env.root, [
+      { type: "user", message: { content: "hello" }, timestamp: new Date().toISOString() },
+    ]);
+
+    await env.watcher.start();
+
+    const row = env.store.getById(sessionId);
+    expect(row).toBeDefined();
+    expect(row!.explicit_exit_seen).toBe(0);
+    expect(row!.last_assistant_stop_reason).toBeNull();
+  });
+});

--- a/server/test/claude-pty-manager-link.test.ts
+++ b/server/test/claude-pty-manager-link.test.ts
@@ -151,7 +151,7 @@ describe("ClaudePtyManager DB link", () => {
     expect(row.terminal_attached_clients).toBe(0);
   });
 
-  it("calling kill() marks the linked session disconnected", () => {
+  it("calling kill() marks the linked session done on a clean exit", () => {
     // Give s1 a real event so it is not a ghost and won't be deleted on exit.
     env.store.insertEvent({ session_id: "s1", role: "user", text: "hello" });
     env.mgr._seedEntryForTest({ terminalId: "t3", linkedSessionId: null });
@@ -162,8 +162,10 @@ describe("ClaudePtyManager DB link", () => {
 
     env.mgr.kill("t3");
 
-    // After kill: the session row state should be "disconnected".
-    expect(env.store.getById("s1")!.state).toBe("disconnected");
+    // The fake proc fires {exitCode: 0, signal: null} → clean process exit
+    // → transient state should be "done". The next heartbeat sweep will
+    // re-derive from the recorded facts.
+    expect(env.store.getById("s1")!.state).toBe("done");
   });
 
   it("calling kill() deletes a ghost session (no events, no JSONL)", () => {

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -40,6 +40,7 @@ const stubDeps = {
     clearTerminal: () => {},
     setAttachedClients: () => {},
     deleteSession: () => {},
+    markUserStopRequested: () => {},
   } as any,
   db: stubDb,
   broadcastUiEvent: () => {},
@@ -122,6 +123,67 @@ describe("ClaudePtyManager", () => {
     expect(mgr.kill(terminalId)).toBe(true);
     mgr.disposeAll();
     expect(mgr.list()).toHaveLength(0);
+  });
+
+  describe("kill(reason: 'user_stop') marks the linked session", () => {
+    // Tracks markUserStopRequested invocations so we can assert wiring
+    // without needing a full SqliteSessionStore.
+    function makeTrackingDeps() {
+      const calls: string[] = [];
+      const deps = {
+        ...stubDeps,
+        sessionStore: {
+          ...stubDeps.sessionStore,
+          markUserStopRequested: (id: string) => { calls.push(id); },
+        } as any,
+      };
+      return { deps, calls };
+    }
+
+    it("calls markUserStopRequested with the linked sessionId when reason is 'user_stop'", () => {
+      const { deps, calls } = makeTrackingDeps();
+      const m = new ClaudePtyManager(deps);
+      if (!m.isPtyAvailable()) return;
+      const { terminalId } = m.spawn({
+        kind: "claude_resume",
+        command: SLEEP, args: SLEEP_ARGS, cwd: tmpdir(),
+        env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+      });
+      m.setLinkedSession(terminalId, "session-A");
+      expect(m.kill(terminalId, { reason: "user_stop" })).toBe(true);
+      expect(calls).toEqual(["session-A"]);
+      m.disposeAll();
+    });
+
+    it("does NOT mark on a plain kill() (no reason → system shutdown / disposeAll path)", () => {
+      const { deps, calls } = makeTrackingDeps();
+      const m = new ClaudePtyManager(deps);
+      if (!m.isPtyAvailable()) return;
+      const { terminalId } = m.spawn({
+        kind: "claude_resume",
+        command: SLEEP, args: SLEEP_ARGS, cwd: tmpdir(),
+        env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+      });
+      m.setLinkedSession(terminalId, "session-B");
+      expect(m.kill(terminalId)).toBe(true);
+      expect(calls).toEqual([]);
+      m.disposeAll();
+    });
+
+    it("does NOT mark on a user-stop kill of an unlinked terminal", () => {
+      const { deps, calls } = makeTrackingDeps();
+      const m = new ClaudePtyManager(deps);
+      if (!m.isPtyAvailable()) return;
+      const { terminalId } = m.spawn({
+        kind: "claude_new",
+        command: SLEEP, args: SLEEP_ARGS, cwd: tmpdir(),
+        env: { HOME: homedir(), PATH: process.env.PATH ?? "" },
+      });
+      // No setLinkedSession — terminal has no session attached yet.
+      expect(m.kill(terminalId, { reason: "user_stop" })).toBe(true);
+      expect(calls).toEqual([]);
+      m.disposeAll();
+    });
   });
 
   it("reaps a zombie entry whose process has died on next spawn", async () => {

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -284,6 +284,35 @@ describe("ClaudePtyManager _handleExit records exit facts", () => {
     expect(row.clean_process_exit).toBe(0);
   });
 
+  // Regression: a user_stop kill (UI red-square click) ends with
+  // exitCode 129 + signal SIGHUP. The pre-fix _handleExit branch wrote
+  // 'disconnected' transiently (because cleanProcessExit was false), and
+  // the heartbeat sweep ~15s later re-derived it to 'done'. The user saw
+  // red, then grey. After this fix _handleExit calls the shared
+  // deriveState, sees user_stop_requested_at + the just-recorded exit
+  // facts, and writes 'done' immediately — no transient red.
+  it("user_stop kill (SIGHUP + exitCode 129) writes state=done immediately", () => {
+    env.store.markUserStopRequested(env.sessionId);
+    (env.mgr as unknown as { _handleExit: (e: unknown, x: { exitCode: number; signal: string | null }) => void })
+      ._handleExit(env.entry, { exitCode: 129, signal: "SIGHUP" });
+    const row = env.store.getById(env.sessionId)!;
+    // Exit facts captured.
+    expect(row.exit_code).toBe(129);
+    expect(row.exit_signal).toBe("SIGHUP");
+    expect(row.clean_process_exit).toBe(0);
+    expect(row.user_stop_requested_at).not.toBeNull();
+    // State is 'done', NOT a transient 'disconnected' awaiting the heartbeat sweep.
+    expect(row.state).toBe("done");
+  });
+
+  it("external SIGKILL with no user_stop intent stays disconnected after _handleExit", () => {
+    (env.mgr as unknown as { _handleExit: (e: unknown, x: { exitCode: number; signal: string | null }) => void })
+      ._handleExit(env.entry, { exitCode: 137, signal: "SIGKILL" });
+    const row = env.store.getById(env.sessionId)!;
+    expect(row.user_stop_requested_at).toBeNull();
+    expect(row.state).toBe("disconnected");
+  });
+
   it("translates numeric signal from node-pty onExit to SIGxxx name", () => {
     // Drive the production onExit wrapper end-to-end: seed an entry whose
     // fake proc.kill() fires onExit with a numeric signal (matching node-pty's

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -221,4 +221,31 @@ describe("ClaudePtyManager _handleExit records exit facts", () => {
     expect(row.exit_signal).toBe("SIGKILL");
     expect(row.clean_process_exit).toBe(0);
   });
+
+  it("translates numeric signal from node-pty onExit to SIGxxx name", () => {
+    // Drive the production onExit wrapper end-to-end: seed an entry whose
+    // fake proc.kill() fires onExit with a numeric signal (matching node-pty's
+    // actual type), then assert the DB recorded the human-readable name.
+    const dir = mkdtempSync(join(tmpdir(), "oyster-pty-exit-num-"));
+    const db = initDb(dir);
+    const store = new SqliteSessionStore(db);
+    const mgr = new ClaudePtyManager({ sessionStore: store, db, broadcastUiEvent: () => {} });
+    const sessionId = "s2";
+    store.insertSession({ id: sessionId, space_id: null, agent: "claude-code", state: "active" });
+    store.insertEvent({ session_id: sessionId, role: "user", text: "hello" });
+    mgr._seedEntryForTest({
+      terminalId: "t2",
+      linkedSessionId: null,
+      killExit: { exitCode: 137, signal: 9 },
+    });
+    mgr.linkTerminalForTest("t2", sessionId);
+    mgr.kill("t2");
+    const row = store.getById(sessionId)!;
+    expect(row.exit_code).toBe(137);
+    expect(row.exit_signal).toBe("SIGKILL");
+    expect(row.clean_process_exit).toBe(0);
+    mgr.disposeAll();
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
 });

--- a/server/test/claude-pty-manager.test.ts
+++ b/server/test/claude-pty-manager.test.ts
@@ -5,6 +5,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ClaudePtyManager, TerminalCapError, PtyUnavailableError } from "../src/claude-pty-manager.js";
 import { tmpdir, homedir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
 
 const stubDb = {
   prepare: () => ({ get: () => undefined, run: () => {} }),
@@ -174,5 +178,47 @@ describe("ClaudePtyManager", () => {
       cwd: tmpdir(),
       env: {},
     })).toThrow(PtyUnavailableError);
+  });
+});
+
+function makeExitEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-pty-exit-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  const mgr = new ClaudePtyManager({ sessionStore: store, db, broadcastUiEvent: () => {} });
+  const sessionId = "s1";
+  store.insertSession({ id: sessionId, space_id: null, agent: "claude-code", state: "active" });
+  // Give the session a real event so deleteIfGhostOnExit doesn't drop the row.
+  store.insertEvent({ session_id: sessionId, role: "user", text: "hello" });
+  mgr._seedEntryForTest({ terminalId: "t1", linkedSessionId: null });
+  mgr.linkTerminalForTest("t1", sessionId);
+  const entry = mgr.getEntry("t1")!;
+  return {
+    db, store, mgr, sessionId, entry,
+    dispose: () => { mgr.disposeAll(); db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("ClaudePtyManager _handleExit records exit facts", () => {
+  let env: ReturnType<typeof makeExitEnv>;
+  beforeEach(() => { env = makeExitEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("records exit code/signal and marks clean_process_exit on exit=0", () => {
+    (env.mgr as unknown as { _handleExit: (e: unknown, x: { exitCode: number; signal: string | null }) => void })
+      ._handleExit(env.entry, { exitCode: 0, signal: null });
+    const row = env.store.getById(env.sessionId)!;
+    expect(row.exit_code).toBe(0);
+    expect(row.exit_signal).toBeNull();
+    expect(row.clean_process_exit).toBe(1);
+  });
+
+  it("records non-zero exit without setting clean_process_exit", () => {
+    (env.mgr as unknown as { _handleExit: (e: unknown, x: { exitCode: number; signal: string | null }) => void })
+      ._handleExit(env.entry, { exitCode: 137, signal: "SIGKILL" });
+    const row = env.store.getById(env.sessionId)!;
+    expect(row.exit_code).toBe(137);
+    expect(row.exit_signal).toBe("SIGKILL");
+    expect(row.clean_process_exit).toBe(0);
   });
 });

--- a/server/test/derive-reason.test.ts
+++ b/server/test/derive-reason.test.ts
@@ -97,19 +97,20 @@ describe("deriveReason", () => {
     );
   });
 
-  it("managed + null stop_reason (pre-first-assistant) → 'working'", () => {
-    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: null })).toBe("working");
+  // Cases that don't add info beyond colour + age return "" so the
+  // Reason column renders dark (suppressed).
+
+  it("managed + null stop_reason (pre-first-assistant) → '' (purple dot + age says enough)", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: null })).toBe("");
   });
 
-  it("managed + unknown stop_reason → 'working'", () => {
-    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "future_value" })).toBe(
-      "working",
-    );
+  it("managed + unknown stop_reason → '' (suppressed)", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "future_value" })).toBe("");
   });
 
-  // 6. Unmanaged — time + probe drives the copy.
-  it("unmanaged + age < 60s → 'active'", () => {
-    expect(deriveReason({ ...base, ageMs: 30_000 })).toBe("active");
+  // 6. Unmanaged — only surface probe-derived copy that adds info beyond age.
+  it("unmanaged + age < 60s → '' (green dot + age says enough)", () => {
+    expect(deriveReason({ ...base, ageMs: 30_000 })).toBe("");
   });
 
   it("unmanaged + 60s–30min + probe alive → 'idle, process detected'", () => {
@@ -124,24 +125,16 @@ describe("deriveReason", () => {
     );
   });
 
-  it("unmanaged + 60s–30min + probe unknown → 'idle'", () => {
-    expect(deriveReason({ ...base, ageMs: 5 * MIN, probeSignal: "unknown" })).toBe("idle");
+  it("unmanaged + 60s–30min + probe unknown → '' (no probe info to add)", () => {
+    expect(deriveReason({ ...base, ageMs: 5 * MIN, probeSignal: "unknown" })).toBe("");
   });
 
-  it("unmanaged + 30min–8h → 'quiet <age>'", () => {
-    expect(deriveReason({ ...base, ageMs: 2 * HOUR })).toBe("quiet 2h");
+  it("unmanaged + 30min–8h → '' (red dot + LAST ACTIVE says enough)", () => {
+    expect(deriveReason({ ...base, ageMs: 2 * HOUR })).toBe("");
   });
 
-  it("unmanaged + 8h+ → 'quiet <age>'", () => {
-    expect(deriveReason({ ...base, ageMs: 12 * HOUR })).toBe("quiet 12h");
-  });
-
-  it("unmanaged + multi-day → 'quiet 3d'", () => {
-    expect(deriveReason({ ...base, ageMs: 3 * 24 * HOUR })).toBe("quiet 3d");
-  });
-
-  it("unmanaged + 30min exactly → 'quiet 30m' (boundary)", () => {
-    expect(deriveReason({ ...base, ageMs: 30 * MIN })).toBe("quiet 30m");
+  it("unmanaged + 8h+ → '' (grey dormant dot + LAST ACTIVE says enough)", () => {
+    expect(deriveReason({ ...base, ageMs: 12 * HOUR })).toBe("");
   });
 
   // Sanity: deriveState + deriveReason agree on the user_stop kill from the

--- a/server/test/derive-reason.test.ts
+++ b/server/test/derive-reason.test.ts
@@ -1,0 +1,160 @@
+// Table-driven tests for deriveReason. Each branch of the priority order
+// in session-state.ts is exercised at least once. The headline case is the
+// user_stop kill (SIGHUP + exitCode 129) — the user-visible bug this whole
+// task fixes — which should read "stopped by user" *and* leave deriveState
+// at "done" with no transient "disconnected".
+
+import { describe, it, expect } from "vitest";
+import { deriveReason, deriveState } from "../src/session-state.js";
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+const base = {
+  terminalId: null as string | null,
+  ageMs: 0,
+  probeSignal: "unknown" as const,
+  exitCode: null as number | null,
+  exitSignal: null as string | null,
+  explicitExitSeen: false,
+  cleanProcessExit: false,
+  userStopRequested: false,
+  lastAssistantStopReason: null as string | null,
+};
+
+describe("deriveReason", () => {
+  // 1. Bad exit, no user-stop intent.
+  it("killed by signal (no user stop intent)", () => {
+    expect(deriveReason({ ...base, exitSignal: "SIGKILL" })).toBe("killed by SIGKILL");
+  });
+
+  it("crashed with non-zero exit code (no signal, no user stop intent)", () => {
+    expect(deriveReason({ ...base, exitCode: 1 })).toBe("crashed (exit 1)");
+  });
+
+  // 2. User stop with exit evidence — the headline case.
+  it("user_stop + SIGHUP + exitCode 129 → 'stopped by user'", () => {
+    const input = {
+      ...base,
+      userStopRequested: true,
+      exitSignal: "SIGHUP",
+      exitCode: 129,
+    };
+    expect(deriveReason(input)).toBe("stopped by user");
+    expect(deriveState(input)).toBe("done");
+  });
+
+  it("user_stop with clean exit → 'stopped by user'", () => {
+    expect(deriveReason({ ...base, userStopRequested: true, cleanProcessExit: true })).toBe(
+      "stopped by user",
+    );
+  });
+
+  // 3. Explicit /exit observed.
+  it("explicit /exit → 'ran /exit'", () => {
+    expect(deriveReason({ ...base, explicitExitSeen: true })).toBe("ran /exit");
+  });
+
+  // 4. Clean process exit (no /exit, no user stop).
+  it("clean process exit → 'exited cleanly'", () => {
+    expect(deriveReason({ ...base, cleanProcessExit: true })).toBe("exited cleanly");
+  });
+
+  // 5. Managed (terminalId set) — assistant stop_reason drives the copy.
+  it("managed + end_turn → 'awaiting input'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "end_turn" })).toBe(
+      "awaiting input",
+    );
+  });
+
+  it("managed + tool_use → 'running a tool'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "tool_use" })).toBe(
+      "running a tool",
+    );
+  });
+
+  it("managed + pause_turn → 'thinking'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "pause_turn" })).toBe(
+      "thinking",
+    );
+  });
+
+  it("managed + max_tokens → 'max tokens — needs continuation'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "max_tokens" })).toBe(
+      "max tokens — needs continuation",
+    );
+  });
+
+  it("managed + refusal → 'refused — needs input'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "refusal" })).toBe(
+      "refused — needs input",
+    );
+  });
+
+  it("managed + stop_sequence → 'stopped at sequence — needs input'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "stop_sequence" })).toBe(
+      "stopped at sequence — needs input",
+    );
+  });
+
+  it("managed + null stop_reason (pre-first-assistant) → 'working'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: null })).toBe("working");
+  });
+
+  it("managed + unknown stop_reason → 'working'", () => {
+    expect(deriveReason({ ...base, terminalId: "t1", lastAssistantStopReason: "future_value" })).toBe(
+      "working",
+    );
+  });
+
+  // 6. Unmanaged — time + probe drives the copy.
+  it("unmanaged + age < 60s → 'active'", () => {
+    expect(deriveReason({ ...base, ageMs: 30_000 })).toBe("active");
+  });
+
+  it("unmanaged + 60s–30min + probe alive → 'idle, process detected'", () => {
+    expect(deriveReason({ ...base, ageMs: 5 * MIN, probeSignal: "alive" })).toBe(
+      "idle, process detected",
+    );
+  });
+
+  it("unmanaged + 60s–30min + probe absent → 'process not found'", () => {
+    expect(deriveReason({ ...base, ageMs: 5 * MIN, probeSignal: "absent" })).toBe(
+      "process not found",
+    );
+  });
+
+  it("unmanaged + 60s–30min + probe unknown → 'idle'", () => {
+    expect(deriveReason({ ...base, ageMs: 5 * MIN, probeSignal: "unknown" })).toBe("idle");
+  });
+
+  it("unmanaged + 30min–8h → 'quiet <age>'", () => {
+    expect(deriveReason({ ...base, ageMs: 2 * HOUR })).toBe("quiet 2h");
+  });
+
+  it("unmanaged + 8h+ → 'quiet <age>'", () => {
+    expect(deriveReason({ ...base, ageMs: 12 * HOUR })).toBe("quiet 12h");
+  });
+
+  it("unmanaged + multi-day → 'quiet 3d'", () => {
+    expect(deriveReason({ ...base, ageMs: 3 * 24 * HOUR })).toBe("quiet 3d");
+  });
+
+  it("unmanaged + 30min exactly → 'quiet 30m' (boundary)", () => {
+    expect(deriveReason({ ...base, ageMs: 30 * MIN })).toBe("quiet 30m");
+  });
+
+  // Sanity: deriveState + deriveReason agree on the user_stop kill from the
+  // headline UX fix. With process-exit evidence + user_stop intent, state is
+  // 'done' and reason is 'stopped by user' — no transient red flicker possible.
+  it("deriveState and deriveReason agree on the headline user_stop kill", () => {
+    const input = {
+      ...base,
+      userStopRequested: true,
+      exitSignal: "SIGHUP",
+      exitCode: 129,
+    };
+    expect(deriveState(input)).toBe("done");
+    expect(deriveReason(input)).toBe("stopped by user");
+  });
+});

--- a/server/test/derive-state.test.ts
+++ b/server/test/derive-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deriveState } from "../src/watchers/claude-code.js";
+import { deriveState } from "../src/session-state.js";
 
 const MIN = 60_000;
 const HOUR = 60 * MIN;

--- a/server/test/derive-state.test.ts
+++ b/server/test/derive-state.test.ts
@@ -28,6 +28,22 @@ describe("deriveState — evidence-first", () => {
     expect(deriveState({ ...base, terminalId: "t1", ageMs: 90_000, lastAssistantStopReason: "tool_use" })).toBe("active");
   });
 
+  it("managed + last stop_reason max_tokens → waiting (truncated, user must continue)", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000, lastAssistantStopReason: "max_tokens" })).toBe("waiting");
+  });
+
+  it("managed + last stop_reason stop_sequence → waiting", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000, lastAssistantStopReason: "stop_sequence" })).toBe("waiting");
+  });
+
+  it("managed + last stop_reason refusal → waiting", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000, lastAssistantStopReason: "refusal" })).toBe("waiting");
+  });
+
+  it("managed + last stop_reason pause_turn → active (interleaved thinking still in flight)", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000, lastAssistantStopReason: "pause_turn" })).toBe("active");
+  });
+
   it("explicit /exit observed → done regardless of age", () => {
     expect(deriveState({ ...base, explicitExitSeen: true, ageMs: 10 * HOUR })).toBe("done");
   });
@@ -52,6 +68,13 @@ describe("deriveState — evidence-first", () => {
 
   it("PTY exit with signal → disconnected", () => {
     expect(deriveState({ ...base, exitSignal: "SIGKILL", ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  it("exit_code = 0 alone (cleanProcessExit flag missing) falls through to time/probe", () => {
+    // Defensive guard against future refactors in claude-pty-manager
+    // that might decouple exit_code === 0 from clean_process_exit.
+    expect(deriveState({ ...base, exitCode: 0, ageMs: 5 * MIN, probeSignal: "absent" })).toBe("disconnected");
+    expect(deriveState({ ...base, exitCode: 0, ageMs: 30_000 })).toBe("active");
   });
 
   it("unmanaged, <60s → active", () => {

--- a/server/test/derive-state.test.ts
+++ b/server/test/derive-state.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { deriveState } from "../src/watchers/claude-code.js";
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+const base = {
+  terminalId: null as string | null,
+  ageMs: 0,
+  probeSignal: "unknown" as const,
+  exitCode: null as number | null,
+  exitSignal: null as string | null,
+  explicitExitSeen: false,
+  cleanProcessExit: false,
+  lastAssistantStopReason: null as string | null,
+};
+
+describe("deriveState — evidence-first", () => {
+  it("managed + recent activity → active", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000 })).toBe("active");
+  });
+
+  it("managed + last stop_reason end_turn → waiting", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 5_000, lastAssistantStopReason: "end_turn" })).toBe("waiting");
+  });
+
+  it("managed + last stop_reason tool_use → active (still thinking)", () => {
+    expect(deriveState({ ...base, terminalId: "t1", ageMs: 90_000, lastAssistantStopReason: "tool_use" })).toBe("active");
+  });
+
+  it("explicit /exit observed → done regardless of age", () => {
+    expect(deriveState({ ...base, explicitExitSeen: true, ageMs: 10 * HOUR })).toBe("done");
+  });
+
+  it("clean PTY exit observed → done regardless of age", () => {
+    expect(deriveState({ ...base, cleanProcessExit: true, ageMs: 10 * HOUR })).toBe("done");
+  });
+
+  // Precedence: bad exit evidence beats clean exit evidence. A session that
+  // ran /exit but then got SIGKILLed mid-shutdown should read as disconnected.
+  it("bad exit beats explicit /exit", () => {
+    expect(deriveState({ ...base, explicitExitSeen: true, exitSignal: "SIGKILL" })).toBe("disconnected");
+  });
+
+  it("bad exit beats clean process exit", () => {
+    expect(deriveState({ ...base, cleanProcessExit: true, exitCode: 1 })).toBe("disconnected");
+  });
+
+  it("PTY exit with non-zero code → disconnected", () => {
+    expect(deriveState({ ...base, exitCode: 1, ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  it("PTY exit with signal → disconnected", () => {
+    expect(deriveState({ ...base, exitSignal: "SIGKILL", ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  it("unmanaged, <60s → active", () => {
+    expect(deriveState({ ...base, ageMs: 30_000 })).toBe("active");
+  });
+
+  it("unmanaged, 60s–30min, probe alive → waiting", () => {
+    expect(deriveState({ ...base, ageMs: 5 * MIN, probeSignal: "alive" })).toBe("waiting");
+  });
+
+  it("unmanaged, 60s–30min, probe absent → disconnected", () => {
+    expect(deriveState({ ...base, ageMs: 5 * MIN, probeSignal: "absent" })).toBe("disconnected");
+  });
+
+  it("unmanaged, 30min–8h → disconnected", () => {
+    expect(deriveState({ ...base, ageMs: 4 * HOUR })).toBe("disconnected");
+  });
+
+  // 8h+ idle still returns 'disconnected' from deriveState; 'dormant' is
+  // computed at the presentation layer (see Task 6) and never persisted.
+  it("unmanaged, >8h, no exit evidence → disconnected (dormant happens at display time)", () => {
+    expect(deriveState({ ...base, ageMs: 12 * HOUR })).toBe("disconnected");
+  });
+});

--- a/server/test/derive-state.test.ts
+++ b/server/test/derive-state.test.ts
@@ -12,6 +12,7 @@ const base = {
   exitSignal: null as string | null,
   explicitExitSeen: false,
   cleanProcessExit: false,
+  userStopRequested: false,
   lastAssistantStopReason: null as string | null,
 };
 
@@ -68,6 +69,33 @@ describe("deriveState — evidence-first", () => {
 
   it("PTY exit with signal → disconnected", () => {
     expect(deriveState({ ...base, exitSignal: "SIGKILL", ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  // User explicitly clicked the red-square stop button. The signal IS the
+  // shutdown mechanism, not evidence of a crash. The precedence guards
+  // against pre-exit races by ALSO requiring process-exit evidence.
+  it("user stop + SIGHUP exit → done (intentional kill, signal is the mechanism)", () => {
+    expect(deriveState({ ...base, userStopRequested: true, exitSignal: "SIGHUP", ageMs: 1 * MIN })).toBe("done");
+  });
+
+  it("user stop + non-zero exit code → done", () => {
+    expect(deriveState({ ...base, userStopRequested: true, exitCode: 143, ageMs: 1 * MIN })).toBe("done");
+  });
+
+  // The /exit-then-crash semantic stays exactly as today: no user_stop
+  // intent recorded, signal evidence wins.
+  it("/exit then external SIGKILL without user-stop intent → disconnected (crash mid-shutdown)", () => {
+    expect(deriveState({ ...base, explicitExitSeen: true, exitSignal: "SIGKILL", ageMs: 1 * MIN })).toBe("disconnected");
+  });
+
+  // Guards a pre-exit race: if the user-stop flag has been written but the
+  // PTY hasn't actually exited yet, deriveState must NOT report 'done'
+  // (the process is still alive on the other end of the terminal).
+  it("user stop without process exit evidence → falls through (process still alive)", () => {
+    // PTY still linked, recent activity → active
+    expect(deriveState({ ...base, userStopRequested: true, terminalId: "t1", ageMs: 5_000 })).toBe("active");
+    // No exit columns set yet but terminal already unlinked → existing fallthrough
+    expect(deriveState({ ...base, userStopRequested: true, ageMs: 5_000 })).toBe("active");
   });
 
   it("exit_code = 0 alone (cleanProcessExit flag missing) falls through to time/probe", () => {

--- a/server/test/display-state.test.ts
+++ b/server/test/display-state.test.ts
@@ -29,4 +29,12 @@ describe("computeDisplayState", () => {
   it("invalid lastEventAt falls back to the raw state", () => {
     expect(computeDisplayState("disconnected", "not-a-date", now)).toBe("disconnected");
   });
+
+  it("exactly at 8h boundary stays disconnected (strict >)", () => {
+    expect(computeDisplayState("disconnected", new Date(now - 8 * HOUR).toISOString(), now)).toBe("disconnected");
+  });
+
+  it("future lastEventAt (clock skew) stays disconnected", () => {
+    expect(computeDisplayState("disconnected", new Date(now + HOUR).toISOString(), now)).toBe("disconnected");
+  });
 });

--- a/server/test/display-state.test.ts
+++ b/server/test/display-state.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { computeDisplayState } from "../src/session-display-state.js";
+
+const HOUR = 60 * 60 * 1000;
+
+describe("computeDisplayState", () => {
+  const now = new Date("2026-05-21T12:00:00Z").getTime();
+
+  it("active stays active", () => {
+    expect(computeDisplayState("active", new Date(now - 30_000).toISOString(), now)).toBe("active");
+  });
+
+  it("disconnected within 8h stays disconnected", () => {
+    expect(computeDisplayState("disconnected", new Date(now - 4 * HOUR).toISOString(), now)).toBe("disconnected");
+  });
+
+  it("disconnected past 8h becomes dormant", () => {
+    expect(computeDisplayState("disconnected", new Date(now - 9 * HOUR).toISOString(), now)).toBe("dormant");
+  });
+
+  it("done past 8h stays done (not dormant — dormant only widens disconnected)", () => {
+    expect(computeDisplayState("done", new Date(now - 100 * HOUR).toISOString(), now)).toBe("done");
+  });
+
+  it("waiting past 8h stays waiting (heartbeat would have flipped it to disconnected first if process is gone)", () => {
+    expect(computeDisplayState("waiting", new Date(now - 9 * HOUR).toISOString(), now)).toBe("waiting");
+  });
+
+  it("invalid lastEventAt falls back to the raw state", () => {
+    expect(computeDisplayState("disconnected", "not-a-date", now)).toBe("disconnected");
+  });
+});

--- a/server/test/session-store-exit-info.test.ts
+++ b/server/test/session-store-exit-info.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function seed(store: SqliteSessionStore, id: string) {
+  store.insertSession({
+    id, space_id: null, agent: "claude-code", state: "active",
+  });
+}
+
+function makeEnv() {
+  const dir = mkdtempSync(join(tmpdir(), "oyster-exit-info-"));
+  const db = initDb(dir);
+  const store = new SqliteSessionStore(db);
+  return {
+    db, store,
+    dispose: () => { db.close(); rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+describe("SessionStore — exit info + last_assistant_stop_reason", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("recordExit writes exit_code, exit_signal, clean_process_exit", () => {
+    seed(env.store, "s1");
+    env.store.recordExit("s1", { exitCode: 0, exitSignal: null, cleanProcessExit: true });
+    const row = env.db.prepare(
+      "SELECT exit_code, exit_signal, clean_process_exit FROM sessions WHERE id=?"
+    ).get("s1");
+    expect(row).toEqual({ exit_code: 0, exit_signal: null, clean_process_exit: 1 });
+  });
+
+  it("recordExit on bad exit does not set clean_process_exit", () => {
+    seed(env.store, "s1");
+    env.store.recordExit("s1", { exitCode: 137, exitSignal: "SIGKILL", cleanProcessExit: false });
+    const row = env.db.prepare(
+      "SELECT exit_code, exit_signal, clean_process_exit FROM sessions WHERE id=?"
+    ).get("s1");
+    expect(row).toEqual({ exit_code: 137, exit_signal: "SIGKILL", clean_process_exit: 0 });
+  });
+
+  it("setLastAssistantStopReason updates only that column", () => {
+    seed(env.store, "s1");
+    env.store.setLastAssistantStopReason("s1", "end_turn");
+    const row = env.db.prepare(
+      "SELECT last_assistant_stop_reason FROM sessions WHERE id=?"
+    ).get("s1");
+    expect(row).toEqual({ last_assistant_stop_reason: "end_turn" });
+  });
+
+  it("markExplicitExitSeen flips the flag without touching process-exit fields", () => {
+    seed(env.store, "s1");
+    env.store.markExplicitExitSeen("s1");
+    const row = env.db.prepare(
+      "SELECT explicit_exit_seen, exit_code, exit_signal, clean_process_exit FROM sessions WHERE id=?"
+    ).get("s1");
+    expect(row).toEqual({
+      explicit_exit_seen: 1, exit_code: null, exit_signal: null, clean_process_exit: 0,
+    });
+  });
+});

--- a/server/test/sessions-migration-regression.test.ts
+++ b/server/test/sessions-migration-regression.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { initDb } from "../src/db.js";
@@ -23,8 +23,22 @@ import { initDb } from "../src/db.js";
 // *values* round-trip. The rebuild only ever fires on installs old
 // enough that those columns didn't exist at seed time anyway.
 describe("sessions migration — rebuild path", () => {
+  let dir: string;
+  let db: Database.Database | null = null;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+  });
+
+  afterEach(() => {
+    if (db) {
+      db.close();
+      db = null;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("rebuild remaps state, preserves the row, and ends with new + existing ALTER columns present", () => {
-    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
     const dbPath = join(dir, "oyster.db");
 
     // Seed a sessions table in the pre-rename shape: state CHECK uses
@@ -55,7 +69,7 @@ describe("sessions migration — rebuild path", () => {
 
     // Run real init. needsMigrate should fire because the seeded CHECK
     // contains 'running'.
-    const db = initDb(dir);
+    db = initDb(dir);
     const row = db
       .prepare("SELECT * FROM sessions WHERE id = 's1'")
       .get() as Record<string, unknown>;

--- a/server/test/sessions-migration-regression.test.ts
+++ b/server/test/sessions-migration-regression.test.ts
@@ -5,19 +5,31 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { initDb } from "../src/db.js";
 
-// Guard against the migration ever silently dropping ALTER-added columns
-// from existing-install rows. Seed a sessions row with values in every
-// column that's been added via ALTER in the project history, run initDb,
-// and assert the values survive.
-describe("sessions migration — ALTER-added column preservation", () => {
-  it("preserves cwd/assignment_mode/project_id and other ALTER-added column values", () => {
+// Guard against the state-rename rebuild silently dropping additive
+// ALTER-added columns from legacy-shape installs. If `needsMigrate` fires
+// (sessions CHECK still contains 'running'/'awaiting', or dependent FKs
+// reference the phantom `sessions_old` table from the broken intermediate
+// migration), `initDb` drops + recreates the sessions table. We need to
+// make sure that on a real rebuild path:
+//   - the row survives,
+//   - state is remapped from 'running' → 'active',
+//   - the additive ALTER-added columns (the new status-evidence facts as
+//     well as the older cwd / assignment_mode / project_id family) all
+//     end up on the rebuilt table.
+//
+// Caveat: the rebuild's INSERT projection only carries the original
+// columns forward — cwd/assignment_mode/project_id/exit_code/... live
+// purely in post-rebuild ALTERs, so we don't and can't assert their
+// *values* round-trip. The rebuild only ever fires on installs old
+// enough that those columns didn't exist at seed time anyway.
+describe("sessions migration — rebuild path", () => {
+  it("rebuild remaps state, preserves the row, and ends with new + existing ALTER columns present", () => {
     const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
     const dbPath = join(dir, "oyster.db");
 
-    // Hand-build a sessions table matching what an existing install looks
-    // like RIGHT BEFORE the migration runs (post-rename, pre-this-change):
-    //   - state CHECK has four values (no 'dormant')
-    //   - all the ALTER-added columns exist with their declared types
+    // Seed a sessions table in the pre-rename shape: state CHECK uses
+    // the legacy 'running'/'awaiting' names, and the row's state is
+    // 'running'. This is what triggers `needsMigrate` inside initDb.
     {
       const raw = new Database(dbPath);
       raw.exec(`
@@ -26,7 +38,7 @@ describe("sessions migration — ALTER-added column preservation", () => {
           space_id      TEXT,
           agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
           title         TEXT,
-          state         TEXT NOT NULL CHECK (state IN ('active','waiting','disconnected','done')),
+          state         TEXT NOT NULL CHECK (state IN ('running','awaiting','disconnected','done')),
           started_at    TEXT NOT NULL DEFAULT (datetime('now')),
           ended_at      TEXT,
           model         TEXT,
@@ -34,52 +46,47 @@ describe("sessions migration — ALTER-added column preservation", () => {
           last_offset   INTEGER NOT NULL DEFAULT 0
         );
       `);
-      // Replay every ALTER currently in db.ts that adds a column to sessions.
-      // If db.ts grows more ALTERs in future, add them here too.
-      const alters = [
-        "ALTER TABLE sessions ADD COLUMN cwd TEXT",
-        "ALTER TABLE sessions ADD COLUMN assignment_mode TEXT NOT NULL DEFAULT 'auto' CHECK (assignment_mode IN ('auto','manual'))",
-        "ALTER TABLE sessions ADD COLUMN project_id TEXT",
-        "ALTER TABLE sessions ADD COLUMN sync_dirty_at INTEGER",
-        "ALTER TABLE sessions ADD COLUMN cloud_synced_at INTEGER",
-        "ALTER TABLE sessions ADD COLUMN cloud_owner_id TEXT",
-        "ALTER TABLE sessions ADD COLUMN jsonl_synced_at INTEGER",
-        "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE sessions ADD COLUMN jsonl_chunk_count INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE sessions ADD COLUMN bytes_generation INTEGER NOT NULL DEFAULT 0",
-        "ALTER TABLE sessions ADD COLUMN jsonl_path TEXT",
-        "ALTER TABLE sessions ADD COLUMN terminal_id TEXT",
-        "ALTER TABLE sessions ADD COLUMN terminal_attached_clients INTEGER NOT NULL DEFAULT 0",
-      ];
-      for (const sql of alters) {
-        try { raw.exec(sql); } catch { /* column already exists or was retired */ }
-      }
       raw.prepare(`
-        INSERT INTO sessions (
-          id, agent, title, state, last_event_at,
-          cwd, assignment_mode, project_id, jsonl_path, terminal_id
-        ) VALUES (
-          's1', 'claude-code', 'test', 'active', datetime('now'),
-          '/some/cwd', 'manual', 'proj-abc', '/tmp/abc.jsonl', 'term-xyz'
-        )
+        INSERT INTO sessions (id, agent, title, state, last_event_at)
+        VALUES ('s1', 'claude-code', 'test', 'running', datetime('now'))
       `).run();
       raw.close();
     }
 
-    // Run real init.
+    // Run real init. needsMigrate should fire because the seeded CHECK
+    // contains 'running'.
     const db = initDb(dir);
-    const row = db.prepare("SELECT * FROM sessions WHERE id = 's1'").get() as Record<string, unknown>;
+    const row = db
+      .prepare("SELECT * FROM sessions WHERE id = 's1'")
+      .get() as Record<string, unknown>;
 
+    // Row survived the rebuild.
     expect(row).toBeDefined();
-    expect(row.cwd).toBe("/some/cwd");
-    expect(row.assignment_mode).toBe("manual");
-    expect(row.project_id).toBe("proj-abc");
-    expect(row.jsonl_path).toBe("/tmp/abc.jsonl");
-    // terminal_id is reset to NULL on boot by the stale-indicator reset
-    // (PTYs are in-memory only; they don't survive a restart). The point
-    // of this regression guard is that the *column itself* and rows are
-    // preserved — not that values pass through unchanged. Assert the
-    // column exists by reading it (would throw if dropped).
-    expect(Object.prototype.hasOwnProperty.call(row, "terminal_id")).toBe(true);
+    expect(row.id).toBe("s1");
+
+    // state was remapped by the rebuild's CASE statement. If the
+    // rebuild block didn't run, state would still be 'running' — so
+    // this assertion doubles as proof that we exercised the rebuild
+    // path, not the no-op path.
+    expect(row.state).toBe("active");
+
+    // New status-evidence fact columns from this PR.
+    expect(row).toHaveProperty("exit_code");
+    expect(row).toHaveProperty("exit_signal");
+    expect(row).toHaveProperty("explicit_exit_seen");
+    expect(row).toHaveProperty("clean_process_exit");
+    expect(row).toHaveProperty("last_assistant_stop_reason");
+
+    // Pre-existing post-rebuild ALTER-added columns. These are added
+    // by ALTERs that run AFTER the rebuild block, so they should be
+    // present on the rebuilt table.
+    expect(row).toHaveProperty("cwd");
+    expect(row).toHaveProperty("assignment_mode");
+    expect(row).toHaveProperty("project_id");
+    expect(row).toHaveProperty("jsonl_path");
+
+    // terminal_id is reset to NULL on boot by the stale-indicator
+    // reset (PTYs are in-memory only and don't survive a restart).
+    expect(row.terminal_id).toBeNull();
   });
 });

--- a/server/test/sessions-migration-regression.test.ts
+++ b/server/test/sessions-migration-regression.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+// Guard against the migration ever silently dropping ALTER-added columns
+// from existing-install rows. Seed a sessions row with values in every
+// column that's been added via ALTER in the project history, run initDb,
+// and assert the values survive.
+describe("sessions migration — ALTER-added column preservation", () => {
+  it("preserves cwd/assignment_mode/project_id and other ALTER-added column values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    const dbPath = join(dir, "oyster.db");
+
+    // Hand-build a sessions table matching what an existing install looks
+    // like RIGHT BEFORE the migration runs (post-rename, pre-this-change):
+    //   - state CHECK has four values (no 'dormant')
+    //   - all the ALTER-added columns exist with their declared types
+    {
+      const raw = new Database(dbPath);
+      raw.exec(`
+        CREATE TABLE sessions (
+          id            TEXT PRIMARY KEY,
+          space_id      TEXT,
+          agent         TEXT NOT NULL CHECK (agent IN ('claude-code','opencode','codex')),
+          title         TEXT,
+          state         TEXT NOT NULL CHECK (state IN ('active','waiting','disconnected','done')),
+          started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+          ended_at      TEXT,
+          model         TEXT,
+          last_event_at TEXT NOT NULL DEFAULT (datetime('now')),
+          last_offset   INTEGER NOT NULL DEFAULT 0
+        );
+      `);
+      // Replay every ALTER currently in db.ts that adds a column to sessions.
+      // If db.ts grows more ALTERs in future, add them here too.
+      const alters = [
+        "ALTER TABLE sessions ADD COLUMN cwd TEXT",
+        "ALTER TABLE sessions ADD COLUMN assignment_mode TEXT NOT NULL DEFAULT 'auto' CHECK (assignment_mode IN ('auto','manual'))",
+        "ALTER TABLE sessions ADD COLUMN project_id TEXT",
+        "ALTER TABLE sessions ADD COLUMN sync_dirty_at INTEGER",
+        "ALTER TABLE sessions ADD COLUMN cloud_synced_at INTEGER",
+        "ALTER TABLE sessions ADD COLUMN cloud_owner_id TEXT",
+        "ALTER TABLE sessions ADD COLUMN jsonl_synced_at INTEGER",
+        "ALTER TABLE sessions ADD COLUMN jsonl_snapshot_offset INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sessions ADD COLUMN jsonl_chunk_count INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sessions ADD COLUMN bytes_generation INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE sessions ADD COLUMN jsonl_path TEXT",
+        "ALTER TABLE sessions ADD COLUMN terminal_id TEXT",
+        "ALTER TABLE sessions ADD COLUMN terminal_attached_clients INTEGER NOT NULL DEFAULT 0",
+      ];
+      for (const sql of alters) {
+        try { raw.exec(sql); } catch { /* column already exists or was retired */ }
+      }
+      raw.prepare(`
+        INSERT INTO sessions (
+          id, agent, title, state, last_event_at,
+          cwd, assignment_mode, project_id, jsonl_path, terminal_id
+        ) VALUES (
+          's1', 'claude-code', 'test', 'active', datetime('now'),
+          '/some/cwd', 'manual', 'proj-abc', '/tmp/abc.jsonl', 'term-xyz'
+        )
+      `).run();
+      raw.close();
+    }
+
+    // Run real init.
+    const db = initDb(dir);
+    const row = db.prepare("SELECT * FROM sessions WHERE id = 's1'").get() as Record<string, unknown>;
+
+    expect(row).toBeDefined();
+    expect(row.cwd).toBe("/some/cwd");
+    expect(row.assignment_mode).toBe("manual");
+    expect(row.project_id).toBe("proj-abc");
+    expect(row.jsonl_path).toBe("/tmp/abc.jsonl");
+    // terminal_id is reset to NULL on boot by the stale-indicator reset
+    // (PTYs are in-memory only; they don't survive a restart). The point
+    // of this regression guard is that the *column itself* and rows are
+    // preserved — not that values pass through unchanged. Assert the
+    // column exists by reading it (would throw if dropped).
+    expect(Object.prototype.hasOwnProperty.call(row, "terminal_id")).toBe(true);
+  });
+});

--- a/server/test/sessions-table-status-columns.test.ts
+++ b/server/test/sessions-table-status-columns.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+
+describe("sessions table — status-evidence columns", () => {
+  it("has exit_code, exit_signal, explicit_exit_seen, clean_process_exit, last_assistant_stop_reason", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    const db = initDb(dir);
+    const cols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{
+      name: string; notnull: number; dflt_value: unknown;
+    }>;
+    const byName = new Map(cols.map((c) => [c.name, c]));
+    expect(byName.has("exit_code")).toBe(true);
+    expect(byName.has("exit_signal")).toBe(true);
+    expect(byName.has("explicit_exit_seen")).toBe(true);
+    expect(byName.has("clean_process_exit")).toBe(true);
+    expect(byName.has("last_assistant_stop_reason")).toBe(true);
+
+    // Lock in the structural shape — typos like DEAFULT or NULL slip through column-name-only checks.
+    expect(byName.get("explicit_exit_seen")).toMatchObject({ notnull: 1, dflt_value: "0" });
+    expect(byName.get("clean_process_exit")).toMatchObject({ notnull: 1, dflt_value: "0" });
+  });
+
+  it("still rejects 'dormant' as a stored state value (dormant is display-only)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    const db = initDb(dir);
+    expect(() =>
+      db.prepare(`
+        INSERT INTO sessions (id, agent, title, state)
+        VALUES ('s1', 'claude-code', 't', 'dormant')
+      `).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+});

--- a/server/test/sessions-table-status-columns.test.ts
+++ b/server/test/sessions-table-status-columns.test.ts
@@ -1,13 +1,25 @@
-import { describe, it, expect } from "vitest";
-import { mkdtempSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type Database from "better-sqlite3";
 import { initDb } from "../src/db.js";
 
 describe("sessions table — status-evidence columns", () => {
+  let dir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
+    db = initDb(dir);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("has exit_code, exit_signal, explicit_exit_seen, clean_process_exit, last_assistant_stop_reason", () => {
-    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
-    const db = initDb(dir);
     const cols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{
       name: string; notnull: number; dflt_value: unknown;
     }>;
@@ -24,8 +36,6 @@ describe("sessions table — status-evidence columns", () => {
   });
 
   it("still rejects 'dormant' as a stored state value (dormant is display-only)", () => {
-    const dir = mkdtempSync(join(tmpdir(), "oyster-test-"));
-    const db = initDb(dir);
     expect(() =>
       db.prepare(`
         INSERT INTO sessions (id, agent, title, state)

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -80,6 +80,11 @@ export interface ScanResult {
 }
 
 export type SessionState = "active" | "waiting" | "disconnected" | "done";
+/** Wire-format state used by the UI. Same as `SessionState` plus the
+ *  derived `'dormant'` value emitted when a `disconnected` row has been
+ *  idle for 8h+. Never persisted — computed server-side from `state +
+ *  last_event_at` in `computeDisplayState`. */
+export type DisplayState = SessionState | "dormant";
 export type SessionAgent = "claude-code" | "opencode" | "codex";
 
 /** Agent session captured by the watchers (#251). Read-only on the wire — UI mutations come later. */
@@ -98,6 +103,10 @@ export interface Session {
   agent: SessionAgent;
   title: string | null;
   state: SessionState;
+  /** Derived from `state + lastEventAt` server-side. Identical to `state`
+   *  except a `disconnected` row idle for 8h+ becomes `'dormant'` so the
+   *  UI can dim its urgency. Never persisted. */
+  displayState: DisplayState;
   startedAt: string;
   endedAt: string | null;
   model: string | null;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -107,6 +107,12 @@ export interface Session {
    *  except a `disconnected` row idle for 8h+ becomes `'dormant'` so the
    *  UI can dim its urgency. Never persisted. */
   displayState: DisplayState;
+  /** Short, lowercase, human-readable explanation of the row's current
+   *  state ("stopped by user", "awaiting input", "killed by SIGKILL",
+   *  etc). Computed server-side from the same evidence deriveState reads;
+   *  never persisted. Used by the sessions list (REASON column) and the
+   *  status-dot tooltip. */
+  displayReason: string;
   startedAt: string;
   endedAt: string | null;
   model: string | null;

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2768,6 +2768,13 @@ body {
    green and waiting amber pips. */
 .home-row-status.rd--attached,
 .home-row-status.rd--running { background: #a78bfa; box-shadow: 0 0 8px rgba(167,139,250,0.85); }
+/* Managed + waiting: amber fill (waiting), purple ring (managed). The
+   ring is rendered with box-shadow inset-like offset so the dot keeps
+   its 8px footprint without growing into neighbouring grid cells. */
+.home-row-status.rd--managed-waiting {
+  background: var(--home-amber);
+  box-shadow: 0 0 0 2px #a78bfa, 0 0 8px rgba(167,139,250,0.55);
+}
 /* Row action chips (Connect on live rows; Resume on dormant rows).
    Hidden by default; the parent `.home-row:hover` / `:focus-within`
    reveals them so the row stays visually quiet at rest. */

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -547,6 +547,9 @@
 .home-status.done::before {
   background: rgba(255, 255, 255, 0.18);
 }
+.home-status.dormant::before {
+  background: rgba(255, 255, 255, 0.18); /* same as .done */
+}
 @keyframes home-breathe {
   0%, 100% { opacity: 0.85; transform: scale(1); }
   50%       { opacity: 1;    transform: scale(1.1); }

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -718,7 +718,7 @@
   white-space: nowrap;
 }
 
-/* Sessions-table column header — same 5-col grid as .home-row so labels
+/* Sessions-table column header — same 6-col grid as .home-row so labels
    sit above the data cells, but with quieter type and no hover/cursor
    so it doesn't read as clickable. */
 .home-row--header {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -635,7 +635,7 @@
 
 .home-row {
   display: grid;
-  grid-template-columns: 18px 130px 1fr 130px 130px;
+  grid-template-columns: 18px 130px 1fr 130px 150px 130px;
   gap: 14px;
   align-items: center;
   padding: 12px 18px;
@@ -700,6 +700,15 @@
 .home-row-agent.cc    .home-agent-pip { background: #ff9b7a; }
 .home-row-agent.codex .home-agent-pip { background: #6ee7a8; }
 .home-row-agent.oc    .home-agent-pip { background: #b3a8ff; }
+
+.home-row-reason {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .home-row-time {
   font-family: var(--font-mono);
@@ -800,7 +809,7 @@
     grid-template-areas:
       "s sp tm"
       "s tt tt"
-      "s ag ag";
+      "s ag rs";
     gap: 4px 12px;
     padding: 12px 14px;
   }
@@ -808,6 +817,7 @@
   .home-row-space  { grid-area: sp; }
   .home-row-title  { grid-area: tt; }
   .home-row-agent  { grid-area: ag; }
+  .home-row-reason { grid-area: rs; text-align: right; }
   .home-row-time   { grid-area: tm; text-align: right; }
 }
 

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -651,7 +651,8 @@
 .home-row-status.active { background: var(--home-green); box-shadow: 0 0 6px var(--home-green); animation: home-breathe 2.4s ease-in-out infinite; }
 .home-row-status.waiting { background: var(--home-amber); box-shadow: 0 0 6px var(--home-amber); }
 .home-row-status.disconnected { background: var(--home-red); box-shadow: 0 0 6px var(--home-red); }
-.home-row-status.done { background: rgba(255, 255, 255, 0.18); }
+.home-row-status.done,
+.home-row-status.dormant { background: rgba(255, 255, 255, 0.18); }
 
 .home-row-space {
   font-family: var(--font-mono);

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -76,7 +76,7 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
       role={onOpen ? "button" : undefined}
       tabIndex={onOpen ? 0 : undefined}
     >
-      <span className={`home-row-status ${statusDotClass}`} title={session.displayReason} />
+      <span className={`home-row-status ${statusDotClass}`} title={session.displayReason || undefined} />
       <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
       <span className="home-row-title">
         <span className="home-row-title-inner" title={title}>
@@ -122,7 +122,7 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
         <span className="home-agent-pip" />
         {session.agent}
       </span>
-      <span className="home-row-reason" title={session.displayReason}>{session.displayReason}</span>
+      <span className="home-row-reason" title={session.displayReason || undefined}>{session.displayReason}</span>
       <span className="home-row-time">{time}</span>
     </div>
   );

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -40,8 +40,10 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
     ? (livePresence.state === "attached" ? " sr--attached" : " sr--running")
     : "";
   const statusDotClass = livePresence
-    ? (livePresence.state === "attached" ? "rd--attached" : "rd--running")
-    : session.state;
+    ? (session.displayState === "waiting"
+        ? "rd--managed-waiting"
+        : (livePresence.state === "attached" ? "rd--attached" : "rd--running"))
+    : session.displayState;
 
   // Row click always opens the Session Inspector. The Connect chip (live
   // sessions) and Resume chip (non-live sessions) handle the terminal

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -76,7 +76,7 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
       role={onOpen ? "button" : undefined}
       tabIndex={onOpen ? 0 : undefined}
     >
-      <span className={`home-row-status ${statusDotClass}`} />
+      <span className={`home-row-status ${statusDotClass}`} title={session.displayReason} />
       <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
       <span className="home-row-title">
         <span className="home-row-title-inner" title={title}>
@@ -122,6 +122,7 @@ export function SessionRow({ session, spaces, myDeviceId, livePresence, onOpen, 
         <span className="home-agent-pip" />
         {session.agent}
       </span>
+      <span className="home-row-reason" title={session.displayReason}>{session.displayReason}</span>
       <span className="home-row-time">{time}</span>
     </div>
   );

--- a/web/src/components/Home/SessionTile.tsx
+++ b/web/src/components/Home/SessionTile.tsx
@@ -56,7 +56,7 @@ export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, livePr
           </span>
         )}
         <span className="home-agent-mark">{AGENT_LETTERS[session.agent]}</span>
-        <span className={`home-status ${session.displayState}`} title={session.displayReason} />
+        <span className={`home-status ${session.displayState}`} title={session.displayReason || undefined} />
         {livePresence && (
           <span
             className={`tile-presence-dot${livePresence.state === "attached" ? " tpd--attached" : " tpd--running"}`}

--- a/web/src/components/Home/SessionTile.tsx
+++ b/web/src/components/Home/SessionTile.tsx
@@ -56,7 +56,7 @@ export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, livePr
           </span>
         )}
         <span className="home-agent-mark">{AGENT_LETTERS[session.agent]}</span>
-        <span className={`home-status ${session.state}`} />
+        <span className={`home-status ${session.displayState}`} />
         {livePresence && (
           <span
             className={`tile-presence-dot${livePresence.state === "attached" ? " tpd--attached" : " tpd--running"}`}

--- a/web/src/components/Home/SessionTile.tsx
+++ b/web/src/components/Home/SessionTile.tsx
@@ -56,7 +56,7 @@ export function SessionTile({ session, spaces, showSpaceChip, myDeviceId, livePr
           </span>
         )}
         <span className="home-agent-mark">{AGENT_LETTERS[session.agent]}</span>
-        <span className={`home-status ${session.displayState}`} />
+        <span className={`home-status ${session.displayState}`} title={session.displayReason} />
         {livePresence && (
           <span
             className={`tile-presence-dot${livePresence.state === "attached" ? " tpd--attached" : " tpd--running"}`}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -308,9 +308,12 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   // when a folder is selected. Everything below this point (chips,
   // list) does narrow.
   const spaceCounts = useMemo(() => {
-    const counts: Record<StateFilter, number> = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: scopedSessions.length };
-    for (const s of scopedSessions) counts[s.state]++;
-    counts.done += counts.disconnected;
+    // `dormant` is a display-time projection of `done` (no first-class
+    // chip in v1) — fold it into `done` so the count chip totals
+    // "nothing to do" sessions regardless of how they got there.
+    const counts: Record<StateFilter, number> & { dormant: number } = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, dormant: 0, all: scopedSessions.length };
+    for (const s of scopedSessions) counts[s.displayState]++;
+    counts.done += counts.disconnected + counts.dormant;
     counts.disconnected = 0;
     counts.live = counts.active + counts.waiting;
     return counts;
@@ -329,9 +332,12 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   }, [scopedSessions, selectedProjectId, selectedOrphanCwd, showElsewhere, isHomeView]);
 
   const stateCounts = useMemo(() => {
-    const counts: Record<StateFilter, number> = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, all: folderScopedSessions.length };
-    for (const s of folderScopedSessions) counts[s.state]++;
-    counts.done += counts.disconnected;
+    // Bucket by `displayState` (the wire's 5-state projection) so dormant
+    // rows count toward the same "done" chip as cleanly-exited and PTY-
+    // exited rows — they all read as grey on the surface.
+    const counts: Record<StateFilter, number> & { dormant: number } = { live: 0, "live-terminals": 0, active: 0, waiting: 0, disconnected: 0, done: 0, dormant: 0, all: folderScopedSessions.length };
+    for (const s of folderScopedSessions) counts[s.displayState]++;
+    counts.done += counts.disconnected + counts.dormant;
     counts.disconnected = 0;
     counts.live = counts.active + counts.waiting;
     counts["live-terminals"] = folderScopedSessions.filter((s) => presence.byId[s.id] != null).length;
@@ -341,10 +347,13 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   const visibleSessions = useMemo(() => {
     let list: typeof folderScopedSessions;
     if (stateFilter === "all") list = folderScopedSessions;
-    else if (stateFilter === "live") list = folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state));
+    // "live" excludes dormant (a dormant row is non-live by definition,
+    // even though its DB state is still active/waiting).
+    else if (stateFilter === "live") list = folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state) && s.displayState !== "dormant");
     else if (stateFilter === "live-terminals") list = folderScopedSessions.filter((s) => presence.byId[s.id] != null);
-    else if (stateFilter === "done") list = folderScopedSessions.filter((s) => s.state === "done" || s.state === "disconnected");
-    else list = folderScopedSessions.filter((s) => s.state === stateFilter);
+    // "done" chip folds in disconnected + dormant so the list matches the count.
+    else if (stateFilter === "done") list = folderScopedSessions.filter((s) => s.state === "done" || s.state === "disconnected" || s.displayState === "dormant");
+    else list = folderScopedSessions.filter((s) => s.displayState === stateFilter);
     // Pin live (open terminal) rows to the top; within each group preserve
     // descending last-activity order.
     return list.slice().sort((a, b) => {

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1157,6 +1157,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
                       <span role="columnheader">Project</span>
                       <span role="columnheader">Title</span>
                       <span role="columnheader">Agent</span>
+                      <span role="columnheader">Reason</span>
                       <span role="columnheader">Last active</span>
                     </div>
                     {visibleSessions.slice(0, sessionsLimit).map((session) => (

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
 import { ArrowUpRight, Folder, FolderPlus, Shield } from "lucide-react";
-import type { Session, SessionState } from "../../data/sessions-api";
+import type { Session, SessionState, DisplayState } from "../../data/sessions-api";
 import type { Artifact, Space } from "../../../../shared/types";
 import { useMemories } from "../../hooks/useMemories";
 import { useAuthSignedIn } from "../../hooks/useAuthSignedIn";
@@ -347,9 +347,7 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   const visibleSessions = useMemo(() => {
     let list: typeof folderScopedSessions;
     if (stateFilter === "all") list = folderScopedSessions;
-    // "live" excludes dormant (a dormant row is non-live by definition,
-    // even though its DB state is still active/waiting).
-    else if (stateFilter === "live") list = folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state) && s.displayState !== "dormant");
+    else if (stateFilter === "live") list = folderScopedSessions.filter((s) => LIVE_STATES.includes(s.state));
     else if (stateFilter === "live-terminals") list = folderScopedSessions.filter((s) => presence.byId[s.id] != null);
     // "done" chip folds in disconnected + dormant so the list matches the count.
     else if (stateFilter === "done") list = folderScopedSessions.filter((s) => s.state === "done" || s.state === "disconnected" || s.displayState === "dormant");
@@ -365,24 +363,30 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
   }, [folderScopedSessions, stateFilter, presence.byId]);
 
   // Per-space session counts + a separate orphan tally (sessions with
-  // spaceId === null) + a grand total for the Home card.
+  // spaceId === null) + a grand total for the Home card. Buckets by
+  // `displayState` so dormant rows fold into `done` — matches the home
+  // chip semantics where `disconnected` means the 30min–8h band only.
   const { sessionCountsBySpace, orphanCounts, totalCounts } = useMemo(() => {
     const bySpace: Record<string, { total: number; running: number; active: number; waiting: number; disconnected: number; done: number }> = {};
     const orphans = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     const total = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
+    const bump = (c: { active: number; waiting: number; disconnected: number; done: number }, ds: DisplayState) => {
+      if (ds === "dormant") c.done++;
+      else c[ds]++;
+    };
     for (const s of sessions) {
       total.total++;
-      total[s.state]++;
+      bump(total, s.displayState);
       if (presence.byId[s.id]) total.running++;
       if (s.spaceId) {
         const c = bySpace[s.spaceId] ?? { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
         c.total++;
-        c[s.state]++;
+        bump(c, s.displayState);
         if (presence.byId[s.id]) c.running++;
         bySpace[s.spaceId] = c;
       } else {
         orphans.total++;
-        orphans[s.state]++;
+        bump(orphans, s.displayState);
         if (presence.byId[s.id]) orphans.running++;
       }
     }
@@ -403,7 +407,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
       lastEventAt: number;
     }>();
     for (const s of sessions) {
-      if (!s.projectId || !s.spaceId || s.state === "done") continue;
+      // Skip done + dormant: both read as grey "no urgency" on the surface,
+      // so neither belongs in the Active-projects tile counts.
+      if (!s.projectId || !s.spaceId || s.displayState === "done" || s.displayState === "dormant") continue;
       let entry = map.get(s.projectId);
       if (!entry) {
         const cwdBasename = s.cwd ? s.cwd.split(/[\\/]/).filter(Boolean).pop() ?? null : null;
@@ -416,9 +422,9 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
         };
         map.set(s.projectId, entry);
       }
-      if (s.state === "active") entry.counts.active++;
-      else if (s.state === "waiting") entry.counts.waiting++;
-      else if (s.state === "disconnected") entry.counts.disconnected++;
+      if (s.displayState === "active") entry.counts.active++;
+      else if (s.displayState === "waiting") entry.counts.waiting++;
+      else if (s.displayState === "disconnected") entry.counts.disconnected++;
       const t = parseTimestamp(s.lastEventAt);
       if (Number.isFinite(t) && t > entry.lastEventAt) entry.lastEventAt = t;
     }
@@ -433,12 +439,15 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
     for (const s of sessions) {
       if (!s.projectId) continue;
       const isRunning = presence.byId[s.id] != null;
-      if (s.state === "done" && !isRunning) continue;
+      // Drop both done and dormant unless a terminal is still attached —
+      // dormant (>8h) is a grey "no urgency" state and shouldn't surface
+      // as a project-tile signal.
+      if ((s.displayState === "done" || s.displayState === "dormant") && !isRunning) continue;
       const c = out[s.projectId] ?? { running: 0, active: 0, waiting: 0, disconnected: 0 };
       if (isRunning) c.running++;
-      if (s.state === "active") c.active++;
-      else if (s.state === "waiting") c.waiting++;
-      else if (s.state === "disconnected") c.disconnected++;
+      if (s.displayState === "active") c.active++;
+      else if (s.displayState === "waiting") c.waiting++;
+      else if (s.displayState === "disconnected") c.disconnected++;
       out[s.projectId] = c;
     }
     return out;
@@ -472,7 +481,10 @@ export function Home({ activeSpace, spaces, desktopProps, isHero, onSpaceChange,
         };
         map.set(key, entry);
       }
-      entry.counts[s.state]++;
+      // Bucket by displayState; fold dormant into `done` so a grey row
+      // doesn't bump the disconnected count.
+      if (s.displayState === "dormant") entry.counts.done++;
+      else entry.counts[s.displayState]++;
       const t = parseTimestamp(s.lastEventAt);
       if (Number.isFinite(t) && t > entry.lastEventAt) entry.lastEventAt = t;
     }

--- a/web/src/components/Home/utils.tsx
+++ b/web/src/components/Home/utils.tsx
@@ -1,7 +1,7 @@
 // Helpers shared across Home/* sub-components. Extracted from
 // Home/index.tsx — pure functions only, no React state.
-import type { Session, SessionState, SessionAgent } from "../../data/sessions-api";
-import type { Space } from "../../../../shared/types";
+import type { Session, SessionAgent } from "../../data/sessions-api";
+import type { DisplayState, Space } from "../../../../shared/types";
 import { parseTimestamp } from "../../utils/parseTimestamp";
 
 export const AGENT_LETTERS: Record<SessionAgent, string> = {
@@ -51,12 +51,14 @@ export function renderPipCounts(counts: { running?: number; active?: number; wai
   );
 }
 
-export function stateColor(state: SessionState): "green" | "amber" | "red" | "dim" {
+export function stateColor(state: DisplayState): "green" | "amber" | "red" | "dim" {
   switch (state) {
     case "active": return "green";
     case "waiting": return "amber";
     case "disconnected": return "red";
-    case "done": return "dim";
+    case "done":
+    case "dormant":
+      return "dim";
   }
 }
 

--- a/web/src/components/SessionInspector/Banner.tsx
+++ b/web/src/components/SessionInspector/Banner.tsx
@@ -3,7 +3,7 @@ import type { Session } from "../../data/sessions-api";
 import { formatRel } from "./utils";
 
 export function Banner({ session }: { session: Session }) {
-  if (session.state === "disconnected") {
+  if (session.displayState === "disconnected") {
     return (
       <div className="inspector-banner disconnected">
         <div>

--- a/web/src/components/SessionInspector/Header.tsx
+++ b/web/src/components/SessionInspector/Header.tsx
@@ -1,24 +1,26 @@
 // Header — extracted from SessionInspector for navigability.
 import { useState } from "react";
-import type { Session, SessionState } from "../../data/sessions-api";
+import type { Session, DisplayState } from "../../data/sessions-api";
 import { useMyDeviceId } from "../../hooks/useMyDeviceId";
 import { SessionActions } from "./SessionActions";
 import { ResumeDialog, type OpenInOysterResult } from "./ResumeDialog";
 import { formatTs } from "./utils";
 import { formatRelative } from "../Home/utils";
 
-const PIP_CLASS: Record<SessionState, string> = {
+const PIP_CLASS: Record<DisplayState, string> = {
   active: "green",
   waiting: "amber",
   disconnected: "red",
   done: "dim",
+  dormant: "dim",
 };
 
-const STATE_LABEL: Record<SessionState, string> = {
+const STATE_LABEL: Record<DisplayState, string> = {
   active: "active",
   waiting: "waiting on you",
   disconnected: "disconnected",
   done: "done",
+  dormant: "dormant",
 };
 
 export function Header({ session, onClose, onLaunchClaude, onConnect, onOpenInOyster }: {
@@ -52,8 +54,8 @@ export function Header({ session, onClose, onLaunchClaude, onConnect, onOpenInOy
         {session.spaceId && <span>·</span>}
         <span className="agent">{session.agent}</span>
         <span>·</span>
-        <span className={`pip ${PIP_CLASS[session.state]}`} />
-        <span>{STATE_LABEL[session.state]}</span>
+        <span className={`pip ${PIP_CLASS[session.displayState]}`} />
+        <span>{STATE_LABEL[session.displayState]}</span>
         <button type="button" className="close" onClick={onClose} aria-label="Close inspector">✕</button>
       </div>
       <div className="inspector-timestamps">

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -1,6 +1,7 @@
 export type {
   Session,
   SessionState,
+  DisplayState,
   SessionAgent,
   SessionEvent,
   SessionEventRole,


### PR DESCRIPTION
## Summary

Rebuilds the sessions-list dot from a time-based heuristic into an evidence-first state machine with a managed-vs-unmanaged colour split. The whole thing is driven from a single pure `deriveState(input)` function — `_handleExit` (PTY exit handler) and `runHeartbeatSweep` (periodic refresh) used to embed their own ad-hoc logic, which is how the "red flicker before grey settle" bug crept in. They now call the same function.

### What the dots mean now

| Session type   | State             | Dot                             |
|----------------|-------------------|---------------------------------|
| Oyster-managed | active            | solid purple                    |
| Oyster-managed | waiting for input | amber fill with purple ring     |
| Unmanaged      | active            | solid green                     |
| Unmanaged      | waiting           | solid amber                     |
| Either         | disconnected      | solid red                       |
| Either         | done              | solid grey                      |
| Either         | dormant (8h+)     | solid grey                      |

A new `Reason` column (and a hover-tooltip on the dot itself) explains *why* a row is in its current state — "stopped by user", "ran /exit", "killed by SIGKILL", "awaiting input", etc. When the reason would just echo the dot colour + LAST ACTIVE age, the column goes dark.

### Evidence-first storage

New nullable columns on `sessions` (all additive ALTERs, no schema rebuild):

- `exit_code`, `exit_signal` — captured by `ClaudePtyManager._handleExit`
- `clean_process_exit` — set when PTY exits with code 0 and no signal
- `explicit_exit_seen` — set when the watcher sees `<command-name>/exit</command-name>` in the JSONL
- `user_stop_requested_at` — stamped by `kill(id, { reason: 'user_stop' })` **before** the kill signal goes out, so the eventual SIGHUP isn't misclassified as a crash
- `last_assistant_stop_reason` — tracks `end_turn` / `tool_use` / `pause_turn` / `max_tokens` / etc. for managed-session reason copy

`dormant` is **never persisted** — it's derived at the API boundary from `state === 'disconnected' && now - lastEventAt > 8h`. The DB CHECK constraint stays at its 4 values. This avoided a footgun where widening the CHECK would have triggered the legacy table rebuild and silently dropped every later-ALTER'd column. A `sessions-migration-regression.test.ts` guard now exercises the rebuild path explicitly so the next person trying it won't get bitten.

### Wire format

`Session` gains two derived fields:

- `displayState: 'active' | 'waiting' | 'disconnected' | 'done' | 'dormant'`
- `displayReason: string` (empty when colour + age says enough)

Both are pure derivations, computed at the row→wire conversion in `routes/sessions.ts`.

### The headline UX fix

Clicking the red-square stop button used to flash red for ~15s before settling on grey. Sequence:

1. `kill(id, { reason: 'user_stop' })` stamps `user_stop_requested_at` *before* sending SIGHUP.
2. `_handleExit` reloads the row after `recordExit(...)` and calls the shared `deriveState` — which sees `userStopRequested && hasProcessExitEvidence → 'done'`.
3. SSE fires once with the final state. No transient `'disconnected'`, no flicker.

A regression test in `server/test/claude-pty-manager.test.ts` drives `_handleExit({exitCode: 129, signal: "SIGHUP"})` with intent set and asserts `row.state === 'done'` synchronously after the handler returns.

## Architecture notes

- `server/src/session-state.ts` is the single source of truth for state derivation. `deriveState(input)` and `deriveReason(input)` are pure functions over the same evidence shape. Adding a new state (e.g. "needs decision", "rate-limited") means growing the test table and the function, not chasing call sites.
- `_handleExit`, `runHeartbeatSweep`, the boot-scan reconciler, and the wire mapper all route through it. No more drifting state machines.
- Bad-exit evidence (non-zero exit code or unknown signal) beats clean-exit claims. A session that ran `/exit` then got SIGKILLed mid-shutdown still reads `disconnected`.

## Test plan

- [x] Unit tests for `deriveState` — table-driven, every branch (`server/test/derive-state.test.ts`)
- [x] Unit tests for `deriveReason` — every branch, including the user-stop case (`server/test/derive-reason.test.ts`)
- [x] `computeDisplayState` boundary + clock-skew tests (`server/test/display-state.test.ts`)
- [x] Watcher evidence-capture tests, including live-ingest path (`server/test/claude-code-watcher-evidence.test.ts`)
- [x] PTY-manager exit handler + user-stop wiring + headline regression test (`server/test/claude-pty-manager.test.ts`)
- [x] Session-store evidence writers (`server/test/session-store-exit-info.test.ts`)
- [x] Schema-evidence-columns presence + dormant-rejection (`server/test/sessions-table-status-columns.test.ts`)
- [x] **Migration regression** — seeds pre-rename schema, runs `initDb` for real, asserts the rebuild path doesn't drop ALTER-added columns (`server/test/sessions-migration-regression.test.ts`)
- [x] All 524 tests pass; server + web TypeScript clean
- [x] Manually dogfooded end-to-end: managed Claude session in dev, click stop button, row flips directly to grey + "stopped by user"

## Out of scope / follow-ups

A holistic review flagged five minor items deferred for follow-up PRs:

1. Stale `terminal_id` on a zombie PTY (one-line fix in the reaper to call `clearTerminal`)
2. `SessionInspector/Header.tsx` could surface `displayReason` next to the state label
3. Pre-existing `state='done'` rows with no evidence columns will read as `'dormant'` after upgrade (cosmetic — both render grey)
4. Cross-device sessions: remote rows don't carry evidence columns so `displayReason` is empty on remote-origin rows
5. Adding evidence to the cross-device sync payload (so 4 has a real fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)