### PR TITLE
arcade(shared): DRY round 3 — Arcade.EndOverlay + pendingInitials canonical

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -209,6 +209,7 @@
 <script src="../shared/iframe-host.js"></script>
 <script src="../shared/leaderboard.js"></script>
 <script src="../shared/initials.js"></script>
+<script src="../shared/end-overlay.js"></script>
 <audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
 <audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
 <audio id="sfx-shoot"     src="sfx-shoot.mp3"               preload="auto"></audio>
@@ -359,7 +360,7 @@ Arcade.Initials.mount({
   onSubmit: (initials) => {
     const goHi = document.getElementById('go-hiscore');
     if (goHi) goHi.textContent = `SCORE SAVED · ${initials}`;
-    endOverlayInputAllowedAt = performance.now() + 400;
+    Arcade.EndOverlay.extendGrace(400);
     Arcade.Leaderboard.submit(score, initials).then(res => {
       if (!res.ok) console.warn('leaderboard submit failed:', res.error);
       paintSplashHiScore();
@@ -514,12 +515,8 @@ let running = false;
 let score = 0;
 let lives = 3;
 let wave = 1;
-let endOverlayInputAllowedAt = 0;
 let respawnAt = 0;
-// True between endRun() and the first post-grace keypress when the score
-// qualifies for the leaderboard. That keypress opens initials entry; a
-// subsequent keypress restarts.
-let pendingInitials = false;
+// (End-overlay grace + pendingInitials gate now live in Arcade.EndOverlay.)
 
 // Player.
 const PLAYER_Y = PF_H - 24;
@@ -867,8 +864,7 @@ function dismissSplashAndStart() {
 // Post-game-over: if the score qualifies, the first key/tap opens initials
 // entry; the next one restarts. Falls through to splash-dismiss otherwise.
 function consumePendingOrRestart() {
-  if (pendingInitials) {
-    pendingInitials = false;
+  if (Arcade.EndOverlay.consumePending()) {
     Arcade.Initials.open();
     return;
   }
@@ -888,7 +884,7 @@ window.addEventListener('keydown', e => {
   }
   if (running) return;
   // Overlay grace prevents the same key that lost the run from restarting it.
-  if (performance.now() < endOverlayInputAllowedAt) return;
+  if (!Arcade.EndOverlay.acceptsInput()) return;
   consumePendingOrRestart();
   // Halt subsequent same-event handlers (notably the gameplay input listener
   // below) so the key that STARTS the run doesn't also land in keys[] after
@@ -908,7 +904,7 @@ document.addEventListener('pointerdown', e => {
     return;
   }
   if (running) return;
-  if (performance.now() < endOverlayInputAllowedAt) return;
+  if (!Arcade.EndOverlay.acceptsInput()) return;
   consumePendingOrRestart();
 });
 
@@ -1016,35 +1012,19 @@ function endRun(winFlag) {
   // Loss plays the sad SFX. Win path lets the boss-explosion + flash carry
   // the moment instead.
   if (!winFlag) Arcade.Audio.play('sfx-lose', 0.55);
-  const ov = document.getElementById('gameover');
-  const titleEl = document.getElementById('go-title');
-  titleEl.classList.toggle('is-win', !!winFlag);
-  titleEl.textContent = winFlag ? 'GAME COMPLETE' : 'GAME OVER';
-  document.getElementById('go-score-val').textContent = score;
-  const top = Arcade.Leaderboard.getHighScore();
-  const hi = document.getElementById('go-hiscore');
-  hi.textContent = top ? `HIGH ${String(top.score).padStart(4, '0')} ${top.initials || '---'}` : '';
-  document.getElementById('go-prompt').hidden = false;
-  document.getElementById('go-initials').hidden = true;
-  ov.classList.add('is-visible');
-  ov.setAttribute('aria-hidden', 'false');
-  endOverlayInputAllowedAt = performance.now() + GAME_OVER_GRACE_MS;
-  // Defer the initials prompt — the FIRST key/tap after the grace expires
-  // either opens initials entry (if the score qualifies) or restarts the
-  // game (if it doesn't). User asked for "don't progress to name entry
-  // until you press a key".
-  pendingInitials = Arcade.Leaderboard.qualifies(score);
+  Arcade.EndOverlay.show({
+    score,
+    title:      winFlag ? 'GAME COMPLETE' : 'GAME OVER',
+    titleClass: winFlag ? 'is-win' : '',
+    hiscore:    Arcade.Leaderboard.getHighScore(),
+    graceMs:    GAME_OVER_GRACE_MS,
+    qualifies:  Arcade.Leaderboard.qualifies(score),
+  });
 }
 
 function hideEndOverlay() {
-  const ov = document.getElementById('gameover');
-  ov.classList.remove('is-visible');
-  ov.setAttribute('aria-hidden', 'true');
-  document.getElementById('go-initials').hidden = true;
-  document.getElementById('go-prompt').hidden = false;
-  document.getElementById('go-title').classList.remove('is-win');
   Arcade.Initials.close();
-  endOverlayInputAllowedAt = 0;
+  Arcade.EndOverlay.hide();
 }
 
 // (Initials state machine + listeners now live in shared/initials.js — see

--- a/docs/arcade/shared/end-overlay.js
+++ b/docs/arcade/shared/end-overlay.js
@@ -18,11 +18,11 @@
 //   // ...on game over:
 //   Arcade.EndOverlay.show({
 //     score,
-//     title:     win ? 'GAME COMPLETE' : 'GAME OVER',
-//     win,                                       // applies .is-win class
-//     hiscore:   Arcade.Leaderboard.getHighScore(),
-//     graceMs:   1200,
-//     qualifies: Arcade.Leaderboard.qualifies(score),
+//     title:      win ? 'GAME COMPLETE' : 'GAME OVER',
+//     titleClass: win ? 'is-win' : '',          // CSS class on the title el
+//     hiscore:    Arcade.Leaderboard.getHighScore(),
+//     graceMs:    1200,
+//     qualifies:  Arcade.Leaderboard.qualifies(score),
 //   });
 //   // ...in restart listeners:
 //   if (!Arcade.EndOverlay.acceptsInput()) return;
@@ -116,11 +116,13 @@
     return ov ? ov.classList.contains(opts.visibleClass) : false;
   }
 
-  // True once the grace window has elapsed AND the overlay is at least
-  // armed (inputAllowedAt > 0). Returns false outright if show() hasn't
-  // been called yet this run.
+  // True when input is NOT being held back by the grace window. Returns
+  // true when no overlay has been armed yet (inputAllowedAt === 0) so the
+  // initial splash-dismiss path isn't accidentally gated. The only time
+  // this returns false is during the active grace window after show().
   function acceptsInput() {
-    return inputAllowedAt > 0 && performance.now() >= inputAllowedAt;
+    if (inputAllowedAt === 0) return true;
+    return performance.now() >= inputAllowedAt;
   }
 
   // Returns true exactly ONCE per show() if qualifies was true. Game's

--- a/docs/arcade/shared/end-overlay.js
+++ b/docs/arcade/shared/end-overlay.js
@@ -1,0 +1,152 @@
+// Shared GAME OVER / GAME COMPLETE overlay state — show/hide, grace window,
+// and the "first post-grace key opens initials, next one restarts" gate.
+//
+// Canonicalises the Invaders pendingInitials model. Space Jumper previously
+// used a setTimeout that auto-opened initials after the grace; the new model
+// waits for the user's NEXT keypress, which is what players expect (a held
+// key at the moment of death doesn't blow past the prompt accidentally).
+//
+// Each game still owns its own endRun() function — it computes win/loss,
+// picks the grace duration, decides whether the score qualifies for initials,
+// then calls Arcade.EndOverlay.show({ ... }) with those decisions. The
+// module owns the DOM (#gameover + #go-title + #go-score-val + #go-hiscore
+// + #go-prompt) and the timing state.
+//
+// Usage:
+//
+//   Arcade.EndOverlay.mount();                  // defaults to standard DOM
+//   // ...on game over:
+//   Arcade.EndOverlay.show({
+//     score,
+//     title:     win ? 'GAME COMPLETE' : 'GAME OVER',
+//     win,                                       // applies .is-win class
+//     hiscore:   Arcade.Leaderboard.getHighScore(),
+//     graceMs:   1200,
+//     qualifies: Arcade.Leaderboard.qualifies(score),
+//   });
+//   // ...in restart listeners:
+//   if (!Arcade.EndOverlay.acceptsInput()) return;
+//   if (Arcade.EndOverlay.consumePending()) { Arcade.Initials.open(); return; }
+//   // else: dismiss + start new run
+//   Arcade.EndOverlay.hide();
+//   startRun();
+
+(function () {
+  const DEFAULTS = {
+    rootSelector:    '#gameover',
+    titleSelector:   '#go-title',
+    scoreSelector:   '#go-score-val',
+    hiscoreSelector: '#go-hiscore',
+    promptSelector:  '#go-prompt',
+    visibleClass:    'is-visible',
+    hiscoreFormat:   (hs) => `HIGH ${String(hs.score).padStart(4, '0')} ${hs.initials || '---'}`,
+  };
+
+  let opts = null;
+  let inputAllowedAt = 0;
+  let pendingInitials = false;
+  // Title classes the module has applied this show() — removed in hide().
+  let appliedTitleClass = '';
+
+  function mount(o) {
+    opts = Object.assign({}, DEFAULTS, o || {});
+  }
+  function ensure() {
+    if (!opts) opts = Object.assign({}, DEFAULTS);
+  }
+
+  function show({
+    score = 0,
+    hiscore = null,         // { score, initials } | null
+    title = 'GAME OVER',
+    titleClass = '',        // e.g. 'is-win' or 'is-loss' (or '' for none)
+    graceMs = 1200,
+    qualifies = false,
+    hiscoreText = null,     // optional override — bypasses default formatter
+  } = {}) {
+    ensure();
+    const ov       = document.querySelector(opts.rootSelector);
+    const titleEl  = document.querySelector(opts.titleSelector);
+    const scoreEl  = document.querySelector(opts.scoreSelector);
+    const hiEl     = document.querySelector(opts.hiscoreSelector);
+    const promptEl = document.querySelector(opts.promptSelector);
+    if (!ov) return;
+    if (titleEl) {
+      titleEl.textContent = title;
+      // Remove the previously-applied title class first so toggling between
+      // .is-win and .is-loss across runs doesn't accumulate stale classes.
+      if (appliedTitleClass) titleEl.classList.remove(appliedTitleClass);
+      if (titleClass) titleEl.classList.add(titleClass);
+      appliedTitleClass = titleClass || '';
+    }
+    if (scoreEl) scoreEl.textContent = score;
+    if (hiEl) {
+      hiEl.textContent = hiscoreText != null
+        ? hiscoreText
+        : (hiscore ? opts.hiscoreFormat(hiscore) : '');
+    }
+    if (promptEl) promptEl.hidden = false;
+    ov.classList.add(opts.visibleClass);
+    ov.setAttribute('aria-hidden', 'false');
+    inputAllowedAt = performance.now() + (graceMs || 0);
+    pendingInitials = !!qualifies;
+  }
+
+  function hide() {
+    ensure();
+    const ov      = document.querySelector(opts.rootSelector);
+    const titleEl = document.querySelector(opts.titleSelector);
+    const promptEl = document.querySelector(opts.promptSelector);
+    if (ov) {
+      ov.classList.remove(opts.visibleClass);
+      ov.setAttribute('aria-hidden', 'true');
+    }
+    if (titleEl && appliedTitleClass) {
+      titleEl.classList.remove(appliedTitleClass);
+      appliedTitleClass = '';
+    }
+    if (promptEl) promptEl.hidden = false;
+    inputAllowedAt = 0;
+    pendingInitials = false;
+  }
+
+  function isVisible() {
+    ensure();
+    const ov = document.querySelector(opts.rootSelector);
+    return ov ? ov.classList.contains(opts.visibleClass) : false;
+  }
+
+  // True once the grace window has elapsed AND the overlay is at least
+  // armed (inputAllowedAt > 0). Returns false outright if show() hasn't
+  // been called yet this run.
+  function acceptsInput() {
+    return inputAllowedAt > 0 && performance.now() >= inputAllowedAt;
+  }
+
+  // Returns true exactly ONCE per show() if qualifies was true. Game's
+  // restart listener routes to initials entry on a true return, restart
+  // otherwise.
+  function consumePending() {
+    if (!pendingInitials) return false;
+    pendingInitials = false;
+    return true;
+  }
+
+  // Extend the grace window — used after Arcade.Initials.onSubmit to give
+  // the player a beat before their next keypress restarts the game.
+  function extendGrace(ms) {
+    inputAllowedAt = performance.now() + (ms || 0);
+  }
+
+  // Re-mark pendingInitials — useful if the game wants to defer initials
+  // until after a custom celebration / cutscene resolves.
+  function setPendingInitials(v) {
+    pendingInitials = !!v;
+  }
+
+  window.Arcade = window.Arcade || {};
+  window.Arcade.EndOverlay = {
+    mount, show, hide, isVisible,
+    acceptsInput, consumePending, extendGrace, setPendingInitials,
+  };
+})();

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -230,6 +230,7 @@
 <script src="../shared/iframe-host.js"></script>
 <script src="../shared/leaderboard.js"></script>
 <script src="../shared/initials.js"></script>
+<script src="../shared/end-overlay.js"></script>
 <audio id="sfx-powerup"   src="../shared/sfx-powerup.mp3"   preload="auto"></audio>
 <audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
 <audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
@@ -412,7 +413,7 @@ Arcade.Initials.mount({
   onSubmit: (initials) => {
     const goHi = document.getElementById('go-hiscore');
     if (goHi) goHi.textContent = `SCORE SAVED · ${initials}`;
-    endOverlayInputAllowedAt = performance.now() + 400;
+    Arcade.EndOverlay.extendGrace(400);
     Arcade.Leaderboard.submit(score, initials).then(res => {
       if (!res.ok) console.warn('leaderboard submit failed:', res.error);
       paintSplashHiScore();
@@ -442,39 +443,30 @@ Arcade.Leaderboard.refresh().then(paintSplashHiScore);
 // styled via .is-win / .is-loss on the title. Replaces the previous
 // canvas drawGameOver / drawLevelComplete.
 // ============================================
-let endOverlayInputAllowedAt = 0;
-
 function showEndOverlay({ win }) {
-  const ov = document.getElementById('gameover');
-  const titleEl = document.getElementById('go-title');
-  const scoreVal = document.getElementById('go-score-val');
-  const hiEl = document.getElementById('go-hiscore');
-  if (!ov) return;
-  titleEl.textContent = gameComplete ? 'GAME COMPLETE' : (win ? 'LEVEL COMPLETE' : 'GAME OVER');
-  titleEl.classList.toggle('is-win', !!win);
-  titleEl.classList.toggle('is-loss', !win);
-  scoreVal.textContent = score;
-  const top = Arcade.Leaderboard.getHighScore();
-  if (hiEl) hiEl.textContent = top ? `HIGH ${String(top.score).padStart(3, '0')} ${top.initials || '---'}` : '';
   Arcade.Initials.close();
-  ov.classList.add('is-visible');
-  ov.setAttribute('aria-hidden', 'false');
-  const graceMs = win ? LEVEL_COMPLETE_GRACE_MS : GAME_OVER_GRACE_MS;
-  endOverlayInputAllowedAt = performance.now() + graceMs;
-  // After the grace window, prompt for initials if the score qualifies.
-  setTimeout(() => {
-    if (!(gameOver || levelComplete)) return;  // already restarted
-    if (Arcade.Leaderboard.qualifies(score)) Arcade.Initials.open();
-  }, graceMs);
+  Arcade.EndOverlay.show({
+    score,
+    title:      gameComplete ? 'GAME COMPLETE' : (win ? 'LEVEL COMPLETE' : 'GAME OVER'),
+    titleClass: win ? 'is-win' : 'is-loss',
+    hiscore:    Arcade.Leaderboard.getHighScore(),
+    // Space Jumper uses a custom 3-digit hiscore format (legacy from when
+    // scores capped at 999) — pass the rendered string explicitly.
+    hiscoreText: (() => {
+      const top = Arcade.Leaderboard.getHighScore();
+      return top ? `HIGH ${String(top.score).padStart(3, '0')} ${top.initials || '---'}` : '';
+    })(),
+    graceMs:    win ? LEVEL_COMPLETE_GRACE_MS : GAME_OVER_GRACE_MS,
+    qualifies:  Arcade.Leaderboard.qualifies(score),
+  });
+  // (Initials prompt now opens on the player's next keypress after the
+  // grace expires — see consumePending() in the restart listener, not the
+  // old setTimeout auto-open.)
 }
 
 function hideEndOverlay() {
-  const ov = document.getElementById('gameover');
-  if (!ov) return;
-  ov.classList.remove('is-visible');
-  ov.setAttribute('aria-hidden', 'true');
   Arcade.Initials.close();
-  endOverlayInputAllowedAt = 0;
+  Arcade.EndOverlay.hide();
 }
 
 // Title-screen MUSIC / SFX toggles. Read/write through the shared
@@ -1072,16 +1064,25 @@ function update() {
 
   // Level complete / game over: freeze gameplay. Initials entry has its
   // own input path (separate keydown listener); restart input is gated by
-  // endOverlayInputAllowedAt so the same key that triggered the end (or
-  // saved initials) doesn't immediately restart.
+  // Arcade.EndOverlay so the same key that triggered the end (or saved
+  // initials) doesn't immediately restart.
   if (levelComplete || gameOver) {
     if (Arcade.Initials.isActive()) return;
-    if (now < endOverlayInputAllowedAt) return;
+    if (!Arcade.EndOverlay.acceptsInput()) return;
     const anyAction =
       keys[' '] || keys['ArrowUp'] || keys['w'] || keys['W'] ||
       keys['ArrowLeft'] || keys['ArrowRight'] || keys['a'] || keys['d'] ||
       keys['A'] || keys['D'] || keys['Enter'];
-    if (anyAction) resetRun();
+    if (anyAction) {
+      // First post-grace keypress with a qualifying score → initials entry.
+      // Subsequent keypress (or any keypress on a non-qualifying score) →
+      // restart the run. Replaces the previous setTimeout auto-open model.
+      if (Arcade.EndOverlay.consumePending()) {
+        Arcade.Initials.open();
+        return;
+      }
+      resetRun();
+    }
     return;
   }
 

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -445,17 +445,14 @@ Arcade.Leaderboard.refresh().then(paintSplashHiScore);
 // ============================================
 function showEndOverlay({ win }) {
   Arcade.Initials.close();
+  // Space Jumper uses a custom 3-digit hiscore format (legacy from when
+  // scores capped at 999) — pass the rendered string explicitly.
+  const top = Arcade.Leaderboard.getHighScore();
   Arcade.EndOverlay.show({
     score,
     title:      gameComplete ? 'GAME COMPLETE' : (win ? 'LEVEL COMPLETE' : 'GAME OVER'),
     titleClass: win ? 'is-win' : 'is-loss',
-    hiscore:    Arcade.Leaderboard.getHighScore(),
-    // Space Jumper uses a custom 3-digit hiscore format (legacy from when
-    // scores capped at 999) — pass the rendered string explicitly.
-    hiscoreText: (() => {
-      const top = Arcade.Leaderboard.getHighScore();
-      return top ? `HIGH ${String(top.score).padStart(3, '0')} ${top.initials || '---'}` : '';
-    })(),
+    hiscoreText: top ? `HIGH ${String(top.score).padStart(3, '0')} ${top.initials || '---'}` : '',
     graceMs:    win ? LEVEL_COMPLETE_GRACE_MS : GAME_OVER_GRACE_MS,
     qualifies:  Arcade.Leaderboard.qualifies(score),
   });


### PR DESCRIPTION
## Summary

Round 3 of the DRY framework pass — extracts the post-game-over restart-gate state machine into \`shared/end-overlay.js\` and canonicalises on the Invaders \`pendingInitials\` model across all games.

Per the audit, this was the next-highest-payoff target after \`Arcade.Initials\`. Small but bug-prone — getting the \"first key opens initials, next one restarts\" gate right used to be inline state in each game with subtle differences.

## What landed

- **\`shared/end-overlay.js\`** — owns the \`#gameover\` DOM (title, score, hi-score, prompt), the grace-window timestamp, and the \`pendingInitials\` flag. API: \`show({score, title, titleClass, hiscore, graceMs, qualifies})\`, \`hide()\`, \`acceptsInput()\`, \`consumePending()\`, \`extendGrace(ms)\`.
- **Invaders**: 30 lines of DOM manipulation collapse into one \`show()\`/\`hide()\` call each.
- **Space Jumper**: same migration + **upgraded** to the pendingInitials model. Previously it used \`setTimeout\` to auto-open initials at the end of the grace; that meant a held key at the moment of death could blow past the prompt accidentally. Now the player has to press a key themselves to open initials.

## What's deferred

- **Rocket Ship** — its end-overlay flow is materially different (pre-initials celebration animation, attract-mode hand-off after submit, no in-place restart). Worth its own pass.

## Visible behaviour change

Space Jumper: initials prompt no longer auto-opens after the grace window. The next key press routes there (if score qualifies) or to restart (otherwise). Matches Invaders' behaviour. Worth flagging since existing Space Jumper players might briefly wonder why nothing happened — but the first key press resolves it instantly.

## Test plan

- [ ] Play Invaders, die with a qualifying score → game-over overlay, wait for grace, press any key → initials opens, save → next key restarts
- [ ] Play Invaders, die with a non-qualifying score → game-over overlay, wait for grace, press any key → restart immediately
- [ ] Play Space Jumper, die with a qualifying score → game-over overlay, grace expires, press any key → initials opens (NEW: previously auto-opened on grace timeout)
- [ ] Play Space Jumper, level-complete a level → 'LEVEL COMPLETE' title in green/gold, normal flow continues
- [ ] Play Space Jumper, beat the game (final boss) → 'GAME COMPLETE' title shows
- [ ] Verify Rocket Ship still works (untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)