### PR TITLE
arcade(shared): DRY round 4 — Arcade.Leaderboard.paintHiScoreRow + paintList

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -367,49 +367,16 @@ Arcade.Initials.mount({
   },
 });
 
-// Always show the hi-score row, falling back to 0000 / --- on a fresh
-// install — matches the rocket-ship pattern so an empty cabinet still
-// reads as a proper arcade title screen.
+// Splash painters delegate to Arcade.Leaderboard (shared DOM builders).
 function paintSplashHiScore() {
-  const val = document.getElementById('hs-val-splash');
-  const ini = document.getElementById('hs-initials-splash');
-  if (!val || !ini) return;
-  const top = Arcade.Leaderboard.getHighScore();
-  val.textContent = String(top ? top.score : 0).padStart(4, '0');
-  ini.textContent = (top && top.initials) || '---';
-}
-
-// Title ↔ leaderboard cycle on the splash.
-function paintLeaderboard() {
-  const ol = document.getElementById('lb-list');
-  if (!ol) return;
-  ol.textContent = '';
-  const list = Arcade.Leaderboard.read();
-  if (!list.length) {
-    const li = document.createElement('li');
-    const span = document.createElement('span');
-    span.className = 'lb-empty';
-    span.textContent = 'NO SCORES YET — BE THE FIRST';
-    li.appendChild(span);
-    ol.appendChild(li);
-    return;
-  }
-  // Build via DOM so user-supplied initials can't be interpreted as HTML.
-  list.forEach((e, i) => {
-    const li = document.createElement('li');
-    const cols = [
-      ['lb-rank',     String(i + 1).padStart(2, '0') + '.'],
-      ['lb-initials', e.initials || '---'],
-      ['lb-score',    String(e.score).padStart(4, '0')],
-    ];
-    for (const [cls, text] of cols) {
-      const span = document.createElement('span');
-      span.className = cls;
-      span.textContent = text;
-      li.appendChild(span);
-    }
-    ol.appendChild(li);
+  Arcade.Leaderboard.paintHiScoreRow({
+    valueSelector:    '#hs-val-splash',
+    initialsSelector: '#hs-initials-splash',
+    pad: 4,
   });
+}
+function paintLeaderboard() {
+  Arcade.Leaderboard.paintList({ listSelector: '#lb-list', pad: 4 });
 }
 
 let splashCycleTimer = null;

--- a/docs/arcade/shared/leaderboard.js
+++ b/docs/arcade/shared/leaderboard.js
@@ -108,6 +108,77 @@
     } catch (_) { return { ok: false, error: 'network' }; }
   }
 
+  // -------------------------------------------------------------------------
+  // Splash painters — fold the duplicated DOM build code from each game's
+  // paintSplashHiScore + paintLeaderboard into the shared module.
+  // -------------------------------------------------------------------------
+
+  // Paints the splash's "HIGH SCORE 0000 ABC" row from the current top entry.
+  // When hideWhenEmpty is true, the row element (if a rowSelector was given)
+  // gets its `hidden` attribute set to true on an empty board — otherwise the
+  // row stays visible and paints "0" / "---" placeholders.
+  function paintHiScoreRow(opts) {
+    opts = opts || {};
+    const pad = opts.pad || 4;
+    const val = opts.valueSelector    && document.querySelector(opts.valueSelector);
+    const ini = opts.initialsSelector && document.querySelector(opts.initialsSelector);
+    const row = opts.rowSelector      && document.querySelector(opts.rowSelector);
+    if (!val || !ini) return;
+    const top = getHighScore();
+    if (!top && opts.hideWhenEmpty) {
+      if (row) row.hidden = true;
+      return;
+    }
+    if (row) row.hidden = false;
+    val.textContent = String(top ? top.score : 0).padStart(pad, '0');
+    ini.textContent = (top && top.initials) || '---';
+  }
+
+  // Paints the top-N list into the splash's <ol id="lb-list">. Builds each
+  // entry via document.createElement so user-supplied initials can't be
+  // interpreted as HTML. Optional lb-since column for games that want a
+  // humanised timestamp (Rocket Ship uses this — passes its own
+  // sinceFormatter).
+  function paintList(opts) {
+    opts = opts || {};
+    const ol = opts.listSelector && document.querySelector(opts.listSelector);
+    if (!ol) return;
+    const pad       = opts.pad || 4;
+    const emptyText = opts.emptyText || 'NO SCORES YET — BE THE FIRST';
+    const showSince = !!opts.showSince;
+    const fmtSince  = opts.sinceFormatter || (() => '');
+    const list = read();
+    ol.textContent = '';
+    if (!list.length) {
+      const li = document.createElement('li');
+      const span = document.createElement('span');
+      span.className = 'lb-empty';
+      span.textContent = emptyText;
+      li.appendChild(span);
+      ol.appendChild(li);
+      return;
+    }
+    list.forEach((e, i) => {
+      const li = document.createElement('li');
+      const cols = [
+        ['lb-rank',     String(i + 1).padStart(2, '0') + '.'],
+        ['lb-initials', e.initials || '---'],
+        ['lb-score',    String(e.score).padStart(pad, '0')],
+      ];
+      if (showSince) cols.push(['lb-since', fmtSince(e.created_at)]);
+      for (const [cls, text] of cols) {
+        const span = document.createElement('span');
+        span.className = cls;
+        span.textContent = text;
+        li.appendChild(span);
+      }
+      ol.appendChild(li);
+    });
+  }
+
   window.Arcade = window.Arcade || {};
-  window.Arcade.Leaderboard = { init, read, refresh, qualifies, getHighScore, submit };
+  window.Arcade.Leaderboard = {
+    init, read, refresh, qualifies, getHighScore, submit,
+    paintHiScoreRow, paintList,
+  };
 })();

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -420,15 +420,16 @@ Arcade.Initials.mount({
   },
 });
 function paintSplashHiScore() {
-  const row = document.getElementById('hiscore-row');
-  const val = document.getElementById('hs-val-splash');
-  const ini = document.getElementById('hs-initials-splash');
-  if (!row || !val || !ini) return;
-  const top = Arcade.Leaderboard.getHighScore();
-  if (!top) { row.hidden = true; return; }
-  row.hidden = false;
-  val.textContent = String(top.score).padStart(3, '0');
-  ini.textContent = top.initials || '---';
+  // Space Jumper hides the row entirely when there are no scores (vs Invaders'
+  // "show 0000 ---" placeholder). 3-digit pad — legacy from when scores
+  // capped at 999.
+  Arcade.Leaderboard.paintHiScoreRow({
+    rowSelector:      '#hiscore-row',
+    valueSelector:    '#hs-val-splash',
+    initialsSelector: '#hs-initials-splash',
+    pad: 3,
+    hideWhenEmpty: true,
+  });
 }
 paintSplashHiScore();
 // Fire-and-forget cloud refresh; repaint when it lands.

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -1644,43 +1644,20 @@ function sincePhrase(ts) {
 }
 
 function paintSplashHighScore() {
-  const hs = getHighScore();
-  const v = document.getElementById('hs-val-splash');
-  const i = document.getElementById('hs-initials-splash');
-  if (v) v.textContent = String(hs.score).padStart(3, '0');
-  if (i) i.textContent = hs.initials;
+  Arcade.Leaderboard.paintHiScoreRow({
+    valueSelector:    '#hs-val-splash',
+    initialsSelector: '#hs-initials-splash',
+    pad: 3,
+  });
 }
 function paintLeaderboard() {
-  const list = readLeaderboard();
-  const ol = document.getElementById('lb-list');
-  if (!ol) return;
-  // Clear safely
-  ol.textContent = '';
-  if (!list.length) {
-    const li = document.createElement('li');
-    const span = document.createElement('span');
-    span.className = 'lb-empty';
-    span.textContent = 'NO SCORES YET — BE THE FIRST';
-    li.appendChild(span);
-    ol.appendChild(li);
-    return;
-  }
-  // Build via DOM nodes so user-provided initials can't be interpreted as HTML.
-  list.forEach((e, i) => {
-    const li = document.createElement('li');
-    const cols = [
-      ['lb-rank', String(i + 1).padStart(2, '0') + '.'],
-      ['lb-initials', e.initials],
-      ['lb-score', String(e.score).padStart(3, '0')],
-      ['lb-since', sincePhrase(e.created_at)],
-    ];
-    for (const [cls, text] of cols) {
-      const span = document.createElement('span');
-      span.className = cls;
-      span.textContent = text;
-      li.appendChild(span);
-    }
-    ol.appendChild(li);
+  // Rocket Ship is the only game showing the humanised "since" column on the
+  // leaderboard list. Module supports it via showSince + sinceFormatter.
+  Arcade.Leaderboard.paintList({
+    listSelector:   '#lb-list',
+    pad:            3,
+    showSince:      true,
+    sinceFormatter: sincePhrase,
   });
 }
 paintSplashHighScore();


### PR DESCRIPTION
## Summary

DRY round 4 — small one. Three games had near-identical \`paintSplashHiScore\` + \`paintLeaderboard\` helpers building the same DOM in three places, with tiny per-game flavour (3- vs 4-digit pad, optional row-hide on empty, optional lb-since column for Rocket Ship's humanised timestamp).

Folded both into \`Arcade.Leaderboard\` with config knobs for the variations.

## What landed

- \`Arcade.Leaderboard.paintHiScoreRow({ rowSelector, valueSelector, initialsSelector, pad, hideWhenEmpty })\`
- \`Arcade.Leaderboard.paintList({ listSelector, pad, showSince, sinceFormatter, emptyText })\`
- Invaders / Space Jumper / Rocket Ship each replace their local builders with a single shared-module call. ~80 lines of DOM thrash removed across the three games.

## Per-game flavour preserved via config

| Game | pad | hideWhenEmpty | showSince |
|---|---|---|---|
| Invaders | 4 | no | no |
| Space Jumper | 3 | yes | no |
| Rocket Ship | 3 | no | yes (passes its own \`sincePhrase\`) |

## Test plan

- [ ] Open arcade.oyster.to → Invaders splash → HIGH SCORE row shows \`0000 ---\` on a fresh install (no row hide)
- [ ] Space Jumper splash → HIGH SCORE row hidden entirely on a fresh install; appears once a score is saved
- [ ] Rocket Ship → HIGH SCORES list shows the humanised "today / 2d / 3w" column on the right
- [ ] Submit a new high score in any game → row + list refresh correctly across all three splashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)