### PR TITLE
arcade(shared): DRY round 5 — extract game-over CSS to shared/overlays.css

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -9,9 +9,9 @@
 <link rel="stylesheet" href="../shared/touch.css">
 <link rel="stylesheet" href="../shared/overlays.css">
 <style>
-  /* Splash + game-over overlay styles — copied from space-jumper/index.html
-     lines ~31-230 with palette tweaks. Keep ONE source of truth per game;
-     don't extract into shared CSS until a third game wants it. */
+  /* Splash styles for Invaders. The game-over overlay now lives in
+     ../shared/overlays.css — Invaders uses its defaults verbatim. Splash
+     is still inline here (Round 6 of the DRY pass will extract it). */
   .splash {
     position: absolute; inset: 0; z-index: 3; overflow: hidden;
     background: linear-gradient(180deg, #0d1a60 0%, #050a30 100%);

--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../shared/pixel-font.css">
 <link rel="stylesheet" href="../shared/cabinet.css">
 <link rel="stylesheet" href="../shared/touch.css">
+<link rel="stylesheet" href="../shared/overlays.css">
 <style>
   /* Splash + game-over overlay styles — copied from space-jumper/index.html
      lines ~31-230 with palette tweaks. Keep ONE source of truth per game;
@@ -152,47 +153,9 @@
     color: #fff;
   }
 
-  /* Game-over overlay — verbatim from space-jumper/index.html ~140-230. */
-  .gameover {
-    position: absolute; inset: 0; z-index: 4;
-    background: rgba(0, 0, 0, 0.88);
-    display: none; flex-direction: column;
-    align-items: center; justify-content: center;
-    text-align: center;
-    font-family: 'Press Start 2P', ui-monospace, monospace;
-    color: #fff;
-    gap: clamp(16px, 2.6vw, 26px);
-    padding: 40px 24px;
-    animation: splash-poweron 0.3s ease-out;
-  }
-  .gameover.is-visible { display: flex; }
-  .gameover .go-title {
-    font-size: clamp(28px, 6.5vw, 60px);
-    color: #ff3aa1;
-    text-shadow: 3px 3px 0 #2dd4ff, 6px 6px 0 #ffd84a, 0 0 16px rgba(255, 58, 161, 0.45);
-  }
-  .gameover .go-title.is-win {
-    color: #4ade80;
-    text-shadow: 3px 3px 0 #ffd84a, 6px 6px 0 #2dd4ff, 0 0 22px rgba(74, 222, 128, 0.55);
-  }
-  .gameover .go-score { font-size: clamp(14px, 2.2vw, 18px); color: #ffd84a; letter-spacing: 0.18em; }
-  .gameover .go-hiscore { font-size: clamp(9px, 1.3vw, 12px); color: #2dd4ff; letter-spacing: 0.18em; min-height: 14px; }
-  .gameover .go-prompt {
-    font-size: clamp(10px, 1.6vw, 14px); letter-spacing: 0.18em; color: #fff;
-    animation: arcade-blink 1s steps(1) infinite;
-  }
-  .gameover .go-initials { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: 8px; }
-  .gameover .go-initials-label { font-size: clamp(10px, 1.5vw, 13px); letter-spacing: 0.2em; color: #ff3aa1; }
-  .gameover .go-initials-slots {
-    display: inline-flex; gap: 18px;
-    font-size: clamp(28px, 5vw, 44px);
-    color: #ffd84a;
-    text-shadow: 2px 2px 0 #ff3aa1, 4px 4px 0 #2dd4ff;
-    letter-spacing: 0.1em;
-  }
-  .gameover .go-slot { display: inline-block; min-width: 1ch; padding: 0 4px; border-bottom: 4px solid rgba(255, 216, 74, 0.3); }
-  .gameover .go-slot.is-active { border-bottom-color: #2dd4ff; animation: arcade-blink 0.6s steps(1) infinite; }
-  .gameover .go-initials-hint { font-size: clamp(8px, 1.1vw, 10px); letter-spacing: 0.16em; color: rgba(255, 255, 255, 0.6); }
+  /* Game-over overlay (.gameover + .go-*) styles live in shared/overlays.css.
+     Invaders uses the default palette baked into that stylesheet, so no
+     per-game CSS variable overrides are needed here. */
 
   /* Canvas is the playfield. Crisp pixels — nearest-neighbour scaling so
      the chunky sprites read like an arcade screen, not antialiased mush. */

--- a/docs/arcade/shared/overlays.css
+++ b/docs/arcade/shared/overlays.css
@@ -8,12 +8,17 @@
  * Defaults below use Invaders' palette. Other games set --go-* vars in
  * their own <style> block to retint without duplicating geometry.
  *
+ * Dependencies: the @keyframes splash-poweron and arcade-blink used below
+ * live in ../shared/cabinet.css — each consuming game must <link> that
+ * stylesheet too (every game already does for the cabinet shell).
+ *
  * Usage (each game):
+ *   <link rel="stylesheet" href="../shared/cabinet.css">
  *   <link rel="stylesheet" href="../shared/overlays.css">
  *
  *   <style>
  *     :root {
- *       --go-title-color-win: #ffd84a;          // example override
+ *       --go-title-color-win: #ffd84a;          (example override)
  *     }
  *   </style>
  *

--- a/docs/arcade/shared/overlays.css
+++ b/docs/arcade/shared/overlays.css
@@ -1,0 +1,128 @@
+/* Shared GAME-OVER / WIN / LEVEL-COMPLETE overlay styles.
+ *
+ * Lifts the ~80-line .gameover + .go-* block that lived inline in every
+ * arcade game. Layout/font/animation are constants; the colour palette is
+ * exposed as CSS variables so games can override only what they care about
+ * (the per-game personality) instead of re-stating the whole stack.
+ *
+ * Defaults below use Invaders' palette. Other games set --go-* vars in
+ * their own <style> block to retint without duplicating geometry.
+ *
+ * Usage (each game):
+ *   <link rel="stylesheet" href="../shared/overlays.css">
+ *
+ *   <style>
+ *     :root {
+ *       --go-title-color-win: #ffd84a;          // example override
+ *     }
+ *   </style>
+ *
+ * Variables (with defaults):
+ *   --go-title-color        default-state title colour      #ff3aa1
+ *   --go-title-shadow-1     first shadow layer              3px 3px 0 #2dd4ff
+ *   --go-title-shadow-2     second shadow layer             6px 6px 0 #ffd84a
+ *   --go-title-glow         glow shadow                     0 0 16px rgba(255,58,161,0.45)
+ *   --go-title-color-win    .is-win title colour            #4ade80
+ *   --go-title-shadow-1-win first shadow when .is-win       3px 3px 0 #ffd84a
+ *   --go-title-shadow-2-win second shadow when .is-win      6px 6px 0 #2dd4ff
+ *   --go-title-glow-win     .is-win glow                    0 0 22px rgba(74,222,128,0.55)
+ *   --go-title-color-loss   .is-loss title colour           #ff3aa1
+ *   --go-score-color        SCORE value colour              #ffd84a
+ *   --go-hiscore-color      HIGH-line colour                #2dd4ff
+ *   --go-initials-label-color  "NEW HIGH SCORE…" colour     #ff3aa1
+ *   --go-slot-color         initials slot character colour  #ffd84a
+ *   --go-slot-shadow        initials slot shadow stack      2px 2px 0 #ff3aa1, 4px 4px 0 #2dd4ff
+ *   --go-slot-border        underline border colour         rgba(255,216,74,0.3)
+ *   --go-slot-active-border underline when slot is active   #2dd4ff
+ */
+
+.gameover {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  background: rgba(0, 0, 0, 0.88);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-family: 'Press Start 2P', ui-monospace, monospace;
+  color: #fff;
+  gap: clamp(16px, 2.6vw, 26px);
+  padding: 40px 24px;
+  animation: splash-poweron 0.3s ease-out;
+}
+.gameover.is-visible { display: flex; }
+
+.gameover .go-title {
+  font-size: clamp(28px, 6.5vw, 60px);
+  color: var(--go-title-color, #ff3aa1);
+  text-shadow:
+    var(--go-title-shadow-1, 3px 3px 0 #2dd4ff),
+    var(--go-title-shadow-2, 6px 6px 0 #ffd84a),
+    var(--go-title-glow, 0 0 16px rgba(255, 58, 161, 0.45));
+}
+.gameover .go-title.is-win {
+  color: var(--go-title-color-win, #4ade80);
+  text-shadow:
+    var(--go-title-shadow-1-win, 3px 3px 0 #ffd84a),
+    var(--go-title-shadow-2-win, 6px 6px 0 #2dd4ff),
+    var(--go-title-glow-win,     0 0 22px rgba(74, 222, 128, 0.55));
+}
+.gameover .go-title.is-loss {
+  color: var(--go-title-color-loss, #ff3aa1);
+}
+
+.gameover .go-score {
+  font-size: clamp(14px, 2.2vw, 18px);
+  color: var(--go-score-color, #ffd84a);
+  letter-spacing: 0.18em;
+}
+.gameover .go-hiscore {
+  font-size: clamp(9px, 1.3vw, 12px);
+  color: var(--go-hiscore-color, #2dd4ff);
+  letter-spacing: 0.18em;
+  min-height: 14px;
+}
+.gameover .go-prompt {
+  font-size: clamp(10px, 1.6vw, 14px);
+  letter-spacing: 0.18em;
+  color: #fff;
+  animation: arcade-blink 1s steps(1) infinite;
+}
+
+.gameover .go-initials {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+.gameover .go-initials-label {
+  font-size: clamp(10px, 1.5vw, 13px);
+  letter-spacing: 0.2em;
+  color: var(--go-initials-label-color, #ff3aa1);
+}
+.gameover .go-initials-slots {
+  display: inline-flex;
+  gap: 18px;
+  font-size: clamp(28px, 5vw, 44px);
+  color: var(--go-slot-color, #ffd84a);
+  text-shadow: var(--go-slot-shadow, 2px 2px 0 #ff3aa1, 4px 4px 0 #2dd4ff);
+  letter-spacing: 0.1em;
+}
+.gameover .go-slot {
+  display: inline-block;
+  min-width: 1ch;
+  padding: 0 4px;
+  border-bottom: 4px solid var(--go-slot-border, rgba(255, 216, 74, 0.3));
+}
+.gameover .go-slot.is-active {
+  border-bottom-color: var(--go-slot-active-border, #2dd4ff);
+  animation: arcade-blink 0.6s steps(1) infinite;
+}
+.gameover .go-initials-hint {
+  font-size: clamp(8px, 1.1vw, 10px);
+  letter-spacing: 0.16em;
+  color: rgba(255, 255, 255, 0.6);
+}

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="../shared/pixel-font.css">
 <link rel="stylesheet" href="../shared/cabinet.css">
 <link rel="stylesheet" href="../shared/touch.css">
+<link rel="stylesheet" href="../shared/overlays.css">
 <style>
   /* Platformer-specific styles. Cabinet, pixel font, and touch base styles
      come from ../shared/ — see <link> tags above. */
@@ -137,89 +138,14 @@
   }
 
   /* Game-over / level-complete panel. Same shell for both states; the
-     .go-title gets a state class that swaps colour. Verbatim style stack
-     lifted from rocket-ship so the phase-5 extraction is a copy.        */
-  .gameover {
-    position: absolute;
-    inset: 0;
-    z-index: 4;
-    background: rgba(0, 0, 0, 0.88);
-    display: none;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    font-family: 'Press Start 2P', ui-monospace, monospace;
-    color: #fff;
-    gap: clamp(16px, 2.6vw, 26px);
-    padding: 40px 24px;
-    animation: splash-poweron 0.3s ease-out;
-  }
-  .gameover.is-visible { display: flex; }
-  .gameover .go-title {
-    font-size: clamp(28px, 6.5vw, 60px);
-    text-shadow:
-      3px 3px 0 #2dd4ff,
-      6px 6px 0 #ffd84a,
-      0 0 16px rgba(255, 58, 161, 0.45);
-  }
-  .gameover .go-title.is-loss { color: #ff3aa1; }
-  .gameover .go-title.is-win  {
-    color: #ffd84a;
-    text-shadow:
-      3px 3px 0 #ff3aa1,
-      6px 6px 0 #2dd4ff,
-      0 0 18px rgba(255, 216, 74, 0.45);
-  }
-  .gameover .go-score {
-    font-size: clamp(14px, 2.2vw, 18px);
-    color: #ffd84a;
-    letter-spacing: 0.18em;
-  }
-  .gameover .go-hiscore {
-    font-size: clamp(9px, 1.3vw, 12px);
-    color: #2dd4ff;
-    letter-spacing: 0.18em;
-    min-height: 14px;
-  }
-  .gameover .go-prompt {
-    font-size: clamp(10px, 1.6vw, 14px);
-    letter-spacing: 0.18em;
-    color: #fff;
-    animation: arcade-blink 1s steps(1) infinite;
-  }
-  .gameover .go-initials {
-    display: flex; flex-direction: column;
-    align-items: center; gap: 12px;
-    margin-top: 8px;
-  }
-  .gameover .go-initials-label {
-    font-size: clamp(10px, 1.5vw, 13px);
-    letter-spacing: 0.2em;
-    color: #ff3aa1;
-  }
-  .gameover .go-initials-slots {
-    display: inline-flex;
-    gap: 18px;
-    font-size: clamp(28px, 5vw, 44px);
-    color: #ffd84a;
-    text-shadow: 2px 2px 0 #ff3aa1, 4px 4px 0 #2dd4ff;
-    letter-spacing: 0.1em;
-  }
-  .gameover .go-slot {
-    display: inline-block;
-    min-width: 1ch;
-    padding: 0 4px;
-    border-bottom: 4px solid rgba(255, 216, 74, 0.3);
-  }
-  .gameover .go-slot.is-active {
-    border-bottom-color: #2dd4ff;
-    animation: arcade-blink 0.6s steps(1) infinite;
-  }
-  .gameover .go-initials-hint {
-    font-size: clamp(8px, 1.1vw, 10px);
-    letter-spacing: 0.16em;
-    color: rgba(255, 255, 255, 0.6);
+     .go-title gets a state class that swaps colour. Most rules now live
+     in shared/overlays.css — Space Jumper overrides only its win-state
+     palette (gold instead of green) via CSS variables. */
+  :root {
+    --go-title-color-win:    #ffd84a;
+    --go-title-shadow-1-win: 3px 3px 0 #ff3aa1;
+    --go-title-shadow-2-win: 6px 6px 0 #2dd4ff;
+    --go-title-glow-win:     0 0 18px rgba(255, 216, 74, 0.45);
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary

Round 5 of the DRY pass across the arcade games. Lifts the ~80-line `.gameover` + `.go-*` block that lived inline in both Invaders and Space Jumper into a new `docs/arcade/shared/overlays.css`. Layout/font/animation/slot geometry are constants; the palette is exposed through ~14 CSS variables so games override only the bits that differ.

- **Invaders** takes the defaults verbatim — just `<link>`s the stylesheet and drops the inline block.
- **Space Jumper** overrides `--go-title-color-win` and the three win-state shadow vars to keep its gold `.is-win` look (vs Invaders' green).

Defaults baked into shared CSS (pink default title, green `.is-win`, pink `.is-loss`) line up with each game's existing visuals, so this is byte-equivalent at the rendered-pixel level.

## Diff shape

- `docs/arcade/shared/overlays.css` **+128** (new)
- `docs/arcade/invaders/index.html` **+3 / −42**
- `docs/arcade/space-jumper/index.html` **+10 / −82**

Net **+141 / −124** — but every future game now inherits the overlay shell for free.

## Test plan

- [ ] Open `docs/arcade/invaders/index.html` — die, game-over overlay renders identically (pink title, green on completion)
- [ ] Open `docs/arcade/space-jumper/index.html` — die (pink GAME OVER) and clear a level (gold LEVEL COMPLETE)
- [ ] Initials entry styling unchanged in both (yellow slot, cyan active underline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)