### PR TITLE
arcade(shared): DRY round 7 — Arcade.Splash auto-cycler module

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -48,25 +48,9 @@
       5px 5px 0 #0a0a0a,                /* black slab behind it for weight */
       0 0 22px rgba(255, 48, 48, 0.45); /* soft warm glow */
   }
-  /* Two splash views (title-card + leaderboard) auto-cycle every ~5.5 s.
-     Pattern lifted from rocket-ship.html so the arcade feels consistent. */
-  .splash-main .splash-view {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: clamp(14px, 2.4vw, 28px);
-    padding: 40px 24px;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.5s ease;
-  }
-  .splash-main .splash-view.is-active {
-    opacity: 1;
-    pointer-events: auto;
-  }
+  /* Splash-view cycling (.splash-view + .is-active) lives in
+     ../shared/splash.css. The cycler itself (Arcade.Splash.startCycle)
+     lives in ../shared/splash.js. */
   .leaderboard {
     color: #fff;
     font-family: 'Press Start 2P', ui-monospace, monospace;
@@ -132,6 +116,7 @@
 <script src="../shared/leaderboard.js"></script>
 <script src="../shared/initials.js"></script>
 <script src="../shared/end-overlay.js"></script>
+<script src="../shared/splash.js"></script>
 <audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
 <audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
 <audio id="sfx-shoot"     src="sfx-shoot.mp3"               preload="auto"></audio>
@@ -302,25 +287,17 @@ function paintLeaderboard() {
   Arcade.Leaderboard.paintList({ listSelector: '#lb-list', pad: 4 });
 }
 
-let splashCycleTimer = null;
-function startSplashCycle() {
-  stopSplashCycle();
-  const views = document.querySelectorAll('#splash .splash-view');
-  if (!views.length) return;
-  let idx = 0;
-  splashCycleTimer = setInterval(() => {
-    idx = (idx + 1) % views.length;
-    views.forEach((v, i) => v.classList.toggle('is-active', i === idx));
-    if (views[idx].classList.contains('leaderboard')) paintLeaderboard();
-  }, 5500);
-}
-function stopSplashCycle() {
-  if (splashCycleTimer) { clearInterval(splashCycleTimer); splashCycleTimer = null; }
-}
-
+// Title ↔ leaderboard auto-cycle on the splash. Cycler implementation
+// lives in shared/splash.js; we just say "repaint the leaderboard when
+// it's the active view" so the list shows fresh remote scores after
+// each refresh.
 paintSplashHiScore();
 paintLeaderboard();
-startSplashCycle();
+Arcade.Splash.startCycle({
+  onShow(view) {
+    if (view.classList.contains('leaderboard')) paintLeaderboard();
+  },
+});
 Arcade.Leaderboard.refresh().then(() => {
   paintSplashHiScore();
   paintLeaderboard();
@@ -741,7 +718,7 @@ function startRun() {
 
 // Unified restart handler — covers splash dismiss AND post-game-over keypress.
 function dismissSplashAndStart() {
-  stopSplashCycle();
+  Arcade.Splash.stopCycle();
   splashEl.classList.add('is-hidden');
   document.querySelector('.tube').classList.add('is-ready');
   Arcade.Audio.ensureCtx();

--- a/docs/arcade/shared/splash.css
+++ b/docs/arcade/shared/splash.css
@@ -109,6 +109,9 @@
 @media (prefers-reduced-motion: reduce) {
   .splash { animation: none; }
   .splash .start { animation: none; opacity: 1; }
+  /* Skip the .splash-view opacity fade too — the cycler still toggles
+     .is-active, but views snap instead of crossfading. */
+  .splash-main .splash-view { transition: none; }
 }
 
 /* Splash-view auto-cycler styling. Games that want a title ↔ leaderboard

--- a/docs/arcade/shared/splash.css
+++ b/docs/arcade/shared/splash.css
@@ -110,3 +110,27 @@
   .splash { animation: none; }
   .splash .start { animation: none; opacity: 1; }
 }
+
+/* Splash-view auto-cycler styling. Games that want a title ↔ leaderboard
+   (or similar) marquee use Arcade.Splash.startCycle (see shared/splash.js)
+   to rotate the .is-active class through these views every few seconds.
+   Each view fades in/out via opacity transition; only the active one is
+   pointer-interactive so links/buttons in inactive views don't catch
+   accidental taps. */
+.splash-main .splash-view {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(14px, 2.4vw, 28px);
+  padding: 40px 24px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+.splash-main .splash-view.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/docs/arcade/shared/splash.js
+++ b/docs/arcade/shared/splash.js
@@ -36,12 +36,19 @@
     const onShow     = typeof opts.onShow === 'function' ? opts.onShow : null;
     const views = document.querySelectorAll(sel);
     if (!views.length) return;
+    // Force view[0] active immediately so the module works regardless of
+    // whether the HTML pre-marked any view — and so a stopCycle + new
+    // startCycle reliably resets to the first view.
     let idx = 0;
+    views.forEach((v, i) => v.classList.toggle('is-active', i === idx));
+    if (onShow) {
+      try { onShow(views[idx], idx); } catch (e) { console.warn('Arcade.Splash onShow threw:', e); }
+    }
     cycleTimer = setInterval(() => {
       idx = (idx + 1) % views.length;
       views.forEach((v, i) => v.classList.toggle('is-active', i === idx));
       if (onShow) {
-        try { onShow(views[idx], idx); } catch (_) {}
+        try { onShow(views[idx], idx); } catch (e) { console.warn('Arcade.Splash onShow threw:', e); }
       }
     }, intervalMs);
   }

--- a/docs/arcade/shared/splash.js
+++ b/docs/arcade/shared/splash.js
@@ -1,0 +1,57 @@
+// Shared SPLASH-view auto-cycler.
+//
+// Most arcade games' splash screens cycle between two or more "views"
+// (e.g. title-card ↔ leaderboard) every few seconds for marquee effect.
+// The cycler is the same in every game: query a NodeList of .splash-view
+// elements, toggle .is-active around the active index on an interval,
+// and let the game decide what to repaint when a particular view comes
+// into focus (e.g. refresh the leaderboard list).
+//
+// Usage (each game):
+//   <link rel="stylesheet" href="../shared/splash.css">    // .splash-view rules
+//   <script src="../shared/splash.js"></script>
+//
+//   Arcade.Splash.startCycle({
+//     viewsSelector: '#splash .splash-view',
+//     intervalMs:    5500,
+//     onShow(view, idx) {
+//       if (view.classList.contains('leaderboard')) paintLeaderboard();
+//     },
+//   });
+//
+//   // ...when the player launches a run:
+//   Arcade.Splash.stopCycle();
+//
+// Calling startCycle() again automatically stops any prior interval, so
+// it's safe to invoke unconditionally on splash mount.
+
+(function () {
+  let cycleTimer = null;
+
+  function startCycle(opts) {
+    opts = opts || {};
+    stopCycle();
+    const sel        = opts.viewsSelector || '#splash .splash-view';
+    const intervalMs = opts.intervalMs    || 5500;
+    const onShow     = typeof opts.onShow === 'function' ? opts.onShow : null;
+    const views = document.querySelectorAll(sel);
+    if (!views.length) return;
+    let idx = 0;
+    cycleTimer = setInterval(() => {
+      idx = (idx + 1) % views.length;
+      views.forEach((v, i) => v.classList.toggle('is-active', i === idx));
+      if (onShow) {
+        try { onShow(views[idx], idx); } catch (_) {}
+      }
+    }, intervalMs);
+  }
+
+  function stopCycle() {
+    if (cycleTimer) { clearInterval(cycleTimer); cycleTimer = null; }
+  }
+
+  function isCycling() { return cycleTimer !== null; }
+
+  window.Arcade = window.Arcade || {};
+  window.Arcade.Splash = { startCycle, stopCycle, isCycling };
+})();


### PR DESCRIPTION
## Summary

Round 7. Lifts Invaders' splash-view auto-cycler (title-card ↔ leaderboard, toggled every ~5.5s) into a shared `Arcade.Splash` module. Round 6 extracted the splash shell; this is the next layer up so any future game can drop in a `.splash-view` and get the marquee for free.

**New `shared/splash.js`:**

```js
Arcade.Splash.startCycle({
  viewsSelector: '#splash .splash-view',   // default
  intervalMs:    5500,                     // default
  onShow(view, idx) {
    if (view.classList.contains('leaderboard')) paintLeaderboard();
  },
});
Arcade.Splash.stopCycle();
```

The `onShow` callback lets each game decide what to repaint when a view comes into focus — keeps the leaderboard-refresh logic out of the shared module.

**`shared/splash.css`:** appended the `.splash-view` + `.splash-view.is-active` rules (opacity fade + pointer-events gating).

**`invaders/index.html`:** drops 19 lines of inline cycler JS + 19 lines of inline `.splash-view` CSS, replaces with the new module.

## Diff shape

- `docs/arcade/shared/splash.js` ~70 (new)
- `docs/arcade/shared/splash.css` ~+27 (cycler rules + reduced-motion override)
- `docs/arcade/invaders/index.html` −37 (cycler JS + CSS removed, three new lines for the `startCycle` call + script tag)

Same pixel + timing behaviour.

## Deferred (intentionally)

- `.leaderboard` CSS block stays inline in Invaders. Promote when a 2nd game adopts the title↔leaderboard cycler pattern — same DRY-only-when-2+-consumers rule we've followed.

## Test plan

- [ ] Open `docs/arcade/invaders/index.html` — splash cycles title-card ↔ leaderboard every ~5.5s; leaderboard list shows live entries from `Arcade.Leaderboard.paintList`
- [ ] Press ENTER to launch — cycler stops, splash fades out
- [ ] Submit a new high score → splash hi-score row repaints after `Arcade.Leaderboard.submit` resolves
- [ ] Toggle system `prefers-reduced-motion: reduce` → splash `.is-active` views snap instead of crossfading

🤖 Generated with [Claude Code](https://claude.com/claude-code)