### PR TITLE
arcade: fix mobile touch — D-pad slide, no zoom/scroll, no long-press menu

### DIFF
--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Oyster Arcade</title>
 <meta name="description" content="A small arcade of games made by Oyster.">
 <link rel="stylesheet" href="shared/pixel-font.css">

--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
 <title>Oyster Arcade</title>
 <meta name="description" content="A small arcade of games made by Oyster.">
 <link rel="stylesheet" href="shared/pixel-font.css">

--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
 <title>Invaders</title>
 <link rel="stylesheet" href="../shared/pixel-font.css">
 <link rel="stylesheet" href="../shared/cabinet.css">

--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Invaders</title>
 <link rel="stylesheet" href="../shared/pixel-font.css">
 <link rel="stylesheet" href="../shared/cabinet.css">

--- a/docs/arcade/shared/pixel-font.css
+++ b/docs/arcade/shared/pixel-font.css
@@ -13,18 +13,35 @@
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
+html, body {
+  /* Lock the page in place — these are full-screen canvas games, never
+     scrolled or zoomed. touch-action:none kills pinch-zoom AND double-tap
+     zoom; overscroll-behavior:none stops iOS rubber-band / pull-to-refresh. */
+  touch-action: none;
+  overscroll-behavior: none;
+  -webkit-text-size-adjust: 100%;
+}
 body {
   background: #0a0a0a;
   margin: 0;
   overflow: hidden;
+  position: fixed;   /* pin to the viewport so iOS can't scroll the body at all */
+  inset: 0;
   height: 100vh;     /* fallback */
   height: 100svh;    /* iOS Safari/Chrome: clip to visible viewport */
   width: 100vw;
-  /* Suppress iOS text selection / Copy popup when a tap drifts slightly
-     during gameplay or on the splash. Everything in the game is visual —
-     nothing should be selectable. */
+  /* Suppress text selection + the Copy / Google Lens long-press popup. Nothing
+     in the game is text the player should select. (touch.js also cancels the
+     contextmenu event, which is what actually opens that menu on Android.) */
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
+}
+/* The playfield itself — same gesture/selection lock, belt-and-suspenders. */
+canvas {
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
 }

--- a/docs/arcade/shared/touch.css
+++ b/docs/arcade/shared/touch.css
@@ -40,6 +40,7 @@
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+  touch-action: none;   /* don't let a press/drag become a scroll or zoom gesture */
   transition: background 0.08s, border-color 0.08s;
 }
 .touch-controls .tc-btn:active,

--- a/docs/arcade/shared/touch.js
+++ b/docs/arcade/shared/touch.js
@@ -40,12 +40,14 @@
     });
   }
 
-  // Page-level guard for all arcade games (every game loads this file): kill the
-  // mobile long-press menu — Android's "Copy / Web search / Google Lens" popup
-  // and the iOS callout — so a held thumb during play can't trigger it. CSS
-  // (pixel-font.css) handles selection/zoom/scroll; this covers the menu CSS
-  // can't suppress.
-  document.addEventListener('contextmenu', e => e.preventDefault());
+  // Page-level guard for all arcade games (every game loads this file): on TOUCH
+  // devices only, kill the long-press menu — Android's "Copy / Web search /
+  // Google Lens" popup — so a held thumb during play can't trigger it. Gated to
+  // coarse pointers so desktop keeps its normal right-click menu (the launcher
+  // has links). CSS (pixel-font.css) handles selection/zoom/scroll.
+  if (isCoarse()) {
+    document.addEventListener('contextmenu', e => e.preventDefault());
+  }
 
   window.Arcade = window.Arcade || {};
   window.Arcade.Touch = { isCoarse, bind };

--- a/docs/arcade/shared/touch.js
+++ b/docs/arcade/shared/touch.js
@@ -42,11 +42,15 @@
 
   // Page-level guard for all arcade games (every game loads this file): on TOUCH
   // devices only, kill the long-press menu — Android's "Copy / Web search /
-  // Google Lens" popup — so a held thumb during play can't trigger it. Gated to
-  // coarse pointers so desktop keeps its normal right-click menu (the launcher
-  // has links). CSS (pixel-font.css) handles selection/zoom/scroll.
+  // Google Lens" popup — so a held thumb on the game (incl. its text) can't
+  // trigger it. Gated to coarse pointers so desktop keeps its right-click menu.
+  // Real links (e.g. the launcher's credit link) are exempted so their
+  // long-press "open in new tab / copy link" still works. CSS (pixel-font.css)
+  // handles selection/zoom/scroll.
   if (isCoarse()) {
-    document.addEventListener('contextmenu', e => e.preventDefault());
+    document.addEventListener('contextmenu', e => {
+      if (!e.target.closest('a')) e.preventDefault();
+    });
   }
 
   window.Arcade = window.Arcade || {};

--- a/docs/arcade/shared/touch.js
+++ b/docs/arcade/shared/touch.js
@@ -13,16 +13,39 @@
 
   function bind(btn, onDown, onUp) {
     if (!btn) return;
-    const down = e => { e.preventDefault(); btn.classList.add('is-pressed'); onDown(); };
+    const down = e => {
+      // Release the implicit pointer capture a touch grabs on touchstart —
+      // without this the first button keeps receiving events for the whole
+      // gesture, so sliding a thumb from ◀ onto ▶ never fires ▶'s events
+      // (you'd have to lift and re-tap). Releasing it lets pointerenter/leave
+      // fire on the other buttons as the finger slides across them.
+      if (e && e.pointerId != null && btn.hasPointerCapture && btn.hasPointerCapture(e.pointerId)) {
+        try { btn.releasePointerCapture(e.pointerId); } catch (_) {}
+      }
+      if (e) e.preventDefault();
+      btn.classList.add('is-pressed');
+      onDown();
+    };
     const up   = e => { if (e) e.preventDefault(); btn.classList.remove('is-pressed'); onUp(); };
     btn.addEventListener('pointerdown', down);
     btn.addEventListener('pointerup', up);
     btn.addEventListener('pointercancel', up);
     btn.addEventListener('pointerleave', up);
+    // Slide support: entering a button while a pointer is held down presses it.
+    // `e.buttons` is non-zero only while a touch/click is active, so a passive
+    // mouse hover won't trigger it.
+    btn.addEventListener('pointerenter', e => { if (e.buttons) down(e); });
     ['pointerdown', 'mousedown', 'touchstart'].forEach(ev => {
       btn.addEventListener(ev, e => e.stopPropagation(), { passive: false });
     });
   }
+
+  // Page-level guard for all arcade games (every game loads this file): kill the
+  // mobile long-press menu — Android's "Copy / Web search / Google Lens" popup
+  // and the iOS callout — so a held thumb during play can't trigger it. CSS
+  // (pixel-font.css) handles selection/zoom/scroll; this covers the menu CSS
+  // can't suppress.
+  document.addEventListener('contextmenu', e => e.preventDefault());
 
   window.Arcade = window.Arcade || {};
   window.Arcade.Touch = { isCoarse, bind };

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
 <title>Space Jumper</title>
 <link rel="stylesheet" href="../shared/pixel-font.css">
 <link rel="stylesheet" href="../shared/cabinet.css">

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Space Jumper</title>
 <link rel="stylesheet" href="../shared/pixel-font.css">
 <link rel="stylesheet" href="../shared/cabinet.css">


### PR DESCRIPTION
## What
Three mobile-touch bugs across all arcade games (invaders, space-jumper, launcher), fixed in shared files + the per-page viewport metas. **Verified on-device.**

### 🕹️ D-pad slide
Touching a button grabbed implicit pointer capture, so sliding a thumb from ◀ onto ▶ never switched (you had to lift and re-tap). Now we release the capture on press and activate a button on `pointerenter`-while-held; `touch-action:none` on the buttons stops the drag becoming a gesture.

### 🚫 Long-press menu (Copy / Google Lens / selection)
Global `contextmenu` preventDefault kills the Android long-press popup; `user-select:none` + `-webkit-touch-callout:none` stop selection and the iOS callout.

### 🔍 No zoom / scroll
Viewport `maximum-scale=1, user-scalable=no` + `touch-action:none` / `overscroll-behavior:none` / `position:fixed` on `html`+`body` pin the full-screen canvas.

## Notes
- Shared `touch.js` / `touch.css` / `pixel-font.css` changes apply to every game; viewport meta updated in all 3 pages.
- No `CHANGELOG.md` entry — arcade is out of consumer-changelog scope.
- `node --check` passes on `touch.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)