### PR TITLE
fix(home): raise projects section stacking order

### DIFF
--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1231,6 +1231,7 @@
  */
 .home-projects-section {
   margin-top: 0;
+  z-index: 2;
 }
 .home-project-tile {
   position: relative;


### PR DESCRIPTION
## What
Adds `z-index: 2` to `.home-projects-section` on the home view so it stacks above the lower/default-stacked elements around it.

```css
.home-projects-section {
  margin-top: 0;
+ z-index: 2;
}
```

## Notes
- One-line CSS change to the consumer web app (`web/src/components/Home/Home.css`). Independent of the arcade work.
- No `CHANGELOG.md` entry (per maintainer).
- Reviewer: please confirm this resolves the intended overlap/stacking issue on the home view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)