### PR TITLE
arcade(invaders-mp): Phase A — port SP pixel-art sprites

### DIFF
--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -186,6 +186,12 @@
     INV_W, INV_H,
     SEATS, MAX_SEATS,
   } from './engine.js';
+  import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
+  // INV_COLS isn't exported by engine.js (it's a private constant)
+  // but the grid stride is fixed by the wire snapshot, so we mirror
+  // it here for the renderer's row math. If engine.js ever changes
+  // the grid width this has to move in lockstep.
+  const SPRITE_COLS = 8;
 
   // Per-seat colours for the canvas. Indexed by seat position so the
   // same player reads as the same colour on every viewer's screen.
@@ -1053,11 +1059,11 @@
       const x = isMine && localShip.x !== null
         ? localShip.x
         : lerp(pa.x, pb.x);
-      ctx.fillStyle = SHIP_COLORS[i];
-      ctx.fillRect(x, SHIP_Y, SHIP_W, SHIP_H);
+      paintShip(ctx, x, SHIP_Y, SHIP_W, SHIP_COLORS[i]);
       if (live.name && nameAlpha > 0) {
         ctx.globalAlpha = nameAlpha;
-        ctx.fillText(live.name, x + SHIP_W / 2, SHIP_Y - 3);
+        ctx.fillStyle = SHIP_COLORS[i];
+        ctx.fillText(live.name, x + SHIP_W / 2, SHIP_Y - 7);
         ctx.globalAlpha = 1;
       }
     }
@@ -1065,12 +1071,21 @@
     // Invaders — lerp by array index (engine emits the grid in a stable
     // order; dead invaders stay in the array with a:false). The classic
     // chunky shuffle becomes a smooth slide between marches.
-    ctx.fillStyle = '#ffffff';
+    // Sprite + colour come from the grid row (squid / crab / crab /
+    // octopus / octopus, top → bottom). Two-frame animation toggles
+    // every 300 ms — same cadence as the SP original.
     const n = Math.min(a.invaders.length, b.invaders.length);
+    const frame = Math.floor(renderNowEarly / 300) % 2;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide
-      ctx.fillRect(lerp(ia.x, ib.x), lerp(ia.y, ib.y), INV_W, INV_H);
+      const row = Math.floor(i / SPRITE_COLS);
+      const { frames, w } = spriteForRow(row);
+      // Centre the sprite in the engine's INV_W cell so collisions
+      // (which use INV_W) stay aligned with what the eye sees.
+      const cellX = lerp(ia.x, ib.x) + (INV_W - w) / 2;
+      const cellY = lerp(ia.y, ib.y);
+      paintPixels(ctx, cellX, cellY, frames[frame], 1, ROW_COLORS[row] || '#ffffff');
     }
 
     // Bullets — drawn from the latest snapshot (server-authoritative

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -59,12 +59,9 @@ export function paintPixels(ctx, px, py, pixels, scale, color) {
   }
 }
 
-// Player ship — a body + narrow turret base + white turret tip. Drawn
-// at scale=1 (raw playfield units) so it sits inside the SHIP_W ×
-// SHIP_H footprint the engine uses for collisions.
-//
-//   SHIP_W = 16, ship.y = SHIP_Y, ship height = 8 total (4 body +
-//   2 turret base + 2 turret tip stacked upward).
+// Player ship — body sits at shipY (the engine's collision top edge);
+// turret base + white tip stack upward above it, matching the SP
+// cabinet silhouette where the antenna pokes out above the hit box.
 export function paintShip(ctx, x, shipY, shipW, color) {
   ctx.fillStyle = color;
   ctx.fillRect(x,            shipY,            shipW,         4); // body

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -1,0 +1,74 @@
+// Pixel-art sprites for the MP client. Ported from the original
+// single-player `docs/arcade/invaders/index.html` so MP's visual
+// language matches the SP version. Pure rendering data + a paint
+// helper — engine.js stays free of any visual concerns.
+//
+// Each invader sprite is a pair of frames (toggled every 300 ms in
+// the renderer). Each frame is an array of strings, one per row,
+// where 'X' = filled pixel, anything else = transparent. paintPixels
+// draws them at a given playfield position + scale + colour.
+
+// Per-row pastel palette, top → bottom. Matches the SP arcade pal.
+//   row 0 — mint    squid
+//   row 1 — pink    crab
+//   row 2 — yellow  crab
+//   row 3 — orange  octopus
+//   row 4 — blue    octopus
+export const ROW_COLORS = ['#7adfb1', '#f088bc', '#f0d070', '#f0a070', '#7088dc'];
+
+// 6×8 source. Half a column narrower than the crab/octopus tiers so
+// the renderer adds a small horizontal offset to centre it in the
+// 8-wide grid cell.
+export const SQUID = [
+  ['..XX..', '.XXXX.', 'XXXXXX', 'XX..XX', 'XXXXXX', '.X..X.', 'X.XX.X', '.X..X.'],
+  ['..XX..', '.XXXX.', 'XXXXXX', 'XX..XX', 'XXXXXX', '.X..X.', 'X....X', 'X.XX.X'],
+];
+export const SQUID_W = 6;
+
+// 8×8 source.
+export const CRAB = [
+  ['..X..X..', '...XX...', '..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'X.XXXX.X', 'X.X..X.X', '.X....X.'],
+  ['X..X..X.', '.X.XX.X.', 'XXXXXXXX', 'XXX..XXX', 'XXXXXXXX', '.XXXXXX.', 'X......X', '.X....X.'],
+];
+
+// 8×8 source.
+export const OCTOPUS = [
+  ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '..X..X..', '.X.XX.X.', 'X.X..X.X'],
+  ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '...XX...', '..X..X..', '.X....X.'],
+];
+
+// Pick the invader bitmap for a grid row (0-indexed from the top).
+// MP grid is 5 rows: squid / crab / crab / octopus / octopus.
+export function spriteForRow(row) {
+  if (row === 0) return { frames: SQUID, w: SQUID_W };
+  if (row === 1 || row === 2) return { frames: CRAB, w: 8 };
+  return { frames: OCTOPUS, w: 8 };
+}
+
+// Paint a bitmap to the canvas in playfield units. Each source pixel
+// becomes a scale × scale rect.
+export function paintPixels(ctx, px, py, pixels, scale, color) {
+  ctx.fillStyle = color;
+  for (let y = 0; y < pixels.length; y++) {
+    const row = pixels[y];
+    for (let x = 0; x < row.length; x++) {
+      if (row[x] === 'X') {
+        ctx.fillRect(px + x * scale, py + y * scale, scale, scale);
+      }
+    }
+  }
+}
+
+// Player ship — a body + narrow turret base + white turret tip. Drawn
+// at scale=1 (raw playfield units) so it sits inside the SHIP_W ×
+// SHIP_H footprint the engine uses for collisions.
+//
+//   SHIP_W = 16, ship.y = SHIP_Y, ship height = 8 total (4 body +
+//   2 turret base + 2 turret tip stacked upward).
+export function paintShip(ctx, x, shipY, shipW, color) {
+  ctx.fillStyle = color;
+  ctx.fillRect(x,            shipY,            shipW,         4); // body
+  ctx.fillRect(x + 4,        shipY - 2,        shipW - 8,     2); // turret base
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(x + shipW/2 - 2, shipY - 4,     4,             2); // turret tip
+}


### PR DESCRIPTION
## Summary

First step on the SP → MP convergence path. Replaces the rectangle placeholders in MP with the original Space Invaders pixel-art sprite set, ported from `docs/arcade/invaders/`.

After this lands, MP looks like proper Invaders. Phases B–G (audio, chrome, shields, supers, bosses, etc.) are queued behind it — each its own PR — leading to the eventual deprecation of SP `/invaders/` in favour of MP.

## What's in this PR

**New** `docs/arcade/invaders-mp/sprites.js` — pure rendering data + 2 small helpers:
- `SQUID` (6×8, 2 frames), `CRAB` (8×8, 2 frames), `OCTOPUS` (8×8, 2 frames) — verbatim from the SP source
- `ROW_COLORS` — pastel mint / pink / yellow / orange / blue palette, top → bottom (same as SP)
- `spriteForRow(row)` — row 0 = squid, rows 1–2 = crab, rows 3–4 = octopus
- `paintPixels(ctx, x, y, pixels, scale, color)` — bitmap blitter
- `paintShip(ctx, x, shipY, shipW, color)` — multi-rect ship: body in seat colour, turret base in seat colour, white turret tip

**Renderer changes** in `index.html`:
- Invaders now draw via `paintPixels` using `spriteForRow(row).frames[frame]`. Frame toggles every 300 ms (same cadence as SP). Sprite is horizontally centred inside the engine's `INV_W` cell so the collision footprint stays aligned with what the eye sees.
- Ships now draw via `paintShip` — seat colour drives body + turret base, turret tip is always white.
- Player name labels moved from `SHIP_Y - 3` → `SHIP_Y - 7` so they sit above the new turret tip instead of overlapping it. Label colour also changed from white to the seat colour for stronger identity.

## What's NOT in this PR (queued)

- Phase B: shared `audio.js` + fire/kill/gameover sounds
- Phase C: shared `touch.css`/`cabinet.css` chrome
- Phase D: stage progression, popups, UFO
- Phase E: shields, super shots, combos (need multiplayer design call)
- Phase F: bosses, win cutscene
- Phase G: leaderboard integration, deprecate `/invaders/`

## Test plan

- [ ] Open `/invaders-mp/` → solo. Confirm: ship has a white turret tip; invader grid renders as 5 rows of pastel sprites (top mint squids, middle pink/yellow crabs, bottom orange/blue octopuses); each row's invaders animate (visible bob/leg-shuffle every ~300 ms).
- [ ] 2-player: each player's ship shows its own colour; names appear above each ship in matching colour during lobby/countdown, fade out on ATTACK.
- [ ] 3- and 4-player: same. No regression.
- [ ] Bullets unchanged (still rectangles).

## Notes

- Client-only change. No wire-shape change. NETCODE_VERSION stays at 20 (no protocol change to verify).
- The grid stride `SPRITE_COLS = 8` is mirrored in the client — `engine.js` doesn't export `INV_COLS` (it's a module-private constant). If the engine ever changes the grid width, the constant has to move in lockstep. Acceptable for now; we can export from engine in a later phase if it becomes load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)