### PR TITLE
arcade(invaders-mp): Phase B — audio (fire/kill/explosion/lose)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 .claude/
 *.tgz
 
+# Wrangler local cache (account info, asset hashes, dev tmp) — never commit
+.wrangler/
+
 # Build output
 server/dist/
 shared/types.js

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -175,6 +175,15 @@
   </div>
 </div>
 
+<!-- SFX fallback elements — used by Arcade.Audio.play() in the brief
+     window between page load and the WebAudio buffer decode finishing.
+     Their ids MUST match the keys passed to Arcade.Audio.init below. -->
+<audio id="sfx-shoot"     src="../invaders/sfx-shoot.mp3" preload="auto"></audio>
+<audio id="sfx-kill"      src="../invaders/sfx-kill.wav"  preload="auto"></audio>
+<audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
+<audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
+
+<script src="../shared/audio.js"></script>
 <script src="./simple-peer.min.js"></script>
 <script type="module">
   // Single source of truth for game logic, shared with the server
@@ -192,6 +201,20 @@
   // it here for the renderer's row math. If engine.js ever changes
   // the grid width this has to move in lockstep.
   const SPRITE_COLS = 8;
+
+  // Register SFX with the shared audio module. The volume/muted keys
+  // are the global arcade keys so the slider state carries across
+  // every arcade game (SP Invaders, Space Jumper, …).
+  Arcade.Audio.init({
+    sfx: {
+      'sfx-shoot':     '../invaders/sfx-shoot.mp3',
+      'sfx-kill':      '../invaders/sfx-kill.wav',
+      'sfx-explosion': '../shared/sfx-explosion.mp3',
+      'sfx-lose':      '../shared/sfx-lose.mp3',
+    },
+    volumeKey: 'oyster-arcade-sfx-volume',
+    mutedKey:  'oyster-arcade-sfx-muted',
+  });
 
   // Per-seat colours for the canvas. Indexed by seat position so the
   // same player reads as the same colour on every viewer's screen.
@@ -790,6 +813,26 @@
       return;
     }
     if (msg.type === 'state') {
+      // Diff the new snapshot against the previous one to fire SFX on
+      // transitions: score jumping = invader kill, my seat going
+      // dead-this-tick = ship explosion, status flipping to gameover
+      // = end-of-run jingle (only the losing variant — wins stay
+      // silent because the "you won" overlay carries the moment).
+      // prevState is captured BEFORE overwriting lastState below.
+      const prev = lastState;
+      const seatIdx = mySeat ? SEATS.indexOf(mySeat) : -1;
+      if (prev) {
+        if (msg.score > prev.score) Arcade.Audio.play('sfx-kill', 0.5);
+        if (seatIdx >= 0
+            && prev.players[seatIdx]?.alive
+            && !msg.players[seatIdx]?.alive
+            && msg.status === 'running') {
+          Arcade.Audio.play('sfx-explosion', 0.6);
+        }
+        if (msg.status === 'gameover' && prev.status !== 'gameover' && !msg.won) {
+          Arcade.Audio.play('sfx-lose', 0.6);
+        }
+      }
       lastState = msg;
       snapBuffer.push(msg);
       latestServerT     = msg.t;
@@ -842,6 +885,9 @@
   }
 
   startBtn.addEventListener('click', () => {
+    // iOS needs the AudioContext created/resumed inside a real user
+    // gesture. Start is the first guaranteed tap, so do it here.
+    Arcade.Audio.ensureCtx();
     // Engage host mode on Start if at least one peer is up (host can
     // serve them; later joiners get added to the peer pool as their
     // WebRTC handshakes complete). Otherwise fall back to cloud relay.
@@ -988,6 +1034,7 @@
         born: now,
       });
       localShip.cooldown = FIRE_COOLDOWN;
+      Arcade.Audio.play('sfx-shoot', 0.55);
     }
     for (const gb of ghostBullets) gb.y -= BULLET_SPEED * dt;
     for (let i = ghostBullets.length - 1; i >= 0; i--) {

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -826,7 +826,12 @@
         if (seatIdx >= 0
             && prev.players[seatIdx]?.alive
             && !msg.players[seatIdx]?.alive
-            && msg.status === 'running') {
+            && prev.status === 'running') {
+          // Gate on prev.status, not msg.status — the engine can flip
+          // status to 'gameover' on the same tick the last ship dies
+          // (resolveCollisions then checkEnd in step()), so checking
+          // msg.status would swallow the explosion on round-ending
+          // deaths. The lose jingle still fires separately below.
           Arcade.Audio.play('sfx-explosion', 0.6);
         }
         if (msg.status === 'gameover' && prev.status !== 'gameover' && !msg.won) {

--- a/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
+++ b/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
@@ -1,0 +1,6 @@
+{
+  "account": {
+    "id": "13abdfec5a4d89806c6344bfd0a205f3",
+    "name": "Matthew@slight.me's Account"
+  }
+}

--- a/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
+++ b/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
@@ -1,6 +1,0 @@
-{
-  "account": {
-    "id": "13abdfec5a4d89806c6344bfd0a205f3",
-    "name": "Matthew@slight.me's Account"
-  }
-}


### PR DESCRIPTION
## Summary

Phase B of the SP→MP convergence: wire `shared/audio.js` into the MP client so invaders-mp now makes the same noises SP does — shot on FIRE, kill chirp on every score tick, explosion when the local ship dies, lose jingle on gameover.

- **FIRE** → `sfx-shoot` on ghost-bullet spawn (input-driven, fires immediately alongside the visual ghost).
- **Snapshot diff in `handle()`**:
  - score-up → `sfx-kill`
  - my-seat alive→dead during running → `sfx-explosion`
  - status→gameover && `!won` → `sfx-lose` (wins stay silent — the "you won" overlay carries that moment)
- One hook point covers all three snapshot sources (cloud-relay, host self via `handle(snap)` at L496, peer DC).

iOS gesture: `Arcade.Audio.ensureCtx()` runs inside the Start click handler so the AudioContext unlocks on a real user gesture — otherwise iOS keeps it suspended and `play()` is silent.

Audio files are referenced in place from `docs/arcade/invaders/sfx-*` and `docs/arcade/shared/sfx-*` — no duplication. SP keeps its own wiring untouched.

## Phase scope note

Original Phase B was "audio + chrome (~100 LoC)" with splash/pause/touch CSS. The chrome CSS classes assume the cabinet shell (`.screen > .tube.is-ready > canvas + .overlay`) which MP doesn't have yet — that restructure is already in Phase C ("Touch polish + cabinet"). Doing partial chrome now would just mean revisiting the same DOM nodes when the cabinet lands. So Phase C absorbs the chrome CSS; Phase B is audio-only at 47 LoC.

## Test plan

- [ ] Deploy arcade-site: \`cd infra/oyster-arcade-site && npx wrangler deploy\`
- [ ] Hard-refresh \`arcade.oyster.to/invaders-mp/\`, enter a room
- [ ] Tap FIRE — hear shoot sound
- [ ] Kill an invader — hear kill chirp
- [ ] Let an invader bullet hit your ship — hear explosion
- [ ] Lose the round (invaders reach you / all ships dead) — hear lose jingle
- [ ] Win the round — no lose jingle (silence; overlay only)
- [ ] On iPad — confirm audio plays after Start (gesture unlock)
- [ ] Pause/volume slider from another arcade game still controls MP volume (shared localStorage key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)