### PR TITLE
arcade(invaders-mp): fix invader animation flicker (Phase A regression)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 .claude/
 *.tgz
 
+# Wrangler local cache (account info, asset hashes, dev tmp) — never commit
+.wrangler/
+
 # Build output
 server/dist/
 shared/types.js

--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -40,6 +40,9 @@ export interface GameState {
   invaderDir: 1 | -1;
   invaderDropRemaining: number;
   invaderFireAccum: number;
+  /** Current 0/1 sprite frame; advanced by horizontal distance travelled. */
+  invaderFrame: 0 | 1;
+  invaderFrameAccum: number;
   /** Per-seat display name; empty string = no label. */
   names: Record<Seat, string>;
   /** Server-clock ms; only meaningful while status === 'countdown'. */
@@ -56,6 +59,8 @@ export interface WireSnapshot {
   bullets: Array<{ x: number; y: number; o: Seat | null }>;
   invaderBullets: Array<{ x: number; y: number }>;
   invaders: Array<{ x: number; y: number; a: boolean }>;
+  /** Authoritative swarm animation frame (0 or 1). */
+  iFrame: 0 | 1;
 }
 
 export const PF_W: number;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -92,6 +92,12 @@ export function initState() {
     invaderDir: 1,
     invaderDropRemaining: 0,
     invaderFireAccum: 0,
+    // 2-frame "shuffle" animation. Advances by horizontal distance
+    // travelled, mirroring SP's discrete-step flip (~2 units per
+    // beat) — so the animation cadence is tied to march speed and
+    // accelerates naturally as the swarm thins.
+    invaderFrame: 0,
+    invaderFrameAccum: 0,
     // Per-seat display name, broadcast in snapshots so every viewer
     // sees the same labels. Set via the `name` wire message. Empty
     // string = no label rendered.
@@ -190,6 +196,15 @@ function stepInvaders(state, dt) {
     state.invaderDropRemaining = INV_DROP;
   } else {
     for (const inv of state.invaders) if (inv.alive) inv.x += dx;
+    // Distance-based frame flip — matches SP's "every step = pose
+    // change" feel. STRIDE chosen so initial 3.6 u/s march flips at
+    // ~550 ms (SP's starting cadence); end-game 20 u/s flips at ~100 ms.
+    state.invaderFrameAccum += Math.abs(dx);
+    if (state.invaderFrameAccum >= 2) {
+      const flips = Math.floor(state.invaderFrameAccum / 2);
+      state.invaderFrame = (state.invaderFrame + flips) & 1;
+      state.invaderFrameAccum -= flips * 2;
+    }
   }
 }
 
@@ -296,5 +311,9 @@ export function snapshotForClient(state) {
     bullets:        state.bullets.map(b => ({ x: round(b.x), y: round(b.y), o: b.owner })),
     invaderBullets: state.invaderBullets.map(b => ({ x: round(b.x), y: round(b.y) })),
     invaders:       state.invaders.map(i => ({ x: round(i.x), y: round(i.y), a: i.alive })),
+    // Current swarm animation frame (0 or 1). Authoritative — every
+    // client renders the same pose at the same tick instead of each
+    // running its own time-based ticker.
+    iFrame:         state.invaderFrame,
   };
 }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1084,9 +1084,14 @@
       const row = Math.floor(i / SPRITE_COLS);
       const { frames, w } = spriteForRow(row);
       // Centre the sprite in the engine's INV_W cell so collisions
-      // (which use INV_W) stay aligned with what the eye sees.
-      const cellX = lerp(ia.x, ib.x) + (INV_W - w) / 2;
-      const cellY = lerp(ia.y, ib.y);
+      // (which use INV_W) stay aligned with what the eye sees. Snap
+      // to integer playfield pixels — fillRect at fractional coords
+      // anti-aliases each sprite-pixel's edge across two screen pixels
+      // at varying alpha, which reads as flicker during continuous
+      // motion. Rounding makes the swarm step pixel-by-pixel (the
+      // pixel-art look) instead of sub-pixel sliding.
+      const cellX = Math.round(lerp(ia.x, ib.x) + (INV_W - w) / 2);
+      const cellY = Math.round(lerp(ia.y, ib.y));
       paintPixels(ctx, cellX, cellY, frames[frame], 1, ROW_COLORS[row] || '#ffffff');
     }
 

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1074,10 +1074,14 @@
     // Sprite + colour come from the grid row (squid / crab / crab /
     // octopus / octopus, top → bottom). Frame index is authoritative
     // (server-driven, distance-based) — same flip cadence as SP, where
-    // the pose changes with each march step. Falls back to 0 if an
-    // older snapshot somehow lacks the field.
+    // the pose changes with each march step. Pick the frame nearest to
+    // the rendered time within the [a, b] interpolation span so pose and
+    // lerped position match: first half of span = a's pose, second half
+    // = b's. Without this the pose can switch at alpha≈0 while position
+    // is still close to a → a tiny pose/motion mismatch. Falls back to
+    // 0 if an older snapshot somehow lacks the field.
     const n = Math.min(a.invaders.length, b.invaders.length);
-    const frame = (b.iFrame ?? 0) & 1;
+    const frame = ((alpha < 0.5 ? a.iFrame : b.iFrame) ?? 0) & 1;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1072,10 +1072,12 @@
     // order; dead invaders stay in the array with a:false). The classic
     // chunky shuffle becomes a smooth slide between marches.
     // Sprite + colour come from the grid row (squid / crab / crab /
-    // octopus / octopus, top → bottom). Two-frame animation toggles
-    // every 300 ms — same cadence as the SP original.
+    // octopus / octopus, top → bottom). Frame index is authoritative
+    // (server-driven, distance-based) — same flip cadence as SP, where
+    // the pose changes with each march step. Falls back to 0 if an
+    // older snapshot somehow lacks the field.
     const n = Math.min(a.invaders.length, b.invaders.length);
-    const frame = Math.floor(renderNowEarly / 300) % 2;
+    const frame = (b.iFrame ?? 0) & 1;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide

--- a/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
+++ b/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
@@ -1,0 +1,6 @@
+{
+  "account": {
+    "id": "13abdfec5a4d89806c6344bfd0a205f3",
+    "name": "Matthew@slight.me's Account"
+  }
+}

--- a/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
+++ b/infra/oyster-arcade-site/.wrangler/cache/wrangler-account.json
@@ -1,6 +1,0 @@
-{
-  "account": {
-    "id": "13abdfec5a4d89806c6344bfd0a205f3",
-    "name": "Matthew@slight.me's Account"
-  }
-}


### PR DESCRIPTION
## Summary

Phase A (#568) added a time-based frame ticker (\`Math.floor(renderNowEarly / 300) % 2\`) that toggles the 2-frame invader sprite every 300 ms regardless of march speed. Reads as flicker rather than the iconic Invaders shuffle.

SP behavior: frame flips on each march step, so animation cadence tracks march speed — slow at the start, frantic as the swarm thins. This PR ports that behavior.

## What changes

- **engine.js**: \`invaderFrame\` (0|1) + \`invaderFrameAccum\` join \`GameState\`. \`stepInvaders\` accumulates \`|dx|\` and flips the frame every 2 units of horizontal motion (matches SP's per-step cadence).
- **Snapshot**: new additive field \`iFrame\` carries the authoritative frame to all viewers.
- **Renderer**: reads \`b.iFrame ?? 0\` instead of running its own timer. Every viewer renders the same pose at the same tick — no per-client drift.

## Cadence

- Start: 3.6 u/s ÷ 2 = **~550 ms per flip** (matches SP's starting beat)
- End-game: 20 u/s ÷ 2 = **~100 ms per flip** (panic mode, also matches SP)

## Compatibility

\`iFrame\` is additive — \`b.iFrame ?? 0\` falls back to 0 if a client connects to a worker without the new field, so the sprite freezes on pose 0 until the worker redeploys. No NETCODE_VERSION bump (no breaking wire change).

## Test plan

- [ ] Deploy MP worker: \`cd infra/oyster-arcade-mp && npx wrangler deploy\`
- [ ] Deploy arcade-site: \`cd infra/oyster-arcade-site && npx wrangler deploy\`
- [ ] Open \`arcade.oyster.to/invaders-mp/TEST\`, start a game
- [ ] Invaders shuffle visibly slower at start, animation speeds up as they thin
- [ ] No "old movie" flicker — pose changes feel paired with movement
- [ ] Two devices on the same room: both render the same pose at the same time

🤖 Generated with [Claude Code](https://claude.com/claude-code)