### PR TITLE
chore: remove dead POST /api/projects/:id/claim route

### DIFF
--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -9,7 +9,6 @@
 //                                          name? } — writes .oyster/id, claims
 //                                          orphans, undeletes a soft-deleted
 //                                          project whose UUID is on disk
-//   POST /api/projects/:id/claim          bulk-tag orphan sessions { cwd }
 //   PATCH /api/projects/:id               rename
 //   DELETE /api/projects/:id              soft-delete
 
@@ -127,28 +126,6 @@ export async function tryHandleProjectsRoute(
         broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: "" } });
         sendJson(updated);
       }
-    } catch (err) { sendError(err); }
-    return true;
-  }
-
-  const claimMatch = pathname.match(/^\/api\/projects\/([^/]+)\/claim$/);
-  if (claimMatch && req.method === "POST") {
-    if (rejectIfNonLocalOrigin()) return true;
-    try {
-      const projectId = safeDecode(claimMatch[1]!);
-      if (projectId === null) {
-        sendJson({ error: "Invalid URL encoding" }, 400);
-        return true;
-      }
-      const body = await readJsonBody();
-      const cwd = typeof body.cwd === "string" ? body.cwd : null;
-      if (!cwd) {
-        sendJson({ error: "cwd is required" }, 400);
-        return true;
-      }
-      const result = projectService.claimOrphan({ cwd, projectId });
-      broadcastUiEvent({ version: 1, command: "session_changed", payload: { id: "" } });
-      sendJson(result);
     } catch (err) { sendError(err); }
     return true;
   }

--- a/server/test/projects-route.test.ts
+++ b/server/test/projects-route.test.ts
@@ -56,25 +56,6 @@ describe("routes/projects", () => {
     expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({ command: "session_changed" }));
   });
 
-  it("POST /api/projects/:id/claim runs claimOrphan and broadcasts", async () => {
-    const broadcast = vi.fn();
-    const projectService = {
-      claimOrphan: vi.fn().mockReturnValue({ claimed: 3 }),
-    };
-    const { ctx, captured } = fakeCtx({ cwd: "/foo/bar" });
-
-    await tryHandleProjectsRoute(
-      { method: "POST" } as any, {} as any,
-      "/api/projects/p1/claim",
-      ctx as any,
-      { projectService: projectService as any, broadcastUiEvent: broadcast },
-    );
-
-    expect(projectService.claimOrphan).toHaveBeenCalledWith({ cwd: "/foo/bar", projectId: "p1" });
-    expect(captured.json).toEqual({ claimed: 3 });
-    expect(broadcast).toHaveBeenCalled();
-  });
-
   it("rejects POST /api/projects with missing fields", async () => {
     const projectService = { createProject: vi.fn() };
     const { ctx, captured } = fakeCtx({ space_id: "work" }); // missing name


### PR DESCRIPTION
## Summary

- Deletes the HTTP route handler + its test for \`POST /api/projects/:id/claim\`. Confirmed dead during the sessions-first audit: no web call sites (the old \`claimOrphan\` export was removed in #551), no MCP wrapper, no internal server callers, no external GitHub matches.
- Leaves \`projectService.claimOrphan()\` in place — still called internally by \`attachFolder\`.
- Net: −42 lines.

## Test plan

- [x] \`npm run build\` clean (web + server tsc)
- [x] \`vitest run test/projects-route.test.ts\` — 6/6 pass (was 7, removed the claim route test)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)