### PR TITLE
ci: sync published deps authoritatively at release, advisory in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,14 @@ jobs:
           cd server && npm ci && cd ..
 
       - name: Verify root deps mirror server runtime deps
-        # Advisory only: release.yml re-syncs authoritatively before publish,
-        # so committed drift (e.g. from a dependabot server bump) can't reach
-        # end users. Surfaces drift in PR checks without blocking the merge.
-        continue-on-error: true
-        run: node scripts/sync-published-deps.mjs --check
+        # Advisory: release.yml re-syncs authoritatively before publish, so
+        # committed drift (e.g. from a dependabot server bump) can't reach end
+        # users. Don't block the merge on it — but surface drift as a warning
+        # annotation (visible in the PR checks/summary) rather than swallowing
+        # it, so it isn't silently ignored.
+        run: |
+          node scripts/sync-published-deps.mjs --check \
+            || echo "::warning title=Dependency mirror drift::root package.json drifts from server/package.json. release.yml re-syncs before publish; run 'node scripts/sync-published-deps.mjs' to update the committed mirror."
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           cd server && npm ci && cd ..
 
       - name: Verify root deps mirror server runtime deps
+        # Advisory only: release.yml re-syncs authoritatively before publish,
+        # so committed drift (e.g. from a dependabot server bump) can't reach
+        # end users. Surfaces drift in PR checks without blocking the merge.
+        continue-on-error: true
         run: node scripts/sync-published-deps.mjs --check
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,14 @@ jobs:
           cd web && npm ci && cd ..
           cd server && npm ci && cd ..
 
+      - name: Sync root deps from server (authoritative for publish)
+        # server/package.json is the source of truth for runtime deps. Mirror
+        # it into root package.json here so the published tarball always pins
+        # the same versions, regardless of committed drift. package-lock.json
+        # isn't published and a global install re-resolves ranges, so only
+        # package.json needs syncing.
+        run: node scripts/sync-published-deps.mjs
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Why

Dependabot bumps `server/package.json` (the source of truth for runtime deps) but can't run `scripts/sync-published-deps.mjs`, so the root `package.json` mirror drifts and the CI `--check` guard fails on **every** server runtime-dep bump. #563 hit exactly this — it needed a manual sync commit to go green, and it'll recur weekly.

## What

Fix it where it actually matters — at publish time — and stop the guard from blocking:

- **`release.yml`**: run `sync-published-deps.mjs` before build/publish, so the published `oyster-os` tarball always pins versions matching `server/`, regardless of committed drift. (Only `package.json` needs syncing — `package-lock.json` isn't published and a global install re-resolves ranges.)
- **`ci.yml`**: downgrade the `--check` guard to `continue-on-error: true`. It still surfaces drift in PR checks but no longer fails the build — matching the existing non-blocking lint step.

## Tradeoff

Committed root `package.json` may show slightly stale versions between releases. This is cosmetic: nothing consumes committed root runtime deps in that window except CI's own `npm ci` (which stays internally consistent). The published artifact — the only place these deps truly matter — is now guaranteed correct.

## Not included

No CHANGELOG entry — this is CI plumbing, not user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)