### PR TITLE
arcade(invaders-mp): Phase D — playfield widen + per-player score + shared lives + HUD

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -71,6 +71,14 @@ export interface WireSnapshot {
   invaders: Array<{ x: number; y: number; a: boolean }>;
   /** Authoritative swarm animation frame (0 or 1). */
   iFrame: 0 | 1;
+  /**
+   * Per-seat occupancy. Set by the transport layer (room.ts on the
+   * server, hostTick on the client) after snapshotForClient returns,
+   * NOT by the engine itself. Optional because mid-deploy a client
+   * may briefly receive a pre-Phase-D snapshot without it — fall back
+   * to `players[i].alive` in that case.
+   */
+  seats?: Record<Seat, boolean>;
 }
 
 export const PF_W: number;

--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -15,6 +15,12 @@ export interface Ship {
   x: number;
   alive: boolean;
   cooldown: number;
+  /** Per-player score (kills × ROW_POINTS[row]). */
+  score: number;
+  /** Seconds until respawn; 0 = not respawning (either alive or permanent-dead). */
+  respawnIn: number;
+  /** Seconds of post-respawn invulnerability remaining; 0 = vulnerable. */
+  invulnFor: number;
 }
 
 export interface Bullet {
@@ -32,7 +38,8 @@ export interface Invader {
 export interface GameState {
   status: Status;
   won: boolean;
-  score: number;
+  /** Shared respawn-pool counter (starts at STARTING_LIVES, decrements per death). */
+  lives: number;
   ships: Record<Seat, Ship>;
   bullets: Bullet[];
   invaderBullets: Bullet[];
@@ -52,10 +59,13 @@ export interface GameState {
 export interface WireSnapshot {
   status: Status;
   won: boolean;
+  /** Sum of all per-player scores; convenience for HUD/team copy. */
   score: number;
+  /** Shared respawn pool. */
+  lives: number;
   countdownEndMs: number;
   /** Always MAX_SEATS entries, indexed by seat position (p1 → 0, …). */
-  players: Array<{ x: number; alive: boolean; name: string }>;
+  players: Array<{ x: number; alive: boolean; name: string; score: number }>;
   bullets: Array<{ x: number; y: number; o: Seat | null }>;
   invaderBullets: Array<{ x: number; y: number }>;
   invaders: Array<{ x: number; y: number; a: boolean }>;
@@ -75,6 +85,9 @@ export const BULLET_H: number;
 export const BULLET_SPEED: number;
 export const INV_W: number;
 export const INV_H: number;
+export const INV_COLS: number;
+export const ROW_POINTS: readonly number[];
+export const STARTING_LIVES: number;
 
 export const SEATS: readonly Seat[];
 export const MAX_SEATS: number;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -3,7 +3,7 @@
 // as a <script type="module">). Pure functions only — no I/O, no
 // globals. The caller drives time and supplies input bags.
 //
-// Logical units: 240 wide × 280 tall (the client scales the canvas).
+// Logical units: 260 wide × 280 tall (the client scales the canvas).
 // Origin is top-left. Down = +y.
 //
 // Types live in engine.d.ts as an ambient sibling declaration so
@@ -11,7 +11,11 @@
 // without an allowJs build flag.
 
 // === Playfield ===
-export const PF_W = 240;
+// Widened from 240 in Phase D to match SP and host the 11-column
+// invader grid. With 4 ships at SHIP_W=16, the spawn margin is now
+// (260 - 64) / 5 = 39.2 per ship (vs 35.2 at PF_W=240) so the ships
+// also sit slightly less crowded.
+export const PF_W = 260;
 export const PF_H = 280;
 
 // === Seats / players ===
@@ -37,14 +41,21 @@ const INV_BULLET_SPEED = 120;
 
 // === Invaders ===
 const INV_ROWS = 5;
-const INV_COLS = 8;
+// 11 columns to match SP. With INV_GAP_X=18 and INV_W=12, the grid
+// spans (11-1)*18 + 12 = 192 PF units wide; centred in the PF=260
+// playfield leaves a (260-192)/2 = 34 PF left/right margin.
+export const INV_COLS = 11;
 export const INV_W = 12;
 export const INV_H = 8;
 const INV_GAP_X = 18;
 const INV_GAP_Y = 14;
-const INV_ORIGIN_X = 18;
+const INV_ORIGIN_X = 34;
 const INV_ORIGIN_Y = 24;
 const INV_DROP = 8;
+// Per-row point value, top→bottom. Matches SP — top row (squid) is
+// worth most, bottom rows (octopus) least, so going for the top row
+// first is the strategic play.
+export const ROW_POINTS = [30, 20, 20, 10, 10];
 // Continuous-march speed (u/s) shrinks as the swarm thins so the last
 // few invaders sprint. The discrete-shuffle version of this used a
 // step every ~0.55 s with a 2-unit jump (≈3.6 u/s).
@@ -55,7 +66,14 @@ const INV_SPEED_MIN  = 20;
 const INV_DROP_SPEED = 64;
 const INV_FIRE_INTERVAL = 1.4;
 
-const SCORE_PER_KILL = 10;
+// === Lives + respawn ===
+// Shared pool of respawn tokens. 3 means up to 3 ship deaths get
+// brought back; the 4th (and beyond) is permanent. With 4 ships +
+// 3 respawns = 7 total deaths before gameover — generous error
+// budget for kid co-op.
+export const STARTING_LIVES = 3;
+const RESPAWN_SEC = 2;
+const INVULN_SEC = 1;
 
 export function zeroInput() {
   return { left: false, right: false, fire: false };
@@ -72,10 +90,25 @@ function spawnX(seatIndex) {
 }
 
 function freshShips() {
-  /** @type {Record<string, {x:number,alive:boolean,cooldown:number}>} */
+  /** @type {Record<string, {x:number,alive:boolean,cooldown:number,score:number,respawnIn:number,invulnFor:number}>} */
   const ships = {};
   for (let i = 0; i < MAX_SEATS; i++) {
-    ships[SEATS[i]] = { x: spawnX(i), alive: true, cooldown: 0 };
+    ships[SEATS[i]] = {
+      x: spawnX(i),
+      alive: true,
+      cooldown: 0,
+      // Per-player score — replaces the old top-level state.score.
+      // Each kill awards ROW_POINTS[invader-row] to the bullet owner.
+      score: 0,
+      // Seconds until respawn (0 = not respawning). Set when a death
+      // consumes a shared life token; ticked down each step; on hit-0
+      // the ship blinks back at spawnX with invulnFor set.
+      respawnIn: 0,
+      // Seconds of post-respawn invulnerability remaining. Renderer
+      // blinks the ship while > 0 so the player can see the grace
+      // window. Also makes resolveCollisions skip damage.
+      invulnFor: 0,
+    };
   }
   return ships;
 }
@@ -84,7 +117,8 @@ export function initState() {
   return {
     status: 'waiting',
     won: false,
-    score: 0,
+    // Shared pool of respawn tokens (see STARTING_LIVES).
+    lives: STARTING_LIVES,
     ships: freshShips(),
     bullets: [],
     invaderBullets: [],
@@ -131,12 +165,36 @@ const ALL_OCCUPIED = Object.freeze(
 
 export function step(state, inputs, dt, occupied = ALL_OCCUPIED) {
   if (state.status !== 'running') return;
+  tickRespawnAndInvuln(state, dt);
   stepShips(state, inputs, dt, occupied);
   stepBullets(state, dt);
   stepInvaders(state, dt);
   stepInvaderFire(state, dt);
   resolveCollisions(state, occupied);
   checkEnd(state, occupied);
+}
+
+function tickRespawnAndInvuln(state, dt) {
+  // Count down respawn + invuln timers each tick. On respawn complete
+  // (timer hits 0 from > 0), reset that ship to alive at its spawnX
+  // with the grace window armed. Permanent-dead ships (lives==0 when
+  // they died) have respawnIn = 0 and stay dead — this branch is
+  // skipped for them because the > 0 check fails.
+  for (let i = 0; i < MAX_SEATS; i++) {
+    const ship = state.ships[SEATS[i]];
+    if (ship.invulnFor > 0) {
+      ship.invulnFor = Math.max(0, ship.invulnFor - dt);
+    }
+    if (ship.respawnIn > 0) {
+      ship.respawnIn = Math.max(0, ship.respawnIn - dt);
+      if (ship.respawnIn === 0) {
+        ship.x = spawnX(i);
+        ship.alive = true;
+        ship.cooldown = 0;
+        ship.invulnFor = INVULN_SEC;
+      }
+    }
+  }
 }
 
 function stepShips(state, inputs, dt, occupied) {
@@ -237,28 +295,39 @@ function stepInvaderFire(state, dt) {
 function resolveCollisions(state, occupied) {
   // Player bullets vs invaders. Out-of-array marker (b.y = -999) gets
   // swept by the next stepBullets — cheaper than splicing inside
-  // a nested loop.
+  // a nested loop. Points are credited to the bullet's owner using
+  // the row of the killed invader (top row = squid = 30, bottom row
+  // = octopus = 10).
   for (const b of state.bullets) {
     if (b.y < -BULLET_H) continue;
-    for (const inv of state.invaders) {
+    for (let i = 0; i < state.invaders.length; i++) {
+      const inv = state.invaders[i];
       if (!inv.alive) continue;
       if (overlap(b.x, b.y, BULLET_W, BULLET_H, inv.x, inv.y, INV_W, INV_H)) {
         inv.alive = false;
         b.y = -999;
-        state.score += SCORE_PER_KILL;
+        const owner = b.owner && state.ships[b.owner];
+        if (owner) owner.score += ROW_POINTS[Math.floor(i / INV_COLS)] || 0;
         break;
       }
     }
   }
   state.bullets = state.bullets.filter(b => b.y > -BULLET_H);
 
-  // Invader bullets vs ships. Unoccupied seats can't take damage.
+  // Invader bullets vs ships. Skip unoccupied seats AND ships that
+  // are in their post-respawn invulnerability window. On hit: if the
+  // shared lives pool has tokens, consume one and queue a respawn;
+  // otherwise the ship stays dead permanently.
   for (const b of state.invaderBullets) {
     for (const seat of SEATS) {
       const ship = state.ships[seat];
-      if (!ship.alive || !occupied[seat]) continue;
+      if (!ship.alive || !occupied[seat] || ship.invulnFor > 0) continue;
       if (overlap(b.x, b.y, BULLET_W, BULLET_H, ship.x, SHIP_Y, SHIP_W, SHIP_H)) {
         ship.alive = false;
+        if (state.lives > 0) {
+          state.lives--;
+          ship.respawnIn = RESPAWN_SEC;
+        }
         b.y = PF_H + 999;
       }
     }
@@ -267,12 +336,21 @@ function resolveCollisions(state, occupied) {
 }
 
 function checkEnd(state, occupied) {
-  // Loss: any invader at the ship row, or no playable ship remains.
-  // "Playable" = alive AND occupied — so a solo death ends the game
-  // even if other seats are empty-but-technically-alive.
+  // Loss conditions:
+  //  - any invader has reached the ship row (instant gameover, no
+  //    respawn can save you from a swarm breach), OR
+  //  - every playable seat is dead AND nobody has a pending respawn
+  //    AND the shared lives pool is empty (i.e. no one's coming back).
   const breach = state.invaders.some(i => i.alive && i.y + INV_H >= SHIP_Y);
-  const wipe = SEATS.every((s) => !(state.ships[s].alive && occupied[s]));
-  if (breach || wipe) { state.status = 'gameover'; state.won = false; return; }
+  if (breach) { state.status = 'gameover'; state.won = false; return; }
+
+  const noOneAlive  = SEATS.every((s) => !(state.ships[s].alive && occupied[s]));
+  const noOneComing = SEATS.every((s) => state.ships[s].respawnIn === 0);
+  if (noOneAlive && noOneComing) {
+    state.status = 'gameover';
+    state.won = false;
+    return;
+  }
 
   // Win: every invader dead.
   if (!state.invaders.some(i => i.alive)) { state.status = 'gameover'; state.won = true; }
@@ -287,10 +365,19 @@ function overlap(ax, ay, aw, ah, bx, by, bw, bh) {
 function round(n) { return Math.round(n * 10) / 10; }
 
 export function snapshotForClient(state) {
+  let teamScore = 0;
+  for (const s of SEATS) teamScore += state.ships[s].score | 0;
   return {
     status: state.status,
     won: state.won,
-    score: state.score,
+    // Team score = sum of per-player scores. Kept on the wire because
+    // the gameover/lobby copy ("Earth is safe! Score: 250") reads
+    // cleanly as one team number, and external bits (sfx-kill diff)
+    // can just watch this for "any kill happened".
+    score: teamScore,
+    // Shared respawn-pool counter. Decremented each time a ship dies
+    // (down to 0). Renderer shows it as the LIVES HUD value.
+    lives: state.lives,
     // Server clock the countdown should end at (only meaningful while
     // status === 'countdown'). Client computes seconds-remaining from
     // (countdownEndMs - serverNow) and renders the big overlay.
@@ -304,6 +391,8 @@ export function snapshotForClient(state) {
       x: round(state.ships[s].x),
       alive: state.ships[s].alive,
       name: state.names?.[s] ?? '',
+      // Per-player score (replaces the old top-level state.score).
+      score: state.ships[s].score,
     })),
     // `o` (owner) is the firing seat — lets the client filter "my
     // bullets" if it ever wants per-bullet prediction. Invader

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -104,9 +104,10 @@ function freshShips() {
       // consumes a shared life token; ticked down each step; on hit-0
       // the ship blinks back at spawnX with invulnFor set.
       respawnIn: 0,
-      // Seconds of post-respawn invulnerability remaining. Renderer
-      // blinks the ship while > 0 so the player can see the grace
-      // window. Also makes resolveCollisions skip damage.
+      // Seconds of post-respawn invulnerability remaining. Engine-
+      // internal — resolveCollisions skips damage while > 0. Not on
+      // the wire (yet); a future PR can expose it for a respawn-blink
+      // visual, but for now the ship just reappears at spawnX.
       invulnFor: 0,
     };
   }
@@ -345,7 +346,10 @@ function checkEnd(state, occupied) {
   if (breach) { state.status = 'gameover'; state.won = false; return; }
 
   const noOneAlive  = SEATS.every((s) => !(state.ships[s].alive && occupied[s]));
-  const noOneComing = SEATS.every((s) => state.ships[s].respawnIn === 0);
+  // A "coming back" seat must be both occupied AND mid-respawn — a
+  // disconnected seat's leftover respawnIn shouldn't keep the match
+  // running when no one's actually there to come back to.
+  const noOneComing = SEATS.every((s) => !(occupied[s] && state.ships[s].respawnIn > 0));
   if (noOneAlive && noOneComing) {
     state.status = 'gameover';
     state.won = false;

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1534,16 +1534,17 @@
         ctx.restore();
       }
 
-      // Transport + ping indicator — tiny status badge below LIVES,
-      // visible during gameplay so a "felt laggy" report has numbers
-      // to back it up. Single colour-coded line (green/yellow/red on
-      // the ping bucket — the alarming bit); transport label gives
-      // context. Hidden in kid view (?clean) so non-debug builds
-      // stay clean.
+      // Transport + ping indicator — tucked into the bottom-left
+      // corner of the canvas (below the ship row, mirrors SCORE's
+      // top-left position). Out of the HUD strip so it doesn't
+      // compete with the gameplay numbers. Single colour-coded line
+      // (green/yellow/red on the ping bucket — the alarming bit);
+      // transport label drawn muted alongside as context. Hidden
+      // in kid view (?clean).
       if (!isClean) {
         const labelMap = { p2p: 'P2P', connecting: 'P2P…', relay: 'RELAY' };
         const label = labelMap[currentTransport] || 'RELAY';
-        let color = '#bbbbbb';                                   // unknown ping
+        let color = '#777777';                                   // unknown ping → muted
         if (lastRTT != null) {
           if      (lastRTT < 80)   color = '#6bff8c';            // green — snappy
           else if (lastRTT < 180)  color = '#ffd84a';            // yellow — playable
@@ -1551,9 +1552,14 @@
         }
         const pingStr = lastRTT != null ? `${lastRTT}ms` : '—';
         ctx.font = '5px "Press Start 2P", monospace';
-        ctx.textAlign = 'right';
+        ctx.textAlign = 'left';
+        // Transport label muted; ping coloured. Tiny gap between
+        // them so the colour-coded number reads as the headline.
+        ctx.fillStyle = '#777777';
+        ctx.fillText(label, 6, PF_H - 6);
+        const gap = ctx.measureText(label + ' ').width;
         ctx.fillStyle = color;
-        ctx.fillText(`${label} ${pingStr}`, PF_W - 6, 22);
+        ctx.fillText(pingStr, 6 + gap, PF_H - 6);
       }
     }
   }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -64,12 +64,13 @@
     pointer-events: none;
   }
 
-  /* Debug-only items — netcode/ping/transport diagnostic line and the
-     Retry P2P button. Hidden by default; the URL ?debug query enables
-     them by adding .is-debug on <body>. Keeps the kid view clean while
-     leaving the tools one URL tweak away. */
-  body:not(.is-debug) #prescreen .meta,
-  body:not(.is-debug) #prescreen #retryBtn {
+  /* Diagnostic line (netcode / ping / transport) + Retry P2P button.
+     Visible by default during the testing phase — they're genuinely
+     useful for spotting bad transport / version mismatches. The URL
+     ?clean query hides them via body.is-clean for the kid view, and
+     we'll flip the default back to "hidden unless ?debug" at release. */
+  body.is-clean #prescreen .meta,
+  body.is-clean #prescreen #retryBtn {
     display: none;
   }
 
@@ -412,10 +413,10 @@
   if (!roomCode) roomCode = randomCode();
   // Normalise the address bar to the clean path form regardless of how
   // we arrived — query-string bookmarks rewrite themselves on first
-  // load and stay shareable in the new form. We preserve ?debug across
-  // the rewrite so the debug toggle survives bookmarks/reloads.
-  const isDebug = new URLSearchParams(location.search).has('debug');
-  const cleanPath = '/invaders-mp/' + roomCode + (isDebug ? '?debug' : '');
+  // load and stay shareable in the new form. We preserve ?clean across
+  // the rewrite so the kid-view bookmark survives reloads.
+  const isClean = new URLSearchParams(location.search).has('clean');
+  const cleanPath = '/invaders-mp/' + roomCode + (isClean ? '?clean' : '');
   if ((location.pathname + location.search) !== cleanPath) {
     history.replaceState(null, '', cleanPath);
   }
@@ -433,12 +434,11 @@
   document.getElementById('roomCode').textContent = roomCode;
   renderQR(location.href);
 
-  // ?debug on the URL reveals the diagnostic meta line (netcode /
-  // ping / transport) and the Retry P2P button. Kept off by default
-  // so the kid view stays clean. The flag is captured before the
-  // history.replaceState above so the original ?debug isn't lost in
-  // the path normalisation; reuse it here.
-  if (isDebug) document.body.classList.add('is-debug');
+  // ?clean on the URL hides the diagnostic meta line + Retry P2P for
+  // the kid view. Default is to show them — they're handy while we're
+  // actively testing. Flag captured before history.replaceState above
+  // so the original ?clean survives path normalisation.
+  if (isClean) document.body.classList.add('is-clean');
 
   // QR code for the join URL. Type 0 = auto-fit the smallest matrix
   // that fits the URL; 'M' = medium error-correction (handles a 7-bit
@@ -1435,46 +1435,37 @@
       drawCenteredOverlay('ATTACK!', `rgba(255, 58, 161, ${alpha.toFixed(2)})`, 22);
     }
 
-    // HUD — top of canvas, in three columns matching SP's layout but
-    // adapted for MP: per-player SCORE pairs in seat colour on the
-    // left, a STAGE placeholder in the centre (real progression lands
-    // in Phase G), and the shared LIVES count on the right. Two lines
-    // (label / value) so a growing score doesn't push the label off
-    // screen.
+    // HUD — three SP-style columns across the top of the canvas:
+    // SCORE (local player only, in their seat colour) | STAGE (real
+    // progression lands in Phase G) | LIVES (shared respawn pool).
+    // Two-line layout (label above value) so growing digits don't
+    // push the label off screen.
     if (latestSnap.status === 'running' || latestSnap.status === 'gameover') {
       ctx.font = '6px "Press Start 2P", monospace';
-      ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
 
-      // SCORE: P1 + P2 share the top-left column, P3 + P4 share the
-      // column just to their right. Each entry shows "P1" label in
-      // the seat colour above a 4-digit value in white.
-      const SCORE_COL_W = 26;
-      const SCORE_ROW_H = 8;
-      for (let i = 0; i < MAX_SEATS; i++) {
-        const col = i % 2;                   // 0 → left, 1 → right column
-        const row = Math.floor(i / 2);       // 0 → top, 1 → bottom row
-        const x = 6 + col * SCORE_COL_W;
-        const y = 4 + row * SCORE_ROW_H;
-        const p = latestSnap.players[i];
-        ctx.fillStyle = SHIP_COLORS[i];
-        ctx.fillText('P' + (i + 1), x, y);
-        ctx.fillStyle = '#ffffff';
-        const score = (p && p.score) || 0;
-        ctx.fillText(String(score).padStart(4, '0'), x + 10, y);
-      }
+      // SCORE — local player only. Friends' scores were cluttering
+      // the HUD; each player sees their own score in their own
+      // colour. Spectators (no assigned seat) get a neutral white
+      // "0000" fallback.
+      const seatIdx = mySeat ? SEATS.indexOf(mySeat) : -1;
+      const me = seatIdx >= 0 ? latestSnap.players[seatIdx] : null;
+      const myScore = (me && me.score) || 0;
+      ctx.textAlign = 'left';
+      ctx.fillStyle = '#ffffff';
+      ctx.fillText('SCORE', 6, 4);
+      ctx.fillStyle = seatIdx >= 0 ? SHIP_COLORS[seatIdx] : '#ffffff';
+      ctx.fillText(String(myScore).padStart(4, '0'), 6, 12);
 
-      // STAGE — centred. Real progression lands in Phase G; for now
-      // it always says 1-1 so the slot is reserved in the HUD.
+      // STAGE — centred. Placeholder "1-1" until Phase G.
       ctx.textAlign = 'center';
       ctx.fillStyle = '#ffffff';
       ctx.fillText('STAGE', PF_W / 2, 4);
       ctx.fillStyle = '#ffd84a';
       ctx.fillText('1-1', PF_W / 2, 12);
 
-      // LIVES — shared respawn-pool counter on the right. Renders even
-      // if the field is missing (older snapshot) by falling back to a
-      // blank "—" so the layout doesn't jitter.
+      // LIVES — shared respawn-pool counter, right-aligned. "—" if
+      // an older snapshot omits the field.
       ctx.textAlign = 'right';
       ctx.fillStyle = '#ffffff';
       ctx.fillText('LIVES', PF_W - 6, 4);

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -36,6 +36,21 @@
     image-rendering: crisp-edges;
   }
 
+  /* Touch-device safe-area. Shared cabinet.css drops .screen padding
+     to 0 on coarse pointers (edge-to-edge phone look), which strips
+     the browser-chrome insets too — on iPad landscape Safari that
+     lets the cabinet extend under the toolbar and crops the HUD +
+     top invader row. Re-add the safe-area insets so content always
+     lives inside the visible region. */
+  @media (pointer: coarse) {
+    #stage.screen {
+      padding-top:    env(safe-area-inset-top);
+      padding-right:  env(safe-area-inset-right);
+      padding-bottom: env(safe-area-inset-bottom);
+      padding-left:   env(safe-area-inset-left);
+    }
+  }
+
   /* Prescreen — covers the tube while the game is in the waiting,
      ready, or gameover states (the lobby/restart UI). Hidden during
      countdown + running, when .tube.is-ready is set by refreshLobby
@@ -1008,6 +1023,13 @@
         if (msg.status === 'gameover' && prev.status !== 'gameover' && !msg.won) {
           Arcade.Audio.play('sfx-lose', 0.6);
         }
+        if (typeof msg.lives === 'number' && typeof prev.lives === 'number'
+            && msg.lives < prev.lives) {
+          // Shared-pool tick: brief flash + "-1" popup near the LIVES
+          // HUD so the whole team can see "we just lost one" instead
+          // of having to spot a quiet number change while shooting.
+          livesFlashUntil = performance.now() + LIVES_FLASH_MS;
+        }
       }
       lastState = msg;
       snapBuffer.push(msg);
@@ -1465,13 +1487,38 @@
       ctx.fillText('1-1', PF_W / 2, 12);
 
       // LIVES — shared respawn-pool counter, right-aligned. "—" if
-      // an older snapshot omits the field.
+      // an older snapshot omits the field. The value flashes brighter
+      // (yellow→white) and a floating "-1" rises and fades for
+      // LIVES_FLASH_MS after the pool decrements, so the whole team
+      // sees the loss instead of having to spot a quiet tick.
       ctx.textAlign = 'right';
       ctx.fillStyle = '#ffffff';
       ctx.fillText('LIVES', PF_W - 6, 4);
-      ctx.fillStyle = '#ffd84a';
       const lives = (latestSnap.lives != null) ? String(latestSnap.lives) : '—';
+      const flashFor = Math.max(0, livesFlashUntil - performance.now());
+      if (flashFor > 0) {
+        // t: 1 at flash start, 0 at end. Brighten yellow towards white
+        // by lifting green + blue channels.
+        const t = flashFor / LIVES_FLASH_MS;
+        const g = Math.round(216 + (255 - 216) * t);
+        const b = Math.round(74  + (255 - 74)  * t);
+        ctx.fillStyle = `rgb(255, ${g}, ${b})`;
+      } else {
+        ctx.fillStyle = '#ffd84a';
+      }
       ctx.fillText(lives, PF_W - 6, 12);
+
+      // Floating "-1" — animates up from just below the LIVES value
+      // and fades as t→0. Only rendered while flashFor > 0.
+      if (flashFor > 0) {
+        const t = flashFor / LIVES_FLASH_MS;
+        ctx.save();
+        ctx.globalAlpha = t;
+        ctx.fillStyle = '#ff6666';
+        ctx.font = '7px "Press Start 2P", monospace';
+        ctx.fillText('-1', PF_W - 6, 22 - 10 * (1 - t));
+        ctx.restore();
+      }
     }
   }
 
@@ -1479,6 +1526,11 @@
   let attackOverlayUntil = 0;
   let nameFadeStartAt = 0;
   const NAME_FADE_MS = 800;
+  // Lives-decrement HUD flash. Set when a snapshot diff sees lives go
+  // down; the HUD renderer brightens the LIVES value and floats a
+  // "-1" popup above it until this clock passes.
+  let livesFlashUntil = 0;
+  const LIVES_FLASH_MS = 600;
   function drawCenteredOverlay(text, color, sizePx) {
     ctx.save();
     ctx.font = sizePx + 'px "Press Start 2P", monospace';

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -725,11 +725,14 @@
   function allOccupiedPeersConnected() {
     // Host (P1): every occupied non-P1 seat must have a connected peer.
     // Client (non-P1): we just need a connected peer to P1.
+    // Uses seatOccupied() (authoritative `seats` field) rather than
+    // .alive so a mid-respawn ship doesn't briefly read as "vacant"
+    // and demote the transport badge to "connecting" or "relay".
     if (!mySeat || !lastState) return false;
     if (mySeat === 'p1') {
       let anyOther = false;
       for (let i = 1; i < SEATS.length; i++) {
-        if (!lastState.players[i]?.alive) continue;
+        if (!seatOccupied(i)) continue;
         anyOther = true;
         if (!peerConnectedTo(SEATS[i])) return false;
       }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -532,6 +532,7 @@
   }
   function applyPong(serverT) {
     const rtt = Math.round(performance.now() - serverT);
+    lastRTT = rtt;
     pingEl.textContent = rtt + ' ms';
     pingEl.classList.remove('low', 'mid', 'high');
     if      (rtt < 80)  pingEl.classList.add('low');
@@ -784,6 +785,7 @@
 
   const transportEl = document.getElementById('transport');
   function setTransport(state) {
+    currentTransport = state;
     transportEl.classList.remove('p2p', 'connecting');
     if (state === 'p2p')             { transportEl.textContent = 'P2P';  transportEl.classList.add('p2p'); }
     else if (state === 'connecting') { transportEl.textContent = 'P2P…'; transportEl.classList.add('connecting'); }
@@ -1531,6 +1533,28 @@
         ctx.fillText('-1', PF_W - 6, 22 - 10 * (1 - t));
         ctx.restore();
       }
+
+      // Transport + ping indicator — tiny status badge below LIVES,
+      // visible during gameplay so a "felt laggy" report has numbers
+      // to back it up. Single colour-coded line (green/yellow/red on
+      // the ping bucket — the alarming bit); transport label gives
+      // context. Hidden in kid view (?clean) so non-debug builds
+      // stay clean.
+      if (!isClean) {
+        const labelMap = { p2p: 'P2P', connecting: 'P2P…', relay: 'RELAY' };
+        const label = labelMap[currentTransport] || 'RELAY';
+        let color = '#bbbbbb';                                   // unknown ping
+        if (lastRTT != null) {
+          if      (lastRTT < 80)   color = '#6bff8c';            // green — snappy
+          else if (lastRTT < 180)  color = '#ffd84a';            // yellow — playable
+          else                     color = '#ff6666';            // red — laggy
+        }
+        const pingStr = lastRTT != null ? `${lastRTT}ms` : '—';
+        ctx.font = '5px "Press Start 2P", monospace';
+        ctx.textAlign = 'right';
+        ctx.fillStyle = color;
+        ctx.fillText(`${label} ${pingStr}`, PF_W - 6, 22);
+      }
     }
   }
 
@@ -1543,6 +1567,13 @@
   // "-1" popup above it until this clock passes.
   let livesFlashUntil = 0;
   const LIVES_FLASH_MS = 600;
+  // Latest measured RTT (ms) + current transport state. Mirrored to
+  // the prescreen meta DOM by applyPong/setTransport AND read by the
+  // in-canvas HUD so lag/transport are visible during gameplay too,
+  // not just in the lobby. Henry called out a "laggy" round with no
+  // visible evidence — this surfaces both at a glance.
+  let lastRTT = null;
+  let currentTransport = 'relay';
   function drawCenteredOverlay(text, color, sizePx) {
     ctx.save();
     ctx.font = sizePx + 'px "Press Start 2P", monospace';

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -21,7 +21,7 @@
   }
   /* Canvas centring + crisp pixel-art scaling. cabinet.css has a
      `canvas { width: 100%; height: 100% }` rule for games whose
-     engines size the bitmap to the tube; MP keeps a fixed 240×280
+     engines size the bitmap to the tube; MP keeps a fixed 260×280
      bitmap and rescales via fitCanvas's inline style.width/height
      (integer multiples → no sub-pixel blur). The .tube canvas
      selector is more specific so this wins. */
@@ -267,7 +267,7 @@
      comes back so a player can hit Start again to replay. -->
 <div id="stage" class="screen">
   <div class="tube">
-    <canvas id="cv" width="240" height="280"></canvas>
+    <canvas id="cv" width="260" height="280"></canvas>
     <div class="overlay"></div>
     <div class="vignette"></div>
     <div class="touch-controls">
@@ -342,15 +342,12 @@
     initState, step, snapshotForClient, zeroInput,
     PF_W, PF_H, SHIP_W, SHIP_H, SHIP_Y, SHIP_SPEED, FIRE_COOLDOWN,
     BULLET_W, BULLET_H, BULLET_SPEED,
-    INV_W, INV_H,
+    INV_W, INV_H, INV_COLS,
     SEATS, MAX_SEATS,
   } from './engine.js';
   import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
-  // INV_COLS isn't exported by engine.js (it's a private constant)
-  // but the grid stride is fixed by the wire snapshot, so we mirror
-  // it here for the renderer's row math. If engine.js ever changes
-  // the grid width this has to move in lockstep.
-  const SPRITE_COLS = 8;
+  // Renderer uses INV_COLS for row-major sprite picks.
+  const SPRITE_COLS = INV_COLS;
 
   // Register SFX with the shared audio module. The volume/muted keys
   // are the global arcade keys so the slider state carries across
@@ -380,7 +377,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 20;
+  const NETCODE_VERSION = 21;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1205,7 +1202,7 @@
     // a small slack so the canvas doesn't touch the rounded-glass
     // corners.
     //
-    // Use the largest scale that preserves the 240:280 aspect. We
+    // Use the largest scale that preserves the 260:280 aspect. We
     // *don't* floor to integers: on a laptop the available scale is
     // ~3.6× and on an iPhone portrait it's ~1.6×, both of which round
     // down to 3 and 1 — wasting ~25% of the playfield area in either
@@ -1438,18 +1435,52 @@
       drawCenteredOverlay('ATTACK!', `rgba(255, 58, 161, ${alpha.toFixed(2)})`, 22);
     }
 
-    // Score HUD — top-left corner, in-canvas so it lives inside the
-    // cabinet's CRT/scanlines instead of bleeding outside the tube.
-    // SP draws labels above values on two lines; we do the same so a
-    // running score doesn't push the label off-screen as digits grow.
+    // HUD — top of canvas, in three columns matching SP's layout but
+    // adapted for MP: per-player SCORE pairs in seat colour on the
+    // left, a STAGE placeholder in the centre (real progression lands
+    // in Phase G), and the shared LIVES count on the right. Two lines
+    // (label / value) so a growing score doesn't push the label off
+    // screen.
     if (latestSnap.status === 'running' || latestSnap.status === 'gameover') {
-      ctx.fillStyle = '#ffffff';
       ctx.font = '6px "Press Start 2P", monospace';
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
-      ctx.fillText('SCORE', 6, 4);
+
+      // SCORE: P1 + P2 share the top-left column, P3 + P4 share the
+      // column just to their right. Each entry shows "P1" label in
+      // the seat colour above a 4-digit value in white.
+      const SCORE_COL_W = 26;
+      const SCORE_ROW_H = 8;
+      for (let i = 0; i < MAX_SEATS; i++) {
+        const col = i % 2;                   // 0 → left, 1 → right column
+        const row = Math.floor(i / 2);       // 0 → top, 1 → bottom row
+        const x = 6 + col * SCORE_COL_W;
+        const y = 4 + row * SCORE_ROW_H;
+        const p = latestSnap.players[i];
+        ctx.fillStyle = SHIP_COLORS[i];
+        ctx.fillText('P' + (i + 1), x, y);
+        ctx.fillStyle = '#ffffff';
+        const score = (p && p.score) || 0;
+        ctx.fillText(String(score).padStart(4, '0'), x + 10, y);
+      }
+
+      // STAGE — centred. Real progression lands in Phase G; for now
+      // it always says 1-1 so the slot is reserved in the HUD.
+      ctx.textAlign = 'center';
+      ctx.fillStyle = '#ffffff';
+      ctx.fillText('STAGE', PF_W / 2, 4);
       ctx.fillStyle = '#ffd84a';
-      ctx.fillText(String(latestSnap.score).padStart(4, '0'), 6, 12);
+      ctx.fillText('1-1', PF_W / 2, 12);
+
+      // LIVES — shared respawn-pool counter on the right. Renders even
+      // if the field is missing (older snapshot) by falling back to a
+      // blank "—" so the layout doesn't jitter.
+      ctx.textAlign = 'right';
+      ctx.fillStyle = '#ffffff';
+      ctx.fillText('LIVES', PF_W - 6, 4);
+      ctx.fillStyle = '#ffd84a';
+      const lives = (latestSnap.lives != null) ? String(latestSnap.lives) : '—';
+      ctx.fillText(lives, PF_W - 6, 12);
     }
   }
 

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -358,12 +358,16 @@
     initState, step, snapshotForClient, zeroInput,
     PF_W, PF_H, SHIP_W, SHIP_H, SHIP_Y, SHIP_SPEED, FIRE_COOLDOWN,
     BULLET_W, BULLET_H, BULLET_SPEED,
-    INV_W, INV_H, INV_COLS,
+    INV_W, INV_H,
     SEATS, MAX_SEATS,
   } from './engine.js';
   import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
-  // Renderer uses INV_COLS for row-major sprite picks.
-  const SPRITE_COLS = INV_COLS;
+  // Mirror engine.js's INV_COLS instead of named-importing it. Named
+  // imports of missing exports are a hard module-link error: if an old
+  // edge-cached engine.js gets paired with this fresh index.html (rare
+  // but possible during a deploy crossover), the page wouldn't load
+  // at all. Keep this in sync when engine.js changes the grid width.
+  const SPRITE_COLS = 11;
 
   // Register SFX with the shared audio module. The volume/muted keys
   // are the global arcade keys so the slider state carries across
@@ -673,7 +677,10 @@
       step(hostState, hostInputs, dt, occupied);
     }
 
-    const snap = { type: 'state', t: now, ...snapshotForClient(hostState) };
+    // `seats` mirrors the server-side wire field so clients can tell
+    // "connected but dead/respawning" from "vacant seat" — `alive`
+    // alone became ambiguous once respawns landed in Phase D.
+    const snap = { type: 'state', t: now, ...snapshotForClient(hostState), seats: { ...occupied } };
     for (let i = 0; i < SEATS.length; i++) {
       if (!occupied[SEATS[i]]) snap.players[i].alive = false;
     }
@@ -879,6 +886,15 @@
   // Idempotent — call from state handler / on demand. Host (P1)
   // creates one peer per other occupied seat; clients create exactly
   // one peer to P1 once P1 shows alive in the snapshot.
+  // Prefer the wire `seats` map (authoritative connected-or-not, set
+  // by the transport layer) over `players[i].alive` (which now flips
+  // false during mid-respawn windows too). Falls back to `alive` for
+  // pre-Phase-D snapshots that lack the field.
+  function seatOccupied(i) {
+    if (!lastState) return false;
+    if (lastState.seats) return !!lastState.seats[SEATS[i]];
+    return !!lastState.players[i]?.alive;
+  }
   function maybeCreatePeers() {
     if (typeof SimplePeer === 'undefined') return;
     if (!mySeat || !lastState) return;
@@ -886,11 +902,11 @@
       for (let i = 1; i < SEATS.length; i++) {
         const other = SEATS[i];
         if (peers.has(other)) continue;
-        if (lastState.players[i]?.alive) makePeerTo(other);
+        if (seatOccupied(i)) makePeerTo(other);
       }
     } else {
       if (peers.has('p1')) return;
-      if (lastState.players[0]?.alive) makePeerTo('p1');
+      if (seatOccupied(0)) makePeerTo('p1');
     }
   }
 
@@ -1069,15 +1085,11 @@
       const slot = playerSlotEls[i];
       if (!slot) continue;
       const p = lastState.players[i];
-      // alive doubles as the occupancy mask the server applies before
-      // broadcasting (initState marks every fresh ship alive; the
-      // broadcast loop overwrites alive=false for any seat with no
-      // socket). Caveat: during 'gameover' a player who actually died
-      // also reads as alive=false here, so their slot briefly shows
-      // empty until Start triggers a fresh initState. Pragmatic for
-      // the spike; if it bites we'll add a dedicated `seats` field
-      // to the wire.
-      const occupied = !!p?.alive;
+      // Prefer the authoritative `seats` map (added in Phase D) over
+      // `players[i].alive` — once respawns landed, alive can be false
+      // for a connected seat that's mid-respawn or just died at end
+      // of a round. Falls back to alive for pre-Phase-D snapshots.
+      const occupied = seatOccupied(i);
       slot.classList.toggle('is-active', occupied);
       slot.classList.toggle('is-empty', !occupied);
       const nameEl = slot.querySelector('.ps-name');
@@ -1104,11 +1116,11 @@
   function refreshLobby() {
     if (!lastState) return;
     const s = lastState.status;
-    // The server masks unoccupied seats as alive:false on the wire,
-    // so a non-running game's player.alive count is a clean occupancy
-    // proxy. During a running game players may legitimately be dead
-    // — the count still reads as "currently active".
-    const occupied = lastState.players.filter(p => p && p.alive).length;
+    // Use the authoritative `seats` map (added in Phase D) — true
+    // occupancy regardless of alive/respawn state. Pre-Phase-D
+    // snapshots fall back to the alive proxy via seatOccupied().
+    let occupied = 0;
+    for (let i = 0; i < MAX_SEATS; i++) if (seatOccupied(i)) occupied++;
     // Reveal the cabinet (canvas visible + prescreen faded) once the
     // countdown begins, so the 3-2-1 → ATTACK overlay paints on a
     // visible canvas. Goes back to the prescreen on waiting/ready (no

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -89,7 +89,14 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        (3) handleStart now runs a 3 s countdown — game state goes
 //        ready/waiting/gameover → 'countdown' → 'running', with the
 //        end time on the wire so the client can render 3/2/1/ATTACK.
-const NETCODE_VERSION = 20;
+// v21 — Phase D: PF_W widened to 260 with an 11-column invader grid.
+//        Per-player score (players[i].score) replaces the old top-level
+//        state.score (kept on the wire as the sum for back-compat).
+//        Shared lives pool: state.lives, decremented on each death;
+//        ship.respawnIn + ship.invulnFor drive the 2 s respawn + 1 s
+//        invulnerability grace window. Row-tiered kill points
+//        (30/20/20/10/10 top→bottom) instead of flat 10.
+const NETCODE_VERSION = 21;
 
 type ClientMessage =
   | { type: 'ping';   t: number }

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -416,10 +416,17 @@ export class InvadersRoom {
     // doesn't paint a sitting-duck ghost while waiting for other
     // players. The server-side ship stays alive in the simulation;
     // it just can't take damage or contribute to the wipe check.
+    // Also build a `seats` map so the client can distinguish
+    // "connected but dead/respawning" from "vacant seat" — `alive`
+    // alone became ambiguous once respawns landed in Phase D.
+    const seats = {} as Record<Seat, boolean>;
     for (let i = 0; i < MAX_SEATS; i++) {
-      if (!this.sockets.has(SEATS[i])) snap.players[i].alive = false;
+      const s = SEATS[i];
+      const here = this.sockets.has(s);
+      seats[s] = here;
+      if (!here) snap.players[i].alive = false;
     }
-    const msg = JSON.stringify({ type: 'state', t: Date.now(), ...snap });
+    const msg = JSON.stringify({ type: 'state', t: Date.now(), ...snap, seats });
     for (const ws of this.sockets.values()) {
       try { ws.send(msg); }
       catch { /* socket dying; close handler will clean up */ }


### PR DESCRIPTION
## Summary

First of the SP-parity visual phases. Brings MP up to SP's playfield dimensions, splits the global score into per-player tallies, introduces a shared respawn pool, and paints an SP-style HUD across the top of the canvas.

## Engine

- **PF_W 240 → 260** (matches SP). **INV_COLS 8 → 11** (55-invader grid, up from 40). New `INV_ORIGIN_X = 34` keeps the grid centred. Ship spawn margin recalculates to `(260 - 64)/5 = 39.2` per ship — slightly less crowded for 4 players.
- **Ship state** adds `score`, `respawnIn`, `invulnFor`. **State** adds `lives` (shared respawn pool, `STARTING_LIVES = 3`) and drops the old top-level `score` (wire keeps it as a sum for back-compat).
- **Row-tiered points** `ROW_POINTS = [30, 20, 20, 10, 10]`. Each kill awards `ROW_POINTS[row]` to the bullet owner's ship.
- `step()` ticks `respawnIn`/`invulnFor` each frame. On hit-zero `respawnIn` the ship blinks back at `spawnX` with a 1s invuln window.
- `resolveCollisions` skips ships in their invuln window. On hit: consume one shared life and queue a 2s respawn — or stay dead permanently if the pool is empty.
- `checkEnd` gameover only when no ships are alive AND no occupied seat is mid-respawn. Breach loss unchanged.

## Wire

- **NETCODE_VERSION 20 → 21** (additive — old clients degrade gracefully).
- `players[i].score: number` — per-seat tally.
- Top-level `lives: number` — shared pool.
- Top-level `score` repurposed as `sum(players[i].score)` (back-compat for older clients + sfx-kill diff + gameover copy).
- `seats: Record<Seat, boolean>` — authoritative occupancy. Replaces the old "alive-as-occupancy" overload that broke once respawns landed (a mid-respawn seat reads `alive=false` but is still connected). New `seatOccupied(i)` client helper prefers this, falls back to `alive` for pre-v21 snapshots.

## Client

- Canvas bitmap `width="240"` → `260`. `SPRITE_COLS` mirrors engine's `INV_COLS` as a local const (no named import — avoids hard module-link errors if a stale edge cache pairs an old `engine.js` with a fresh `index.html`).
- HUD replaces the single SCORE label with three columns:
  - **SCORE** — local player only, in their seat colour (friends' scores cluttered the HUD; each player just sees their own)
  - **STAGE** — centre, placeholder `"1-1"` until Phase G
  - **LIVES** — right, shared pool value (falls back to `"—"` for older snapshots); brightens + floats a red `−1` popup whenever the pool ticks down
- **Transport + ping badge** bottom-left of canvas during gameplay (mirrors SCORE's top-left position). Single colour-coded line: green <80ms, yellow <180ms, red ≥180ms. Hidden in kid view (`?clean`).
- iPad safe-area: re-applies `env(safe-area-inset-*)` on touch devices so the cabinet doesn't extend under iPad Safari landscape's toolbar (was cropping the HUD + top invader row).

## Defaults during testing

- `?clean` URL flag = kid view (hides netcode/ping/transport line + Retry P2P button)
- Default = debug view (shows them) — useful while we're actively iterating

## Lives budget

4 ships + 3 respawns = **7 total deaths before gameover** in a 4-player game. Generous error budget for kid co-op. Easy to tweak `STARTING_LIVES` after playtesting.

## Test plan

- [ ] Deploy MP worker + arcade-site (engine.js is bundled into BOTH)
- [ ] Hard-refresh — wider playfield, 11-column grid visible
- [ ] HUD: own score top-left in seat colour | STAGE 1-1 | LIVES 3
- [ ] Top-row squid kill = 30 pts, middle crab = 20 pts, bottom octopus = 10 pts
- [ ] Get hit → ship disappears, LIVES ticks 3→2→1→0 with brighter flash + red `−1` popup
- [ ] After pool empty, additional deaths are permanent
- [ ] All ships dead + lives = 0 → gameover with team score
- [ ] Two devices on same room — both render same HUD, both see same LIVES tick
- [ ] Transport badge bottom-left: P2P green if connected, RELAY yellow/red otherwise
- [ ] `?clean` hides the diagnostic chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)