### PR TITLE
arcade(shared): one touch tap = one action (fix initials letter-skip)

### DIFF
--- a/docs/arcade/shared/overlays.css
+++ b/docs/arcade/shared/overlays.css
@@ -102,6 +102,7 @@
   align-items: center;
   gap: 12px;
   margin-top: 8px;
+  touch-action: none;
 }
 .gameover .go-initials-label {
   font-size: clamp(10px, 1.5vw, 13px);
@@ -121,6 +122,14 @@
   min-width: 1ch;
   padding: 0 4px;
   border-bottom: 4px solid var(--go-slot-border, rgba(255, 216, 74, 0.3));
+  /* The slots are the tap targets, so lock gestures on them directly rather
+     than relying on the body. touch-action isn't inherited, and iOS ignores
+     user-scalable=no — so without this a double-tap zooms and a long-press
+     opens the iOS callout (Copy / Look Up / Search). Mirrors the canvas lock. */
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
 }
 .gameover .go-slot.is-active {
   border-bottom-color: var(--go-slot-active-border, #2dd4ff);

--- a/docs/arcade/shared/touch.js
+++ b/docs/arcade/shared/touch.js
@@ -13,20 +13,37 @@
 
   function bind(btn, onDown, onUp) {
     if (!btn) return;
+    // One press = one onDown, one release = one onUp. A single touch tap fires
+    // BOTH pointerdown and pointerenter (on no-hover devices pointerenter fires
+    // as a result of pointerdown, with buttons===1), and a release fires both
+    // pointerup and pointerleave. Without this latch each tap fired twice —
+    // harmless for idempotent movement keys, but the initials screen advances a
+    // letter per call, so taps skipped letters (A-C-E…) and slot/save misfired.
+    let pressed = false;
     const down = e => {
       // Release the implicit pointer capture a touch grabs on touchstart —
       // without this the first button keeps receiving events for the whole
       // gesture, so sliding a thumb from ◀ onto ▶ never fires ▶'s events
       // (you'd have to lift and re-tap). Releasing it lets pointerenter/leave
-      // fire on the other buttons as the finger slides across them.
+      // fire on the other buttons as the finger slides across them. This runs
+      // on every pointerdown regardless of the latch — touch fires pointerenter
+      // before pointerdown, so latching first would skip the release.
       if (e && e.pointerId != null && btn.hasPointerCapture && btn.hasPointerCapture(e.pointerId)) {
         try { btn.releasePointerCapture(e.pointerId); } catch (_) {}
       }
       if (e) e.preventDefault();
+      if (pressed) return;
+      pressed = true;
       btn.classList.add('is-pressed');
       onDown();
     };
-    const up   = e => { if (e) e.preventDefault(); btn.classList.remove('is-pressed'); onUp(); };
+    const up   = e => {
+      if (e) e.preventDefault();
+      if (!pressed) return;
+      pressed = false;
+      btn.classList.remove('is-pressed');
+      onUp();
+    };
     btn.addEventListener('pointerdown', down);
     btn.addEventListener('pointerup', up);
     btn.addEventListener('pointercancel', up);

--- a/docs/arcade/shared/touch.test.cjs
+++ b/docs/arcade/shared/touch.test.cjs
@@ -1,0 +1,115 @@
+// Regression test for Arcade.Touch.bind — run with `node touch.test.cjs`.
+//
+// Bug: on touch devices a single tap fires BOTH pointerdown AND pointerenter
+// (MDN: on no-hover devices pointerenter fires "as a result of pointerdown",
+// with buttons===1 for the whole contact). bind() calls onDown from both
+// listeners, so a tap invoked onDown twice. Harmless for idempotent movement
+// key-flags, but the initials screen's letter-next/advance mutate on every
+// call — so each tap advanced two letters (A-C-E…) and slot/submit misfired.
+//
+// We load the REAL touch.js into a minimal DOM stub and assert a tap presses
+// exactly once, while a slide from one button onto another still presses the
+// destination once (the feature we must not break).
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function makeButton() {
+  const listeners = {};
+  const captured = new Set();
+  const btn = {
+    dataset: {}, style: {},
+    classList: {
+      _s: new Set(),
+      add(c) { this._s.add(c); }, remove(c) { this._s.delete(c); },
+      contains(c) { return this._s.has(c); },
+    },
+    setAttribute() {}, getAttribute() { return null; },
+    hasPointerCapture(id) { return captured.has(id); },
+    setPointerCapture(id) { captured.add(id); },
+    releasePointerCapture(id) { captured.delete(id); },
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+    closest() { return null; },
+    fire(type, props = {}) {
+      const e = { type, target: btn, pointerId: 1, pointerType: 'touch',
+                  preventDefault() {}, stopPropagation() {}, ...props };
+      (listeners[type] || []).forEach(fn => fn(e));
+    },
+  };
+  return btn;
+}
+
+// Load the real source into a sandbox where `window` is the global object.
+const code = fs.readFileSync(path.join(__dirname, 'touch.js'), 'utf8');
+const sandbox = {};
+sandbox.window = sandbox;
+sandbox.matchMedia = () => ({ matches: false });
+sandbox.document = { addEventListener() {} };
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+const bind = sandbox.Arcade.Touch.bind;
+
+let failures = 0;
+function check(label, got, want) {
+  const ok = got === want;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${got}, want ${want}`);
+  if (!ok) failures++;
+}
+
+// --- Case 1: a single touch tap presses exactly once ------------------------
+{
+  const a = makeButton();
+  let down = 0, up = 0;
+  bind(a, () => down++, () => up++);
+  // Real touch tap, per MDN ordering (enter fires alongside down, buttons=1):
+  a.fire('pointerover',  { buttons: 1 });
+  a.fire('pointerenter', { buttons: 1 });
+  a.fire('pointerdown',  { buttons: 1 });
+  a.fire('pointerup',    { buttons: 0 });
+  a.fire('pointerout',   { buttons: 0 });
+  a.fire('pointerleave', { buttons: 0 });
+  check('tap -> onDown once', down, 1);
+  check('tap -> onUp once',   up,   1);
+}
+
+// --- Case 2: sliding a held finger from B onto A presses A once -------------
+//     (the slide feature must keep working after the fix)
+{
+  const a = makeButton(), b = makeButton();
+  let aDown = 0, aUp = 0, bDown = 0, bUp = 0;
+  bind(a, () => aDown++, () => aUp++);
+  bind(b, () => bDown++, () => bUp++);
+  // finger lands on B
+  b.fire('pointerover',  { buttons: 1 });
+  b.fire('pointerenter', { buttons: 1 });
+  b.fire('pointerdown',  { buttons: 1 });
+  // finger slides off B onto A while still held
+  b.fire('pointerleave', { buttons: 1 });
+  a.fire('pointerenter', { buttons: 1 });
+  // finger lifts on A
+  a.fire('pointerup',    { buttons: 0 });
+  a.fire('pointerleave', { buttons: 0 });
+  check('slide B->A presses B once', bDown, 1);
+  check('slide B->A releases B once', bUp, 1);
+  check('slide B->A presses A once',  aDown, 1);
+  check('slide B->A releases A once', aUp, 1);
+}
+
+// --- Case 3: implicit capture grabbed at pointerdown is still released ------
+//     even though pointerenter already fired onDown first (touch fires enter
+//     before down, when capture isn't set yet). The release is what lets the
+//     finger slide onto neighbouring buttons — it must not be skipped.
+{
+  const a = makeButton();
+  let down = 0;
+  bind(a, () => down++, () => {});
+  a.fire('pointerenter', { buttons: 1 });   // onDown #1; no capture set yet
+  a.setPointerCapture(1);                   // UA grabs implicit capture at pointerdown
+  a.fire('pointerdown',  { buttons: 1 });   // must release capture, must NOT re-fire onDown
+  check('implicit capture released on pointerdown', a.hasPointerCapture(1), false);
+  check('pointerdown after enter does not re-fire onDown', down, 1);
+}
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What

A single touch tap on the on-screen ◀ ▶ FIRE buttons fired the press handler **twice**, so on the high-score **initials** screen each tap advanced two letters (A‑C‑E…, odd letters like **H** unreachable) and the third-slot / save behaved erratically. Reported by a real player (kid testing invaders SP).

## Why

`Arcade.Touch.bind` (`docs/arcade/shared/touch.js`) called `onDown` from both `pointerdown` **and** `pointerenter` (the latter to support sliding a thumb between buttons). On no-hover touch devices `pointerenter` fires as a result of `pointerdown` with `buttons===1`, so one tap hit both listeners. Invisible during play (movement just sets an idempotent key flag) but the initials screen calls `Initials.action()` per press, which *increments*.

## Fix

Latch each binding: **one press = one `onDown`, one release = one `onUp`**. The implicit-capture release still runs on every `pointerdown` (touch fires `pointerenter` first, before capture is set), so thumb-sliding across buttons keeps working.

Affects both games sharing the helper: **invaders (SP)** and **space-jumper**.

## Tests

`docs/arcade/shared/touch.test.cjs` loads the real module and replays the documented touch sequence:

- tap → `onDown`/`onUp` once each (was twice)
- slide ◀→▶ still presses the target once
- implicit capture still released on `pointerdown` (slide stays enabled)

Run: `node docs/arcade/shared/touch.test.cjs`

No CHANGELOG entry (arcade changes are out of scope per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)