### PR TITLE
arcade(invaders-mp): Phase E — shared shields + tighten invader grid

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -44,6 +44,8 @@ export interface GameState {
   bullets: Bullet[];
   invaderBullets: Bullet[];
   invaders: Invader[];
+  /** Flat shared shield bitmap; 1 = solid, 0 = chipped. Length = SHIELD_COUNT * SHIELD_W * SHIELD_H. */
+  shields: Uint8Array;
   invaderDir: 1 | -1;
   invaderDropRemaining: number;
   invaderFireAccum: number;
@@ -71,6 +73,8 @@ export interface WireSnapshot {
   invaders: Array<{ x: number; y: number; a: boolean }>;
   /** Authoritative swarm animation frame (0 or 1). */
   iFrame: 0 | 1;
+  /** Packed shield bitmap (base64 of SHIELD_COUNT * SHIELD_W * SHIELD_H bits). */
+  shieldsBits: string;
   /**
    * Per-seat occupancy. Set by the transport layer (room.ts on the
    * server, hostTick on the client) after snapshotForClient returns,
@@ -96,6 +100,10 @@ export const INV_H: number;
 export const INV_COLS: number;
 export const ROW_POINTS: readonly number[];
 export const STARTING_LIVES: number;
+export const SHIELD_W: number;
+export const SHIELD_H: number;
+export const SHIELD_COUNT: number;
+export const SHIELD_Y: number;
 
 export const SEATS: readonly Seat[];
 export const MAX_SEATS: number;
@@ -109,3 +117,6 @@ export function step(
   occupied?: Record<Seat, boolean>,
 ): void;
 export function snapshotForClient(state: GameState): WireSnapshot;
+export function encodeShields(bits: Uint8Array): string;
+export function decodeShields(b64: string): Uint8Array;
+export function shieldOffsets(): number[];

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -396,7 +396,8 @@ function resolveCollisions(state, occupied) {
   // Player bullets vs shields, FIRST — a bullet that clipped the top
   // of a shield never reaches an invader, so we resolve shields before
   // invader hits. Killed bullets are flagged with the out-of-bounds
-  // marker (-999) and swept by the next stepBullets.
+  // marker (-999); the .filter sweep at the bottom of this function
+  // removes them in the same tick (no carry-over to next step).
   for (const b of state.bullets) {
     if (b.y < -BULLET_H) continue;
     if (damageShields(state, b.x, b.y, BULLET_W, BULLET_H)) {
@@ -404,8 +405,8 @@ function resolveCollisions(state, occupied) {
     }
   }
 
-  // Player bullets vs invaders. Out-of-array marker (b.y = -999) gets
-  // swept by the next stepBullets — cheaper than splicing inside
+  // Player bullets vs invaders. Out-of-array marker (b.y = -999) is
+  // filtered out at the bottom of this function — cheaper than splicing inside
   // a nested loop. Points are credited to the bullet's owner using
   // the row of the killed invader (top row = squid = 30, bottom row
   // = octopus = 10).
@@ -498,9 +499,10 @@ export function encodeShields(bits) {
   for (let i = 0; i < bits.length; i++) {
     if (bits[i]) packed[i >> 3] |= 1 << (7 - (i & 7));
   }
-  let bin = '';
-  for (let i = 0; i < packed.length; i++) bin += String.fromCharCode(packed[i]);
-  return btoa(bin);
+  // Single-call fromCharCode via spread — avoids the repeated string
+  // allocation + GC churn of `bin += ...` in a loop. The packed
+  // bitmap is 176 bytes, well under JS engines' call-arg limits.
+  return btoa(String.fromCharCode.apply(null, packed));
 }
 
 // Inverse of encodeShields — client-side, takes the base64 string

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -41,15 +41,18 @@ const INV_BULLET_SPEED = 120;
 
 // === Invaders ===
 const INV_ROWS = 5;
-// 11 columns to match SP. With INV_GAP_X=18 and INV_W=12, the grid
-// spans (11-1)*18 + 12 = 192 PF units wide; centred in the PF=260
-// playfield leaves a (260-192)/2 = 34 PF left/right margin.
+// 11 columns to match SP. Cells are 18×16 (sprites render at 2×
+// scale, so the 8×8 source sprite paints 16×16 with 1px padding
+// inside the 18-wide cell). With INV_GAP_X = 18 the cells touch
+// edge-to-edge, giving the dense SP look. Grid spans
+// (11-1)*18 + 18 = 198 PF wide; centred in PF=260 leaves
+// (260-198)/2 = 31 PF margin each side.
 export const INV_COLS = 11;
-export const INV_W = 12;
-export const INV_H = 8;
+export const INV_W = 18;
+export const INV_H = 16;
 const INV_GAP_X = 18;
-const INV_GAP_Y = 14;
-const INV_ORIGIN_X = 34;
+const INV_GAP_Y = 19;            // 16-tall sprite + 3 PF row gap
+const INV_ORIGIN_X = 31;
 const INV_ORIGIN_Y = 24;
 const INV_DROP = 8;
 // Per-row point value, top→bottom. Matches SP — top row (squid) is
@@ -65,6 +68,56 @@ const INV_SPEED_MIN  = 20;
 // teleport at the current tick rate.
 const INV_DROP_SPEED = 64;
 const INV_FIRE_INTERVAL = 1.4;
+
+// === Shields ===
+// 4 destructible bunkers between the swarm and the ship row, ported
+// from SP. Shared across all players in MP: the whole team shoots
+// through the same bunkers and both player + invader bullets chip
+// the same bitmap. State lives in state.shields as a flat Uint8Array
+// of length SHIELD_COUNT * SHIELD_W * SHIELD_H (each cell 0 or 1).
+export const SHIELD_W = 22;
+export const SHIELD_H = 16;
+export const SHIELD_COUNT = 4;
+export const SHIELD_Y = SHIP_Y - 30;            // sits just above the ship row
+const SHIELD_GAP = (PF_W - SHIELD_W * SHIELD_COUNT) / (SHIELD_COUNT + 1);
+// Pre-computed left-x of each shield — collision + render reuse.
+const SHIELD_X = [];
+for (let s = 0; s < SHIELD_COUNT; s++) SHIELD_X.push(SHIELD_GAP + s * (SHIELD_W + SHIELD_GAP));
+
+// Classic Invaders bunker silhouette: dome top + flat sides + a small
+// arched alcove at the bottom centre so the ship can crouch under it.
+// Each row is SHIELD_W chars; 'X' = solid, anything else = empty.
+const SHIELD_SHAPE = [
+  '.....XXXXXXXXXXXX.....',
+  '...XXXXXXXXXXXXXXXX...',
+  '..XXXXXXXXXXXXXXXXXX..',
+  '.XXXXXXXXXXXXXXXXXXXX.',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXXXXXXXXXXXXXXXX',
+  'XXXXXXXX......XXXXXXXX',
+  'XXXXXXX........XXXXXXX',
+  'XXXXXXX........XXXXXXX',
+  'XXXXXXX........XXXXXXX',
+];
+function makeShields() {
+  const buf = new Uint8Array(SHIELD_COUNT * SHIELD_W * SHIELD_H);
+  for (let s = 0; s < SHIELD_COUNT; s++) {
+    const base = s * SHIELD_W * SHIELD_H;
+    for (let y = 0; y < SHIELD_H; y++) {
+      const row = SHIELD_SHAPE[y];
+      for (let x = 0; x < SHIELD_W; x++) {
+        buf[base + y * SHIELD_W + x] = row[x] === 'X' ? 1 : 0;
+      }
+    }
+  }
+  return buf;
+}
 
 // === Lives + respawn ===
 // Shared pool of respawn tokens. 3 means up to 3 ship deaths get
@@ -124,6 +177,10 @@ export function initState() {
     bullets: [],
     invaderBullets: [],
     invaders: buildGrid(),
+    // Shared destructible shields — flat Uint8Array of all
+    // SHIELD_COUNT bunkers. Bullets chip cells to 0; renderer reads
+    // the bitmap directly.
+    shields: makeShields(),
     invaderDir: 1,
     invaderDropRemaining: 0,
     invaderFireAccum: 0,
@@ -293,7 +350,48 @@ function stepInvaderFire(state, dt) {
   });
 }
 
+// Chip the shared shield bitmap where a bullet AABB overlaps.
+// Returns true if at least one solid cell was destroyed (caller kills
+// the bullet on hit). Walks only the overlap region — typically a
+// 2×6 (player bullet) or 2×6 (invader bullet) cell window, so this
+// stays cheap even with many bullets.
+function damageShields(state, bx, by, bw, bh) {
+  for (let s = 0; s < SHIELD_COUNT; s++) {
+    const sx = SHIELD_X[s];
+    if (bx + bw <= sx || bx >= sx + SHIELD_W) continue;
+    if (by + bh <= SHIELD_Y || by >= SHIELD_Y + SHIELD_H) continue;
+    const base = s * SHIELD_W * SHIELD_H;
+    const xLo = Math.max(0, Math.floor(bx - sx));
+    const xHi = Math.min(SHIELD_W, Math.ceil(bx + bw - sx));
+    const yLo = Math.max(0, Math.floor(by - SHIELD_Y));
+    const yHi = Math.min(SHIELD_H, Math.ceil(by + bh - SHIELD_Y));
+    let hit = false;
+    for (let y = yLo; y < yHi; y++) {
+      const row = base + y * SHIELD_W;
+      for (let x = xLo; x < xHi; x++) {
+        if (state.shields[row + x]) {
+          state.shields[row + x] = 0;
+          hit = true;
+        }
+      }
+    }
+    if (hit) return true;       // a bullet only hits one shield at a time
+  }
+  return false;
+}
+
 function resolveCollisions(state, occupied) {
+  // Player bullets vs shields, FIRST — a bullet that clipped the top
+  // of a shield never reaches an invader, so we resolve shields before
+  // invader hits. Killed bullets are flagged with the out-of-bounds
+  // marker (-999) and swept by the next stepBullets.
+  for (const b of state.bullets) {
+    if (b.y < -BULLET_H) continue;
+    if (damageShields(state, b.x, b.y, BULLET_W, BULLET_H)) {
+      b.y = -999;
+    }
+  }
+
   // Player bullets vs invaders. Out-of-array marker (b.y = -999) gets
   // swept by the next stepBullets — cheaper than splicing inside
   // a nested loop. Points are credited to the bullet's owner using
@@ -314,6 +412,16 @@ function resolveCollisions(state, occupied) {
     }
   }
   state.bullets = state.bullets.filter(b => b.y > -BULLET_H);
+
+  // Invader bullets vs shields, FIRST — chip the bunkers, kill the
+  // bullet, before any per-ship check. A bullet that hit a shield
+  // never reaches the ship below it.
+  for (const b of state.invaderBullets) {
+    if (b.y > PF_H) continue;
+    if (damageShields(state, b.x, b.y, BULLET_W, BULLET_H)) {
+      b.y = PF_H + 999;
+    }
+  }
 
   // Invader bullets vs ships. Skip unoccupied seats AND ships that
   // are in their post-respawn invulnerability window. On hit: if the
@@ -368,6 +476,39 @@ function overlap(ax, ay, aw, ah, bx, by, bw, bh) {
 
 function round(n) { return Math.round(n * 10) / 10; }
 
+// Pack the SHIELD_COUNT * SHIELD_W * SHIELD_H bit array into a
+// base64 string for the wire. 1408 bits / 8 = 176 bytes → ~236
+// chars of base64. Renders the whole bitmap, no diff/RLE — easy to
+// reason about, trivial bandwidth. btoa is supported in both
+// browsers and Cloudflare Workers.
+export function encodeShields(bits) {
+  const packed = new Uint8Array((bits.length + 7) >> 3);
+  for (let i = 0; i < bits.length; i++) {
+    if (bits[i]) packed[i >> 3] |= 1 << (7 - (i & 7));
+  }
+  let bin = '';
+  for (let i = 0; i < packed.length; i++) bin += String.fromCharCode(packed[i]);
+  return btoa(bin);
+}
+
+// Inverse of encodeShields — client-side, takes the base64 string
+// from the wire and returns the bits Uint8Array suitable for direct
+// rendering.
+export function decodeShields(b64) {
+  const bin = atob(b64);
+  const bits = new Uint8Array(SHIELD_COUNT * SHIELD_W * SHIELD_H);
+  for (let i = 0; i < bits.length; i++) {
+    if (bin.charCodeAt(i >> 3) & (1 << (7 - (i & 7)))) bits[i] = 1;
+  }
+  return bits;
+}
+
+// Public accessor for the per-shield left-x positions — the renderer
+// uses these to translate the bitmap into world coordinates.
+export function shieldOffsets() {
+  return SHIELD_X.slice();
+}
+
 export function snapshotForClient(state) {
   let teamScore = 0;
   for (const s of SEATS) teamScore += state.ships[s].score | 0;
@@ -408,5 +549,10 @@ export function snapshotForClient(state) {
     // client renders the same pose at the same tick instead of each
     // running its own time-based ticker.
     iFrame:         state.invaderFrame,
+    // Packed shield bitmap (~236 chars). Every snapshot includes
+    // the full bitmap — small enough that diffing or change-tracking
+    // would be premature optimisation. Client decodes once per
+    // snapshot and renders straight from the resulting Uint8Array.
+    shieldsBits:    encodeShields(state.shields),
   };
 }

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -41,17 +41,20 @@ const INV_BULLET_SPEED = 120;
 
 // === Invaders ===
 const INV_ROWS = 5;
-// 11 columns to match SP. Cells are 18×16 (sprites render at 2×
-// scale, so the 8×8 source sprite paints 16×16 with 1px padding
-// inside the 18-wide cell). With INV_GAP_X = 18 the cells touch
-// edge-to-edge, giving the dense SP look. Grid spans
-// (11-1)*18 + 18 = 198 PF wide; centred in PF=260 leaves
-// (260-198)/2 = 31 PF margin each side.
+// SP parity: 11 cols, 18×12 cells, sprites rendered at 1.5× so an
+// 8×8 source paints 12×12, with 3 PF padding inside the 18-wide cell.
+// INV_GAP_X = 18 → cells touch edge-to-edge. INV_GAP_Y = 15 → 3 PF
+// row gap (sprite 12 tall + 3 = 15). Grid spans 11*18 = 198 PF in
+// PF=260 → 31 PF margin each side. Fractional sprite scale is fine
+// here because cellX/cellY are Math.round'd in the renderer, so the
+// within-sprite fractional offsets are constant per-frame (anti-
+// aliased edges stay still — no flicker; only positions changing
+// per-frame caused the old shimmer).
 export const INV_COLS = 11;
 export const INV_W = 18;
-export const INV_H = 16;
+export const INV_H = 12;
 const INV_GAP_X = 18;
-const INV_GAP_Y = 19;            // 16-tall sprite + 3 PF row gap
+const INV_GAP_Y = 15;
 const INV_ORIGIN_X = 31;
 const INV_ORIGIN_Y = 24;
 const INV_DROP = 8;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -82,10 +82,19 @@ export const SHIELD_W = 22;
 export const SHIELD_H = 16;
 export const SHIELD_COUNT = 4;
 export const SHIELD_Y = SHIP_Y - 30;            // sits just above the ship row
-const SHIELD_GAP = (PF_W - SHIELD_W * SHIELD_COUNT) / (SHIELD_COUNT + 1);
-// Pre-computed left-x of each shield — collision + render reuse.
+// Pre-computed left-x of each shield — integer PF coords so fillRect
+// stays on whole device pixels (fractional positions would anti-alias
+// edges and make collision math vary with sub-pixel offsets). With
+// PF_W=260, 4×22 wide + 5 gaps = 172 PF for 5 gaps → 34 base each +
+// 2 remainder. Spread the remainder symmetrically into the outermost
+// (left + right) margins so shields stay centred.
+const SHIELD_BASE_GAP = Math.floor((PF_W - SHIELD_W * SHIELD_COUNT) / (SHIELD_COUNT + 1));
+const SHIELD_REM      = PF_W - SHIELD_W * SHIELD_COUNT - SHIELD_BASE_GAP * (SHIELD_COUNT + 1);
+const SHIELD_LEFT_PAD = SHIELD_BASE_GAP + Math.ceil(SHIELD_REM / 2);
 const SHIELD_X = [];
-for (let s = 0; s < SHIELD_COUNT; s++) SHIELD_X.push(SHIELD_GAP + s * (SHIELD_W + SHIELD_GAP));
+for (let s = 0; s < SHIELD_COUNT; s++) {
+  SHIELD_X.push(SHIELD_LEFT_PAD + s * (SHIELD_W + SHIELD_BASE_GAP));
+}
 
 // Classic Invaders bunker silhouette: dome top + flat sides + a small
 // arched alcove at the bottom centre so the ship can crouch under it.

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -363,7 +363,7 @@
     decodeShields, shieldOffsets,
     SEATS, MAX_SEATS,
   } from './engine.js';
-  import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
+  import { ROW_COLORS, spriteForRow, getInvaderSprite, paintShip } from './sprites.js';
   // Mirror engine.js's INV_COLS instead of named-importing it. Named
   // imports of missing exports are a hard module-link error: if an old
   // edge-cached engine.js gets paired with this fresh index.html (rare
@@ -1236,6 +1236,9 @@
   // ship + ghost bullets layered on top.
   const canvas = document.getElementById('cv');
   const ctx = canvas.getContext('2d');
+  // Crisp pixel-art upscaling for all drawImage calls (used by the
+  // invader sprite blitter). fillRect / fillText aren't affected.
+  ctx.imageSmoothingEnabled = false;
 
   function fitCanvas() {
     // Measure the tube, not the screen — the screen includes bezel
@@ -1420,28 +1423,27 @@
     // 0 if an older snapshot somehow lacks the field.
     const n = Math.min(a.invaders.length, b.invaders.length);
     const frame = ((alpha < 0.5 ? a.iFrame : b.iFrame) ?? 0) & 1;
+    // 1.5× SP-exact sprite scale (8-px source paints 12 PF visible).
+    // Painting with fillRect at fractional coords smears edges; instead
+    // we grab a pre-rendered 1:1 offscreen canvas for each (row, frame)
+    // and let drawImage do nearest-neighbour upscale. Sprites are
+    // LEFT-aligned in the 18 PF cell (not centred), matching SP's
+    // invaders/index.html: the consistent right-padding produces a
+    // uniform 6 PF visible gap between sprite edges. Squid is 9 PF
+    // wide (vs 12 for crab/octopus) so SP nudges it +2 PF rightward
+    // to keep columns lining up; we mirror that.
+    const SPRITE_SCALE = 1.5;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide
       const row = Math.floor(i / SPRITE_COLS);
-      const { frames, w } = spriteForRow(row);
-      // Centre the sprite in the engine's INV_W cell so collisions
-      // (which use INV_W) stay aligned with what the eye sees. Snap
-      // to integer playfield pixels — fillRect at fractional coords
-      // anti-aliases each sprite-pixel's edge across two screen pixels
-      // at varying alpha, which reads as flicker during continuous
-      // motion. Rounding makes the swarm step pixel-by-pixel (the
-      // pixel-art look) instead of sub-pixel sliding.
-      // 1.5× sprite scale = SP-exact match. 8-px source sprite paints
-      // 12 PF wide inside the 18 PF cell with 3 PF padding each side.
-      // Fractional scale is OK because cellX/cellY are Math.round'd —
-      // the within-sprite offsets are then constant per-frame, so
-      // anti-aliased edges stay still (no flicker on the canvas
-      // bitmap, just slightly soft edges when CSS-upscaled).
-      const SPRITE_SCALE = 1.5;
-      const cellX = Math.round(lerp(ia.x, ib.x) + (INV_W - w * SPRITE_SCALE) / 2);
+      const sprite = getInvaderSprite(row, frame);
+      const dstW = Math.round(sprite.w * SPRITE_SCALE);
+      const dstH = Math.round(sprite.h * SPRITE_SCALE);
+      const ox  = row === 0 ? 2 : 0;     // SP-style squid nudge
+      const cellX = Math.round(lerp(ia.x, ib.x) + ox);
       const cellY = Math.round(lerp(ia.y, ib.y));
-      paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, ROW_COLORS[row] || '#ffffff');
+      ctx.drawImage(sprite.canvas, cellX, cellY, dstW, dstH);
     }
 
     // Shields — decode the packed bitmap from the snapshot once when

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -32,8 +32,12 @@
   }
   .tube canvas {
     width: auto; height: auto;
-    image-rendering: pixelated;
-    image-rendering: crisp-edges;
+    /* No image-rendering — fitCanvas sizes the canvas to its CSS
+       display size × DPR (SP's approach), so there's no
+       browser-level upscale to control. The canvas bitmap is at
+       device-pixel resolution; the in-engine ctx.setTransform maps
+       PF coords directly. Crisp at any scale, no nearest-neighbour
+       8→12 warping. */
   }
 
   /* Touch-device safe-area. Shared cabinet.css drops .screen padding
@@ -363,7 +367,7 @@
     decodeShields, shieldOffsets,
     SEATS, MAX_SEATS,
   } from './engine.js';
-  import { ROW_COLORS, spriteForRow, getInvaderSprite, paintShip } from './sprites.js';
+  import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
   // Mirror engine.js's INV_COLS instead of named-importing it. Named
   // imports of missing exports are a hard module-link error: if an old
   // edge-cached engine.js gets paired with this fresh index.html (rare
@@ -1236,30 +1240,37 @@
   // ship + ghost bullets layered on top.
   const canvas = document.getElementById('cv');
   const ctx = canvas.getContext('2d');
-  // Crisp pixel-art upscaling for all drawImage calls (used by the
-  // invader sprite blitter). fillRect / fillText aren't affected.
-  ctx.imageSmoothingEnabled = false;
-
   function fitCanvas() {
-    // Measure the tube, not the screen — the screen includes bezel
-    // padding; the tube is the actual visible playfield area. Subtract
-    // a small slack so the canvas doesn't touch the rounded-glass
-    // corners.
-    //
-    // Use the largest scale that preserves the 260:280 aspect. We
-    // *don't* floor to integers: on a laptop the available scale is
-    // ~3.6× and on an iPhone portrait it's ~1.6×, both of which round
-    // down to 3 and 1 — wasting ~25% of the playfield area in either
-    // direction. Fractional scales are crisp because the canvas has
-    // image-rendering: pixelated (nearest-neighbour upscale, so each
-    // sprite pixel maps to a whole number of screen pixels even if
-    // the multiplier is fractional).
+    // Match SP's rendering pipeline: canvas bitmap is sized to the
+    // CSS display size × devicePixelRatio, so each canvas pixel = one
+    // device pixel. ctx.setTransform then maps PF coords to canvas
+    // pixels at a floating-point scale. This avoids the "fixed PF
+    // bitmap, then CSS-upscale-with-nearest-neighbour" approach,
+    // which warped 8-px source sprites into asymmetric 1/2-PF-wide
+    // columns when scaled to 12 PF visible. At display resolution
+    // any fillRect anti-aliasing is sub-pixel and invisible.
     const tube = canvas.parentElement;          // .tube
     const sw = tube.clientWidth  - 16;
     const sh = tube.clientHeight - 16;
     const scale = Math.max(1, Math.min(sw / PF_W, sh / PF_H));
-    canvas.style.width  = Math.round(PF_W * scale) + 'px';
-    canvas.style.height = Math.round(PF_H * scale) + 'px';
+    const cssW = Math.round(PF_W * scale);
+    const cssH = Math.round(PF_H * scale);
+    const dpr  = window.devicePixelRatio || 1;
+    canvas.style.width  = cssW + 'px';
+    canvas.style.height = cssH + 'px';
+    canvas.width  = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    // setTransform replaces the matrix (cheap on resize), maps the
+    // 260×280 PF playfield onto the full canvas pixel grid. All
+    // existing render code uses PF coords — no per-call changes.
+    const px = canvas.width / PF_W;
+    ctx.setTransform(px, 0, 0, px, 0, 0);
+    // Re-enable smooth interpolation for the invader drawImage path
+    // — at display resolution the bilinear filter actually looks
+    // crisper than nearest-neighbour because it averages within a
+    // sub-pixel where the eye can't resolve individual pixels.
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
   }
   window.addEventListener('resize', fitCanvas);
   window.addEventListener('orientationchange', fitCanvas);
@@ -1423,27 +1434,23 @@
     // 0 if an older snapshot somehow lacks the field.
     const n = Math.min(a.invaders.length, b.invaders.length);
     const frame = ((alpha < 0.5 ? a.iFrame : b.iFrame) ?? 0) & 1;
-    // 1.5× SP-exact sprite scale (8-px source paints 12 PF visible).
-    // Painting with fillRect at fractional coords smears edges; instead
-    // we grab a pre-rendered 1:1 offscreen canvas for each (row, frame)
-    // and let drawImage do nearest-neighbour upscale. Sprites are
-    // LEFT-aligned in the 18 PF cell (not centred), matching SP's
-    // invaders/index.html: the consistent right-padding produces a
-    // uniform 6 PF visible gap between sprite edges. Squid is 9 PF
-    // wide (vs 12 for crab/octopus) so SP nudges it +2 PF rightward
-    // to keep columns lining up; we mirror that.
+    // SP-exact rendering: paintPixels draws each 8×8 source pixel as
+    // a 1.5×1.5 PF fillRect on the canvas. fitCanvas sized the canvas
+    // to display resolution × DPR, so fillRect's anti-aliased edges
+    // are at sub-device-pixel level and invisible. Sprites are
+    // LEFT-aligned in the 18 PF cell (not centred) for SP's uniform
+    // 6 PF right-padding gap; squid (9 PF wide) gets the SP-style
+    // +2 PF rightward nudge to align columns under the wider rows.
     const SPRITE_SCALE = 1.5;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide
       const row = Math.floor(i / SPRITE_COLS);
-      const sprite = getInvaderSprite(row, frame);
-      const dstW = Math.round(sprite.w * SPRITE_SCALE);
-      const dstH = Math.round(sprite.h * SPRITE_SCALE);
-      const ox  = row === 0 ? 2 : 0;     // SP-style squid nudge
+      const { frames, w } = spriteForRow(row);
+      const ox = row === 0 ? 2 : 0;
       const cellX = Math.round(lerp(ia.x, ib.x) + ox);
       const cellY = Math.round(lerp(ia.y, ib.y));
-      ctx.drawImage(sprite.canvas, cellX, cellY, dstW, dstH);
+      paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, ROW_COLORS[row] || '#ffffff');
     }
 
     // Shields — decode the packed bitmap from the snapshot once when

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -358,22 +358,29 @@
 <script type="module">
   // Single source of truth for game logic, shared with the server
   // (which bundles this same file via wrangler import).
-  import {
+  // Namespace import (not destructured `import { ... }`) so a missing
+  // export from a stale-cached engine.js doesn't hard-fail the module
+  // link and white-screen the page. Destructure below; any missing
+  // member becomes `undefined` rather than a load-time error, so the
+  // page still renders (just hides the affected feature) during a
+  // brief deploy-crossover window.
+  import * as engine from './engine.js';
+  const {
     initState, step, snapshotForClient, zeroInput,
     PF_W, PF_H, SHIP_W, SHIP_H, SHIP_Y, SHIP_SPEED, FIRE_COOLDOWN,
     BULLET_W, BULLET_H, BULLET_SPEED,
-    INV_W, INV_H,
+    INV_W, INV_H, INV_COLS,
     SHIELD_W, SHIELD_H, SHIELD_COUNT, SHIELD_Y,
     decodeShields, shieldOffsets,
     SEATS, MAX_SEATS,
-  } from './engine.js';
+  } = engine;
   import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
-  // Mirror engine.js's INV_COLS instead of named-importing it. Named
-  // imports of missing exports are a hard module-link error: if an old
-  // edge-cached engine.js gets paired with this fresh index.html (rare
-  // but possible during a deploy crossover), the page wouldn't load
-  // at all. Keep this in sync when engine.js changes the grid width.
-  const SPRITE_COLS = 11;
+  // Renderer uses INV_COLS to map invader array index → grid row. It
+  // happens to equal 11 in the current engine; mirror as a const so a
+  // future engine.INV_COLS change forces an audit here rather than
+  // silently picking up a different value (the sprite-row map +
+  // bullet-fire column logic depend on it).
+  const SPRITE_COLS = INV_COLS ?? 11;
 
   // Register SFX with the shared audio module. The volume/muted keys
   // are the global arcade keys so the slider state carries across

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1432,11 +1432,13 @@
       // at varying alpha, which reads as flicker during continuous
       // motion. Rounding makes the swarm step pixel-by-pixel (the
       // pixel-art look) instead of sub-pixel sliding.
-      // 2× scale matches SP's chunky invader silhouette. Integer
-      // scale keeps every sprite pixel landing on whole PF coords,
-      // so image-rendering: pixelated stays crisp on the canvas
-      // upscale even as the swarm slides.
-      const SPRITE_SCALE = 2;
+      // 1.5× sprite scale = SP-exact match. 8-px source sprite paints
+      // 12 PF wide inside the 18 PF cell with 3 PF padding each side.
+      // Fractional scale is OK because cellX/cellY are Math.round'd —
+      // the within-sprite offsets are then constant per-frame, so
+      // anti-aliased edges stay still (no flicker on the canvas
+      // bitmap, just slightly soft edges when CSS-upscaled).
+      const SPRITE_SCALE = 1.5;
       const cellX = Math.round(lerp(ia.x, ib.x) + (INV_W - w * SPRITE_SCALE) / 2);
       const cellY = Math.round(lerp(ia.y, ib.y));
       paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, ROW_COLORS[row] || '#ffffff');

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1261,16 +1261,15 @@
     canvas.width  = Math.round(cssW * dpr);
     canvas.height = Math.round(cssH * dpr);
     // setTransform replaces the matrix (cheap on resize), maps the
-    // 260×280 PF playfield onto the full canvas pixel grid. All
-    // existing render code uses PF coords — no per-call changes.
-    const px = canvas.width / PF_W;
-    ctx.setTransform(px, 0, 0, px, 0, 0);
-    // Re-enable smooth interpolation for the invader drawImage path
-    // — at display resolution the bilinear filter actually looks
-    // crisper than nearest-neighbour because it averages within a
-    // sub-pixel where the eye can't resolve individual pixels.
-    ctx.imageSmoothingEnabled = true;
-    ctx.imageSmoothingQuality = 'high';
+    // 260×280 PF playfield onto the full canvas pixel grid. Use
+    // separate sx/sy because Math.round on cssW/cssH can leave their
+    // ratios slightly off PF_W:PF_H — a single uniform scale would
+    // sub-pixel-stretch one axis. Independent factors keep the
+    // playfield exactly aligned to canvas edges. All existing render
+    // code uses PF coords — no per-call changes.
+    const sx = canvas.width  / PF_W;
+    const sy = canvas.height / PF_H;
+    ctx.setTransform(sx, 0, 0, sy, 0, 0);
   }
   window.addEventListener('resize', fitCanvas);
   window.addEventListener('orientationchange', fitCanvas);

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -359,6 +359,8 @@
     PF_W, PF_H, SHIP_W, SHIP_H, SHIP_Y, SHIP_SPEED, FIRE_COOLDOWN,
     BULLET_W, BULLET_H, BULLET_SPEED,
     INV_W, INV_H,
+    SHIELD_W, SHIELD_H, SHIELD_COUNT, SHIELD_Y,
+    decodeShields, shieldOffsets,
     SEATS, MAX_SEATS,
   } from './engine.js';
   import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
@@ -397,7 +399,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 21;
+  const NETCODE_VERSION = 22;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1430,9 +1432,38 @@
       // at varying alpha, which reads as flicker during continuous
       // motion. Rounding makes the swarm step pixel-by-pixel (the
       // pixel-art look) instead of sub-pixel sliding.
-      const cellX = Math.round(lerp(ia.x, ib.x) + (INV_W - w) / 2);
+      // 2× scale matches SP's chunky invader silhouette. Integer
+      // scale keeps every sprite pixel landing on whole PF coords,
+      // so image-rendering: pixelated stays crisp on the canvas
+      // upscale even as the swarm slides.
+      const SPRITE_SCALE = 2;
+      const cellX = Math.round(lerp(ia.x, ib.x) + (INV_W - w * SPRITE_SCALE) / 2);
       const cellY = Math.round(lerp(ia.y, ib.y));
-      paintPixels(ctx, cellX, cellY, frames[frame], 1, ROW_COLORS[row] || '#ffffff');
+      paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, ROW_COLORS[row] || '#ffffff');
+    }
+
+    // Shields — decode the packed bitmap from the snapshot once when
+    // it changes, then blit each set cell as a 1×1 PF px rect. Cap is
+    // SHIELD_COUNT * SHIELD_W * SHIELD_H = 1408 cells; canvas handles
+    // this at 60 Hz without breaking sweat. Cyan to match SP's
+    // bunker colour. Hidden until at least one snapshot decodes.
+    if (latestSnap.shieldsBits && latestSnap.shieldsBits !== lastShieldsBits) {
+      shieldBitmap = decodeShields(latestSnap.shieldsBits);
+      lastShieldsBits = latestSnap.shieldsBits;
+    }
+    if (shieldBitmap) {
+      ctx.fillStyle = '#7ad0e0';
+      for (let s = 0; s < SHIELD_COUNT; s++) {
+        const sx = SHIELD_X[s];
+        const base = s * SHIELD_W * SHIELD_H;
+        for (let y = 0; y < SHIELD_H; y++) {
+          const wy = SHIELD_Y + y;
+          const rowBase = base + y * SHIELD_W;
+          for (let x = 0; x < SHIELD_W; x++) {
+            if (shieldBitmap[rowBase + x]) ctx.fillRect(sx + x, wy, 1, 1);
+          }
+        }
+      }
     }
 
     // Bullets — drawn from the latest snapshot (server-authoritative
@@ -1583,6 +1614,14 @@
   // visible evidence — this surfaces both at a glance.
   let lastRTT = null;
   let currentTransport = 'relay';
+
+  // Shield bitmap cache. The wire's `shieldsBits` is a base64 string;
+  // decode once when it changes, render straight from the cached
+  // Uint8Array each frame. SHIELD_X is precomputed by the engine —
+  // grab once at module load.
+  let shieldBitmap = null;
+  let lastShieldsBits = null;
+  const SHIELD_X = shieldOffsets();
   function drawCenteredOverlay(text, color, sizePx) {
     ctx.save();
     ctx.font = sizePx + 'px "Press Start 2P", monospace';

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -46,9 +46,12 @@ export function spriteForRow(row) {
 }
 
 // Paint a bitmap to the canvas in playfield units. Each source pixel
-// becomes a scale × scale rect. Kept exported for ad-hoc use; the
-// invader renderer prefers getInvaderSprite + drawImage so it can
-// land non-integer scales (1.5× SP match) without anti-aliased blur.
+// becomes a scale × scale rect. Used by the invader renderer with
+// scale=1.5 to match SP's drawSquid/drawCrab/drawOctopus pipeline —
+// the canvas is at display resolution (set via fitCanvas), so
+// fractional rects anti-alias at sub-device-pixel level (invisible)
+// rather than warping like they would in a low-res CSS-upscaled
+// bitmap.
 export function paintPixels(ctx, px, py, pixels, scale, color) {
   ctx.fillStyle = color;
   for (let y = 0; y < pixels.length; y++) {
@@ -59,42 +62,6 @@ export function paintPixels(ctx, px, py, pixels, scale, color) {
       }
     }
   }
-}
-
-// Pre-rendered invader sprite cache. Each row/frame combo gets one
-// offscreen canvas at the sprite's native source resolution (8×8 or
-// 6×8), painted once at 1:1 — no fractional pixels in the source.
-// The renderer later does ctx.drawImage(sprite, dx, dy, dstW, dstH)
-// with ctx.imageSmoothingEnabled = false, so the browser does
-// nearest-neighbour upscale to the destination size. That keeps
-// pixels crisp even at non-integer scales (8→12 at SP's 1.5×
-// produces a mix of 1- and 2-PF-wide sprite pixels — the standard
-// pixel-art trade for sub-integer scaling, still sharp not blurry).
-const _invaderCache = new Map();
-export function getInvaderSprite(row, frame) {
-  const key = row * 2 + (frame & 1);
-  const hit = _invaderCache.get(key);
-  if (hit) return hit;
-
-  const { frames, w } = spriteForRow(row);
-  const px = frames[frame & 1];
-  const h = px.length;
-  const color = ROW_COLORS[row] || '#ffffff';
-
-  const canvas = document.createElement('canvas');
-  canvas.width = w;
-  canvas.height = h;
-  const cctx = canvas.getContext('2d');
-  cctx.fillStyle = color;
-  for (let y = 0; y < h; y++) {
-    const rowStr = px[y];
-    for (let x = 0; x < w; x++) {
-      if (rowStr[x] === 'X') cctx.fillRect(x, y, 1, 1);
-    }
-  }
-  const sprite = { canvas, w, h };
-  _invaderCache.set(key, sprite);
-  return sprite;
 }
 
 // Player ship — body sits at shipY (the engine's collision top edge);

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -46,7 +46,9 @@ export function spriteForRow(row) {
 }
 
 // Paint a bitmap to the canvas in playfield units. Each source pixel
-// becomes a scale × scale rect.
+// becomes a scale × scale rect. Kept exported for ad-hoc use; the
+// invader renderer prefers getInvaderSprite + drawImage so it can
+// land non-integer scales (1.5× SP match) without anti-aliased blur.
 export function paintPixels(ctx, px, py, pixels, scale, color) {
   ctx.fillStyle = color;
   for (let y = 0; y < pixels.length; y++) {
@@ -57,6 +59,42 @@ export function paintPixels(ctx, px, py, pixels, scale, color) {
       }
     }
   }
+}
+
+// Pre-rendered invader sprite cache. Each row/frame combo gets one
+// offscreen canvas at the sprite's native source resolution (8×8 or
+// 6×8), painted once at 1:1 — no fractional pixels in the source.
+// The renderer later does ctx.drawImage(sprite, dx, dy, dstW, dstH)
+// with ctx.imageSmoothingEnabled = false, so the browser does
+// nearest-neighbour upscale to the destination size. That keeps
+// pixels crisp even at non-integer scales (8→12 at SP's 1.5×
+// produces a mix of 1- and 2-PF-wide sprite pixels — the standard
+// pixel-art trade for sub-integer scaling, still sharp not blurry).
+const _invaderCache = new Map();
+export function getInvaderSprite(row, frame) {
+  const key = row * 2 + (frame & 1);
+  const hit = _invaderCache.get(key);
+  if (hit) return hit;
+
+  const { frames, w } = spriteForRow(row);
+  const px = frames[frame & 1];
+  const h = px.length;
+  const color = ROW_COLORS[row] || '#ffffff';
+
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const cctx = canvas.getContext('2d');
+  cctx.fillStyle = color;
+  for (let y = 0; y < h; y++) {
+    const rowStr = px[y];
+    for (let x = 0; x < w; x++) {
+      if (rowStr[x] === 'X') cctx.fillRect(x, y, 1, 1);
+    }
+  }
+  const sprite = { canvas, w, h };
+  _invaderCache.set(key, sprite);
+  return sprite;
 }
 
 // Player ship — body sits at shipY (the engine's collision top edge);

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -101,8 +101,10 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 // v22 — Phase E: shared destructible shields (4 bunkers between the
 //        swarm and the ship row). snapshot.shieldsBits carries the
 //        packed bitmap (~236 chars/tick) — both player + invader
-//        bullets chip the same shared bitmap. Invader cells upsized
-//        to 18×16 (sprite render at 2× scale) to match SP density.
+//        bullets chip the same shared bitmap. Invader cells aligned
+//        with SP at 18×12, sprites rendered at 1.5× scale on a
+//        display-resolution canvas (fitCanvas + ctx.setTransform)
+//        for crisp pixel art without warp.
 const NETCODE_VERSION = 22;
 
 type ClientMessage =

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -95,8 +95,15 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        Shared lives pool: state.lives, decremented on each death;
 //        ship.respawnIn + ship.invulnFor drive the 2 s respawn + 1 s
 //        invulnerability grace window. Row-tiered kill points
-//        (30/20/20/10/10 top→bottom) instead of flat 10.
-const NETCODE_VERSION = 21;
+//        (30/20/20/10/10 top→bottom) instead of flat 10. Also adds
+//        a `seats` field to the wire so clients can distinguish
+//        "connected but dead/respawning" from "vacant seat".
+// v22 — Phase E: shared destructible shields (4 bunkers between the
+//        swarm and the ship row). snapshot.shieldsBits carries the
+//        packed bitmap (~236 chars/tick) — both player + invader
+//        bullets chip the same shared bitmap. Invader cells upsized
+//        to 18×16 (sprite render at 2× scale) to match SP density.
+const NETCODE_VERSION = 22;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Two interlocking visual gaps closed in one PR — both called out side-by-side during dogfooding.

## Shared shields

- Engine: \`SHIELD_W/H/COUNT/Y\` constants + \`SHIELD_SHAPE\` (classic dome + alcove, 22×16). \`state.shields\` is a flat Uint8Array of \`SHIELD_COUNT * SHIELD_W * SHIELD_H\` = 1408 cells. \`damageShields(state, bx, by, bw, bh)\` carves cells under a bullet's AABB.
- \`resolveCollisions\` chips shields **first** for both player bullets (up) and invader bullets (down) — a hit that lands on the bunker never reaches the invader / ship below.
- Wire: \`snapshot.shieldsBits\` is the packed bitmap, base64-encoded. 1408 bits = 176 bytes = ~236 chars per tick — cheap and late-joiner-safe without diff/RLE plumbing.
- Client: \`decodeShields()\` once per snapshot, blit each set cell as 1×1 PF rect in SP's cyan (\`#7ad0e0\`). Cache so re-decodes only happen when the bitmap changes.
- Shield positions snapped to integer PF coords (34 PF base gap with the 2-PF remainder spread into the outer margins) so fillRect lands on whole device pixels and collision math is deterministic.

## Match SP's visual pipeline

The previous "fixed 260×280 canvas bitmap + CSS-upscale with image-rendering: pixelated" approach warped 8-px source sprites into asymmetric 1- and 2-PF-wide columns when nearest-neighbour-scaled to 12 PF visible. Tried 2×, 1.5× fillRect, drawImage-with-no-smoothing — all looked bad in different ways.

Real fix: match SP's rendering pipeline.

- \`fitCanvas\` now sizes \`canvas.width/height\` to display CSS size × \`devicePixelRatio\`. The bitmap IS at device-pixel resolution.
- \`ctx.setTransform(sx, 0, 0, sy, 0, 0)\` maps PF coords directly to canvas pixels. Separate sx/sy so independent rounding of width/height doesn't sub-pixel-stretch one axis.
- All existing render code keeps using PF coords — zero per-call changes.
- CSS dropped \`image-rendering: pixelated\` (no upscale happens; display res = canvas res).

Invader renderer uses \`paintPixels\` (each source pixel = a 1.5×1.5 PF fillRect), exactly mirroring SP's \`drawSquid\`/\`drawCrab\`/\`drawOctopus\`. At display res any fillRect anti-aliasing is sub-device-pixel and invisible. Engine constants match SP: \`INV_W=18, INV_H=12, INV_GAP_X=18, INV_GAP_Y=15\`. SP-style left-alignment in cells with squid \`ox=2\` nudge.

## NETCODE_VERSION 21 → 22

## Test plan

- [ ] Deploy: \`cd ~/Dev/oyster.worktrees/invaders-shields/infra/oyster-arcade-mp && npx wrangler deploy\` then \`cd ../oyster-arcade-site && npx wrangler deploy\`
- [ ] Hard-refresh \`arcade.oyster.to/invaders-mp/FROG\`
- [ ] **Sprites**: invaders look exactly like SP — crisp, symmetric, dense grid
- [ ] **Shields**: 4 cyan bunkers between swarm and ship row at startup, symmetric margins
- [ ] **Player bullet chips shield**: notch appears, bullet stops, score doesn't increase
- [ ] **Invader bullet chips shield**: notch appears, bullet stops, lives don't decrement
- [ ] **Shields shared**: P2 chips a shield, P1 sees the same chipped pattern
- [ ] **Fully destroyed**: bunkers can be eroded away; invader bullets get through afterwards
- [ ] \`?debug\` shows \`netcode v22\` no mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)