### PR TITLE
arcade: analog ◀▶ d-pad + slip-proof buttons + stuck-key fix

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -835,15 +835,19 @@ window.addEventListener('keyup', e => keys[e.key] = false);
   const left  = document.getElementById('tc-left');
   const right = document.getElementById('tc-right');
   const fire  = document.getElementById('tc-fire');
-  Arcade.Touch.bind(left,
+  // ◀▶ as one analog d-pad: slip off the edge keeps moving, cross the midline
+  // flips direction, lift stops. (Discrete letter-stepping in initials.)
+  // Release always clears the key — never gate the up-handler on initials, or a
+  // direction held when you die (and the screen flips to initials) sticks into
+  // the next game. Clearing during initials is harmless.
+  Arcade.Touch.movePad(left, right,
     () => { if (Arcade.Initials.isActive()) { Arcade.Initials.action('letter-prev'); return; } keys['ArrowLeft']  = true;  },
-    () => { if (Arcade.Initials.isActive()) return; keys['ArrowLeft']  = false; });
-  Arcade.Touch.bind(right,
+    () => { keys['ArrowLeft']  = false; },
     () => { if (Arcade.Initials.isActive()) { Arcade.Initials.action('letter-next'); return; } keys['ArrowRight'] = true;  },
-    () => { if (Arcade.Initials.isActive()) return; keys['ArrowRight'] = false; });
+    () => { keys['ArrowRight'] = false; });
   Arcade.Touch.bind(fire,
     () => { if (Arcade.Initials.isActive()) { Arcade.Initials.action('advance');     return; } keys[' '] = true; },
-    () => { if (Arcade.Initials.isActive()) return; keys[' '] = false; });
+    () => { keys[' '] = false; });
 })();
 
 // ============================================

--- a/docs/arcade/shared/touch.js
+++ b/docs/arcade/shared/touch.js
@@ -1,59 +1,137 @@
-// Shared touch-button binding helper.
+// Shared touch-control helpers.
 //
-// The game declares its own <button> elements (left/right/jump/thrust/…)
-// and wires each up with Arcade.Touch.bind(btn, onDown, onUp). The helper
-// handles the pointer events (down + up + cancel + leave), the visual
-// `.is-pressed` flip, and stops bubbling so a tap on a button doesn't
-// also fire the splash's global dismiss listener.
+//   Arcade.Touch.bind(btn, onDown, onUp)
+//     A standalone hold/tap button (jump, fire, thrust, launcher prev/next).
+//
+//   Arcade.Touch.movePad(leftBtn, rightBtn, onLeftDown, onLeftUp, onRightDown, onRightUp)
+//     The in-game ◀▶ pair as one analog d-pad (see below).
+//
+// Both stop event bubbling so a press doesn't also fire the splash's global
+// dismiss listener, and both flip the `.is-pressed` visual.
 
 (function () {
   function isCoarse() {
     return !!(window.matchMedia && matchMedia('(pointer: coarse)').matches);
   }
 
+  function initialsActive() {
+    return !!(window.Arcade && window.Arcade.Initials &&
+              window.Arcade.Initials.isActive && window.Arcade.Initials.isActive());
+  }
+
   function bind(btn, onDown, onUp) {
     if (!btn) return;
-    // One press = one onDown, one release = one onUp. A single touch tap fires
-    // BOTH pointerdown and pointerenter (on no-hover devices pointerenter fires
-    // as a result of pointerdown, with buttons===1), and a release fires both
-    // pointerup and pointerleave. Without this latch each tap fired twice —
-    // harmless for idempotent movement keys, but the initials screen advances a
-    // letter per call, so taps skipped letters (A-C-E…) and slot/save misfired.
+    // One press = one onDown, one release = one onUp, and the press is
+    // slip-proof: release fires ONLY on lift (pointerup) or cancel — never on
+    // pointerleave — so sliding a finger off the edge keeps a held jump /
+    // super-shot alive; only lifting ends it. We capture the pointer AND listen
+    // for lift on `window`, matched by pointerId: capture usually keeps events
+    // on the button, but the window listener guarantees release even if capture
+    // didn't take (a finger lifted off the button can't leave the key stuck).
+    // There's deliberately no pointerenter "slide onto me" path — that lived
+    // here once and made a single touch tap fire twice (skip-a-letter /
+    // skip-a-game). Adjacent ◀▶ sliding now lives in movePad().
     let pressed = false;
-    const down = e => {
-      // Release the implicit pointer capture a touch grabs on touchstart —
-      // without this the first button keeps receiving events for the whole
-      // gesture, so sliding a thumb from ◀ onto ▶ never fires ▶'s events
-      // (you'd have to lift and re-tap). Releasing it lets pointerenter/leave
-      // fire on the other buttons as the finger slides across them. This runs
-      // on every pointerdown regardless of the latch — touch fires pointerenter
-      // before pointerdown, so latching first would skip the release.
-      if (e && e.pointerId != null && btn.hasPointerCapture && btn.hasPointerCapture(e.pointerId)) {
-        try { btn.releasePointerCapture(e.pointerId); } catch (_) {}
-      }
-      if (e) e.preventDefault();
-      if (pressed) return;
-      pressed = true;
-      btn.classList.add('is-pressed');
-      onDown();
-    };
-    const up   = e => {
+    let activeId = null;
+    const up = e => {
+      if (e && e.pointerId != null && activeId != null && e.pointerId !== activeId) return;
       if (e) e.preventDefault();
       if (!pressed) return;
       pressed = false;
+      activeId = null;
+      window.removeEventListener('pointerup', up);
+      window.removeEventListener('pointercancel', up);
       btn.classList.remove('is-pressed');
       onUp();
     };
+    const down = e => {
+      if (pressed) return;
+      pressed = true;
+      if (e) {
+        activeId = e.pointerId != null ? e.pointerId : null;
+        e.preventDefault();
+        if (e.pointerId != null && btn.setPointerCapture) {
+          try { btn.setPointerCapture(e.pointerId); } catch (_) {}
+        }
+      }
+      window.addEventListener('pointerup', up);
+      window.addEventListener('pointercancel', up);
+      btn.classList.add('is-pressed');
+      onDown();
+    };
     btn.addEventListener('pointerdown', down);
-    btn.addEventListener('pointerup', up);
-    btn.addEventListener('pointercancel', up);
-    btn.addEventListener('pointerleave', up);
-    // Slide support: entering a button while a pointer is held down presses it.
-    // `e.buttons` is non-zero only while a touch/click is active, so a passive
-    // mouse hover won't trigger it.
-    btn.addEventListener('pointerenter', e => { if (e.buttons) down(e); });
     ['pointerdown', 'mousedown', 'touchstart'].forEach(ev => {
       btn.addEventListener(ev, e => e.stopPropagation(), { passive: false });
+    });
+  }
+
+  // The ◀▶ movement pair as one analog d-pad. A press must START on ◀ or ▶;
+  // the active direction then tracks which side of the line midway between the
+  // two buttons the finger is on. So slipping off the outer edge keeps you
+  // moving, crossing the midline flips direction, and only lifting stops you —
+  // a stray tap elsewhere does nothing (we only attach pointerdown to the two
+  // buttons). On the initials screen ◀▶ are a discrete letter-stepper, not a
+  // joystick, so we fall back to a one-shot tap with no capture/tracking.
+  //
+  // The live gesture is tracked on `window` (not the buttons): the finger
+  // roams off the buttons by design, so move/up must keep arriving regardless
+  // of where it is or whether pointer capture took. The divider is measured
+  // once per gesture — the buttons don't move mid-drag, so there's no need to
+  // hit getBoundingClientRect() on every pointermove.
+  function movePad(leftBtn, rightBtn, onLeftDown, onLeftUp, onRightDown, onRightUp) {
+    if (!leftBtn || !rightBtn) return;
+    let activeId = null;   // pointerId of the live gesture, or null
+    let dir = null;        // 'left' | 'right' | null
+    let divider = 0;       // cached midline x for the current gesture
+
+    function setDir(next) {
+      if (next === dir) return;
+      if (dir === 'left')  { leftBtn.classList.remove('is-pressed');  onLeftUp(); }
+      if (dir === 'right') { rightBtn.classList.remove('is-pressed'); onRightUp(); }
+      dir = next;
+      if (dir === 'left')  { leftBtn.classList.add('is-pressed');  onLeftDown(); }
+      if (dir === 'right') { rightBtn.classList.add('is-pressed'); onRightDown(); }
+    }
+
+    function onMove(e) {
+      if (activeId === null || e.pointerId !== activeId) return;
+      setDir(e.clientX < divider ? 'left' : 'right');
+    }
+    function onUp(e) {
+      if (activeId === null || e.pointerId !== activeId) return;
+      activeId = null;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+      setDir(null);
+    }
+    function onDown(e, startedOn) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (initialsActive()) {           // discrete letter step — no capture/track
+        (startedOn === 'left' ? onLeftDown : onRightDown)();
+        return;
+      }
+      if (activeId !== null) return;    // one finger drives the pad at a time
+      activeId = e.pointerId;
+      const el = startedOn === 'left' ? leftBtn : rightBtn;
+      if (e.pointerId != null && el.setPointerCapture) {
+        try { el.setPointerCapture(e.pointerId); } catch (_) {}
+      }
+      divider = (leftBtn.getBoundingClientRect().right +
+                 rightBtn.getBoundingClientRect().left) / 2;
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      window.addEventListener('pointercancel', onUp);
+      setDir(e.clientX < divider ? 'left' : 'right');
+    }
+
+    leftBtn.addEventListener('pointerdown',  e => onDown(e, 'left'));
+    rightBtn.addEventListener('pointerdown', e => onDown(e, 'right'));
+    [leftBtn, rightBtn].forEach(b => {
+      ['pointerdown', 'mousedown', 'touchstart'].forEach(ev => {
+        b.addEventListener(ev, e => e.stopPropagation(), { passive: false });
+      });
     });
   }
 
@@ -71,5 +149,5 @@
   }
 
   window.Arcade = window.Arcade || {};
-  window.Arcade.Touch = { isCoarse, bind };
+  window.Arcade.Touch = { isCoarse, bind, movePad };
 })();

--- a/docs/arcade/shared/touch.test.cjs
+++ b/docs/arcade/shared/touch.test.cjs
@@ -1,24 +1,40 @@
-// Regression test for Arcade.Touch.bind — run with `node touch.test.cjs`.
+// Regression tests for shared/touch.js — run with `node touch.test.cjs`.
 //
-// Bug: on touch devices a single tap fires BOTH pointerdown AND pointerenter
-// (MDN: on no-hover devices pointerenter fires "as a result of pointerdown",
-// with buttons===1 for the whole contact). bind() calls onDown from both
-// listeners, so a tap invoked onDown twice. Harmless for idempotent movement
-// key-flags, but the initials screen's letter-next/advance mutate on every
-// call — so each tap advanced two letters (A-C-E…) and slot/submit misfired.
+// Loads the REAL module into a minimal DOM stub and drives pointer events.
 //
-// We load the REAL touch.js into a minimal DOM stub and assert a tap presses
-// exactly once, while a slide from one button onto another still presses the
-// destination once (the feature we must not break).
+// bind():    standalone buttons (jump/fire/thrust, launcher prev/next).
+//            One press = one onDown, one release = one onUp. Slip-proof:
+//            releases only on lift/cancel (NOT pointerleave). The live press is
+//            tracked on `window` (matched by pointerId) so it releases even if
+//            pointer capture didn't take. No pointerenter "slide" path (that
+//            caused a tap to double-fire — A-C-E / skip-a-game).
+// movePad(): the in-game ◀▶ pair. Press must start on a button; the active
+//            direction follows which side of the line midway between the two
+//            buttons the finger is on (divider measured once per gesture). Slip
+//            off the outer edge → keep going; cross the midline → switch; lift →
+//            stop. The gesture is tracked on `window` so the finger can roam off
+//            the buttons. On the initials screen it's a discrete one-letter tap.
 
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
-function makeButton() {
+// Window-level event registry (movePad / bind track live gestures on window).
+let winListeners = {};
+function clearWin() { winListeners = {}; }
+function fireWindow(type, props = {}) {
+  const e = { type, preventDefault() {}, stopPropagation() {},
+              pointerId: 1, pointerType: 'touch', ...props };
+  (winListeners[type] || []).slice().forEach(fn => fn(e));
+}
+
+function makeButton(rect) {
   const listeners = {};
   const captured = new Set();
   const btn = {
+    _rect: rect || { left: 0, right: 80, top: 0, bottom: 80, width: 80, height: 80 },
+    _rectCalls: 0,
+    _captureThrows: false,
     dataset: {}, style: {},
     classList: {
       _s: new Set(),
@@ -26,8 +42,9 @@ function makeButton() {
       contains(c) { return this._s.has(c); },
     },
     setAttribute() {}, getAttribute() { return null; },
+    getBoundingClientRect() { this._rectCalls++; return this._rect; },
     hasPointerCapture(id) { return captured.has(id); },
-    setPointerCapture(id) { captured.add(id); },
+    setPointerCapture(id) { if (this._captureThrows) throw new Error('no capture'); captured.add(id); },
     releasePointerCapture(id) { captured.delete(id); },
     addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
     closest() { return null; },
@@ -40,75 +57,182 @@ function makeButton() {
   return btn;
 }
 
-// Load the real source into a sandbox where `window` is the global object.
+// Load the real source; `window` is the global object.
 const code = fs.readFileSync(path.join(__dirname, 'touch.js'), 'utf8');
 const sandbox = {};
 sandbox.window = sandbox;
 sandbox.matchMedia = () => ({ matches: false });
 sandbox.document = { addEventListener() {} };
+sandbox.addEventListener    = (t, fn) => { (winListeners[t] = winListeners[t] || []).push(fn); };
+sandbox.removeEventListener = (t, fn) => { if (winListeners[t]) winListeners[t] = winListeners[t].filter(f => f !== fn); };
 vm.createContext(sandbox);
 vm.runInContext(code, sandbox);
-const bind = sandbox.Arcade.Touch.bind;
+const { bind, movePad } = sandbox.Arcade.Touch;
+
+// Toggleable initials stub that movePad consults for discrete mode.
+let initialsActive = false;
+sandbox.Arcade.Initials = { isActive: () => initialsActive };
 
 let failures = 0;
 function check(label, got, want) {
   const ok = got === want;
-  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${got}, want ${want}`);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
   if (!ok) failures++;
 }
 
-// --- Case 1: a single touch tap presses exactly once ------------------------
+// ============================ bind() ============================
+
+// Case 1: a single tap presses and releases exactly once (release via window).
 {
+  clearWin();
   const a = makeButton();
   let down = 0, up = 0;
   bind(a, () => down++, () => up++);
-  // Real touch tap, per MDN ordering (enter fires alongside down, buttons=1):
-  a.fire('pointerover',  { buttons: 1 });
-  a.fire('pointerenter', { buttons: 1 });
+  a.fire('pointerenter', { buttons: 1 });  // pre-down enter must NOT press (slide removed)
   a.fire('pointerdown',  { buttons: 1 });
-  a.fire('pointerup',    { buttons: 0 });
-  a.fire('pointerout',   { buttons: 0 });
-  a.fire('pointerleave', { buttons: 0 });
-  check('tap -> onDown once', down, 1);
-  check('tap -> onUp once',   up,   1);
+  fireWindow('pointerup', { pointerId: 1 });
+  check('bind tap -> onDown once', down, 1);
+  check('bind tap -> onUp once',   up,   1);
 }
 
-// --- Case 2: sliding a held finger from B onto A presses A once -------------
-//     (the slide feature must keep working after the fix)
+// Case 2: slip-proof — leaving the button does NOT release; only lifting does.
 {
-  const a = makeButton(), b = makeButton();
-  let aDown = 0, aUp = 0, bDown = 0, bUp = 0;
-  bind(a, () => aDown++, () => aUp++);
-  bind(b, () => bDown++, () => bUp++);
-  // finger lands on B
-  b.fire('pointerover',  { buttons: 1 });
-  b.fire('pointerenter', { buttons: 1 });
-  b.fire('pointerdown',  { buttons: 1 });
-  // finger slides off B onto A while still held
-  b.fire('pointerleave', { buttons: 1 });
-  a.fire('pointerenter', { buttons: 1 });
-  // finger lifts on A
-  a.fire('pointerup',    { buttons: 0 });
-  a.fire('pointerleave', { buttons: 0 });
-  check('slide B->A presses B once', bDown, 1);
-  check('slide B->A releases B once', bUp, 1);
-  check('slide B->A presses A once',  aDown, 1);
-  check('slide B->A releases A once', aUp, 1);
+  clearWin();
+  const a = makeButton();
+  let down = 0, up = 0;
+  bind(a, () => down++, () => up++);
+  a.fire('pointerdown',  { buttons: 1 });
+  a.fire('pointerleave', { buttons: 1 });  // no longer wired — must be a no-op
+  check('bind slip-off keeps it held (onUp not yet)', up, 0);
+  fireWindow('pointerup', { pointerId: 1 });
+  check('bind lift releases once', up, 1);
+  check('bind held the whole time (onDown once)', down, 1);
 }
 
-// --- Case 3: implicit capture grabbed at pointerdown is still released ------
-//     even though pointerenter already fired onDown first (touch fires enter
-//     before down, when capture isn't set yet). The release is what lets the
-//     finger slide onto neighbouring buttons — it must not be skipped.
+// Case 3: a lone pointerenter with buttons held must NOT press (no slide path).
 {
+  clearWin();
   const a = makeButton();
   let down = 0;
   bind(a, () => down++, () => {});
-  a.fire('pointerenter', { buttons: 1 });   // onDown #1; no capture set yet
-  a.setPointerCapture(1);                   // UA grabs implicit capture at pointerdown
-  a.fire('pointerdown',  { buttons: 1 });   // must release capture, must NOT re-fire onDown
-  check('implicit capture released on pointerdown', a.hasPointerCapture(1), false);
-  check('pointerdown after enter does not re-fire onDown', down, 1);
+  a.fire('pointerenter', { buttons: 1 });
+  check('bind pointerenter alone does not press', down, 0);
+}
+
+// Case 4: press captures the pointer (so lift/cancel usually come back here).
+{
+  clearWin();
+  const a = makeButton();
+  bind(a, () => {}, () => {});
+  a.fire('pointerdown', { buttons: 1, pointerId: 7 });
+  check('bind captures pointer on press', a.hasPointerCapture(7), true);
+}
+
+// Case 5: capture FAILS (unsupported / throws) — release still fires via the
+// window listener when the finger lifts off the button. And a different
+// pointer's lift must not release this one.
+{
+  clearWin();
+  const a = makeButton();
+  a._captureThrows = true;
+  let up = 0;
+  bind(a, () => {}, () => up++);
+  a.fire('pointerdown', { pointerId: 1 });
+  fireWindow('pointerup', { pointerId: 2 });   // someone else's finger
+  check('bind: other pointer lift does not release', up, 0);
+  fireWindow('pointerup', { pointerId: 1 });   // our finger, lifted off the button
+  check('bind: window lift releases even without capture', up, 1);
+}
+
+// ============================ movePad() ============================
+// left  = [0..80], right = [96..176]  ->  divider at (80+96)/2 = 88
+
+function makePad() {
+  const left  = makeButton({ left: 0,  right: 80,  top: 0, bottom: 80, width: 80, height: 80 });
+  const right = makeButton({ left: 96, right: 176, top: 0, bottom: 80, width: 80, height: 80 });
+  const c = { lDown: 0, lUp: 0, rDown: 0, rUp: 0 };
+  movePad(left, right,
+    () => c.lDown++, () => c.lUp++,
+    () => c.rDown++, () => c.rUp++);
+  return { left, right, c };
+}
+
+// Case 6: slip off the outer edge of ▶ keeps moving right (the reported bug).
+{
+  clearWin(); initialsActive = false;
+  const { right, c } = makePad();
+  right.fire('pointerdown', { clientX: 130 });   // press right
+  fireWindow('pointermove', { clientX: 300 });   // slid way off to the right
+  check('movePad slip-off stays right (rDown once)', c.rDown, 1);
+  check('movePad slip-off did NOT release', c.rUp, 0);
+  fireWindow('pointerup',   { clientX: 300 });
+  check('movePad lift releases right', c.rUp, 1);
+  check('movePad never pressed left', c.lDown, 0);
+}
+
+// Case 7: crossing the midline switches direction; lift releases.
+{
+  clearWin(); initialsActive = false;
+  const { right, c } = makePad();
+  right.fire('pointerdown', { clientX: 130 });   // right
+  fireWindow('pointermove', { clientX: 40  });   // cross to left half
+  check('cross -> released right', c.rUp, 1);
+  check('cross -> pressed left',   c.lDown, 1);
+  fireWindow('pointermove', { clientX: 130 });   // cross back to right
+  check('cross back -> released left', c.lUp, 1);
+  check('cross back -> pressed right', c.rDown, 2);
+  fireWindow('pointerup',   { clientX: 130 });
+  check('lift releases right (total rUp 2)', c.rUp, 2);
+}
+
+// Case 8: gameplay press captures the pointer.
+{
+  clearWin(); initialsActive = false;
+  const { right } = makePad();
+  right.fire('pointerdown', { clientX: 130, pointerId: 3 });
+  check('movePad captures pointer in gameplay', right.hasPointerCapture(3), true);
+  fireWindow('pointerup', { pointerId: 3 });
+}
+
+// Case 9: on the initials screen ◀▶ are discrete taps — no capture, no zone.
+{
+  clearWin(); initialsActive = true;
+  const { left, c } = makePad();
+  left.fire('pointerdown', { clientX: 40, pointerId: 9 });
+  fireWindow('pointermove', { clientX: 300, pointerId: 9 });  // would-be zone move: ignored
+  fireWindow('pointerup',   { clientX: 300, pointerId: 9 });
+  check('initials: one tap = one letter step', c.lDown, 1);
+  check('initials: no zone tracking on move', c.rDown, 0);
+  check('initials: no capture', left.hasPointerCapture(9), false);
+  initialsActive = false;
+}
+
+// Case 10: a direction held when you die (screen flips to initials) must STILL
+// release on lift — else the key sticks into the next game.
+{
+  clearWin(); initialsActive = false;
+  const { right, c } = makePad();
+  right.fire('pointerdown', { clientX: 130 });   // holding right in gameplay
+  check('held-right pressed', c.rDown, 1);
+  initialsActive = true;                          // died -> initials opened, finger still down
+  fireWindow('pointerup', { clientX: 130 });      // finger lifts
+  check('release fires even though initials now active', c.rUp, 1);
+  initialsActive = false;
+}
+
+// Case 11: the divider is measured once per gesture, not on every pointermove
+// (no getBoundingClientRect layout read in the hot path).
+{
+  clearWin(); initialsActive = false;
+  const { left, right } = makePad();
+  left._rectCalls = 0; right._rectCalls = 0;
+  right.fire('pointerdown', { clientX: 130 });
+  fireWindow('pointermove', { clientX: 140 });
+  fireWindow('pointermove', { clientX: 60  });
+  fireWindow('pointermove', { clientX: 150 });
+  check('divider rect read once per gesture (left)',  left._rectCalls,  1);
+  check('divider rect read once per gesture (right)', right._rectCalls, 1);
+  fireWindow('pointerup', { clientX: 150 });
 }
 
 console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -222,15 +222,19 @@ window.addEventListener('keydown', e => {
   const left  = document.getElementById('tc-left');
   const right = document.getElementById('tc-right');
   const jump  = document.getElementById('tc-jump');
-  Arcade.Touch.bind(left,
+  // ◀▶ as one analog d-pad: slip off the edge keeps moving, cross the midline
+  // flips direction, lift stops. (Discrete letter-stepping in initials.)
+  // Release always clears the key — never gate the up-handler on initials, or a
+  // direction held when you die (and the screen flips to initials) sticks into
+  // the next game. Clearing during initials is harmless.
+  Arcade.Touch.movePad(left, right,
     () => { if (Arcade.Initials.isActive()) { Arcade.Initials.action('letter-prev'); return; } keys['ArrowLeft']  = true;  },
-    () => { if (Arcade.Initials.isActive()) return; keys['ArrowLeft']  = false; });
-  Arcade.Touch.bind(right,
+    () => { keys['ArrowLeft']  = false; },
     () => { if (Arcade.Initials.isActive()) { Arcade.Initials.action('letter-next'); return; } keys['ArrowRight'] = true;  },
-    () => { if (Arcade.Initials.isActive()) return; keys['ArrowRight'] = false; });
+    () => { keys['ArrowRight'] = false; });
   Arcade.Touch.bind(jump,
     () => { if (Arcade.Initials.isActive()) { Arcade.Initials.action('advance');     return; } keys[' ']          = true;  },
-    () => { if (Arcade.Initials.isActive()) return; keys[' ']          = false; });
+    () => { keys[' ']          = false; });
 })();
 
 // ============================================

--- a/docs/rocket-ship.html
+++ b/docs/rocket-ship.html
@@ -974,10 +974,11 @@ let touchThrust = false;
     const handler = window.__rocketGameOverTouch;
     return !!(handler && handler(action));
   }
-  Arcade.Touch.bind(document.getElementById('tc-left'),
+  // ◀▶ as one analog d-pad: slip off the edge keeps steering, cross the midline
+  // flips direction, lift stops. (Discrete letter-stepping in initials.)
+  Arcade.Touch.movePad(document.getElementById('tc-left'), document.getElementById('tc-right'),
     () => { if (!goConsumed('letter-prev')) keys['ArrowLeft']  = true; },
-    () => keys['ArrowLeft']  = false);
-  Arcade.Touch.bind(document.getElementById('tc-right'),
+    () => keys['ArrowLeft']  = false,
     () => { if (!goConsumed('letter-next')) keys['ArrowRight'] = true; },
     () => keys['ArrowRight'] = false);
   Arcade.Touch.bind(document.getElementById('tc-thrust'),


### PR DESCRIPTION
Touch-control follow-up to the initials latch (#577). All confirmed on-device via a local LAN server.

## Changes

**`movePad()` — the in-game `◀▶` pair is now one analog d-pad.**
A press must *start* on a button and captures the finger; the active direction follows which side of the line **midway between the two buttons** the finger is on. So:
- slip off the outer edge / below → keeps moving (the reported Space Jumper bug),
- cross the midline → switches direction,
- lift → stops,
- a stray tap off the buttons → does nothing.
On the initials screen `◀▶` stay discrete one-letter taps (no joystick). Used by **invaders (SP), space-jumper, rocket-ship**.

**`bind()` is now slip-proof.** Captures on press, releases only on lift/cancel — never on `pointerleave` — so a held jump / super-shot survives a finger slip. Also **drops the `pointerenter` "slide onto me" path**: on touch that made a single tap fire twice (skip-a-letter on initials, skip-a-game on the launcher). Adjacent-button sliding now lives in `movePad`, so this is removed at the source rather than latched around.

**Release handlers no longer gate on `Initials.isActive()`.** A direction held when you die (screen flips to initials) was sticking into the next game — the character walked off with no finger down. Clearing the key during initials is harmless; rocket-ship already did it this way.

## Tests
`docs/arcade/shared/touch.test.cjs` — 21 headless cases against the real module (run: `node touch.test.cjs`): tap=one action, slip-proof, no-slide, capture, d-pad slip-stays / cross-switches / tap-off-noop / initials-discrete, and "release fires even if initials opened mid-hold."

No CHANGELOG entry (arcade changes are out of scope per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)