### PR TITLE
arcade(invaders-mp): Phase F — per-player combos + super shots

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -15,18 +15,30 @@ export interface Ship {
   x: number;
   alive: boolean;
   cooldown: number;
-  /** Per-player score (kills × ROW_POINTS[row]). */
+  /** Per-player score (kills × ROW_POINTS[row] × combo multiplier). */
   score: number;
   /** Seconds until respawn; 0 = not respawning (either alive or permanent-dead). */
   respawnIn: number;
   /** Seconds of post-respawn invulnerability remaining; 0 = vulnerable. */
   invulnFor: number;
+  /** Consecutive kills within the combo decay window. */
+  combo: number;
+  /** Seconds left before combo decays back to 0. */
+  comboDecayIn: number;
+  /** Charged-fire ammo remaining (0..SUPER_SHOT_MAX). */
+  superAmmo: number;
+  /** Accumulated FIRE-hold time in seconds; resets on release or shot spawn. */
+  chargeSec: number;
+  /** Score threshold for the next earned ammo refill. */
+  nextSuperAt: number;
 }
 
 export interface Bullet {
   x: number;
   y: number;
   owner: Seat | null;
+  /** True for super-shot bullets — pierces invaders, tunnels through shields. */
+  charged?: boolean;
 }
 
 export interface Invader {
@@ -67,8 +79,16 @@ export interface WireSnapshot {
   lives: number;
   countdownEndMs: number;
   /** Always MAX_SEATS entries, indexed by seat position (p1 → 0, …). */
-  players: Array<{ x: number; alive: boolean; name: string; score: number }>;
-  bullets: Array<{ x: number; y: number; o: Seat | null }>;
+  players: Array<{
+    x: number;
+    alive: boolean;
+    name: string;
+    score: number;
+    combo: number;
+    superAmmo: number;
+    chargeSec: number;
+  }>;
+  bullets: Array<{ x: number; y: number; o: Seat | null; c: boolean }>;
   invaderBullets: Array<{ x: number; y: number }>;
   invaders: Array<{ x: number; y: number; a: boolean }>;
   /** Authoritative swarm animation frame (0 or 1). */
@@ -104,6 +124,11 @@ export const SHIELD_W: number;
 export const SHIELD_H: number;
 export const SHIELD_COUNT: number;
 export const SHIELD_Y: number;
+export const SUPER_SHOT_MAX: number;
+export const CHARGE_THRESHOLD_SEC: number;
+export const CHARGED_BULLET_W: number;
+export const CHARGED_BULLET_H: number;
+export function comboMultiplier(count: number): number;
 
 export const SEATS: readonly Seat[];
 export const MAX_SEATS: number;

--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -27,8 +27,10 @@ export interface Ship {
   comboDecayIn: number;
   /** Charged-fire ammo remaining (0..SUPER_SHOT_MAX). */
   superAmmo: number;
-  /** Accumulated FIRE-hold time in seconds; resets on release or shot spawn. */
+  /** Accumulated FIRE-hold time in seconds; resets on release. */
   chargeSec: number;
+  /** Previous tick's fire input — drives release-to-fire edge detection. */
+  wasFiring: boolean;
   /** Score threshold for the next earned ammo refill. */
   nextSuperAt: number;
 }

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -165,7 +165,7 @@ export const CHARGE_THRESHOLD_SEC = 0.5;
 const SUPER_SCORE_INTERVAL = 1000;
 export const CHARGED_BULLET_W = 4;
 export const CHARGED_BULLET_H = 12;
-const CHARGED_BULLET_SPEED = 380;
+export const CHARGED_BULLET_SPEED = 380;
 
 export function zeroInput() {
   return { left: false, right: false, fire: false };
@@ -205,12 +205,14 @@ function freshShips() {
       combo: 0,
       comboDecayIn: 0,
       // Super-shot ammo + charge accumulator. chargeSec ticks up
-      // while FIRE is held; on cooldown-clear, if chargeSec ≥
-      // CHARGE_THRESHOLD_SEC and superAmmo > 0 we spawn a charged
-      // bullet and decrement ammo. nextSuperAt is the score
-      // threshold for the next earned ammo refill.
+      // while FIRE is held. SP-style release-to-fire: a shot spawns
+      // on the input.fire true→false transition — if chargeSec was
+      // ≥ CHARGE_THRESHOLD_SEC AND superAmmo > 0 it's a charged
+      // bullet, otherwise a normal one. wasFiring tracks the previous
+      // tick's input so we can detect the edge.
       superAmmo: SUPER_SHOT_MAX,
       chargeSec: 0,
+      wasFiring: false,
       nextSuperAt: SUPER_SCORE_INTERVAL,
     };
   }
@@ -318,19 +320,26 @@ function tickRespawnAndInvuln(state, dt) {
 function stepShips(state, inputs, dt, occupied) {
   // Ship horizontal position is client-authoritative: the caller
   // streams `pos` updates and writes them straight into ship.x. This
-  // function handles fire (cooldown + bullet spawn host-controlled
-  // for fair per-player fire rate) and super-shot charging.
+  // function handles fire + super-shot charging via SP-style release
+  // semantics: shots spawn on the input.fire true→false edge. Holding
+  // accumulates charge; on release the spawn is charged if held ≥
+  // CHARGE_THRESHOLD_SEC AND superAmmo > 0, else normal. Auto-fire on
+  // hold is gone (it conflicted with charging — FIRE_COOLDOWN 0.45s
+  // < CHARGE_THRESHOLD_SEC 0.5s would have rapid-fired before the
+  // charge ever completed). Players tap-tap-tap for rapid normal
+  // fire, hold-and-release for charged.
   for (const seat of SEATS) {
     const ship = state.ships[seat];
     if (!ship.alive || !occupied[seat]) continue;
     const input = inputs[seat];
-    if (!input) continue;
+    if (!input) { ship.wasFiring = false; continue; }
     ship.cooldown = Math.max(0, ship.cooldown - dt);
-    if (input.fire) {
-      // Hold accumulates charge time. We don't gate this on superAmmo
-      // > 0 — the check happens at spawn time, so the bar fills
-      // visibly even when empty (just doesn't spawn a charged shot).
+    const firing = !!input.fire;
+    if (firing) {
       ship.chargeSec += dt;
+    } else if (ship.wasFiring) {
+      // Release edge: spawn a shot if cooldown is clear. Otherwise
+      // the input was just spam — drop the charge silently.
       if (ship.cooldown <= 0) {
         const charged = ship.chargeSec >= CHARGE_THRESHOLD_SEC && ship.superAmmo > 0;
         const bw = charged ? CHARGED_BULLET_W : BULLET_W;
@@ -343,11 +352,10 @@ function stepShips(state, inputs, dt, occupied) {
         });
         ship.cooldown = FIRE_COOLDOWN;
         if (charged) ship.superAmmo--;
-        ship.chargeSec = 0;        // reset; next charged needs another hold
       }
-    } else {
-      ship.chargeSec = 0;          // released → drop the charge
+      ship.chargeSec = 0;
     }
+    ship.wasFiring = firing;
   }
 }
 

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -307,11 +307,15 @@ function tickRespawnAndInvuln(state, dt) {
         ship.cooldown = 0;
         ship.invulnFor = INVULN_SEC;
         // Fresh start on respawn — drop any in-flight combo or
-        // mid-hold charge. superAmmo + nextSuperAt persist (they're
-        // a long-term resource, not a per-life one).
+        // mid-hold charge AND clear the wasFiring edge tracker, so
+        // a player who died holding FIRE doesn't get an unintended
+        // release-edge spawn on the first post-respawn tick.
+        // superAmmo + nextSuperAt persist (long-term resource, not
+        // per-life).
         ship.combo = 0;
         ship.comboDecayIn = 0;
         ship.chargeSec = 0;
+        ship.wasFiring = false;
       }
     }
   }
@@ -332,7 +336,14 @@ function stepShips(state, inputs, dt, occupied) {
     const ship = state.ships[seat];
     if (!ship.alive || !occupied[seat]) continue;
     const input = inputs[seat];
-    if (!input) { ship.wasFiring = false; continue; }
+    // Missing input → treat as neutral (released, no charge). Clear
+    // chargeSec too so a dropped input tick during a hold can't bank
+    // stale charge that fires a charged shot on the next release.
+    if (!input) {
+      ship.wasFiring = false;
+      ship.chargeSec = 0;
+      continue;
+    }
     ship.cooldown = Math.max(0, ship.cooldown - dt);
     const firing = !!input.fire;
     if (firing) {
@@ -471,9 +482,12 @@ function resolveCollisions(state, occupied) {
   // killed by the first contact. Marker (-999) is swept by the
   // .filter at the bottom of this function (same tick).
   for (const b of state.bullets) {
-    if (b.y < -BULLET_H) continue;
     const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
     const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
+    // Off-screen guard uses the bullet's own height — charged bullets
+    // are taller (12 vs 6), so -BULLET_H would skip collisions for
+    // charged bullets that are still partially on-screen.
+    if (b.y < -bh) continue;
     if (damageShields(state, b.x, b.y, bw, bh) && !b.charged) {
       b.y = -999;
     }
@@ -486,9 +500,9 @@ function resolveCollisions(state, occupied) {
   // swarm sloped at a wall-bounce more can stack). Earned ammo:
   // crossing nextSuperAt threshold yields +1 (capped at MAX).
   for (const b of state.bullets) {
-    if (b.y < -BULLET_H) continue;
     const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
     const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
+    if (b.y < -bh) continue;
     for (let i = 0; i < state.invaders.length; i++) {
       const inv = state.invaders[i];
       if (!inv.alive) continue;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -140,6 +140,33 @@ export const STARTING_LIVES = 3;
 const RESPAWN_SEC = 2;
 const INVULN_SEC = 1;
 
+// === Combos ===
+// Kills within COMBO_WINDOW_SEC of the previous extend the chain.
+// Multiplier ramps at SP's thresholds: 1× → 2× (3 kills) → 3× (5) →
+// 4× (8). Each kill awards ROW_POINTS[row] × multiplier to the owner.
+// Per-player state — each ship maintains its own chain so kills by
+// one player don't boost a teammate's multiplier.
+const COMBO_WINDOW_SEC = 1.5;
+export function comboMultiplier(count) {
+  if (count >= 8) return 4;
+  if (count >= 5) return 3;
+  if (count >= 3) return 2;
+  return 1;
+}
+
+// === Super shots (charged fire) ===
+// Hold FIRE for ≥ CHARGE_THRESHOLD_SEC with superAmmo > 0 and the
+// next bullet spawned is a fat golden piercer: passes through
+// shields (carves but isn't consumed) and through invaders (kills
+// every one in its path, not just the first). Earned +1 ammo every
+// SUPER_SCORE_INTERVAL points; UFO refill to max in Phase G.
+export const SUPER_SHOT_MAX = 3;
+export const CHARGE_THRESHOLD_SEC = 0.5;
+const SUPER_SCORE_INTERVAL = 1000;
+export const CHARGED_BULLET_W = 4;
+export const CHARGED_BULLET_H = 12;
+const CHARGED_BULLET_SPEED = 380;
+
 export function zeroInput() {
   return { left: false, right: false, fire: false };
 }
@@ -155,7 +182,6 @@ function spawnX(seatIndex) {
 }
 
 function freshShips() {
-  /** @type {Record<string, {x:number,alive:boolean,cooldown:number,score:number,respawnIn:number,invulnFor:number}>} */
   const ships = {};
   for (let i = 0; i < MAX_SEATS; i++) {
     ships[SEATS[i]] = {
@@ -163,17 +189,29 @@ function freshShips() {
       alive: true,
       cooldown: 0,
       // Per-player score — replaces the old top-level state.score.
-      // Each kill awards ROW_POINTS[invader-row] to the bullet owner.
+      // Each kill awards ROW_POINTS[invader-row] × combo multiplier.
       score: 0,
       // Seconds until respawn (0 = not respawning). Set when a death
       // consumes a shared life token; ticked down each step; on hit-0
       // the ship blinks back at spawnX with invulnFor set.
       respawnIn: 0,
       // Seconds of post-respawn invulnerability remaining. Engine-
-      // internal — resolveCollisions skips damage while > 0. Not on
-      // the wire (yet); a future PR can expose it for a respawn-blink
-      // visual, but for now the ship just reappears at spawnX.
+      // internal — resolveCollisions skips damage while > 0.
       invulnFor: 0,
+      // Combo chain — how many consecutive kills within the decay
+      // window. comboDecayIn ticks down each step; when it hits 0,
+      // combo resets to 0. comboMultiplier(combo) gives the score
+      // bonus 1×/2×/3×/4×.
+      combo: 0,
+      comboDecayIn: 0,
+      // Super-shot ammo + charge accumulator. chargeSec ticks up
+      // while FIRE is held; on cooldown-clear, if chargeSec ≥
+      // CHARGE_THRESHOLD_SEC and superAmmo > 0 we spawn a charged
+      // bullet and decrement ammo. nextSuperAt is the score
+      // threshold for the next earned ammo refill.
+      superAmmo: SUPER_SHOT_MAX,
+      chargeSec: 0,
+      nextSuperAt: SUPER_SCORE_INTERVAL,
     };
   }
   return ships;
@@ -245,15 +283,19 @@ export function step(state, inputs, dt, occupied = ALL_OCCUPIED) {
 }
 
 function tickRespawnAndInvuln(state, dt) {
-  // Count down respawn + invuln timers each tick. On respawn complete
-  // (timer hits 0 from > 0), reset that ship to alive at its spawnX
-  // with the grace window armed. Permanent-dead ships (lives==0 when
-  // they died) have respawnIn = 0 and stay dead — this branch is
-  // skipped for them because the > 0 check fails.
+  // Count down respawn + invuln + combo-decay timers each tick. On
+  // respawn complete (respawnIn hits 0 from > 0), reset that ship
+  // alive at its spawnX with the grace window armed. Permanent-dead
+  // ships (lives==0 when they died) have respawnIn = 0 and stay dead
+  // — that branch is skipped because the > 0 check fails.
   for (let i = 0; i < MAX_SEATS; i++) {
     const ship = state.ships[SEATS[i]];
     if (ship.invulnFor > 0) {
       ship.invulnFor = Math.max(0, ship.invulnFor - dt);
+    }
+    if (ship.comboDecayIn > 0) {
+      ship.comboDecayIn = Math.max(0, ship.comboDecayIn - dt);
+      if (ship.comboDecayIn === 0) ship.combo = 0;
     }
     if (ship.respawnIn > 0) {
       ship.respawnIn = Math.max(0, ship.respawnIn - dt);
@@ -262,6 +304,12 @@ function tickRespawnAndInvuln(state, dt) {
         ship.alive = true;
         ship.cooldown = 0;
         ship.invulnFor = INVULN_SEC;
+        // Fresh start on respawn — drop any in-flight combo or
+        // mid-hold charge. superAmmo + nextSuperAt persist (they're
+        // a long-term resource, not a per-life one).
+        ship.combo = 0;
+        ship.comboDecayIn = 0;
+        ship.chargeSec = 0;
       }
     }
   }
@@ -270,29 +318,46 @@ function tickRespawnAndInvuln(state, dt) {
 function stepShips(state, inputs, dt, occupied) {
   // Ship horizontal position is client-authoritative: the caller
   // streams `pos` updates and writes them straight into ship.x. This
-  // function only handles fire (so the cooldown + bullet spawn are
-  // host-controlled, keeping per-player fire rate fair).
+  // function handles fire (cooldown + bullet spawn host-controlled
+  // for fair per-player fire rate) and super-shot charging.
   for (const seat of SEATS) {
     const ship = state.ships[seat];
     if (!ship.alive || !occupied[seat]) continue;
     const input = inputs[seat];
     if (!input) continue;
     ship.cooldown = Math.max(0, ship.cooldown - dt);
-    if (input.fire && ship.cooldown <= 0) {
-      state.bullets.push({
-        x: ship.x + SHIP_W / 2 - BULLET_W / 2,
-        y: SHIP_Y - BULLET_H,
-        owner: seat,
-      });
-      ship.cooldown = FIRE_COOLDOWN;
+    if (input.fire) {
+      // Hold accumulates charge time. We don't gate this on superAmmo
+      // > 0 — the check happens at spawn time, so the bar fills
+      // visibly even when empty (just doesn't spawn a charged shot).
+      ship.chargeSec += dt;
+      if (ship.cooldown <= 0) {
+        const charged = ship.chargeSec >= CHARGE_THRESHOLD_SEC && ship.superAmmo > 0;
+        const bw = charged ? CHARGED_BULLET_W : BULLET_W;
+        const bh = charged ? CHARGED_BULLET_H : BULLET_H;
+        state.bullets.push({
+          x: ship.x + SHIP_W / 2 - bw / 2,
+          y: SHIP_Y - bh,
+          owner: seat,
+          charged: charged,
+        });
+        ship.cooldown = FIRE_COOLDOWN;
+        if (charged) ship.superAmmo--;
+        ship.chargeSec = 0;        // reset; next charged needs another hold
+      }
+    } else {
+      ship.chargeSec = 0;          // released → drop the charge
     }
   }
 }
 
 function stepBullets(state, dt) {
-  for (const b of state.bullets)        b.y -= BULLET_SPEED * dt;
+  // Charged bullets travel faster than the standard variant — matches
+  // SP and makes the super read as a punchy salvo, not just a fat
+  // ordinary shot.
+  for (const b of state.bullets)        b.y -= (b.charged ? CHARGED_BULLET_SPEED : BULLET_SPEED) * dt;
   for (const b of state.invaderBullets) b.y += INV_BULLET_SPEED * dt;
-  state.bullets        = state.bullets.filter(b => b.y + BULLET_H > 0);
+  state.bullets        = state.bullets.filter(b => b.y + (b.charged ? CHARGED_BULLET_H : BULLET_H) > 0);
   state.invaderBullets = state.invaderBullets.filter(b => b.y < PF_H);
 }
 
@@ -393,35 +458,49 @@ function damageShields(state, bx, by, bw, bh) {
 }
 
 function resolveCollisions(state, occupied) {
-  // Player bullets vs shields, FIRST — a bullet that clipped the top
-  // of a shield never reaches an invader, so we resolve shields before
-  // invader hits. Killed bullets are flagged with the out-of-bounds
-  // marker (-999); the .filter sweep at the bottom of this function
-  // removes them in the same tick (no carry-over to next step).
+  // Player bullets vs shields. Charged bullets carve cells but
+  // aren't consumed — they tunnel through. Normal bullets are
+  // killed by the first contact. Marker (-999) is swept by the
+  // .filter at the bottom of this function (same tick).
   for (const b of state.bullets) {
     if (b.y < -BULLET_H) continue;
-    if (damageShields(state, b.x, b.y, BULLET_W, BULLET_H)) {
+    const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
+    const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
+    if (damageShields(state, b.x, b.y, bw, bh) && !b.charged) {
       b.y = -999;
     }
   }
 
-  // Player bullets vs invaders. Out-of-array marker (b.y = -999) is
-  // filtered out at the bottom of this function — cheaper than splicing inside
-  // a nested loop. Points are credited to the bullet's owner using
-  // the row of the killed invader (top row = squid = 30, bottom row
-  // = octopus = 10).
+  // Player bullets vs invaders. Score = ROW_POINTS[row] × combo
+  // multiplier; the kill extends the owner's combo chain. Normal
+  // bullets stop at the first hit; charged bullets pierce every
+  // overlap (typically a 1-cell column on its way up, but if the
+  // swarm sloped at a wall-bounce more can stack). Earned ammo:
+  // crossing nextSuperAt threshold yields +1 (capped at MAX).
   for (const b of state.bullets) {
     if (b.y < -BULLET_H) continue;
+    const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
+    const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
     for (let i = 0; i < state.invaders.length; i++) {
       const inv = state.invaders[i];
       if (!inv.alive) continue;
-      if (overlap(b.x, b.y, BULLET_W, BULLET_H, inv.x, inv.y, INV_W, INV_H)) {
-        inv.alive = false;
-        b.y = -999;
-        const owner = b.owner && state.ships[b.owner];
-        if (owner) owner.score += ROW_POINTS[Math.floor(i / INV_COLS)] || 0;
-        break;
+      if (!overlap(b.x, b.y, bw, bh, inv.x, inv.y, INV_W, INV_H)) continue;
+      inv.alive = false;
+      const owner = b.owner && state.ships[b.owner];
+      if (owner) {
+        owner.combo += 1;
+        owner.comboDecayIn = COMBO_WINDOW_SEC;
+        const basePts = ROW_POINTS[Math.floor(i / INV_COLS)] || 0;
+        owner.score += basePts * comboMultiplier(owner.combo);
+        // Earned-ammo threshold crossings — bump the threshold even
+        // when at max so a long high-score run isn't "wasted".
+        while (owner.score >= owner.nextSuperAt) {
+          if (owner.superAmmo < SUPER_SHOT_MAX) owner.superAmmo++;
+          owner.nextSuperAt += SUPER_SCORE_INTERVAL;
+        }
       }
+      if (!b.charged) { b.y = -999; break; }
+      // charged: keep checking other invaders this tick
     }
   }
   state.bullets = state.bullets.filter(b => b.y > -BULLET_H);
@@ -546,17 +625,27 @@ export function snapshotForClient(state) {
     // alive:false before sending so the client can use this array
     // directly to decide which ships to draw. `name` is the per-seat
     // display name (empty = no label).
-    players: SEATS.map((s) => ({
-      x: round(state.ships[s].x),
-      alive: state.ships[s].alive,
-      name: state.names?.[s] ?? '',
-      // Per-player score (replaces the old top-level state.score).
-      score: state.ships[s].score,
-    })),
+    players: SEATS.map((s) => {
+      const ship = state.ships[s];
+      return {
+        x: round(ship.x),
+        alive: ship.alive,
+        name: state.names?.[s] ?? '',
+        // Per-player score (replaces the old top-level state.score).
+        score: ship.score,
+        // Phase F per-player additions — combo chain length, current
+        // super-shot ammo, and the live charge accumulator (so the
+        // client can draw a charge progress bar above the ship).
+        combo: ship.combo,
+        superAmmo: ship.superAmmo,
+        chargeSec: round(ship.chargeSec),
+      };
+    }),
     // `o` (owner) is the firing seat — lets the client filter "my
-    // bullets" if it ever wants per-bullet prediction. Invader
-    // bullets have no owner.
-    bullets:        state.bullets.map(b => ({ x: round(b.x), y: round(b.y), o: b.owner })),
+    // bullets" if it ever wants per-bullet prediction. `c` marks
+    // a charged bullet (renderer draws it bigger + gold; collision
+    // already handled server-side as pierce + shield pass-through).
+    bullets:        state.bullets.map(b => ({ x: round(b.x), y: round(b.y), o: b.owner, c: !!b.charged })),
     invaderBullets: state.invaderBullets.map(b => ({ x: round(b.x), y: round(b.y) })),
     invaders:       state.invaders.map(i => ({ x: round(i.x), y: round(i.y), a: i.alive })),
     // Current swarm animation frame (0 or 1). Authoritative — every

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1257,11 +1257,6 @@
   // ship + ghost bullets layered on top.
   const canvas = document.getElementById('cv');
   const ctx = canvas.getContext('2d');
-  // Navy background gradient (SP-matched). Built once per resize in
-  // fitCanvas; renderInterpolated paints it as the playfield bg each
-  // frame. Declared here (before fitCanvas) so the first call from
-  // module init doesn't hit the let TDZ.
-  let bgGradient = null;
   function fitCanvas() {
     // Match SP's rendering pipeline: canvas bitmap is sized to the
     // CSS display size × devicePixelRatio, so each canvas pixel = one
@@ -1292,13 +1287,6 @@
     const sx = canvas.width  / PF_W;
     const sy = canvas.height / PF_H;
     ctx.setTransform(sx, 0, 0, sy, 0, 0);
-    // SP's washed navy gradient — rebuilt each resize because gradient
-    // objects are bound to the canvas dimensions, not the user-space
-    // transform. Stored in module scope; renderInterpolated paints it
-    // every frame as the playfield background.
-    bgGradient = ctx.createLinearGradient(0, 0, 0, PF_H);
-    bgGradient.addColorStop(0, '#0d1a60');
-    bgGradient.addColorStop(1, '#050a30');
   }
   window.addEventListener('resize', fitCanvas);
   window.addEventListener('orientationchange', fitCanvas);
@@ -1419,8 +1407,12 @@
   }
 
   function renderInterpolated() {
-    ctx.fillStyle = bgGradient || '#000';
-    ctx.fillRect(0, 0, PF_W, PF_H);
+    // Transparent clear — the navy gradient is painted by the tube's
+    // CSS background underneath, so the canvas just lets it show
+    // through. Painting our own gradient on the canvas at PF_H scale
+    // didn't line up with the tube's CSS gradient at tube-height
+    // scale, producing a visible seam at the canvas edges.
+    ctx.clearRect(0, 0, PF_W, PF_H);
 
     if (snapBuffer.length === 0) return;
 

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -373,7 +373,7 @@
     SHIELD_W, SHIELD_H, SHIELD_COUNT, SHIELD_Y,
     decodeShields, shieldOffsets,
     SUPER_SHOT_MAX, CHARGE_THRESHOLD_SEC,
-    CHARGED_BULLET_W, CHARGED_BULLET_H,
+    CHARGED_BULLET_W, CHARGED_BULLET_H, CHARGED_BULLET_SPEED,
     comboMultiplier,
     SEATS, MAX_SEATS,
   } = engine;
@@ -623,7 +623,7 @@
   // Local prediction state — only the seat we own. Integrated from
   // input each rAF frame using server-identical physics, snapped to the
   // server when we diverge (network drops, death/respawn).
-  const localShip = { x: null, cooldown: 0, holdSec: 0 };
+  const localShip = { x: null, cooldown: 0, holdSec: 0, wasFiring: false };
   const ghostBullets = []; // [{ x, y, born }] — locally-predicted, fade after GHOST_TTL_MS
   let prevFrameT = 0;
   let posTimer = null;
@@ -1341,12 +1341,14 @@
     //    time the server's authoritative bullet has appeared in a
     //    snapshot and taken over the visual.
     localShip.cooldown = Math.max(0, localShip.cooldown - dt);
-    // Mirror the engine's hold-time tracking so the ghost bullet can
-    // preview a super-shot the moment the threshold is crossed (and
-    // ammo is still in stock per the latest snapshot).
+    // Release-to-fire mirrors the engine: chargeSec accumulates while
+    // holding, the shot spawns on the true→false edge. localAlive +
+    // cooldown gate the spawn so a held button can't queue infinite
+    // shots, and tap-tap-tap rapid-fire respects FIRE_COOLDOWN. The
+    // ghost previews charged mode the moment hold ≥ threshold + the
+    // latest snapshot says we have ammo.
     if (input.fire) localShip.holdSec += dt;
-    else            localShip.holdSec = 0;
-    if (input.fire && localShip.cooldown <= 0 && localAlive()) {
+    if (localShip.wasFiring && !input.fire && localShip.cooldown <= 0 && localAlive()) {
       const me = mySeat && lastState ? lastState.players[SEATS.indexOf(mySeat)] : null;
       const myAmmo = me ? (me.superAmmo | 0) : 0;
       const charged = localShip.holdSec >= CHARGE_THRESHOLD_SEC && myAmmo > 0;
@@ -1359,14 +1361,17 @@
         charged: charged,
       });
       localShip.cooldown = FIRE_COOLDOWN;
-      localShip.holdSec = 0;
       Arcade.Audio.play('sfx-shoot', charged ? 0.75 : 0.55);
     }
-    // Ghost bullets travel at the same speeds the engine uses (BULLET_
-    // SPEED for normal, CHARGED_BULLET_SPEED for super) so the visual
-    // hand-off lines up cleanly when the authoritative snapshot lands.
-    const CHARGED_GHOST_SPEED = 380;
-    for (const gb of ghostBullets) gb.y -= (gb.charged ? CHARGED_GHOST_SPEED : BULLET_SPEED) * dt;
+    if (!input.fire) localShip.holdSec = 0;
+    localShip.wasFiring = !!input.fire;
+    // Ghost bullets travel at the same speeds the engine uses so the
+    // visual hand-off lines up cleanly when the authoritative snapshot
+    // lands. CHARGED_BULLET_SPEED is imported from the engine to keep
+    // the predictor locked to sim values; falls back to a constant if
+    // a stale engine.js doesn't export it yet.
+    const chargedSpeed = CHARGED_BULLET_SPEED ?? 380;
+    for (const gb of ghostBullets) gb.y -= (gb.charged ? chargedSpeed : BULLET_SPEED) * dt;
     for (let i = ghostBullets.length - 1; i >= 0; i--) {
       if (now - ghostBullets[i].born > GHOST_TTL_MS || ghostBullets[i].y < -BULLET_H) {
         ghostBullets.splice(i, 1);

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1354,7 +1354,16 @@
     // shots, and tap-tap-tap rapid-fire respects FIRE_COOLDOWN. The
     // ghost previews charged mode the moment hold ≥ threshold + the
     // latest snapshot says we have ammo.
-    if (input.fire) localShip.holdSec += dt;
+    if (!localAlive()) {
+      // Server resets chargeSec + wasFiring on respawn — mirror that
+      // here so a player who died holding FIRE doesn't carry stale
+      // hold-time across the death/respawn boundary and fire a
+      // ghost-charged shot the server won't honour.
+      localShip.holdSec = 0;
+      localShip.wasFiring = false;
+    } else if (input.fire) {
+      localShip.holdSec += dt;
+    }
     if (localShip.wasFiring && !input.fire && localShip.cooldown <= 0 && localAlive()) {
       const me = mySeat && lastState ? lastState.players[SEATS.indexOf(mySeat)] : null;
       const myAmmo = me ? (me.superAmmo | 0) : 0;

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1453,9 +1453,17 @@
       // drawPlayer block (pips line, optional charge bar, halo when
       // fully charged). Skipped during the name fade-in window so
       // the lobby/countdown looks clean; only renders during play.
+      // For the local player, the charge bar reads from
+      // localShip.holdSec instead of the snapshot — the wire round-
+      // trip (~150–300 ms RTT) would otherwise delay every "hold to
+      // charge" interaction, so the bar feels broken on first press.
+      // Other players' charge bars stay snapshot-driven (we don't
+      // have their local input).
       if (latestSnap.status === 'running') {
         const ammo = (live.superAmmo | 0);
-        const charge = (live.chargeSec || 0);
+        const charge = isMine
+          ? (input.fire ? (localShip.holdSec || 0) : 0)
+          : (live.chargeSec || 0);
         const pipY = SHIP_Y - 14;
         // 3 pips, 3 PF wide each, 2 PF gap. Filled gold if armed,
         // dim outline if used — same convention as SP.

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -372,6 +372,9 @@
     INV_W, INV_H, INV_COLS,
     SHIELD_W, SHIELD_H, SHIELD_COUNT, SHIELD_Y,
     decodeShields, shieldOffsets,
+    SUPER_SHOT_MAX, CHARGE_THRESHOLD_SEC,
+    CHARGED_BULLET_W, CHARGED_BULLET_H,
+    comboMultiplier,
     SEATS, MAX_SEATS,
   } = engine;
   import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
@@ -410,7 +413,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 22;
+  const NETCODE_VERSION = 23;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -620,7 +623,7 @@
   // Local prediction state — only the seat we own. Integrated from
   // input each rAF frame using server-identical physics, snapped to the
   // server when we diverge (network drops, death/respawn).
-  const localShip = { x: null, cooldown: 0 };
+  const localShip = { x: null, cooldown: 0, holdSec: 0 };
   const ghostBullets = []; // [{ x, y, born }] — locally-predicted, fade after GHOST_TTL_MS
   let prevFrameT = 0;
   let posTimer = null;
@@ -1338,16 +1341,32 @@
     //    time the server's authoritative bullet has appeared in a
     //    snapshot and taken over the visual.
     localShip.cooldown = Math.max(0, localShip.cooldown - dt);
+    // Mirror the engine's hold-time tracking so the ghost bullet can
+    // preview a super-shot the moment the threshold is crossed (and
+    // ammo is still in stock per the latest snapshot).
+    if (input.fire) localShip.holdSec += dt;
+    else            localShip.holdSec = 0;
     if (input.fire && localShip.cooldown <= 0 && localAlive()) {
+      const me = mySeat && lastState ? lastState.players[SEATS.indexOf(mySeat)] : null;
+      const myAmmo = me ? (me.superAmmo | 0) : 0;
+      const charged = localShip.holdSec >= CHARGE_THRESHOLD_SEC && myAmmo > 0;
+      const bw = charged ? CHARGED_BULLET_W : BULLET_W;
+      const bh = charged ? CHARGED_BULLET_H : BULLET_H;
       ghostBullets.push({
-        x: localShip.x + SHIP_W / 2 - BULLET_W / 2,
-        y: SHIP_Y - BULLET_H,
+        x: localShip.x + SHIP_W / 2 - bw / 2,
+        y: SHIP_Y - bh,
         born: now,
+        charged: charged,
       });
       localShip.cooldown = FIRE_COOLDOWN;
-      Arcade.Audio.play('sfx-shoot', 0.55);
+      localShip.holdSec = 0;
+      Arcade.Audio.play('sfx-shoot', charged ? 0.75 : 0.55);
     }
-    for (const gb of ghostBullets) gb.y -= BULLET_SPEED * dt;
+    // Ghost bullets travel at the same speeds the engine uses (BULLET_
+    // SPEED for normal, CHARGED_BULLET_SPEED for super) so the visual
+    // hand-off lines up cleanly when the authoritative snapshot lands.
+    const CHARGED_GHOST_SPEED = 380;
+    for (const gb of ghostBullets) gb.y -= (gb.charged ? CHARGED_GHOST_SPEED : BULLET_SPEED) * dt;
     for (let i = ghostBullets.length - 1; i >= 0; i--) {
       if (now - ghostBullets[i].born > GHOST_TTL_MS || ghostBullets[i].y < -BULLET_H) {
         ghostBullets.splice(i, 1);
@@ -1424,6 +1443,47 @@
         ctx.fillText(live.name, x + SHIP_W / 2, SHIP_Y - 7);
         ctx.globalAlpha = 1;
       }
+
+      // Super-shot pips + charge bar above the ship. Mirrors SP's
+      // drawPlayer block (pips line, optional charge bar, halo when
+      // fully charged). Skipped during the name fade-in window so
+      // the lobby/countdown looks clean; only renders during play.
+      if (latestSnap.status === 'running') {
+        const ammo = (live.superAmmo | 0);
+        const charge = (live.chargeSec || 0);
+        const pipY = SHIP_Y - 14;
+        // 3 pips, 3 PF wide each, 2 PF gap. Filled gold if armed,
+        // dim outline if used — same convention as SP.
+        for (let p = 0; p < SUPER_SHOT_MAX; p++) {
+          const px = x + 1 + p * 5;
+          if (p < ammo) {
+            ctx.fillStyle = '#ffd84a';
+            ctx.fillRect(px, pipY, 3, 3);
+          } else {
+            ctx.fillStyle = 'rgba(255, 216, 74, 0.22)';
+            ctx.fillRect(px, pipY, 3, 3);
+          }
+        }
+        // Charge progress bar under the pips while holding (only
+        // when there's ammo to consume — bar wouldn't fire a super
+        // otherwise so don't tease the player).
+        if (charge > 0 && ammo > 0) {
+          const ratio = Math.min(1, charge / CHARGE_THRESHOLD_SEC);
+          ctx.fillStyle = 'rgba(255, 216, 74, 0.25)';
+          ctx.fillRect(x, SHIP_Y - 7, SHIP_W, 2);
+          ctx.fillStyle = '#ffd84a';
+          ctx.fillRect(x, SHIP_Y - 7, SHIP_W * ratio, 2);
+        }
+        // Pulsing halo when fully charged + ready to release. Tiny
+        // 1-PF inflation/contraction every 90 ms; subtle, just enough
+        // to draw the eye to "tap fire now".
+        if (charge >= CHARGE_THRESHOLD_SEC && ammo > 0) {
+          const pulse = 1 + Math.floor(performance.now() / 90) % 2;
+          ctx.fillStyle = 'rgba(255, 216, 74, 0.35)';
+          ctx.fillRect(x - pulse, SHIP_Y - 4 - pulse,
+                       SHIP_W + pulse * 2, 4 + 4 + pulse * 2);
+        }
+      }
     }
 
     // Invaders — lerp by array index (engine emits the grid in a stable
@@ -1484,13 +1544,34 @@
     }
 
     // Bullets — drawn from the latest snapshot (server-authoritative
-    // for spawn time + trajectory). Ghost bullets layered on top.
-    ctx.fillStyle = '#ffd84a';
-    for (const bl of latestSnap.bullets)        ctx.fillRect(bl.x, bl.y, BULLET_W, BULLET_H);
+    // for spawn time + trajectory). Normal bullets paint gold-on-
+    // white-core; charged super-shots paint fat gold + white core
+    // like SP, so the punch reads at a glance. Ghost bullets layered
+    // on top with the same charged/normal distinction.
+    for (const bl of latestSnap.bullets) {
+      if (bl.c) {
+        ctx.fillStyle = '#ffd84a';
+        ctx.fillRect(bl.x, bl.y, CHARGED_BULLET_W, CHARGED_BULLET_H);
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(bl.x + 1, bl.y + 1, CHARGED_BULLET_W - 2, CHARGED_BULLET_H - 2);
+      } else {
+        ctx.fillStyle = '#ffd84a';
+        ctx.fillRect(bl.x, bl.y, BULLET_W, BULLET_H);
+      }
+    }
     ctx.fillStyle = '#ff6666';
     for (const bl of latestSnap.invaderBullets) ctx.fillRect(bl.x, bl.y, BULLET_W, BULLET_H);
-    ctx.fillStyle = 'rgba(255, 216, 74, 0.7)';
-    for (const gb of ghostBullets)              ctx.fillRect(gb.x, gb.y, BULLET_W, BULLET_H);
+    for (const gb of ghostBullets) {
+      if (gb.charged) {
+        ctx.fillStyle = 'rgba(255, 216, 74, 0.7)';
+        ctx.fillRect(gb.x, gb.y, CHARGED_BULLET_W, CHARGED_BULLET_H);
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.7)';
+        ctx.fillRect(gb.x + 1, gb.y + 1, CHARGED_BULLET_W - 2, CHARGED_BULLET_H - 2);
+      } else {
+        ctx.fillStyle = 'rgba(255, 216, 74, 0.7)';
+        ctx.fillRect(gb.x, gb.y, BULLET_W, BULLET_H);
+      }
+    }
 
     // Countdown overlay (3/2/1) + a brief ATTACK! flash on the
     // countdown → running transition. Server publishes
@@ -1543,6 +1624,16 @@
       ctx.fillText('SCORE', 6, 4);
       ctx.fillStyle = seatIdx >= 0 ? SHIP_COLORS[seatIdx] : '#ffffff';
       ctx.fillText(String(myScore).padStart(4, '0'), 6, 12);
+      // Combo multiplier badge next to the score — only shown when
+      // the chain is at ×2 or higher (×1 = "no combo", don't add
+      // noise). Gold so it reads as a positive bonus indicator.
+      if (me && me.combo > 0) {
+        const mult = comboMultiplier(me.combo);
+        if (mult > 1) {
+          ctx.fillStyle = '#ffd84a';
+          ctx.fillText('x' + mult, 6 + 26, 12);
+        }
+      }
 
       // STAGE — centred. Placeholder "1-1" until Phase G.
       ctx.textAlign = 'center';

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1250,6 +1250,11 @@
   // ship + ghost bullets layered on top.
   const canvas = document.getElementById('cv');
   const ctx = canvas.getContext('2d');
+  // Navy background gradient (SP-matched). Built once per resize in
+  // fitCanvas; renderInterpolated paints it as the playfield bg each
+  // frame. Declared here (before fitCanvas) so the first call from
+  // module init doesn't hit the let TDZ.
+  let bgGradient = null;
   function fitCanvas() {
     // Match SP's rendering pipeline: canvas bitmap is sized to the
     // CSS display size × devicePixelRatio, so each canvas pixel = one
@@ -1280,6 +1285,13 @@
     const sx = canvas.width  / PF_W;
     const sy = canvas.height / PF_H;
     ctx.setTransform(sx, 0, 0, sy, 0, 0);
+    // SP's washed navy gradient — rebuilt each resize because gradient
+    // objects are bound to the canvas dimensions, not the user-space
+    // transform. Stored in module scope; renderInterpolated paints it
+    // every frame as the playfield background.
+    bgGradient = ctx.createLinearGradient(0, 0, 0, PF_H);
+    bgGradient.addColorStop(0, '#0d1a60');
+    bgGradient.addColorStop(1, '#050a30');
   }
   window.addEventListener('resize', fitCanvas);
   window.addEventListener('orientationchange', fitCanvas);
@@ -1400,7 +1412,7 @@
   }
 
   function renderInterpolated() {
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = bgGradient || '#000';
     ctx.fillRect(0, 0, PF_W, PF_H);
 
     if (snapBuffer.length === 0) return;

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -29,6 +29,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    /* Extend the playfield's navy gradient over the whole tube so
+       the canvas's edges blend invisibly into the surrounding cabinet
+       area (the canvas itself paints the same gradient internally).
+       Shared cabinet.css defaults .tube to solid #000; override here
+       just for MP. Vertical gradient matches the canvas one stop-for-
+       stop (#0d1a60 top → #050a30 bottom). */
+    background: linear-gradient(180deg, #0d1a60 0%, #050a30 100%);
   }
   .tube canvas {
     width: auto; height: auto;

--- a/docs/plans/invaders-mp-sp-audit.md
+++ b/docs/plans/invaders-mp-sp-audit.md
@@ -57,16 +57,14 @@ Fix is one line in `renderInterpolated`: build a navy gradient once and reuse. T
 ### Combo scoring
 
 - **SP:** kills within `COMBO_WINDOW_MS = 1500` extend a chain; multiplier ramps 1 → 2 → 3 → 4 by kill count (`comboMultiplier()` thresholds at 3, 5, 8 kills) (`invaders/index.html:~1668-1673`). Each kill adds `rowPoints × multiplier` and emits a `+30` / `×3 +60` popup.
-- **MP:** absent. Flat 10 per kill, no chain state.
-- **MP-specific call:** **per-player combo chain** (recommend) — each player has their own combo state. Avoids the "P1 kills, P2 gets the multiplier" weirdness. Adds `players[i].combo: number` and `players[i].lastKillAt: number` to engine state, exposed in snapshot.
+- **MP (shipped in Phase F):** per-player chain. Engine: `ship.combo: number` (chain count) + `ship.comboDecayIn: number` (seconds left before reset). On each kill: `combo++`, `comboDecayIn = COMBO_WINDOW_SEC` (1.5). The tick handler decays `comboDecayIn` and zeroes `combo` when it hits 0. Wire exposes `players[i].combo`; renderer reads it via `comboMultiplier(combo)` and draws the `xN` HUD badge.
 
 ### Super shots (charged fire)
 
 - **SP:** hold SPACE → after `CHARGE_THRESHOLD_MS=500ms` with `superShotAmmo > 0`, releasing fires a fat golden piercing bullet (`CHARGED_BULLET_W=4, CHARGED_BULLET_H=12, CHARGED_BULLET_SPEED=380`) that passes through shields and damages the whole column.
   - Ammo: `SUPER_SHOT_MAX = 3`, start with full clip, +1 awarded every `SUPER_SCORE_INTERVAL=1000` points, refilled to MAX on UFO kill.
   - UI: 3 gold pips above the ship, charge progress bar below the pips while holding, pulsing halo when fully charged & ready (`drawPlayer` `~L1837-1879`).
-- **MP:** absent. Ship has only the basic `fire` input → single white bullet.
-- **MP-specific call:** **per-player ammo + charge state**. Adds `players[i].superAmmo: number` and `players[i].charging: boolean` (+ `chargeStartAt` server-side). Pips render above each ship in that seat's colour. Touch input stays "hold FIRE" — no separate super button.
+- **MP (shipped in Phase F):** per-player ammo + release-to-fire charging. Engine: `ship.superAmmo: number` (cap `SUPER_SHOT_MAX = 3`), `ship.chargeSec: number` (accumulates while FIRE held, resets on release), `ship.wasFiring: boolean` (edge tracker), `ship.nextSuperAt: number` (score threshold for next earned ammo). Wire exposes `players[i].superAmmo` + `players[i].chargeSec`. Engine exports `SUPER_SHOT_MAX`, `CHARGE_THRESHOLD_SEC`, `CHARGED_BULLET_W/H/SPEED`. Pips + charge bar + halo render above each ship in seat colour; local charge bar reads `localShip.holdSec` for zero-RTT feedback. UFO ammo refill arrives with Phase G.
 
 ### Lives + ship death + respawn
 

--- a/docs/plans/invaders-mp-sp-audit.md
+++ b/docs/plans/invaders-mp-sp-audit.md
@@ -1,0 +1,287 @@
+# Invaders MP — SP parity audit + phase replan
+
+> Snapshot of where MP stands vs single-player Invaders. Source of truth for the remaining phases of the SP→MP convergence.
+>
+> SP is `docs/arcade/invaders/index.html` (~3000 LoC, all logic inline). MP is `docs/arcade/invaders-mp/index.html` (~1500 LoC client) + `engine.js` (~300 LoC authoritative sim, bundled into both client host-mode and server worker) + `room.ts` (Cloudflare DO transport).
+
+## TL;DR
+
+**Biggest gaps (priority order):**
+1. **Lives** — MP currently does 1-shot-and-out. SP gives 3. Without lives MP rounds are seconds long and frustrating for kids.
+2. **Per-player scoring + HUD** — MP shows one global SCORE; needs `players[i].score` on the wire + a per-ship scoreboard. User-confirmed requirement.
+3. **Shields** — SP has 4 destructible shields between ships and invaders. MP has none. User-confirmed: shields are **shared across all players** in MP.
+
+**MP-specific design calls that need a decision before Phase D code:**
+1. Per-player lives vs shared pool (recommend: per-player, 3 each)
+2. Per-player combo chain vs shared (recommend: per-player)
+3. Playfield width (240 → wider for 11-col grid?) (recommend: stay 240 for now, accept 8-col grid as the MP variant)
+
+**Revised phase plan:** Phase D = HUD + per-player score + lives; E = shields (shared); F = combos + supers (per-player); G = stages + UFO + popups; H = bosses + win cutscene; I = splash polish + pause overlay; J = leaderboard + deprecate `/invaders/`.
+
+---
+
+## Audit by area
+
+### HUD
+
+The single biggest visual gap. SP renders a tri-column header on the canvas; MP renders only SCORE.
+
+| Element | SP (`drawHUD` ~L1799) | MP (`renderInterpolated` L1190ish) | Gap |
+|--|--|--|--|
+| SCORE | top-left, "SCORE" label + 4-digit value, white/yellow | "SCORE" + 4-digit value top-left during `running`/`gameover` | needs per-ship variant in seat colour, possibly per-player columns |
+| STAGE | top-centre, "STAGE 1-1" / "1-BOSS" | absent | depends on Phase G (stage progression) |
+| LIVES | top-right, "LIVES 2" | absent | depends on Phase D (lives system) |
+| HI-SCORE | shown on splash + carries during play | absent | Phase J (leaderboard) |
+
+SP scoring is row-tiered: `ROW_POINTS = [30, 20, 20, 10, 10]` (`invaders/index.html:568`). MP uses flat `SCORE_PER_KILL = 10` (`engine.js:58`). Worth porting the row tier — it makes top-row kills feel valuable and creates the strategic "shoot down the squids first" play.
+
+### Background / palette
+
+- **SP:** `bgGradient = linear-gradient(#0d1a60 → #050a30)`, drawn into the canvas via `ctx.createLinearGradient` in `resize()` (`invaders/index.html:218-220`).
+- **MP:** `ctx.fillStyle = '#000'; ctx.fillRect(0, 0, PF_W, PF_H);` (`index.html:1100`) — pure black.
+
+Fix is one line in `renderInterpolated`: build a navy gradient once and reuse. The cabinet bezel already gives the brown frame; the playfield should be the SP navy.
+
+### Shields
+
+- **SP:** 4 destructible bunkers between the player and the swarm.
+  - Constants: `SHIELD_W=22, SHIELD_H=16, SHIELD_Y=PLAYER_Y-30, SHIELD_COUNT=4` (`invaders/index.html:~520`)
+  - Shape: `SHIELD_SHAPE` is a 22×16 ASCII bitmap (`X`=solid, `.`=empty) with the classic dome + alcove silhouette.
+  - Damage: bullets erode the bitmap pixel-by-pixel — SP iterates the bitmap on collision and zeros hit pixels. Both player bullets going up and invader bullets coming down chip away at the shield.
+  - Per-shield gap formula: `(PF_W - SHIELD_W * SHIELD_COUNT) / (SHIELD_COUNT + 1)`. SP gap = `(260-88)/5 = 34.4`. MP at PF_W=240 would be `(240-88)/5 = 30.4` — workable.
+
+- **MP:** absent. No shield concept in engine, snapshot, or render.
+
+- **MP-specific call (user-confirmed):** **shields are shared across all players**. Engine owns the bitmap; the wire snapshot exposes it (compressed — see Phase E notes); every player's bullets chip the same shields.
+
+### Combo scoring
+
+- **SP:** kills within `COMBO_WINDOW_MS = 1500` extend a chain; multiplier ramps 1 → 2 → 3 → 4 by kill count (`comboMultiplier()` thresholds at 3, 5, 8 kills) (`invaders/index.html:~1668-1673`). Each kill adds `rowPoints × multiplier` and emits a `+30` / `×3 +60` popup.
+- **MP:** absent. Flat 10 per kill, no chain state.
+- **MP-specific call:** **per-player combo chain** (recommend) — each player has their own combo state. Avoids the "P1 kills, P2 gets the multiplier" weirdness. Adds `players[i].combo: number` and `players[i].lastKillAt: number` to engine state, exposed in snapshot.
+
+### Super shots (charged fire)
+
+- **SP:** hold SPACE → after `CHARGE_THRESHOLD_MS=500ms` with `superShotAmmo > 0`, releasing fires a fat golden piercing bullet (`CHARGED_BULLET_W=4, CHARGED_BULLET_H=12, CHARGED_BULLET_SPEED=380`) that passes through shields and damages the whole column.
+  - Ammo: `SUPER_SHOT_MAX = 3`, start with full clip, +1 awarded every `SUPER_SCORE_INTERVAL=1000` points, refilled to MAX on UFO kill.
+  - UI: 3 gold pips above the ship, charge progress bar below the pips while holding, pulsing halo when fully charged & ready (`drawPlayer` `~L1837-1879`).
+- **MP:** absent. Ship has only the basic `fire` input → single white bullet.
+- **MP-specific call:** **per-player ammo + charge state**. Adds `players[i].superAmmo: number` and `players[i].charging: boolean` (+ `chargeStartAt` server-side). Pips render above each ship in that seat's colour. Touch input stays "hold FIRE" — no separate super button.
+
+### Lives + ship death + respawn
+
+- **SP:** `lives = 3` (`invaders/index.html:382`). Ship hit → death animation → respawn at centre, `lives--`. Gameover when `lives === 0`.
+- **MP:** ship hit → `alive = false` permanently. Game ends when ALL ships dead (`engine.js:259`). No respawn.
+
+**MP design (decided):** **Shared pool of 3 respawns**, can adjust after playtesting.
+- Engine: `state.lives: number` (default 3).
+- On any ship death: if `lives > 0`, decrement lives and respawn that ship after 2s (1s invuln). If `lives === 0`, ship stays permanently dead.
+- Gameover when zero ships alive AND no lives left.
+- Total deaths before gameover with 4 players: 4 (initial fleet) + 3 (respawns) = **7 deaths** of error budget. Generous for co-op.
+- HUD shows single `LIVES: N` value (not per-player columns) — kids share the pool, fewer numbers on screen.
+
+### Stages + progression
+
+- **SP:** `STAGES_PER_SET = 3` (`~L497`). Stages labelled 1-1 → 1-2 → 1-3 → 1-BOSS → 2-1... Each normal stage spawns a fresh grid, harder (faster march, sometimes a marked-cell side effect). Stage announce overlay fades in/out at the top of each.
+- **MP:** absent. One round = one grid, then `gameover`. No stage advance, no boss trigger.
+- **Design:** stages are shared (one engine state). On grid clear with `phase === 'grid'`, advance `stageNum`; if at `STAGES_PER_SET`, transition to `phase === 'boss'`.
+
+### UFO bonus enemy
+
+- **SP:** flies across the top occasionally. `UFO_SCORES = [50, 100, 150, 300]` (kill point varies by `progress` across the screen — classic Invaders). Spawn interval 25-45s random. UFO kill refills super ammo to MAX. Synth warble plays while on-screen.
+- **MP:** absent.
+- **Design:** UFO is shared (one per stage). "Who scores it" = whoever lands the killing bullet — consistent with normal kills.
+
+### Score popups
+
+- **SP:** `popups[]` array of `{x, y, text, colour, untilMs}` (`~L436`). Spawned on every kill, boss damage, UFO kill. Fade out 600ms. Drawn over the grid with `ctx.globalAlpha`.
+- **MP:** absent.
+- **Design:** purely visual. Could live on the client (don't need wire bandwidth) — derive from snapshot score delta. Simpler: spawn popup in the engine and broadcast (~3 floats per popup × ~10 active = trivial).
+
+### Bosses + win cutscene
+
+- **SP:** 4 boss types (`BOSS_TYPES`, `~L461`), each `BOSS_W=BOSS_H=40 PF px`, HP varies (~30+). Spawned at end of each set (`1-BOSS`, `2-BOSS`, ...). `BOSS_ADD_SCORE=50`, boss adds (smaller minions) respawn every `BOSS_ADD_RESPAWN_MS=5000`. Boss death fires the win cutscene if it was the final boss; otherwise advance to next set.
+- **Win cutscene:** `phase === 'cutscene'`, `CUTSCENE_MS` for animation (~9.5s), pixel Earth + orbiting ship + flag + "EARTH IS SAFE". Player input dismisses to restart.
+- **MP:** absent.
+- **Design:** shared (one boss per stage). Boss death scores split among damage-dealers OR awarded to killer; recommend killer-gets-it for simplicity.
+
+### Marked invader (side effect)
+
+- **SP:** one random cell per grid is "marked" — killing it triggers a side effect (probably a popup or score bonus; check `markedCell` usage `~L427, L1004`).
+- **MP:** absent. Lower priority.
+
+### Easter egg — Claude invader
+
+- **SP:** exactly one row-3 invader is replaced by a Claude creature sprite, terracotta colour `#d97757` (`~L573`). Cosmetic; scores like a normal row-3 octopus.
+- **MP:** absent. Trivial port (sprite + per-grid claudeCol pick + render swap).
+
+### Audio gaps
+
+MP has shoot/kill/explosion/lose wired (Phase B). SP has additionally:
+
+- **March beat synth** — four notes `[E2, D2, C2, B1]` looped on the march tick (`MARCH_NOTES`, `~L348`). Speeds up as the swarm thins. The iconic Invaders heartbeat.
+- **UFO warble synth** — sine sweep up-down while UFO on-screen (`~L356`).
+- **Super-shot fire** — distinct sound for charged shot release (in SP `synth.shoot(charged)` branches on the boolean).
+- **BGM tracks** — 3 tracks: main gameplay, boss (Egyptian-flavoured), win cutscene (`~L240`). Loops; switches on phase change.
+
+### Overlays / chrome
+
+- **Splash chrome** (`splash.css` + `splash.js`): SP uses the full `.splash` shell with CRT power-on animation, marquee, hi-score row, title↔leaderboard cycling. MP's prescreen is a custom panel — not using `.splash`.
+- **Pause overlay** (`pause.js`): SP has a pause menu with volume slider. MP has no pause UI; SFX volume is controlled by another arcade game's slider (shared localStorage key).
+- **End overlay** (`end-overlay.js`): SP shows "GAME OVER" / score saved / new high score in a styled overlay. MP shows the gameover state via the prescreen text only.
+- **Initials entry** (`initials.js`): on new high score, SP prompts for 3-letter initials. MP has nothing — would need a leaderboard server first.
+- **Leaderboard** (`leaderboard.js`): SP fetches from the leaderboard worker (`infra/leaderboard-worker`). MP not wired.
+
+### Screen effects
+
+- **SP:** `crt-shake` keyframe in cabinet.css triggered via `.tube.is-shaking` for collisions/deaths. Screen flash on explosion. SP wires this from gameplay events.
+- **MP:** none. Easy add — apply class on local explosion event.
+
+---
+
+## MP-specific design calls (needs decision before Phase D)
+
+For each: SP behaviour, MP options, recommended pick.
+
+### 1. Per-player vs shared score
+**SP:** single `score` var.
+**MP options:** (a) per-player, summed for team display; (b) per-player only, no team total; (c) shared pool (current MP).
+**Recommend (a)** — user already said per-player. Wire change: `players[i].score: number` + optional `teamScore` derived. HUD has per-ship columns with seat-colour scores.
+
+### 2. Lives — shared pool of 3 (decided)
+Single `state.lives = 3` carried on the wire. Death decrements; respawn if > 0; permanent if 0. HUD shows one `LIVES: N` value. Generous 7-deaths-before-gameover budget for 4-player co-op.
+
+### 3. Shields shared (user-confirmed)
+**SP:** single shield grid.
+**MP:** engine holds one shared shield bitmap; snapshot exposes it (e.g. RLE-compressed Uint8Array → base64, or per-shield bitmaps as compact ints). Every player's bullets chip the same shields.
+**Wire size:** `4 shields × 22 × 16 = 1408 bits = 176 bytes`. Even without compression, fine. With RLE-on-changed-only, trivial.
+
+### 4. Combo chain per-player
+**Recommend:** `players[i].combo` and `players[i].lastKillAt` in engine state. Each player's combo decays on their own clock. Combo HUD shows multiplier next to that ship's score (×2 / ×3 / ×4 glow).
+
+### 5. Super shots per-player
+**Recommend:** `players[i].superAmmo: number` (capped at SUPER_SHOT_MAX=3), `players[i].chargeStartAt: number` (server clock). Charge bar + pips render above each ship in seat colour. UFO kill refills the killer's ammo only — not the team's.
+
+### 6. UFO kill scoring
+**Recommend:** killer gets the points + super ammo refill. Same model as normal kills.
+
+### 7. Stages, bosses, marked cells — all shared
+One engine state, all players see the same boss/grid/stage. Killer gets credit for individual bullets.
+
+### 8. Respawn cadence
+**Recommend:** 2-second respawn delay at fixed spawn-X (the original even-spacing position), 1-second invulnerability after respawn so they don't die instantly to the same bullet wall.
+
+### 9. Playfield width — widen to 260, 11-col grid (decided)
+Match SP. PF_W: 240 → 260. Grid: 8 cols → 11 cols (55 invaders, up from 40). Ship spawn margin recalculates from `(260 - 4*16)/5 = 39.2` per ship (slightly wider spacing than current 35.2 — better for 4 ships not crowding). Canvas bitmap `<canvas width=260>`. fitCanvas already aspect-correct.
+
+This is a 2-line engine change but cascades through render code that assumes 240 — needs a small "preflight" pass during Phase D since lives + 11-col grid touch the same code paths.
+
+### 10. Touch input for supers
+**SP:** hold FIRE to charge → release to fire normal or super based on ammo + hold duration.
+**MP:** keep the same model. No new touch button needed. The `fire` input on the wire stays a boolean; the engine tracks the hold duration server-side.
+
+---
+
+## Revised phase plan
+
+Each phase = a single PR you'd actually want to review. LoC estimates honest based on the audit.
+
+### Phase D — Playfield widen + HUD + per-player score + shared lives (~300 LoC)
+The user-flagged "scores need to be individual" + lives + the playfield widening that the rest of the phases depend on.
+
+**Engine changes:**
+- `PF_W: 240 → 260` (matches SP), `INV_COLS: 8 → 11` (55-invader grid).
+- `players[i].score: number` (replaces global `score`; keep `teamScore` derived for HUD).
+- Row-tiered points: `ROW_POINTS = [30, 20, 20, 10, 10]` (instead of flat 10).
+- `state.lives: number` (default 3, shared pool).
+- Death flow: bullet hits ship → `alive = false` + `respawnAt = now + 2000ms`. Step decrements `lives` if > 0 and resets ship on respawnAt; otherwise stays dead.
+- 1s invulnerability after respawn (`ship.invulnUntil = now + 1000`).
+- Gameover when no ships alive AND `lives === 0`.
+
+**Wire:**
+- `players[i].score` added, top-level `score` dropped (or kept as `teamScore` if useful).
+- Top-level `lives` added.
+- `players[i].respawnAt` (for client respawn-timer rendering) and `players[i].invulnUntil` (for blink effect).
+
+**Renderer:**
+- HUD across top: `SCORE` per-player columns in seat colour | `STAGE 1-1` (placeholder until Phase G) | `LIVES N` (single shared value, white).
+- Respawn blink during invuln (toggle ship visibility every 100ms).
+- Possibly draw per-player score above each ship in seat colour (visually associated, kid-friendly).
+
+**Files:** `engine.js`, `engine.d.ts`, `index.html` (canvas width + renderer), `room.ts` (carry new fields, no logic change).
+
+**Wire-version bump:** netcode v21 — but additive fields with default fallbacks so mixed-version clients degrade rather than break.
+
+### Phase E — Shields, shared (~250 LoC)
+- Engine: `shields: Uint8Array(SHIELD_COUNT * SHIELD_W * SHIELD_H)` + `SHIELD_SHAPE` constant. Bullet vs shield collision iterates the bitmap, zeros hit pixels.
+- Wire: snapshot's `shields` as RLE-compressed (changed-cells delta if bandwidth is a concern; full bitmap otherwise — 176B/tick is fine).
+- Renderer: draw shields from the bitmap.
+- Position constants: `SHIELD_Y = SHIP_Y - 30`, `SHIELD_COUNT = 4`, gap formula per PF_W.
+- Files: `engine.js`, `engine.d.ts`, `sprites.js` (or new `shields.js` for the shape), `index.html` (renderer).
+
+### Phase F — Combos + supers, per-player (~300 LoC)
+- Engine: `players[i].combo`, `players[i].lastKillAt`, `players[i].superAmmo`, `players[i].chargeStartAt`. `comboMultiplier(count)` 1/2/3/4. Charged-bullet physics (`CHARGED_BULLET_W/H/SPEED`, passes through shields).
+- Wire: add the 4 new player fields.
+- Renderer: per-ship combo multiplier glow, super ammo pips + charge bar + halo (port from SP `drawPlayer`).
+- Audio: separate `sfx-shoot-charged` SFX (could reuse, or vendor a new one).
+- Files: same as D plus a new SFX file.
+
+### Phase G — Stages + UFO + popups (~300 LoC)
+- Engine: `phase: 'grid'|'boss'|'cutscene'`, `stageSet`, `stageNum`, stage transition on grid clear, UFO spawn timer + state, `popups[]` array.
+- Wire: `phase`, `stageSet`, `stageNum`, `ufo: {x,dir}|null`, `popups: [{x,y,text,colour,untilMs}]`.
+- Renderer: stage announce overlay, UFO sprite + warble synth wiring, popup floats.
+- Audio: UFO warble synth (port from SP synth, no MP3 needed).
+- Files: same as F.
+
+### Phase H — Bosses + win cutscene (~400 LoC)
+- Engine: 4 boss types (`BOSS_TYPES`), boss spawn at end of set, boss adds, boss → cutscene transition.
+- Renderer: boss sprite + adds + damage popups + the win cutscene (pixel Earth animation + EARTH IS SAFE pose).
+- Audio: boss BGM + win BGM (these are the biggest deltas — would need to either vendor MP3s or commit to ditching BGM in MP).
+- Files: same as G.
+
+### Phase I — Splash polish + pause overlay (~150 LoC)
+- Adopt `shared/splash.css` + `splash.js` for CRT power-on and title-cycle.
+- Adopt `shared/pause.js` for the volume slider (pause-the-game semantics need MP-specific design — probably "pause = mute, game keeps running" since you can't pause MP).
+- Files: `index.html`, possibly small `shared/*` tweaks.
+
+### Phase J — Leaderboard + deprecate `/invaders/` (~100 LoC)
+- Wire MP to `infra/leaderboard-worker` (shared with SP).
+- Initials entry on new high score (`shared/initials.js`).
+- Redirect `/invaders/*` → `/invaders-mp/` once MP has full parity + lives + supers + bosses.
+- Files: `index.html`, `infra/oyster-arcade-site/src/worker.ts` (redirect rule).
+
+---
+
+## Files this affects, at a glance
+
+| Phase | engine.js / .d.ts | sprites.js | index.html | room.ts | shared/* |
+|--|--|--|--|--|--|
+| D — HUD + score + lives | heavy | — | medium (renderer) | — | — |
+| E — Shields | heavy (new state + collisions) | small (shield shape) | medium | — | — |
+| F — Combos + supers | heavy | — | medium | — | possibly new sfx |
+| G — Stages + UFO + popups | heavy | small (UFO sprite) | medium | — | — |
+| H — Bosses + cutscene | heavy | medium (boss sprites) | heavy | — | possibly BGM |
+| I — Splash + pause | — | — | medium | — | small splash.js tweaks |
+| J — Leaderboard + dep | — | — | medium | — | wire initials.js, leaderboard.js |
+
+## Open questions (still to decide)
+
+1. ~~Lives model~~ — **decided: shared pool of 3.**
+2. **Boss / cutscene BGM** (Phase H) — port the MP3s from SP, or skip BGM in MP entirely (lighter bundle, kid-friendlier on iPad with a parent nearby)?
+3. ~~Playfield width~~ — **decided: widen to 260, 11-col grid.**
+4. **Marked invader side effects** — port now (Phase G) or defer indefinitely?
+5. ~~Phase order~~ — **decided: D=HUD+score+lives → E=shields → F=combos+supers → G=stages+UFO+popups → H=bosses+cutscene → I=splash+pause → J=leaderboard.**
+
+## Netcode backlog (post-game-feature)
+
+Defer until the game features land (Phase G+). User priorities, in order:
+
+1. **Solo player skips the DO entirely.** ~95% of sessions are 1-player or 1+kid-joining-mid-round. The current path always opens a WebSocket to the Cloudflare DO, which adds 150–365 ms RTT round-trip from UAE depending on which colo CF picked that day. For solo, run host-mode locally from the start (engine ticks in the same JS context, no wire) — instant. Connect to the DO only when a 2nd player joins via the room code.
+
+2. **Same-LAN MP prefers WebRTC P2P even more aggressively.** Currently signalling goes through the DO and gameplay starts on cloud relay until WebRTC's handshake completes (a few seconds). Defer DO contact further and use a simpler in-LAN discovery (BroadcastChannel? WebRTC over local IP?) when possible. Cloud relay stays as the fallback for cross-network play.
+
+3. **Pin `locationHint: 'weur'` on `idFromName`.** Cuts the CDG-vs-SIN day-to-day variance Henry reported (365 ms on a SIN day vs 150 ms on a CDG day). Worst case stays ~150 ms; no more 2× spikes.
+
+4. **Investigate why P2P doesn't always engage in same-LAN sessions** (Henry's "felt laggy" rounds where the transport badge presumably said RELAY). Possible: router AP isolation, cellular vs Wi-Fi mismatch, signalling stall.
+
+The user's framing: "if I am single player it should be smooth / we prefer LAN/P2P, netcode can stay as a fallback but 95% of cases will be me or my son doing single player and then us joining sitting next to each other."

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -105,7 +105,14 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        with SP at 18×12, sprites rendered at 1.5× scale on a
 //        display-resolution canvas (fitCanvas + ctx.setTransform)
 //        for crisp pixel art without warp.
-const NETCODE_VERSION = 22;
+// v23 — Phase F: per-player combos + super shots. Each player has
+//        their own combo chain (×1/2/3/4 at 3/5/8 kills, 1.5 s
+//        decay) and ammo counter (cap 3, +1 per 1000 pts). Hold
+//        FIRE ≥ 500 ms with ammo → next bullet is a fat golden
+//        piercer (tunnels through shields, kills every aligned
+//        invader). New wire fields: players[i].combo /
+//        .superAmmo / .chargeSec, bullets[].c.
+const NETCODE_VERSION = 23;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Two stacked mechanics added on top of the SP-parity foundation:

- **Per-player combo chains** — consecutive kills within 1.5 s extend the chain; score gets multiplied (×2 at 3 kills, ×3 at 5, ×4 at 8). Each player has their own chain — kills by P1 don't boost P2's multiplier.
- **Per-player charged fire (super shots)** — hold FIRE for ≥ 500 ms with ammo and the next bullet is a fat golden piercer that tunnels through shields and pierces every aligned invader. Cap 3 ammo, earn +1 per 1000 pts.

## Engine

- `ship.combo` + `ship.comboDecayIn` per player. `comboMultiplier(count)` returns 1/2/3/4 at SP's 3/5/8 thresholds. Score = `ROW_POINTS[row] × multiplier`.
- `ship.superAmmo` (cap `SUPER_SHOT_MAX = 3`) + `ship.chargeSec` accumulator + `ship.nextSuperAt` earned-ammo threshold.
- Hold FIRE → `chargeSec += dt`. On cooldown-clear, if `chargeSec ≥ CHARGE_THRESHOLD_SEC && superAmmo > 0` → spawn a charged bullet (`CHARGED_BULLET_W/H/SPEED` = 4/12/380), decrement ammo, reset charge. Release → reset charge.
- Charged bullets `tunnel through shields` (damageShields carves but bullet isn't consumed) and `pierce invaders` (no break on first hit).
- Respawn resets per-life state (combo, chargeSec) but keeps long-term resources (superAmmo, nextSuperAt).

## Wire (NETCODE_VERSION 22 → 23, additive)

- `players[i].combo / superAmmo / chargeSec`
- `bullets[].c` — true for charged

## Client

- Charged bullets render fat-gold + white core (matches SP).
- Ghost bullets predict charged mode locally — tracks `localShip.holdSec`, reads `superAmmo` from latest snapshot, marks ghost as charged on spawn if both gates pass. Same travel speed as engine for clean visual hand-off.
- Above each occupied ship: 3 super-shot pips (gold filled = armed, dim outline = used), charge progress bar below pips while holding with ammo, pulsing halo when fully charged + ready. Ported from SP's `drawPlayer`.
- HUD combo badge `xN` next to local score when multiplier ≥ 2 (×1 = "no combo", omitted to avoid noise).

## Netcode backlog

User flagged a separate netcode improvement during Phase F: solo player should skip the DO entirely (run host-mode locally, no cloud round-trip), same-LAN MP should prefer WebRTC P2P even more aggressively. Added to `docs/plans/invaders-mp-sp-audit.md` as a Netcode backlog section to attack after Phase J. Also includes the `locationHint: 'weur'` pin to cut the CDG↔SIN day-to-day RTT variance.

## Test plan

- [ ] Deploy: \`cd ~/Dev/oyster.worktrees/invaders-combos-supers/infra/oyster-arcade-mp && npx wrangler deploy\` then \`cd ../oyster-arcade-site && npx wrangler deploy\`
- [ ] Hard-refresh \`arcade.oyster.to/invaders-mp/FROG\`
- [ ] **Pips visible**: 3 gold pips above the ship at startup
- [ ] **Hold to charge**: hold FIRE — yellow bar fills under the pips over 500 ms; once full, gold halo pulses around the ship
- [ ] **Charged shot**: with hold + ammo, next shot is fat gold + white core. Tunnels through a shield (notch appears, bullet continues). Kills every invader in its vertical column.
- [ ] **Ammo cap**: kill 3 supers in a row → no more charge until you earn another via score
- [ ] **Earn refill**: cross 1000 pts → ammo +1 (pip lights back up)
- [ ] **Combo**: chain kills fast — score badge \`x2\` appears at 3 kills, \`x3\` at 5, \`x4\` at 8. Wait 1.5 s without a kill → badge disappears
- [ ] **Per-player**: in 2-player, P1's combo doesn't boost P2's score (each chain independent)
- [ ] **\`?debug\` netcode badge says v23**, no mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)