### PR TITLE
Artifact's home is the project; space is derived (drop artifacts.space_id)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-artifact-project-home.md
+++ b/docs/superpowers/plans/2026-05-24-artifact-project-home.md
@@ -388,12 +388,26 @@ this.stmts = {
   getByPath: db.prepare(`${SELECT} WHERE json_extract(a.storage_config,'$.path') = ? AND a.removed_at IS NULL`),
   getDistinctSpaces: db.prepare(`SELECT p.space_id AS space_id, COUNT(*) as count FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id ORDER BY p.space_id`),
   getByProjectAndSourceRef: db.prepare(`${SELECT} WHERE a.project_id = ? AND a.source_ref = ?`),
-  insert: db.prepare(`
-    INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
-    VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`),
+  // INSERT must be built dynamically too: `space_id` is still NOT NULL until
+  // Task 7 drops it, so while the column exists we must supply a value ('') to
+  // satisfy the constraint; once dropped, we must NOT name it. Mirror the
+  // SELECT's PRAGMA approach.
+  insert: db.prepare(
+    hasSpaceCol
+      ? `INSERT INTO artifacts (id, owner_id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
+         VALUES (@id, @owner_id, '', @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`
+      : `INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
+         VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`,
+  ),
   delete: db.prepare("DELETE FROM artifacts WHERE id = ?"),
 };
 ```
+
+where `hasSpaceCol` is computed once at the top of the constructor:
+```typescript
+const hasSpaceCol = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+```
+The transitional `''` is never read (derived reads use the join alias), and once Task 7 drops the column the store is reconstructed with `hasSpaceCol = false` so the column is no longer named.
 
 > `getBySpaceId` uses `LEFT JOIN` + `WHERE p.space_id = ?` — orphan artifacts (`project_id NULL` → `p.space_id NULL`) never match a real space id, so they're correctly excluded. `getAll` orders by `p.space_id` (the column is gone post-drop). `getDistinctSpaces` inner-joins (orphans absent), matching old behaviour where every artifact had a space.
 

--- a/docs/superpowers/plans/2026-05-24-artifact-project-home.md
+++ b/docs/superpowers/plans/2026-05-24-artifact-project-home.md
@@ -62,8 +62,16 @@ describe("ensureNativeProject", () => {
     const path = db.prepare("SELECT path FROM project_paths WHERE project_id = ?").get(id1) as { path: string };
     expect(path.path).toBe(join(userland, "spaces", "work"));
   });
+
+  it("creates the native folder on disk", () => {
+    const id = ensureNativeProject(db, userland, "work");
+    expect(existsSync(join(userland, "spaces", "work"))).toBe(true);
+    expect(id).toBeTruthy();
+  });
 });
 ```
+
+> Add `existsSync` to the imports: `import { mkdtempSync, rmSync, existsSync } from "node:fs";`
 
 - [ ] **Step 2: Run it, verify it fails**
 
@@ -76,15 +84,26 @@ Expected: FAIL — `ensureNativeProject` not found.
 // server/src/native-project.ts
 import type Database from "better-sqlite3";
 import { join } from "node:path";
+import { mkdirSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 
-/** The native workspace folder for a space (`<userland>/spaces/<id>`) is
- *  itself a project, filed under that space. This keeps the model uniform:
- *  every artefact — repo file or agent-created content — is project-parented,
- *  and its space derives via that project. Idempotent: returns the existing
- *  native project id if one is already registered for the folder. */
+/** The native workspace folder for a space (`<userland>/spaces/<id>`) is the
+ *  path where `create_artifact` writes content (via getNativeSourcePath).
+ *  Compute it the same way the rest of the server does — via `path.join`, so
+ *  the separator is platform-correct. */
+export function nativeSpaceDir(userlandDir: string, spaceId: string): string {
+  return join(userlandDir, "spaces", spaceId);
+}
+
+/** The native workspace folder for a space is itself a project, filed under
+ *  that space. This keeps the model uniform: every artefact — repo file or
+ *  agent-created content — is project-parented, and its space derives via
+ *  that project. Ensures the folder exists on disk (create_artifact writes
+ *  into it). Idempotent: returns the existing native project id if one is
+ *  already registered for the folder. */
 export function ensureNativeProject(db: Database.Database, userlandDir: string, spaceId: string): string {
-  const nativePath = join(userlandDir, "spaces", spaceId);
+  const nativePath = nativeSpaceDir(userlandDir, spaceId);
+  mkdirSync(nativePath, { recursive: true });
   const existing = db
     .prepare("SELECT project_id FROM project_paths WHERE path = ?")
     .get(nativePath) as { project_id: string } | undefined;
@@ -182,6 +201,7 @@ Expected: FAIL — module not found.
 ```typescript
 // server/src/artifact-space-migration.ts
 import type Database from "better-sqlite3";
+import { join, relative, sep, isAbsolute } from "node:path";
 import { ensureNativeProject } from "./native-project.js";
 
 export interface ArtifactSpaceReport {
@@ -195,20 +215,14 @@ export interface ArtifactSpaceReport {
 /** Backfill artifacts.project_id from the file path so space can be derived
  *  via project. Native workspace files (<userland>/spaces/<id>) get a native
  *  project for their space first. Does NOT drop space_id — that is a separate
- *  step run only after all readers stop using the column. Idempotent. */
+ *  step run only after all readers stop using the column.
+ *
+ *  Idempotent AND safe after space_id has been dropped: the SELECT shape is
+ *  chosen from PRAGMA, so it never names a column that no longer exists. */
 export function backfillArtifactProjects(db: Database.Database, userlandDir: string): ArtifactSpaceReport {
   const cols = db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[];
   const hasSpaceCol = cols.some((c) => c.name === "space_id");
 
-  const rows = db
-    .prepare(
-      `SELECT id, space_id, json_extract(storage_config,'$.path') AS path
-         FROM artifacts
-        WHERE project_id IS NULL AND json_extract(storage_config,'$.path') IS NOT NULL`,
-    )
-    .all() as { id: string; space_id: string | null; path: string }[];
-
-  const nativePrefix = `${userlandDir}/spaces/`;
   const resolveProject = db.prepare(
     `SELECT pp.project_id FROM project_paths pp
       WHERE ? LIKE pp.path || '/%' OR ? = pp.path
@@ -216,28 +230,53 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
   );
   const setProject = db.prepare("UPDATE artifacts SET project_id = ? WHERE id = ?");
   const projectSpace = db.prepare("SELECT space_id FROM projects WHERE id = ?");
+  const nativeRoot = join(userlandDir, "spaces");
 
   const report: ArtifactSpaceReport = { total: 0, hadSpace: 0, backfilled: 0, stillOrphan: 0, mismatches: [] };
   const txn = db.transaction(() => {
-    const allCount = db.prepare("SELECT COUNT(*) AS n FROM artifacts").get() as { n: number };
-    report.total = allCount.n;
+    report.total = (db.prepare("SELECT COUNT(*) AS n FROM artifacts").get() as { n: number }).n;
     if (hasSpaceCol) {
       report.hadSpace = (db.prepare("SELECT COUNT(*) AS n FROM artifacts WHERE space_id IS NOT NULL AND space_id != ''").get() as { n: number }).n;
     }
-    for (const row of rows) {
+
+    // 1. Backfill project_id for rows missing it. The query NEVER references
+    //    space_id directly — it may have been dropped on a prior boot.
+    const needBackfill = db
+      .prepare(
+        `SELECT id, json_extract(storage_config,'$.path') AS path
+           FROM artifacts
+          WHERE project_id IS NULL AND json_extract(storage_config,'$.path') IS NOT NULL`,
+      )
+      .all() as { id: string; path: string }[];
+    for (const row of needBackfill) {
       // Native workspace file → ensure its space's native project first.
-      if (row.path.startsWith(nativePrefix) && row.space_id) {
-        const rest = row.path.slice(nativePrefix.length);
-        const spaceId = rest.split("/")[0];
+      const rel = relative(nativeRoot, row.path);
+      if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+        const spaceId = rel.split(sep)[0];
         if (spaceId) ensureNativeProject(db, userlandDir, spaceId);
       }
       const hit = resolveProject.get(row.path, row.path) as { project_id: string } | undefined;
       if (!hit) { report.stillOrphan++; continue; }
       setProject.run(hit.project_id, row.id);
       report.backfilled++;
-      const newSpace = (projectSpace.get(hit.project_id) as { space_id: string | null }).space_id;
-      if (row.space_id && row.space_id !== "" && row.space_id !== newSpace) {
-        report.mismatches.push({ id: row.id, path: row.path, oldSpace: row.space_id, newSpace });
+    }
+
+    // 2. Mismatch report — only possible while space_id still exists. Covers
+    //    ALL parented rows (pre-existing project_id too), not just the ones
+    //    just backfilled, so a stale manual space assignment is surfaced.
+    if (hasSpaceCol) {
+      const withBoth = db
+        .prepare(
+          `SELECT id, space_id, project_id, json_extract(storage_config,'$.path') AS path
+             FROM artifacts
+            WHERE project_id IS NOT NULL AND space_id IS NOT NULL AND space_id != ''`,
+        )
+        .all() as { id: string; space_id: string; project_id: string; path: string }[];
+      for (const row of withBoth) {
+        const newSpace = (projectSpace.get(row.project_id) as { space_id: string | null }).space_id;
+        if (row.space_id !== newSpace) {
+          report.mismatches.push({ id: row.id, path: row.path, oldSpace: row.space_id, newSpace });
+        }
       }
     }
   });
@@ -245,6 +284,8 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
   return report;
 }
 ```
+
+> The mismatch test in Step 1 still holds: `a-mismatch` is parented to `p-repo` (space `work`) in pass 1, then pass 2 finds its old space `home ≠ work` and reports it. Add a second assertion to the test that a row with a *pre-existing* `project_id` whose old `space_id` disagrees is also reported (seed one before calling).
 
 - [ ] **Step 4: Run it, verify it passes**
 
@@ -328,20 +369,25 @@ Expected: FAIL — `insert` still requires `space_id` (TS error or runtime: `a1`
 
 - [ ] **Step 3: Implement — rewrite SELECTs + insert + UPDATABLE_COLUMNS**
 
-In `server/src/artifact-store.ts`, replace the SELECT statements (`:73-80`) so each derives space via join (alias kept as `space_id`):
+In `server/src/artifact-store.ts`, replace the SELECT statements (`:73-80`). **Do not use `a.*`** — build the artifact column list dynamically from `PRAGMA table_info`, excluding `space_id`, and append the derived alias. This is robust whether or not the column still exists, and never produces a duplicate `space_id` column (so we don't rely on better-sqlite3's row-key overwrite order):
 
 ```typescript
-const SELECT = `SELECT a.*, COALESCE(p.space_id,'') AS space_id
+// Column list for SELECTs: every artifact column EXCEPT space_id, plus the
+// derived space alias. Built once; correct pre- and post-column-drop.
+const artCols = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[])
+  .map((c) => c.name)
+  .filter((n) => n !== "space_id")
+  .map((n) => `a.${n}`)
+  .join(", ");
+const SELECT = `SELECT ${artCols}, COALESCE(p.space_id,'') AS space_id
                   FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id`;
-// note: a.* no longer includes space_id once the column is dropped (Task 7);
-// before then, the aliased COALESCE column shadows a.space_id in the result.
 this.stmts = {
-  getAll: db.prepare(`${SELECT} WHERE a.removed_at IS NULL ORDER BY a.space_id, a.created_at`),
+  getAll: db.prepare(`${SELECT} WHERE a.removed_at IS NULL ORDER BY p.space_id, a.created_at`),
   getById: db.prepare(`${SELECT} WHERE a.id = ?`),
-  getBySpaceId: db.prepare(`SELECT a.*, p.space_id AS space_id FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE p.space_id = ? AND a.removed_at IS NULL ORDER BY a.created_at`),
+  getBySpaceId: db.prepare(`${SELECT} WHERE p.space_id = ? AND a.removed_at IS NULL ORDER BY a.created_at`),
   getByPath: db.prepare(`${SELECT} WHERE json_extract(a.storage_config,'$.path') = ? AND a.removed_at IS NULL`),
   getDistinctSpaces: db.prepare(`SELECT p.space_id AS space_id, COUNT(*) as count FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id ORDER BY p.space_id`),
-  getBySpaceAndSourceRef: db.prepare(`SELECT a.*, p.space_id AS space_id FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE p.space_id = ? AND a.source_ref = ?`),
+  getByProjectAndSourceRef: db.prepare(`${SELECT} WHERE a.project_id = ? AND a.source_ref = ?`),
   insert: db.prepare(`
     INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
     VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`),
@@ -349,9 +395,11 @@ this.stmts = {
 };
 ```
 
-> `getAll`'s `ORDER BY a.space_id` must change once the column is dropped (Task 7) — change it to `ORDER BY p.space_id` there. For now `a.space_id` still exists.
+> `getBySpaceId` uses `LEFT JOIN` + `WHERE p.space_id = ?` — orphan artifacts (`project_id NULL` → `p.space_id NULL`) never match a real space id, so they're correctly excluded. `getAll` orders by `p.space_id` (the column is gone post-drop). `getDistinctSpaces` inner-joins (orphans absent), matching old behaviour where every artifact had a space.
 
-Update `InsertRow` (`:33`): **add `"space_id"` to the `Omit<ArtifactRow, ...>` list** so it is no longer a required insert field (callers stop supplying it; `project_id` is the home now). `ArtifactRow.space_id` (`:8`) **stays** `string` — it is now populated by the derived `space_id` alias from the SELECT (the alias is listed *after* `a.*`, so better-sqlite3's row object takes the derived value, shadowing the stored column while it still exists, and supplying it once the column is dropped). Add a comment on `ArtifactRow.space_id` noting it is derived, not stored.
+**Rename `getBySpaceAndSourceRef` → `getByProjectAndSourceRef`** (signature `(projectId: string, sourceRef: string)`), keyed on `(project_id, source_ref)` to match the new dedup index — space-keyed lookup is ambiguous now (multiple projects per space). Update the `ArtifactStore` interface (`:45`) and the method body. The audit found **zero external callers**, so no call sites need updating; grep to confirm: `grep -rn "getBySpaceAndSourceRef" server/src`.
+
+Update `InsertRow` (`:33`): **add `"space_id"` to the `Omit<ArtifactRow, ...>` list** so it is no longer a required insert field (callers stop supplying it; `project_id` is the home now). `ArtifactRow.space_id` (`:8`) **stays** `string` — populated by the derived alias (which is the *only* `space_id` column in the result, so no shadowing ambiguity). Add a comment on `ArtifactRow.space_id` noting it is derived, not stored.
 
 Remove `"space_id"` from `UPDATABLE_COLUMNS` (`:130-134`):
 
@@ -548,13 +596,18 @@ Expected: FAIL — `dropArtifactSpaceColumn` not exported; index still keyed on 
 // append to server/src/artifact-space-migration.ts
 export function dropArtifactSpaceColumn(db: Database.Database): void {
   const hasCol = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
-  if (!hasCol) return; // idempotent
-  db.exec("DROP INDEX IF EXISTS artifacts_space_source_ref_uq");
-  try {
+  if (hasCol) {
+    db.exec("DROP INDEX IF EXISTS artifacts_space_source_ref_uq");
+    // DROP COLUMN requires SQLite ≥ 3.35 (2021); better-sqlite3 v12 bundles a
+    // newer SQLite, so this is supported. We deliberately do NOT swallow a
+    // failure — dropping the column is the whole point of this migration; a
+    // silent no-op would hide a real problem and leave the schema half-done.
+    // If a future runtime ever lacks DROP COLUMN support, this throws at boot
+    // (loud + visible) rather than degrading quietly.
     db.exec("ALTER TABLE artifacts DROP COLUMN space_id");
-  } catch {
-    /* SQLite < 3.35: column stays but nothing reads it. Acceptable. */
   }
+  // Idempotent: ensure the new dedup index exists regardless of whether the
+  // column was just dropped or dropped on a prior boot.
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS artifacts_project_source_ref_uq
              ON artifacts(project_id, source_ref) WHERE source_ref IS NOT NULL`);
 }
@@ -568,18 +621,14 @@ In `server/src/db.ts`, replace the `artifacts_space_source_ref_uq` creation bloc
 dropArtifactSpaceColumn(db); // import alongside backfillArtifactProjects
 ```
 
-> Order matters: `backfillArtifactProjects` (needs `space_id` for the report) runs first, then `dropArtifactSpaceColumn`. The old `artifacts_space_source_ref_uq` CREATE at `:114-120` must be **removed** (the column won't exist), or guarded — delete those lines since the drop function now owns the dedup index.
+> Order matters: `backfillArtifactProjects` (needs `space_id` for the report) runs first, then `dropArtifactSpaceColumn`. The old `artifacts_space_source_ref_uq` CREATE at `db.ts:114-120` must be **removed** (the column won't exist) — delete those lines; `dropArtifactSpaceColumn` now owns the dedup index. (`getAll`'s ORDER BY already uses `p.space_id` from Task 3, so nothing to change here.)
 
-- [ ] **Step 5: Fix `getAll` ORDER BY in artifact-store.ts**
-
-Change `getAll`'s `ORDER BY a.space_id, a.created_at` → `ORDER BY p.space_id, a.created_at` (the column is gone now).
-
-- [ ] **Step 6: Run tests + full suite + build**
+- [ ] **Step 5: Run tests + full suite + build**
 
 Run: `npm --prefix server test && npm --prefix server run build`
 Expected: all PASS, tsc clean.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add server/src/artifact-space-migration.ts server/src/db.ts server/src/artifact-store.ts server/test/artifact-space-migration.test.ts
@@ -627,3 +676,4 @@ git commit -m "docs(changelog): artefacts follow their project's space"
 - **Don't remove `projects.space_id`** or any space plumbing — spaces still organise projects. Out of scope.
 - **No reactive registration** — that's Plan 2 (`2026-05-24-session-output-registration-design.md`), built on this.
 - If a TS call site breaks because it passed `space_id` to `registerArtifact`, that's expected — switch it to omit `space_id` (project resolves from path) or pass `project_id`.
+- **Path portability (residual):** native-folder construction and containment now use `path.join` / `path.relative` / `path.sep` (platform-correct). One known residual remains — the longest-prefix `resolveProject` SQL uses `LIKE pp.path || '/%'` with a hard-coded `/`. On the current (macOS) machine all stored `storage_config.path` and `project_paths.path` are POSIX, so this is correct here. If Oyster targets Windows, normalise both sides to `/` before the `LIKE` (or store canonical POSIX paths). Out of scope for this PR; flagged so it isn't a silent surprise.

--- a/docs/superpowers/plans/2026-05-24-artifact-project-home.md
+++ b/docs/superpowers/plans/2026-05-24-artifact-project-home.md
@@ -1,0 +1,629 @@
+# Artifact's home is the project, space is derived — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drop the legacy `artifacts.space_id` parent column; an artifact's home becomes its `project_id`, and its space is derived (`artifact → project → space`).
+
+**Architecture:** Derive `space_id` once at the store read boundary via `LEFT JOIN projects` (`COALESCE(p.space_id,'')`), so `ArtifactRow.space_id` / `Artifact.spaceId` keep their `string` shape and all ~18 web consumers + `rowToArtifact` stay untouched. A boot migration backfills `project_id` (longest-prefix `project_paths`; native space folders become projects), logs a before/after report, then drops the column and re-keys the dedup index to `(project_id, source_ref)`. Tasks are ordered so **every commit leaves the app working** — the column is dropped only after all readers/writers stop using it.
+
+**Tech Stack:** TypeScript, better-sqlite3, vitest (`server/test/*.test.ts`, run with `npm --prefix server test`). Spec: `docs/superpowers/specs/2026-05-24-artifact-project-home-design.md`.
+
+---
+
+## File structure
+
+- **Create** `server/src/native-project.ts` — `ensureNativeProject(db, userlandDir, spaceId)` shared by the migration (`db.ts`) and `createArtifact` (`artifact-service.ts`).
+- **Create** `server/src/artifact-space-migration.ts` — the backfill + report + drop logic, called from `initDb`. (Keeps `db.ts` lean; `db.ts` just invokes it.)
+- **Modify** `server/src/db.ts` — call the migration; re-key the dedup index.
+- **Modify** `server/src/artifact-store.ts` — derive `space_id` via join in SELECTs; drop it from insert + `UPDATABLE_COLUMNS`.
+- **Modify** `server/src/artifact-service.ts` — `registerArtifact`/`createArtifact` resolve `project_id`; `updateArtifact` drops space reassignment.
+- **Modify** `server/src/mcp-server.ts` — `register_artifact`/`update_artifact` drop `space_id`; `create_artifact` parents to native project.
+- **Modify** `server/src/publish-service.ts` — derive `space_id` via join.
+- **Modify** `server/src/import.ts`, `server/src/routes/import.ts` — resolve `project_id`.
+- **Create** `server/test/artifact-space-derivation.test.ts`, `server/test/artifact-space-migration.test.ts`.
+
+---
+
+## Task 1: Native-project helper
+
+**Files:**
+- Create: `server/src/native-project.ts`
+- Test: `server/test/native-project.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// server/test/native-project.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { ensureNativeProject } from "../src/native-project.js";
+
+describe("ensureNativeProject", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-np-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("creates a project bound to the space with the native folder path, idempotently", () => {
+    const id1 = ensureNativeProject(db, userland, "work");
+    const id2 = ensureNativeProject(db, userland, "work");
+    expect(id1).toBe(id2); // idempotent — same project reused
+
+    const proj = db.prepare("SELECT space_id FROM projects WHERE id = ?").get(id1) as { space_id: string };
+    expect(proj.space_id).toBe("work");
+
+    const path = db.prepare("SELECT path FROM project_paths WHERE project_id = ?").get(id1) as { path: string };
+    expect(path.path).toBe(join(userland, "spaces", "work"));
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npm --prefix server test -- native-project`
+Expected: FAIL — `ensureNativeProject` not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// server/src/native-project.ts
+import type Database from "better-sqlite3";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+/** The native workspace folder for a space (`<userland>/spaces/<id>`) is
+ *  itself a project, filed under that space. This keeps the model uniform:
+ *  every artefact — repo file or agent-created content — is project-parented,
+ *  and its space derives via that project. Idempotent: returns the existing
+ *  native project id if one is already registered for the folder. */
+export function ensureNativeProject(db: Database.Database, userlandDir: string, spaceId: string): string {
+  const nativePath = join(userlandDir, "spaces", spaceId);
+  const existing = db
+    .prepare("SELECT project_id FROM project_paths WHERE path = ?")
+    .get(nativePath) as { project_id: string } | undefined;
+  if (existing) return existing.project_id;
+
+  const id = randomUUID();
+  db.prepare("INSERT INTO projects (id, space_id, name) VALUES (?, ?, ?)").run(id, spaceId, spaceId);
+  db.prepare("INSERT INTO project_paths (project_id, path) VALUES (?, ?)").run(id, nativePath);
+  return id;
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `npm --prefix server test -- native-project`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/native-project.ts server/test/native-project.test.ts
+git commit -m "feat(artifacts): ensureNativeProject — native space folder as a project"
+```
+
+---
+
+## Task 2: Migration — native projects + project_id backfill + before/after report
+
+**Files:**
+- Create: `server/src/artifact-space-migration.ts`
+- Test: `server/test/artifact-space-migration.test.ts`
+
+This task does the backfill and report **without dropping `space_id`** (drop happens in Task 7, after all readers move). The function is split into `backfillArtifactProjects` (this task) and `dropArtifactSpaceColumn` (Task 7).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// server/test/artifact-space-migration.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { backfillArtifactProjects } from "../src/artifact-space-migration.js";
+
+function seedArtifact(db: ReturnType<typeof initDb>, id: string, spaceId: string, path: string) {
+  db.prepare(
+    `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config)
+     VALUES (?, ?, ?, 'notes', 'filesystem', ?, 'static_file', '{}')`,
+  ).run(id, spaceId, id, JSON.stringify({ path }));
+}
+
+describe("backfillArtifactProjects", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-asm-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none'),('home','Home','#111','none')`);
+    // A repo project at /repo, in space 'work'
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-repo','work','repo')").run();
+    db.prepare("INSERT INTO project_paths (project_id, path) VALUES ('p-repo','/repo')").run();
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("backfills project_id from longest-prefix path, makes native projects, reports counts + mismatches", () => {
+    seedArtifact(db, "a-repo", "work", "/repo/docs/report.md");        // resolves to p-repo (space work — matches)
+    seedArtifact(db, "a-mismatch", "home", "/repo/docs/other.md");      // resolves to p-repo (space work) — mismatch vs 'home'
+    seedArtifact(db, "a-native", "work", join(userland, "spaces", "work", "note.md")); // native folder → native project
+    seedArtifact(db, "a-orphan", "home", "/elsewhere/loose.md");        // no project → stays null
+
+    const report = backfillArtifactProjects(db, userland);
+
+    expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-repo'").get()).toEqual({ project_id: "p-repo" });
+    const nativePid = (db.prepare("SELECT project_id FROM artifacts WHERE id='a-native'").get() as { project_id: string }).project_id;
+    expect(nativePid).toBeTruthy();
+    expect(db.prepare("SELECT space_id FROM projects WHERE id=?").get(nativePid)).toEqual({ space_id: "work" });
+    expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-orphan'").get()).toEqual({ project_id: null });
+
+    expect(report.total).toBe(4);
+    expect(report.backfilled).toBe(3);       // repo, mismatch, native
+    expect(report.stillOrphan).toBe(1);      // a-orphan
+    expect(report.mismatches.map((m) => m.id)).toContain("a-mismatch");
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npm --prefix server test -- artifact-space-migration`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// server/src/artifact-space-migration.ts
+import type Database from "better-sqlite3";
+import { ensureNativeProject } from "./native-project.js";
+
+export interface ArtifactSpaceReport {
+  total: number;
+  hadSpace: number;
+  backfilled: number;
+  stillOrphan: number;
+  mismatches: { id: string; path: string; oldSpace: string; newSpace: string | null }[];
+}
+
+/** Backfill artifacts.project_id from the file path so space can be derived
+ *  via project. Native workspace files (<userland>/spaces/<id>) get a native
+ *  project for their space first. Does NOT drop space_id — that is a separate
+ *  step run only after all readers stop using the column. Idempotent. */
+export function backfillArtifactProjects(db: Database.Database, userlandDir: string): ArtifactSpaceReport {
+  const cols = db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[];
+  const hasSpaceCol = cols.some((c) => c.name === "space_id");
+
+  const rows = db
+    .prepare(
+      `SELECT id, space_id, json_extract(storage_config,'$.path') AS path
+         FROM artifacts
+        WHERE project_id IS NULL AND json_extract(storage_config,'$.path') IS NOT NULL`,
+    )
+    .all() as { id: string; space_id: string | null; path: string }[];
+
+  const nativePrefix = `${userlandDir}/spaces/`;
+  const resolveProject = db.prepare(
+    `SELECT pp.project_id FROM project_paths pp
+      WHERE ? LIKE pp.path || '/%' OR ? = pp.path
+      ORDER BY LENGTH(pp.path) DESC LIMIT 1`,
+  );
+  const setProject = db.prepare("UPDATE artifacts SET project_id = ? WHERE id = ?");
+  const projectSpace = db.prepare("SELECT space_id FROM projects WHERE id = ?");
+
+  const report: ArtifactSpaceReport = { total: 0, hadSpace: 0, backfilled: 0, stillOrphan: 0, mismatches: [] };
+  const txn = db.transaction(() => {
+    const allCount = db.prepare("SELECT COUNT(*) AS n FROM artifacts").get() as { n: number };
+    report.total = allCount.n;
+    if (hasSpaceCol) {
+      report.hadSpace = (db.prepare("SELECT COUNT(*) AS n FROM artifacts WHERE space_id IS NOT NULL AND space_id != ''").get() as { n: number }).n;
+    }
+    for (const row of rows) {
+      // Native workspace file → ensure its space's native project first.
+      if (row.path.startsWith(nativePrefix) && row.space_id) {
+        const rest = row.path.slice(nativePrefix.length);
+        const spaceId = rest.split("/")[0];
+        if (spaceId) ensureNativeProject(db, userlandDir, spaceId);
+      }
+      const hit = resolveProject.get(row.path, row.path) as { project_id: string } | undefined;
+      if (!hit) { report.stillOrphan++; continue; }
+      setProject.run(hit.project_id, row.id);
+      report.backfilled++;
+      const newSpace = (projectSpace.get(hit.project_id) as { space_id: string | null }).space_id;
+      if (row.space_id && row.space_id !== "" && row.space_id !== newSpace) {
+        report.mismatches.push({ id: row.id, path: row.path, oldSpace: row.space_id, newSpace });
+      }
+    }
+  });
+  txn();
+  return report;
+}
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `npm --prefix server test -- artifact-space-migration`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into `initDb` (with logging) and verify the suite still boots**
+
+In `server/src/db.ts`, after the `project_id` ADD COLUMN block (around `:500-502`), add:
+
+```typescript
+import { backfillArtifactProjects } from "./artifact-space-migration.js"; // top of file
+// … after artifacts.project_id index is created:
+{
+  const r = backfillArtifactProjects(db, userlandDir);
+  if (r.backfilled > 0 || r.mismatches.length > 0) {
+    console.log(`[artifact-space] backfilled ${r.backfilled} project_id (of ${r.total}; ${r.hadSpace} had space; ${r.stillOrphan} orphan)`);
+    for (const m of r.mismatches) console.log(`[artifact-space] mismatch ${m.id} (${m.path}): space ${m.oldSpace} → ${m.newSpace} (project wins)`);
+  }
+}
+```
+
+Run: `npm --prefix server test`
+Expected: existing tests still PASS (column not yet dropped; nothing else changed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/artifact-space-migration.ts server/test/artifact-space-migration.test.ts server/src/db.ts
+git commit -m "feat(artifacts): backfill project_id from path + before/after report"
+```
+
+---
+
+## Task 3: Derive space_id in the store SELECTs; stop reading/writing the column
+
+**Files:**
+- Modify: `server/src/artifact-store.ts:73-93` (SELECTs + insert), `:130-134` (UPDATABLE_COLUMNS)
+- Test: `server/test/artifact-space-derivation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// server/test/artifact-space-derivation.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+describe("artifact store derives space via project", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+  let store: SqliteArtifactStore;
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-asd-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p1','work','repo')").run();
+    store = new SqliteArtifactStore(db);
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("derives space_id from the artifact's project; orphan → empty string", () => {
+    store.insert({ id: "a1", owner_id: null, label: "r", artifact_kind: "notes", storage_kind: "filesystem", storage_config: JSON.stringify({ path: "/repo/r.md" }), runtime_kind: "static_file", runtime_config: "{}", group_name: null, project_id: "p1" });
+    store.insert({ id: "a2", owner_id: null, label: "o", artifact_kind: "notes", storage_kind: "filesystem", storage_config: JSON.stringify({ path: "/x/o.md" }), runtime_kind: "static_file", runtime_config: "{}", group_name: null, project_id: null });
+
+    expect(store.getById("a1")!.space_id).toBe("work");
+    expect(store.getById("a2")!.space_id).toBe("");                // orphan
+    expect(store.getBySpaceId("work").map((r) => r.id)).toEqual(["a1"]); // orphan excluded
+    expect(store.getDistinctSpaces()).toEqual([{ space_id: "work", count: 1 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npm --prefix server test -- artifact-space-derivation`
+Expected: FAIL — `insert` still requires `space_id` (TS error or runtime: `a1` space_id is the stored value, `a2` insert errors on missing space_id).
+
+- [ ] **Step 3: Implement — rewrite SELECTs + insert + UPDATABLE_COLUMNS**
+
+In `server/src/artifact-store.ts`, replace the SELECT statements (`:73-80`) so each derives space via join (alias kept as `space_id`):
+
+```typescript
+const SELECT = `SELECT a.*, COALESCE(p.space_id,'') AS space_id
+                  FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id`;
+// note: a.* no longer includes space_id once the column is dropped (Task 7);
+// before then, the aliased COALESCE column shadows a.space_id in the result.
+this.stmts = {
+  getAll: db.prepare(`${SELECT} WHERE a.removed_at IS NULL ORDER BY a.space_id, a.created_at`),
+  getById: db.prepare(`${SELECT} WHERE a.id = ?`),
+  getBySpaceId: db.prepare(`SELECT a.*, p.space_id AS space_id FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE p.space_id = ? AND a.removed_at IS NULL ORDER BY a.created_at`),
+  getByPath: db.prepare(`${SELECT} WHERE json_extract(a.storage_config,'$.path') = ? AND a.removed_at IS NULL`),
+  getDistinctSpaces: db.prepare(`SELECT p.space_id AS space_id, COUNT(*) as count FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id ORDER BY p.space_id`),
+  getBySpaceAndSourceRef: db.prepare(`SELECT a.*, p.space_id AS space_id FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE p.space_id = ? AND a.source_ref = ?`),
+  insert: db.prepare(`
+    INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
+    VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`),
+  delete: db.prepare("DELETE FROM artifacts WHERE id = ?"),
+};
+```
+
+> `getAll`'s `ORDER BY a.space_id` must change once the column is dropped (Task 7) — change it to `ORDER BY p.space_id` there. For now `a.space_id` still exists.
+
+Update `InsertRow` (`:33`): **add `"space_id"` to the `Omit<ArtifactRow, ...>` list** so it is no longer a required insert field (callers stop supplying it; `project_id` is the home now). `ArtifactRow.space_id` (`:8`) **stays** `string` — it is now populated by the derived `space_id` alias from the SELECT (the alias is listed *after* `a.*`, so better-sqlite3's row object takes the derived value, shadowing the stored column while it still exists, and supplying it once the column is dropped). Add a comment on `ArtifactRow.space_id` noting it is derived, not stored.
+
+Remove `"space_id"` from `UPDATABLE_COLUMNS` (`:130-134`):
+
+```typescript
+private static readonly UPDATABLE_COLUMNS = new Set([
+  "owner_id", "label", "artifact_kind",
+  "storage_kind", "storage_config", "runtime_kind", "runtime_config",
+  "group_name", "removed_at", "source_origin", "source_ref", "project_id",
+]);
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `npm --prefix server test -- artifact-space-derivation`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/artifact-store.ts server/test/artifact-space-derivation.test.ts
+git commit -m "feat(artifacts): derive space_id via project in store SELECTs; drop column writes"
+```
+
+---
+
+## Task 4: Service layer — resolve project_id; drop space reassignment
+
+**Files:**
+- Modify: `server/src/artifact-service.ts:296-358` (`registerArtifact`), `:452-510` (`createArtifact`), `:589-593` (`updateArtifact`)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to server/test/artifact-space-derivation.test.ts
+it("registerArtifact parents to the project resolved from the file path (no space_id param)", async () => {
+  // (construct ArtifactService with this store + db per existing service test setup)
+  // seed project p1 at /repo (space 'work'); register /repo/r.md with NO space_id:
+  // expect the returned Artifact.spaceId === 'work', and the row's project_id === 'p1'.
+});
+```
+
+> Model the service construction on `server/test/session-service.test.ts` / existing service tests. Assert: `registerArtifact({ path: "/repo/r.md", label: "r" }, [])` resolves `project_id='p1'` via `lookupProject(db, dirname(path))` and the returned `Artifact.spaceId` is `'work'`.
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npm --prefix server test -- artifact-space-derivation`
+Expected: FAIL — `registerArtifact` still requires `space_id`.
+
+- [ ] **Step 3: Implement**
+
+`registerArtifact` (`:296`): change the param type — replace `space_id: string;` with `project_id?: string | null;`. After `const absPath = resolve(params.path);`, resolve the project when not supplied:
+
+```typescript
+import { dirname } from "node:path";           // ensure imported
+import { lookupProject } from "./lookup-project.js"; // ensure imported
+// …
+const projectId = params.project_id !== undefined
+  ? params.project_id
+  : lookupProject(this.db, dirname(absPath)).projectId;
+```
+
+In the resurface `store.update` (`:347-354`) replace `space_id: params.space_id,` with `project_id: projectId,`. In the new-row `store.insert` (`:363`) replace `space_id: params.space_id,` with `project_id: projectId,`. In the returned literal (`:386-397`) drop `spaceId` (it's set by `rowToArtifact` everywhere else; this hand-built literal should instead `return await this.rowToArtifact(this.store.getById(id)!);` for consistency — verify the existing literal isn't relied on for a field `rowToArtifact` omits; if it is, keep the literal but set `spaceId` from `lookupProject(...).spaceId`).
+
+`createArtifact` (`:452`): it already has `space_id`. Keep that param (it picks the native folder). After computing the file path, ensure the native project and pass its id:
+
+```typescript
+import { ensureNativeProject } from "./native-project.js"; // ensure imported
+// inside createArtifact, before the registerArtifact call (~:506):
+const projectId = ensureNativeProject(this.db, this.userlandDir, space_id);
+return await this.registerArtifact(
+  { path: absPath, project_id: projectId, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id, source_origin: params.source_origin },
+  /* approvedRoots */ [],
+);
+```
+
+> Confirm `ArtifactService` has `this.userlandDir` (or pass it in). If not, thread it through the constructor — check `server/src/index.ts` where the service is built.
+
+`updateArtifact` (`:589-593`): delete the `fields.space_id` block entirely. Moving an artifact between spaces is no longer a direct operation (it's done by moving the project). Update the method's `fields` type to drop `space_id`.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `npm --prefix server test -- artifact-space-derivation && npm --prefix server run build`
+Expected: PASS; `build` (tsc) clean — fix any call sites the type change surfaces (e.g. callers passing `space_id` to `registerArtifact`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/artifact-service.ts server/test/artifact-space-derivation.test.ts
+git commit -m "feat(artifacts): registerArtifact resolves project_id from path; createArtifact uses native project; drop space reassignment"
+```
+
+---
+
+## Task 5: MCP tools — drop space_id from register/update; keep it as storage target in create
+
+**Files:**
+- Modify: `server/src/mcp-server.ts:581-597` (register_artifact), `:628-644` (create_artifact), `:663` (update_artifact)
+
+- [ ] **Step 1: Edit register_artifact** — remove the `space_id: z.string()...` param (`:585`) and the `space_id` argument from the handler call (`:594-597`). Update the tool description to drop "Space to place…". 
+
+- [ ] **Step 2: Edit update_artifact** — remove `space_id` from its input schema and from the `updateArtifact({...})` call (`:663`). Update description: it can rename / regroup, not reassign space.
+
+- [ ] **Step 3: Edit create_artifact** — **keep** `space_id` (storage target). No code change to its handler beyond confirming it still passes `space_id` to `deps.service.createArtifact` (which now ensures the native project internally). Update description to note the artifact is filed under that space via its native project.
+
+- [ ] **Step 4: Verify list_artifacts still filters by space** — `:556-558` filters `a.spaceId === space_id` off built `Artifact` objects (derived). No change needed; confirm by reading.
+
+- [ ] **Step 5: Typecheck + commit**
+
+Run: `npm --prefix server run build`
+Expected: clean.
+
+```bash
+git add server/src/mcp-server.ts
+git commit -m "feat(mcp): register/update drop space_id; create_artifact files via native project"
+```
+
+---
+
+## Task 6: publish-service + import — derive space, resolve project
+
+**Files:**
+- Modify: `server/src/publish-service.ts:143`, `:444`
+- Modify: `server/src/import.ts:538-580`, `server/src/routes/import.ts:84`
+
+- [ ] **Step 1: publish-service SELECTs** — both `SELECT ... space_id FROM artifacts WHERE id = ?` (`:143`, `:444`) become joins:
+
+```sql
+SELECT a.id, a.artifact_kind, a.owner_id, a.share_token, a.unpublished_at, a.label,
+       COALESCE(p.space_id,'') AS space_id
+  FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id
+ WHERE a.id = ?
+```
+(and the `:444` one analogously with its `label, space_id` columns). The wire payload is unchanged — only how `space_id` is obtained.
+
+- [ ] **Step 2: import.ts** — `createArtifact({ space_id: spaceId, ... })` calls (`:538-580`) are unchanged in signature (createArtifact still takes `space_id` as the storage target and now ensures the native project). Confirm no direct `store.insert({ space_id })` exists in import. `routes/import.ts:84` `store.getBySpaceId(s.id)` is unchanged (the store method now joins). Read both to confirm no remaining direct `space_id` writes.
+
+- [ ] **Step 3: Typecheck + targeted publish test**
+
+Run: `npm --prefix server run build && npm --prefix server test -- publish`
+Expected: clean + publish tests pass (fix the SELECT-derived `space_id` if any test asserts the old shape).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/publish-service.ts server/src/import.ts server/src/routes/import.ts
+git commit -m "feat(publish,import): derive artifact space via project"
+```
+
+---
+
+## Task 7: Drop the space_id column + re-key the dedup index
+
+**Files:**
+- Modify: `server/src/artifact-space-migration.ts` (add `dropArtifactSpaceColumn`), `server/src/db.ts` (call it; re-key index), `server/src/artifact-store.ts` (fix `getAll` ORDER BY)
+- Test: `server/test/artifact-space-migration.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to server/test/artifact-space-migration.test.ts
+import { backfillArtifactProjects, dropArtifactSpaceColumn } from "../src/artifact-space-migration.js";
+
+it("drops space_id and is idempotent", () => {
+  seedArtifact(db, "a-repo", "work", "/repo/r.md");
+  backfillArtifactProjects(db, userland);
+  dropArtifactSpaceColumn(db);
+  const cols = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).map((c) => c.name);
+  expect(cols).not.toContain("space_id");
+  // idempotent — second call is a no-op
+  expect(() => dropArtifactSpaceColumn(db)).not.toThrow();
+});
+
+it("re-keyed dedup index: same source_ref same project rejected; orphans allowed", () => {
+  backfillArtifactProjects(db, userland);
+  dropArtifactSpaceColumn(db);
+  const ins = (id: string, projectId: string | null, ref: string) => db.prepare(
+    `INSERT INTO artifacts (id,label,artifact_kind,storage_kind,storage_config,runtime_kind,runtime_config,source_ref,project_id)
+     VALUES (?,?, 'notes','filesystem','{}','static_file','{}',?,?)`).run(id, id, ref, projectId);
+  ins("x1", "p-repo", "README.md:notes");
+  expect(() => ins("x2", "p-repo", "README.md:notes")).toThrow(); // same project+ref
+  expect(() => ins("x3", null, "README.md:notes")).not.toThrow(); // orphan
+  expect(() => ins("x4", null, "README.md:notes")).not.toThrow(); // orphan NULLs distinct (intentional)
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `npm --prefix server test -- artifact-space-migration`
+Expected: FAIL — `dropArtifactSpaceColumn` not exported; index still keyed on space_id.
+
+- [ ] **Step 3: Implement `dropArtifactSpaceColumn`**
+
+```typescript
+// append to server/src/artifact-space-migration.ts
+export function dropArtifactSpaceColumn(db: Database.Database): void {
+  const hasCol = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+  if (!hasCol) return; // idempotent
+  db.exec("DROP INDEX IF EXISTS artifacts_space_source_ref_uq");
+  try {
+    db.exec("ALTER TABLE artifacts DROP COLUMN space_id");
+  } catch {
+    /* SQLite < 3.35: column stays but nothing reads it. Acceptable. */
+  }
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS artifacts_project_source_ref_uq
+             ON artifacts(project_id, source_ref) WHERE source_ref IS NOT NULL`);
+}
+```
+
+- [ ] **Step 4: Re-key the index in `db.ts` and call the drop**
+
+In `server/src/db.ts`, replace the `artifacts_space_source_ref_uq` creation block (`:114-120`) — leave it (it's harmless if the column's already dropped via IF NOT EXISTS guard order); the authoritative index is now created in `dropArtifactSpaceColumn`. After the `backfillArtifactProjects` call added in Task 2, add:
+
+```typescript
+dropArtifactSpaceColumn(db); // import alongside backfillArtifactProjects
+```
+
+> Order matters: `backfillArtifactProjects` (needs `space_id` for the report) runs first, then `dropArtifactSpaceColumn`. The old `artifacts_space_source_ref_uq` CREATE at `:114-120` must be **removed** (the column won't exist), or guarded — delete those lines since the drop function now owns the dedup index.
+
+- [ ] **Step 5: Fix `getAll` ORDER BY in artifact-store.ts**
+
+Change `getAll`'s `ORDER BY a.space_id, a.created_at` → `ORDER BY p.space_id, a.created_at` (the column is gone now).
+
+- [ ] **Step 6: Run tests + full suite + build**
+
+Run: `npm --prefix server test && npm --prefix server run build`
+Expected: all PASS, tsc clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/artifact-space-migration.ts server/src/db.ts server/src/artifact-store.ts server/test/artifact-space-migration.test.ts
+git commit -m "feat(artifacts): drop space_id column; re-key dedup index to (project_id, source_ref)"
+```
+
+---
+
+## Task 8: Full verification + changelog check
+
+- [ ] **Step 1: Whole suite + typecheck + web build**
+
+Run: `npm --prefix server test && npm --prefix server run build && npm --prefix web run build`
+Expected: all green. The web build confirms no `Artifact.spaceId` type ripple.
+
+- [ ] **Step 2: Boot against a copy of the real DB and read the report**
+
+```bash
+cp -r ~/Oyster /tmp/oyster-modelfix-check
+OYSTER_USERLAND=/tmp/oyster-modelfix-check node server/dist/server/src/index.js  # observe [artifact-space] log lines, then Ctrl-C
+```
+Expected: `[artifact-space] backfilled ~131 …` and a short mismatch list. Eyeball the mismatches with Matthew; the project should be the correct owner in each.
+
+- [ ] **Step 3: Changelog decision**
+
+The model fix is internal. **User-visible only if** the desktop UI exposes "move artefact to a different space" (which `update_artifact`/the route no longer supports directly). Grep web for an artefact-space-move control:
+
+Run: `grep -rniE "move.*art+e?fact|artifact.*space|changeSpace" web/src | head`
+- If a UI control exists → add a CHANGELOG `Changed` bullet ("Artefacts now follow their project's space") and run `npm run build:changelog`.
+- If not → no changelog entry (internal change).
+
+- [ ] **Step 4: Final commit (if changelog touched)**
+
+```bash
+git add CHANGELOG.md docs/changelog.html
+git commit -m "docs(changelog): artefacts follow their project's space"
+```
+
+---
+
+## Notes for the implementer
+
+- **Every commit leaves the app working.** The column is read until Task 3, written until Task 4, and only dropped in Task 7 once nothing uses it.
+- **Don't touch `shared/types.ts` `Artifact.spaceId`** — it stays `string`, populated by the derived store column.
+- **Don't remove `projects.space_id`** or any space plumbing — spaces still organise projects. Out of scope.
+- **No reactive registration** — that's Plan 2 (`2026-05-24-session-output-registration-design.md`), built on this.
+- If a TS call site breaks because it passed `space_id` to `registerArtifact`, that's expected — switch it to omit `space_id` (project resolves from path) or pass `project_id`.

--- a/docs/superpowers/specs/2026-05-24-artifact-project-home-design.md
+++ b/docs/superpowers/specs/2026-05-24-artifact-project-home-design.md
@@ -59,9 +59,13 @@ Run as one transaction in `initDb`, guarded so repeat boots are no-ops (detect `
     WHERE project_id IS NULL
       AND json_extract(storage_config,'$.path') IS NOT NULL;
    ```
-2. **Report mismatches** to the log (not a failure): artifacts whose *old* `space_id` differs from their newly-resolved `project → space_id`. Matthew eyeballs these once; with 506 path-derived `discovered` artifacts the disagreement set should be tiny.
+2. **Log a before/after report** (informational, never a failure), captured *before* the column is dropped:
+   - total artifacts; how many had a non-empty `space_id`; how many `project_id` were just backfilled; how many still have `project_id IS NULL` after backfill (→ will be orphan); 
+   - the **mismatch list**: artifacts whose *old* `space_id` differs from their newly-resolved `project → space_id` (id, path, old space, new space). Matthew eyeballs these once; with 506 path-derived `discovered` artifacts the set should be tiny. The project wins — this is just visibility, not a prompt.
 3. **Rebuild the table without `space_id`** (SQLite `ALTER TABLE artifacts DROP COLUMN space_id` is available ≥3.35 and already used at `db.ts:112` for `repo_path`; prefer it, fall back to a `_artifacts_new` rebuild if a dependent object blocks it). Data preserved.
-4. **Rebuild the dedup index** `artifacts_space_source_ref_uq` (`db.ts:116`) from `(space_id, source_ref)` → **`(project_id, source_ref)`**.
+4. **Rebuild the dedup index** `artifacts_space_source_ref_uq` (`db.ts:116`) from `(space_id, source_ref)` → **`(project_id, source_ref) WHERE source_ref IS NOT NULL`** (keep the existing partial predicate).
+
+   **Explicit `project_id IS NULL` behaviour:** SQLite treats `NULL`s as distinct under `UNIQUE`, so this index does **not** constrain orphan artifacts (no project) — multiple orphans with the same `source_ref` are permitted by the index. This is **intentional and safe** because the authoritative dedup for *every* filesystem artifact is `getByPath` (the absolute path in `storage_config`), which is independent of project and `source_ref`. The `(project_id, source_ref)` index is a secondary guard for the scanner's `<path>:<kind>` convention *within a known project*; orphan dedup rides on `getByPath`. (In practice `source_ref`-bearing artifacts are always created in a project context, so orphan + `source_ref` is essentially nonexistent — but the behaviour is now stated rather than accidental.)
 
 ## Code changes (the write/derive paths — from the audit)
 
@@ -96,7 +100,8 @@ Reuse `lookupProject(db, dir, …)` (`lookup-project.ts:35`) for path→project 
 - **Mismatch report:** seed one artifact whose `space_id` disagrees with its resolved project's space; assert it appears in the logged report and the project wins.
 - **Idempotency:** run `initDb` twice; second boot makes no changes (no `space_id` column, no project_id rewrites).
 - **Derived queries:** `getBySpaceId(s)` returns exactly the artifacts whose project is in space `s`; `getDistinctSpaces` matches; an orphan (null project) appears in none.
-- **Dedup index:** two artifacts, same `source_ref`, same project → second insert rejected; same `source_ref`, different project → both allowed.
+- **Dedup index:** two artifacts, same `source_ref`, same project → second insert rejected; same `source_ref`, different project → both allowed; two orphans (`project_id NULL`), same `source_ref` → both allowed (NULLs distinct, intentional), while `getByPath` still rejects a duplicate at the same absolute path.
+- **Before/after report:** assert the migration logs total / had-space / project-backfilled / still-orphan counts and the mismatch list (seed a known mismatch, assert it's reported and the project's space wins).
 - **No regression:** existing artifact tests (`db-artefact-tombstone-recovery.test.ts`, etc.) pass.
 
 ## Non-goals

--- a/docs/superpowers/specs/2026-05-24-artifact-project-home-design.md
+++ b/docs/superpowers/specs/2026-05-24-artifact-project-home-design.md
@@ -1,0 +1,111 @@
+# Artifact's home is the project; space is derived
+
+**Date:** 2026-05-24
+**Status:** Draft — pending Matthew's review
+**Author:** Matthew Slight + Claude
+**Driver:** Surfaced while planning reactive session-output registration. A fresh user has **0 spaces**, but `artifacts.space_id` is `NOT NULL` — so registration can't create artefacts for the very user the feature targets. Root cause: the artifact→space coupling is a 0.4/0.5-era model where space was the artifact's parent. It should be derived.
+
+> **Sequencing:** this is **Plan 1**, a foundational data-model fix. The reactive-registration + search feature (`2026-05-24-session-output-registration-design.md`) is **Plan 2** and builds on the corrected model. Plan 2's spec needs a one-spot amendment after this lands (reactive outputs resolve `project_id` from the touched file, space derived — no `space_id` param).
+
+---
+
+## Principle
+
+An artifact's intrinsic facts are: **its file** (a path), **its home** (the project / folder the file lives in), and **its provenance** (the sessions that touched it). A **space** is none of these — it's a user's *organisational grouping of projects*. So an artifact's space is **derived**: `artifact → project → space`. It must not be a stored, required parent.
+
+```
+Session ──touches──▶ Artifact ──lives in──▶ Project ──filed under (optional)──▶ Space
+            (provenance)         (home: project_id)         (organisation, derived)
+```
+
+`artifacts.space_id NOT NULL` is the last un-demoted holdover of the old "space is parent" model. `artifacts.project_id` already exists (added in the sessions era, `db.ts:500`). Sessions-first already made `sessions.space_id` and `projects.space_id` nullable. This change finishes that migration: **project is the home, space is derived, `artifacts.space_id` is dropped.**
+
+**Confirmed scope is local-only:** the cloud `published_artifacts` table carries `space_id` in its *wire payload* but no schema dependency on the artifact→space coupling exists; `space-sync-service` syncs only the `spaces` table. Production has 3 auth users (Matthew + two one-time sign-ins on 2026-05-16 that never synced); the 13 published / 6 synced-spaces / 144 synced-sessions footprint is all Matthew's. The migration must be **data-preserving and idempotent** (one external install exists), but needs no cloud or backward-compat code shims — we own every reader.
+
+## Current state (measured, main DB)
+
+- 202 active artifacts; **all 202 have a space**, only 71 have a `project_id`.
+- **131 have a space but no project.** All 131 have a file path, and **all 131 resolve to a containing project** via longest-prefix `project_paths` match.
+- 0 have a project but no space.
+
+So a `project_id` backfill can cover every space-bearing artifact before `space_id` is dropped — nobody is orphaned.
+
+## Target model
+
+- `artifacts.project_id` (already exists, nullable) is the **home**. Null = fully orphan (file outside any tracked project) — allowed; such an artifact has no space until its folder is organised.
+- `artifacts.space_id` column is **dropped**.
+- An artifact's space is **derived in the store layer** via `LEFT JOIN projects`. The `Artifact` TypeScript type keeps `spaceId` unchanged — it's now computed, not stored — so **all ~18 web components, `rowToArtifact`, and every API consumer keep working untouched.**
+
+## Derivation strategy — single point, in the store SELECTs
+
+Every artifact-store SELECT gains `LEFT JOIN projects p ON p.id = a.project_id` and selects `COALESCE(p.space_id, '') AS space_id`. The `COALESCE` to `''` (not `NULL`) is deliberate: the codebase already treats empty-string space as "no space" (`db.ts:837` `WHERE space_id IS NOT NULL AND space_id != ''`), so `ArtifactRow.space_id` stays typed `string` and `Artifact.spaceId` keeps its `string` shape — **no type ripple into the 18 consumers**. `rowToArtifact` (`artifact-service.ts:707-750`, both branches set `spaceId: row.space_id`) is **unchanged**. This is the whole trick: derive once at the read boundary, leave consumers alone.
+
+- `getAll` / `getById` / `getByPath` / `getBySpaceAndSourceRef`: rewrite SELECT to `LEFT JOIN projects` and `COALESCE(p.space_id,'') AS space_id`.
+- `getBySpaceId(spaceId)` → `... JOIN projects p ON p.id = a.project_id WHERE p.space_id = ? AND a.removed_at IS NULL` (inner join — orphans aren't in any space).
+- `getDistinctSpaces()` → `... JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id`.
+
+## Migration (boot-time, in `initDb`, idempotent)
+
+Run as one transaction in `initDb`, guarded so repeat boots are no-ops (detect `space_id` column presence via `PRAGMA table_info(artifacts)`).
+
+1. **Backfill `project_id`** for every artifact (active and tombstoned) that has `project_id IS NULL` and a `storage_config.$.path`, using **longest-prefix** `project_paths` match:
+   ```sql
+   UPDATE artifacts
+      SET project_id = (
+        SELECT pp.project_id FROM project_paths pp
+        WHERE json_extract(artifacts.storage_config,'$.path') LIKE pp.path || '/%'
+           OR json_extract(artifacts.storage_config,'$.path') = pp.path
+        ORDER BY LENGTH(pp.path) DESC LIMIT 1)
+    WHERE project_id IS NULL
+      AND json_extract(storage_config,'$.path') IS NOT NULL;
+   ```
+2. **Report mismatches** to the log (not a failure): artifacts whose *old* `space_id` differs from their newly-resolved `project → space_id`. Matthew eyeballs these once; with 506 path-derived `discovered` artifacts the disagreement set should be tiny.
+3. **Rebuild the table without `space_id`** (SQLite `ALTER TABLE artifacts DROP COLUMN space_id` is available ≥3.35 and already used at `db.ts:112` for `repo_path`; prefer it, fall back to a `_artifacts_new` rebuild if a dependent object blocks it). Data preserved.
+4. **Rebuild the dedup index** `artifacts_space_source_ref_uq` (`db.ts:116`) from `(space_id, source_ref)` → **`(project_id, source_ref)`**.
+
+## Code changes (the write/derive paths — from the audit)
+
+- **`artifact-store.ts`**: drop `space_id` from the INSERT column list (`:83`) and from `UPDATABLE_COLUMNS` (`:130-134`); rewrite the six SELECTs to join projects; `getBySpaceAndSourceRef` keys on `(project_id, source_ref)` (`:78`).
+- **`artifact-service.ts`**: `registerArtifact` (`:296`) takes `project_id?: string | null` instead of `space_id`; resolves it from the file path via `lookupProject` when not supplied. `createArtifact` (`:452`) resolves `project_id` from the target path. The returned `Artifact` literal (`:395`) sets `spaceId` from the resolved project's space. `updateArtifact` (`:589`) **drops** direct space reassignment — moving an artifact between spaces now means moving its **project** (or the file); document this. `reconcileGeneratedArtifact` (`:557`) passes `project_id` (from `artifact.projectId`).
+- **`mcp-server.ts`**: `register_artifact` / `create_artifact` (`:594`) drop the `space_id` tool param — the project (and thus space) is determined by the file's path. `update_artifact` (`:663`) drops `space_id` reassignment. **MCP API change**, acceptable (single user, local tools); update tool descriptions.
+- **`publish-service.ts`**: `publishArtifact` (`:143,182`) and `backfillPublications` (`:444-474`) derive `space_id` via `JOIN projects` before bundling it into the cloud payload. Wire format unchanged.
+- **`import.ts`** (`:538-580`) and **`routes/import.ts`** (`:84`): `createArtifact` calls resolve a `project_id` for the target folder/space context instead of passing `space_id`.
+
+## What stays unchanged
+
+- `shared/types.ts` `Artifact.spaceId` (now derived, same shape).
+- `rowToArtifact` — reads `row.space_id` which the joined SELECT still provides.
+- All ~18 web components reading `artifact.spaceId` off API responses (`App.tsx`, `SpotlightSearch.tsx`, `ChatBar.tsx`, `ArtefactInspector.tsx`, …).
+- `getByPath` semantics (matches absolute path in `storage_config`).
+- `space-sync-service` (syncs the `spaces` table only).
+
+## Project resolution helper
+
+Reuse `lookupProject(db, dir, …)` (`lookup-project.ts:35`) for path→project on the live/registration path (marker walk + `project_paths` fallback, returns `{projectId, spaceId}`; pass the file's `dirname`). The migration uses the longest-prefix SQL above directly (it must match orphan-project files too, which `lookupProject` step 2 deliberately skips).
+
+## Error handling & edge cases
+
+- **Path under no project** → `project_id` stays null → derived space `''` → artifact is orphan (valid; matches the existing `space_id != ''` "no space" convention). It gains a space when its folder is organised.
+- **Ambiguous longest-prefix** (two `project_paths` of equal length) → `LIMIT 1` picks one deterministically; logged in the mismatch report.
+- **Tombstoned artifacts** are backfilled too, so undelete/recovery keeps working post-drop.
+- **Repeat boots** → column already absent → migration block skips (idempotent).
+
+## Testing
+
+- **Migration parity (fixture DB):** seed artifacts mirroring the real split (some `space_id` + no project, some both, one path under no project). After migration: every artifact's *derived* space equals its pre-migration `space_id` where a project resolved; the path-less/project-less one becomes null; assert exact counts (e.g. 131-analogue all resolve).
+- **Mismatch report:** seed one artifact whose `space_id` disagrees with its resolved project's space; assert it appears in the logged report and the project wins.
+- **Idempotency:** run `initDb` twice; second boot makes no changes (no `space_id` column, no project_id rewrites).
+- **Derived queries:** `getBySpaceId(s)` returns exactly the artifacts whose project is in space `s`; `getDistinctSpaces` matches; an orphan (null project) appears in none.
+- **Dedup index:** two artifacts, same `source_ref`, same project → second insert rejected; same `source_ref`, different project → both allowed.
+- **No regression:** existing artifact tests (`db-artefact-tombstone-recovery.test.ts`, etc.) pass.
+
+## Non-goals
+
+- No change to the `Artifact` type or web grid behaviour (space still appears, derived).
+- No cloud/worker schema change.
+- No reactive registration (Plan 2).
+- No removal of `projects.space_id` or other space plumbing — spaces still organise projects.
+
+## Key files
+
+`server/src/artifact-store.ts`, `server/src/artifact-service.ts`, `server/src/db.ts`, `server/src/mcp-server.ts`, `server/src/publish-service.ts`, `server/src/import.ts`, `server/src/routes/import.ts`, `server/src/lookup-project.ts`, `shared/types.ts`.

--- a/docs/superpowers/specs/2026-05-24-artifact-project-home-design.md
+++ b/docs/superpowers/specs/2026-05-24-artifact-project-home-design.md
@@ -48,6 +48,7 @@ Every artifact-store SELECT gains `LEFT JOIN projects p ON p.id = a.project_id` 
 
 Run as one transaction in `initDb`, guarded so repeat boots are no-ops (detect `space_id` column presence via `PRAGMA table_info(artifacts)`).
 
+0. **Ensure a native project per space that holds created content.** Artifacts whose file lives under `~/Oyster/spaces/<space-id>/` (agent-created via `create_artifact` — 18 on the main DB, 0 project-resolvable since no `project_paths` point there) get a **native project**: for each such space, ensure a `projects` row bound to that space and a `project_paths` entry `path = <userland>/spaces/<space-id>`. The model stays uniform — *every* artifact is project-parented; a space's native folder is simply a project filed under that space. The backfill in step 1 then resolves these via the same longest-prefix match.
 1. **Backfill `project_id`** for every artifact (active and tombstoned) that has `project_id IS NULL` and a `storage_config.$.path`, using **longest-prefix** `project_paths` match:
    ```sql
    UPDATE artifacts
@@ -71,7 +72,8 @@ Run as one transaction in `initDb`, guarded so repeat boots are no-ops (detect `
 
 - **`artifact-store.ts`**: drop `space_id` from the INSERT column list (`:83`) and from `UPDATABLE_COLUMNS` (`:130-134`); rewrite the six SELECTs to join projects; `getBySpaceAndSourceRef` keys on `(project_id, source_ref)` (`:78`).
 - **`artifact-service.ts`**: `registerArtifact` (`:296`) takes `project_id?: string | null` instead of `space_id`; resolves it from the file path via `lookupProject` when not supplied. `createArtifact` (`:452`) resolves `project_id` from the target path. The returned `Artifact` literal (`:395`) sets `spaceId` from the resolved project's space. `updateArtifact` (`:589`) **drops** direct space reassignment — moving an artifact between spaces now means moving its **project** (or the file); document this. `reconcileGeneratedArtifact` (`:557`) passes `project_id` (from `artifact.projectId`).
-- **`mcp-server.ts`**: `register_artifact` / `create_artifact` (`:594`) drop the `space_id` tool param — the project (and thus space) is determined by the file's path. `update_artifact` (`:663`) drops `space_id` reassignment. **MCP API change**, acceptable (single user, local tools); update tool descriptions.
+- **`mcp-server.ts`**: `register_artifact` (`:594`) drops the `space_id` tool param — project (hence space) comes from the file's path. `create_artifact` (`:640`) **keeps** `space_id` (it still chooses *which* native folder to write into via `getNativeSourcePath(space_id)`), but the created artifact is parented to that space's **native project**, not given a stored `space_id`. `update_artifact` (`:663`) drops `space_id` reassignment. **MCP API change** (register/update), acceptable (single user, local tools); update tool descriptions.
+- **`artifact-service.ts` `createArtifact`** ensures the space's native project exists (idempotent — same helper the migration uses) and passes its `project_id` to `registerArtifact`.
 - **`publish-service.ts`**: `publishArtifact` (`:143,182`) and `backfillPublications` (`:444-474`) derive `space_id` via `JOIN projects` before bundling it into the cloud payload. Wire format unchanged.
 - **`import.ts`** (`:538-580`) and **`routes/import.ts`** (`:84`): `createArtifact` calls resolve a `project_id` for the target folder/space context instead of passing `space_id`.
 

--- a/docs/superpowers/specs/2026-05-24-session-output-registration-design.md
+++ b/docs/superpowers/specs/2026-05-24-session-output-registration-design.md
@@ -1,0 +1,213 @@
+# Reactive session-output registration + path-indexed search
+
+**Date:** 2026-05-24
+**Status:** Draft — pending Matthew's review
+**Author:** Matthew Slight + Claude
+**Driver:** Sessions-first 1.0 (#551) shipped FULL-view artifact chips that render empty for ~75% of an active user's sessions and 100% of a new user's. Diagnostic + design session 2026-05-24.
+
+> **Naming note:** the branch is `artifact-scanner` for continuity with the handover, but there is **no disk scanner** in this design. Registration is reactive (driven by session history), not a filesystem crawl. The doc name reflects the real shape.
+
+---
+
+## Product principle
+
+The requirement is three distinct layers. Conflating them caused the previous session to over-build. They are separate:
+
+| Layer | What the user wants | Engineering answer |
+|---|---|---|
+| **Session chips** | "These are the docs we produced / things we were working on" — `report.md`, `invoice.html`, the app we built. **Not** `.ts`/`.js` churn. | Curated **output** artefacts only, linked to the sessions that touched them. |
+| **Search by source file** | Search `App.jsx`, surface the sessions that edited it — even though it's never a chip. | Embed tool file paths in `session_events.text` so the existing FTS index finds them. |
+| **Artefact grid** | Stays clean and meaningful. | Source files are **never** registered as artefacts. |
+
+The guiding line: **record everything for search, present only useful outputs as artefacts.**
+
+## Why now — the diagnostic
+
+Measured on the two real databases (read-only extraction of the actual touch logic, 2026-05-24):
+
+| | Main DB (power user) | Fresh `/tmp` DB |
+|---|---|---|
+| `session_events` rows | 1,885,834 | ~315k scanned |
+| Total file touches in history | 249,231 | 70,108 |
+| **Distinct OUTPUT artefacts (allow-list + deny-list)** | **374** | **346** |
+| — by kind | 233 notes, 141 wireframe | 214 notes, 132 wireframe |
+| **Session→output links (chips)** | **882** | **765** |
+| One-pass read+parse time | 38.3 s | 9.0 s |
+
+(A looser deny-list-only filter yielded 642/1,400 by also admitting images and stray extensions; the allow-list trims it to the cleaner figures above. In dogfooding history only `notes` and `.html` outputs actually appear — `.csv`/`.pdf`/`.pptx`/`.ipynb` are supported by the classifier but unused so far.)
+
+Two facts drive the design:
+
+1. **Chips are empty because registration is gated on prior registration.** The watcher only records a `session_artifacts` row when the touched file is *already* a registered artefact at tool_use time (`server/src/watchers/claude-code.ts:484`, `:835` — `if (!artifactStore.getByPath(path)) continue`). Files Claude writes are never auto-registered, so the gate is almost never satisfied.
+2. **Search can't find touched files.** `renderEvent` (`claude-code.ts:1077-1090`) renders a `Write`/`Edit`/`Read` tool_use down to `[Write]` and **discards the `file_path`**. The FTS index (`session_events_fts`) indexes only the rendered `text` column, not `raw`. So searching `App.jsx` only hits sessions where the path appeared in prose — not sessions that touched it via a tool call.
+
+The filtering collapses 249,231 touches → **374 output artefacts**. That is the clean grid, proven on the heaviest possible DB.
+
+---
+
+## Architecture
+
+Registration is **reactive**: it is driven by file touches observed in session history, not by crawling the disk.
+
+A **single pass over `session_events`** (newest-first, debounced ~5s after boot, background, non-blocking) parses each event's `raw` **once** and does two jobs:
+
+- **Job A — Search:** re-render `text` to embed the tool's file path (`[Write]` → `[Write src/App.jsx]`). The existing FTS triggers re-index it; historical sessions become searchable by filename.
+- **Job B — Chips:** if the touched path is a *useful output*, register it as an artefact (or reuse the existing one via `getByPath`) and insert a `session_artifacts` link with the real touch timestamp.
+
+A **high-water mark** (last processed `session_events.id`) makes the historical pass one-time. After it completes, live ingestion does both jobs inline as new events arrive — near-zero marginal cost, because ingestion already parses every event.
+
+```
+Boot → watcher ingests JSONL → session_events
+                                     │
+        (debounced ~5s, background, recent-first, id > high_water_mark)
+                                     ▼
+              ┌──────── single pass: parse raw once ────────┐
+              │                                             │
+        Job A: re-render text                        Job B: extract touch
+        with relative path                           ├ allow-list output type?
+        → UPDATE session_events.text                 ├ NOT secret/noise/vendor?
+        → FTS triggers re-index                      └ register output + link session
+              │                                             │
+        search finds App.jsx                          chips show report.md
+```
+
+### Why reactive, not a disk scanner
+
+A disk crawl was the handover's original direction. Rejected because:
+
+- The chip story is "what your agent did" — session history is the correct source, and the watcher already ingests it on boot. A disk crawl answers a different question ("what files exist in my folders") and adds a 15-min rescan cadence + soft-delete-on-missing machinery for no chip-story benefit.
+- Reactive folds into the boot ingestion a fresh user already pays. The measured 38 s / 9 s is the cost of re-processing **already-ingested** events (existing dogfood DBs + the historical re-render). For a genuinely new user, Job A and Job B ride the ingestion pass that creates their sessions in the first place.
+- It satisfies all three layers and drops three subsystems (crawler, cadence, soft-delete sweep).
+
+The one thing reactive cannot show: an output file sitting on disk that no tracked session ever touched. For "your agent's work," that is correctly excluded.
+
+---
+
+## Job A — Path-indexed search
+
+### `renderEvent` embeds relative file paths
+
+`renderEvent` (`claude-code.ts:1041`) gains access to the session `cwd` (already known to the watcher as `meta.cwd` / `tracker.cwd`) and renders tool_use file paths into the text:
+
+- `[Write]` → `[Write src/App.jsx]`
+- Covers `Read`, `Write`, `Edit`, `MultiEdit`, `NotebookEdit`.
+- **Relative path** to the session project root (`cwd`) when the file is under it; otherwise `~`-collapsed absolute (e.g. `~/.claude/settings.json`). **Never** store or display a full local absolute path when avoidable.
+
+This improves the inspector timeline too — tool turns show *what* was touched, not just `[Write]`. **User-visible → CHANGELOG entry required.**
+
+### Historical re-index migration
+
+Old events already have `text` without paths. A one-time, batched, background migration re-renders `text` from `raw` for touch-bearing events and `UPDATE`s the row; the existing FTS `UPDATE` triggers (`db.ts:771-779`) propagate to the index.
+
+- Bounded to events that carry a tool_use `file_path` (~249k on the main DB) — no point rewriting prose turns.
+- This is the **write-heaviest** part of the work (UPDATE + trigger per row), heavier than the 38 s read measurement. Batch it (~20k rows), run in background, share the high-water mark with Job B so both jobs advance together in one sweep.
+- Events with `raw IS NULL` keep their existing text (can't be re-rendered) — acceptable.
+
+---
+
+## Job B — Output registration + linking
+
+### What counts as a "useful output": allow-list, then deny-list
+
+**Step 1 — allow-list by extension → artefact kind.** Register only known output types:
+
+| Kind | Extensions / names |
+|---|---|
+| `notes` | `.md`, `.markdown`, `.txt`, `.rst`, `.rtf`, `.docx`, `.doc`, `.pages`, `.odt` |
+| `table` | `.csv`, `.tsv`, `.xlsx`, `.xls`, `.ods`, `.numbers`, `.parquet` |
+| `deck` | `.pdf`, `.pptx`, `.key`, `.odp` |
+| `diagram` | `.mmd`, `.mermaid`, `.dot`, `.drawio`, `.excalidraw` |
+| `wireframe` | `.html`, `.htm` |
+| `notebook` | `.ipynb` |
+| `app` | directory with `package.json` + a `dev`/`start` script (reuse `artifact-detector.ts`) |
+
+Anything not on the allow-list (source code, config, unknown extensions) is **not registered** — but remains **searchable** via Job A. Images (`.png/.jpg/.svg/...`) are **deferred to v2** — too many icons/logos/screenshots/assets to keep v1 clean.
+
+**Step 2 — hard secret/noise deny-list (applied on top, defense-in-depth).** Even an allowed extension is **skipped** if the path/name matches. Allowed types like `.txt`/`.md`/`.html`/`.ipynb` can still hold sensitive or junk content, so the deny-list wins:
+
+- **Secret:** `.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa`, `id_dsa`, `*.p12`, `*.pfx`, `*.keystore`, `credentials*`, `.npmrc`, `.netrc`, anything under `.ssh/` or `.aws/`, path segment `secrets`
+- **Dependency / vendor:** `node_modules/`, `vendor/`, `bower_components/`, `.pnpm-store/`, `.venv/`, `venv/`
+- **Cache:** `.cache/`, `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`
+- **Build:** `dist/`, `build/`, `target/`, `.next/`, `.nuxt/`, `out/`, `coverage/`
+- **Temp / VCS / hidden:** `/tmp/`, `*.tmp`, `*.temp`, `*~`, `*.swp`, `.DS_Store`, `.git/`, and any path with a directory segment beginning `.`
+
+The rule, stated once: **register only known useful output types, unless the path/name matches a secret, dependency, cache, build, temp, or vendor pattern.**
+
+### Registration is idempotent via `getByPath`
+
+For each qualifying touch: `getByPath(absPath)` — reuse the existing artefact if present (including the legacy 506 `'discovered'` ones still on disk), else `insert` a new one with:
+
+- `source_origin: 'discovered'` (reuse existing enum value; no migration. A semantically-purer `'session'` value is deferred unless the UI needs to distinguish them.)
+- `label`: filename stem (the inferred default; a richer label is a later UX concern, out of scope).
+- `artifact_kind`: from the allow-list table.
+- `storage_kind: 'filesystem'`, `runtime_kind: 'static_file'`.
+
+### Linking — and killing the dup bug (prerequisite migration)
+
+`session_artifacts` currently has **no UNIQUE constraint** (`db.ts:307-318`), so the watcher and backfill can each insert a row for the same touch. Under reactive registration this becomes systematic duplication. **In scope, prerequisite:**
+
+- Migration: `UNIQUE(session_id, artifact_id, role)` on `session_artifacts`. Inserts become `INSERT OR IGNORE`.
+- The link's `when_at` is set from the **event timestamp**, not boot-time `now()` (the current backfill omits `when_at`, defaulting to `now()` — wrong for sorting). With recent-first processing, the latest touch is processed first and wins the `OR IGNORE`, so the row carries the most recent touch time. Chips sort correctly by `whenAt DESC`.
+- Backfill existing duplicate rows as part of the migration (de-dup, keep newest `when_at`).
+
+This replaces the per-artefact `backfillTouchesForNewArtefact` scan (`artifact-service.ts:407`), whose `O(N artefacts × M events)` non-sargable `instr()` design would be a boot cliff if called in a registration loop. The single-pass sweep does the linking in `O(M events)` once.
+
+---
+
+## Data model changes
+
+1. `session_artifacts`: add `UNIQUE(session_id, artifact_id, role)`; switch inserts to `INSERT OR IGNORE`; set `when_at` from event timestamp. One-time de-dup of existing rows.
+2. High-water mark storage: a single scalar (e.g. a `meta`/`kv` row, or reuse an existing settings table) holding the last processed `session_events.id`. Read on boot; advanced as the sweep progresses; persisted so the sweep is resumable and one-time.
+3. No new tables. **No `session_file_touches`** — FTS is sufficient for "find sessions touching App.jsx." A structured per-touch table is deferred unless exact structured queries ("every session that edited this precise path, with timestamps and role") become a real product requirement.
+
+---
+
+## Error handling & edge cases
+
+- **Parse failures:** `JSON.parse(raw)` failures are skipped (measured: 0 parse errors across 1.4M events, but guard anyway).
+- **Path outside cwd:** `~`-collapsed absolute; if not under `~` either, store the absolute path (rare; e.g. system files).
+- **Deleted sessions:** `INSERT OR IGNORE` + FK to `sessions` — a link to a vanished session fails silently (existing behaviour at `artifact-service.ts:445`).
+- **Missing files on disk:** a registered output whose file was later deleted is handled gracefully at open-time (existing artefact-open error path). **No active soft-delete sweep** in this spec.
+- **Sweep interruption:** high-water mark is advanced only after a batch commits, so a crash mid-sweep resumes from the last committed batch.
+
+---
+
+## Testing
+
+Per project preference (prove before/after with **parity tests, not timing assertions**):
+
+- **Unit — classification:** allow-list × deny-list matrix. `report.md` → registered `notes`; `src/App.tsx` → not registered; `.env` → not registered even though… (no allowed ext, but assert a `.env.md`-style trap is denied); `node_modules/foo/readme.md` → denied (vendor); `~/.ssh/config` → denied.
+- **Unit — `renderEvent`:** `Write src/App.jsx` under cwd → `[Write src/App.jsx]`; file outside cwd → `[Write ~/.claude/x]`; `MultiEdit`/`NotebookEdit` covered.
+- **Unit — relative path:** under cwd → relative; under `~` → `~`-collapsed; else absolute.
+- **Integration — single pass on a fixture DB:** seed `session_events` with known touches; run the sweep; assert (a) the right N output artefacts registered, (b) the right session_artifacts links with correct `when_at`, (c) no duplicate links, (d) FTS `MATCH` finds a touched source file by name.
+- **Integration — idempotency:** run the sweep twice; assert no new rows the second time (high-water mark + `INSERT OR IGNORE`).
+- **Parity — counts:** against a copy of the real main DB, assert registered-output count and link count match the measured extraction (~374 artefacts / ~882 links) within tolerance, so refactors don't silently change behaviour.
+
+---
+
+## Non-goals (explicit scope fence)
+
+- **No disk crawl.** Registration is session-history-driven only.
+- **No rescan loop / cadence.** One historical pass + incremental live ingestion.
+- **No soft-delete sweep.** Missing files handled at open-time.
+- **No source files as artefacts.** Ever.
+- **No `session_file_touches` table.** FTS is enough for v1.
+- **No grid presentation / filtering work.** How discovered outputs appear/filter in the grid is a separable follow-up. This spec is registration, linking, and search-indexing only.
+- **No images** (v2).
+- **No richer labels** than filename stem (later UX).
+
+## Follow-ups (noted, not in scope)
+
+- Legacy 506 `'discovered'` artefacts on the main DB (from the dead old scanner): reconcile/clean up stale ones whose files are gone.
+- Grid presentation of discovered outputs (default view, origin filter).
+- A `'session'` `source_origin` value if the UI needs to distinguish reactive-registered from legacy discovered.
+- `session_file_touches` if structured per-touch history becomes a product need.
+
+## Key files
+
+- `server/src/watchers/claude-code.ts` — `renderEvent` (`:1041`), `artifactTouchFromToolUse` (`:1106`), ingestion loops (`backfillRange` `:422`, `consumeOnce` `:680`). Job A + Job B hook here.
+- `server/src/artifact-service.ts` — `registerArtifact` (insert at `:363`), retire/replace `backfillTouchesForNewArtefact` (`:407`).
+- `server/src/db.ts` — `session_artifacts` schema (`:307`), FTS triggers (`:753-779`), migration site.
+- `server/src/session-store.ts` — `searchSessions`/`searchEvents` (`:569`, `:628`) — no change needed; they read FTS.
+- `shared/types.ts` — `Artifact` / `ArtifactSourceOrigin` (`:20`).
+- `web/src/components/Home/SessionRow.tsx` — chip rendering, already wired; no change.

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -9,6 +9,8 @@ import { isPortOpen, isStarting, clearStarting, getGeneratedArtifactEntries } fr
 import { resolveArtifactPathViaProjects } from "./resolve-artifact-path.js";
 import { artifactTouchFromToolUse } from "./watchers/claude-code.js";
 import { slugify, inferKindFromPath, toArtifactKind } from "./utils.js";
+import { lookupProject } from "./lookup-project.js";
+import { ensureNativeProject } from "./native-project.js";
 import { debug, debugEnabled } from "./debug.js";
 
 // ── Config shapes (validated here, not in route handlers) ──
@@ -296,7 +298,7 @@ export class ArtifactService {
   async registerArtifact(
     params: {
       path: string;
-      space_id: string;
+      project_id?: string | null;
       label: string;
       id?: string;
       artifact_kind?: ArtifactKind;
@@ -305,8 +307,12 @@ export class ArtifactService {
     },
     approvedRoots: string[],
   ): Promise<Artifact> {
-    debug("artifact-svc", "registerArtifact called", { path: params.path, label: params.label, id: params.id ?? null, space_id: params.space_id });
+    debug("artifact-svc", "registerArtifact called", { path: params.path, label: params.label, id: params.id ?? null, project_id: params.project_id ?? null });
     const absPath = resolve(params.path);
+
+    const projectId = params.project_id !== undefined
+      ? params.project_id
+      : lookupProject(this.db, dirname(absPath)).projectId;
 
     // Validate file exists
     if (!existsSync(absPath)) {
@@ -345,7 +351,7 @@ export class ArtifactService {
         this.invalidateArchivedPaths();
         const kind = params.artifact_kind || inferKindFromPath(absPath);
         this.store.update(id, {
-          space_id: params.space_id,
+          project_id: projectId,
           label: params.label,
           artifact_kind: kind,
           group_name: params.group_name || null,
@@ -363,7 +369,6 @@ export class ArtifactService {
     this.store.insert({
       id,
       owner_id: null,
-      space_id: params.space_id,
       label: params.label,
       artifact_kind: kind,
       storage_kind: "filesystem",
@@ -373,6 +378,7 @@ export class ArtifactService {
       group_name: params.group_name || null,
       source_origin: params.source_origin ?? "manual",
       source_ref: null,
+      project_id: projectId,
     });
 
     // Backfill session→artefact links. The watcher's live touch-detection
@@ -383,18 +389,7 @@ export class ArtifactService {
     // rows.
     this.backfillTouchesForNewArtefact(id, absPath);
 
-    return {
-      id,
-      label: params.label,
-      artifactKind: kind,
-      spaceId: params.space_id,
-      status: "ready",
-      runtimeKind: "static_file",
-      runtimeConfig: {},
-      url: `/docs/${id}`,
-      createdAt: new Date().toISOString(),
-      groupName: params.group_name || undefined,
-    };
+    return await this.rowToArtifact(this.store.getById(id)!);
   }
 
   // Look back at recent assistant events for tool_use blocks at this
@@ -502,9 +497,10 @@ export class ArtifactService {
     // Approved-root check confirms the file we just wrote stayed within the
     // space's native folder (stricter than the old `[userlandDir]` check —
     // the subdir containment above already guarantees this).
+    const projectId = ensureNativeProject(this.db, this.userlandDir!, space_id);
     try {
       return await this.registerArtifact(
-        { path: absPath, space_id, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id, source_origin: params.source_origin },
+        { path: absPath, project_id: projectId, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id, source_origin: params.source_origin },
         [spaceNativePath],
       );
     } catch (err) {
@@ -554,7 +550,7 @@ export class ArtifactService {
     debug("reconcile", "inserting new row", { label: artifact.label, filePath, newId: "pending-uuid" });
     try {
       this.registerArtifact(
-        { path: filePath, space_id: artifact.spaceId, label: artifact.label, artifact_kind: artifact.artifactKind, id: crypto.randomUUID() },
+        { path: filePath, label: artifact.label, artifact_kind: artifact.artifactKind, id: crypto.randomUUID() },
         [userlandDir],
       );
     } catch (err) {
@@ -575,7 +571,7 @@ export class ArtifactService {
 
   async updateArtifact(
     id: string,
-    fields: { label?: string; space_id?: string; group_name?: string | null; artifact_kind?: ArtifactKind },
+    fields: { label?: string; group_name?: string | null; artifact_kind?: ArtifactKind },
   ): Promise<Artifact> {
     const row = this.store.getById(id);
     if (!row) throw new Error(`Artifact "${id}" not found`);
@@ -585,11 +581,6 @@ export class ArtifactService {
       const label = fields.label.trim();
       if (!label) throw new Error("label must not be empty");
       updateable.label = label;
-    }
-    if (fields.space_id !== undefined) {
-      const space_id = fields.space_id.trim();
-      if (!space_id) throw new Error("space_id must not be empty");
-      updateable.space_id = space_id;
     }
     if (fields.artifact_kind !== undefined) updateable.artifact_kind = fields.artifact_kind;
     if ("group_name" in fields) updateable.group_name = fields.group_name ?? null;

--- a/server/src/artifact-service.ts
+++ b/server/src/artifact-service.ts
@@ -310,11 +310,9 @@ export class ArtifactService {
     debug("artifact-svc", "registerArtifact called", { path: params.path, label: params.label, id: params.id ?? null, project_id: params.project_id ?? null });
     const absPath = resolve(params.path);
 
-    const projectId = params.project_id !== undefined
-      ? params.project_id
-      : lookupProject(this.db, dirname(absPath)).projectId;
-
-    // Validate file exists
+    // Validate file exists before any side-effectful operations (lookupProject
+    // can stamp a .oyster/id marker and cache paths via the project_paths
+    // fallback — we must not do that for a path that doesn't exist).
     if (!existsSync(absPath)) {
       throw new Error(`File does not exist: ${absPath}`);
     }
@@ -329,6 +327,10 @@ export class ArtifactService {
         );
       }
     }
+
+    const projectId = params.project_id !== undefined
+      ? params.project_id
+      : lookupProject(this.db, dirname(absPath)).projectId;
 
     // Infer ID from filename stem if not provided
     const id = params.id || basename(absPath).replace(/\.[^.]+$/, "");
@@ -497,7 +499,8 @@ export class ArtifactService {
     // Approved-root check confirms the file we just wrote stayed within the
     // space's native folder (stricter than the old `[userlandDir]` check —
     // the subdir containment above already guarantees this).
-    const projectId = ensureNativeProject(this.db, this.userlandDir!, space_id);
+    if (!this.userlandDir) throw new Error("createArtifact requires userlandDir (Oyster home) to resolve the native project");
+    const projectId = ensureNativeProject(this.db, this.userlandDir, space_id);
     try {
       return await this.registerArtifact(
         { path: absPath, project_id: projectId, label, artifact_kind: params.artifact_kind, group_name: params.group_name, id, source_origin: params.source_origin },

--- a/server/src/artifact-space-migration.ts
+++ b/server/src/artifact-space-migration.ts
@@ -1,0 +1,83 @@
+import type Database from "better-sqlite3";
+import { join, relative, sep, isAbsolute } from "node:path";
+import { ensureNativeProject } from "./native-project.js";
+
+export interface ArtifactSpaceReport {
+  total: number;
+  hadSpace: number;
+  backfilled: number;
+  stillOrphan: number;
+  mismatches: { id: string; path: string; oldSpace: string; newSpace: string | null }[];
+}
+
+/** Backfill artifacts.project_id from the file path so space can be derived
+ *  via project. Native workspace files (<userland>/spaces/<id>) get a native
+ *  project for their space first. Does NOT drop space_id — that is a separate
+ *  step run only after all readers stop using the column.
+ *
+ *  Idempotent AND safe after space_id has been dropped: the SELECT shape is
+ *  chosen from PRAGMA, so it never names a column that no longer exists. */
+export function backfillArtifactProjects(db: Database.Database, userlandDir: string): ArtifactSpaceReport {
+  const cols = db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[];
+  const hasSpaceCol = cols.some((c) => c.name === "space_id");
+
+  const resolveProject = db.prepare(
+    `SELECT pp.project_id FROM project_paths pp
+      WHERE ? LIKE pp.path || '/%' OR ? = pp.path
+      ORDER BY LENGTH(pp.path) DESC LIMIT 1`,
+  );
+  const setProject = db.prepare("UPDATE artifacts SET project_id = ? WHERE id = ?");
+  const projectSpace = db.prepare("SELECT space_id FROM projects WHERE id = ?");
+  const nativeRoot = join(userlandDir, "spaces");
+
+  const report: ArtifactSpaceReport = { total: 0, hadSpace: 0, backfilled: 0, stillOrphan: 0, mismatches: [] };
+  const txn = db.transaction(() => {
+    report.total = (db.prepare("SELECT COUNT(*) AS n FROM artifacts").get() as { n: number }).n;
+    if (hasSpaceCol) {
+      report.hadSpace = (db.prepare("SELECT COUNT(*) AS n FROM artifacts WHERE space_id IS NOT NULL AND space_id != ''").get() as { n: number }).n;
+    }
+
+    // 1. Backfill project_id for rows missing it. The query NEVER references
+    //    space_id directly — it may have been dropped on a prior boot.
+    const needBackfill = db
+      .prepare(
+        `SELECT id, json_extract(storage_config,'$.path') AS path
+           FROM artifacts
+          WHERE project_id IS NULL AND json_extract(storage_config,'$.path') IS NOT NULL`,
+      )
+      .all() as { id: string; path: string }[];
+    for (const row of needBackfill) {
+      // Native workspace file → ensure its space's native project first.
+      const rel = relative(nativeRoot, row.path);
+      if (rel && !rel.startsWith("..") && !isAbsolute(rel)) {
+        const spaceId = rel.split(sep)[0];
+        if (spaceId) ensureNativeProject(db, userlandDir, spaceId);
+      }
+      const hit = resolveProject.get(row.path, row.path) as { project_id: string } | undefined;
+      if (!hit) { report.stillOrphan++; continue; }
+      setProject.run(hit.project_id, row.id);
+      report.backfilled++;
+    }
+
+    // 2. Mismatch report — only possible while space_id still exists. Covers
+    //    ALL parented rows (pre-existing project_id too), not just the ones
+    //    just backfilled, so a stale manual space assignment is surfaced.
+    if (hasSpaceCol) {
+      const withBoth = db
+        .prepare(
+          `SELECT id, space_id, project_id, json_extract(storage_config,'$.path') AS path
+             FROM artifacts
+            WHERE project_id IS NOT NULL AND space_id IS NOT NULL AND space_id != ''`,
+        )
+        .all() as { id: string; space_id: string; project_id: string; path: string }[];
+      for (const row of withBoth) {
+        const newSpace = (projectSpace.get(row.project_id) as { space_id: string | null }).space_id;
+        if (row.space_id !== newSpace) {
+          report.mismatches.push({ id: row.id, path: row.path, oldSpace: row.space_id, newSpace });
+        }
+      }
+    }
+  });
+  txn();
+  return report;
+}

--- a/server/src/artifact-space-migration.ts
+++ b/server/src/artifact-space-migration.ts
@@ -24,10 +24,14 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
   // Use substr-based prefix matching instead of LIKE to avoid treating `_` and
   // `%` in project paths as SQL wildcards. Mirrors the approach in
   // project-service.ts ~lines 149-163. A path matches if it equals the project
-  // root exactly, or if it is a direct descendant (separated by `/`).
+  // root exactly, or if it is a direct descendant (separated by `/` or `\`).
+  // The backslash variant handles Windows project_paths rows. Three `?` params
+  // map to: exact-match candidate, `/`-separator candidate, `\`-separator candidate.
   const resolveProject = db.prepare(
     `SELECT pp.project_id FROM project_paths pp
-      WHERE ? = pp.path OR substr(?, 1, length(pp.path) + 1) = pp.path || '/'
+      WHERE ? = pp.path
+         OR substr(?, 1, length(pp.path) + 1) = pp.path || '/'
+         OR substr(?, 1, length(pp.path) + 1) = pp.path || '\\'
       ORDER BY LENGTH(pp.path) DESC LIMIT 1`,
   );
   const setProject = db.prepare("UPDATE artifacts SET project_id = ? WHERE id = ?");
@@ -57,7 +61,7 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
         const spaceId = rel.split(sep)[0];
         if (spaceId) ensureNativeProject(db, userlandDir, spaceId);
       }
-      const hit = resolveProject.get(row.path, row.path) as { project_id: string } | undefined;
+      const hit = resolveProject.get(row.path, row.path, row.path) as { project_id: string } | undefined;
       if (!hit) { report.stillOrphan++; continue; }
       setProject.run(hit.project_id, row.id);
       report.backfilled++;

--- a/server/src/artifact-space-migration.ts
+++ b/server/src/artifact-space-migration.ts
@@ -21,9 +21,13 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
   const cols = db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[];
   const hasSpaceCol = cols.some((c) => c.name === "space_id");
 
+  // Use substr-based prefix matching instead of LIKE to avoid treating `_` and
+  // `%` in project paths as SQL wildcards. Mirrors the approach in
+  // project-service.ts ~lines 149-163. A path matches if it equals the project
+  // root exactly, or if it is a direct descendant (separated by `/`).
   const resolveProject = db.prepare(
     `SELECT pp.project_id FROM project_paths pp
-      WHERE ? LIKE pp.path || '/%' OR ? = pp.path
+      WHERE ? = pp.path OR substr(?, 1, length(pp.path) + 1) = pp.path || '/'
       ORDER BY LENGTH(pp.path) DESC LIMIT 1`,
   );
   const setProject = db.prepare("UPDATE artifacts SET project_id = ? WHERE id = ?");

--- a/server/src/artifact-space-migration.ts
+++ b/server/src/artifact-space-migration.ts
@@ -83,3 +83,22 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
   txn();
   return report;
 }
+
+export function dropArtifactSpaceColumn(db: Database.Database): void {
+  const hasCol = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+  if (hasCol) {
+    // The old dedup index includes space_id; SQLite refuses to drop a column
+    // referenced by an index, so drop it first.
+    db.exec("DROP INDEX IF EXISTS artifacts_space_source_ref_uq");
+    // DROP COLUMN requires SQLite ≥ 3.35 (2021); better-sqlite3 v12 bundles a
+    // newer SQLite, so this is supported. We deliberately do NOT swallow a
+    // failure — dropping the column is the point; a silent no-op would hide a
+    // real problem and leave the schema half-migrated. If a future runtime
+    // lacks DROP COLUMN, this throws at boot (loud + visible).
+    db.exec("ALTER TABLE artifacts DROP COLUMN space_id");
+  }
+  // Idempotent: ensure the new dedup index exists whether the column was just
+  // dropped or dropped on a prior boot.
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS artifacts_project_source_ref_uq
+             ON artifacts(project_id, source_ref) WHERE source_ref IS NOT NULL`);
+}

--- a/server/src/artifact-space-migration.ts
+++ b/server/src/artifact-space-migration.ts
@@ -71,7 +71,9 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
         )
         .all() as { id: string; space_id: string; project_id: string; path: string }[];
       for (const row of withBoth) {
-        const newSpace = (projectSpace.get(row.project_id) as { space_id: string | null }).space_id;
+        const projectRow = projectSpace.get(row.project_id) as { space_id: string | null } | undefined;
+        if (!projectRow) continue; // stale project_id — skip
+        const newSpace = projectRow.space_id;
         if (row.space_id !== newSpace) {
           report.mismatches.push({ id: row.id, path: row.path, oldSpace: row.space_id, newSpace });
         }

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -5,6 +5,7 @@ import type Database from "better-sqlite3";
 export interface ArtifactRow {
   id: string;
   owner_id: string | null;
+  /** Derived via LEFT JOIN projects — not stored directly (transitional: column still exists but reads use the join). */
   space_id: string;
   label: string;
   artifact_kind: string;
@@ -30,7 +31,7 @@ export interface ArtifactRow {
 
 // ── Store interface ──
 
-export type InsertRow = Omit<ArtifactRow, "created_at" | "updated_at" | "removed_at" | "source_origin" | "source_ref" | "project_id" | "share_token" | "share_mode" | "share_password_hash" | "published_at" | "share_updated_at" | "unpublished_at" | "pinned_at"> & {
+export type InsertRow = Omit<ArtifactRow, "space_id" | "created_at" | "updated_at" | "removed_at" | "source_origin" | "source_ref" | "project_id" | "share_token" | "share_mode" | "share_password_hash" | "published_at" | "share_updated_at" | "unpublished_at" | "pinned_at"> & {
   source_origin?: "manual" | "discovered" | "ai_generated";
   source_ref?: string | null;
   project_id?: string | null;
@@ -42,7 +43,7 @@ export interface ArtifactStore {
   getBySpaceId(spaceId: string): ArtifactRow[];
   getByPath(absPath: string): ArtifactRow | undefined;
   getDistinctSpaces(): { space_id: string; count: number }[];
-  getBySpaceAndSourceRef(spaceId: string, sourceRef: string): ArtifactRow | undefined;
+  getByProjectAndSourceRef(projectId: string, sourceRef: string): ArtifactRow | undefined;
   insert(row: InsertRow): void;
   update(id: string, fields: Partial<Omit<ArtifactRow, "id" | "created_at">>): void;
   resurface(id: string): void;
@@ -63,32 +64,41 @@ export class SqliteArtifactStore implements ArtifactStore {
     getBySpaceId: Database.Statement;
     getByPath: Database.Statement;
     getDistinctSpaces: Database.Statement;
-    getBySpaceAndSourceRef: Database.Statement;
+    getByProjectAndSourceRef: Database.Statement;
+    getAllArchived: Database.Statement;
     insert: Database.Statement;
     delete: Database.Statement;
   };
 
   constructor(private db: Database.Database) {
+    const hasSpaceCol = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+    // Column list for SELECTs: every artifact column EXCEPT space_id, plus the derived alias.
+    const artCols = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[])
+      .map((c) => c.name).filter((n) => n !== "space_id").map((n) => `a.${n}`).join(", ");
+    const SELECT = `SELECT ${artCols}, COALESCE(p.space_id,'') AS space_id
+                      FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id`;
+
     this.stmts = {
-      getAll: db.prepare("SELECT * FROM artifacts WHERE removed_at IS NULL ORDER BY space_id, created_at"),
-      getById: db.prepare("SELECT * FROM artifacts WHERE id = ?"),
-      getBySpaceId: db.prepare("SELECT * FROM artifacts WHERE space_id = ? AND removed_at IS NULL ORDER BY created_at"),
-      getByPath: db.prepare("SELECT * FROM artifacts WHERE json_extract(storage_config, '$.path') = ? AND removed_at IS NULL"),
-      getDistinctSpaces: db.prepare("SELECT space_id, COUNT(*) as count FROM artifacts WHERE removed_at IS NULL GROUP BY space_id ORDER BY space_id"),
-      getBySpaceAndSourceRef: db.prepare(
-        "SELECT * FROM artifacts WHERE space_id = ? AND source_ref = ?"
+      getAll: db.prepare(`${SELECT} WHERE a.removed_at IS NULL ORDER BY p.space_id, a.created_at`),
+      getById: db.prepare(`${SELECT} WHERE a.id = ?`),
+      getBySpaceId: db.prepare(`${SELECT} WHERE p.space_id = ? AND a.removed_at IS NULL ORDER BY a.created_at`),
+      getByPath: db.prepare(`${SELECT} WHERE json_extract(a.storage_config, '$.path') = ? AND a.removed_at IS NULL`),
+      getDistinctSpaces: db.prepare(
+        "SELECT p.space_id AS space_id, COUNT(*) as count FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id ORDER BY p.space_id"
       ),
-      insert: db.prepare(`
-        INSERT INTO artifacts (
-          id, owner_id, space_id, label, artifact_kind,
-          storage_kind, storage_config, runtime_kind, runtime_config,
-          group_name, source_origin, source_ref, project_id
-        ) VALUES (
-          @id, @owner_id, @space_id, @label, @artifact_kind,
-          @storage_kind, @storage_config, @runtime_kind, @runtime_config,
-          @group_name, COALESCE(@source_origin, 'manual'), @source_ref, @project_id
-        )
-      `),
+      getByProjectAndSourceRef: db.prepare(
+        `${SELECT} WHERE a.project_id = ? AND a.source_ref = ?`
+      ),
+      getAllArchived: db.prepare(
+        `${SELECT} WHERE a.removed_at IS NOT NULL ORDER BY a.removed_at DESC`
+      ),
+      insert: db.prepare(
+        hasSpaceCol
+          ? `INSERT INTO artifacts (id, owner_id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
+             VALUES (@id, @owner_id, '', @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`
+          : `INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
+             VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`,
+      ),
       delete: db.prepare("DELETE FROM artifacts WHERE id = ?"),
     };
   }
@@ -113,12 +123,12 @@ export class SqliteArtifactStore implements ArtifactStore {
     return this.stmts.getDistinctSpaces.all() as { space_id: string; count: number }[];
   }
 
-  getBySpaceAndSourceRef(spaceId: string, sourceRef: string): ArtifactRow | undefined {
-    return this.stmts.getBySpaceAndSourceRef.get(spaceId, sourceRef) as ArtifactRow | undefined;
+  getByProjectAndSourceRef(projectId: string, sourceRef: string): ArtifactRow | undefined {
+    return this.stmts.getByProjectAndSourceRef.get(projectId, sourceRef) as ArtifactRow | undefined;
   }
 
   insert(row: InsertRow): void {
-    this.stmts.insert.run({ project_id: null, ...row });
+    this.stmts.insert.run({ project_id: null, source_origin: null, source_ref: null, ...row });
   }
 
   resurface(id: string): void {
@@ -128,7 +138,7 @@ export class SqliteArtifactStore implements ArtifactStore {
   }
 
   private static readonly UPDATABLE_COLUMNS = new Set([
-    "owner_id", "space_id", "label", "artifact_kind",
+    "owner_id", "label", "artifact_kind",
     "storage_kind", "storage_config", "runtime_kind", "runtime_config",
     "group_name", "removed_at", "source_origin", "source_ref", "project_id",
   ]);
@@ -163,9 +173,7 @@ export class SqliteArtifactStore implements ArtifactStore {
 
   // All rows that have been soft-deleted — newest first, for the Archived view.
   getAllArchived(): ArtifactRow[] {
-    return this.db.prepare(
-      "SELECT * FROM artifacts WHERE removed_at IS NOT NULL ORDER BY removed_at DESC"
-    ).all() as ArtifactRow[];
+    return this.stmts.getAllArchived.all() as ArtifactRow[];
   }
 
   // Paths of soft-deleted filesystem-backed artifacts. Used by getAllArtifacts

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -71,10 +71,10 @@ export class SqliteArtifactStore implements ArtifactStore {
   };
 
   constructor(private db: Database.Database) {
-    const hasSpaceCol = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+    const pragmaCols = db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[];
+    const hasSpaceCol = pragmaCols.some((c) => c.name === "space_id");
     // Column list for SELECTs: every artifact column EXCEPT space_id, plus the derived alias.
-    const artCols = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[])
-      .map((c) => c.name).filter((n) => n !== "space_id").map((n) => `a.${n}`).join(", ");
+    const artCols = pragmaCols.filter((c) => c.name !== "space_id").map((c) => `a.${c.name}`).join(", ");
     const SELECT = `SELECT ${artCols}, COALESCE(p.space_id,'') AS space_id
                       FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id`;
 

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -5,7 +5,7 @@ import type Database from "better-sqlite3";
 export interface ArtifactRow {
   id: string;
   owner_id: string | null;
-  /** Derived via LEFT JOIN projects — not stored directly (transitional: column still exists but reads use the join). */
+  /** Derived via LEFT JOIN projects (artifact → project → space) — not stored in the artifacts table. */
   space_id: string;
   label: string;
   artifact_kind: string;

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -43,7 +43,6 @@ export interface ArtifactStore {
   getBySpaceId(spaceId: string): ArtifactRow[];
   getByPath(absPath: string): ArtifactRow | undefined;
   getDistinctSpaces(): { space_id: string; count: number }[];
-  getByProjectAndSourceRef(projectId: string, sourceRef: string): ArtifactRow | undefined;
   insert(row: InsertRow): void;
   update(id: string, fields: Partial<Omit<ArtifactRow, "id" | "created_at">>): void;
   resurface(id: string): void;
@@ -64,7 +63,6 @@ export class SqliteArtifactStore implements ArtifactStore {
     getBySpaceId: Database.Statement;
     getByPath: Database.Statement;
     getDistinctSpaces: Database.Statement;
-    getByProjectAndSourceRef: Database.Statement;
     getAllArchived: Database.Statement;
     insert: Database.Statement;
     delete: Database.Statement;
@@ -85,9 +83,6 @@ export class SqliteArtifactStore implements ArtifactStore {
       getByPath: db.prepare(`${SELECT} WHERE json_extract(a.storage_config, '$.path') = ? AND a.removed_at IS NULL`),
       getDistinctSpaces: db.prepare(
         "SELECT p.space_id AS space_id, COUNT(*) as count FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id ORDER BY p.space_id"
-      ),
-      getByProjectAndSourceRef: db.prepare(
-        `${SELECT} WHERE a.project_id = ? AND a.source_ref = ? AND a.removed_at IS NULL`
       ),
       getAllArchived: db.prepare(
         `${SELECT} WHERE a.removed_at IS NOT NULL ORDER BY a.removed_at DESC`
@@ -121,10 +116,6 @@ export class SqliteArtifactStore implements ArtifactStore {
 
   getDistinctSpaces(): { space_id: string; count: number }[] {
     return this.stmts.getDistinctSpaces.all() as { space_id: string; count: number }[];
-  }
-
-  getByProjectAndSourceRef(projectId: string, sourceRef: string): ArtifactRow | undefined {
-    return this.stmts.getByProjectAndSourceRef.get(projectId, sourceRef) as ArtifactRow | undefined;
   }
 
   insert(row: InsertRow): void {

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -87,7 +87,7 @@ export class SqliteArtifactStore implements ArtifactStore {
         "SELECT p.space_id AS space_id, COUNT(*) as count FROM artifacts a JOIN projects p ON p.id = a.project_id WHERE a.removed_at IS NULL GROUP BY p.space_id ORDER BY p.space_id"
       ),
       getByProjectAndSourceRef: db.prepare(
-        `${SELECT} WHERE a.project_id = ? AND a.source_ref = ?`
+        `${SELECT} WHERE a.project_id = ? AND a.source_ref = ? AND a.removed_at IS NULL`
       ),
       getAllArchived: db.prepare(
         `${SELECT} WHERE a.removed_at IS NOT NULL ORDER BY a.removed_at DESC`

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -9,7 +9,6 @@ export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS artifacts (
   id             TEXT PRIMARY KEY,
   owner_id       TEXT,
-  space_id       TEXT NOT NULL,
   label          TEXT NOT NULL,
   artifact_kind  TEXT NOT NULL,
   storage_kind   TEXT NOT NULL,
@@ -525,8 +524,8 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
   // space_id NULL — those then render as orphans in the home view even
   // though they belong to a real project. Idempotent: only touches rows
   // whose project is live AND whose space_id disagrees.
-  // artifacts.space_id is no longer stored (dropped above) — space is now
-  // derived at read-time via project JOIN, so no repair is needed there.
+  // artifacts.space_id is derived from the project and is dropped later in
+  // this function; this sessions repair never touched it.
   // ─────────────────────────────────────────────────────────────────────────
   db.exec(`
     UPDATE sessions

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { resolveArtifactPathViaProjects, findProjectAtAncestor } from "./resolve-artifact-path.js";
-import { backfillArtifactProjects } from "./artifact-space-migration.js";
+import { backfillArtifactProjects, dropArtifactSpaceColumn } from "./artifact-space-migration.js";
 
 export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -111,14 +111,6 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
     `);
   } catch { /* column already dropped */ }
   try { db.exec(`ALTER TABLE spaces DROP COLUMN repo_path`); } catch { /* already dropped, fresh install, or SQLite < 3.35 */ }
-
-  try {
-    db.exec(`
-      CREATE UNIQUE INDEX IF NOT EXISTS artifacts_space_source_ref_uq
-        ON artifacts(space_id, source_ref)
-        WHERE source_ref IS NOT NULL
-    `);
-  } catch { /* already exists */ }
 
   // R5 publish & share (#314). Turn an artifact into a shareable URL.
   // share_token gets a UNIQUE index in a separate statement — SQLite
@@ -527,12 +519,14 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
   db.exec("DROP TABLE IF EXISTS sources");
 
   // ─────────────────────────────────────────────────────────────────────────
-  // Repair: heal sessions / artefacts whose space_id is out of sync with
-  // their project's space. Source of the drift: an earlier ad-hoc dedup
-  // SQL with a UPDATE-FROM order bug left some rows with a valid
-  // project_id but space_id NULL — those then render as orphans in the
-  // home view even though they belong to a real project. Idempotent: only
-  // touches rows whose project is live AND whose space_id disagrees.
+  // Repair: heal sessions whose space_id is out of sync with their project's
+  // space. Source of the drift: an earlier ad-hoc dedup SQL with a
+  // UPDATE-FROM order bug left some rows with a valid project_id but
+  // space_id NULL — those then render as orphans in the home view even
+  // though they belong to a real project. Idempotent: only touches rows
+  // whose project is live AND whose space_id disagrees.
+  // artifacts.space_id is no longer stored (dropped above) — space is now
+  // derived at read-time via project JOIN, so no repair is needed there.
   // ─────────────────────────────────────────────────────────────────────────
   db.exec(`
     UPDATE sessions
@@ -546,20 +540,6 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
           WHERE p.id = sessions.project_id
             AND p.removed_at IS NULL
             AND (sessions.space_id IS NULL OR sessions.space_id != p.space_id)
-       );
-  `);
-  db.exec(`
-    UPDATE artifacts
-       SET space_id = (
-         SELECT p.space_id FROM projects p
-          WHERE p.id = artifacts.project_id AND p.removed_at IS NULL
-       )
-     WHERE project_id IS NOT NULL
-       AND EXISTS (
-         SELECT 1 FROM projects p
-          WHERE p.id = artifacts.project_id
-            AND p.removed_at IS NULL
-            AND (artifacts.space_id IS NULL OR artifacts.space_id != p.space_id)
        );
   `);
 
@@ -836,17 +816,23 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
   // repairFtsIfUnhealthy() below, invoked after the server is listening.
 
   // One-time seed: populate spaces from artifact space_ids only if the table is empty.
-  // Using INSERT OR IGNORE on an existing table would resurrect deleted spaces on restart.
-  const spaceCount = (db.prepare("SELECT COUNT(*) as n FROM spaces").get() as { n: number }).n;
-  if (spaceCount === 0) {
-    db.exec(`
-      INSERT OR IGNORE INTO spaces (id, display_name, created_at, updated_at)
-      SELECT DISTINCT space_id, space_id, datetime('now'), datetime('now')
-      FROM artifacts
-      WHERE space_id IS NOT NULL AND space_id != ''
-        AND removed_at IS NULL
-    `);
+  // Only runs while space_id still exists (the column is dropped below). On a
+  // fresh install the artifacts table is empty anyway; on an existing install
+  // spaces already exist so the block is skipped before the column is dropped.
+  {
+    const hasSpaceColForSeed = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+    const spaceCount = (db.prepare("SELECT COUNT(*) as n FROM spaces").get() as { n: number }).n;
+    if (hasSpaceColForSeed && spaceCount === 0) {
+      db.exec(`
+        INSERT OR IGNORE INTO spaces (id, display_name, created_at, updated_at)
+        SELECT DISTINCT space_id, space_id, datetime('now'), datetime('now')
+        FROM artifacts
+        WHERE space_id IS NOT NULL AND space_id != ''
+          AND removed_at IS NULL
+      `);
+    }
   }
+  dropArtifactSpaceColumn(db);
 
   // Allow orphan projects (project rows without a space). Pre-1.0 schema
   // change — `projects.space_id NOT NULL` is dropped to support

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -37,9 +37,9 @@ CREATE TABLE IF NOT EXISTS spaces (
 );
 `;
 
-export function initDb(userlandDir: string): Database.Database {
+export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Database {
   const initT0 = performance.now();
-  const dbPath = join(userlandDir, "oyster.db");
+  const dbPath = join(dbDir, "oyster.db");
   const db = new Database(dbPath);
   db.pragma("journal_mode = WAL");
   // FK enforcement is required for projects.space_id ON DELETE CASCADE to fire.
@@ -503,7 +503,7 @@ export function initDb(userlandDir: string): Database.Database {
   db.exec("CREATE INDEX IF NOT EXISTS artifacts_project_id ON artifacts(project_id) WHERE project_id IS NOT NULL");
 
   {
-    const r = backfillArtifactProjects(db, userlandDir);
+    const r = backfillArtifactProjects(db, oysterHome);
     if (r.backfilled > 0 || r.mismatches.length > 0) {
       console.log(`[artifact-space] backfilled ${r.backfilled} project_id (of ${r.total}; ${r.hadSpace} had space; ${r.stillOrphan} orphan)`);
       for (const m of r.mismatches) console.log(`[artifact-space] mismatch ${m.id} (${m.path}): space ${m.oldSpace} → ${m.newSpace} (project wins)`);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { performance } from "node:perf_hooks";
 import { resolveArtifactPathViaProjects, findProjectAtAncestor } from "./resolve-artifact-path.js";
+import { backfillArtifactProjects } from "./artifact-space-migration.js";
 
 export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS artifacts (
@@ -500,6 +501,14 @@ export function initDb(userlandDir: string): Database.Database {
   try { db.exec("ALTER TABLE artifacts ADD COLUMN project_id TEXT REFERENCES projects(id) ON DELETE SET NULL"); }
   catch { /* already exists */ }
   db.exec("CREATE INDEX IF NOT EXISTS artifacts_project_id ON artifacts(project_id) WHERE project_id IS NOT NULL");
+
+  {
+    const r = backfillArtifactProjects(db, userlandDir);
+    if (r.backfilled > 0 || r.mismatches.length > 0) {
+      console.log(`[artifact-space] backfilled ${r.backfilled} project_id (of ${r.total}; ${r.hadSpace} had space; ${r.stillOrphan} orphan)`);
+      for (const m of r.mismatches) console.log(`[artifact-space] mismatch ${m.id} (${m.path}): space ${m.oldSpace} → ${m.newSpace} (project wins)`);
+    }
+  }
 
   // Sources → projects backfill was a one-shot for pre-rewrite installs;
   // it has already run on the only DB it ever needed to migrate. Fresh

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -493,6 +493,34 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
   catch { /* already exists */ }
   db.exec("CREATE INDEX IF NOT EXISTS artifacts_project_id ON artifacts(project_id) WHERE project_id IS NOT NULL");
 
+  // Seed spaces from artifacts.space_id BEFORE backfillArtifactProjects runs.
+  // On a legacy DB whose `spaces` table is empty (spaces only implied by
+  // artifacts.space_id), ensureNativeProject's FK INSERT would fail because
+  // the referenced space row doesn't exist yet. The seed reads
+  // artifacts.space_id, which is still present at this point (dropped below
+  // by dropArtifactSpaceColumn). Guards: only while the column exists and the
+  // table is empty (an existing install already has space rows).
+  // Also ensure 'home' exists: ensureNativeProject may INSERT projects
+  // referencing 'home' when artifacts live under <oysterHome>/spaces/home/;
+  // 'home' may not appear in any artifact.space_id on the legacy DB.
+  {
+    const hasSpaceColForSeed = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
+    const spaceCount = (db.prepare("SELECT COUNT(*) as n FROM spaces").get() as { n: number }).n;
+    if (hasSpaceColForSeed && spaceCount === 0) {
+      db.exec(`
+        INSERT OR IGNORE INTO spaces (id, display_name, created_at, updated_at)
+        SELECT DISTINCT space_id, space_id, datetime('now'), datetime('now')
+        FROM artifacts
+        WHERE space_id IS NOT NULL AND space_id != ''
+          AND removed_at IS NULL
+      `);
+      // 'home' may not appear in any artifact.space_id (all artifacts could
+      // belong to other spaces), but backfill can still call ensureNativeProject
+      // for a native artifact under <oysterHome>/spaces/home/. Ensure the row.
+      db.exec(`INSERT OR IGNORE INTO spaces (id, display_name, created_at, updated_at) VALUES ('home', 'Home', datetime('now'), datetime('now'))`);
+    }
+  }
+
   {
     const r = backfillArtifactProjects(db, oysterHome);
     if (r.backfilled > 0 || r.mismatches.length > 0) {
@@ -814,23 +842,6 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
   // size of the search index. Repair now happens out-of-band — see
   // repairFtsIfUnhealthy() below, invoked after the server is listening.
 
-  // One-time seed: populate spaces from artifact space_ids only if the table is empty.
-  // Only runs while space_id still exists (the column is dropped below). On a
-  // fresh install the artifacts table is empty anyway; on an existing install
-  // spaces already exist so the block is skipped before the column is dropped.
-  {
-    const hasSpaceColForSeed = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).some((c) => c.name === "space_id");
-    const spaceCount = (db.prepare("SELECT COUNT(*) as n FROM spaces").get() as { n: number }).n;
-    if (hasSpaceColForSeed && spaceCount === 0) {
-      db.exec(`
-        INSERT OR IGNORE INTO spaces (id, display_name, created_at, updated_at)
-        SELECT DISTINCT space_id, space_id, datetime('now'), datetime('now')
-        FROM artifacts
-        WHERE space_id IS NOT NULL AND space_id != ''
-          AND removed_at IS NULL
-      `);
-    }
-  }
   dropArtifactSpaceColumn(db);
 
   // Allow orphan projects (project rows without a space). Pre-1.0 schema

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -272,7 +272,7 @@ delete cleanEnv["OPENAI_API_KEY"];
 
 // ── Artifact store ──
 
-const db = bootTime("initDb (migrations)", () => initDb(DB_DIR));
+const db = bootTime("initDb (migrations)", () => initDb(DB_DIR, OYSTER_HOME));
 const store = new SqliteArtifactStore(db);
 const spaceStore = new SqliteSpaceStore(db);
 const sessionStore = new SqliteSessionStore(db);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -561,7 +561,7 @@ const sessionSnapshotHandle = setInterval(() => {
 }, SESSION_SNAPSHOT_INTERVAL_MS);
 sessionSnapshotHandle.unref();
 
-const spaceService = new SpaceService(spaceStore, store, artifactService, sessionStore, spaceSync);
+const spaceService = new SpaceService(spaceStore, store, artifactService, db, spaceSync);
 const projectService = new ProjectService(db);
 const sessionService = new SessionService(db, sessionStore);
 const claudePtyManager = new ClaudePtyManager({ sessionStore, db, broadcastUiEvent });

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -579,10 +579,9 @@ export function createMcpServer(deps: McpDeps): McpServer {
 
   tool(
     "register_artifact",
-    "Register a file that already exists on disk as a desktop artifact. Use this only when the file already exists. To create new content and register it in one step, use create_artifact instead. Any absolute path the server can read is accepted; prefer files the user controls (inside a registered space folder or a repo the user has attached). Kind and ID are inferred from the filename if not provided.",
+    "Register a file that already exists on disk as a desktop artifact. Use this only when the file already exists. To create new content and register it in one step, use create_artifact instead. Any absolute path the server can read is accepted; prefer files the user controls (inside a registered space folder or a repo the user has attached). The space is derived automatically from the file's path via its project. Kind and ID are inferred from the filename if not provided.",
     {
       path: z.string().describe("Absolute path to the file"),
-      space_id: z.string().describe("Space to place the artifact in (use `list_spaces` to see what's available)"),
       label: z.string().describe("Display name on the desktop"),
       id: z.string().optional().describe("Kebab-case ID (inferred from filename if omitted)"),
       artifact_kind: z
@@ -591,10 +590,10 @@ export function createMcpServer(deps: McpDeps): McpServer {
         .describe("Artifact kind (inferred from file extension if omitted)"),
       group_name: z.string().optional().describe("Group name for visual grouping on the surface"),
     },
-    async ({ path, space_id, label, id, artifact_kind, group_name }) => {
-      debug("mcp", "register_artifact invoked", { path, label, id: id ?? null, space_id, kind: artifact_kind ?? null });
+    async ({ path, label, id, artifact_kind, group_name }) => {
+      debug("mcp", "register_artifact invoked", { path, label, id: id ?? null, kind: artifact_kind ?? null });
       return deps.service.registerArtifact(
-        { path, space_id, label, id, artifact_kind, group_name },
+        { path, label, id, artifact_kind, group_name },
         [], // MCP callers are trusted — no path restriction
       );
     },
@@ -651,18 +650,16 @@ export function createMcpServer(deps: McpDeps): McpServer {
 
   tool(
     "update_artifact",
-    "Update display metadata: label, space assignment, group name, or artifact kind. Does not rename or move the file on disk.",
+    "Update display metadata: label, group name, or artifact kind. Space follows the artifact's project (derived from file path) and cannot be reassigned here. Does not rename or move the file on disk.",
     {
       id: z.string().describe("Artifact ID to update"),
       label: z.string().optional().describe("New display name"),
-      space_id: z.string().optional().describe("Reassign to a different space (tab). Does not move the file."),
       group_name: z.string().optional().describe("Change visual group. Pass empty string to remove grouping."),
       artifact_kind: z.enum(["app", "deck", "map", "notes", "diagram", "wireframe", "table"]).optional().describe("Correct the artifact kind if it was inferred incorrectly."),
     },
-    async ({ id, label, space_id, group_name, artifact_kind }) => {
+    async ({ id, label, group_name, artifact_kind }) => {
       const updated = await deps.service.updateArtifact(id, {
         label,
-        space_id,
         artifact_kind,
         ...(group_name !== undefined ? { group_name: group_name || null } : {}),
       });

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -321,7 +321,7 @@ See the "Set up Oyster for me" playbook above for the full audit + propose + app
 - Use \`create_artifact\` to write a new file and register it in one step.
 - After \`create_artifact\`, always call \`reveal_artifact\` with the new artifact's id — this switches the user's desktop to the right space and highlights the icon so they know where it landed.
 - Use \`read_artifact\` to read the content of an existing static file artifact.
-- Use \`update_artifact\` to rename, reassign to a different space, or change the group.
+- Use \`update_artifact\` to rename, change the kind, or change the group. Space is derived from the artifact's project and cannot be reassigned here.
 - Use \`remove_artifact\` to archive an artifact (hide from surface, reversible). The file and record are preserved and accessible via the archived view.
 
 **Archived / removed artifacts:**

--- a/server/src/native-project.ts
+++ b/server/src/native-project.ts
@@ -19,6 +19,11 @@ export function nativeSpaceDir(userlandDir: string, spaceId: string): string {
  *  already registered for the folder. */
 export function ensureNativeProject(db: Database.Database, userlandDir: string, spaceId: string): string {
   const nativePath = nativeSpaceDir(userlandDir, spaceId);
+  // mkdirSync is called before the DB INSERTs. When invoked from inside a
+  // db.transaction(), the filesystem mkdir isn't rolled back if the txn
+  // aborts — but that's acceptable: the dir will just be empty, and the
+  // next call to ensureNativeProject is idempotent (recursive: true +
+  // path-keyed SELECT-before-INSERT).
   mkdirSync(nativePath, { recursive: true });
   const existing = db
     .prepare("SELECT project_id FROM project_paths WHERE path = ?")

--- a/server/src/native-project.ts
+++ b/server/src/native-project.ts
@@ -1,0 +1,32 @@
+import type Database from "better-sqlite3";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+/** The native workspace folder for a space (`<userland>/spaces/<id>`) is the
+ *  path where `create_artifact` writes content (via getNativeSourcePath).
+ *  Compute it the same way the rest of the server does — via `path.join`, so
+ *  the separator is platform-correct. */
+export function nativeSpaceDir(userlandDir: string, spaceId: string): string {
+  return join(userlandDir, "spaces", spaceId);
+}
+
+/** The native workspace folder for a space is itself a project, filed under
+ *  that space. This keeps the model uniform: every artefact — repo file or
+ *  agent-created content — is project-parented, and its space derives via
+ *  that project. Ensures the folder exists on disk (create_artifact writes
+ *  into it). Idempotent: returns the existing native project id if one is
+ *  already registered for the folder. */
+export function ensureNativeProject(db: Database.Database, userlandDir: string, spaceId: string): string {
+  const nativePath = nativeSpaceDir(userlandDir, spaceId);
+  mkdirSync(nativePath, { recursive: true });
+  const existing = db
+    .prepare("SELECT project_id FROM project_paths WHERE path = ?")
+    .get(nativePath) as { project_id: string } | undefined;
+  if (existing) return existing.project_id;
+
+  const id = randomUUID();
+  db.prepare("INSERT INTO projects (id, space_id, name) VALUES (?, ?, ?)").run(id, spaceId, spaceId);
+  db.prepare("INSERT INTO project_paths (project_id, path) VALUES (?, ?)").run(id, nativePath);
+  return id;
+}

--- a/server/src/project-service.ts
+++ b/server/src/project-service.ts
@@ -261,7 +261,7 @@ export class ProjectService {
         .prepare("UPDATE projects SET removed_at = NULL, space_id = ? WHERE id = ?")
         .run(spaceId, projectId);
       this.db.prepare("UPDATE sessions SET space_id = ? WHERE project_id = ?").run(spaceId, projectId);
-      this.db.prepare("UPDATE artifacts SET space_id = ? WHERE project_id = ?").run(spaceId, projectId);
+      // artifacts.space_id has been dropped; space is derived at read-time via project JOIN.
     })();
   }
 
@@ -344,8 +344,8 @@ export class ProjectService {
         .prepare("UPDATE sessions SET project_id = ?, space_id = ? WHERE project_id = ?")
         .run(into.id, into.space_id, args.fromId);
       const artefacts = this.db
-        .prepare("UPDATE artifacts SET project_id = ?, space_id = ? WHERE project_id = ?")
-        .run(into.id, into.space_id, args.fromId);
+        .prepare("UPDATE artifacts SET project_id = ? WHERE project_id = ?")
+        .run(into.id, args.fromId);
       // De-dup PK conflicts (same path cached against both projects) by
       // dropping the loser's row before the bulk update.
       this.db

--- a/server/src/publish-service.ts
+++ b/server/src/publish-service.ts
@@ -140,7 +140,9 @@ export function createPublishService(deps: PublishServiceDeps): PublishService {
       if (!user || !token) throw new PublishError(401, "sign_in_required", "Sign in to publish artefacts.");
 
       const row = deps.db.prepare(
-        "SELECT id, artifact_kind, owner_id, share_token, unpublished_at, label, space_id FROM artifacts WHERE id = ?"
+        `SELECT a.id, a.artifact_kind, a.owner_id, a.share_token, a.unpublished_at, a.label, COALESCE(p.space_id,'') AS space_id
+           FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id
+          WHERE a.id = ?`
       ).get(args.artifact_id) as ArtifactRow | undefined;
       if (!row) throw new PublishError(404, "artifact_not_found", `No artefact with id ${args.artifact_id}`);
 
@@ -441,7 +443,9 @@ export function createPublishService(deps: PublishServiceDeps): PublishService {
       // inputs); using changes alone would mis-classify such rows as ghosts.
       // The local-context SELECT below also doubles as the existence check.
       const localContextStmt = deps.db.prepare(
-        "SELECT label, space_id FROM artifacts WHERE id = ?"
+        `SELECT a.label, COALESCE(p.space_id,'') AS space_id
+           FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id
+          WHERE a.id = ?`
       );
 
       let mirrored = 0;

--- a/server/src/publish-service.ts
+++ b/server/src/publish-service.ts
@@ -124,6 +124,9 @@ interface ArtifactRow {
   share_token: string | null;
   unpublished_at: number | null;
   label: string;
+  // Derived (artifact → project → space) by the joined SELECTs in
+  // publishArtifact / backfillPublications. NOT selected by unpublishArtifact,
+  // which never reads it.
   space_id: string;
 }
 

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -146,6 +146,15 @@ export class SpaceService {
     for (const pid of projectIds) {
       this.db.prepare("UPDATE projects SET space_id = ? WHERE id = ?").run(targetSpaceId, pid);
     }
+    // sessions.space_id is a stored column (not derived), so reassigning projects
+    // above doesn't automatically move sessions. Sync sessions belonging to those
+    // projects to targetSpaceId.
+    if (projectIds.size > 0) {
+      const placeholders = Array.from(projectIds).map(() => "?").join(", ");
+      this.db
+        .prepare(`UPDATE sessions SET space_id = ? WHERE project_id IN (${placeholders})`)
+        .run(targetSpaceId, ...Array.from(projectIds));
+    }
     // Clear group_name so the artifacts no longer appear as a folder in the source space.
     for (const a of artifacts) {
       this.artifactStore.update(a.id, { group_name: null });
@@ -164,6 +173,9 @@ export class SpaceService {
     // sessions derive the correct space via the project JOIN (artifact.space_id
     // is derived, not stored — writing it would be a silent no-op).
     this.db.prepare("UPDATE projects SET space_id = 'home' WHERE space_id = ?").run(id);
+    // sessions.space_id is a stored column (not derived), so reassigning projects
+    // above doesn't automatically move sessions. Sync them to 'home' here.
+    this.db.prepare("UPDATE sessions SET space_id = 'home' WHERE space_id = ?").run(id);
     // Apply the folder label so the moved artifacts appear grouped in "home"
     // under the deleted space's display name.
     for (const a of artifactsToLabel) {

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -2,10 +2,10 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve, relative, sep } from "node:path";
 import type { Ignore } from "ignore";
 import ignore from "ignore";
+import type Database from "better-sqlite3";
 import type { SpaceStore, SpaceRow } from "./space-store.js";
 import type { ArtifactStore } from "./artifact-store.js";
 import type { ArtifactService } from "./artifact-service.js";
-import type { SessionStore } from "./session-store.js";
 import type { SpaceSyncService } from "./space-sync-service.js";
 import type { Space } from "../../shared/types.js";
 import { slugify, toScanStatus } from "./utils.js";
@@ -72,10 +72,10 @@ export class SpaceService {
     private spaceStore: SpaceStore,
     private artifactStore: ArtifactStore,
     _artifactService: ArtifactService,
-    _sessionStore: SessionStore,
+    private db: Database.Database,
     private spaceSync?: SpaceSyncService,
   ) {
-    void _artifactService; void _sessionStore;
+    void _artifactService;
   }
 
   createSpace(params: { name: string }): Space {
@@ -140,8 +140,15 @@ export class SpaceService {
   convertFolderToSpace(sourceSpaceId: string, folderName: string, targetSpaceId: string): void {
     const artifacts = this.artifactStore.getBySpaceId(sourceSpaceId)
       .filter(a => a.group_name === folderName);
+    // Move the owning projects to the target space so artifacts derive the new
+    // space via the project JOIN (artifact.space_id is derived, not stored).
+    const projectIds = new Set(artifacts.map(a => a.project_id).filter((p): p is string => p !== null));
+    for (const pid of projectIds) {
+      this.db.prepare("UPDATE projects SET space_id = ? WHERE id = ?").run(targetSpaceId, pid);
+    }
+    // Clear group_name so the artifacts no longer appear as a folder in the source space.
     for (const a of artifacts) {
-      this.artifactStore.update(a.id, { space_id: targetSpaceId, group_name: null });
+      this.artifactStore.update(a.id, { group_name: null });
     }
   }
 
@@ -150,10 +157,17 @@ export class SpaceService {
     const row = this.spaceStore.getById(id);
     if (!row) throw new Error(`Space "${id}" not found`);
     const folderName = folderNameOverride ?? row?.display_name ?? id;
-    const artifacts = this.artifactStore.getBySpaceId(id);
-    // Move orphaned artifacts to home in a folder named after the deleted space
-    for (const a of artifacts) {
-      this.artifactStore.update(a.id, { space_id: "home", group_name: folderName });
+    // Collect artifacts that were in the deleted space BEFORE reassigning projects,
+    // so we can apply the folder label to them afterward.
+    const artifactsToLabel = this.artifactStore.getBySpaceId(id);
+    // Reassign the deleted space's projects to "home" so their artifacts and
+    // sessions derive the correct space via the project JOIN (artifact.space_id
+    // is derived, not stored — writing it would be a silent no-op).
+    this.db.prepare("UPDATE projects SET space_id = 'home' WHERE space_id = ?").run(id);
+    // Apply the folder label so the moved artifacts appear grouped in "home"
+    // under the deleted space's display name.
+    for (const a of artifactsToLabel) {
+      this.artifactStore.update(a.id, { group_name: folderName });
     }
     // Soft-delete locally; cloud propagates the tombstone via pushDelete.
     // (pushDelete is fire-and-forget; the pending-delete sweep in the next

--- a/server/src/space-service.ts
+++ b/server/src/space-service.ts
@@ -140,25 +140,31 @@ export class SpaceService {
   convertFolderToSpace(sourceSpaceId: string, folderName: string, targetSpaceId: string): void {
     const artifacts = this.artifactStore.getBySpaceId(sourceSpaceId)
       .filter(a => a.group_name === folderName);
-    // Move the owning projects to the target space so artifacts derive the new
-    // space via the project JOIN (artifact.space_id is derived, not stored).
-    const projectIds = new Set(artifacts.map(a => a.project_id).filter((p): p is string => p !== null));
-    for (const pid of projectIds) {
-      this.db.prepare("UPDATE projects SET space_id = ? WHERE id = ?").run(targetSpaceId, pid);
-    }
-    // sessions.space_id is a stored column (not derived), so reassigning projects
-    // above doesn't automatically move sessions. Sync sessions belonging to those
-    // projects to targetSpaceId.
-    if (projectIds.size > 0) {
-      const placeholders = Array.from(projectIds).map(() => "?").join(", ");
-      this.db
-        .prepare(`UPDATE sessions SET space_id = ? WHERE project_id IN (${placeholders})`)
-        .run(targetSpaceId, ...Array.from(projectIds));
-    }
-    // Clear group_name so the artifacts no longer appear as a folder in the source space.
-    for (const a of artifacts) {
-      this.artifactStore.update(a.id, { group_name: null });
-    }
+    const projectIds = Array.from(
+      new Set(artifacts.map(a => a.project_id).filter((p): p is string => p !== null)),
+    );
+    // Atomic: the project move, session sync, and label clear must all land or
+    // none — a mid-way throw must not leave projects moved but artifacts/sessions
+    // stale (user-visible split state).
+    this.db.transaction(() => {
+      // Move the owning projects to the target space so artifacts derive the new
+      // space via the project JOIN (artifact.space_id is derived, not stored).
+      for (const pid of projectIds) {
+        this.db.prepare("UPDATE projects SET space_id = ? WHERE id = ?").run(targetSpaceId, pid);
+      }
+      // sessions.space_id is a stored column (not derived), so reassigning projects
+      // doesn't move sessions. Sync sessions belonging to those projects.
+      if (projectIds.length > 0) {
+        const placeholders = projectIds.map(() => "?").join(", ");
+        this.db
+          .prepare(`UPDATE sessions SET space_id = ? WHERE project_id IN (${placeholders})`)
+          .run(targetSpaceId, ...projectIds);
+      }
+      // Clear group_name so the artifacts no longer appear as a folder in the source space.
+      for (const a of artifacts) {
+        this.artifactStore.update(a.id, { group_name: null });
+      }
+    })();
   }
 
   deleteSpace(id: string, folderNameOverride?: string): void {
@@ -166,25 +172,39 @@ export class SpaceService {
     const row = this.spaceStore.getById(id);
     if (!row) throw new Error(`Space "${id}" not found`);
     const folderName = folderNameOverride ?? row?.display_name ?? id;
-    // Collect artifacts that were in the deleted space BEFORE reassigning projects,
-    // so we can apply the folder label to them afterward.
-    const artifactsToLabel = this.artifactStore.getBySpaceId(id);
-    // Reassign the deleted space's projects to "home" so their artifacts and
-    // sessions derive the correct space via the project JOIN (artifact.space_id
-    // is derived, not stored — writing it would be a silent no-op).
-    this.db.prepare("UPDATE projects SET space_id = 'home' WHERE space_id = ?").run(id);
-    // sessions.space_id is a stored column (not derived), so reassigning projects
-    // above doesn't automatically move sessions. Sync them to 'home' here.
-    this.db.prepare("UPDATE sessions SET space_id = 'home' WHERE space_id = ?").run(id);
-    // Apply the folder label so the moved artifacts appear grouped in "home"
-    // under the deleted space's display name.
-    for (const a of artifactsToLabel) {
-      this.artifactStore.update(a.id, { group_name: folderName });
-    }
-    // Soft-delete locally; cloud propagates the tombstone via pushDelete.
-    // (pushDelete is fire-and-forget; the pending-delete sweep in the next
-    // reconcile() retries on failure.)
-    this.spaceStore.softDelete(id);
+    // Atomic: sessions sync, project move, artifact relabel, and tombstone must
+    // all land or none. (pushDelete is a network call and stays OUTSIDE the txn.)
+    this.db.transaction(() => {
+      // Collect artifacts in the deleted space BEFORE reassigning projects, so we
+      // can relabel them afterward.
+      const artifactsToLabel = this.artifactStore.getBySpaceId(id);
+      // Capture the deleted space's projects BEFORE moving them, so we can sync
+      // sessions by project membership (covers a session whose stored space_id has
+      // drifted/NULL but whose project is in this space).
+      const projectIds = (this.db.prepare("SELECT id FROM projects WHERE space_id = ?").all(id) as { id: string }[])
+        .map(r => r.id);
+      // Move sessions to 'home' by BOTH project membership and the stored space id.
+      if (projectIds.length > 0) {
+        const placeholders = projectIds.map(() => "?").join(", ");
+        this.db
+          .prepare(`UPDATE sessions SET space_id = 'home' WHERE project_id IN (${placeholders}) OR space_id = ?`)
+          .run(...projectIds, id);
+      } else {
+        this.db.prepare("UPDATE sessions SET space_id = 'home' WHERE space_id = ?").run(id);
+      }
+      // Reassign the deleted space's projects to "home" so their artifacts derive
+      // the correct space via the project JOIN (artifact.space_id is derived, not
+      // stored — writing it would be a silent no-op).
+      this.db.prepare("UPDATE projects SET space_id = 'home' WHERE space_id = ?").run(id);
+      // Apply the folder label so the moved artifacts appear grouped in "home"
+      // under the deleted space's display name.
+      for (const a of artifactsToLabel) {
+        this.artifactStore.update(a.id, { group_name: folderName });
+      }
+      // Soft-delete locally; cloud propagates the tombstone via pushDelete.
+      this.spaceStore.softDelete(id);
+    })();
+    // Fire-and-forget; the pending-delete sweep in the next reconcile() retries on failure.
     void this.spaceSync?.pushDelete(id);
   }
 }

--- a/server/test/artifact-service-create-backfill.test.ts
+++ b/server/test/artifact-service-create-backfill.test.ts
@@ -53,7 +53,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
     recordWriteEvent("sess-1", filePath);
 
     const art = await service.registerArtifact(
-      { path: filePath, space_id: "work", label: "report" },
+      { path: filePath, label: "report" },
       [folder],
     );
 
@@ -69,7 +69,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
     recordWriteEvent("sess-1", filePath);
 
     // First call: inserts + backfills → 1 link.
-    const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "x", id: "fixed-id" }, [folder]);
+    const art = await service.registerArtifact({ path: filePath, label: "x", id: "fixed-id" }, [folder]);
     expect((db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number }).c).toBe(1);
 
     // Soft-delete + re-register: hits the resurrect branch (existing
@@ -77,7 +77,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
     // backfill — the original link is still there, so adding another
     // would produce a duplicate touch.
     db.prepare("UPDATE artifacts SET removed_at = datetime('now') WHERE id = ?").run("fixed-id");
-    await service.registerArtifact({ path: filePath, space_id: "work", label: "x", id: "fixed-id" }, [folder]);
+    await service.registerArtifact({ path: filePath, label: "x", id: "fixed-id" }, [folder]);
     expect((db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number }).c).toBe(1);
   });
 
@@ -90,7 +90,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
       JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Write", input: { file_path: filePath } }] } }),
     );
 
-    const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "tool" }, [folder]);
+    const art = await service.registerArtifact({ path: filePath, label: "tool" }, [folder]);
 
     const link = db.prepare("SELECT session_id, role FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { session_id: string; role: string };
     expect(link).toEqual({ session_id: "sess-1", role: "create" });
@@ -110,7 +110,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
       JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Write", input: { file_path: join(folder, "reportXv1.md") } }] } }),
     );
 
-    const art = await service.registerArtifact({ path: wildPath, space_id: "work", label: "wild" }, [folder]);
+    const art = await service.registerArtifact({ path: wildPath, label: "wild" }, [folder]);
 
     // No false match — the event mentions reportXv1.md, not report_v1.md.
     const count = db.prepare("SELECT COUNT(*) AS c FROM session_artifacts WHERE artifact_id = ?").get(art.id) as { c: number };
@@ -123,7 +123,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
     // No recordWriteEvent — no prior writes for this path.
 
     const art = await service.registerArtifact(
-      { path: filePath, space_id: "work", label: "u" },
+      { path: filePath, label: "u" },
       [folder],
     );
 
@@ -145,7 +145,7 @@ describe("ArtifactService.registerArtifact — session→creation link backfill"
       JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: { file_path: filePath } }] } }),
     );
 
-    const art = await service.registerArtifact({ path: filePath, space_id: "work", label: "e" }, [folder]);
+    const art = await service.registerArtifact({ path: filePath, label: "e" }, [folder]);
 
     const links = db.prepare(
       "SELECT session_id, role FROM session_artifacts WHERE artifact_id = ? ORDER BY session_id",

--- a/server/test/artifact-service-project.test.ts
+++ b/server/test/artifact-service-project.test.ts
@@ -1,0 +1,90 @@
+// Tests that ArtifactService.registerArtifact resolves project_id (and
+// hence spaceId) automatically via lookupProject when no project_id is
+// supplied, and falls back to '' for orphan paths.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { ArtifactService } from "../src/artifact-service.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+describe("ArtifactService.registerArtifact — project_id resolution via lookupProject", () => {
+  let userland: string;
+  let projectDir: string;
+  let orphanDir: string;
+  let db: Database.Database;
+  let service: ArtifactService;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-svc-proj-"));
+    projectDir = mkdtempSync(join(tmpdir(), "oyster-projdir-"));
+    orphanDir = mkdtempSync(join(tmpdir(), "oyster-orphan-"));
+    db = initDb(userland);
+
+    // Seed a space and a project with a project_paths entry so lookupProject
+    // step-2 can resolve files under projectDir.
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work', 'Work', '#000', 'none')`);
+    db.exec(`INSERT INTO projects (id, space_id, name) VALUES ('p1', 'work', 'Test Project')`);
+    db.exec(`INSERT INTO project_paths (project_id, path) VALUES ('p1', '${projectDir}')`);
+
+    service = new ArtifactService(
+      db,
+      new SqliteArtifactStore(db),
+      "https://oyster.to",
+      "https://share.oyster.to",
+      userland,
+    );
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(userland, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(orphanDir, { recursive: true, force: true });
+  });
+
+  it("resolves spaceId from project when file is under a project_paths entry (no project_id passed)", async () => {
+    const filePath = join(projectDir, "notes.md");
+    writeFileSync(filePath, "# hello");
+
+    const art = await service.registerArtifact({ path: filePath, label: "Notes" }, []);
+
+    expect(art.spaceId).toBe("work");
+    expect(art.projectId).toBe("p1");
+  });
+
+  it("resolves to spaceId '' when file is under no known project", async () => {
+    const filePath = join(orphanDir, "readme.md");
+    writeFileSync(filePath, "# orphan");
+
+    const art = await service.registerArtifact({ path: filePath, label: "Readme" }, []);
+
+    expect(art.spaceId).toBe("");
+    expect(art.projectId).toBeNull();
+  });
+
+  it("uses the supplied project_id when explicitly provided, ignoring the file path", async () => {
+    // File lives under orphanDir (no project there), but we override with p1.
+    const filePath = join(orphanDir, "override.md");
+    writeFileSync(filePath, "# override");
+
+    const art = await service.registerArtifact({ path: filePath, label: "Override", project_id: "p1" }, []);
+
+    expect(art.spaceId).toBe("work");
+    expect(art.projectId).toBe("p1");
+  });
+
+  it("allows null project_id to be passed explicitly (orphan regardless of path)", async () => {
+    // File is under projectDir (would resolve p1), but project_id: null overrides.
+    const filePath = join(projectDir, "forced-orphan.md");
+    writeFileSync(filePath, "# forced orphan");
+
+    const art = await service.registerArtifact({ path: filePath, label: "Forced orphan", project_id: null }, []);
+
+    expect(art.spaceId).toBe("");
+    expect(art.projectId).toBeNull();
+  });
+});

--- a/server/test/artifact-service-self-heal.test.ts
+++ b/server/test/artifact-service-self-heal.test.ts
@@ -45,8 +45,8 @@ describe("ArtifactService.getAllArtifacts self-heal — resolver path", () => {
 
   function seedFilesystemArtifact(id: string, path: string, project_id: string | null = null) {
     db.prepare(
-      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)
-       VALUES (?, 'work', ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+      `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)
+       VALUES (?, ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
     ).run(id, "doc", JSON.stringify({ path }), project_id);
   }
 

--- a/server/test/artifact-service.test.ts
+++ b/server/test/artifact-service.test.ts
@@ -31,6 +31,11 @@ function makeDb(): Database.Database {
       unpublished_at       INTEGER,
       pinned_at            INTEGER
     );
+    CREATE TABLE projects (
+      id       TEXT PRIMARY KEY,
+      space_id TEXT NOT NULL,
+      name     TEXT NOT NULL
+    );
   `);
   return db;
 }

--- a/server/test/artifact-space-derivation.test.ts
+++ b/server/test/artifact-space-derivation.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+
+describe("artifact store derives space via project", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+  let store: SqliteArtifactStore;
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-asd-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p1','work','repo')").run();
+    store = new SqliteArtifactStore(db);
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("derives space_id from the artifact's project; orphan → empty string", () => {
+    store.insert({ id: "a1", owner_id: null, label: "r", artifact_kind: "notes", storage_kind: "filesystem", storage_config: JSON.stringify({ path: "/repo/r.md" }), runtime_kind: "static_file", runtime_config: "{}", group_name: null, project_id: "p1" });
+    store.insert({ id: "a2", owner_id: null, label: "o", artifact_kind: "notes", storage_kind: "filesystem", storage_config: JSON.stringify({ path: "/x/o.md" }), runtime_kind: "static_file", runtime_config: "{}", group_name: null, project_id: null });
+
+    expect(store.getById("a1")!.space_id).toBe("work");      // derived from project p1
+    expect(store.getById("a2")!.space_id).toBe("");          // orphan → empty
+    expect(store.getBySpaceId("work").map((r) => r.id)).toEqual(["a1"]); // orphan excluded
+    expect(store.getDistinctSpaces()).toEqual([{ space_id: "work", count: 1 }]);
+  });
+});

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -89,6 +89,22 @@ describe("backfillArtifactProjects", () => {
     expect(() => dropArtifactSpaceColumn(db)).not.toThrow(); // idempotent
   });
 
+  it("underscore in project path does not wildcard-match sibling paths (LIKE escape fix)", () => {
+    // Project root: /a/my_proj  — the underscore must NOT act as a LIKE wildcard.
+    // An artifact at /a/myXproj/f.md must NOT resolve to this project.
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-under','work','underscore')").run();
+    db.prepare("INSERT INTO project_paths (project_id, path) VALUES ('p-under','/a/my_proj')").run();
+    seedArtifact(db, "a-nomatch", "work", "/a/myXproj/f.md");  // 'X' replaces '_' in the path
+    seedArtifact(db, "a-match",   "work", "/a/my_proj/f.md");  // genuine child — must match
+
+    backfillArtifactProjects(db, userland);
+
+    // The sibling path must NOT resolve to p-under
+    expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-nomatch'").get()).toEqual({ project_id: null });
+    // The genuine child must resolve correctly
+    expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-match'").get()).toEqual({ project_id: "p-under" });
+  });
+
   it("re-keyed dedup index: same source_ref same project rejected; orphans allowed", () => {
     backfillArtifactProjects(db, userland);
     dropArtifactSpaceColumn(db);

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { backfillArtifactProjects } from "../src/artifact-space-migration.js";
+
+function seedArtifact(db: ReturnType<typeof initDb>, id: string, spaceId: string, path: string, projectId: string | null = null) {
+  db.prepare(
+    `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)
+     VALUES (?, ?, ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+  ).run(id, spaceId, id, JSON.stringify({ path }), projectId);
+}
+
+describe("backfillArtifactProjects", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-asm-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none'),('home','Home','#111','none')`);
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-repo','work','repo')").run();
+    db.prepare("INSERT INTO project_paths (project_id, path) VALUES ('p-repo','/repo')").run();
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("backfills project_id from longest-prefix path, makes native projects, reports counts + mismatches", () => {
+    seedArtifact(db, "a-repo", "work", "/repo/docs/report.md");           // resolves to p-repo (space work — matches)
+    seedArtifact(db, "a-mismatch", "home", "/repo/docs/other.md");         // resolves to p-repo (space work) — mismatch vs 'home'
+    seedArtifact(db, "a-native", "work", join(userland, "spaces", "work", "note.md")); // native folder → native project
+    seedArtifact(db, "a-orphan", "home", "/elsewhere/loose.md");           // no project → stays null
+    // pre-existing project_id whose old space disagrees with the project's space:
+    seedArtifact(db, "a-pre", "home", "/repo/docs/pre.md", "p-repo");      // project p-repo (space work) ≠ old 'home'
+
+    const report = backfillArtifactProjects(db, userland);
+
+    expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-repo'").get()).toEqual({ project_id: "p-repo" });
+    const nativePid = (db.prepare("SELECT project_id FROM artifacts WHERE id='a-native'").get() as { project_id: string }).project_id;
+    expect(nativePid).toBeTruthy();
+    expect(db.prepare("SELECT space_id FROM projects WHERE id=?").get(nativePid)).toEqual({ space_id: "work" });
+    expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-orphan'").get()).toEqual({ project_id: null });
+
+    expect(report.total).toBe(5);
+    expect(report.backfilled).toBe(3);       // repo, mismatch, native (a-orphan unresolved, a-pre already had project)
+    expect(report.stillOrphan).toBe(1);      // a-orphan
+    const mmIds = report.mismatches.map((m) => m.id);
+    expect(mmIds).toContain("a-mismatch");   // newly backfilled, space disagrees
+    expect(mmIds).toContain("a-pre");        // pre-existing project, space disagrees
+  });
+});

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
 import { initDb } from "../src/db.js";
 import { backfillArtifactProjects, dropArtifactSpaceColumn } from "../src/artifact-space-migration.js";
 
@@ -97,5 +98,34 @@ describe("backfillArtifactProjects", () => {
     expect(() => ins("x2", "p-repo", "README.md:notes")).toThrow(); // same project+ref → UNIQUE violation
     expect(() => ins("x3", null, "README.md:notes")).not.toThrow(); // orphan
     expect(() => ins("x4", null, "README.md:notes")).not.toThrow(); // orphan NULLs distinct (intentional)
+  });
+
+  it("reports a stored space_id that disagrees with the resolved project's space (column present)", () => {
+    // Build a minimal schema WITH artifacts.space_id present (mimics a pre-migration DB),
+    // WITHOUT initDb (which would drop the column).
+    const mem = new Database(":memory:");
+    mem.exec(`
+      CREATE TABLE spaces (id TEXT PRIMARY KEY, display_name TEXT, color TEXT, scan_status TEXT);
+      CREATE TABLE projects (id TEXT PRIMARY KEY, space_id TEXT, name TEXT);
+      CREATE TABLE project_paths (project_id TEXT, path TEXT);
+      CREATE TABLE artifacts (
+        id TEXT PRIMARY KEY, space_id TEXT NOT NULL, project_id TEXT,
+        label TEXT, artifact_kind TEXT, storage_kind TEXT,
+        storage_config TEXT, runtime_kind TEXT, runtime_config TEXT,
+        source_ref TEXT, removed_at TEXT
+      );
+    `);
+    mem.exec(`INSERT INTO spaces (id,display_name,color,scan_status) VALUES ('work','Work','#000','none'),('home','Home','#111','none')`);
+    mem.prepare("INSERT INTO projects (id,space_id,name) VALUES ('p-repo','work','repo')").run();
+    mem.prepare("INSERT INTO project_paths (project_id,path) VALUES ('p-repo','/repo')").run();
+    // artifact stored under space 'home' but its path resolves to p-repo (space 'work') → mismatch
+    mem.prepare(`INSERT INTO artifacts (id,space_id,label,artifact_kind,storage_kind,storage_config,runtime_kind,runtime_config)
+                 VALUES ('a-mm','home','x','notes','filesystem',?, 'static_file','{}')`).run(JSON.stringify({ path: "/repo/x.md" }));
+
+    const report = backfillArtifactProjects(mem, "/tmp/whatever-oyster-home");
+    expect(report.backfilled).toBe(1);
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0]).toMatchObject({ id: "a-mm", oldSpace: "home", newSpace: "work" });
+    mem.close();
   });
 });

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -3,13 +3,13 @@ import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { initDb } from "../src/db.js";
-import { backfillArtifactProjects } from "../src/artifact-space-migration.js";
+import { backfillArtifactProjects, dropArtifactSpaceColumn } from "../src/artifact-space-migration.js";
 
-function seedArtifact(db: ReturnType<typeof initDb>, id: string, spaceId: string, path: string, projectId: string | null = null) {
+function seedArtifact(db: ReturnType<typeof initDb>, id: string, _spaceId: string, path: string, projectId: string | null = null) {
   db.prepare(
-    `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)
-     VALUES (?, ?, ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
-  ).run(id, spaceId, id, JSON.stringify({ path }), projectId);
+    `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)
+     VALUES (?, ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+  ).run(id, id, JSON.stringify({ path }), projectId);
 }
 
 describe("backfillArtifactProjects", () => {
@@ -38,8 +38,8 @@ describe("backfillArtifactProjects", () => {
       distinctDb.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
       const nativePath = join(oysterHome, "spaces", "work", "note.md");
       distinctDb.prepare(
-        `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config)
-         VALUES ('a-native-dist', 'work', 'note', 'notes', 'filesystem', ?, 'static_file', '{}')`,
+        `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config)
+         VALUES ('a-native-dist', 'note', 'notes', 'filesystem', ?, 'static_file', '{}')`,
       ).run(JSON.stringify({ path: nativePath }));
 
       const report = backfillArtifactProjects(distinctDb, oysterHome);
@@ -73,8 +73,29 @@ describe("backfillArtifactProjects", () => {
     expect(report.total).toBe(5);
     expect(report.backfilled).toBe(3);       // repo, mismatch, native (a-orphan unresolved, a-pre already had project)
     expect(report.stillOrphan).toBe(1);      // a-orphan
-    const mmIds = report.mismatches.map((m) => m.id);
-    expect(mmIds).toContain("a-mismatch");   // newly backfilled, space disagrees
-    expect(mmIds).toContain("a-pre");        // pre-existing project, space disagrees
+    // space_id column is dropped by initDb before seeds run; mismatch detection
+    // requires the column and is skipped — mismatches is empty.
+    expect(report.mismatches).toHaveLength(0);
+  });
+
+  it("drops space_id and is idempotent", () => {
+    seedArtifact(db, "a-repo", "work", "/repo/r.md");
+    backfillArtifactProjects(db, userland);
+    dropArtifactSpaceColumn(db);
+    const cols = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).map((c) => c.name);
+    expect(cols).not.toContain("space_id");
+    expect(() => dropArtifactSpaceColumn(db)).not.toThrow(); // idempotent
+  });
+
+  it("re-keyed dedup index: same source_ref same project rejected; orphans allowed", () => {
+    backfillArtifactProjects(db, userland);
+    dropArtifactSpaceColumn(db);
+    const ins = (id: string, projectId: string | null, ref: string) => db.prepare(
+      `INSERT INTO artifacts (id,label,artifact_kind,storage_kind,storage_config,runtime_kind,runtime_config,source_ref,project_id)
+       VALUES (?,?, 'notes','filesystem','{}','static_file','{}',?,?)`).run(id, id, ref, projectId);
+    ins("x1", "p-repo", "README.md:notes");
+    expect(() => ins("x2", "p-repo", "README.md:notes")).toThrow(); // same project+ref → UNIQUE violation
+    expect(() => ins("x3", null, "README.md:notes")).not.toThrow(); // orphan
+    expect(() => ins("x4", null, "README.md:notes")).not.toThrow(); // orphan NULLs distinct (intentional)
   });
 });

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { initDb } from "../src/db.js";
 import { backfillArtifactProjects, dropArtifactSpaceColumn } from "../src/artifact-space-migration.js";
+import { ensureNativeProject } from "../src/native-project.js";
 
 // Helper to insert test artifacts; _spaceId is kept for call-site readability (documents pre-migration space) but is intentionally not inserted.
 function seedArtifact(db: ReturnType<typeof initDb>, id: string, _spaceId: string, path: string, projectId: string | null = null) {
@@ -105,6 +106,41 @@ describe("backfillArtifactProjects", () => {
     expect(db.prepare("SELECT project_id FROM artifacts WHERE id='a-match'").get()).toEqual({ project_id: "p-under" });
   });
 
+  it("Windows-style backslash path separator: artifact under project resolves correctly", () => {
+    // Project path uses backslash separators (Windows). A child artifact using
+    // `\` must resolve to the project; a sibling at the same depth must NOT.
+    const mem = new Database(":memory:");
+    mem.exec(`
+      CREATE TABLE spaces (id TEXT PRIMARY KEY, display_name TEXT, color TEXT, scan_status TEXT);
+      CREATE TABLE projects (id TEXT PRIMARY KEY, space_id TEXT, name TEXT);
+      CREATE TABLE project_paths (project_id TEXT, path TEXT);
+      CREATE TABLE artifacts (
+        id TEXT PRIMARY KEY, project_id TEXT,
+        label TEXT, artifact_kind TEXT, storage_kind TEXT,
+        storage_config TEXT, runtime_kind TEXT, runtime_config TEXT,
+        source_ref TEXT, removed_at TEXT
+      );
+    `);
+    mem.exec(`INSERT INTO spaces (id,display_name,color,scan_status) VALUES ('w','W','#000','none')`);
+    mem.prepare("INSERT INTO projects (id,space_id,name) VALUES ('p-win','w','win-proj')").run();
+    // Project path uses single backslash separator (Windows style: C:\proj).
+    // In JS string, `\\` = one backslash character stored in SQLite.
+    mem.prepare("INSERT INTO project_paths (project_id,path) VALUES ('p-win','C:\\proj')").run();
+
+    // Child artifact: C:\proj\file.md — should match p-win via backslash clause.
+    mem.prepare(`INSERT INTO artifacts (id,label,artifact_kind,storage_kind,storage_config,runtime_kind,runtime_config)
+                 VALUES ('a-child','f','notes','filesystem',?,'static_file','{}')`).run(JSON.stringify({ path: "C:\\proj\\file.md" }));
+    // Sibling artifact: C:\proj-other\file.md — must NOT match p-win.
+    mem.prepare(`INSERT INTO artifacts (id,label,artifact_kind,storage_kind,storage_config,runtime_kind,runtime_config)
+                 VALUES ('a-sibling','g','notes','filesystem',?,'static_file','{}')`).run(JSON.stringify({ path: "C:\\proj-other\\file.md" }));
+
+    backfillArtifactProjects(mem, "/irrelevant");
+
+    expect((mem.prepare("SELECT project_id FROM artifacts WHERE id='a-child'").get() as { project_id: string | null }).project_id).toBe("p-win");
+    expect((mem.prepare("SELECT project_id FROM artifacts WHERE id='a-sibling'").get() as { project_id: string | null }).project_id).toBeNull();
+    mem.close();
+  });
+
   it("re-keyed dedup index: same source_ref same project rejected; orphans allowed", () => {
     backfillArtifactProjects(db, userland);
     dropArtifactSpaceColumn(db);
@@ -144,5 +180,154 @@ describe("backfillArtifactProjects", () => {
     expect(report.mismatches).toHaveLength(1);
     expect(report.mismatches[0]).toMatchObject({ id: "a-mm", oldSpace: "home", newSpace: "work" });
     mem.close();
+  });
+});
+
+describe("FK ordering regression: seed spaces before backfill", () => {
+  it("ensureNativeProject does NOT throw FK error when spaces row is seeded first", () => {
+    // Simulates the pre-migration state: empty `spaces` table, artifact with a
+    // space_id that has no corresponding `spaces` row yet. The old ordering
+    // called backfillArtifactProjects (which calls ensureNativeProject → INSERT
+    // into projects(space_id=?)) BEFORE seeding spaces from artifacts.space_id,
+    // causing a FK violation when foreign_keys=ON. The fix seeds spaces first.
+    //
+    // This test drives the functions in the CORRECT order (seed → ensure) and
+    // verifies no FK error. A companion assertion proves the WRONG order fails.
+
+    const mem = new Database(":memory:");
+    mem.pragma("foreign_keys = ON");
+    mem.exec(`
+      CREATE TABLE spaces (
+        id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL REFERENCES spaces(id),
+        name TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        removed_at TEXT
+      );
+      CREATE TABLE project_paths (
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        path TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (project_id, path)
+      );
+    `);
+
+    const spaceId = "s1";
+    const oysterHome = mkdtempSync(join(tmpdir(), "oyster-fktest-"));
+    try {
+      // Seed the space row FIRST (correct order).
+      mem.exec(`INSERT OR IGNORE INTO spaces (id, display_name) VALUES ('${spaceId}', '${spaceId}')`);
+
+      // Now ensureNativeProject should succeed — space row exists.
+      expect(() => ensureNativeProject(mem, oysterHome, spaceId)).not.toThrow();
+
+      // Sanity: the native project was actually created.
+      const rows = mem.prepare("SELECT id FROM projects WHERE space_id = ?").all(spaceId) as { id: string }[];
+      expect(rows.length).toBe(1);
+    } finally {
+      mem.close();
+      rmSync(oysterHome, { recursive: true, force: true });
+    }
+  });
+
+  it("ensureNativeProject DOES throw FK error when spaces row is absent (proves reorder necessity)", () => {
+    // Wrong order: call ensureNativeProject before the space row exists.
+    const mem = new Database(":memory:");
+    mem.pragma("foreign_keys = ON");
+    mem.exec(`
+      CREATE TABLE spaces (
+        id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        space_id TEXT NOT NULL REFERENCES spaces(id),
+        name TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        removed_at TEXT
+      );
+      CREATE TABLE project_paths (
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        path TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (project_id, path)
+      );
+    `);
+
+    const oysterHome = mkdtempSync(join(tmpdir(), "oyster-fktest2-"));
+    try {
+      // spaces table is empty — ensureNativeProject's INSERT INTO projects
+      // references a non-existent space_id, which violates the FK.
+      expect(() => ensureNativeProject(mem, oysterHome, "nonexistent-space")).toThrow();
+    } finally {
+      mem.close();
+      rmSync(oysterHome, { recursive: true, force: true });
+    }
+  });
+
+  it("initDb does NOT throw when legacy DB has artifacts referencing a space not yet in spaces table", () => {
+    // Full-stack regression: build a DB file that looks like a legacy install
+    // (space_id column present, spaces table empty, artifact referencing a
+    // space) and call initDb. Before the fix, this threw an FK error during
+    // backfillArtifactProjects. After the fix it must succeed.
+    const oysterHome = mkdtempSync(join(tmpdir(), "oyster-fkfull-"));
+    const dbDir = join(oysterHome, "db");
+    mkdirSync(dbDir, { recursive: true });
+
+    // 1. Create a raw DB that looks like pre-migration state: space_id column
+    //    present on artifacts, spaces table empty, artifact with space_id set.
+    const legacySpaceId = "myspace";
+    {
+      const raw = new Database(join(dbDir, "oyster.db"));
+      raw.pragma("foreign_keys = OFF"); // no FK enforcement during manual setup
+      raw.exec(`
+        CREATE TABLE spaces (
+          id TEXT PRIMARY KEY, display_name TEXT NOT NULL, color TEXT,
+          scan_status TEXT NOT NULL DEFAULT 'none',
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE artifacts (
+          id TEXT PRIMARY KEY, space_id TEXT, project_id TEXT,
+          label TEXT NOT NULL, artifact_kind TEXT NOT NULL,
+          storage_kind TEXT NOT NULL, storage_config TEXT NOT NULL DEFAULT '{}',
+          runtime_kind TEXT NOT NULL, runtime_config TEXT NOT NULL DEFAULT '{}',
+          source_origin TEXT NOT NULL DEFAULT 'manual', source_ref TEXT,
+          removed_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+      // Native workspace artifact — space_id set, but spaces table empty.
+      const nativePath = join(oysterHome, "spaces", legacySpaceId, "note.md");
+      mkdirSync(join(oysterHome, "spaces", legacySpaceId), { recursive: true });
+      writeFileSync(nativePath, "# hello");
+      raw.prepare(
+        `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, space_id)
+         VALUES ('a1', 'note', 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+      ).run(JSON.stringify({ path: nativePath }), legacySpaceId);
+      raw.close();
+    }
+
+    // 2. Call initDb — must NOT throw.
+    let db: ReturnType<typeof initDb> | undefined;
+    try {
+      expect(() => { db = initDb(dbDir, oysterHome); }).not.toThrow();
+      // The spaces table must now have the legacy space id (seeded from artifact.space_id).
+      const spaceRow = db!.prepare("SELECT id FROM spaces WHERE id = ?").get(legacySpaceId) as { id: string } | undefined;
+      expect(spaceRow?.id).toBe(legacySpaceId);
+      // The artifact must have been assigned a project_id (backfill succeeded).
+      const artRow = db!.prepare("SELECT project_id FROM artifacts WHERE id = 'a1'").get() as { project_id: string | null };
+      expect(artRow.project_id).toBeTruthy();
+    } finally {
+      db?.close();
+      rmSync(oysterHome, { recursive: true, force: true });
+    }
   });
 });

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { initDb } from "../src/db.js";
@@ -23,6 +23,36 @@ describe("backfillArtifactProjects", () => {
     db.prepare("INSERT INTO project_paths (project_id, path) VALUES ('p-repo','/repo')").run();
   });
   afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("native artifacts resolve correctly when dbDir and oysterHome are distinct dirs", () => {
+    // Simulate the production layout: dbDir = oysterHome/db, oysterHome != dbDir.
+    // The DB lives at oysterHome/db/oyster.db, native artifacts at oysterHome/spaces/<id>/.
+    // Previously initDb forwarded dbDir to the migration, so nativeRoot was
+    // oysterHome/db/spaces — and every native-workspace artifact silently stayed orphan.
+    const oysterHome = mkdtempSync(join(tmpdir(), "oyster-home-"));
+    const dbDir = join(oysterHome, "db");
+    mkdirSync(dbDir, { recursive: true });
+    let distinctDb: ReturnType<typeof initDb> | undefined;
+    try {
+      distinctDb = initDb(dbDir, oysterHome);
+      distinctDb.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+      const nativePath = join(oysterHome, "spaces", "work", "note.md");
+      distinctDb.prepare(
+        `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config)
+         VALUES ('a-native-dist', 'work', 'note', 'notes', 'filesystem', ?, 'static_file', '{}')`,
+      ).run(JSON.stringify({ path: nativePath }));
+
+      const report = backfillArtifactProjects(distinctDb, oysterHome);
+
+      // The native artifact must have been assigned a project_id (not orphaned).
+      const row = distinctDb.prepare("SELECT project_id FROM artifacts WHERE id='a-native-dist'").get() as { project_id: string | null };
+      expect(row.project_id).toBeTruthy();
+      expect(report.stillOrphan).toBe(0);
+    } finally {
+      distinctDb?.close();
+      rmSync(oysterHome, { recursive: true, force: true });
+    }
+  });
 
   it("backfills project_id from longest-prefix path, makes native projects, reports counts + mismatches", () => {
     seedArtifact(db, "a-repo", "work", "/repo/docs/report.md");           // resolves to p-repo (space work — matches)

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -6,6 +6,7 @@ import Database from "better-sqlite3";
 import { initDb } from "../src/db.js";
 import { backfillArtifactProjects, dropArtifactSpaceColumn } from "../src/artifact-space-migration.js";
 
+// Helper to insert test artifacts; _spaceId is kept for call-site readability (documents pre-migration space) but is intentionally not inserted.
 function seedArtifact(db: ReturnType<typeof initDb>, id: string, _spaceId: string, path: string, projectId: string | null = null) {
   db.prepare(
     `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id)

--- a/server/test/db-artefact-dedup.test.ts
+++ b/server/test/db-artefact-dedup.test.ts
@@ -25,8 +25,8 @@ describe("initDb artefact dedup by path", () => {
 
   function seedArtifact(db: ReturnType<typeof initDb>, id: string, path: string, createdAt: string) {
     db.prepare(
-      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, created_at)
-       VALUES (?, 'home', ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
+      `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, created_at)
+       VALUES (?, ?, 'notes', 'filesystem', ?, 'static_file', '{}', ?)`,
     ).run(id, id, JSON.stringify({ path }), createdAt);
   }
 
@@ -96,8 +96,8 @@ describe("initDb artefact dedup by path", () => {
     const path = "/abs/ts/y.md";
     seedArtifact(db, "alive", path, "2026-05-14 10:00:00");
     db.prepare(
-      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, created_at, removed_at)
-       VALUES ('dead', 'home', 'd', 'notes', 'filesystem', ?, 'static_file', '{}', '2026-05-14 09:00:00', datetime('now'))`,
+      `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, created_at, removed_at)
+       VALUES ('dead', 'd', 'notes', 'filesystem', ?, 'static_file', '{}', '2026-05-14 09:00:00', datetime('now'))`,
     ).run(JSON.stringify({ path }));
     db.close();
 

--- a/server/test/db-artefact-tombstone-recovery.test.ts
+++ b/server/test/db-artefact-tombstone-recovery.test.ts
@@ -33,8 +33,8 @@ describe("initDb artefact tombstone recovery", () => {
     db.prepare(`INSERT OR IGNORE INTO project_paths (project_id, path) VALUES (?, ?)`).run(PROJ_ID, oldDir);
     db.prepare(`INSERT OR IGNORE INTO project_paths (project_id, path) VALUES (?, ?)`).run(PROJ_ID, newDir);
     db.prepare(
-      `INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, removed_at)
-       VALUES (?, 'work', 'doc', 'notes', 'filesystem', ?, 'static_file', '{}', datetime('now'))`,
+      `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, removed_at)
+       VALUES (?, 'doc', 'notes', 'filesystem', ?, 'static_file', '{}', datetime('now'))`,
     ).run(id, JSON.stringify({ path }));
   }
 

--- a/server/test/db-space-id-repair.test.ts
+++ b/server/test/db-space-id-repair.test.ts
@@ -32,21 +32,14 @@ describe("initDb space_id repair", () => {
     db2.close();
   });
 
-  it("syncs artefacts.space_id from project's space too (stale-space case)", () => {
+  it("artefacts no longer have a stored space_id (column dropped by initDb)", () => {
+    // artifacts.space_id was dropped as part of the artifact→project model
+    // refactor; space is now derived at read-time via project JOIN. Verify
+    // the column is absent after initDb runs.
     const db = initDb(dir);
-    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work', 'Work', '#000', 'none')`);
-    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('home', 'Home', '#000', 'none')`);
-    db.exec(`INSERT INTO projects (id, space_id, name) VALUES ('22222222-2222-2222-2222-222222222222', 'work', 'Proj')`);
-    // Stale space — project moved to 'work' but artefact still points 'home'.
-    // (artifacts.space_id is NOT NULL, so the bad-state we repair is a
-    // stale value rather than NULL.)
-    db.exec(`INSERT INTO artifacts (id, space_id, label, artifact_kind, storage_kind, runtime_kind, project_id) VALUES ('a', 'home', 'l', 'notes', 'filesystem', 'static_file', '22222222-2222-2222-2222-222222222222')`);
+    const cols = (db.prepare("PRAGMA table_info(artifacts)").all() as { name: string }[]).map((c) => c.name);
+    expect(cols).not.toContain("space_id");
     db.close();
-
-    const db2 = initDb(dir);
-    const row = db2.prepare("SELECT space_id FROM artifacts WHERE id = 'a'").get() as { space_id: string };
-    expect(row.space_id).toBe("work");
-    db2.close();
   });
 
   it("leaves space_id alone when project is soft-deleted (don't re-bind to a tombstone)", () => {

--- a/server/test/native-project.test.ts
+++ b/server/test/native-project.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { ensureNativeProject } from "../src/native-project.js";
+
+describe("ensureNativeProject", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-np-"));
+    db = initDb(userland);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("creates a project bound to the space with the native folder path, idempotently", () => {
+    const id1 = ensureNativeProject(db, userland, "work");
+    const id2 = ensureNativeProject(db, userland, "work");
+    expect(id1).toBe(id2); // idempotent — same project reused
+
+    const proj = db.prepare("SELECT space_id FROM projects WHERE id = ?").get(id1) as { space_id: string };
+    expect(proj.space_id).toBe("work");
+
+    const path = db.prepare("SELECT path FROM project_paths WHERE project_id = ?").get(id1) as { path: string };
+    expect(path.path).toBe(join(userland, "spaces", "work"));
+  });
+
+  it("creates the native folder on disk", () => {
+    const id = ensureNativeProject(db, userland, "work");
+    expect(existsSync(join(userland, "spaces", "work"))).toBe(true);
+    expect(id).toBeTruthy();
+  });
+});

--- a/server/test/publish-service.test.ts
+++ b/server/test/publish-service.test.ts
@@ -25,7 +25,7 @@ function makeDb(): Database.Database {
     CREATE TABLE artifacts (
       id                   TEXT PRIMARY KEY,
       owner_id             TEXT,
-      space_id             TEXT NOT NULL DEFAULT '',
+      space_id             TEXT NOT NULL DEFAULT '', -- test convenience; space is derived via project; legacy column kept until dropped
       project_id           TEXT REFERENCES projects(id) ON DELETE SET NULL,
       label                TEXT NOT NULL,
       artifact_kind        TEXT NOT NULL,

--- a/server/test/publish-service.test.ts
+++ b/server/test/publish-service.test.ts
@@ -9,10 +9,24 @@ import { createPublishService } from "../src/publish-service.js";
 function makeDb(): Database.Database {
   const db = new Database(":memory:");
   db.exec(`
+    CREATE TABLE spaces (
+      id           TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL DEFAULT ''
+    );
+    INSERT INTO spaces (id, display_name) VALUES ('home', 'Home'), ('client-projects', 'Client Projects');
+
+    CREATE TABLE projects (
+      id        TEXT PRIMARY KEY,
+      space_id  TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+      name      TEXT NOT NULL DEFAULT '',
+      removed_at INTEGER
+    );
+
     CREATE TABLE artifacts (
       id                   TEXT PRIMARY KEY,
       owner_id             TEXT,
-      space_id             TEXT NOT NULL,
+      space_id             TEXT NOT NULL DEFAULT '',
+      project_id           TEXT REFERENCES projects(id) ON DELETE SET NULL,
       label                TEXT NOT NULL,
       artifact_kind        TEXT NOT NULL,
       storage_kind         TEXT NOT NULL,
@@ -32,13 +46,21 @@ function makeDb(): Database.Database {
   return db;
 }
 
-function seedArtifact(db: Database.Database, opts: { id?: string; artifact_kind?: string; owner_id?: string | null } = {}) {
+function seedArtifact(db: Database.Database, opts: { id?: string; artifact_kind?: string; owner_id?: string | null; project_id?: string | null } = {}) {
   const id = opts.id ?? "art_1";
   db.prepare(
     `INSERT INTO artifacts
-       (id, owner_id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config)
-     VALUES (?, ?, 'home', 'test', ?, 'filesystem', '{"path":"/tmp/fake.md"}', 'static_file', '{}')`
-  ).run(id, opts.owner_id ?? null, opts.artifact_kind ?? "notes");
+       (id, owner_id, project_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config)
+     VALUES (?, ?, ?, 'test', ?, 'filesystem', '{"path":"/tmp/fake.md"}', 'static_file', '{}')`
+  ).run(id, opts.owner_id ?? null, opts.project_id ?? null, opts.artifact_kind ?? "notes");
+  return id;
+}
+
+/** Insert a project row and return its id. */
+function seedProject(db: Database.Database, opts: { id?: string; space_id?: string } = {}) {
+  const id = opts.id ?? "proj_1";
+  db.prepare(`INSERT INTO projects (id, space_id, name) VALUES (?, ?, 'Test Project')`)
+    .run(id, opts.space_id ?? "home");
   return id;
 }
 
@@ -528,9 +550,10 @@ describe("backfillPublications", () => {
 
   it("opportunistically pushes local label + space_id to D1 when cloud row is stale", async () => {
     const db = makeDb();
-    seedArtifact(db, { id: "art_present", owner_id: null });
-    db.prepare("UPDATE artifacts SET label = ?, space_id = ? WHERE id = ?")
-      .run("Friendly Label", "client-projects", "art_present");
+    const projId = seedProject(db, { id: "proj_cp", space_id: "client-projects" });
+    seedArtifact(db, { id: "art_present", owner_id: null, project_id: projId });
+    db.prepare("UPDATE artifacts SET label = ? WHERE id = ?")
+      .run("Friendly Label", "art_present");
 
     let mineCalls = 0;
     let patchCall: { url?: string; body?: any } = {};
@@ -580,9 +603,10 @@ describe("backfillPublications", () => {
 
   it("does NOT fire context up-sync when cloud + local already agree", async () => {
     const db = makeDb();
-    seedArtifact(db, { id: "art_present", owner_id: null });
-    db.prepare("UPDATE artifacts SET label = ?, space_id = ? WHERE id = ?")
-      .run("Same Label", "home", "art_present");
+    const projId = seedProject(db, { id: "proj_home", space_id: "home" });
+    seedArtifact(db, { id: "art_present", owner_id: null, project_id: projId });
+    db.prepare("UPDATE artifacts SET label = ? WHERE id = ?")
+      .run("Same Label", "art_present");
 
     const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith("/api/publish/mine")) {
@@ -591,7 +615,7 @@ describe("backfillPublications", () => {
             share_token: "tok", artifact_id: "art_present", artifact_kind: "notes",
             mode: "open", content_type: "text/plain", size_bytes: 10,
             published_at: 1, updated_at: 1,
-            label: "Same Label", space_id: "home",    // matches local
+            label: "Same Label", space_id: "home",    // matches local derived space
           }],
         }), { status: 200, headers: { "content-type": "application/json" } });
       }

--- a/server/test/space-service-reassign.test.ts
+++ b/server/test/space-service-reassign.test.ts
@@ -186,6 +186,21 @@ describe("SpaceService session sync on deleteSpace / convertFolderToSpace", () =
     expect(row.space_id).toBe("home");
   });
 
+  it("deleteSpace: session whose project is in the deleted space moves to home even if its stored space_id has drifted (NULL)", () => {
+    // s-drift belongs to p-work (in 'work') but its own space_id is NULL — a
+    // drifted state. Matching only by space_id would miss it; matching by project
+    // membership catches it.
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, space_id, project_id) VALUES ('s-drift', 'claude-code', 'done', NULL, 'p-work')`,
+    ).run();
+
+    const { svc } = makeService(db);
+    svc.deleteSpace("work");
+
+    const row = db.prepare("SELECT space_id FROM sessions WHERE id = 's-drift'").get() as { space_id: string };
+    expect(row.space_id).toBe("home");
+  });
+
   it("deleteSpace: session in a different space is unaffected", () => {
     db.prepare(
       `INSERT INTO sessions (id, agent, state, space_id, project_id) VALUES ('s-home', 'claude-code', 'done', 'home', 'p-home')`,

--- a/server/test/space-service-reassign.test.ts
+++ b/server/test/space-service-reassign.test.ts
@@ -157,3 +157,70 @@ describe("SpaceService.convertFolderToSpace — reassigns project to target spac
     expect(artifactStore.getById("a6")!.group_name).toBe("OtherFolder");
   });
 });
+
+describe("SpaceService session sync on deleteSpace / convertFolderToSpace", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-sess-"));
+    db = initDb(userland);
+    ensureHomeSpace(db);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('target','Target','#000','none')`);
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-work','work','work-proj')").run();
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-home','home','home-proj')").run();
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-folder','home','my-folder')").run();
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("deleteSpace: session in deleted space is moved to home", () => {
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, space_id, project_id) VALUES ('s-work', 'claude-code', 'done', 'work', 'p-work')`,
+    ).run();
+
+    const { svc } = makeService(db);
+    svc.deleteSpace("work");
+
+    const row = db.prepare("SELECT space_id FROM sessions WHERE id = 's-work'").get() as { space_id: string };
+    expect(row.space_id).toBe("home");
+  });
+
+  it("deleteSpace: session in a different space is unaffected", () => {
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, space_id, project_id) VALUES ('s-home', 'claude-code', 'done', 'home', 'p-home')`,
+    ).run();
+
+    const { svc } = makeService(db);
+    svc.deleteSpace("work");
+
+    const row = db.prepare("SELECT space_id FROM sessions WHERE id = 's-home'").get() as { space_id: string };
+    expect(row.space_id).toBe("home"); // unchanged
+  });
+
+  it("convertFolderToSpace: session bound to converted project gets targetSpaceId", () => {
+    seedArtifact(db, "a-folder", "p-folder", "MyFolder");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, space_id, project_id) VALUES ('s-folder', 'claude-code', 'done', 'home', 'p-folder')`,
+    ).run();
+
+    const { svc } = makeService(db);
+    svc.convertFolderToSpace("home", "MyFolder", "target");
+
+    const row = db.prepare("SELECT space_id FROM sessions WHERE id = 's-folder'").get() as { space_id: string };
+    expect(row.space_id).toBe("target");
+  });
+
+  it("convertFolderToSpace: session bound to unaffected project keeps its space", () => {
+    seedArtifact(db, "a-folder", "p-folder", "MyFolder");
+    db.prepare(
+      `INSERT INTO sessions (id, agent, state, space_id, project_id) VALUES ('s-other', 'claude-code', 'done', 'home', 'p-home')`,
+    ).run();
+
+    const { svc } = makeService(db);
+    svc.convertFolderToSpace("home", "MyFolder", "target");
+
+    const row = db.prepare("SELECT space_id FROM sessions WHERE id = 's-other'").get() as { space_id: string };
+    expect(row.space_id).toBe("home"); // unchanged
+  });
+});

--- a/server/test/space-service-reassign.test.ts
+++ b/server/test/space-service-reassign.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb } from "../src/db.js";
+import { SqliteArtifactStore } from "../src/artifact-store.js";
+import { SqliteSpaceStore } from "../src/space-store.js";
+import { SpaceService } from "../src/space-service.js";
+import type { ArtifactService } from "../src/artifact-service.js";
+
+// Minimal helpers
+function makeService(db: ReturnType<typeof initDb>) {
+  const artifactStore = new SqliteArtifactStore(db);
+  const spaceStore = new SqliteSpaceStore(db);
+  // _artifactService is discarded by SpaceService — safe to pass null
+  const svc = new SpaceService(spaceStore, artifactStore, null as unknown as ArtifactService, db);
+  return { svc, artifactStore, spaceStore };
+}
+
+function seedArtifact(
+  db: ReturnType<typeof initDb>,
+  id: string,
+  projectId: string | null,
+  groupName: string | null = null,
+) {
+  db.prepare(
+    `INSERT INTO artifacts (id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, project_id, group_name)
+     VALUES (?, ?, 'notes', 'filesystem', '{"path":"/x"}', 'static_file', '{}', ?, ?)`,
+  ).run(id, id, projectId, groupName);
+}
+
+function ensureHomeSpace(db: ReturnType<typeof initDb>) {
+  const exists = db.prepare("SELECT id FROM spaces WHERE id='home'").get();
+  if (!exists) {
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('home','Home','#000','none')`);
+  }
+}
+
+describe("SpaceService.deleteSpace — reassigns artifacts via project", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-svc-"));
+    db = initDb(userland);
+    ensureHomeSpace(db);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('work','Work','#000','none')`);
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-work','work','work-proj')").run();
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-home','home','home-proj')").run();
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("artifact previously in deleted space derives 'home' afterward (not orphaned)", () => {
+    seedArtifact(db, "a1", "p-work");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.deleteSpace("work");
+
+    const row = artifactStore.getById("a1");
+    expect(row).toBeDefined();
+    expect(row!.space_id).toBe("home");
+  });
+
+  it("artifact gets the folder label (deleted space display name) after deletion", () => {
+    seedArtifact(db, "a2", "p-work");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.deleteSpace("work");
+
+    const row = artifactStore.getById("a2");
+    expect(row!.group_name).toBe("Work"); // display_name of the deleted space
+  });
+
+  it("artifact already in home is unaffected by the deletion of another space", () => {
+    seedArtifact(db, "a-home", "p-home");
+    seedArtifact(db, "a-work", "p-work");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.deleteSpace("work");
+
+    const homeArtifact = artifactStore.getById("a-home");
+    expect(homeArtifact!.space_id).toBe("home");
+    expect(homeArtifact!.group_name).toBeNull(); // untouched
+  });
+
+  it("getBySpaceId('home') returns the moved artifact after deleteSpace", () => {
+    seedArtifact(db, "a3", "p-work");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.deleteSpace("work");
+
+    const inHome = artifactStore.getBySpaceId("home").map((r) => r.id);
+    expect(inHome).toContain("a3");
+  });
+
+  it("throws when deleting reserved space 'home'", () => {
+    const { svc } = makeService(db);
+    expect(() => svc.deleteSpace("home")).toThrow(/reserved/);
+  });
+});
+
+describe("SpaceService.convertFolderToSpace — reassigns project to target space", () => {
+  let userland: string;
+  let db: ReturnType<typeof initDb>;
+
+  beforeEach(() => {
+    userland = mkdtempSync(join(tmpdir(), "oyster-cfs-"));
+    db = initDb(userland);
+    ensureHomeSpace(db);
+    db.exec(`INSERT INTO spaces (id, display_name, color, scan_status) VALUES ('target','Target','#000','none')`);
+    // Two projects in home, one per folder (folders ARE projects in the new model)
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-folder','home','my-folder')").run();
+    db.prepare("INSERT INTO projects (id, space_id, name) VALUES ('p-other','home','other-folder')").run();
+  });
+  afterEach(() => { db.close(); rmSync(userland, { recursive: true, force: true }); });
+
+  it("folder artifacts derive the target space afterward via project JOIN", () => {
+    seedArtifact(db, "a1", "p-folder", "MyFolder");
+    seedArtifact(db, "a2", "p-folder", "MyFolder");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.convertFolderToSpace("home", "MyFolder", "target");
+
+    expect(artifactStore.getById("a1")!.space_id).toBe("target");
+    expect(artifactStore.getById("a2")!.space_id).toBe("target");
+  });
+
+  it("group_name is cleared on converted artifacts", () => {
+    seedArtifact(db, "a3", "p-folder", "MyFolder");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.convertFolderToSpace("home", "MyFolder", "target");
+
+    expect(artifactStore.getById("a3")!.group_name).toBeNull();
+  });
+
+  it("getBySpaceId('target') returns the converted artifacts", () => {
+    seedArtifact(db, "a4", "p-folder", "MyFolder");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.convertFolderToSpace("home", "MyFolder", "target");
+
+    const inTarget = artifactStore.getBySpaceId("target").map((r) => r.id);
+    expect(inTarget).toContain("a4");
+  });
+
+  it("artifacts in a different project/folder are unaffected", () => {
+    seedArtifact(db, "a5", "p-folder", "MyFolder");
+    // a6 belongs to a DIFFERENT project (different folder = different project)
+    seedArtifact(db, "a6", "p-other", "OtherFolder");
+    const { svc, artifactStore } = makeService(db);
+
+    svc.convertFolderToSpace("home", "MyFolder", "target");
+
+    // OtherFolder artifact stays in home (its project was not moved)
+    expect(artifactStore.getById("a6")!.space_id).toBe("home");
+    expect(artifactStore.getById("a6")!.group_name).toBe("OtherFolder");
+  });
+});


### PR DESCRIPTION
## Summary

Foundational data-model fix (Plan 1 of the artifact-scanner work). An artifact's home is now its **project**; its space is **derived** via `artifact → project → space`. The legacy `artifacts.space_id` stored column — a 0.4/0.5-era holdover — is dropped.

- **Derivation at the store boundary:** every artifact SELECT does `LEFT JOIN projects` + `COALESCE(p.space_id,'')`, so `Artifact.spaceId` keeps its `string` shape and all ~18 web consumers are untouched.
- **Boot migration** (`artifact-space-migration.ts`): backfills `project_id` from each file's path (longest-prefix `project_paths`, exact-prefix matching — no LIKE wildcards); native workspace folders `~/Oyster/spaces/<id>` become projects bound to their space; logs a before/after + mismatch report; then drops the column and re-keys the dedup index to `(project_id, source_ref)`. Fail-loud, idempotent, safe on fresh + existing installs.
- **Write paths updated:** service (`registerArtifact` resolves project via `lookupProject`; `createArtifact` via the native project), MCP tools (register/update drop `space_id`; create keeps it as storage target), publish-service (derives via join), and `space-service` (`deleteSpace`/`convertFolderToSpace` reassign via project, not the now-no-op `space_id` write).
- **Includes** the design spec for the upcoming reactive session-output registration (Plan 2) — docs only, no code.

## Verified on real data

Ran live against the production `~/Oyster` DB (backup taken first):
- `backfilled 325 project_id (of 552; 552 had space; 0 orphan)` — every artifact keeps a project.
- 17 space changes: **10 corrections** (files in `~/Oyster/spaces/{home,blunderfixer,tokinvest}/` that were mis-tagged `oyster` → re-filed to their real folder) and ~4 repo files dropping to unsorted (their repo has no space; they rejoin one when the repo is organised).
- Server booted clean; UI verified.

## Test plan

- [x] 558 server tests pass; `tsc` clean
- [x] Web build unaffected (`Artifact.spaceId` type unchanged)
- [x] Migration idempotent across boots; dedup index NULL-permissive for orphans (tested)
- [x] Mismatch detection unit-tested (column-present path)
- [x] Live migration on real DB matches dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)