### PR TITLE
arcade(invaders-mp): Phase G — stage progression + UFO + score popups

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -49,6 +49,20 @@ export interface Invader {
   alive: boolean;
 }
 
+export interface Popup {
+  x: number;
+  y: number;
+  text: string;
+  col: string;
+  /** Seconds of life remaining; renderer fades by life/POPUP_LIFE_SEC. */
+  life: number;
+}
+
+export interface Ufo {
+  x: number;
+  dir: 1 | -1;
+}
+
 export interface GameState {
   status: Status;
   won: boolean;
@@ -60,6 +74,18 @@ export interface GameState {
   invaders: Invader[];
   /** Flat shared shield bitmap; 1 = solid, 0 = chipped. Length = SHIELD_COUNT * SHIELD_W * SHIELD_H. */
   shields: Uint8Array;
+  /** Stage label set (1, 2, 3, …) — boss interrupt arrives in Phase H. */
+  stageSet: number;
+  /** Stage label number within the set (1..STAGES_PER_SET). */
+  stageNum: number;
+  /** Seconds remaining of the "STAGE n-m" overlay between waves. */
+  stageAnnounceIn: number;
+  /** Bonus UFO when on-screen; null when between spawns. */
+  ufo: Ufo | null;
+  /** Seconds until the next UFO spawns. */
+  ufoNextSec: number;
+  /** Live floating score popups; filtered to life > 0. */
+  popups: Popup[];
   invaderDir: 1 | -1;
   invaderDropRemaining: number;
   invaderFireAccum: number;
@@ -97,6 +123,16 @@ export interface WireSnapshot {
   iFrame: 0 | 1;
   /** Packed shield bitmap (base64 of SHIELD_COUNT * SHIELD_W * SHIELD_H bits). */
   shieldsBits: string;
+  /** Stage label set (1, 2, 3, …). */
+  stageSet: number;
+  /** Stage label number within the set (1..STAGES_PER_SET). */
+  stageNum: number;
+  /** Seconds remaining of the centred "STAGE n-m" announce overlay. */
+  stageAnnounceIn: number;
+  /** Bonus UFO when on-screen (x = left edge, d = travel direction); null between spawns. */
+  ufo: { x: number; d: 1 | -1 } | null;
+  /** Floating score popups; client renders + fades by `l` / POPUP_LIFE_SEC. */
+  popups: Array<{ x: number; y: number; t: string; c: string; l: number }>;
   /**
    * Per-seat occupancy. Set by the transport layer (room.ts on the
    * server, hostTick on the client) after snapshotForClient returns,
@@ -130,6 +166,10 @@ export const SUPER_SHOT_MAX: number;
 export const CHARGE_THRESHOLD_SEC: number;
 export const CHARGED_BULLET_W: number;
 export const CHARGED_BULLET_H: number;
+export const CHARGED_BULLET_SPEED: number;
+export const UFO_W_EXPORT: number;
+export const UFO_H_EXPORT: number;
+export const UFO_Y_EXPORT: number;
 export function comboMultiplier(count: number): number;
 
 export const SEATS: readonly Seat[];

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -656,7 +656,14 @@ function resolveCollisions(state, occupied) {
       const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
       if (b.y < -bh) continue;
       if (overlap(b.x, b.y, bw, bh, state.ufo.x, UFO_Y, UFO_W, UFO_H)) {
-        const progress = (state.ufo.x + UFO_W) / (PF_W + UFO_W * 2);
+        // Progress = distance travelled from the spawn edge, so left-
+        // and right-spawning UFOs both pay 0 at their spawn point and
+        // ramp up to the max as they approach the despawn edge —
+        // symmetric scoring regardless of direction.
+        const dir = state.ufo.dir;
+        const travelMax = PF_W + UFO_W * 2;
+        const travelled = dir > 0 ? (state.ufo.x + UFO_W) : (PF_W - state.ufo.x);
+        const progress = travelled / travelMax;
         const idx = Math.min(UFO_SCORES.length - 1, Math.max(0, Math.floor(progress * UFO_SCORES.length)));
         const pts = UFO_SCORES[idx];
         const owner = b.owner && state.ships[b.owner];
@@ -678,7 +685,11 @@ function resolveCollisions(state, occupied) {
       }
     }
   }
-  state.bullets = state.bullets.filter(b => b.y > -BULLET_H);
+  // Filter using each bullet's own height — charged bullets are
+  // 12 PF tall, so the -BULLET_H constant would cull them ~6 PF
+  // early while their bottom edge is still on-screen. Killed bullets
+  // (marker y = -999) get caught by either height check.
+  state.bullets = state.bullets.filter(b => b.y > -(b.charged ? CHARGED_BULLET_H : BULLET_H));
 
   // Invader bullets vs shields, FIRST — chip the bunkers, kill the
   // bullet, before any per-ship check. A bullet that hit a shield

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -131,6 +131,41 @@ function makeShields() {
   return buf;
 }
 
+// === Stages ===
+// Stages are labelled "set-num" (1-1, 1-2, 1-3, 2-1, ...). Endless
+// for now — the boss interrupt every set lands in Phase H. On grid
+// clear we advance the counter, rebuild the swarm, and trigger a
+// 2 s "STAGE n-m" announce overlay. Player state (score, ammo,
+// combo) persists across stages.
+const STAGES_PER_SET = 3;
+const STAGE_ANNOUNCE_SEC = 2;
+
+// === UFO ===
+// Bonus enemy that flies across the top of the playfield occasionally.
+// Spawns from a random edge moving inward, despawns when it exits the
+// opposite edge or gets shot. Score depends on where you hit it
+// (UFO_SCORES sampled by progress across the screen — classic). A
+// kill refills the shooter's super-shot ammo to MAX, which is the
+// strategic reason to interrupt your aim and chase the UFO.
+const UFO_W = 16;
+const UFO_H = 7;
+const UFO_Y = 12;                        // sits above the invader grid (INV_ORIGIN_Y=24)
+const UFO_SPEED = 50;                    // PF/sec
+const UFO_MIN_INTERVAL = 25;             // seconds — earliest possible respawn
+const UFO_MAX_INTERVAL = 45;             // seconds — latest
+const UFO_SCORES = [50, 100, 150, 300];
+export const UFO_W_EXPORT = UFO_W;        // for renderer + collision
+export const UFO_H_EXPORT = UFO_H;
+export const UFO_Y_EXPORT = UFO_Y;
+
+// === Score popups ===
+// Floating "+30" / "x3 +60" text spawned on each kill, fades over
+// POPUP_LIFE_SEC. Lives only on the wire when active. Server pushes
+// new ones into state.popups; tick decrements life + floats up; the
+// snapshot dump filters out expired entries before broadcast.
+const POPUP_LIFE_SEC = 0.6;
+const POPUP_FLOAT_SPEED = 18;             // PF/sec, upward drift
+
 // === Lives + respawn ===
 // Shared pool of respawn tokens. 3 means up to 3 ship deaths get
 // brought back; the 4th (and beyond) is permanent. With 4 ships +
@@ -233,6 +268,20 @@ export function initState() {
     // SHIELD_COUNT bunkers. Bullets chip cells to 0; renderer reads
     // the bitmap directly.
     shields: makeShields(),
+    // Stage progression (Phase G). stageSet 1..∞, stageNum 1..3,
+    // labelled "1-1" / "1-2" / ... by the renderer. announceIn counts
+    // down a brief "STAGE n-m" overlay fade after each wave clear.
+    stageSet: 1,
+    stageNum: 1,
+    stageAnnounceIn: 0,
+    // UFO bonus enemy. ufo is null when off-screen; ufoNextSec ticks
+    // down the time until the next spawn (randomised on each despawn).
+    ufo: null,
+    ufoNextSec: UFO_MIN_INTERVAL + Math.random() * (UFO_MAX_INTERVAL - UFO_MIN_INTERVAL),
+    // Floating "+30" / "x3 +60" score popups. Each entry {x, y, text,
+    // col, life} where life is seconds remaining; tick decays + drifts
+    // y upward; expired entries filtered out before broadcast.
+    popups: [],
     invaderDir: 1,
     invaderDropRemaining: 0,
     invaderFireAccum: 0,
@@ -276,12 +325,70 @@ const ALL_OCCUPIED = Object.freeze(
 export function step(state, inputs, dt, occupied = ALL_OCCUPIED) {
   if (state.status !== 'running') return;
   tickRespawnAndInvuln(state, dt);
+  tickStageAnnounce(state, dt);
   stepShips(state, inputs, dt, occupied);
   stepBullets(state, dt);
   stepInvaders(state, dt);
   stepInvaderFire(state, dt);
+  stepUfo(state, dt);
+  stepPopups(state, dt);
   resolveCollisions(state, occupied);
+  checkStageClear(state);
   checkEnd(state, occupied);
+}
+
+function tickStageAnnounce(state, dt) {
+  if (state.stageAnnounceIn > 0) {
+    state.stageAnnounceIn = Math.max(0, state.stageAnnounceIn - dt);
+  }
+}
+
+function stepUfo(state, dt) {
+  if (state.ufo) {
+    state.ufo.x += UFO_SPEED * state.ufo.dir * dt;
+    // Despawn once fully past the opposite edge.
+    if ((state.ufo.dir > 0 && state.ufo.x > PF_W) ||
+        (state.ufo.dir < 0 && state.ufo.x + UFO_W < 0)) {
+      state.ufo = null;
+      state.ufoNextSec = UFO_MIN_INTERVAL + Math.random() * (UFO_MAX_INTERVAL - UFO_MIN_INTERVAL);
+    }
+    return;
+  }
+  state.ufoNextSec -= dt;
+  if (state.ufoNextSec <= 0) {
+    const fromLeft = Math.random() < 0.5;
+    state.ufo = { x: fromLeft ? -UFO_W : PF_W, dir: fromLeft ? 1 : -1 };
+  }
+}
+
+function stepPopups(state, dt) {
+  if (state.popups.length === 0) return;
+  for (const p of state.popups) {
+    p.life -= dt;
+    p.y -= POPUP_FLOAT_SPEED * dt;
+  }
+  state.popups = state.popups.filter(p => p.life > 0);
+}
+
+// Called after resolveCollisions. If every invader is dead the wave
+// is over — bump the stage counter, rebuild the grid, fire the
+// announce overlay. Player state (score, ammo, combo, lives) carries
+// forward. Bullets persist (they'll fly through to no-op) and
+// invaderBullets are cleared so a leftover doesn't reach the ship
+// during the announce. UFO + popups stay too.
+function checkStageClear(state) {
+  if (state.invaders.some(i => i.alive)) return;
+  state.stageNum += 1;
+  if (state.stageNum > STAGES_PER_SET) {
+    state.stageNum = 1;
+    state.stageSet += 1;
+  }
+  state.invaders = buildGrid();
+  state.invaderDir = 1;
+  state.invaderDropRemaining = 0;
+  state.invaderFireAccum = 0;
+  state.invaderBullets = [];
+  state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
 }
 
 function tickRespawnAndInvuln(state, dt) {
@@ -513,7 +620,20 @@ function resolveCollisions(state, occupied) {
         owner.combo += 1;
         owner.comboDecayIn = COMBO_WINDOW_SEC;
         const basePts = ROW_POINTS[Math.floor(i / INV_COLS)] || 0;
-        owner.score += basePts * comboMultiplier(owner.combo);
+        const mult = comboMultiplier(owner.combo);
+        const pts = basePts * mult;
+        owner.score += pts;
+        // Floating score popup: "+30" for a vanilla kill, "x3 +60"
+        // when a multiplier's active. Drawn at the killed invader's
+        // position, drifts up and fades.
+        const text = mult > 1 ? `x${mult} +${pts}` : `+${pts}`;
+        state.popups.push({
+          x: inv.x + INV_W / 2,
+          y: inv.y,
+          text: text,
+          col: '#ffffff',
+          life: POPUP_LIFE_SEC,
+        });
         // Earned-ammo threshold crossings — bump the threshold even
         // when at max so a long high-score run isn't "wasted".
         while (owner.score >= owner.nextSuperAt) {
@@ -523,6 +643,39 @@ function resolveCollisions(state, occupied) {
       }
       if (!b.charged) { b.y = -999; break; }
       // charged: keep checking other invaders this tick
+    }
+  }
+
+  // Player bullets vs UFO. Charged bullets one-shot a UFO too. Score
+  // is sampled from UFO_SCORES by where the UFO is across the screen
+  // — closer to the centre/far edge = higher payout. Kill refills
+  // the shooter's super ammo to MAX (the strategic carrot).
+  if (state.ufo) {
+    for (const b of state.bullets) {
+      const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
+      const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
+      if (b.y < -bh) continue;
+      if (overlap(b.x, b.y, bw, bh, state.ufo.x, UFO_Y, UFO_W, UFO_H)) {
+        const progress = (state.ufo.x + UFO_W) / (PF_W + UFO_W * 2);
+        const idx = Math.min(UFO_SCORES.length - 1, Math.max(0, Math.floor(progress * UFO_SCORES.length)));
+        const pts = UFO_SCORES[idx];
+        const owner = b.owner && state.ships[b.owner];
+        if (owner) {
+          owner.score += pts;
+          owner.superAmmo = SUPER_SHOT_MAX;
+          state.popups.push({
+            x: state.ufo.x + UFO_W / 2,
+            y: UFO_Y,
+            text: `+${pts}`,
+            col: '#ffd84a',          // gold to celebrate the bonus
+            life: POPUP_LIFE_SEC,
+          });
+        }
+        state.ufo = null;
+        state.ufoNextSec = UFO_MIN_INTERVAL + Math.random() * (UFO_MAX_INTERVAL - UFO_MIN_INTERVAL);
+        if (!b.charged) b.y = -999;
+        break;                       // one bullet hits at most one UFO
+      }
     }
   }
   state.bullets = state.bullets.filter(b => b.y > -BULLET_H);
@@ -578,8 +731,10 @@ function checkEnd(state, occupied) {
     return;
   }
 
-  // Win: every invader dead.
-  if (!state.invaders.some(i => i.alive)) { state.status = 'gameover'; state.won = true; }
+  // No more "every invader dead = win" — stages are endless until
+  // a boss interrupts (Phase H) or you lose to breach/wipe.
+  // checkStageClear (called before this in step()) handles the
+  // grid-clear case by rebuilding the next stage.
 }
 
 function overlap(ax, ay, aw, ah, bx, by, bw, bh) {
@@ -679,5 +834,16 @@ export function snapshotForClient(state) {
     // would be premature optimisation. Client decodes once per
     // snapshot and renders straight from the resulting Uint8Array.
     shieldsBits:    encodeShields(state.shields),
+    // Phase G: stage + UFO + popups. stageSet/stageNum render as
+    // "n-m" in the HUD; stageAnnounceIn drives the centred overlay
+    // between waves. ufo is null when off-screen. popups is the
+    // floating-text list (already filtered to live entries).
+    stageSet:       state.stageSet,
+    stageNum:       state.stageNum,
+    stageAnnounceIn: round(state.stageAnnounceIn),
+    ufo:            state.ufo ? { x: round(state.ufo.x), d: state.ufo.dir } : null,
+    popups:         state.popups.map(p => ({
+      x: round(p.x), y: round(p.y), t: p.text, c: p.col, l: round(p.life),
+    })),
   };
 }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -381,9 +381,15 @@
     decodeShields, shieldOffsets,
     SUPER_SHOT_MAX, CHARGE_THRESHOLD_SEC,
     CHARGED_BULLET_W, CHARGED_BULLET_H, CHARGED_BULLET_SPEED,
+    UFO_W_EXPORT, UFO_H_EXPORT, UFO_Y_EXPORT,
     comboMultiplier,
     SEATS, MAX_SEATS,
   } = engine;
+  // Local aliases so the renderer reads UFO_W / UFO_H / UFO_Y like the
+  // engine code does, without colliding with anything else.
+  const UFO_W = UFO_W_EXPORT ?? 16;
+  const UFO_H = UFO_H_EXPORT ?? 7;
+  const UFO_Y = UFO_Y_EXPORT ?? 12;
   import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
   // Renderer uses INV_COLS to map invader array index → grid row. It
   // happens to equal 11 in the current engine; mirror as a const so a
@@ -420,7 +426,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 23;
+  const NETCODE_VERSION = 24;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1576,6 +1582,21 @@
       }
     }
 
+    // UFO bonus enemy — saucer silhouette ported from SP's drawUfo.
+    // Position is server-authoritative; render straight from the
+    // snapshot's ufo.x at the fixed UFO_Y row above the swarm.
+    if (latestSnap.ufo) {
+      const ux = latestSnap.ufo.x;
+      ctx.fillStyle = '#a855f7';                       // purple body
+      ctx.fillRect(ux + 2,           UFO_Y + 0, UFO_W - 4, 1);
+      ctx.fillRect(ux + 0,           UFO_Y + 1, UFO_W,     2);
+      ctx.fillRect(ux + 2,           UFO_Y + 3, UFO_W - 4, 1);
+      ctx.fillRect(ux + 4,           UFO_Y + 4, UFO_W - 8, 1);
+      ctx.fillStyle = '#2dd4ff';                       // cyan undercarriage glints
+      ctx.fillRect(ux + 1,           UFO_Y + 4, 2, 1);
+      ctx.fillRect(ux + UFO_W - 3,   UFO_Y + 4, 2, 1);
+    }
+
     // Bullets — drawn from the latest snapshot (server-authoritative
     // for spawn time + trajectory). Normal bullets paint gold-on-
     // white-core; charged super-shots paint fat gold + white core
@@ -1636,6 +1657,36 @@
       drawCenteredOverlay('ATTACK!', `rgba(255, 58, 161, ${alpha.toFixed(2)})`, 22);
     }
 
+    // Stage announce overlay — "STAGE n-m" centred + fades out as
+    // stageAnnounceIn drops to 0. Server keeps the timer, so all
+    // clients show it in sync. Skip the overlay during the very first
+    // stage (stageAnnounceIn defaults to 0 in initState) so the wave
+    // doesn't get an extra "STAGE 1-1" flash before play even starts.
+    if ((latestSnap.stageAnnounceIn || 0) > 0) {
+      const STAGE_ANNOUNCE_TOTAL = 2;
+      const t = Math.min(1, (latestSnap.stageAnnounceIn || 0) / STAGE_ANNOUNCE_TOTAL);
+      const label = 'STAGE ' + (latestSnap.stageSet ?? 1) + '-' + (latestSnap.stageNum ?? 1);
+      drawCenteredOverlay(label, `rgba(255, 216, 74, ${t.toFixed(2)})`, 18);
+    }
+
+    // Floating score popups — server-spawned on each kill, live for
+    // POPUP_LIFE_SEC (0.6 s), drift upward. Each renders centred on
+    // its (x, y) with alpha = life / POPUP_LIFE_SEC. Tiny font so
+    // multiple stacked popups in a combo stay readable.
+    if (latestSnap.popups && latestSnap.popups.length) {
+      const POPUP_TOTAL = 0.6;
+      ctx.font = '5px "Press Start 2P", monospace';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      for (const p of latestSnap.popups) {
+        const alpha = Math.max(0, Math.min(1, (p.l || 0) / POPUP_TOTAL));
+        ctx.globalAlpha = alpha;
+        ctx.fillStyle = p.c || '#ffffff';
+        ctx.fillText(p.t || '', p.x, p.y);
+      }
+      ctx.globalAlpha = 1;
+    }
+
     // HUD — three SP-style columns across the top of the canvas:
     // SCORE (local player only, in their seat colour) | STAGE (real
     // progression lands in Phase G) | LIVES (shared respawn pool).
@@ -1673,7 +1724,9 @@
       ctx.fillStyle = '#ffffff';
       ctx.fillText('STAGE', PF_W / 2, 4);
       ctx.fillStyle = '#ffd84a';
-      ctx.fillText('1-1', PF_W / 2, 12);
+      const stageSet = latestSnap.stageSet ?? 1;
+      const stageNum = latestSnap.stageNum ?? 1;
+      ctx.fillText(stageSet + '-' + stageNum, PF_W / 2, 12);
 
       // LIVES — shared respawn-pool counter, right-aligned. "—" if
       // an older snapshot omits the field. The value flashes brighter

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -112,7 +112,14 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        piercer (tunnels through shields, kills every aligned
 //        invader). New wire fields: players[i].combo /
 //        .superAmmo / .chargeSec, bullets[].c.
-const NETCODE_VERSION = 23;
+// v24 — Phase G: stage progression (1-1, 1-2, 1-3, 2-1, ...) advances
+//        on grid clear; "STAGE n-m" announce overlay fades between
+//        waves. UFO bonus enemy spawns 25-45 s apart, points 50/100/
+//        150/300 by screen progress, kill refills the shooter's
+//        super ammo to MAX. Floating score popups ("+30" / "x3 +60"
+//        / UFO bonus) on each kill. New wire fields: stageSet /
+//        stageNum / stageAnnounceIn / ufo / popups.
+const NETCODE_VERSION = 24;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Three SP-parity mechanics. The MP game finally feels like classic Invaders instead of "one round and done".

## Stage progression

- `state.stageSet` + `stageNum` + `stageAnnounceIn`. Labels `"1-1, 1-2, 1-3, 2-1, ..."` (`STAGES_PER_SET = 3`). On grid clear, \`checkStageClear\` bumps the counter, rebuilds the swarm, clears in-flight invader bullets so a leftover can't kill you during the announce, and fires a 2 s "STAGE n-m" overlay.
- Player score / ammo / combo / lives all persist across stages.
- HUD STAGE column now reads the live label (was a "1-1" placeholder).
- \`checkEnd\`'s "every invader dead = won" branch removed — stages are endless until the boss interrupt (Phase H) or a lose condition.

## UFO bonus enemy

- \`state.ufo\` (null off-screen) + \`state.ufoNextSec\` (random 25–45 s between spawns). Spawns at a random edge moving inward, despawns when it exits the opposite edge.
- Player bullet vs UFO: scoring by progress across the screen (\`UFO_SCORES = [50, 100, 150, 300]\`). **Kill refills the shooter's super ammo to MAX** — the strategic reason to interrupt your aim and chase the UFO.
- Charged bullets one-shot it like normal hits.
- Saucer sprite ported verbatim from SP's `drawUfo` (purple body + cyan glints, 6 rects).

## Score popups

- \`state.popups\`: floating "+30" / "x3 +60" text on each invader kill, "+N" gold on UFO kills. `life` ticks down (POPUP_LIFE_SEC = 0.6), drifts upward at 18 PF/s. Filtered to live entries before broadcast.
- Renderer fades by `life / total`. Tiny 5 px font so combo popups stay readable when they stack.

## Wire (NETCODE_VERSION 23 → 24)

Additive:
- `stageSet / stageNum / stageAnnounceIn`
- `ufo: { x, d } | null`
- `popups: [{ x, y, t, c, l }]`

## Deferred

- **UFO warble synth** — SP plays a continuous sine sweep while UFO is on-screen. Skipped here to keep the PR bounded; will land alongside boss BGM in Phase H if we decide to ship audio for it.
- **Per-stage difficulty scaling** — march speed could ramp per set. Keeping current values for now; revisit after kid playtest.

## Test plan

- [ ] Deploy: \`cd ~/Dev/oyster.worktrees/invaders-stages-ufo/infra/oyster-arcade-mp && npx wrangler deploy\` then \`cd ../oyster-arcade-site && npx wrangler deploy\`
- [ ] Hard-refresh \`arcade.oyster.to/invaders-mp/FROG\`
- [ ] **Stage progression**: kill the full grid → 2 s "STAGE 1-2" overlay → fresh swarm. Repeat to see 1-3 → 2-1 etc.
- [ ] **STAGE HUD** reads the live label.
- [ ] **UFO**: wait 25-45 s during play. Purple saucer flies across the top. Shoot it — score jumps + super ammo pip lights back to full + gold "+150" popup.
- [ ] **Popups**: each kill spawns a "+30" / "+20" / "+10" white popup that drifts up and fades. Combo kills show "x2 +60" etc.
- [ ] \`?debug\` netcode badge says **v24** no mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)