### PR TITLE
arcade(invaders-mp): Phase H (1/2) — boss waves (1 boss type, no cutscene)

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -63,6 +63,16 @@ export interface Ufo {
   dir: 1 | -1;
 }
 
+export interface Boss {
+  x: number;
+  hp: number;
+  hpMax: number;
+  dir: 1 | -1;
+  speed: number;
+  fireAccum: number;
+  fireInterval: number;
+}
+
 export interface GameState {
   status: Status;
   won: boolean;
@@ -74,12 +84,16 @@ export interface GameState {
   invaders: Invader[];
   /** Flat shared shield bitmap; 1 = solid, 0 = chipped. Length = SHIELD_COUNT * SHIELD_W * SHIELD_H. */
   shields: Uint8Array;
-  /** Stage label set (1, 2, 3, …) — boss interrupt arrives in Phase H. */
+  /** Stage label set (1, 2, 3, …). */
   stageSet: number;
-  /** Stage label number within the set (1..STAGES_PER_SET). */
+  /** Stage label number within the set (1..STAGES_PER_SET; sentinel value above means boss wave). */
   stageNum: number;
-  /** Seconds remaining of the "STAGE n-m" overlay between waves. */
+  /** Seconds remaining of the "STAGE n-m" / "STAGE n-BOSS" overlay between waves. */
   stageAnnounceIn: number;
+  /** 'grid' during normal waves; 'boss' during a boss interrupt. */
+  phase: 'grid' | 'boss';
+  /** Active boss entity while phase === 'boss'; null otherwise. */
+  boss: Boss | null;
   /** Bonus UFO when on-screen; null when between spawns. */
   ufo: Ufo | null;
   /** Seconds until the next UFO spawns. */
@@ -133,6 +147,10 @@ export interface WireSnapshot {
   ufo: { x: number; d: 1 | -1 } | null;
   /** Floating score popups; client renders + fades by `l` / POPUP_LIFE_SEC. */
   popups: Array<{ x: number; y: number; t: string; c: string; l: number }>;
+  /** 'grid' during normal waves; 'boss' during a boss interrupt. */
+  phase: 'grid' | 'boss';
+  /** Active boss for the renderer; null between bosses. */
+  boss: { x: number; hp: number; hpMax: number } | null;
   /**
    * Per-seat occupancy. Set by the transport layer (room.ts on the
    * server, hostTick on the client) after snapshotForClient returns,
@@ -170,6 +188,9 @@ export const CHARGED_BULLET_SPEED: number;
 export const UFO_W_EXPORT: number;
 export const UFO_H_EXPORT: number;
 export const UFO_Y_EXPORT: number;
+export const BOSS_W: number;
+export const BOSS_H: number;
+export const BOSS_Y: number;
 export function comboMultiplier(count: number): number;
 
 export const SEATS: readonly Seat[];

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -132,13 +132,32 @@ function makeShields() {
 }
 
 // === Stages ===
-// Stages are labelled "set-num" (1-1, 1-2, 1-3, 2-1, ...). Endless
-// for now — the boss interrupt every set lands in Phase H. On grid
-// clear we advance the counter, rebuild the swarm, and trigger a
-// 2 s "STAGE n-m" announce overlay. Player state (score, ammo,
-// combo) persists across stages.
+// Stages are labelled "set-num" (1-1, 1-2, 1-3, 1-BOSS, 2-1, ...).
+// After STAGES_PER_SET (3) normal waves the next "stage" is a boss:
+// state.phase flips to 'boss', state.boss spawns, normal swarm
+// stays cleared. Defeat boss → phase back to 'grid', stageSet++,
+// fresh wave. Player state (score, ammo, combo) persists across
+// stages + sets.
 const STAGES_PER_SET = 3;
 const STAGE_ANNOUNCE_SEC = 2;
+
+// === Boss ===
+// Single boss type for Phase H (a chunky 8×8 octopus scaled 5× to
+// 40 PF). Multiple boss types + minion adds + win cutscene deferred
+// to a follow-up. HP, speed, and fire interval all ramp per set so
+// later bosses feel progressively scarier.
+export const BOSS_W = 40;
+export const BOSS_H = 40;
+export const BOSS_Y = 24;                        // sits where the top invader row would
+const BOSS_BASE_HP = 30;                         // ~10 charged hits or 30 normal at set 1
+const BOSS_HP_PER_SET = 15;                      // +15 HP per set
+const BOSS_BASE_SPEED = 38;                      // PF/sec at set 1
+const BOSS_SPEED_PER_SET = 12;
+const BOSS_FIRE_INTERVAL_BASE = 1.1;             // seconds at set 1
+const BOSS_FIRE_INTERVAL_MIN = 0.38;             // floor — fastest possible
+const BOSS_FIRE_INTERVAL_STEP = 0.2;             // shrinks per set
+const BOSS_HIT_SCORE = 50;                       // points per damaging hit
+const BOSS_DEFEAT_SCORE = 500;                   // bonus on kill
 
 // === UFO ===
 // Bonus enemy that flies across the top of the playfield occasionally.
@@ -270,10 +289,15 @@ export function initState() {
     shields: makeShields(),
     // Stage progression (Phase G). stageSet 1..∞, stageNum 1..3,
     // labelled "1-1" / "1-2" / ... by the renderer. announceIn counts
-    // down a brief "STAGE n-m" overlay fade after each wave clear.
+    // down a brief "STAGE n-m" / "STAGE n-BOSS" overlay fade after
+    // each wave clear. phase distinguishes the normal grid wave from
+    // a boss interrupt — boss waves spawn after STAGES_PER_SET normal
+    // stages clear. state.boss is null between bosses.
     stageSet: 1,
     stageNum: 1,
     stageAnnounceIn: 0,
+    phase: 'grid',                        // 'grid' | 'boss'
+    boss: null,
     // UFO bonus enemy. ufo is null when off-screen; ufoNextSec ticks
     // down the time until the next spawn (randomised on each despawn).
     ufo: null,
@@ -328,8 +352,15 @@ export function step(state, inputs, dt, occupied = ALL_OCCUPIED) {
   tickStageAnnounce(state, dt);
   stepShips(state, inputs, dt, occupied);
   stepBullets(state, dt);
-  stepInvaders(state, dt);
-  stepInvaderFire(state, dt);
+  // During a boss wave the normal swarm logic stays dormant — invaders
+  // array is empty so stepInvaders + stepInvaderFire short-circuit.
+  // stepBoss takes over movement + fire from the single boss entity.
+  if (state.phase === 'boss') {
+    stepBoss(state, dt);
+  } else {
+    stepInvaders(state, dt);
+    stepInvaderFire(state, dt);
+  }
   stepUfo(state, dt);
   stepPopups(state, dt);
   resolveCollisions(state, occupied);
@@ -370,18 +401,80 @@ function stepPopups(state, dt) {
   state.popups = state.popups.filter(p => p.life > 0);
 }
 
-// Called after resolveCollisions. If every invader is dead the wave
-// is over — bump the stage counter, rebuild the grid, fire the
-// announce overlay. Player state (score, ammo, combo, lives) carries
-// forward. Bullets persist (they'll fly through to no-op) and
-// invaderBullets are cleared so a leftover doesn't reach the ship
-// during the announce. UFO + popups stay too.
+function spawnBoss(setNum) {
+  const hp = BOSS_BASE_HP + (setNum - 1) * BOSS_HP_PER_SET;
+  return {
+    x: PF_W / 2 - BOSS_W / 2,
+    hp,
+    hpMax: hp,
+    dir: 1,
+    speed: BOSS_BASE_SPEED + (setNum - 1) * BOSS_SPEED_PER_SET,
+    fireAccum: 0,
+    fireInterval: Math.max(
+      BOSS_FIRE_INTERVAL_MIN,
+      BOSS_FIRE_INTERVAL_BASE - (setNum - 1) * BOSS_FIRE_INTERVAL_STEP,
+    ),
+  };
+}
+
+// Boss tick: horizontal bounce + periodic fire from centre-bottom.
+// No vertical descent — the boss stays parked at BOSS_Y and applies
+// pressure via bullets instead of swarm-pushdown.
+function stepBoss(state, dt) {
+  if (state.phase !== 'boss' || !state.boss) return;
+  const b = state.boss;
+  b.x += b.speed * b.dir * dt;
+  // 8 PF wall padding gives a satisfying back-and-forth instead of
+  // edge-grinding.
+  if (b.x < 8)                  { b.x = 8;                  b.dir = 1;  }
+  if (b.x > PF_W - 8 - BOSS_W)  { b.x = PF_W - 8 - BOSS_W;  b.dir = -1; }
+  b.fireAccum += dt;
+  if (b.fireAccum >= b.fireInterval) {
+    b.fireAccum = 0;
+    state.invaderBullets.push({
+      x: b.x + BOSS_W / 2 - BULLET_W / 2,
+      y: BOSS_Y + BOSS_H,
+      owner: null,
+    });
+  }
+}
+
+// Called after resolveCollisions. Two clear paths:
+//   - phase 'grid', grid empty: bump stage counter. If we just
+//     cleared the STAGES_PER_SET'th normal wave, the next "stage"
+//     is the boss — phase flips and we spawn it. Otherwise it's
+//     the next normal wave.
+//   - phase 'boss', boss.hp <= 0: defeat. stageSet++, phase back
+//     to 'grid', wave 1 spawns. Player keeps everything.
+// Player state (score, ammo, combo, lives) carries forward through
+// both transitions. Bullets persist; invaderBullets clear so a
+// leftover doesn't kill anyone during the announce.
 function checkStageClear(state) {
+  if (state.phase === 'boss') {
+    if (!state.boss || state.boss.hp > 0) return;
+    state.phase = 'grid';
+    state.boss = null;
+    state.stageSet += 1;
+    state.stageNum = 1;
+    state.invaders = buildGrid();
+    state.invaderDir = 1;
+    state.invaderDropRemaining = 0;
+    state.invaderFireAccum = 0;
+    state.invaderBullets = [];
+    state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
+    return;
+  }
   if (state.invaders.some(i => i.alive)) return;
   state.stageNum += 1;
   if (state.stageNum > STAGES_PER_SET) {
-    state.stageNum = 1;
-    state.stageSet += 1;
+    // Boss wave instead of another normal wave. stageNum stays at
+    // STAGES_PER_SET + 1 as a sentinel for the renderer's "n-BOSS"
+    // label (also derivable from phase, but explicit is easier).
+    state.phase = 'boss';
+    state.boss = spawnBoss(state.stageSet);
+    state.invaderBullets = [];
+    state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
+    return;
   }
   state.invaders = buildGrid();
   state.invaderDir = 1;
@@ -646,6 +739,47 @@ function resolveCollisions(state, occupied) {
     }
   }
 
+  // Player bullets vs boss. Damage = 1 (normal) or 3 (charged).
+  // Charged bullets still tunnel (don't get consumed) so a sustained
+  // hold of FIRE while standing under the boss can grind it down
+  // fast. Score per damaging hit + bigger bonus on the killing blow.
+  // Damage popup floats off the impact site.
+  if (state.phase === 'boss' && state.boss && state.boss.hp > 0) {
+    const bs = state.boss;
+    for (const b of state.bullets) {
+      const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
+      const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
+      if (b.y < -bh) continue;
+      if (!overlap(b.x, b.y, bw, bh, bs.x, BOSS_Y, BOSS_W, BOSS_H)) continue;
+      const dmg = b.charged ? 3 : 1;
+      bs.hp = Math.max(0, bs.hp - dmg);
+      const owner = b.owner && state.ships[b.owner];
+      if (owner) {
+        owner.score += BOSS_HIT_SCORE;
+        state.popups.push({
+          x: bs.x + BOSS_W / 2,
+          y: BOSS_Y,
+          text: `-${dmg}`,
+          col: '#ff7a7a',
+          life: POPUP_LIFE_SEC,
+        });
+        if (bs.hp === 0) {
+          owner.score += BOSS_DEFEAT_SCORE;
+          state.popups.push({
+            x: bs.x + BOSS_W / 2,
+            y: BOSS_Y + BOSS_H / 2,
+            text: `+${BOSS_DEFEAT_SCORE}`,
+            col: '#ffd84a',
+            life: POPUP_LIFE_SEC * 2,
+          });
+        }
+      }
+      if (!b.charged) { b.y = -999; break; }
+      // charged: keep tunneling — already inflicted damage this tick
+      if (bs.hp === 0) break;
+    }
+  }
+
   // Player bullets vs UFO. Charged bullets one-shot a UFO too. Score
   // is sampled from UFO_SCORES by where the UFO is across the screen
   // — closer to the centre/far edge = higher payout. Kill refills
@@ -856,5 +990,14 @@ export function snapshotForClient(state) {
     popups:         state.popups.map(p => ({
       x: round(p.x), y: round(p.y), t: p.text, c: p.col, l: round(p.life),
     })),
+    // Phase H: boss waves. phase 'grid' for normal stages, 'boss'
+    // while a boss is on-screen. boss carries x + hp + hpMax for the
+    // renderer's sprite + health bar. null between bosses.
+    phase:          state.phase,
+    boss:           state.boss ? {
+      x:    round(state.boss.x),
+      hp:   state.boss.hp,
+      hpMax: state.boss.hpMax,
+    } : null,
   };
 }

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -287,12 +287,13 @@ export function initState() {
     // SHIELD_COUNT bunkers. Bullets chip cells to 0; renderer reads
     // the bitmap directly.
     shields: makeShields(),
-    // Stage progression (Phase G). stageSet 1..∞, stageNum 1..3,
-    // labelled "1-1" / "1-2" / ... by the renderer. announceIn counts
-    // down a brief "STAGE n-m" / "STAGE n-BOSS" overlay fade after
-    // each wave clear. phase distinguishes the normal grid wave from
-    // a boss interrupt — boss waves spawn after STAGES_PER_SET normal
-    // stages clear. state.boss is null between bosses.
+    // Stage progression. stageSet 1..∞. stageNum runs 1..STAGES_PER_SET
+    // for normal waves; it gets bumped to STAGES_PER_SET + 1 as a
+    // sentinel when phase flips to 'boss' (the renderer reads `phase`
+    // for the label, not stageNum, but the bump keeps the counter
+    // monotonic). announceIn counts down a brief "STAGE n-m" /
+    // "STAGE n-BOSS" overlay fade after each wave clear. state.boss
+    // is null between bosses.
     stageSet: 1,
     stageNum: 1,
     stageAnnounceIn: 0,
@@ -747,6 +748,9 @@ function resolveCollisions(state, occupied) {
   if (state.phase === 'boss' && state.boss && state.boss.hp > 0) {
     const bs = state.boss;
     for (const b of state.bullets) {
+      // Stop accepting hits as soon as the boss dies this tick — no
+      // double-kill bonus, no extra popups.
+      if (bs.hp === 0) break;
       const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
       const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
       if (b.y < -bh) continue;
@@ -774,9 +778,11 @@ function resolveCollisions(state, occupied) {
           });
         }
       }
-      if (!b.charged) { b.y = -999; break; }
-      // charged: keep tunneling — already inflicted damage this tick
-      if (bs.hp === 0) break;
+      // Mark normal bullets consumed; charged tunnel through and stay
+      // alive for further targets. Either way: keep iterating other
+      // bullets so multiple players' shots can damage the boss in
+      // the same tick.
+      if (!b.charged) b.y = -999;
     }
   }
 

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -382,6 +382,7 @@
     SUPER_SHOT_MAX, CHARGE_THRESHOLD_SEC,
     CHARGED_BULLET_W, CHARGED_BULLET_H, CHARGED_BULLET_SPEED,
     UFO_W_EXPORT, UFO_H_EXPORT, UFO_Y_EXPORT,
+    BOSS_W, BOSS_H, BOSS_Y,
     comboMultiplier,
     SEATS, MAX_SEATS,
   } = engine;
@@ -390,7 +391,7 @@
   const UFO_W = UFO_W_EXPORT ?? 16;
   const UFO_H = UFO_H_EXPORT ?? 7;
   const UFO_Y = UFO_Y_EXPORT ?? 12;
-  import { ROW_COLORS, spriteForRow, paintPixels, paintShip } from './sprites.js';
+  import { ROW_COLORS, spriteForRow, paintPixels, paintShip, paintBoss } from './sprites.js';
   // Renderer uses INV_COLS to map invader array index → grid row. It
   // happens to equal 11 in the current engine; mirror as a const so a
   // future engine.INV_COLS change forces an audit here rather than
@@ -426,7 +427,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 24;
+  const NETCODE_VERSION = 25;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1582,6 +1583,23 @@
       }
     }
 
+    // Boss — chunky 40×40 octopus + a green→yellow→red HP bar above
+    // it. Same 2-frame animation cadence as the regular swarm (toggle
+    // every 300 ms). HP ratio drives the bar fill colour for a quick
+    // glance read.
+    if (latestSnap.phase === 'boss' && latestSnap.boss) {
+      const bf = Math.floor(performance.now() / 300) & 1;
+      paintBoss(ctx, latestSnap.boss.x, BOSS_Y, 5, bf);
+      const hp = latestSnap.boss.hp;
+      const hpMax = latestSnap.boss.hpMax || 1;
+      const ratio = Math.max(0, Math.min(1, hp / hpMax));
+      const barY = BOSS_Y - 4;
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+      ctx.fillRect(latestSnap.boss.x, barY, BOSS_W, 2);
+      ctx.fillStyle = ratio > 0.6 ? '#6bff8c' : ratio > 0.3 ? '#ffd84a' : '#ff6666';
+      ctx.fillRect(latestSnap.boss.x, barY, BOSS_W * ratio, 2);
+    }
+
     // UFO bonus enemy — saucer silhouette ported from SP's drawUfo.
     // Position is server-authoritative; render straight from the
     // snapshot's ufo.x at the fixed UFO_Y row above the swarm.
@@ -1726,7 +1744,10 @@
       ctx.fillStyle = '#ffd84a';
       const stageSet = latestSnap.stageSet ?? 1;
       const stageNum = latestSnap.stageNum ?? 1;
-      ctx.fillText(stageSet + '-' + stageNum, PF_W / 2, 12);
+      const stageLabel = latestSnap.phase === 'boss'
+        ? stageSet + '-BOSS'
+        : stageSet + '-' + stageNum;
+      ctx.fillText(stageLabel, PF_W / 2, 12);
 
       // LIVES — shared respawn-pool counter, right-aligned. "—" if
       // an older snapshot omits the field. The value flashes brighter

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1683,7 +1683,12 @@
     if ((latestSnap.stageAnnounceIn || 0) > 0) {
       const STAGE_ANNOUNCE_TOTAL = 2;
       const t = Math.min(1, (latestSnap.stageAnnounceIn || 0) / STAGE_ANNOUNCE_TOTAL);
-      const label = 'STAGE ' + (latestSnap.stageSet ?? 1) + '-' + (latestSnap.stageNum ?? 1);
+      // Use the same phase-aware label as the HUD column — otherwise
+      // the overlay reads "STAGE 1-4" while STAGE column shows
+      // "STAGE 1-BOSS" because stageNum is at its sentinel value.
+      const setN = latestSnap.stageSet ?? 1;
+      const numN = latestSnap.stageNum ?? 1;
+      const label = 'STAGE ' + (latestSnap.phase === 'boss' ? setN + '-BOSS' : setN + '-' + numN);
       drawCenteredOverlay(label, `rgba(255, 216, 74, ${t.toFixed(2)})`, 18);
     }
 

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -84,13 +84,13 @@ export const BOSS_FRAMES = [
   ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '..X..X..', '.X.XX.X.', 'X.X..X.X'],
   ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '...XX...', '..X..X..', '.X....X.'],
 ];
-const BOSS_BAND_COLOURS = ['#ff7a7a', '#e05050', '#c0303a'];   // hi / mid / shadow
+const BOSS_BAND_COLORS = ['#ff7a7a', '#e05050', '#c0303a'];   // hi / mid / shadow
 
 export function paintBoss(ctx, x, y, scale, frame) {
   const px = BOSS_FRAMES[frame & 1];
   for (let row = 0; row < px.length; row++) {
     const band = row < 3 ? 0 : (row < 5 ? 1 : 2);
-    ctx.fillStyle = BOSS_BAND_COLOURS[band];
+    ctx.fillStyle = BOSS_BAND_COLORS[band];
     const cells = px[row];
     const py = y + row * scale;
     for (let col = 0; col < cells.length; col++) {

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -74,3 +74,27 @@ export function paintShip(ctx, x, shipY, shipW, color) {
   ctx.fillStyle = '#ffffff';
   ctx.fillRect(x + shipW/2 - 2, shipY - 4,     4,             2); // turret tip
 }
+
+// Boss sprite (Phase H — single CRIMSON OCTOPUS type for now).
+// 8×8 source painted at scale 5 → 40×40 PF. Two-frame animation
+// toggles every ~300 ms in the renderer. Body uses a 3-band gradient
+// (top=highlight, middle=mid red, bottom=deep red) so the chunky
+// silhouette reads with some depth instead of as a flat blob.
+export const BOSS_FRAMES = [
+  ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '..X..X..', '.X.XX.X.', 'X.X..X.X'],
+  ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '...XX...', '..X..X..', '.X....X.'],
+];
+const BOSS_BAND_COLOURS = ['#ff7a7a', '#e05050', '#c0303a'];   // hi / mid / shadow
+
+export function paintBoss(ctx, x, y, scale, frame) {
+  const px = BOSS_FRAMES[frame & 1];
+  for (let row = 0; row < px.length; row++) {
+    const band = row < 3 ? 0 : (row < 5 ? 1 : 2);
+    ctx.fillStyle = BOSS_BAND_COLOURS[band];
+    const cells = px[row];
+    const py = y + row * scale;
+    for (let col = 0; col < cells.length; col++) {
+      if (cells[col] === 'X') ctx.fillRect(x + col * scale, py, scale, scale);
+    }
+  }
+}

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -119,7 +119,15 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        super ammo to MAX. Floating score popups ("+30" / "x3 +60"
 //        / UFO bonus) on each kill. New wire fields: stageSet /
 //        stageNum / stageAnnounceIn / ufo / popups.
-const NETCODE_VERSION = 24;
+// v25 — Phase H (1/2): boss waves. After STAGES_PER_SET normal
+//        stages, the next "stage" is a boss instead — phase flips to
+//        'boss', a chunky 40×40 octopus spawns at the top, HP ramps
+//        per set (30 + 15*set). Normal bullets deal 1 dmg, charged
+//        deal 3 (and tunnel). Defeat → phase back to 'grid', stageSet
+//        +1, fresh wave at n-1. STAGE label shows "n-BOSS" during
+//        the fight. Multiple boss types + minion adds + win cutscene
+//        deferred to Phase H/2. New wire fields: phase / boss.
+const NETCODE_VERSION = 25;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

After 3 normal stages each set, the next "stage" is a chunky boss interrupt instead of another grid. STAGE label reads `n-BOSS`. Defeat the boss → advance to the next set's wave 1.

**Scoped tight on purpose** — one boss type, no minion adds, no win cutscene. Will follow up with Phase H/2 if/when you want more.

## Engine

- `state.phase: 'grid' | 'boss'`. `state.boss` is `null` between bosses.
- `spawnBoss(setNum)` ramps difficulty: HP `30 + 15*set`, speed `38 + 12*set`, fire interval `1.1 → 0.38 s` floor. Set 1 = ~30 normal hits or ~10 charged.
- `stepBoss`: horizontal wall-bounce at top, periodic fire via existing `invaderBullets`. No descent — boss applies pressure with bullets, not push-down.
- `checkStageClear` extends Phase G: 3rd wave clear → phase flips to `'boss'` + `spawnBoss(stageSet)`. Boss HP 0 → phase back to `'grid'`, `stageSet++`, fresh wave at `n-1`.
- `resolveCollisions`: player bullet vs boss = 1 dmg normal, **3 dmg charged** (and charged tunnels for extra hits). +50 score per damaging hit, +500 on the killing blow. Red `-N` popup on hit, gold `+500` on kill.

## Wire (NETCODE_VERSION 24 → 25)

Additive:
- `phase: 'grid' | 'boss'`
- `boss: { x, hp, hpMax } | null`

## Client

- `paintBoss` helper in `sprites.js`: 8×8 source painted at scale 5 (40×40 PF), 2-frame anim (300 ms toggle), 3-band red gradient.
- HP bar above the boss — green/yellow/red by ratio.
- STAGE HUD reads `n-BOSS` during the fight, else `n-m`.

## Deferred (follow-up Phase H/2)

- 3 other boss types (VIOLET CRAB, AZURE SQUID, JADE SKULL) — sprites + colour bands
- Boss minion adds (the diving small enemies that flank the boss)
- Win cutscene + finite end condition (right now sets cycle endlessly)
- Boss BGM

## Test plan

- [ ] Deploy: \`cd ~/Dev/oyster.worktrees/invaders-bosses/infra/oyster-arcade-mp && npx wrangler deploy\` then \`cd ../oyster-arcade-site && npx wrangler deploy\`
- [ ] Hard-refresh `arcade.oyster.to/invaders-mp/FROG`
- [ ] Play through 3 normal stages (1-1, 1-2, 1-3) — easiest with charged shots
- [ ] After 1-3 clears, "STAGE 1-BOSS" overlay fades in, the octopus boss spawns at top
- [ ] Boss moves back and forth, fires periodically down the centre
- [ ] Shoot it: green→yellow→red HP bar above the boss drops, red `-1` / `-3` popups float off
- [ ] Defeat it → gold `+500` popup, "STAGE 2-1" overlay, fresh swarm spawns
- [ ] Reach 2-BOSS — same boss, more HP, faster, fires more often
- [ ] `?debug` netcode badge says **v25**

🤖 Generated with [Claude Code](https://claude.com/claude-code)