### PR TITLE
arcade: shared splash/attract lifecycle + Space Jumper attract mode & title

### DIFF
--- a/docs/arcade/shared/initials.js
+++ b/docs/arcade/shared/initials.js
@@ -129,13 +129,15 @@
       else if (e.key === 'ArrowRight') act = 'slot-next';
       else if (e.key === 'Enter' || e.key === ' ') act = 'advance';
       // Game-supplied extra bindings (e.g. Space Jumper maps W/S to letter prev/next).
-      else if (opts.extraKeys) {
+      if (!act && opts.extraKeys) {
         for (const [a, keys] of Object.entries(opts.extraKeys)) {
           if (keys.includes(e.key)) { act = a; break; }
         }
       }
-      else if (e.key.length === 1) {
-        // Type-a-letter shortcut — jump to the typed char + auto-advance.
+      // Type-a-letter shortcut — jump to the typed char + auto-advance. Runs as
+      // a fallback AFTER extraKeys (not instead of it), so typing any letter
+      // works even in games that bind W/S to letter prev/next.
+      if (!act && e.key.length === 1) {
         const c = e.key.toUpperCase();
         const idx = opts.charset.indexOf(c);
         if (idx >= 0) {

--- a/docs/arcade/shared/splash.js
+++ b/docs/arcade/shared/splash.js
@@ -55,6 +55,9 @@
   let phase = 'booting';   // 'booting' | 'title' | 'playing'
   let views = [];
   let viewIdx = 0;
+  let ignoreUntil = 0;     // swallow dismiss input briefly after a transition
+
+  const arm = () => { ignoreUntil = Date.now() + cfg.graceMs; };
 
   const q = sel => (sel ? document.querySelector(sel) : null);
   const safe = fn => { if (typeof fn === 'function') { try { fn(); } catch (e) { console.warn('Arcade.Splash hook threw:', e); } } };
@@ -73,6 +76,7 @@
 
   function enterTitle(startIdx) {
     phase = 'title';
+    arm();   // ignore the input that brought us here (e.g. the initials save)
     const splash = q(cfg.splash), tube = q(cfg.tube), boot = q(cfg.boot);
     if (splash) splash.classList.remove('is-hidden');
     if (tube)   tube.classList.remove('is-ready');
@@ -83,6 +87,7 @@
   }
   function enterPlay() {
     phase = 'playing';
+    arm();
     stopCycle();
     const splash = q(cfg.splash), tube = q(cfg.tube);
     if (splash) splash.classList.add('is-hidden');
@@ -95,7 +100,9 @@
   // title card, start the game.
   function tryDismiss() {
     if (phase !== 'title') return;
+    if (Date.now() < ignoreUntil) return;     // grace: ignore the transition input + its paired click
     if (cfg.isBusy && cfg.isBusy()) return;
+    arm();                                     // and ignore the next rapid repeat (touchstart→click)
     safe(cfg.unlockAudio);
     if (views.length > 1 && viewIdx === cfg.leaderboardIndex) {
       stopCycle();
@@ -109,6 +116,7 @@
     cfg = Object.assign({
       splash: '#splash', tube: '.tube', views: '#splash .splash-view',
       boot: null, titleIndex: 0, leaderboardIndex: 1, cycleMs: 5500, bootMs: 0,
+      graceMs: 450,   // ignore dismiss input for this long after a transition
       ignore: null,   // CSS selector for taps that must NOT start (e.g. sound toggles)
       onTitle: null, onPlay: null, onLeaderboardShow: null, unlockAudio: null, isBusy: null,
     }, opts || {});

--- a/docs/arcade/shared/splash.js
+++ b/docs/arcade/shared/splash.js
@@ -1,33 +1,36 @@
-// Shared SPLASH-view auto-cycler.
+// Shared SPLASH controller — view-cycler + full attract-mode lifecycle.
 //
-// Most arcade games' splash screens cycle between two or more "views"
-// (e.g. title-card ↔ leaderboard) every few seconds for marquee effect.
-// The cycler is the same in every game: query a NodeList of .splash-view
-// elements, toggle .is-active around the active index on an interval,
-// and let the game decide what to repaint when a particular view comes
-// into focus (e.g. refresh the leaderboard list).
+// Two layers:
 //
-// Usage (each game):
-//   <link rel="stylesheet" href="../shared/splash.css">    // .splash-view rules
-//   <script src="../shared/splash.js"></script>
+//   1. startCycle()/stopCycle() — the low-level title↔leaderboard auto-cycler
+//      (toggle .is-active across .splash-view elements on an interval). Kept
+//      for games that only want the marquee and drive their own start/restart.
 //
-//   Arcade.Splash.startCycle({
-//     viewsSelector: '#splash .splash-view',
-//     intervalMs:    5500,
-//     onShow(view, idx) {
-//       if (view.classList.contains('leaderboard')) paintLeaderboard();
-//     },
+//   2. mount() — the full cabinet lifecycle: booting → title → playing →
+//      attract → title … It owns the cycle, the "tap to start" dismiss, the
+//      per-view click handling (leaderboard view → advance to title; title →
+//      start), and re-entry to attract mode after a game. Each game configures
+//      it declaratively and supplies a few hooks; the bespoke ~150-line splash
+//      controllers in the games collapse to one mount() call.
+//
+//   Arcade.Splash.mount({
+//     splash: '#splash', tube: '.tube', views: '#splash .splash-view',
+//     titleIndex: 0, leaderboardIndex: 1, cycleMs: 5500, bootMs: 0,
+//     onTitle()           { /* title music on, game music off */ },
+//     onPlay()            { /* game music on, resetRun(), go live */ },
+//     onLeaderboardShow() { /* repaint the leaderboard list */ },
+//     unlockAudio()       { /* iOS: first title gesture unlocks audio */ },
+//     isBusy: () => Arcade.Initials.isActive(),   // suppress dismiss
 //   });
-//
-//   // ...when the player launches a run:
-//   Arcade.Splash.stopCycle();
-//
-// Calling startCycle() again automatically stops any prior interval, so
-// it's safe to invoke unconditionally on splash mount.
+//   // ...on game-over / after initials submit:
+//   Arcade.Splash.enterAttract();
+//   // ...in the game loop:
+//   if (!Arcade.Splash.isPlaying()) return;   // freeze world on title/attract
 
 (function () {
   let cycleTimer = null;
 
+  // ---- Low-level cycler (also used internally by the lifecycle) -------------
   function startCycle(opts) {
     opts = opts || {};
     stopCycle();
@@ -36,29 +39,118 @@
     const onShow     = typeof opts.onShow === 'function' ? opts.onShow : null;
     const views = document.querySelectorAll(sel);
     if (!views.length) return;
-    // Force view[0] active immediately so the module works regardless of
-    // whether the HTML pre-marked any view — and so a stopCycle + new
-    // startCycle reliably resets to the first view.
-    let idx = 0;
-    views.forEach((v, i) => v.classList.toggle('is-active', i === idx));
-    if (onShow) {
-      try { onShow(views[idx], idx); } catch (e) { console.warn('Arcade.Splash onShow threw:', e); }
-    }
-    cycleTimer = setInterval(() => {
-      idx = (idx + 1) % views.length;
+    let idx = opts.startIndex || 0;
+    const show = () => {
       views.forEach((v, i) => v.classList.toggle('is-active', i === idx));
-      if (onShow) {
-        try { onShow(views[idx], idx); } catch (e) { console.warn('Arcade.Splash onShow threw:', e); }
-      }
-    }, intervalMs);
+      if (onShow) { try { onShow(views[idx], idx); } catch (e) { console.warn('Arcade.Splash onShow threw:', e); } }
+    };
+    show();
+    cycleTimer = setInterval(() => { idx = (idx + 1) % views.length; show(); }, intervalMs);
   }
-
-  function stopCycle() {
-    if (cycleTimer) { clearInterval(cycleTimer); cycleTimer = null; }
-  }
-
+  function stopCycle() { if (cycleTimer) { clearInterval(cycleTimer); cycleTimer = null; } }
   function isCycling() { return cycleTimer !== null; }
 
+  // ---- Lifecycle controller -------------------------------------------------
+  let cfg = null;
+  let phase = 'booting';   // 'booting' | 'title' | 'playing'
+  let views = [];
+  let viewIdx = 0;
+
+  const q = sel => (sel ? document.querySelector(sel) : null);
+  const safe = fn => { if (typeof fn === 'function') { try { fn(); } catch (e) { console.warn('Arcade.Splash hook threw:', e); } } };
+
+  function setView(i) {
+    if (!views.length) return;
+    viewIdx = i;
+    views.forEach((v, k) => v.classList.toggle('is-active', k === i));
+    if (i === cfg.leaderboardIndex) safe(cfg.onLeaderboardShow);
+  }
+  function cycleFrom(startIdx) {
+    stopCycle();
+    setView(startIdx);
+    cycleTimer = setInterval(() => setView((viewIdx + 1) % views.length), cfg.cycleMs);
+  }
+
+  function enterTitle(startIdx) {
+    phase = 'title';
+    const splash = q(cfg.splash), tube = q(cfg.tube), boot = q(cfg.boot);
+    if (splash) splash.classList.remove('is-hidden');
+    if (tube)   tube.classList.remove('is-ready');
+    document.body.classList.remove('is-ingame');
+    if (boot) boot.style.display = 'none';
+    cycleFrom(startIdx);
+    safe(cfg.onTitle);
+  }
+  function enterPlay() {
+    phase = 'playing';
+    stopCycle();
+    const splash = q(cfg.splash), tube = q(cfg.tube);
+    if (splash) splash.classList.add('is-hidden');
+    if (tube)   tube.classList.add('is-ready');
+    document.body.classList.add('is-ingame');
+    safe(cfg.onPlay);
+  }
+  // A key/tap while the splash is up: on the leaderboard view, advance to the
+  // title card (and freeze the cycle — the player is in control now); on the
+  // title card, start the game.
+  function tryDismiss() {
+    if (phase !== 'title') return;
+    if (cfg.isBusy && cfg.isBusy()) return;
+    safe(cfg.unlockAudio);
+    if (views.length > 1 && viewIdx === cfg.leaderboardIndex) {
+      stopCycle();
+      setView(cfg.titleIndex);
+      return;
+    }
+    enterPlay();
+  }
+
+  function mount(opts) {
+    cfg = Object.assign({
+      splash: '#splash', tube: '.tube', views: '#splash .splash-view',
+      boot: null, titleIndex: 0, leaderboardIndex: 1, cycleMs: 5500, bootMs: 0,
+      ignore: null,   // CSS selector for taps that must NOT start (e.g. sound toggles)
+      onTitle: null, onPlay: null, onLeaderboardShow: null, unlockAudio: null, isBusy: null,
+    }, opts || {});
+    views = Array.prototype.slice.call(document.querySelectorAll(cfg.views));
+    phase = 'booting';
+
+    // A pointer tap dismisses unless it landed on an opted-out control (sound
+    // toggle, etc.). Keyboard can't hit those, so keydown dismisses freely.
+    const onPointer = e => {
+      if (cfg.ignore && e && e.target && e.target.closest && e.target.closest(cfg.ignore)) return;
+      tryDismiss();
+    };
+    window.addEventListener('keydown', e => { if (e.key === 'Escape') return; tryDismiss(); });
+    window.addEventListener('mousedown', onPointer);
+    window.addEventListener('touchstart', onPointer, { passive: true });
+    // Per-view click: window touch can be flaky inside an iframe on iOS, and a
+    // .splash-view only has pointer-events while .is-active, so this fires for
+    // the visible view only.
+    views.forEach(v => v.addEventListener('click', tryDismiss));
+
+    // Boot → title. When embedded in the arcade cabinet the boot art is hidden
+    // via CSS, so go straight to title (otherwise early taps are ignored). A
+    // zero delay resolves synchronously so the title is interactive at once.
+    const embedded = document.documentElement.classList.contains('is-arcade-embedded');
+    const delay = embedded ? 0 : (cfg.bootMs || 0);
+    if (delay <= 0) enterTitle(cfg.titleIndex);
+    else setTimeout(() => { if (phase === 'booting') enterTitle(cfg.titleIndex); }, delay);
+  }
+
+  // Re-show the splash after a game — start on the leaderboard so the player
+  // sees the score, then cycle back to the title card.
+  function enterAttract() {
+    if (!cfg) return;
+    enterTitle(cfg.leaderboardIndex);
+  }
+
   window.Arcade = window.Arcade || {};
-  window.Arcade.Splash = { startCycle, stopCycle, isCycling };
+  window.Arcade.Splash = {
+    startCycle, stopCycle, isCycling,
+    mount, enterAttract,
+    isPlaying: () => phase === 'playing',
+    isTitle:   () => phase === 'title',
+    start:     () => { if (phase === 'title') enterPlay(); },
+  };
 })();

--- a/docs/arcade/shared/splash.test.cjs
+++ b/docs/arcade/shared/splash.test.cjs
@@ -1,0 +1,111 @@
+// Tests for Arcade.Splash.mount() lifecycle — run with `node splash.test.cjs`.
+// Loads the real shared/splash.js into a minimal DOM stub and drives the
+// boot → title → playing → attract → title transitions.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function makeEl() {
+  return {
+    style: {}, _clicks: [],
+    classList: {
+      _s: new Set(),
+      add(c) { this._s.add(c); }, remove(c) { this._s.delete(c); },
+      toggle(c, on) { if (on) this._s.add(c); else this._s.delete(c); },
+      contains(c) { return this._s.has(c); },
+    },
+    addEventListener(t, fn) { if (t === 'click') this._clicks.push(fn); },
+    click() { this._clicks.slice().forEach(fn => fn({ preventDefault() {} })); },
+  };
+}
+
+const splashEl = makeEl(), tubeEl = makeEl(), bodyEl = makeEl(), docEl = makeEl();
+const view0 = makeEl(), view1 = makeEl();
+
+const winL = {};
+function fireWin(type, props = {}) {
+  const e = { type, preventDefault() {}, ...props };
+  (winL[type] || []).slice().forEach(fn => fn(e));
+}
+
+const sandbox = {
+  console,
+  setTimeout, clearTimeout, setInterval, clearInterval,
+  addEventListener:    (t, fn) => { (winL[t] = winL[t] || []).push(fn); },
+  removeEventListener: (t, fn) => { if (winL[t]) winL[t] = winL[t].filter(f => f !== fn); },
+  document: {
+    body: bodyEl,
+    documentElement: docEl,
+    querySelector(sel) { return sel === '#splash' ? splashEl : sel === '.tube' ? tubeEl : null; },
+    querySelectorAll() { return [view0, view1]; },
+    addEventListener() {},
+  },
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(__dirname, 'splash.js'), 'utf8'), sandbox);
+const S = sandbox.Arcade.Splash;
+
+const hits = { title: 0, play: 0, lb: 0, unlock: 0 };
+let busy = false;
+S.mount({
+  cycleMs: 999999,   // keep the interval from firing during the test
+  onTitle:  () => hits.title++,
+  onPlay:   () => hits.play++,
+  onLeaderboardShow: () => hits.lb++,
+  unlockAudio: () => hits.unlock++,
+  isBusy: () => busy,
+});
+
+let failures = 0;
+function check(label, got, want) {
+  const ok = got === want;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  if (!ok) failures++;
+}
+
+// boot (bootMs 0) resolves synchronously to title
+check('boots straight to title', S.isTitle(), true);
+check('not playing at title', S.isPlaying(), false);
+check('onTitle fired on boot', hits.title, 1);
+check('title view active', view0.classList.contains('is-active'), true);
+
+// ESC must NOT dismiss
+fireWin('keydown', { key: 'Escape' });
+check('ESC does not start', S.isPlaying(), false);
+
+// isBusy suppresses dismiss (e.g. initials open)
+busy = true;
+fireWin('keydown', { key: ' ' });
+check('busy suppresses start', S.isPlaying(), false);
+busy = false;
+
+// a tap on the title card starts the game
+fireWin('keydown', { key: ' ' });
+check('title tap -> playing', S.isPlaying(), true);
+check('onPlay fired', hits.play, 1);
+check('unlockAudio fired on gesture', hits.unlock, 1);
+check('splash hidden on play', splashEl.classList.contains('is-hidden'), true);
+check('tube ready on play', tubeEl.classList.contains('is-ready'), true);
+
+// game over -> attract: re-shows splash starting on the leaderboard view
+S.enterAttract();
+check('attract -> title phase', S.isTitle(), true);
+check('attract -> not playing', S.isPlaying(), false);
+check('attract starts on leaderboard view', view1.classList.contains('is-active'), true);
+check('onLeaderboardShow fired in attract', hits.lb >= 1, true);
+check('splash re-shown in attract', splashEl.classList.contains('is-hidden'), false);
+
+// on the leaderboard view, a tap advances to the title card (does NOT start)
+fireWin('keydown', { key: ' ' });
+check('leaderboard tap -> title card (not playing)', S.isPlaying(), false);
+check('advanced to title view', view0.classList.contains('is-active'), true);
+
+// now on the title card, a tap starts a fresh game
+fireWin('keydown', { key: ' ' });
+check('title tap after attract -> playing', S.isPlaying(), true);
+
+S.stopCycle();
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/docs/arcade/shared/splash.test.cjs
+++ b/docs/arcade/shared/splash.test.cjs
@@ -51,6 +51,7 @@ const hits = { title: 0, play: 0, lb: 0, unlock: 0 };
 let busy = false;
 S.mount({
   cycleMs: 999999,   // keep the interval from firing during the test
+  graceMs: 0,        // no transition grace — these checks fire input synchronously
   onTitle:  () => hits.title++,
   onPlay:   () => hits.play++,
   onLeaderboardShow: () => hits.lb++,
@@ -107,5 +108,15 @@ fireWin('keydown', { key: ' ' });
 check('title tap after attract -> playing', S.isPlaying(), true);
 
 S.stopCycle();
+
+// Grace window: the input that triggers a transition (and its paired
+// touchstart→click) must NOT immediately dismiss the freshly-shown splash —
+// otherwise saving initials bleeds straight into starting a new game.
+Object.keys(winL).forEach(k => delete winL[k]);   // drop the first mount's listeners
+S.mount({ cycleMs: 999999, graceMs: 10000, onTitle: () => {}, onPlay: () => {} });
+fireWin('keydown', { key: ' ' });   // arrives within the grace window
+check('grace: input right after a transition is ignored', S.isPlaying(), false);
+S.stopCycle();
+
 console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/docs/arcade/shared/splash.test.cjs
+++ b/docs/arcade/shared/splash.test.cjs
@@ -112,7 +112,10 @@ S.stopCycle();
 // Grace window: the input that triggers a transition (and its paired
 // touchstart→click) must NOT immediately dismiss the freshly-shown splash —
 // otherwise saving initials bleeds straight into starting a new game.
-Object.keys(winL).forEach(k => delete winL[k]);   // drop the first mount's listeners
+// Fully reset listeners from the first mount before remounting: window
+// listeners AND the per-view click handlers (else this mount duplicates them).
+Object.keys(winL).forEach(k => delete winL[k]);
+view0._clicks.length = 0; view1._clicks.length = 0;
 S.mount({ cycleMs: 999999, graceMs: 10000, onTitle: () => {}, onPlay: () => {} });
 fireWin('keydown', { key: ' ' });   // arrives within the grace window
 check('grace: input right after a transition is ignored', S.isPlaying(), false);

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -40,9 +40,9 @@
     line-height: 1.2;
     color: #ffd84a;
     text-shadow:
-      3px 3px 0 #ff3aa1,
-      6px 6px 0 #2dd4ff,
-      0 0 18px rgba(255, 216, 74, 0.45);
+      2px 2px 0 #ff3aa1,
+      4px 4px 0 #2dd4ff,
+      0 0 24px rgba(255, 216, 74, 0.35);
   }
   /* Splash leaderboard view (title ↔ leaderboard cycle). Palette matches the
      title; can move to shared/ once Invaders + Rocket Ship adopt the shared
@@ -70,6 +70,154 @@
     font-size: clamp(10px, 1.4vw, 12px);
     color: rgba(255, 255, 255, 0.55);
     grid-column: 1 / -1; text-align: center;
+  }
+  /* ── Title scene: Rogers jetpacking through space ──────────────────────
+     A deep-space backdrop behind the splash — nebula glow, twinkling stars, a
+     planet and floating platforms, with Rogers hovering on his jetpack (flame
+     flickering below). Sits behind .splash-main; only ever visible on the
+     title / leaderboard (the whole splash hides in-game). */
+  /* .splash and .splash-main are already position:absolute/inset:0 from
+     shared/splash.css — just lift the content above the scene with z-index;
+     re-positioning them collapses the full-bleed splash (black screen). */
+  .splash .splash-main { z-index: 1; }
+  .sj-scene {
+    position: absolute; inset: 0; z-index: 0; overflow: hidden;
+    background:
+      radial-gradient(120% 70% at 50% 6%,  rgba(124,58,237,.35), transparent 60%),
+      radial-gradient(90% 60% at 82% 100%, rgba(45,212,255,.16), transparent 55%),
+      linear-gradient(180deg, #120a33 0%, #0a0626 45%, #050313 100%);
+    box-shadow: inset 0 0 24vmin rgba(0,0,0,.55);   /* vignette to frame the scene */
+  }
+  .sj-scene .sj-stars {
+    position: absolute; inset: 0;
+    background-image:
+      radial-gradient(1.5px 1.5px at 18% 22%, #fff, transparent),
+      radial-gradient(1.5px 1.5px at 72% 16%, #cfe7ff, transparent),
+      radial-gradient(1px 1px at 41% 38%, #fff, transparent),
+      radial-gradient(1.5px 1.5px at 86% 30%, #fff, transparent),
+      radial-gradient(1px 1px at 56% 10%, #aad4ff, transparent),
+      radial-gradient(1px 1px at 9% 46%, #fff, transparent),
+      radial-gradient(1.5px 1.5px at 92% 8%, #fff, transparent),
+      radial-gradient(1px 1px at 31% 7%, #cfe7ff, transparent),
+      radial-gradient(1px 1px at 64% 34%, #fff, transparent),
+      radial-gradient(1px 1px at 24% 66%, #fff, transparent),
+      radial-gradient(1.5px 1.5px at 78% 58%, #cfe7ff, transparent);
+    animation: sj-twinkle 3.6s ease-in-out infinite;
+  }
+  /* Distant planet, lower-left, partly off-screen. */
+  .sj-scene .sj-planet {
+    position: absolute; left: -8vmin; bottom: -12vmin;
+    width: 40vmin; height: 40vmin; border-radius: 50%; overflow: hidden;
+    background:
+      radial-gradient(circle at 29% 25%, rgba(255,255,255,.6) 0%, rgba(255,255,255,0) 15%),    /* specular glint */
+      radial-gradient(ellipse 30% 22% at 64% 46%, rgba(74,52,120,.55), transparent 70%),         /* continent */
+      radial-gradient(ellipse 26% 20% at 42% 72%, rgba(16,34,82,.55), transparent 70%),          /* dark sea */
+      radial-gradient(ellipse 20% 16% at 80% 34%, rgba(120,235,255,.4), transparent 70%),        /* bright patch */
+      radial-gradient(circle at 34% 30%, #9af1ff 0%, #2dd4ff 26%, #4f7be8 60%, #2a2270 100%);     /* base sphere */
+    box-shadow: 0 0 55px rgba(45,212,255,.28), 0 0 14px rgba(154,241,255,.25);
+  }
+  /* Latitudinal cloud bands. */
+  .sj-scene .sj-planet::before {
+    content: ''; position: absolute; inset: -25%;
+    background: repeating-linear-gradient(7deg,
+      transparent 0 6%, rgba(0,0,0,.16) 6% 8.5%,
+      transparent 8.5% 15%, rgba(255,255,255,.07) 15% 17%);
+    mix-blend-mode: soft-light;
+  }
+  /* Terminator shadow + sunlit rim (lit from upper-left). */
+  .sj-scene .sj-planet::after {
+    content: ''; position: absolute; inset: 0; border-radius: 50%;
+    box-shadow:
+      inset -15px -17px 46px rgba(5,3,20,.66),     /* terminator (unlit, lower-right) */
+      inset 12px 14px 26px rgba(190,245,255,.45),  /* sunlit rim (upper-left) */
+      inset 0 0 18px 5px rgba(45,212,255,.22);     /* atmospheric limb glow */
+  }
+  /* Floating pixel platforms (grass-topped, like the game's tiles). */
+  .sj-scene .sj-plat {
+    position: absolute; height: 3vmin; border-radius: 1px;
+    /* grass crown over a dirt body, like the game's tiles */
+    background: linear-gradient(180deg, #4ade80 0 20%, #16a34a 20% 40%, #3b2f1a 40% 100%);
+    box-shadow: inset 0 -0.5vmin 0 rgba(0,0,0,.35), 0 0.5vmin 0 rgba(0,0,0,.45);
+    animation: sj-float 4.5s ease-in-out infinite;
+  }
+  .sj-scene .sj-plat.p1 { width: 16vmin; left: 11%; top: 32%; }
+  .sj-scene .sj-plat.p2 { width: 11vmin; right: 13%; top: 64%; animation-delay: -2.2s; }
+  /* Alien (the game's green critter) perched on the top-left platform; bobs in
+     sync with platform p1 and blinks its antenna tips. */
+  .sj-scene .sj-alien {
+    position: absolute; left: 14.5%; top: 25.5%;   /* feet on platform p1 */
+    width: min(7vw, 5vh); height: auto;
+    image-rendering: pixelated;
+    filter: drop-shadow(0 2px 0 rgba(0,0,0,.4)) drop-shadow(0 0 6px rgba(74,222,128,.4));
+    animation: sj-float 4.5s ease-in-out infinite;
+  }
+  .sj-scene .sj-alien .tip { animation: sj-blink .5s steps(1) infinite; }
+  /* Rogers hovering on his jetpack — inline-SVG sprite + flame, bobbing. */
+  /* Entrance is split across two wrappers so the arc is one smooth, continuous
+     motion (no waypoint judder): .sj-hero eases horizontally into centre while
+     .sj-hero-y shoots up with a slight overshoot — the differing single-bézier
+     curves trace the arc. Both wait (fill backwards) on the platform until the
+     music's ~2.0s drop, then boost over 1.2s. Resting state = on the platform. */
+  .sj-scene .sj-hero {
+    position: absolute; left: 50%; top: 6%;            /* hovers clear above the logo */
+    transform: translateX(-50%) translateX(30vw);      /* platform X */
+  }
+  .sj-scene .sj-hero-y { transform: translateY(52vh) scale(.32); }   /* platform Y + small (relative to the higher hover spot) */
+  .sj-scene.is-go .sj-hero   { animation: sj-boost-x 1.2s cubic-bezier(.25, .55, .2, 1)  1.1s both; }
+  .sj-scene.is-go .sj-hero-y { animation: sj-boost-y 1.2s cubic-bezier(.2, .8, .2, 1.25) 1.1s both; }
+  .sj-scene .sj-hero-bob { display: flex; flex-direction: column; align-items: center; }
+  .sj-scene.is-go .sj-hero-bob { animation: sj-hover 2.4s ease-in-out 2.3s infinite; }
+  .sj-scene .sj-rogers {
+    width: min(17vw, 12vh); height: auto;
+    image-rendering: pixelated;
+    filter: drop-shadow(0 2px 0 rgba(0,0,0,.4)) drop-shadow(0 0 10px rgba(45,212,255,.35));
+  }
+  /* Jetpack exhaust — a broad orange cone with a bright inner core, each
+     flickering at its own rate so it reads as a live thruster. */
+  .sj-scene .sj-flame { position: relative; width: min(7vw, 4.6vh); height: min(13vw, 8vh); margin-top: -2px; transform-origin: 50% 0; opacity: 0; }
+  .sj-scene.is-go .sj-flame { animation: sj-ignite .5s ease-out 1.1s both; }   /* ignites on the launch */
+  .sj-scene .sj-flame span { position: absolute; left: 50%; top: 0; transform: translateX(-50%); transform-origin: 50% 0; }
+  .sj-scene .sj-flame .f-outer {
+    width: 100%; height: 100%;
+    background: linear-gradient(180deg, #ffd84a 0%, #ff8a3c 45%, rgba(255,58,161,0) 100%);
+    clip-path: polygon(50% 100%, 8% 0, 92% 0);
+    filter: drop-shadow(0 0 9px rgba(255,138,60,.8));
+    animation: sj-flame-o .1s steps(2, jump-none) infinite;
+  }
+  .sj-scene .sj-flame .f-inner {
+    width: 52%; height: 72%;
+    background: linear-gradient(180deg, #fffceb 0%, #fff3a8 42%, #ffd84a 100%);
+    clip-path: polygon(50% 100%, 16% 0, 84% 0);
+    animation: sj-flame-i .08s steps(2, jump-none) infinite;
+  }
+  @keyframes sj-twinkle { 0%, 100% { opacity: .55; } 50% { opacity: 1; } }
+  @keyframes sj-hover { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-1.4vh); } }
+  /* Stand on the platform, then swoop up-and-around into the hover spot:
+     launch up the right side, arc up-and-over the top (leaning into it),
+     then settle down into centre. */
+  @keyframes sj-boost-x { to { transform: translateX(-50%) translateX(0); } }
+  @keyframes sj-boost-y { to { transform: translateY(0) scale(1); } }
+  @keyframes sj-ignite { 0% { opacity: 0; transform: scaleY(0); } 100% { opacity: 1; transform: scaleY(1); } }
+  @keyframes sj-float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-1.2vh); } }
+  @keyframes sj-blink { 0%, 49% { fill: #ff3aa1; } 50%, 100% { fill: #7f1d4e; } }
+  @keyframes sj-flame-o { 0% { transform: translateX(-50%) scaleY(1)   scaleX(1);  opacity: 1; }   100% { transform: translateX(-50%) scaleY(.78) scaleX(.86); opacity: .8; } }
+  @keyframes sj-flame-i { 0% { transform: translateX(-50%) scaleY(.92) scaleX(1);  opacity: .95; } 100% { transform: translateX(-50%) scaleY(1.08) scaleX(.88); opacity: 1; } }
+  /* CRT power-on: the title flickers up out of a scanline as the screen lands. */
+  .splash-view.is-active .title { animation: sj-poweron .85s ease-out both; }
+  @keyframes sj-poweron {
+    0%   { opacity: 0; transform: scaleY(.02); filter: brightness(3.5); }
+    45%  { opacity: 1; transform: scaleY(1.1);  filter: brightness(2.4); }
+    65%  { transform: scaleY(.97); }
+    100% { transform: scaleY(1); filter: brightness(1); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sj-scene .sj-stars, .sj-scene .sj-plat, .sj-scene .sj-alien, .sj-scene .sj-alien .tip,
+    .sj-scene .sj-hero, .sj-scene .sj-hero-y, .sj-scene .sj-hero-bob, .sj-scene .sj-flame, .sj-scene .sj-flame span { animation: none; }
+    /* Skip the entrance — show Rogers already at the hover spot, flame lit. */
+    .sj-scene .sj-hero { transform: translateX(-50%); }
+    .sj-scene .sj-hero-y { transform: none; }
+    .sj-scene .sj-flame { opacity: 1; }
+    .splash-view.is-active .title { animation: none; }
   }
   .splash .sound-controls {
     position: absolute;
@@ -167,6 +315,56 @@
       </div>
     </div>
     <div class="splash" id="splash">
+      <div class="sj-scene" aria-hidden="true">
+        <div class="sj-stars"></div>
+        <div class="sj-planet"></div>
+        <div class="sj-plat p1"></div>
+        <div class="sj-plat p2"></div>
+        <svg class="sj-alien" viewBox="0 0 10 10" shape-rendering="crispEdges" aria-hidden="true">
+          <rect class="tip" x="1" y="0" width="2" height="1" fill="#ff3aa1"/>
+          <rect class="tip" x="7" y="0" width="2" height="1" fill="#ff3aa1"/>
+          <rect x="2" y="1" width="1" height="2" fill="#22c55e"/>
+          <rect x="7" y="1" width="1" height="2" fill="#22c55e"/>
+          <rect x="2" y="3" width="6" height="1" fill="#4ade80"/>
+          <rect x="1" y="4" width="8" height="3" fill="#4ade80"/>
+          <rect x="1" y="6" width="8" height="1" fill="#16a34a"/>
+          <rect x="2" y="4" width="2" height="2" fill="#0a0a14"/>
+          <rect x="6" y="4" width="2" height="2" fill="#0a0a14"/>
+          <rect x="3" y="4" width="1" height="1" fill="#fff"/>
+          <rect x="7" y="4" width="1" height="1" fill="#fff"/>
+          <rect x="2" y="7" width="6" height="2" fill="#22c55e"/>
+          <rect x="4" y="6" width="2" height="1" fill="#0a0a14"/>
+          <rect x="1" y="9" width="3" height="1" fill="#0f5132"/>
+          <rect x="6" y="9" width="3" height="1" fill="#0f5132"/>
+        </svg>
+        <div class="sj-hero">
+          <div class="sj-hero-y">
+          <div class="sj-hero-bob">
+          <svg class="sj-rogers" viewBox="0 0 10 13" shape-rendering="crispEdges" aria-hidden="true">
+            <rect x="2" y="0" width="6" height="2" fill="#a855f7"/>
+            <rect x="1" y="2" width="8" height="1" fill="#a855f7"/>
+            <rect x="7" y="3" width="2" height="1" fill="#a855f7"/>
+            <rect x="2" y="3" width="6" height="3" fill="#ffd6c8"/>
+            <rect x="6" y="4" width="2" height="1" fill="#0a0a0a"/>
+            <rect x="3" y="6" width="3" height="1" fill="#0a0a0a"/>
+            <rect x="2" y="7" width="6" height="3" fill="#ff3aa1"/>
+            <rect x="2" y="7" width="6" height="1" fill="#c92670"/>
+            <rect x="0" y="7" width="2" height="2" fill="#c92670"/>
+            <rect x="8" y="7" width="2" height="2" fill="#c92670"/>
+            <rect x="0" y="9" width="2" height="1" fill="#ffd6c8"/>
+            <rect x="8" y="9" width="2" height="1" fill="#ffd6c8"/>
+            <rect x="2" y="9" width="6" height="1" fill="#ffd84a"/>
+            <rect x="4" y="9" width="2" height="1" fill="#c79b00"/>
+            <rect x="2" y="10" width="2" height="3" fill="#2dd4ff"/>
+            <rect x="6" y="10" width="2" height="3" fill="#2dd4ff"/>
+            <rect x="1" y="12" width="3" height="1" fill="#0a0a0a"/>
+            <rect x="6" y="12" width="3" height="1" fill="#0a0a0a"/>
+          </svg>
+          <div class="sj-flame"><span class="f-outer"></span><span class="f-inner"></span></div>
+          </div>
+          </div>
+        </div>
+      </div>
       <div class="splash-main">
         <div class="title-card splash-view is-active">
           <div class="title">SPACE JUMPER</div>
@@ -430,6 +628,19 @@ function hideEndOverlay() {
 const _bgm      = () => document.getElementById('bgm');        // level music
 const _bgmTheme = () => document.getElementById('bgm-theme');  // title theme
 
+// (Re)start the title intro animation in lockstep with the theme. The track
+// fades in over its first ~2s then explodes into the main hook at ~2.0s, so
+// the CSS entrance (.is-go) holds Rogers on the platform until then and boosts
+// on the drop. Called from onTitle right beside play() so the two start
+// together; the class toggle + reflow restarts the keyframes on attract re-entry.
+function runTitleSequence() {
+  const s = document.querySelector('.sj-scene');
+  if (!s) return;
+  s.classList.remove('is-go');
+  void s.offsetWidth;
+  s.classList.add('is-go');
+}
+
 Arcade.Splash.mount({
   views:  '#splash .splash-view',
   ignore: '.sound-controls',                 // taps on the sound toggles don't start
@@ -437,6 +648,7 @@ Arcade.Splash.mount({
   onTitle() {
     const b = _bgm();      if (b) { b.pause(); b.currentTime = 0; }
     const t = _bgmTheme(); if (t) { t.volume = 0.4; t.currentTime = 0; t.play().catch(() => {}); }
+    runTitleSequence();   // start Rogers' entrance in time with the theme's intro
   },
   onPlay() {
     const t = _bgmTheme(); if (t) { t.pause(); t.currentTime = 0; }
@@ -447,7 +659,7 @@ Arcade.Splash.mount({
   onLeaderboardShow: () => refreshLeaderboard(),
   unlockAudio() {                            // iOS: first title gesture unlocks audio
     Arcade.Audio.ensureCtx();
-    const t = _bgmTheme(); if (t) t.play().catch(() => {});
+    const t = _bgmTheme(); if (t && t.paused) { t.volume = 0.4; t.play().catch(() => {}); runTitleSequence(); }
   },
 });
 

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -44,6 +44,33 @@
       6px 6px 0 #2dd4ff,
       0 0 18px rgba(255, 216, 74, 0.45);
   }
+  /* Splash leaderboard view (title ↔ leaderboard cycle). Palette matches the
+     title; can move to shared/ once Invaders + Rocket Ship adopt the shared
+     splash lifecycle. */
+  .leaderboard { color: #fff; font-family: 'Press Start 2P', ui-monospace, monospace; }
+  .leaderboard .lb-title {
+    font-size: clamp(16px, 3vw, 28px);
+    color: #ffd84a;
+    letter-spacing: 0.12em;
+    text-shadow: 3px 3px 0 #ff3aa1, 5px 5px 0 #2dd4ff;
+    margin-bottom: clamp(8px, 1.5vw, 16px);
+  }
+  .leaderboard .lb-list {
+    list-style: none; padding: 0; margin: 0;
+    display: grid; grid-template-columns: auto auto auto;
+    gap: 6px 22px;
+    font-size: clamp(10px, 1.5vw, 14px);
+    letter-spacing: 0.14em; align-items: center;
+  }
+  .leaderboard .lb-list li { display: contents; }
+  .leaderboard .lb-rank     { color: #ff3aa1; text-align: right; }
+  .leaderboard .lb-initials { color: #2dd4ff; text-align: left; letter-spacing: 0.2em; }
+  .leaderboard .lb-score    { color: #ffd84a; text-align: right; }
+  .leaderboard .lb-empty {
+    font-size: clamp(10px, 1.4vw, 12px);
+    color: rgba(255, 255, 255, 0.55);
+    grid-column: 1 / -1; text-align: center;
+  }
   .splash .sound-controls {
     position: absolute;
     top: clamp(10px, 1.6vw, 18px);
@@ -95,6 +122,7 @@
 <script src="../shared/touch.js"></script>
 <script src="../shared/iframe-host.js"></script>
 <script src="../shared/leaderboard.js"></script>
+<script src="../shared/splash.js"></script>
 <script src="../shared/initials.js"></script>
 <script src="../shared/end-overlay.js"></script>
 <audio id="sfx-powerup"   src="../shared/sfx-powerup.mp3"   preload="auto"></audio>
@@ -140,7 +168,7 @@
     </div>
     <div class="splash" id="splash">
       <div class="splash-main">
-        <div class="title-card">
+        <div class="title-card splash-view is-active">
           <div class="title">SPACE JUMPER</div>
           <div class="start"><span class="key-only">INSERT COIN TO PLAY</span><span class="touch-only">TAP TO PLAY</span></div>
           <div class="controls">
@@ -148,6 +176,11 @@
             <div class="key key-only">SPACE</div><div class="key touch-only">TAP JUMP</div><div class="desc">JUMP</div>
           </div>
           <div class="hiscore-row" id="hiscore-row" hidden>HIGH SCORE <span class="hs-val" id="hs-val-splash">000</span> <span class="hs-initials" id="hs-initials-splash">---</span></div>
+          <div class="credit">© OYSTER 2026 — <span class="key-only">PRESS ANY KEY</span><span class="touch-only">TAP TO PLAY</span></div>
+        </div>
+        <div class="leaderboard splash-view">
+          <div class="lb-title">HIGH SCORES</div>
+          <ol class="lb-list" id="lb-list"></ol>
           <div class="credit">© OYSTER 2026 — <span class="key-only">PRESS ANY KEY</span><span class="touch-only">TAP TO PLAY</span></div>
         </div>
       </div>
@@ -281,13 +314,15 @@ Arcade.Initials.mount({
   fireLabel:  { idle: 'JUMP', select: 'SELECT' },
   extraKeys:  { 'letter-prev': ['w', 'W'], 'letter-next': ['s', 'S'] },
   onSubmit: (initials) => {
-    const goHi = document.getElementById('go-hiscore');
-    if (goHi) goHi.textContent = `SCORE SAVED · ${initials}`;
-    Arcade.EndOverlay.extendGrace(400);
+    hideEndOverlay();
     Arcade.Leaderboard.submit(score, initials).then(res => {
       if (!res.ok) console.warn('leaderboard submit failed:', res.error);
       paintSplashHiScore();
+      paintLeaderboard();
     });
+    // Back to attract mode — opens on the leaderboard so the new score shows,
+    // then cycles to the title card; a tap there starts a fresh run.
+    Arcade.Splash.enterAttract();
   },
 });
 function paintSplashHiScore() {
@@ -302,9 +337,15 @@ function paintSplashHiScore() {
     hideWhenEmpty: true,
   });
 }
+// Top-10 list for the splash's leaderboard view (3-digit pad, legacy from
+// when scores capped at 999).
+function paintLeaderboard() {
+  Arcade.Leaderboard.paintList({ listSelector: '#lb-list', pad: 3 });
+}
 paintSplashHiScore();
-// Fire-and-forget cloud refresh; repaint when it lands.
-Arcade.Leaderboard.refresh().then(paintSplashHiScore);
+paintLeaderboard();
+// Fire-and-forget cloud refresh; repaint both splash views when it lands.
+Arcade.Leaderboard.refresh().then(() => { paintSplashHiScore(); paintLeaderboard(); });
 
 // (Initials state machine + listeners now live in shared/initials.js — see
 // the Arcade.Initials.mount(...) call above for the per-game config.)
@@ -377,52 +418,31 @@ function hideEndOverlay() {
 // ============================================
 // SPLASH — dismiss on any input, unlock audio on same gesture.
 // ============================================
-const splash = document.getElementById('splash');
-const tube = document.querySelector('.tube');
-let started = false;
-function startGame() {
-  if (started) return;
-  started = true;
-  Arcade.Audio.ensureCtx();
-  splash.classList.add('is-hidden');
-  if (tube) tube.classList.add('is-ready');
-  document.body.classList.add('is-ingame');
-  // Cross-fade from the title theme to the level-1 music. Same user
-  // gesture also unlocks audio on iOS — if the theme failed to autoplay
-  // earlier (cross-origin / direct visit), .play() here is what
-  // actually unlocks the audio system for the bgm track too.
-  const bgmTheme = document.getElementById('bgm-theme');
-  if (bgmTheme) { bgmTheme.pause(); bgmTheme.currentTime = 0; }
-  const bgm = document.getElementById('bgm');
-  if (bgm) {
-    bgm.volume = 0.35;
-    bgm.currentTime = 0;
-    bgm.play().catch(() => {});
-  }
-}
+// Splash + attract-mode lifecycle (shared/splash.js). Boots to the title,
+// cycles title ↔ leaderboard, and returns to attract after a game (see the
+// enterAttract() calls below). Replaces the old one-shot startGame() latch.
+const _bgm      = () => document.getElementById('bgm');        // level music
+const _bgmTheme = () => document.getElementById('bgm-theme');  // title theme
 
-// Title theme — try to autoplay on page load so visitors hear something
-// while reading the title. Browsers block autoplay without a user
-// gesture; if rejected here, the same media starts inside startGame()
-// via its first-tap gesture (then immediately pauses for level-1 BGM).
-// The arcade iframe sets `allow="autoplay"` so launches from the
-// cabinet bypass the block.
-(function () {
-  // Belt + braces: make absolutely sure the level music isn't already
-  // playing at title-screen time (defends against any stray autoplay
-  // path from older deployed JS / cached state).
-  const bgm = document.getElementById('bgm');
-  if (bgm) { bgm.pause(); bgm.currentTime = 0; }
-  const bgmTheme = document.getElementById('bgm-theme');
-  if (!bgmTheme) return;
-  bgmTheme.volume = 0.4;
-  bgmTheme.play().catch(() => {});
-})();
-window.addEventListener('keydown', e => { if (e.key !== 'Escape') startGame(); });
-splash.addEventListener('pointerdown', e => {
-  // Ignore taps on the sound toggle.
-  if (e.target.closest('.sound-toggle')) return;
-  startGame();
+Arcade.Splash.mount({
+  views:  '#splash .splash-view',
+  ignore: '.sound-controls',                 // taps on the sound toggles don't start
+  isBusy: () => Arcade.Initials.isActive(),  // never start/advance mid-initials
+  onTitle() {
+    const b = _bgm();      if (b) { b.pause(); b.currentTime = 0; }
+    const t = _bgmTheme(); if (t) { t.volume = 0.4; t.currentTime = 0; t.play().catch(() => {}); }
+  },
+  onPlay() {
+    const t = _bgmTheme(); if (t) { t.pause(); t.currentTime = 0; }
+    const b = _bgm();      if (b) b.volume = 0.35;
+    Arcade.Audio.ensureCtx();
+    resetRun();                              // resumeBgm() runs inside (now 'playing')
+  },
+  onLeaderboardShow: () => paintLeaderboard(),
+  unlockAudio() {                            // iOS: first title gesture unlocks audio
+    Arcade.Audio.ensureCtx();
+    const t = _bgmTheme(); if (t) t.play().catch(() => {});
+  },
 });
 
 // ============================================
@@ -757,12 +777,10 @@ function resetRun() {
   hideEndOverlay();
   initEnemies();
   resetPlayer();
-  // Only kick the level BGM if the game has been started at least once.
-  // The initial call (script bootstrap) leaves the level music silent so
-  // the title-theme IIFE owns the title screen alone — psykick starts
-  // when the level actually begins (first startGame, or restart after
-  // game-over / level-complete, both of which happen after `started`).
-  if (started) resumeBgm();
+  // Only kick the level BGM once we're actually playing. The bootstrap call
+  // leaves it silent so the title theme owns the title screen; onPlay flips
+  // the phase to 'playing' before calling resetRun(), so this fires then.
+  if (Arcade.Splash.isPlaying()) resumeBgm();
 }
 
 // Lose a life but keep score and coin progress. If lives drop to 0 the
@@ -949,7 +967,10 @@ function update() {
         Arcade.Initials.open();
         return;
       }
-      resetRun();
+      // GAME OVER / GAME COMPLETE → bow out to the attract screen instead of
+      // restarting immediately: the leaderboard shows, then a tap plays again.
+      hideEndOverlay();
+      Arcade.Splash.enterAttract();
     }
     return;
   }
@@ -2724,7 +2745,7 @@ function drawLivesScreen() {
 }
 
 function loop() {
-  if (started) {
+  if (Arcade.Splash.isPlaying()) {
     update();
     draw();
   }

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -317,8 +317,7 @@ Arcade.Initials.mount({
     hideEndOverlay();
     Arcade.Leaderboard.submit(score, initials).then(res => {
       if (!res.ok) console.warn('leaderboard submit failed:', res.error);
-      paintSplashHiScore();
-      paintLeaderboard();
+      refreshLeaderboard(true);   // pull fresh so the just-saved score shows
     });
     // Back to attract mode — opens on the leaderboard so the new score shows,
     // then cycles to the title card; a tap there starts a fresh run.
@@ -342,10 +341,17 @@ function paintSplashHiScore() {
 function paintLeaderboard() {
   Arcade.Leaderboard.paintList({ listSelector: '#lb-list', pad: 3 });
 }
+// Pull live scores from the DB whenever the board is shown — so the splash
+// stays current (including the score you just saved), not just at boot.
+// Throttled so the 5.5s title↔leaderboard cycle doesn't hammer the worker.
+let _lbRefreshAt = 0;
+function refreshLeaderboard(force) {
+  if (!force && Date.now() - _lbRefreshAt < 8000) { paintLeaderboard(); return; }
+  _lbRefreshAt = Date.now();
+  Arcade.Leaderboard.refresh().then(() => { paintSplashHiScore(); paintLeaderboard(); });
+}
 paintSplashHiScore();
-paintLeaderboard();
-// Fire-and-forget cloud refresh; repaint both splash views when it lands.
-Arcade.Leaderboard.refresh().then(() => { paintSplashHiScore(); paintLeaderboard(); });
+refreshLeaderboard(true);
 
 // (Initials state machine + listeners now live in shared/initials.js — see
 // the Arcade.Initials.mount(...) call above for the per-game config.)
@@ -438,7 +444,7 @@ Arcade.Splash.mount({
     Arcade.Audio.ensureCtx();
     resetRun();                              // resumeBgm() runs inside (now 'playing')
   },
-  onLeaderboardShow: () => paintLeaderboard(),
+  onLeaderboardShow: () => refreshLeaderboard(),
   unlockAudio() {                            // iOS: first title gesture unlocks audio
     Arcade.Audio.ensureCtx();
     const t = _bgmTheme(); if (t) t.play().catch(() => {});


### PR DESCRIPTION
Introduces the missing piece of the arcade shared framework — a splash/attract **lifecycle controller** — and puts Space Jumper on it, with a new on-theme title screen. Tested on-device via a local LAN server throughout.

## Shared framework

**`Arcade.Splash.mount()`** — grows `shared/splash.js` (previously just a view-cycler) into the full `booting → title → playing → attract → title` lifecycle that every game currently hand-rolls (only Rocket Ship had real attract mode). Owns the title↔leaderboard cycle, "tap to start" dismiss (with an `ignore` selector + a grace window so the triggering tap/click doesn't bleed through), per-view clicks, and attract re-entry. Games configure it declaratively with a few hooks (`onTitle`/`onPlay`/`onLeaderboardShow`/`unlockAudio`/`isBusy`). Headless tests in `shared/splash.test.cjs` (20 cases).

**`shared/initials.js`** — fix: the type-a-letter shortcut was unreachable in any game that set `extraKeys` (e.g. Space Jumper's W/S), because it was an `else if` after the extraKeys branch. Now both are independent fall-throughs → typing any letter works everywhere.

## Space Jumper

- **Attract mode** — after a run (or saving a high score) it returns to the splash on the leaderboard view, cycles to the title, and a tap starts fresh — instead of diving straight into a new game. Replaces the one-shot `startGame()` latch; the loop and `resetRun()` gate on `Arcade.Splash.isPlaying()`.
- **Live splash leaderboard** — refreshes from the DB whenever the board is shown (throttled), and after a save.
- **On-theme title scene** — deep-space backdrop (nebula glow, twinkling stars, vignette), a detailed planet (surface mottling, specular glint, atmospheric limb, cloud bands), grass-and-dirt platforms, the game's alien perched on one, and **Rogers** (inline SVG of the real 10×13 sprite) hovering above the logo. He makes an entrance timed to the theme: waits on the lower platform through the soft intro, then on the music's drop boosts up in one smooth curved arc (split-axis béziers, no waypoint judder; jetpack flame igniting on launch) and settles into a gentle hover. CRT power-on title kept; all motion is `prefers-reduced-motion`-gated.

## Follow-ups (separate PRs)
- **Rocket Ship** → migrate its bespoke ~150-line `Splash` onto `Arcade.Splash.mount()` (parity, no behaviour change — the correctness proof for the abstraction).
- **Invaders** → adopt the controller (gains attract mode it currently lacks).

No CHANGELOG entry (arcade changes are out of scope per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)