### PR TITLE
arcade(invaders-mp): Phase H/2 — 4 boss types + win cutscene

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -64,6 +64,8 @@ export interface Ufo {
 }
 
 export interface Boss {
+  /** Index into sprites.js BOSS_TYPES (0..BOSS_TYPE_COUNT-1). */
+  type: number;
   x: number;
   hp: number;
   hpMax: number;
@@ -90,10 +92,15 @@ export interface GameState {
   stageNum: number;
   /** Seconds remaining of the "STAGE n-m" / "STAGE n-BOSS" overlay between waves. */
   stageAnnounceIn: number;
-  /** 'grid' during normal waves; 'boss' during a boss interrupt. */
-  phase: 'grid' | 'boss';
+  /**
+   * 'grid' during normal waves, 'boss' during a boss interrupt,
+   * 'cutscene' between the final boss death and the gameover lobby.
+   */
+  phase: 'grid' | 'boss' | 'cutscene';
   /** Active boss entity while phase === 'boss'; null otherwise. */
   boss: Boss | null;
+  /** Seconds left on the win cutscene; 0 outside phase === 'cutscene'. */
+  cutsceneIn: number;
   /** Bonus UFO when on-screen; null when between spawns. */
   ufo: Ufo | null;
   /** Seconds until the next UFO spawns. */
@@ -147,10 +154,15 @@ export interface WireSnapshot {
   ufo: { x: number; d: 1 | -1 } | null;
   /** Floating score popups; client renders + fades by `l` / POPUP_LIFE_SEC. */
   popups: Array<{ x: number; y: number; t: string; c: string; l: number }>;
-  /** 'grid' during normal waves; 'boss' during a boss interrupt. */
-  phase: 'grid' | 'boss';
-  /** Active boss for the renderer; null between bosses. */
-  boss: { x: number; hp: number; hpMax: number } | null;
+  /**
+   * 'grid' during normal waves, 'boss' during a boss interrupt,
+   * 'cutscene' for the win celebration before status → 'gameover'.
+   */
+  phase: 'grid' | 'boss' | 'cutscene';
+  /** Active boss for the renderer; null between bosses. `type` indexes sprites.js BOSS_TYPES. */
+  boss: { x: number; hp: number; hpMax: number; type: number } | null;
+  /** Seconds left on the win cutscene; 0 outside phase === 'cutscene'. */
+  cutsceneIn: number;
   /**
    * Per-seat occupancy. Set by the transport layer (room.ts on the
    * server, hostTick on the client) after snapshotForClient returns,
@@ -191,6 +203,8 @@ export const UFO_Y_EXPORT: number;
 export const BOSS_W: number;
 export const BOSS_H: number;
 export const BOSS_Y: number;
+export const BOSS_TYPE_COUNT: number;
+export const CUTSCENE_SEC: number;
 export function comboMultiplier(count: number): number;
 
 export const SEATS: readonly Seat[];

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -494,6 +494,12 @@ function checkStageClear(state) {
       state.cutsceneIn = CUTSCENE_SEC;
       state.invaderBullets = [];
       state.bullets = [];
+      // Clear any in-flight "STAGE n-BOSS" announce — step() short-
+      // circuits during the cutscene so tickStageAnnounce wouldn't
+      // drain it, and the renderer's phase-aware label would read
+      // the meaningless "STAGE 4-4" once phase flipped away from
+      // 'boss'. Leave only the cutscene overlay on screen.
+      state.stageAnnounceIn = 0;
       return;
     }
     state.phase = 'grid';

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -142,13 +142,20 @@ const STAGES_PER_SET = 3;
 const STAGE_ANNOUNCE_SEC = 2;
 
 // === Boss ===
-// Single boss type for Phase H (a chunky 8×8 octopus scaled 5× to
-// 40 PF). Multiple boss types + minion adds + win cutscene deferred
-// to a follow-up. HP, speed, and fire interval all ramp per set so
-// later bosses feel progressively scarier.
+// Phase H/2: four boss types (one per set) plus a win cutscene
+// after the final boss falls. Sprite roster lives in sprites.js as
+// BOSS_TYPES; the engine just stores a `type` index on state.boss.
+// HP, speed, and fire interval all ramp per set so later bosses
+// feel progressively scarier. Minion adds are still deferred.
 export const BOSS_W = 40;
 export const BOSS_H = 40;
 export const BOSS_Y = 24;                        // sits where the top invader row would
+// Kept in sync with sprites.js BOSS_TYPES.length. Defeating the
+// BOSS_TYPE_COUNT'th boss triggers the win cutscene → game over.
+export const BOSS_TYPE_COUNT = 4;
+// Length of the win cutscene before status flips to 'gameover'.
+// Short enough to feel like a beat, long enough for kids to whoop.
+export const CUTSCENE_SEC = 5;
 const BOSS_BASE_HP = 30;                         // ~10 charged hits or 30 normal at set 1
 const BOSS_HP_PER_SET = 15;                      // +15 HP per set
 const BOSS_BASE_SPEED = 38;                      // PF/sec at set 1
@@ -297,8 +304,15 @@ export function initState() {
     stageSet: 1,
     stageNum: 1,
     stageAnnounceIn: 0,
-    phase: 'grid',                        // 'grid' | 'boss'
+    // 'grid' = normal wave, 'boss' = boss fight, 'cutscene' = win
+    // celebration playing between the final boss death and status
+    // flipping to 'gameover' (won=true).
+    phase: 'grid',
     boss: null,
+    // Counts down during phase==='cutscene'. When it hits 0 the
+    // engine flips status='gameover', won=true. 0 outside the
+    // cutscene window.
+    cutsceneIn: 0,
     // UFO bonus enemy. ufo is null when off-screen; ufoNextSec ticks
     // down the time until the next spawn (randomised on each despawn).
     ufo: null,
@@ -349,6 +363,19 @@ const ALL_OCCUPIED = Object.freeze(
 
 export function step(state, inputs, dt, occupied = ALL_OCCUPIED) {
   if (state.status !== 'running') return;
+  // Cutscene short-circuit: gameplay frozen, only the cutscene timer
+  // and the popups (so the "+500" from the final blow can finish its
+  // float) keep ticking. When the timer hits 0, status flips to
+  // 'gameover' with won=true and the room broadcasts the lobby state.
+  if (state.phase === 'cutscene') {
+    state.cutsceneIn = Math.max(0, state.cutsceneIn - dt);
+    stepPopups(state, dt);
+    if (state.cutsceneIn === 0) {
+      state.status = 'gameover';
+      state.won = true;
+    }
+    return;
+  }
   tickRespawnAndInvuln(state, dt);
   tickStageAnnounce(state, dt);
   stepShips(state, inputs, dt, occupied);
@@ -405,6 +432,11 @@ function stepPopups(state, dt) {
 function spawnBoss(setNum) {
   const hp = BOSS_BASE_HP + (setNum - 1) * BOSS_HP_PER_SET;
   return {
+    // setNum is 1-indexed; (setNum - 1) % BOSS_TYPE_COUNT cycles
+    // 0..3 over sets 1..4 and rolls over thereafter (defensive — in
+    // practice the cutscene fires on set BOSS_TYPE_COUNT so this
+    // never wraps in a real game).
+    type: (setNum - 1) % BOSS_TYPE_COUNT,
     x: PF_W / 2 - BOSS_W / 2,
     hp,
     hpMax: hp,
@@ -453,6 +485,17 @@ function stepBoss(state, dt) {
 function checkStageClear(state) {
   if (state.phase === 'boss') {
     if (!state.boss || state.boss.hp > 0) return;
+    // Final boss defeated → start the win cutscene instead of
+    // looping to set BOSS_TYPE_COUNT+1. The cutscene tick in step()
+    // flips status to 'gameover' with won=true when the timer ends.
+    if (state.stageSet >= BOSS_TYPE_COUNT) {
+      state.phase = 'cutscene';
+      state.boss = null;
+      state.cutsceneIn = CUTSCENE_SEC;
+      state.invaderBullets = [];
+      state.bullets = [];
+      return;
+    }
     state.phase = 'grid';
     state.boss = null;
     state.stageSet += 1;
@@ -996,14 +1039,19 @@ export function snapshotForClient(state) {
     popups:         state.popups.map(p => ({
       x: round(p.x), y: round(p.y), t: p.text, c: p.col, l: round(p.life),
     })),
-    // Phase H: boss waves. phase 'grid' for normal stages, 'boss'
-    // while a boss is on-screen. boss carries x + hp + hpMax for the
-    // renderer's sprite + health bar. null between bosses.
+    // Phase H/2: boss waves + win cutscene. phase 'grid' for normal
+    // stages, 'boss' while a boss is on-screen, 'cutscene' between
+    // the final boss death and the lobby return. boss carries x +
+    // hp + hpMax + type (index into sprites.js BOSS_TYPES). null
+    // between bosses or during cutscene. cutsceneIn is the seconds
+    // remaining on the win cutscene (0 outside that window).
     phase:          state.phase,
     boss:           state.boss ? {
       x:    round(state.boss.x),
       hp:   state.boss.hp,
       hpMax: state.boss.hpMax,
+      type: state.boss.type | 0,
     } : null,
+    cutsceneIn:     round(state.cutsceneIn),
   };
 }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -427,7 +427,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 25;
+  const NETCODE_VERSION = 26;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1583,13 +1583,14 @@
       }
     }
 
-    // Boss — chunky 40×40 octopus + a green→yellow→red HP bar above
-    // it. Same 2-frame animation cadence as the regular swarm (toggle
-    // every 300 ms). HP ratio drives the bar fill colour for a quick
-    // glance read.
+    // Boss — chunky 40×40 sprite + a green→yellow→red HP bar above
+    // it. `type` (0..BOSS_TYPE_COUNT-1) picks the sprite from the
+    // BOSS_TYPES roster in sprites.js. Same 2-frame animation cadence
+    // as the regular swarm (toggle every 300 ms). HP ratio drives the
+    // bar fill colour for a quick-glance read.
     if (latestSnap.phase === 'boss' && latestSnap.boss) {
       const bf = Math.floor(performance.now() / 300) & 1;
-      paintBoss(ctx, latestSnap.boss.x, BOSS_Y, 5, bf);
+      paintBoss(ctx, latestSnap.boss.x, BOSS_Y, 5, bf, latestSnap.boss.type || 0);
       const hp = latestSnap.boss.hp;
       const hpMax = latestSnap.boss.hpMax || 1;
       const ratio = Math.max(0, Math.min(1, hp / hpMax));
@@ -1692,6 +1693,24 @@
       drawCenteredOverlay(label, `rgba(255, 216, 74, ${t.toFixed(2)})`, 18);
     }
 
+    // Win cutscene — plays for CUTSCENE_SEC after the final boss
+    // falls, before status flips to 'gameover'. Two stacked lines:
+    // a big gold "EARTH IS SAFE" headline and the team score below.
+    // No fade — the cutscene is short enough that a steady reveal
+    // reads cleaner than a wobbly alpha ramp.
+    if (latestSnap.phase === 'cutscene') {
+      ctx.save();
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.font = '14px "Press Start 2P", monospace';
+      ctx.fillStyle = '#ffd84a';
+      ctx.fillText('EARTH IS SAFE', PF_W / 2, PF_H / 2 - 12);
+      ctx.font = '8px "Press Start 2P", monospace';
+      ctx.fillStyle = '#ffffff';
+      ctx.fillText('SCORE ' + (latestSnap.score | 0), PF_W / 2, PF_H / 2 + 8);
+      ctx.restore();
+    }
+
     // Floating score popups — server-spawned on each kill, live for
     // POPUP_LIFE_SEC (0.6 s), drift upward. Each renders centred on
     // its (x, y) with alpha = life / POPUP_LIFE_SEC. Tiny font so
@@ -1749,9 +1768,10 @@
       ctx.fillStyle = '#ffd84a';
       const stageSet = latestSnap.stageSet ?? 1;
       const stageNum = latestSnap.stageNum ?? 1;
-      const stageLabel = latestSnap.phase === 'boss'
-        ? stageSet + '-BOSS'
-        : stageSet + '-' + stageNum;
+      const stageLabel =
+        latestSnap.phase === 'cutscene' ? 'WIN!' :
+        latestSnap.phase === 'boss'     ? stageSet + '-BOSS' :
+                                          stageSet + '-' + stageNum;
       ctx.fillText(stageLabel, PF_W / 2, 12);
 
       // LIVES — shared respawn-pool counter, right-aligned. "—" if

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -75,22 +75,57 @@ export function paintShip(ctx, x, shipY, shipW, color) {
   ctx.fillRect(x + shipW/2 - 2, shipY - 4,     4,             2); // turret tip
 }
 
-// Boss sprite (Phase H — single CRIMSON OCTOPUS type for now).
-// 8×8 source painted at scale 5 → 40×40 PF. Two-frame animation
-// toggles every ~300 ms in the renderer. Body uses a 3-band gradient
-// (top=highlight, middle=mid red, bottom=deep red) so the chunky
-// silhouette reads with some depth instead of as a flat blob.
-export const BOSS_FRAMES = [
-  ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '..X..X..', '.X.XX.X.', 'X.X..X.X'],
-  ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '...XX...', '..X..X..', '.X....X.'],
+// Boss sprite roster (Phase H/2). 4 types — one per set — ported
+// from SP's BOSS_TYPES. Each entry: two 8×8 frames + a 3-band colour
+// gradient (hi → mid → shadow, applied to rows 0-2, 3-4, 5-7).
+// Painted at scale 5 → 40×40 PF; 2-frame anim toggles every ~300 ms.
+//
+// Set rotation: stageSet 1 → CRIMSON OCTOPUS, 2 → VIOLET CRAB,
+// 3 → AZURE SQUID, 4 → JADE SKULL. Defeating the JADE SKULL boss
+// triggers the win cutscene — the game has a real end.
+export const BOSS_TYPES = [
+  {
+    name: 'CRIMSON OCTOPUS',
+    frames: [
+      ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '..X..X..', '.X.XX.X.', 'X.X..X.X'],
+      ['..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '...XX...', '..X..X..', '.X....X.'],
+    ],
+    bands: ['#ff7a7a', '#e05050', '#c0303a'],
+  },
+  {
+    name: 'VIOLET CRAB',
+    frames: [
+      ['.X....X.', '..X..X..', '.XXXXXX.', 'XX.XX.XX', 'XXXXXXXX', 'X.XXXX.X', '.X....X.', 'X.X..X.X'],
+      ['X.X..X.X', '.X.XX.X.', 'XXXXXXXX', 'XXX..XXX', 'XXXXXXXX', '.XXXXXX.', 'X......X', '.X....X.'],
+    ],
+    bands: ['#b080f0', '#8050d0', '#5020a0'],
+  },
+  {
+    name: 'AZURE SQUID',
+    frames: [
+      ['...XX...', '..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', '.X....X.', 'X.X..X.X'],
+      ['...XX...', '..XXXX..', '.XXXXXX.', 'XXXXXXXX', 'XX.XX.XX', 'XXXXXXXX', 'X......X', '.X.XX.X.'],
+    ],
+    bands: ['#50d0f0', '#30a0c0', '#1070a0'],
+  },
+  {
+    name: 'JADE SKULL',
+    frames: [
+      ['.XXXXXX.', 'X.XXXX.X', 'XXXXXXXX', 'X.X..X.X', 'XXXXXXXX', 'XX.XX.XX', 'X.XXXX.X', '.X.XX.X.'],
+      ['.XXXXXX.', 'X.XXXX.X', 'XXXXXXXX', 'X.X..X.X', 'XXXXXXXX', 'XXX..XXX', 'X.XXXX.X', '..X..X..'],
+    ],
+    bands: ['#60c060', '#408040', '#205020'],
+  },
 ];
-const BOSS_BAND_COLORS = ['#ff7a7a', '#e05050', '#c0303a'];   // hi / mid / shadow
 
-export function paintBoss(ctx, x, y, scale, frame) {
-  const px = BOSS_FRAMES[frame & 1];
+// Paint a boss frame at (x, y) PF coords. `type` is an index into
+// BOSS_TYPES; out-of-range defensively falls back to the first.
+export function paintBoss(ctx, x, y, scale, frame, type) {
+  const def = BOSS_TYPES[type | 0] || BOSS_TYPES[0];
+  const px = def.frames[frame & 1];
   for (let row = 0; row < px.length; row++) {
     const band = row < 3 ? 0 : (row < 5 ? 1 : 2);
-    ctx.fillStyle = BOSS_BAND_COLORS[band];
+    ctx.fillStyle = def.bands[band];
     const cells = px[row];
     const py = y + row * scale;
     for (let col = 0; col < cells.length; col++) {

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -127,7 +127,13 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        +1, fresh wave at n-1. STAGE label shows "n-BOSS" during
 //        the fight. Multiple boss types + minion adds + win cutscene
 //        deferred to Phase H/2. New wire fields: phase / boss.
-const NETCODE_VERSION = 25;
+// v26 — Phase H/2: 4 boss types (CRIMSON OCTOPUS / VIOLET CRAB /
+//        AZURE SQUID / JADE SKULL) one per set, indexed via the new
+//        boss.type wire field. Defeating the JADE SKULL (set 4)
+//        triggers a 5-second win cutscene — phase 'cutscene', then
+//        status → 'gameover' with won=true. New wire fields:
+//        boss.type / cutsceneIn / phase adds 'cutscene' variant.
+const NETCODE_VERSION = 26;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Closes the boss arc started in #583. After the JADE SKULL falls (set 4), the game has a real **win**.

- **4 boss types**, one per set, ported from SP's `BOSS_TYPES`:
  - Set 1 → **CRIMSON OCTOPUS** (red)
  - Set 2 → **VIOLET CRAB** (purple)
  - Set 3 → **AZURE SQUID** (cyan)
  - Set 4 → **JADE SKULL** (green) — final
- **Win cutscene**: defeating the JADE SKULL flips `phase` to `'cutscene'` for `CUTSCENE_SEC` (5 s), then `status` → `'gameover'` with `won=true`. Big gold "EARTH IS SAFE" + team score, then back to the lobby.
- **Wire**: `boss.type` (index into `sprites.js BOSS_TYPES`), `cutsceneIn` (seconds left on the cutscene). Phase union grows to `'grid' | 'boss' | 'cutscene'`. **Netcode v25 → v26.**
- HUD stage label reads `WIN!` during cutscene (instead of the meaningless `4-4` it'd otherwise resolve to).
- During cutscene the engine short-circuits gameplay but keeps popups ticking so the `+500` from the final blow still floats off.

**Still deferred to a follow-up:** boss minion adds (per audit doc).

## Test plan

- [ ] **Boss roster reads correctly** — play through, set 1 should show a red CRIMSON OCTOPUS, set 2 a violet CRAB, set 3 a blue SQUID, set 4 a green SKULL. (Cheat: temporarily lower `STAGES_PER_SET` to 1 to speed iteration.)
- [ ] **HP / fire interval still ramps per set** — set-4 boss should fire noticeably faster and take more hits than the set-1 boss.
- [ ] **Charged shots still deal 3 dmg and tunnel** through the boss.
- [ ] **Win cutscene fires** after the JADE SKULL dies — overlay shows for ~5 s, then prescreen returns with "Earth is safe! Score: …".
- [ ] **Gameplay frozen during cutscene** — bullets cleared, ships unresponsive, no new invader bullets.
- [ ] **Popups keep floating** during cutscene — the `+500` boss-defeat popup completes its float instead of vanishing on the phase flip.
- [ ] **No netcode mismatch warning** after deploy — both client and server should report `v26`.
- [ ] **Multiplayer still co-op-friendly** — 2 players damaging the boss simultaneously both register hits (regression check on the fix from H/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)