### PR TITLE
arcade(invaders-mp): B-key debug skip

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -222,3 +222,5 @@ export function snapshotForClient(state: GameState): WireSnapshot;
 export function encodeShields(bits: Uint8Array): string;
 export function decodeShields(b64: string): Uint8Array;
 export function shieldOffsets(): number[];
+/** Debug skip — kill current grid (→ boss) or current boss (→ next set / cutscene). No-op outside 'running'. */
+export function cheatSkip(state: GameState): void;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -941,6 +941,29 @@ function overlap(ax, ay, aw, ah, bx, by, bw, bh) {
   return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
 }
 
+// === Debug cheats ===
+
+// Server-authoritative skip — mirrors SP's B-key cheat. One call =
+// one threat skipped:
+//   grid:     kill every live invader and snap stageNum to
+//             STAGES_PER_SET so the next checkStageClear tick spawns
+//             the set's boss instead of another normal wave.
+//   boss:     set boss.hp to 0 so the next checkStageClear tick
+//             advances to the next set's wave or fires the win
+//             cutscene if this was the JADE SKULL.
+//   cutscene: no-op — don't shortcut the win celebration.
+// Called from room.ts (cloud mode) or hostReceive (host mode) on
+// receipt of a {type:'cheat'} message. No-op outside 'running'.
+export function cheatSkip(state) {
+  if (state.status !== 'running') return;
+  if (state.phase === 'grid') {
+    for (const inv of state.invaders) inv.alive = false;
+    state.stageNum = STAGES_PER_SET;
+  } else if (state.phase === 'boss' && state.boss) {
+    state.boss.hp = 0;
+  }
+}
+
 // === Snapshot for the wire ===
 
 function round(n) { return Math.round(n * 10) / 10; }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -427,7 +427,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 26;
+  const NETCODE_VERSION = 27;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -734,6 +734,10 @@
     } else if (msg.type === 'name') {
       if (typeof msg.name !== 'string') return;
       hostState.names[seat] = msg.name.trim().slice(0, NAME_MAX_CHARS);
+    } else if (msg.type === 'cheat') {
+      // Debug B-key skip — applied to local hostState. Engine helper
+      // gates by status/phase so we don't need to guard here.
+      engine.cheatSkip && engine.cheatSkip(hostState);
     }
   }
 
@@ -1233,6 +1237,17 @@
     if (e.key === 'ArrowLeft'  || e.key === 'a' || e.key === 'A') setInput('left',  true);
     else if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') setInput('right', true);
     else if (e.key === ' ' || e.key === 'Spacebar') { setInput('fire', true); e.preventDefault(); }
+    else if (e.key === 'b' || e.key === 'B') {
+      // Debug skip — mirrors SP's B-key cheat. One press = one threat
+      // skipped (kill grid → boss spawn, or kill boss → next set /
+      // cutscene). Server gates by status/phase so spamming B during
+      // the lobby or cutscene is a no-op. Skipped when focus is in a
+      // text field (e.g. the name input) so typing a 'b' in your name
+      // doesn't blast the swarm.
+      const t = e.target;
+      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      sendToServer({ type: 'cheat' });
+    }
   });
   window.addEventListener('keyup', (e) => {
     if (e.key === 'ArrowLeft'  || e.key === 'a' || e.key === 'A') setInput('left',  false);

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -19,6 +19,7 @@ import {
   snapshotForClient,
   step,
   zeroInput,
+  cheatSkip,
   PF_W,
   SHIP_W,
   SEATS,
@@ -133,7 +134,12 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        triggers a 5-second win cutscene — phase 'cutscene', then
 //        status → 'gameover' with won=true. New wire fields:
 //        boss.type / cutsceneIn / phase adds 'cutscene' variant.
-const NETCODE_VERSION = 26;
+// v27 — Debug: 'cheat' client→server message that triggers
+//        engine.cheatSkip (kill current grid → boss spawn, or kill
+//        current boss → next set / cutscene). Bound to the B key in
+//        the client. Backwards-compatible — older servers silently
+//        ignore the unknown message type.
+const NETCODE_VERSION = 27;
 
 type ClientMessage =
   | { type: 'ping';   t: number }
@@ -142,7 +148,8 @@ type ClientMessage =
   | { type: 'start' }
   | { type: 'name';   name: unknown }
   // `to` is untrusted wire data — narrowed by isSeat() in relaySignal.
-  | { type: 'signal'; to: unknown; payload: unknown };
+  | { type: 'signal'; to: unknown; payload: unknown }
+  | { type: 'cheat' };
 
 // 3-2-1-ATTACK countdown duration. status flips to 'running' when the
 // server clock catches up to game.countdownEndMs.
@@ -315,6 +322,13 @@ export class InvadersRoom {
         return;
       case 'start':
         this.handleStart();
+        return;
+      case 'cheat':
+        // Debug-only: any seat can press B to skip the current threat.
+        // No auth — cloud mode is co-op, cheating among friends is on
+        // the honour system (and the score line is going to look
+        // ridiculous either way).
+        cheatSkip(this.game);
         return;
     }
   }


### PR DESCRIPTION
## Summary

Mirrors SP's B-key cheat for fast iteration on the new boss arc. One press = one threat skipped:

| Phase    | Effect                                                                    |
|----------|---------------------------------------------------------------------------|
| grid     | kill all live invaders + snap `stageNum = STAGES_PER_SET` → next tick spawns boss |
| boss     | set `boss.hp = 0` → next tick advances to next set, or fires win cutscene |
| cutscene | no-op (don't shortcut the win)                                            |

So `B B B B` from a fresh start gets you to set 1's boss in ~one second of holding; `B` again kills it; repeat to walk through all four bosses + the cutscene in ~10 seconds total.

Skipped when focus is in a text field so typing a `b` in the name input doesn't blast the swarm.

## Wire change

New client→server message `{type:'cheat'}`. Backwards-compatible — older servers silently ignore the unknown type. Netcode **v26 → v27**.

Implemented in three places by design:
- `engine.js` `cheatSkip(state)` — single source of truth for the behavior
- `room.ts` — cloud-mode handler calls `cheatSkip` on the DO's game state
- `index.html` `hostReceive` — host-mode handler calls `engine.cheatSkip(hostState)`

## Test plan

- [ ] Hit B during a normal wave — all invaders die instantly; boss spawns ~half a second later (STAGE n-BOSS announce overlay).
- [ ] Hit B during a boss fight — boss falls, next set's wave 1-1 spawns (or JADE SKULL → cutscene).
- [ ] Hit B during the cutscene — nothing happens (the "EARTH IS SAFE" overlay stays put).
- [ ] Hit B in the lobby (status = 'ready') — nothing happens.
- [ ] Type a name containing 'b' into the name field — name updates normally, swarm is untouched.
- [ ] Verify host-mode (P2P) path: connect a second player, become host, press B from p1's laptop — both clients see the skip applied.
- [ ] No netcode mismatch banner after deploy — client + server both at v27.

> Note: This stays in mainline for now per the user's "we can disable it again in future" call. No score-disqualify flag (yet) — keep an eye on the team-score readout if you want an honest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)