### PR TITLE
arcade(invaders-mp): boss minion adds

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -63,6 +63,22 @@ export interface Ufo {
   dir: 1 | -1;
 }
 
+export interface BossAdd {
+  /** Resting position the minion swoops away from + returns to. */
+  baseX: number;
+  baseY: number;
+  /** Live position. Computed each tick from baseX/baseY + phase. */
+  x: number;
+  y: number;
+  alive: boolean;
+  /** 0..1 swoop cycle position; advances by dt * phaseSpeed each tick. */
+  phase: number;
+  /** 1 / swoop-period (seconds). Randomised per minion at spawn. */
+  phaseSpeed: number;
+  /** Seconds until the minion respawns at base; 0 while alive. */
+  respawnIn: number;
+}
+
 export interface Boss {
   /** Index into sprites.js BOSS_TYPES (0..BOSS_TYPE_COUNT-1). */
   type: number;
@@ -73,6 +89,8 @@ export interface Boss {
   speed: number;
   fireAccum: number;
   fireInterval: number;
+  /** Swooping minion adds — 2 + (setNum-1) per boss. */
+  adds: BossAdd[];
 }
 
 export interface GameState {
@@ -159,8 +177,14 @@ export interface WireSnapshot {
    * 'cutscene' for the win celebration before status → 'gameover'.
    */
   phase: 'grid' | 'boss' | 'cutscene';
-  /** Active boss for the renderer; null between bosses. `type` indexes sprites.js BOSS_TYPES. */
-  boss: { x: number; hp: number; hpMax: number; type: number } | null;
+  /** Active boss for the renderer; null between bosses. `type` indexes sprites.js BOSS_TYPES, `adds` is the live minion positions. */
+  boss: {
+    x: number;
+    hp: number;
+    hpMax: number;
+    type: number;
+    adds: Array<{ x: number; y: number; a: boolean }>;
+  } | null;
   /** Seconds left on the win cutscene; 0 outside phase === 'cutscene'. */
   cutsceneIn: number;
   /**
@@ -203,6 +227,8 @@ export const UFO_Y_EXPORT: number;
 export const BOSS_W: number;
 export const BOSS_H: number;
 export const BOSS_Y: number;
+export const BOSS_ADD_W: number;
+export const BOSS_ADD_H: number;
 export const BOSS_TYPE_COUNT: number;
 export const CUTSCENE_SEC: number;
 export function comboMultiplier(count: number): number;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -146,7 +146,7 @@ const STAGE_ANNOUNCE_SEC = 2;
 // after the final boss falls. Sprite roster lives in sprites.js as
 // BOSS_TYPES; the engine just stores a `type` index on state.boss.
 // HP, speed, and fire interval all ramp per set so later bosses
-// feel progressively scarier. Minion adds are still deferred.
+// feel progressively scarier. Minion adds land in this PR.
 export const BOSS_W = 40;
 export const BOSS_H = 40;
 export const BOSS_Y = 24;                        // sits where the top invader row would
@@ -165,6 +165,30 @@ const BOSS_FIRE_INTERVAL_MIN = 0.38;             // floor — fastest possible
 const BOSS_FIRE_INTERVAL_STEP = 0.2;             // shrinks per set
 const BOSS_HIT_SCORE = 50;                       // points per damaging hit
 const BOSS_DEFEAT_SCORE = 500;                   // bonus on kill
+
+// === Boss minion adds ===
+// Small swooping minions that escort the boss. Count scales 2/3/4/5
+// across the 4 sets — set N has BOSS_ADD_COUNT_BASE + (N-1) minions.
+// They sit just below the boss at BOSS_ADD_Y, swoop down-and-back
+// on a cosine ease with a horizontal sin-wiggle (period randomised
+// 4.5–6 s per minion at spawn). Catch player bullets before the boss
+// reaches them — charged shots pierce (consistent with grid pierce),
+// normal shots are consumed. Killed minions respawn at base position
+// BOSS_ADD_RESPAWN_SEC later. Don't fire; they're a damage sponge,
+// not a threat in their own right.
+const BOSS_ADD_COUNT_BASE = 2;
+const BOSS_ADD_RESPAWN_SEC = 5;
+const BOSS_ADD_SCORE = 50;
+const BOSS_ADD_Y = BOSS_Y + BOSS_H + 24;         // sits just under the boss
+const BOSS_ADD_SWOOP_MIN_SEC = 4.5;
+const BOSS_ADD_SWOOP_MAX_SEC = 6;
+const BOSS_ADD_SWOOP_AMOUNT = 80;                // peak dy of the dive in PF
+const BOSS_ADD_WIGGLE_AMOUNT = 22;               // peak |dx| of the horizontal wiggle
+// Use the existing grid cell box for collision so a charged shot
+// piercing a minion uses the same overlap geometry as piercing an
+// invader. Sprite paints inside this box at scale 1.5 (SP parity).
+export const BOSS_ADD_W = INV_W;
+export const BOSS_ADD_H = INV_H;
 
 // === UFO ===
 // Bonus enemy that flies across the top of the playfield occasionally.
@@ -447,12 +471,73 @@ function spawnBoss(setNum) {
       BOSS_FIRE_INTERVAL_MIN,
       BOSS_FIRE_INTERVAL_BASE - (setNum - 1) * BOSS_FIRE_INTERVAL_STEP,
     ),
+    adds: spawnBossAdds(setNum),
   };
 }
 
-// Boss tick: horizontal bounce + periodic fire from centre-bottom.
-// No vertical descent — the boss stays parked at BOSS_Y and applies
-// pressure via bullets instead of swarm-pushdown.
+// 2/3/4/5 minions across sets 1/2/3/4, evenly spaced across the
+// playfield below the boss. Phases staggered by 0.15 per minion so
+// they don't all peak at the same instant. Per-minion swoop period
+// randomised inside [MIN, MAX] for organic variation. Math.random
+// is the same seed source as UFO/firing — divergence between client
+// host-mode and DO server-mode is already accepted (snapshots are
+// authoritative).
+function spawnBossAdds(setNum) {
+  const count = BOSS_ADD_COUNT_BASE + (setNum - 1);
+  const adds = [];
+  const totalW = PF_W - 60;
+  const step = totalW / (count + 1);
+  for (let i = 0; i < count; i++) {
+    const baseX = 30 + step * (i + 1) - BOSS_ADD_W / 2;
+    const period = BOSS_ADD_SWOOP_MIN_SEC + Math.random() * (BOSS_ADD_SWOOP_MAX_SEC - BOSS_ADD_SWOOP_MIN_SEC);
+    adds.push({
+      baseX,
+      baseY: BOSS_ADD_Y,
+      x: baseX,
+      y: BOSS_ADD_Y,
+      alive: true,
+      phase: (i * 0.15) % 1,          // staggered initial phase
+      phaseSpeed: 1 / period,         // 1/sec → full cycle per `period`
+      respawnIn: 0,                   // 0 while alive
+    });
+  }
+  return adds;
+}
+
+// Advance one minion's swoop animation. Pure function — caller is
+// responsible for the alive/respawn gating. Cosine ease 0→1→0 over
+// the cycle drives both the dive depth and the wiggle amplitude
+// (so the horizontal wiggle is biggest at peak dive and zero at
+// the rest position — feels purposeful, not jittery).
+function tickBossAdd(a, dt) {
+  a.phase = (a.phase + dt * a.phaseSpeed) % 1;
+  const easeV = 0.5 - 0.5 * Math.cos(a.phase * Math.PI * 2);
+  const dy = easeV * BOSS_ADD_SWOOP_AMOUNT;
+  const dx = Math.sin(a.phase * Math.PI * 4) * BOSS_ADD_WIGGLE_AMOUNT * easeV;
+  a.x = a.baseX + dx;
+  a.y = a.baseY + dy;
+}
+
+function stepBossAdds(state, dt) {
+  if (!state.boss || !state.boss.adds) return;
+  for (const a of state.boss.adds) {
+    if (a.alive) {
+      tickBossAdd(a, dt);
+    } else {
+      a.respawnIn = Math.max(0, a.respawnIn - dt);
+      if (a.respawnIn === 0) {
+        a.alive = true;
+        a.phase = 0;
+        a.x = a.baseX;
+        a.y = a.baseY;
+      }
+    }
+  }
+}
+
+// Boss tick: horizontal bounce + periodic fire from centre-bottom +
+// minion swoop animation. No vertical descent — the boss stays parked
+// at BOSS_Y and applies pressure via bullets + minion shielding.
 function stepBoss(state, dt) {
   if (state.phase !== 'boss' || !state.boss) return;
   const b = state.boss;
@@ -470,6 +555,7 @@ function stepBoss(state, dt) {
       owner: null,
     });
   }
+  stepBossAdds(state, dt);
 }
 
 // Called after resolveCollisions. Two clear paths:
@@ -789,6 +875,40 @@ function resolveCollisions(state, occupied) {
     }
   }
 
+  // Player bullets vs boss minions. Minions catch bullets BEFORE the
+  // boss (their whole purpose — shield it). Normal bullets are
+  // consumed on first contact; charged bullets pierce (consistent
+  // with the grid pierce rule). Each kill → +BOSS_ADD_SCORE to the
+  // owner, popup, 5-second respawn timer. Skipped when the boss is
+  // dead so the closing tick doesn't strip minion bullets after the
+  // win.
+  if (state.phase === 'boss' && state.boss && state.boss.hp > 0 && state.boss.adds) {
+    for (const b of state.bullets) {
+      const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
+      const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
+      if (b.y < -bh) continue;
+      for (const a of state.boss.adds) {
+        if (!a.alive) continue;
+        if (!overlap(b.x, b.y, bw, bh, a.x, a.y, BOSS_ADD_W, BOSS_ADD_H)) continue;
+        a.alive = false;
+        a.respawnIn = BOSS_ADD_RESPAWN_SEC;
+        const owner = b.owner && state.ships[b.owner];
+        if (owner) {
+          owner.score += BOSS_ADD_SCORE;
+          state.popups.push({
+            x: a.x + BOSS_ADD_W / 2,
+            y: a.y,
+            text: `+${BOSS_ADD_SCORE}`,
+            col: '#ffffff',
+            life: POPUP_LIFE_SEC,
+          });
+        }
+        if (!b.charged) { b.y = -999; break; }
+        // charged: keep checking other minions this tick
+      }
+    }
+  }
+
   // Player bullets vs boss. Damage = 1 (normal) or 3 (charged).
   // Charged bullets still tunnel (don't get consumed) so a sustained
   // hold of FIRE while standing under the boss can grind it down
@@ -1071,7 +1191,8 @@ export function snapshotForClient(state) {
     // Phase H/2: boss waves + win cutscene. phase 'grid' for normal
     // stages, 'boss' while a boss is on-screen, 'cutscene' between
     // the final boss death and the lobby return. boss carries x +
-    // hp + hpMax + type (index into sprites.js BOSS_TYPES). null
+    // hp + hpMax + type (index into sprites.js BOSS_TYPES) + adds
+    // (current minion positions, count = 2 + (setNum - 1)). null
     // between bosses or during cutscene. cutsceneIn is the seconds
     // remaining on the win cutscene (0 outside that window).
     phase:          state.phase,
@@ -1080,6 +1201,7 @@ export function snapshotForClient(state) {
       hp:   state.boss.hp,
       hpMax: state.boss.hpMax,
       type: state.boss.type | 0,
+      adds: (state.boss.adds || []).map(a => ({ x: round(a.x), y: round(a.y), a: a.alive })),
     } : null,
     cutsceneIn:     round(state.cutsceneIn),
   };

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -427,7 +427,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 27;
+  const NETCODE_VERSION = 28;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1641,6 +1641,25 @@
       ctx.fillRect(latestSnap.boss.x, barY, BOSS_W, 2);
       ctx.fillStyle = ratio > 0.6 ? '#6bff8c' : ratio > 0.3 ? '#ffd84a' : '#ff6666';
       ctx.fillRect(latestSnap.boss.x, barY, BOSS_W * ratio, 2);
+
+      // Boss minion adds — small swooping crabs that shield the boss.
+      // Server-authoritative positions arrive in boss.adds; we just
+      // paint them at scale 1.5 (matching grid invader scale) using
+      // the CRAB sprite. Pulse the colour white ↔ pink at ~12.5 Hz
+      // so they read as "flashing minion" not "tiny ordinary
+      // invader". Frame toggle uses the same 300 ms cadence as the
+      // grid for visual consistency.
+      const adds = latestSnap.boss.adds || [];
+      if (adds.length) {
+        const renderNow = performance.now();
+        const flash = Math.floor(renderNow / 80) % 2 === 0 ? '#ffffff' : ROW_COLORS[1];
+        const addFrame = Math.floor(renderNow / 300) & 1;
+        const { frames: addFrames } = spriteForRow(1);
+        for (const ad of adds) {
+          if (!ad.a) continue;
+          paintPixels(ctx, Math.round(ad.x), Math.round(ad.y), addFrames[addFrame], 1.5, flash);
+        }
+      }
     }
 
     // UFO bonus enemy — saucer silhouette ported from SP's drawUfo.

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -139,7 +139,11 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        current boss → next set / cutscene). Bound to the B key in
 //        the client. Backwards-compatible — older servers silently
 //        ignore the unknown message type.
-const NETCODE_VERSION = 27;
+// v28 — Boss minion adds. Each boss spawns with 2 + (setNum-1)
+//        swooping minions that catch player bullets before the boss
+//        (charged pierces, normal consumed). Worth +50; respawn 5 s
+//        after kill. New wire field: boss.adds[].
+const NETCODE_VERSION = 28;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Closes the H/2 deferred work. Each boss spawns with **2 + (setNum - 1)** swooping minions — 2 for CRIMSON OCTOPUS, 3 for VIOLET CRAB, 4 for AZURE SQUID, 5 for JADE SKULL. They sit below the boss, dive on a cosine-eased swoop with a horizontal sin-wiggle, and **catch player bullets BEFORE the boss reaches them**.

Strategic dynamic restored from SP: you have to clear the minions (or use charged shots to pierce through them) before you can grind the boss down.

## Bullet vs minion rules

| Bullet         | Behavior on minion hit                                                           |
|----------------|----------------------------------------------------------------------------------|
| Normal         | Kills the minion, bullet consumed (one minion per shot)                          |
| Charged super  | Kills the minion, bullet **pierces** (continues to hit further minions + boss)   |

Mirrors the grid-pierce rule for normal-vs-charged. Minion kills: **+50** to the shooter's score, popup floats off the kill site, 5-second respawn at the base position.

## Movement

Each minion has a `baseX/baseY` rest position. Animation is a deterministic 0→1 phase advanced by `dt * phaseSpeed`. Each tick computes:
- `easeV = 0.5 - 0.5 * cos(phase * 2π)` — smooth 0→1→0 envelope
- `dy = easeV * 80` — dive down ~80 PF, then return
- `dx = sin(phase * 4π) * 22 * easeV` — horizontal wiggle that fades with the envelope (so they wiggle at peak dive, sit still at rest)

Swoop period randomised 4.5–6 s per minion at spawn for organic variation, initial phases staggered by 0.15 per minion so they don't all dive in sync.

## Wire change

Added to the existing boss field:
```
boss: { x, hp, hpMax, type, adds: [{x, y, a}, ...] }
```

5 minions × 3 fields × 60 Hz = trivial. Netcode **v27 → v28**.

## Test plan

- [ ] `B` to skip to CRIMSON OCTOPUS — 2 pink-crab minions visible below the boss, swooping in and out.
- [ ] Shoot a minion with a normal bullet — minion dies, bullet consumed, +50 floats off, 5 s later it respawns at its base position.
- [ ] Shoot a minion with a charged bullet (hold FIRE ≥ 0.5 s + release with super ammo) — minion dies AND the charged shot continues up to hit the boss.
- [ ] `B` to AZURE SQUID set — 4 minions visible. JADE SKULL set — 5 minions.
- [ ] Boss death — minions vanish with the boss (no orphans). Next-set boss spawns with its fresh minions.
- [ ] Win cutscene still fires correctly after JADE SKULL's last hit (boss death clears the adds before the cutscene short-circuit kicks in).
- [ ] Multiplayer: two players' bullets can both score on different minions in the same tick (no bullet-loop early-exit regression).

## Out of scope (mentioned for the follow-up pile)

While the boss collision code: charged bullets currently **tunnel through the boss** (don't get consumed on hit). SP discovered + fixed this same bug; a sustained-FIRE hold can grind the boss down absurdly fast. Not fixed here to keep this PR surgical, but worth a separate one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)