### PR TITLE
Session meta-tools: open a past session from chat (list_sessions + open_session)

### DIFF
--- a/.opencode/agents/oyster.md
+++ b/.opencode/agents/oyster.md
@@ -66,6 +66,8 @@ You have MCP tools (the `oyster` server) for managing the desktop surface direct
 | `register_artifact` | Register a file that **already exists on disk** as a desktop artifact. Only for pre-existing files — for new content, use `create_artifact`. |
 | `open_artifact` | Open an artifact in the user's viewer window by exact ID. Use `list_artifacts(search: ...)` first to find the right ID. |
 | `switch_space` | Switch the user's desktop to a different space by exact ID. Use `list_spaces` first if you need to find available spaces. |
+| `list_sessions` | List recent sessions (most-recent first), optionally scoped to a space. Slim metadata only — no transcript text. Use it to find a session to open. |
+| `open_session` | Open a past session in the inspector by exact ID — transcript, artefacts, memory. Get the id from `recall_transcripts` or `list_sessions`; pass `event_id` to land on a specific turn. |
 | `remember` | Store a memory. Only when the user explicitly asks or shares a durable fact. |
 | `recall` | Search memories by natural language query. Use at session start for relevant context. |
 | `forget` | Remove a memory from active recall by ID. |
@@ -81,6 +83,7 @@ You have MCP tools (the `oyster` server) for managing the desktop surface direct
 - **Reorganising**: use `update_artifact(id, { space_id, group_name, label })` to move between spaces or groups.
 - Always call `list_spaces` and `list_artifacts` first to understand what exists before creating or modifying.
 - **"Show me X" / "open X"** → call `list_artifacts(search: "...")` to find matching artifacts, then `open_artifact(id)` with the exact ID to open it in the viewer.
+- **"Show me / open this session"** → `open_session(session_id)` with the id from a `recall_transcripts` hit or `list_sessions`. Pass the hit's `event_id` to jump to the exact turn. Treat it as an instant navigation command like `open_artifact` — call it immediately, one-line confirmation after.
 - **"Switch to Y" / "go to Y"** → call `switch_space(id)` directly if you already know the space ID from context. Only call `list_spaces` first if you're unsure what spaces exist.
 - `create_artifact` kind determines file extension: `notes`→`.md`, `diagram`→`.mmd`, all others→`.html`
 - New artifacts appear immediately on the desktop after creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Ask to see a past session, and Oyster opens it.** Say "show me the session about X" and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.
+
 ## [0.10.0] - 2026-05-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Browser → http://localhost:4444
 
 **Artefacts** — typed outputs on the surface (app, notes, diagram, deck, wireframe, table, map). Registered in SQLite, files in `~/Oyster/spaces/<space-id>/` (user work) or `~/Oyster/apps/` (installed bundles). `source_origin` tracks provenance: `manual` | `discovered` | `ai_generated`.
 
-**MCP** — the server exposes 21 tools at `/mcp/` (17 artifact/space + 4 memory). Any MCP client (Claude Code, Cursor, etc.) can connect and control the surface.
+**MCP** — the server exposes MCP tools at `/mcp/` covering spaces, artefacts, sessions, and memory. Any MCP client (Claude Code, Cursor, etc.) can connect and control the surface.
 
 ## Key Files
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -289,6 +289,7 @@
   </section>
 
   <nav class="version-pills" aria-label="Jump to version">
+      <a class="version-pill" href="#v-unreleased">Unreleased</a>
       <a class="version-pill" href="#v-0-10-0">0.10</a>
       <a class="version-pill" href="#v-0-9-8">0.9</a>
       <a class="version-pill" href="#v-0-8-2">0.8</a>
@@ -303,6 +304,11 @@
   </nav>
 
   <main class="entries">
+<h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.10.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
+<h3>Added</h3>
+<ul>
+<li><strong>Ask to see a past session, and Oyster opens it.</strong> Say &quot;show me the session about X&quot; and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.</li>
+</ul>
 <h2 id="v-0-10-0"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.8...v0.10.0" rel="noopener noreferrer"><span class="release-version">0.10.0</span></a><span class="release-date"> — 2026-05-24</span></h2>
 <h3>Added</h3>
 <ul>

--- a/docs/superpowers/plans/2026-05-25-session-meta-tools.md
+++ b/docs/superpowers/plans/2026-05-25-session-meta-tools.md
@@ -1,0 +1,458 @@
+# Session meta-tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the in-app agent surface a past session in the UI — adding `list_sessions` (recency-ordered discovery) and `open_session` (open a session in the existing inspector, optionally focused on a transcript turn).
+
+**Architecture:** A new `listRecent` store query backs a thin `list_sessions` MCP tool. `open_session` looks up the session and broadcasts a `UiCommand` over the existing SSE channel; `App.tsx` re-dispatches it as the `oyster:open-session` window event that `Home` + `SessionInspector` already consume (the exact path Spotlight uses). No new UI, no new routing.
+
+**Tech Stack:** TypeScript, better-sqlite3, `@modelcontextprotocol/sdk` (via the in-repo `makeTool` helper), Zod, React, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-session-meta-tools-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `server/src/session-store.ts` | SQLite session persistence | Add `listRecent` (interface + prepared stmt + method) |
+| `server/test/session-list-recent.test.ts` | Unit tests for `listRecent` | Create |
+| `server/src/mcp-server.ts` | MCP tool surface | Add `list_sessions` + `open_session` tools |
+| `web/src/App.tsx` | Root SSE command handling | Add `open_session` → `oyster:open-session` re-dispatch |
+| `.opencode/agents/oyster.md` | Agent guidance | Add tool-table rows + usage bullet |
+| `CHANGELOG.md` / `docs/changelog.html` | User-facing changelog | Add Unreleased entry + rebuild |
+| `CLAUDE.md` | Project context | Reword the brittle tool-count line |
+
+All automated testing lives in Task 1 (the store query — the only non-trivial logic). The MCP tools, web handler, and docs are thin wrappers / prose with no unit-test seam in this codebase (there are no `mcp-server` unit tests today); they're verified by typecheck + the manual end-to-end test in Task 7. This is deliberate — do not scaffold a new MCP protocol-level test harness.
+
+---
+
+## Task 1: `listRecent` store query
+
+**Files:**
+- Modify: `server/src/session-store.ts` (interface near line 179; `stmts` type near line 242; constructor near line 270; method near line 432)
+- Test: `server/test/session-list-recent.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/test/session-list-recent.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function makeEnv() {
+  const userland = mkdtempSync(join(tmpdir(), "oyster-listrecent-"));
+  const db = initDb(userland);
+  const store = new SqliteSessionStore(db);
+  return {
+    db,
+    store,
+    dispose: () => { db.close(); rmSync(userland, { recursive: true, force: true }); },
+  };
+}
+
+interface InsertOpts {
+  spaceId?: string | null;
+  title?: string | null;
+  startedAt?: string;
+  lastEventAt?: string;
+}
+
+function insertSession(db: Database.Database, id: string, opts: InsertOpts = {}) {
+  db.prepare(
+    `INSERT INTO sessions (id, space_id, project_id, cwd, agent, title, state, started_at, last_event_at, assignment_mode)
+     VALUES (?, ?, NULL, NULL, 'claude-code', ?, 'disconnected', ?, ?, 'auto')`,
+  ).run(
+    id,
+    opts.spaceId ?? null,
+    opts.title ?? null,
+    opts.startedAt ?? "2026-01-01 00:00:00",
+    opts.lastEventAt ?? "2026-01-01 00:00:00",
+  );
+}
+
+describe("SqliteSessionStore.listRecent", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("orders by last_event_at descending", () => {
+    insertSession(env.db, "s-old", { title: "old", lastEventAt: "2026-01-01 00:00:00" });
+    insertSession(env.db, "s-mid", { title: "mid", lastEventAt: "2026-01-02 00:00:00" });
+    insertSession(env.db, "s-new", { title: "new", lastEventAt: "2026-01-03 00:00:00" });
+    expect(env.store.listRecent().map((s) => s.id)).toEqual(["s-new", "s-mid", "s-old"]);
+  });
+
+  it("breaks last_event_at ties by started_at then id, descending", () => {
+    // Identical last_event_at + started_at: only id differs → id DESC wins.
+    insertSession(env.db, "id-1", { title: "a", startedAt: "2026-02-01 00:00:00", lastEventAt: "2026-02-09 00:00:00" });
+    insertSession(env.db, "id-2", { title: "b", startedAt: "2026-02-01 00:00:00", lastEventAt: "2026-02-09 00:00:00" });
+    // Same last_event_at but later started_at → sorts above the two above.
+    insertSession(env.db, "id-0", { title: "c", startedAt: "2026-02-05 00:00:00", lastEventAt: "2026-02-09 00:00:00" });
+    expect(env.store.listRecent().map((s) => s.id)).toEqual(["id-0", "id-2", "id-1"]);
+  });
+
+  it("defaults to 20 rows and caps at 100", () => {
+    for (let i = 0; i < 101; i++) {
+      // Zero-padded ids keep ordering deterministic under the id tie-breaker.
+      insertSession(env.db, `s-${String(i).padStart(3, "0")}`, {
+        title: `t${i}`,
+        lastEventAt: "2026-03-01 00:00:00",
+      });
+    }
+    expect(env.store.listRecent().length).toBe(20);
+    expect(env.store.listRecent({ limit: 1000 }).length).toBe(100);
+    expect(env.store.listRecent({ limit: 5 }).length).toBe(5);
+  });
+
+  it("returns empty for an unknown space", () => {
+    insertSession(env.db, "s-1", { title: "x", spaceId: "home" });
+    expect(env.store.listRecent({ spaceId: "does-not-exist" })).toEqual([]);
+  });
+
+  it("scopes to a space when spaceId is given", () => {
+    insertSession(env.db, "s-home", { title: "h", spaceId: "home" });
+    insertSession(env.db, "s-work", { title: "w", spaceId: "work" });
+    expect(env.store.listRecent({ spaceId: "home" }).map((s) => s.id)).toEqual(["s-home"]);
+  });
+
+  it("excludes empty stubs but keeps titled or evented rows", () => {
+    insertSession(env.db, "s-stub", { title: null });           // no title, no events → excluded
+    insertSession(env.db, "s-titled", { title: "has a title" }); // titled, no events → kept
+    insertSession(env.db, "s-evented", { title: null });         // no title, has events → kept
+    env.store.insertEvent({ session_id: "s-evented", role: "assistant", text: "hello" });
+    const ids = env.store.listRecent().map((s) => s.id).sort();
+    expect(ids).toEqual(["s-evented", "s-titled"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && npx vitest run test/session-list-recent.test.ts`
+Expected: FAIL — `env.store.listRecent is not a function` (method not yet defined).
+
+- [ ] **Step 3: Add `listRecent` to the `SessionStore` interface**
+
+In `server/src/session-store.ts`, immediately after the `getById` line in the `SessionStore` interface (the line `getById(id: string): SessionRow | undefined;`, ~line 180):
+
+```ts
+  /** Recent sessions for discovery (the list_sessions MCP tool). Recency-
+   *  ordered (last_event_at desc, then started_at, then id), optionally
+   *  scoped to a space. Excludes empty stubs (no title AND no events).
+   *  Limit defaults to 20 and is capped at 100. */
+  listRecent(opts?: { spaceId?: string | null; limit?: number }): SessionRow[];
+```
+
+- [ ] **Step 4: Declare the prepared statement**
+
+In the `SqliteSessionStore` `private stmts: { … }` type, after `getById: Database.Statement;` (~line 242):
+
+```ts
+    listRecent: Database.Statement;
+```
+
+- [ ] **Step 5: Prepare the statement in the constructor**
+
+In the constructor's `this.stmts = { … }` block, after the `getById: db.prepare("SELECT * FROM sessions WHERE id = ?"),` line (~line 270):
+
+```ts
+      // Discovery query for list_sessions. @spaceId null = all spaces.
+      // last_event_at is NOT NULL today, so COALESCE is defensive only;
+      // the started_at/id tie-breakers give a stable order for equal
+      // timestamps. Empty stubs (no title AND no events) are filtered out.
+      listRecent: db.prepare(`
+        SELECT * FROM sessions
+        WHERE (@spaceId IS NULL OR space_id = @spaceId)
+          AND ( (title IS NOT NULL AND title <> '')
+                OR EXISTS (SELECT 1 FROM session_events e WHERE e.session_id = sessions.id) )
+        ORDER BY COALESCE(last_event_at, started_at) DESC, started_at DESC, id DESC
+        LIMIT @limit
+      `),
+```
+
+- [ ] **Step 6: Implement the method**
+
+In `SqliteSessionStore`, immediately after the `getById` method (the block `getById(id: string): SessionRow | undefined { return this.stmts.getById.get(id) as SessionRow | undefined; }`, ~line 432):
+
+```ts
+  listRecent(opts?: { spaceId?: string | null; limit?: number }): SessionRow[] {
+    const limit = Math.min(Math.max(1, Math.trunc(opts?.limit ?? 20)), 100);
+    return this.stmts.listRecent.all({ spaceId: opts?.spaceId ?? null, limit }) as SessionRow[];
+  }
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd server && npx vitest run test/session-list-recent.test.ts`
+Expected: PASS — all 6 tests green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/src/session-store.ts server/test/session-list-recent.test.ts
+git commit -m "feat(sessions): listRecent store query for session discovery
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `list_sessions` + `open_session` MCP tools
+
+**Files:**
+- Modify: `server/src/mcp-server.ts` (insert between the `open_artifact` tool block, which ends ~line 738, and the `// ── switch_space ──` comment ~line 740)
+
+- [ ] **Step 1: Add both tool blocks**
+
+In `server/src/mcp-server.ts`, immediately after the closing `);` of the `open_artifact` `tool(...)` call and before the `// ── switch_space ──` comment, insert:
+
+```ts
+  // ── list_sessions ──
+
+  tool(
+    "list_sessions",
+    "List recent sessions for discovery — most-recently-active first, optionally scoped to a space by id. Returns slim metadata only (no transcript text). Use recall_transcripts to search session content, or open_session to surface a session in the inspector.",
+    {
+      space_id: z.string().optional().describe("Scope to a single space id (omit for all spaces). Unknown id returns an empty list."),
+      limit: z.number().int().positive().optional().describe("Max sessions to return. Defaults to 20, capped at 100."),
+    },
+    async ({ space_id, limit }) => {
+      const rows = deps.sessionStore.listRecent({ spaceId: space_id, limit });
+      return rows.map((s) => ({
+        id: s.id,
+        title: s.title,
+        space_id: s.space_id,
+        agent: s.agent,
+        state: s.state,
+        started_at: s.started_at,
+        last_event_at: s.last_event_at,
+        ended_at: s.ended_at,
+      }));
+    },
+  );
+
+  // ── open_session ──
+
+  tool(
+    "open_session",
+    "Open a past session in the user's session inspector by exact ID — shows its transcript, artefacts, and memory. The inspector opens immediately over the current surface. Find the id with recall_transcripts or list_sessions. Pass event_id (from a recall_transcripts hit) to land on that exact transcript turn, and query to pre-fill the in-transcript find bar.",
+    {
+      session_id: z.string().describe("ID of the session to open"),
+      event_id: z.number().int().optional().describe("Transcript event id from a recall_transcripts hit to scroll to and highlight. Best-effort: a stale/missing id still opens the session."),
+      query: z.string().optional().describe("Text to pre-fill the in-transcript find bar (e.g. the phrase recall_transcripts matched)."),
+    },
+    async ({ session_id, event_id, query }) => {
+      const session = deps.sessionStore.getById(session_id);
+      if (!session) throw new Error(`Session "${session_id}" not found. Use list_sessions or recall_transcripts to find a session id.`);
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "open_session",
+        payload: { sessionId: session.id, eventId: event_id, query },
+      });
+      return `Opened session "${session.title ?? session.id}"`;
+    },
+  );
+```
+
+- [ ] **Step 2: Typecheck the server**
+
+Run: `cd server && npm run build`
+Expected: `tsc` exits 0, no type errors. (`z`, `tool`, `deps.sessionStore`, `deps.broadcastUiEvent` are all already in scope in this file.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src/mcp-server.ts
+git commit -m "feat(mcp): list_sessions + open_session tools
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `open_session` web handler
+
+**Files:**
+- Modify: `web/src/App.tsx` (inside the `subscribeUiEvents` callback in the SSE `useEffect`, after the `terminal_session_linked` block ~line 231)
+
+- [ ] **Step 1: Add the handler**
+
+In `web/src/App.tsx`, inside the `useEffect(() => subscribeUiEvents((event) => { … })` callback, after the closing `}` of the `if (event.command === "terminal_session_linked") { … }` block and before the callback's closing `})`, insert:
+
+```ts
+    if (event.command === "open_session") {
+      // Mirror Spotlight: re-dispatch as the window event Home already
+      // listens for. No route push — Home is always mounted, so this opens
+      // the inspector from any space. eventId → focusEventId, query →
+      // initialSearchQuery; both best-effort (a stale eventId still opens).
+      const { sessionId, eventId, query } = event.payload as {
+        sessionId: string; eventId?: number; query?: string;
+      };
+      window.dispatchEvent(new CustomEvent("oyster:open-session", {
+        detail: { id: sessionId, eventId, query },
+      }));
+    }
+```
+
+- [ ] **Step 2: Typecheck the web app**
+
+Run: `cd web && npx tsc -b`
+Expected: exits 0, no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/App.tsx
+git commit -m "feat(web): open_session SSE command opens the session inspector
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Agent guidance
+
+**Files:**
+- Modify: `.opencode/agents/oyster.md` (tool table after the `open_artifact` / `switch_space` rows ~line 67-68; usage bullets after line 83)
+
+- [ ] **Step 1: Add the tool-table rows**
+
+In `.opencode/agents/oyster.md`, immediately after the `| `switch_space` | … |` row (~line 68), add two rows:
+
+```markdown
+| `list_sessions` | List recent sessions (most-recent first), optionally scoped to a space. Slim metadata only — no transcript text. Use it to find a session to open. |
+| `open_session` | Open a past session in the inspector by exact ID — transcript, artefacts, memory. Get the id from `recall_transcripts` or `list_sessions`; pass `event_id` to land on a specific turn. |
+```
+
+- [ ] **Step 2: Add the usage bullet**
+
+After the `- **"Show me X" / "open X"** → … open_artifact(id) …` bullet (~line 83), add:
+
+```markdown
+- **"Show me / open this session"** → `open_session(session_id)` with the id from a `recall_transcripts` hit or `list_sessions`. Pass the hit's `event_id` to jump to the exact turn. Treat it as an instant navigation command like `open_artifact` — call it immediately, one-line confirmation after.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .opencode/agents/oyster.md
+git commit -m "docs(agent): guide open_session / list_sessions usage
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CHANGELOG + CLAUDE.md
+
+**Files:**
+- Modify: `CHANGELOG.md` (the `## [Unreleased]` section near line 5)
+- Modify: `CLAUDE.md` (line 42, the tool-count line)
+- Regenerate: `docs/changelog.html`
+
+- [ ] **Step 1: Add the Unreleased entry**
+
+In `CHANGELOG.md`, replace the lone `## [Unreleased]` heading (line 5) with:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **Ask to see a past session, and Oyster opens it.** Say "show me the session about X" and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.
+```
+
+- [ ] **Step 2: Reword the CLAUDE.md tool-count line**
+
+In `CLAUDE.md`, replace line 42:
+
+```markdown
+**MCP** — the server exposes 21 tools at `/mcp/` (17 artifact/space + 4 memory). Any MCP client (Claude Code, Cursor, etc.) can connect and control the surface.
+```
+
+with:
+
+```markdown
+**MCP** — the server exposes MCP tools at `/mcp/` covering spaces, artefacts, sessions, and memory. Any MCP client (Claude Code, Cursor, etc.) can connect and control the surface.
+```
+
+- [ ] **Step 3: Regenerate the changelog HTML**
+
+Run: `npm run build:changelog`
+Expected: exits 0; `docs/changelog.html` is rewritten to include the Unreleased "Added" entry.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md docs/changelog.html CLAUDE.md
+git commit -m "docs: changelog entry for session opening; de-brittle MCP tool count
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full build
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the whole project**
+
+Run: `npm run build`
+Expected: web build (`tsc -b && vite build`) and server build (`tsc`) both succeed; `web/dist` is copied into `server/dist/public`. Exit 0.
+
+- [ ] **Step 2: Run the server test suite**
+
+Run: `cd server && npm test`
+Expected: all tests pass, including `session-list-recent.test.ts`.
+
+---
+
+## Task 7: Manual end-to-end verification
+
+**Files:** none (manual)
+
+> Run the dev server from the worktree. Because dev and the installed package share `~/Oyster/` under a single-instance lockfile, either stop any other running Oyster first, or isolate this worktree's workspace with `OYSTER_USERLAND=/tmp/oyster-meta-tools` so it can't collide. From the worktree root: `npm run dev`, then open the Vite URL (`http://localhost:7337`).
+
+- [ ] **Step 1: Happy path — open by content**
+
+In the chat bar, ask: "which session was working with PR 593?" then "show me that session."
+Expected: the agent calls `recall_transcripts` then `open_session`, and the `SessionInspector` opens on the matched session.
+
+- [ ] **Step 2: Focused turn**
+
+Ask the agent to open a session "at the part where we discussed <phrase>" so it passes `event_id` (from a `recall_transcripts` hit).
+Expected: the inspector opens scrolled to that turn, which flashes briefly; the find bar is pre-filled if `query` was passed.
+
+- [ ] **Step 3: Stale event_id is best-effort**
+
+(Optional, via an MCP client or by editing the agent's call.) Call `open_session` with a valid `session_id` but a bogus `event_id` (e.g. `999999999`).
+Expected: the session still opens (no error) — it simply shows a valid window of that session's events without scrolling/flashing a missing one.
+
+- [ ] **Step 4: list_sessions discovery**
+
+Ask: "what are my most recent sessions?"
+Expected: the agent calls `list_sessions` and lists recent sessions (titled or evented only — no empty stubs), most-recent first.
+
+- [ ] **Step 5: Protect the "Home always mounted" assumption**
+
+Open an artifact in the viewer (or navigate to a deep-linked `/s/<space>/a/<id>` URL) so the surface is not on the default Home view, then ask the agent to "show me <session>".
+Expected: the `SessionInspector` still opens over the current surface. (If a future refactor unmounts `Home`, this step is where it breaks.)
+
+- [ ] **Step 6: Final commit (if any manual-fix tweaks were needed)**
+
+Only if Steps 1-5 surfaced a fix. Otherwise nothing to commit.
+
+---
+
+## Done
+
+The user story — "find the relevant session, then show it" — is complete: `list_sessions` + `recall_transcripts` find a session; `open_session` surfaces it in the inspector, optionally on the exact turn.

--- a/docs/superpowers/specs/2026-05-25-session-meta-tools-design.md
+++ b/docs/superpowers/specs/2026-05-25-session-meta-tools-design.md
@@ -1,0 +1,180 @@
+# Session meta-tools — `list_sessions` + `open_session`
+
+**Date:** 2026-05-25
+**Status:** Approved design, pre-implementation
+**Branch:** `session-meta-tools`
+
+## Problem
+
+A user can ask the in-app agent meta-questions about past work and get answers
+("which session was working with PR 593?" resolves today via `recall_transcripts`).
+But the follow-up — "show me this session" — fails: the agent has no lever to
+surface a past session in the UI, so it can only offer to search or resume.
+
+The UI to *display* a session already exists (`SessionInspector`). The only
+missing piece is an MCP tool the agent can call to open it.
+
+## Goal
+
+Complete the user story **"find the relevant session, then show it"** with two
+MCP tools shipped together:
+
+- `list_sessions` — discovery (recency-ordered, optionally space-scoped).
+- `open_session` — surface a session in the inspector, optionally focused on a
+  specific transcript turn.
+
+Out of scope: richer cross-session analytics, new UI, changes to artifact
+opening (`open_artifact` already covers artifacts).
+
+## Existing machinery being reused (no changes)
+
+| Layer | Component | Ref |
+|---|---|---|
+| Inspector UI | `SessionInspector` (transcript / artefacts / memory tabs) | `web/src/components/SessionInspector/index.tsx` |
+| Cross-cutting "open this session" trigger | `window` CustomEvent `oyster:open-session` with `{ id, eventId?, query? }` → sets `activePanel = { kind: "session", … }` | `web/src/components/Home/index.tsx:665` |
+| Proven caller of that event | Spotlight click-through | `web/src/components/SpotlightSearch.tsx:267` |
+| MCP → UI push | `broadcastUiEvent()` → SSE `/api/ui/events` → `App.tsx` handler | `server/src/index.ts:751`, `web/src/App.tsx:198` |
+| Session lookup | `sessionStore.getById(id)` | `server/src/session-store.ts:430` |
+| MCP deps already wired | `deps.sessionStore`, `deps.broadcastUiEvent` | `server/src/mcp-server.ts:128,130` |
+
+`UiCommand.command` is a free-form `string` (`shared/types.ts:244`), so no union
+needs extending for a new `open_session` command.
+
+## Design
+
+### 1. Store — `server/src/session-store.ts`
+
+Add a recency query (interface + implementation):
+
+```ts
+listRecent(opts?: { spaceId?: string; limit?: number }): SessionRow[];
+```
+
+SQL:
+
+```sql
+SELECT * FROM sessions
+[WHERE space_id = ?]
+ORDER BY COALESCE(last_event_at, started_at) DESC
+LIMIT ?
+```
+
+- `COALESCE(last_event_at, started_at)` guards against null/stale `last_event_at`
+  on stub sessions.
+- An unknown `spaceId` simply yields zero rows — no error (the WHERE clause just
+  doesn't match).
+
+### 2. MCP tools — `server/src/mcp-server.ts`
+
+Placed beside `open_artifact`.
+
+**`list_sessions`** — discovery only, never returns transcript text.
+
+- Params: `space_id?: string`, `limit?: number` (default **20**, max **100**).
+- Returns slim rows: `{ id, title, space_id, agent, state, started_at, last_event_at, ended_at }`.
+- Maps `sessionStore.listRecent({ spaceId: space_id, limit })`.
+- Unknown `space_id` → empty array (not an error).
+
+**`open_session`** — dumb broadcaster. Does **not** navigate routes or set space
+itself; it only emits the command and lets the web app react.
+
+- Params: `session_id: string` (required), `event_id?: number` (optional).
+- Look up `sessionStore.getById(session_id)`. If missing → throw with a hint to
+  use `list_sessions` / `recall_transcripts`.
+- `event_id` is **best-effort and NOT validated** here — pass it straight
+  through. If the event is missing, deleted, or belongs to another session, the
+  inspector still opens (falls back to the latest tail); the open never fails on
+  a bad `event_id`.
+- Broadcast with the **canonical payload shape**:
+
+  ```ts
+  deps.broadcastUiEvent({
+    version: 1,
+    command: "open_session",
+    payload: { sessionId: session.id, eventId: event_id },
+  });
+  ```
+
+- Return `Opened session "<title or id>"`.
+
+### 3. Web handler — `web/src/App.tsx`
+
+In the existing SSE `useEffect` (alongside `open_artifact`, `switch_space`):
+
+```ts
+if (event.command === "open_session") {
+  const { sessionId, eventId } = event.payload as { sessionId: string; eventId?: number };
+  window.dispatchEvent(new CustomEvent("oyster:open-session", {
+    detail: { id: sessionId, eventId },
+  }));
+}
+```
+
+Payload→detail mapping is the one rename point: `{ sessionId, eventId }` (wire) →
+`{ id, eventId }` (the shape `Home`'s `oyster:open-session` handler already
+reads, where `eventId` becomes `focusEventId`). No route push — `Home` is always
+mounted, so the event opens the inspector from any space. Mirrors Spotlight
+exactly.
+
+### 4. Agent guidance — `.opencode/agents/oyster.md`
+
+- Add `list_sessions` and `open_session` to the tool table.
+- Usage bullet: **"'show me / open this session'** → `open_session(session_id)`
+  (id from `recall_transcripts` or `list_sessions`); pass `event_id` to land on
+  the exact turn." Treat it as an instant navigation command like `open_artifact`.
+
+### 5. Secondary
+
+- **`CHANGELOG.md`** — user-visible entry under Added (the agent can now open a
+  past session in the inspector, and list recent sessions). Refresh
+  `docs/changelog.html` via `npm run build:changelog`.
+- **`CLAUDE.md`** — replace the brittle "the server exposes 21 tools at `/mcp/`
+  (17 artifact/space + 4 memory)" count with copy that won't drift, e.g.
+  "the server exposes MCP tools for spaces, artefacts, sessions, and memory."
+
+## Data flow
+
+```
+user: "show me this session"
+  → agent: open_session(session_id, event_id?)
+      → sessionStore.getById  (404 if unknown)
+      → broadcastUiEvent { command:"open_session", payload:{ sessionId, eventId } }
+          → SSE /api/ui/events
+              → App.tsx: dispatch CustomEvent "oyster:open-session" { id, eventId }
+                  → Home: setActivePanel({ kind:"session", id, focusEventId })
+                      → SessionInspector renders (tolerates a missing focusEventId)
+```
+
+## Footguns addressed (from review)
+
+1. `open_session` stays dumb — broadcast only, no direct routing.
+2. Single canonical payload shape `{ sessionId, eventId }`; web maps to `{ id, eventId }`.
+3. `event_id` optional + best-effort; a bad/missing event never fails the open.
+4. `list_sessions` is discovery-only — no transcript snippets.
+5. `limit` default 20 / max 100 so a client can't dump everything.
+6. Ordering uses `COALESCE(last_event_at, started_at)` for null/stale stubs.
+7. `space_id` optional; unknown space → empty list, not an error.
+8. Tool-count copy reworded to avoid drift.
+
+## Testing
+
+- **Store:** `listRecent` returns recency order, respects `limit`, empty on
+  unknown `spaceId`, and sorts a null-`last_event_at` row by its `started_at`.
+- **MCP:** `open_session` 404s on unknown id; broadcasts the canonical payload;
+  passes `event_id` through untouched and still succeeds when it's bogus.
+  `list_sessions` clamps the limit and omits transcript text.
+- **Manual:** in the running app, ask the agent "show me this session" after a
+  `recall_transcripts` hit → inspector opens on the right session; with an
+  `event_id` it lands on the matching turn; with a stale `event_id` it still
+  opens.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `server/src/session-store.ts` | `+ listRecent` (interface + impl) |
+| `server/src/mcp-server.ts` | `+ list_sessions`, `+ open_session` tools |
+| `web/src/App.tsx` | `+ open_session` SSE handler |
+| `.opencode/agents/oyster.md` | tool table + usage bullet |
+| `CHANGELOG.md` / `docs/changelog.html` | Added entry + rebuild |
+| `CLAUDE.md` | reword tool-count line |

--- a/docs/superpowers/specs/2026-05-25-session-meta-tools-design.md
+++ b/docs/superpowers/specs/2026-05-25-session-meta-tools-design.md
@@ -65,9 +65,14 @@ ORDER BY COALESCE(last_event_at, started_at) DESC, started_at DESC, id DESC
 LIMIT @limit
 ```
 
-- `COALESCE(last_event_at, started_at)` guards against null/stale `last_event_at`
-  on stub sessions; the `started_at DESC, id DESC` tie-breakers stop equal-
-  timestamp rows from re-ordering between calls.
+- `last_event_at` is `NOT NULL DEFAULT (datetime('now'))`, so the
+  `COALESCE(last_event_at, started_at)` is defensive only (the NULL branch can't
+  occur on a local row today) — kept for future-proofing. The real work is the
+  `started_at DESC, id DESC` tie-breakers, which stop equal-`last_event_at` rows
+  from re-ordering between calls.
+- `listRecent` normalises the limit itself — default **20**, hard cap **100**,
+  floor **1** — so the cap is unit-tested at the store boundary and no caller
+  (MCP tool or otherwise) can dump the whole table.
 - Empty-stub filter is **always on** for this tool — `list_sessions` is agent-
   facing discovery, so it should never expose contentless rows. It does **not**
   gate `open_session`, which takes an explicit id and opens any session.
@@ -82,9 +87,11 @@ Placed beside `open_artifact`.
 
 **`list_sessions`** — discovery only, never returns transcript text.
 
-- Params: `space_id?: string`, `limit?: number` (default **20**, max **100**).
+- Params: `space_id?: string`, `limit?: number` (zod: positive int, optional —
+  the default-20 / cap-100 normalisation lives in `listRecent`).
 - Returns slim rows: `{ id, title, space_id, agent, state, started_at, last_event_at, ended_at }`.
-- Maps `sessionStore.listRecent({ spaceId: space_id, limit })`.
+- Maps `sessionStore.listRecent({ spaceId: space_id, limit })`, then projects to
+  the slim shape (drops `cwd`, `jsonl_path`, exit/terminal facts, etc.).
 - Unknown `space_id` → empty array (not an error).
 
 **`open_session`** — dumb broadcaster. Does **not** navigate routes or set space
@@ -189,11 +196,10 @@ user: "show me this session"
 
 ## Testing
 
-- **Store:** `listRecent` returns recency order, respects `limit`, empty on
-  unknown `spaceId`, sorts a null-`last_event_at` row by its `started_at`,
-  keeps equal-timestamp rows in stable `id` order, and excludes a no-title /
-  no-event stub while keeping a titled-but-eventless row and an untitled-but-
-  has-events row.
+- **Store:** `listRecent` returns recency order, applies the default-20 / cap-100
+  limit, returns empty on an unknown `spaceId`, orders equal-`last_event_at` rows
+  by `started_at DESC` then `id DESC`, and excludes a no-title / no-event stub
+  while keeping a titled-but-eventless row and an untitled-but-has-events row.
 - **MCP:** `open_session` 404s on unknown id; broadcasts the canonical payload
   `{ sessionId, eventId, query }`; passes `event_id` through untouched and still
   succeeds when it's bogus (no validation). `list_sessions` clamps the limit to

--- a/docs/superpowers/specs/2026-05-25-session-meta-tools-design.md
+++ b/docs/superpowers/specs/2026-05-25-session-meta-tools-design.md
@@ -53,16 +53,28 @@ listRecent(opts?: { spaceId?: string; limit?: number }): SessionRow[];
 SQL:
 
 ```sql
+-- Illustrative; bind via better-sqlite3 named params (@spaceId, @limit).
+-- @spaceId is null when the caller omits space_id.
 SELECT * FROM sessions
-[WHERE space_id = ?]
-ORDER BY COALESCE(last_event_at, started_at) DESC
-LIMIT ?
+WHERE (@spaceId IS NULL OR space_id = @spaceId)
+  -- Drop genuine empty stubs: no title AND no transcript events. Keeps every
+  -- titled session and every session that has any events.
+  AND ( (title IS NOT NULL AND title <> '')
+        OR EXISTS (SELECT 1 FROM session_events e WHERE e.session_id = sessions.id) )
+ORDER BY COALESCE(last_event_at, started_at) DESC, started_at DESC, id DESC
+LIMIT @limit
 ```
 
 - `COALESCE(last_event_at, started_at)` guards against null/stale `last_event_at`
-  on stub sessions.
+  on stub sessions; the `started_at DESC, id DESC` tie-breakers stop equal-
+  timestamp rows from re-ordering between calls.
+- Empty-stub filter is **always on** for this tool — `list_sessions` is agent-
+  facing discovery, so it should never expose contentless rows. It does **not**
+  gate `open_session`, which takes an explicit id and opens any session.
 - An unknown `spaceId` simply yields zero rows — no error (the WHERE clause just
   doesn't match).
+- The `EXISTS` subquery is correlated but bounded by `LIMIT`; trivial at the
+  session-table scale.
 
 ### 2. MCP tools — `server/src/mcp-server.ts`
 
@@ -78,20 +90,29 @@ Placed beside `open_artifact`.
 **`open_session`** — dumb broadcaster. Does **not** navigate routes or set space
 itself; it only emits the command and lets the web app react.
 
-- Params: `session_id: string` (required), `event_id?: number` (optional).
+- Params: `session_id: string` (required), `event_id?: number` (optional),
+  `query?: string` (optional).
 - Look up `sessionStore.getById(session_id)`. If missing → throw with a hint to
   use `list_sessions` / `recall_transcripts`.
-- `event_id` is **best-effort and NOT validated** here — pass it straight
-  through. If the event is missing, deleted, or belongs to another session, the
-  inspector still opens (falls back to the latest tail); the open never fails on
-  a bad `event_id`.
+- `event_id` is the **globally-unique `session_events.id`** (`INTEGER PRIMARY
+  KEY`) — the exact value `recall_transcripts` returns as `event_id`. It is
+  **best-effort and MUST NOT be validated or bounds-checked** here. It is a row
+  id, not a within-transcript position. If the event is missing, deleted, or
+  belongs to another session, pass it through anyway — the inspector falls back
+  to the latest tail and the open never fails on a bad `event_id`.
+- `query` is an optional search/highlight string, threaded purely because the
+  existing `oyster:open-session` event already accepts it (`{ id, eventId?,
+  query? }`). When `recall_transcripts` matched a session on, say, "PR 593", the
+  agent can pass that text so the inspector pre-fills its find bar. Optional and
+  best-effort; unused-but-present is fine and keeps the wire shape aligned with
+  the event the web side already consumes.
 - Broadcast with the **canonical payload shape**:
 
   ```ts
   deps.broadcastUiEvent({
     version: 1,
     command: "open_session",
-    payload: { sessionId: session.id, eventId: event_id },
+    payload: { sessionId: session.id, eventId: event_id, query },
   });
   ```
 
@@ -103,18 +124,21 @@ In the existing SSE `useEffect` (alongside `open_artifact`, `switch_space`):
 
 ```ts
 if (event.command === "open_session") {
-  const { sessionId, eventId } = event.payload as { sessionId: string; eventId?: number };
+  const { sessionId, eventId, query } = event.payload as {
+    sessionId: string; eventId?: number; query?: string;
+  };
   window.dispatchEvent(new CustomEvent("oyster:open-session", {
-    detail: { id: sessionId, eventId },
+    detail: { id: sessionId, eventId, query },
   }));
 }
 ```
 
-Payload→detail mapping is the one rename point: `{ sessionId, eventId }` (wire) →
-`{ id, eventId }` (the shape `Home`'s `oyster:open-session` handler already
-reads, where `eventId` becomes `focusEventId`). No route push — `Home` is always
-mounted, so the event opens the inspector from any space. Mirrors Spotlight
-exactly.
+Payload→detail mapping is the one rename point: `{ sessionId, eventId, query }`
+(wire) → `{ id, eventId, query }` (the shape `Home`'s `oyster:open-session`
+handler already reads, where `eventId` becomes `focusEventId` and `query`
+becomes `initialSearchQuery`). No route push — `Home` is always mounted
+(`App.tsx:597`, base surface layer), so the event opens the inspector from any
+space. Mirrors Spotlight exactly.
 
 ### 4. Agent guidance — `.opencode/agents/oyster.md`
 
@@ -136,37 +160,53 @@ exactly.
 
 ```
 user: "show me this session"
-  → agent: open_session(session_id, event_id?)
+  → agent: open_session(session_id, event_id?, query?)
       → sessionStore.getById  (404 if unknown)
-      → broadcastUiEvent { command:"open_session", payload:{ sessionId, eventId } }
+      → broadcastUiEvent { command:"open_session", payload:{ sessionId, eventId, query } }
           → SSE /api/ui/events
-              → App.tsx: dispatch CustomEvent "oyster:open-session" { id, eventId }
-                  → Home: setActivePanel({ kind:"session", id, focusEventId })
+              → App.tsx: dispatch CustomEvent "oyster:open-session" { id, eventId, query }
+                  → Home: setActivePanel({ kind:"session", id, focusEventId, initialSearchQuery })
                       → SessionInspector renders (tolerates a missing focusEventId)
 ```
 
 ## Footguns addressed (from review)
 
 1. `open_session` stays dumb — broadcast only, no direct routing.
-2. Single canonical payload shape `{ sessionId, eventId }`; web maps to `{ id, eventId }`.
+2. Single canonical payload shape `{ sessionId, eventId, query }`; web maps to `{ id, eventId, query }`.
 3. `event_id` optional + best-effort; a bad/missing event never fails the open.
-4. `list_sessions` is discovery-only — no transcript snippets.
-5. `limit` default 20 / max 100 so a client can't dump everything.
-6. Ordering uses `COALESCE(last_event_at, started_at)` for null/stale stubs.
-7. `space_id` optional; unknown space → empty list, not an error.
-8. Tool-count copy reworded to avoid drift.
+   It is the global `session_events.id` row id, **not** a transcript position —
+   the spec forbids bounds-validating it to prevent a future "hardening" regression.
+4. `query?` threaded now to match the existing event shape `{ id, eventId?, query? }`,
+   so transcript-match highlight works without a later wire change.
+5. `list_sessions` is discovery-only — no transcript snippets.
+6. `limit` default 20 / max 100 so a client can't dump everything.
+7. Ordering `COALESCE(last_event_at, started_at) DESC, started_at DESC, id DESC` —
+   the tie-breakers stop equal-timestamp stub rows from jumping between calls.
+8. `space_id` optional; unknown space → empty list, not an error.
+9. Empty-stub filter (no title AND no events) keeps session-store mess out of
+   the agent-facing list; `open_session` is unaffected (explicit id).
+10. Tool-count copy reworded to avoid drift.
 
 ## Testing
 
 - **Store:** `listRecent` returns recency order, respects `limit`, empty on
-  unknown `spaceId`, and sorts a null-`last_event_at` row by its `started_at`.
-- **MCP:** `open_session` 404s on unknown id; broadcasts the canonical payload;
-  passes `event_id` through untouched and still succeeds when it's bogus.
-  `list_sessions` clamps the limit and omits transcript text.
-- **Manual:** in the running app, ask the agent "show me this session" after a
-  `recall_transcripts` hit → inspector opens on the right session; with an
-  `event_id` it lands on the matching turn; with a stale `event_id` it still
-  opens.
+  unknown `spaceId`, sorts a null-`last_event_at` row by its `started_at`,
+  keeps equal-timestamp rows in stable `id` order, and excludes a no-title /
+  no-event stub while keeping a titled-but-eventless row and an untitled-but-
+  has-events row.
+- **MCP:** `open_session` 404s on unknown id; broadcasts the canonical payload
+  `{ sessionId, eventId, query }`; passes `event_id` through untouched and still
+  succeeds when it's bogus (no validation). `list_sessions` clamps the limit to
+  100, defaults to 20, and omits transcript text.
+- **Manual — happy path:** in the running app, ask the agent "show me this
+  session" after a `recall_transcripts` hit → inspector opens on the right
+  session; with an `event_id` it lands on the matching turn; with a stale
+  `event_id` it still opens.
+- **Manual — protect the "Home always mounted" assumption:** trigger
+  `open_session` while the surface is on a non-default route/view (e.g. an
+  artifact viewer open, or a deep-linked `/s/<space>/a/<id>` URL) and confirm the
+  inspector still opens. If a future refactor unmounts `Home` behind another
+  view, this is where it breaks — the test makes that regression visible.
 
 ## Files touched
 

--- a/server/src/mcp-server.ts
+++ b/server/src/mcp-server.ts
@@ -737,6 +737,52 @@ export function createMcpServer(deps: McpDeps): McpServer {
     },
   );
 
+  // ── list_sessions ──
+
+  tool(
+    "list_sessions",
+    "List recent sessions for discovery — most-recently-active first, optionally scoped to a space by id. Returns slim metadata only (no transcript text). Use recall_transcripts to search session content, or open_session to surface a session in the inspector.",
+    {
+      space_id: z.string().optional().describe("Scope to a single space id (omit for all spaces). Unknown id returns an empty list."),
+      limit: z.number().int().positive().optional().describe("Max sessions to return. Defaults to 20, capped at 100."),
+    },
+    async ({ space_id, limit }) => {
+      const rows = deps.sessionStore.listRecent({ spaceId: space_id, limit });
+      return rows.map((s) => ({
+        id: s.id,
+        title: s.title,
+        space_id: s.space_id,
+        agent: s.agent,
+        state: s.state,
+        started_at: s.started_at,
+        last_event_at: s.last_event_at,
+        ended_at: s.ended_at,
+      }));
+    },
+  );
+
+  // ── open_session ──
+
+  tool(
+    "open_session",
+    "Open a past session in the user's session inspector by exact ID — shows its transcript, artefacts, and memory. The inspector opens immediately over the current surface. Find the id with recall_transcripts or list_sessions. Pass event_id (from a recall_transcripts hit) to land on that exact transcript turn, and query to pre-fill the in-transcript find bar.",
+    {
+      session_id: z.string().describe("ID of the session to open"),
+      event_id: z.number().int().optional().describe("Transcript event id from a recall_transcripts hit to scroll to and highlight. Best-effort: a stale/missing id still opens the session."),
+      query: z.string().optional().describe("Text to pre-fill the in-transcript find bar (e.g. the phrase recall_transcripts matched)."),
+    },
+    async ({ session_id, event_id, query }) => {
+      const session = deps.sessionStore.getById(session_id);
+      if (!session) throw new Error(`Session "${session_id}" not found. Use list_sessions or recall_transcripts to find a session id.`);
+      deps.broadcastUiEvent({
+        version: 1,
+        command: "open_session",
+        payload: { sessionId: session.id, eventId: event_id, query },
+      });
+      return `Opened session "${session.title ?? session.id}"`;
+    },
+  );
+
   // ── switch_space ──
 
   tool(

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -178,6 +178,11 @@ export interface SessionStore {
   // sessions
   getAll(): SessionRow[];
   getById(id: string): SessionRow | undefined;
+  /** Recent sessions for discovery (the list_sessions MCP tool). Recency-
+   *  ordered (last_event_at desc, then started_at, then id), optionally
+   *  scoped to a space. Excludes empty stubs (no title AND no events).
+   *  Limit defaults to 20 and is capped at 100. */
+  listRecent(opts?: { spaceId?: string | null; limit?: number }): SessionRow[];
   /** Most-recently-active session for the given agent (R6 attribution). */
   getMostRecentActiveByAgent(agent: SessionAgent): SessionRow | undefined;
   insertSession(row: InsertSession): void;
@@ -240,6 +245,7 @@ export class SqliteSessionStore implements SessionStore {
   private stmts: {
     getAll: Database.Statement;
     getById: Database.Statement;
+    listRecent: Database.Statement;
     getMostRecentActiveByAgent: Database.Statement;
     insertSession: Database.Statement;
     upsertSession: Database.Statement;
@@ -268,6 +274,18 @@ export class SqliteSessionStore implements SessionStore {
     this.stmts = {
       getAll: db.prepare("SELECT * FROM sessions ORDER BY last_event_at DESC"),
       getById: db.prepare("SELECT * FROM sessions WHERE id = ?"),
+      // Discovery query for list_sessions. @spaceId null = all spaces.
+      // last_event_at is NOT NULL today, so COALESCE is defensive only;
+      // the started_at/id tie-breakers give a stable order for equal
+      // timestamps. Empty stubs (no title AND no events) are filtered out.
+      listRecent: db.prepare(`
+        SELECT * FROM sessions
+        WHERE (@spaceId IS NULL OR space_id = @spaceId)
+          AND ( (title IS NOT NULL AND title <> '')
+                OR EXISTS (SELECT 1 FROM session_events e WHERE e.session_id = sessions.id) )
+        ORDER BY COALESCE(last_event_at, started_at) DESC, started_at DESC, id DESC
+        LIMIT @limit
+      `),
       // R6 (#310): attribute MCP writes to the most recent active session of
       // the calling agent. Falls through 'active' → 'waiting' so a session
       // that's been quiet for a few seconds still gets the credit; 'done' /
@@ -429,6 +447,11 @@ export class SqliteSessionStore implements SessionStore {
 
   getById(id: string): SessionRow | undefined {
     return this.stmts.getById.get(id) as SessionRow | undefined;
+  }
+
+  listRecent(opts?: { spaceId?: string | null; limit?: number }): SessionRow[] {
+    const limit = Math.min(Math.max(1, Math.trunc(opts?.limit ?? 20)), 100);
+    return this.stmts.listRecent.all({ spaceId: opts?.spaceId ?? null, limit }) as SessionRow[];
   }
 
   getMostRecentActiveByAgent(agent: SessionAgent): SessionRow | undefined {

--- a/server/src/session-store.ts
+++ b/server/src/session-store.ts
@@ -182,7 +182,8 @@ export interface SessionStore {
   getById(id: string): SessionRow | undefined;
   /** Recent sessions for discovery (the list_sessions MCP tool). Recency-
    *  ordered (last_event_at desc, then started_at, then id), optionally
-   *  scoped to a space. Excludes empty stubs (no title AND no events).
+   *  scoped to a space. Excludes empty stubs (no title AND no visible
+   *  transcript events — protocol-artifact rows don't count).
    *  Limit defaults to 20 and is capped at 100. */
   listRecent(opts?: { spaceId?: string | null; limit?: number }): SessionRow[];
   /** Most-recently-active session for the given agent (R6 attribution). */
@@ -279,12 +280,16 @@ export class SqliteSessionStore implements SessionStore {
       // Discovery query for list_sessions. @spaceId null = all spaces.
       // last_event_at is NOT NULL today, so COALESCE is defensive only;
       // the started_at/id tie-breakers give a stable order for equal
-      // timestamps. Empty stubs (no title AND no events) are filtered out.
+      // timestamps. Empty stubs are filtered out: a session needs a title
+      // OR at least one *visible* transcript event (is_protocol_artifact = 0)
+      // — protocol-only rows (slash-command machinery, hidden from the
+      // transcript and FTS) don't count, mirroring the event-read queries.
       listRecent: db.prepare(`
         SELECT * FROM sessions
         WHERE (@spaceId IS NULL OR space_id = @spaceId)
           AND ( (title IS NOT NULL AND title <> '')
-                OR EXISTS (SELECT 1 FROM session_events e WHERE e.session_id = sessions.id) )
+                OR EXISTS (SELECT 1 FROM session_events e
+                           WHERE e.session_id = sessions.id AND e.is_protocol_artifact = 0) )
         ORDER BY COALESCE(last_event_at, started_at) DESC, started_at DESC, id DESC
         LIMIT @limit
       `),

--- a/server/test/session-list-recent.test.ts
+++ b/server/test/session-list-recent.test.ts
@@ -92,4 +92,17 @@ describe("SqliteSessionStore.listRecent", () => {
     const ids = env.store.listRecent().map((s) => s.id).sort();
     expect(ids).toEqual(["s-evented", "s-titled"]);
   });
+
+  it("treats a protocol-artifact-only session as an empty stub", () => {
+    // Slash-command machinery (is_protocol_artifact = 1) is hidden from the
+    // transcript and excluded from FTS, so it must not count as "has events".
+    insertSession(env.db, "s-protocol-only", { title: null });
+    env.store.insertEvent({
+      session_id: "s-protocol-only",
+      role: "system",
+      text: "<command-name>/exit</command-name>",
+      is_protocol_artifact: 1,
+    });
+    expect(env.store.listRecent().map((s) => s.id)).toEqual([]);
+  });
 });

--- a/server/test/session-list-recent.test.ts
+++ b/server/test/session-list-recent.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type Database from "better-sqlite3";
+import { initDb } from "../src/db.js";
+import { SqliteSessionStore } from "../src/session-store.js";
+
+function makeEnv() {
+  const userland = mkdtempSync(join(tmpdir(), "oyster-listrecent-"));
+  const db = initDb(userland);
+  const store = new SqliteSessionStore(db);
+  return {
+    db,
+    store,
+    dispose: () => { db.close(); rmSync(userland, { recursive: true, force: true }); },
+  };
+}
+
+interface InsertOpts {
+  spaceId?: string | null;
+  title?: string | null;
+  startedAt?: string;
+  lastEventAt?: string;
+}
+
+function insertSession(db: Database.Database, id: string, opts: InsertOpts = {}) {
+  if (opts.spaceId) {
+    db.prepare(
+      `INSERT OR IGNORE INTO spaces (id, display_name, color, scan_status) VALUES (?, ?, '#000', 'none')`,
+    ).run(opts.spaceId, opts.spaceId);
+  }
+  db.prepare(
+    `INSERT INTO sessions (id, space_id, project_id, cwd, agent, title, state, started_at, last_event_at, assignment_mode)
+     VALUES (?, ?, NULL, NULL, 'claude-code', ?, 'disconnected', ?, ?, 'auto')`,
+  ).run(
+    id,
+    opts.spaceId ?? null,
+    opts.title ?? null,
+    opts.startedAt ?? "2026-01-01 00:00:00",
+    opts.lastEventAt ?? "2026-01-01 00:00:00",
+  );
+}
+
+describe("SqliteSessionStore.listRecent", () => {
+  let env: ReturnType<typeof makeEnv>;
+  beforeEach(() => { env = makeEnv(); });
+  afterEach(() => { env.dispose(); });
+
+  it("orders by last_event_at descending", () => {
+    insertSession(env.db, "s-old", { title: "old", lastEventAt: "2026-01-01 00:00:00" });
+    insertSession(env.db, "s-mid", { title: "mid", lastEventAt: "2026-01-02 00:00:00" });
+    insertSession(env.db, "s-new", { title: "new", lastEventAt: "2026-01-03 00:00:00" });
+    expect(env.store.listRecent().map((s) => s.id)).toEqual(["s-new", "s-mid", "s-old"]);
+  });
+
+  it("breaks last_event_at ties by started_at then id, descending", () => {
+    insertSession(env.db, "id-1", { title: "a", startedAt: "2026-02-01 00:00:00", lastEventAt: "2026-02-09 00:00:00" });
+    insertSession(env.db, "id-2", { title: "b", startedAt: "2026-02-01 00:00:00", lastEventAt: "2026-02-09 00:00:00" });
+    insertSession(env.db, "id-0", { title: "c", startedAt: "2026-02-05 00:00:00", lastEventAt: "2026-02-09 00:00:00" });
+    expect(env.store.listRecent().map((s) => s.id)).toEqual(["id-0", "id-2", "id-1"]);
+  });
+
+  it("defaults to 20 rows and caps at 100", () => {
+    for (let i = 0; i < 101; i++) {
+      insertSession(env.db, `s-${String(i).padStart(3, "0")}`, {
+        title: `t${i}`,
+        lastEventAt: "2026-03-01 00:00:00",
+      });
+    }
+    expect(env.store.listRecent().length).toBe(20);
+    expect(env.store.listRecent({ limit: 1000 }).length).toBe(100);
+    expect(env.store.listRecent({ limit: 5 }).length).toBe(5);
+  });
+
+  it("returns empty for an unknown space", () => {
+    insertSession(env.db, "s-1", { title: "x", spaceId: "home" });
+    expect(env.store.listRecent({ spaceId: "does-not-exist" })).toEqual([]);
+  });
+
+  it("scopes to a space when spaceId is given", () => {
+    insertSession(env.db, "s-home", { title: "h", spaceId: "home" });
+    insertSession(env.db, "s-work", { title: "w", spaceId: "work" });
+    expect(env.store.listRecent({ spaceId: "home" }).map((s) => s.id)).toEqual(["s-home"]);
+  });
+
+  it("excludes empty stubs but keeps titled or evented rows", () => {
+    insertSession(env.db, "s-stub", { title: null });
+    insertSession(env.db, "s-titled", { title: "has a title" });
+    insertSession(env.db, "s-evented", { title: null });
+    env.store.insertEvent({ session_id: "s-evented", role: "assistant", text: "hello" });
+    const ids = env.store.listRecent().map((s) => s.id).sort();
+    expect(ids).toEqual(["s-evented", "s-titled"]);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -229,6 +229,18 @@ export default function App() {
       const { terminalId, sessionId } = event.payload as { terminalId: string; sessionId: string };
       dispatch({ type: "LINK_TERMINAL_SESSION", terminalId, sessionId });
     }
+    if (event.command === "open_session") {
+      // Mirror Spotlight: re-dispatch as the window event Home already
+      // listens for. No route push — Home is always mounted, so this opens
+      // the inspector from any space. eventId → focusEventId, query →
+      // initialSearchQuery; both best-effort (a stale eventId still opens).
+      const { sessionId, eventId, query } = event.payload as {
+        sessionId: string; eventId?: number; query?: string;
+      };
+      window.dispatchEvent(new CustomEvent("oyster:open-session", {
+        detail: { id: sessionId, eventId, query },
+      }));
+    }
   }), [loadArtifacts]);
 
   // Sync state from browser back/forward

--- a/web/src/components/NewSessionPicker.tsx
+++ b/web/src/components/NewSessionPicker.tsx
@@ -181,7 +181,7 @@ export function NewSessionPicker({
       if (!q) return true;
       const name = p.name.toLowerCase();
       const path = (p.recentPath ?? "").toLowerCase();
-      const space = (spaceNameById.get(p.spaceId) ?? "").toLowerCase();
+      const space = (spaceNameById.get(p.spaceId ?? "") ?? "").toLowerCase();
       return name.includes(q) || path.includes(q) || space.includes(q);
     };
 
@@ -194,7 +194,7 @@ export function NewSessionPicker({
 
     const toRow = (p: Project, group: "recent" | "all"): Row => ({
       project: p,
-      spaceName: spaceNameById.get(p.spaceId) ?? p.spaceId,
+      spaceName: spaceNameById.get(p.spaceId ?? "") ?? p.spaceId ?? "",
       group,
       disabled: p.hasLivePath === false,
     });

--- a/web/src/components/PublishModal.tsx
+++ b/web/src/components/PublishModal.tsx
@@ -366,7 +366,7 @@ export function PublishModal({ artifact, onClose }: Props) {
                 </div>
                 <div className="publish-modal-meta">
                   Live · published {publication.publishedAt
-                    ? (formatRelative(publication.publishedAt) ?? "just now")
+                    ? (formatRelative(new Date(publication.publishedAt).toISOString()) ?? "just now")
                     : "just now"}
                 </div>
 


### PR DESCRIPTION
## Why

Today you can *ask* the agent meta-questions about past work — "which session was working with PR 593?" resolves via `recall_transcripts` — but the natural follow-up, **"show me that session,"** fails: the agent has no lever to surface a session in the UI. This adds that lever.

The session inspector UI already exists (`SessionInspector`), and Spotlight already opens it via a `window` event. The only missing piece was an MCP tool the agent could call — so this is a small, pattern-matching change.

## What changed

- **`open_session` (MCP tool)** — opens a past session in the inspector by id. Optional `event_id` (from a `recall_transcripts` hit) jumps to the exact transcript turn; optional `query` pre-fills the find bar. Dumb broadcaster: it only emits a UI command and lets the web app react.
- **`list_sessions` (MCP tool)** — recency-ordered session discovery, optionally space-scoped. Slim metadata only (no transcript text).
- **`listRecent` (store query)** — backs `list_sessions`: orders by `last_event_at, started_at, id` (stable tie-breakers), excludes empty stubs (no title **and** no events), default 20 / cap 100 normalised in the store.
- **Web SSE handler** — on the `open_session` command, re-dispatches the existing `oyster:open-session` window event (the exact path Spotlight uses); `eventId`→`focusEventId`, `query`→`initialSearchQuery`. No new routing.
- **Agent guidance** (`oyster.md`), **CHANGELOG** entry, and a de-brittled MCP tool-count line in `CLAUDE.md`.

## Drive-by fix (unrelated, called out)

The web build (`tsc -b`) was already **red on `main`** from 4 pre-existing type errors in untouched files. Fixed here so `npm run build` is green:
- `NewSessionPicker`: `Project.spaceId` is `string | null`; coalesced before `Map.get` and the string-typed `spaceName`.
- `PublishModal`: `publishedAt` is epoch-ms (`number`) but `formatRelative` only parses strings — it was silently always rendering "just now". Now converts to ISO first.

These are in their own commit (`483b63f`) so they're easy to split out if you'd rather land them separately.

## Testing

- New store unit tests: 6 cases (ordering, tie-breaks, default/cap limit, space scope, unknown space, stub filter).
- Full server suite: **573/573 pass**.
- `npm run build`: **green** (web `tsc -b` + vite + server `tsc`).
- Independent code review: no Critical/Important issues.

## Still to do (manual)

Manual e2e against a real `~/Oyster` workspace — ask the agent "show me the session about X" and confirm the inspector opens (and lands on the right turn with `event_id`), including from a non-Home view to exercise the "Home always mounted" assumption. Steps in `docs/superpowers/plans/2026-05-25-session-meta-tools.md` (Task 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)