### PR TITLE
arcade(invaders-mp): SP-parity polish — marked invader + audio DNA + boss descent

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -63,6 +63,16 @@ export interface Ufo {
   dir: 1 | -1;
 }
 
+export interface MarkedInvader {
+  /** Index into state.invaders — the one currently swooping. */
+  idx: number;
+  /** Seconds remaining before snap-back to the grid slot. */
+  untilSec: number;
+  /** Live swoop offsets added to inv.x / inv.y (NOT absolute). */
+  swoopDX: number;
+  swoopDY: number;
+}
+
 export interface BossAdd {
   /** Resting position the minion swoops away from + returns to. */
   baseX: number;
@@ -83,10 +93,14 @@ export interface Boss {
   /** Index into sprites.js BOSS_TYPES (0..BOSS_TYPE_COUNT-1). */
   type: number;
   x: number;
+  /** Vertical position — descends slowly during the fight. */
+  y: number;
   hp: number;
   hpMax: number;
   dir: 1 | -1;
   speed: number;
+  /** PF/sec downward creep rate. Scales with set number. */
+  descent: number;
   fireAccum: number;
   fireInterval: number;
   /** Swooping minion adds — 2 + (setNum-1) per boss. */
@@ -137,6 +151,10 @@ export interface GameState {
   countdownEndMs: number;
   /** True after any B-press this match — disqualifies all per-player scores from the leaderboard. */
   cheated: boolean;
+  /** Currently-swooping marked invader, or null. Reset between stages. */
+  marked: MarkedInvader | null;
+  /** Seconds until the next mark-spawn attempt while none is active. */
+  markedSpawnIn: number;
 }
 
 export interface WireSnapshot {
@@ -177,9 +195,10 @@ export interface WireSnapshot {
    * 'cutscene' for the win celebration before status → 'gameover'.
    */
   phase: 'grid' | 'boss' | 'cutscene';
-  /** Active boss for the renderer; null between bosses. `type` indexes sprites.js BOSS_TYPES, `adds` is the live minion positions. */
+  /** Active boss for the renderer; null between bosses. `type` indexes sprites.js BOSS_TYPES, `adds` is the live minion positions, `y` descends during the fight. */
   boss: {
     x: number;
+    y: number;
     hp: number;
     hpMax: number;
     type: number;
@@ -189,6 +208,8 @@ export interface WireSnapshot {
   cutsceneIn: number;
   /** True after any B-press this match — clients gate leaderboard submission on this. */
   cheated: boolean;
+  /** Currently-swooping marked invader, or null. `i` indexes the invaders array; dx/dy are swoop offsets added to the invader's grid position. */
+  marked: { i: number; dx: number; dy: number } | null;
   /**
    * Per-seat occupancy. Set by the transport layer (room.ts on the
    * server, hostTick on the client) after snapshotForClient returns,

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -596,9 +596,11 @@ function stepBossAdds(state, dt) {
   }
 }
 
-// Boss tick: horizontal bounce + periodic fire from centre-bottom +
-// minion swoop animation. No vertical descent — the boss stays parked
-// at BOSS_Y and applies pressure via bullets + minion shielding.
+// Boss tick: horizontal bounce + slow downward descent + periodic
+// fire from centre-bottom + minion swoop animation. Descent floors
+// just above the shield row (BOSS_Y_MAX) so the boss never bypasses
+// shields — pressure comes from time + bullets + minions, not from
+// the boss reaching the player line.
 function stepBoss(state, dt) {
   if (state.phase !== 'boss' || !state.boss) return;
   const b = state.boss;
@@ -1010,10 +1012,17 @@ function resolveCollisions(state, occupied) {
         }
       }
       if (isMarked) {
-        // Clear the mark so stepMarked can schedule the next one
-        // next tick. We don't reset markedSpawnIn here — stepMarked
-        // does that with the correct alive-count.
+        // Clear the mark + schedule the next gap right here. If we
+        // only nulled state.marked, stepMarked would see markedSpawnIn
+        // already at 0 next tick and immediately spawn another mark
+        // — breaking the 5-15s (or 0.4-0.9s last-one) cadence. Count
+        // alive AFTER the kill (this invader's .alive was just set
+        // to false above) so the last-invader path triggers when it
+        // should.
         state.marked = null;
+        let aliveLeft = 0;
+        for (const ii of state.invaders) if (ii.alive) aliveLeft++;
+        state.markedSpawnIn = nextMarkedGap(aliveLeft);
       }
       if (!b.charged) { b.y = -999; break; }
       // charged: keep checking other invaders this tick

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -70,7 +70,40 @@ const INV_SPEED_MIN  = 20;
 // Wall-bounce drop speed. 8 units at 64 u/s = 125 ms — a hop, not a
 // teleport at the current tick rate.
 const INV_DROP_SPEED = 64;
-const INV_FIRE_INTERVAL = 1.4;
+// Base fire interval at stageSet 1; shrinks per set, floored above
+// the boss interval so the grid doesn't out-spam its own boss.
+// Set 1 = 1.4 s → set 4 = 0.65 s. SP achieves the same difficulty
+// curve via a fire-chance ramp; we shrink the interval since MP
+// fires deterministically on the timer.
+const INV_FIRE_INTERVAL_BASE = 1.4;
+const INV_FIRE_INTERVAL_MIN  = 0.55;
+const INV_FIRE_INTERVAL_STEP = 0.25;
+function invFireIntervalFor(setNum) {
+  return Math.max(INV_FIRE_INTERVAL_MIN, INV_FIRE_INTERVAL_BASE - (setNum - 1) * INV_FIRE_INTERVAL_STEP);
+}
+
+// === Marked invader ===
+// One random alive invader per grid breaks formation, swoops down
+// in a loop-de-loop, returns to its slot at expiry. Ported from SP
+// — adds dynamism to the grid phase. Worth MARKED_BONUS to the
+// killing player (flat, NOT combo-scaled). The swarm's normal march
+// still moves the marked invader's base position; the swoop is a
+// relative offset on top.
+const MARKED_BONUS = 200;
+const MARKED_DURATION_SEC = 4;
+const MARKED_GAP_MIN_SEC = 5;
+const MARKED_GAP_MAX_SEC = 15;
+const MARKED_LAST_ONE_MIN_SEC = 0.4;   // last invader panics — short gaps
+const MARKED_LAST_ONE_MAX_SEC = 0.9;
+const MARKED_SWOOP_AMOUNT_MAX = 140;
+const MARKED_SWOOP_GUARD = 36;         // PF gap from the ship row
+const MARKED_WAGGLE_AMP = 30;
+function nextMarkedGap(aliveCount) {
+  if (aliveCount === 1) {
+    return MARKED_LAST_ONE_MIN_SEC + Math.random() * (MARKED_LAST_ONE_MAX_SEC - MARKED_LAST_ONE_MIN_SEC);
+  }
+  return MARKED_GAP_MIN_SEC + Math.random() * (MARKED_GAP_MAX_SEC - MARKED_GAP_MIN_SEC);
+}
 
 // === Shields ===
 // 4 destructible bunkers between the swarm and the ship row, ported
@@ -160,6 +193,13 @@ export const BOSS_TYPE_COUNT = 4;
 export const CUTSCENE_SEC = 9.5;
 const BOSS_BASE_HP = 30;                         // ~10 charged hits or 30 normal at set 1
 const BOSS_HP_PER_SET = 15;                      // +15 HP per set
+// Slow downward creep so the boss fight has urgency. SP value =
+// 1.6 + (setNum-1) * 0.8 px/sec. Boss floors out just above the
+// shield row so it doesn't bypass them. Without this the boss
+// parks at BOSS_Y forever and the fight has no time pressure.
+const BOSS_DESCENT_BASE = 1.6;
+const BOSS_DESCENT_PER_SET = 0.8;
+const BOSS_Y_MAX = SHIELD_Y - BOSS_H - 4;        // stops above shields
 const BOSS_BASE_SPEED = 38;                      // PF/sec at set 1
 const BOSS_SPEED_PER_SET = 12;
 const BOSS_FIRE_INTERVAL_BASE = 1.1;             // seconds at set 1
@@ -350,6 +390,16 @@ export function initState() {
     invaderDir: 1,
     invaderDropRemaining: 0,
     invaderFireAccum: 0,
+    // Marked invader — { idx, untilSec, swoopDX, swoopDY } | null
+    // where idx is the index into state.invaders (so the renderer +
+    // collision can identify which one swoops). swoopDX/Y are the
+    // current relative offsets the swoop adds on top of the invader's
+    // grid x/y. Cleared on kill / expiry / stage change.
+    marked: null,
+    // Seconds until the next mark-spawn attempt. Pre-seeded with a
+    // gap so the first stage gets a few seconds of "normal" before
+    // the first swoop. Updated by stepMarked + nextMarkedGap.
+    markedSpawnIn: MARKED_GAP_MIN_SEC,
     // 2-frame "shuffle" animation. Advances by horizontal distance
     // travelled, mirroring SP's discrete-step flip (~2 units per
     // beat) — so the animation cadence is tied to march speed and
@@ -420,6 +470,7 @@ export function step(state, inputs, dt, occupied = ALL_OCCUPIED) {
   } else {
     stepInvaders(state, dt);
     stepInvaderFire(state, dt);
+    stepMarked(state, dt);
   }
   stepUfo(state, dt);
   stepPopups(state, dt);
@@ -470,10 +521,12 @@ function spawnBoss(setNum) {
     // never wraps in a real game).
     type: (setNum - 1) % BOSS_TYPE_COUNT,
     x: PF_W / 2 - BOSS_W / 2,
+    y: BOSS_Y,                                  // starts where the top invader row would
     hp,
     hpMax: hp,
     dir: 1,
     speed: BOSS_BASE_SPEED + (setNum - 1) * BOSS_SPEED_PER_SET,
+    descent: BOSS_DESCENT_BASE + (setNum - 1) * BOSS_DESCENT_PER_SET,
     fireAccum: 0,
     fireInterval: Math.max(
       BOSS_FIRE_INTERVAL_MIN,
@@ -554,12 +607,16 @@ function stepBoss(state, dt) {
   // edge-grinding.
   if (b.x < 8)                  { b.x = 8;                  b.dir = 1;  }
   if (b.x > PF_W - 8 - BOSS_W)  { b.x = PF_W - 8 - BOSS_W;  b.dir = -1; }
+  // Slow descent toward the shield row — adds urgency so the fight
+  // can't be ground out indefinitely. Floors out just above the
+  // shields; never bypasses them.
+  b.y = Math.min(BOSS_Y_MAX, b.y + b.descent * dt);
   b.fireAccum += dt;
   if (b.fireAccum >= b.fireInterval) {
     b.fireAccum = 0;
     state.invaderBullets.push({
       x: b.x + BOSS_W / 2 - BULLET_W / 2,
-      y: BOSS_Y + BOSS_H,
+      y: b.y + BOSS_H,
       owner: null,
     });
   }
@@ -605,6 +662,8 @@ function checkStageClear(state) {
     state.invaderDropRemaining = 0;
     state.invaderFireAccum = 0;
     state.invaderBullets = [];
+    state.marked = null;
+    state.markedSpawnIn = MARKED_GAP_MIN_SEC;
     state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
     return;
   }
@@ -617,6 +676,7 @@ function checkStageClear(state) {
     state.phase = 'boss';
     state.boss = spawnBoss(state.stageSet);
     state.invaderBullets = [];
+    state.marked = null;
     state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
     return;
   }
@@ -625,6 +685,8 @@ function checkStageClear(state) {
   state.invaderDropRemaining = 0;
   state.invaderFireAccum = 0;
   state.invaderBullets = [];
+  state.marked = null;
+  state.markedSpawnIn = MARKED_GAP_MIN_SEC;
   state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
 }
 
@@ -766,7 +828,7 @@ function stepInvaders(state, dt) {
 
 function stepInvaderFire(state, dt) {
   state.invaderFireAccum += dt;
-  if (state.invaderFireAccum < INV_FIRE_INTERVAL) return;
+  if (state.invaderFireAccum < invFireIntervalFor(state.stageSet)) return;
   state.invaderFireAccum = 0;
 
   // Pick a random column with at least one live invader, then fire
@@ -788,6 +850,65 @@ function stepInvaderFire(state, dt) {
     y: shooter.y + INV_H,
     owner: null,
   });
+}
+
+// Marked-invader tick. Only runs during phase==='grid' (gameplay
+// keeps the marked entity ticking; boss/cutscene phases clear it
+// via the boss-spawn / cutscene transitions). Two states:
+//   - no current mark → tick markedSpawnIn down, spawn when ≤ 0.
+//   - active mark → tick untilSec down; update swoopDX/DY; expire
+//     when ≤ 0, then schedule the next gap.
+function stepMarked(state, dt) {
+  const aliveIdxs = [];
+  for (let i = 0; i < state.invaders.length; i++) {
+    if (state.invaders[i].alive) aliveIdxs.push(i);
+  }
+  if (aliveIdxs.length === 0) {
+    state.marked = null;                       // grid wiped — drop any in-flight mark
+    return;
+  }
+  if (state.marked) {
+    const m = state.marked;
+    // If the marked invader died via collision in this same tick,
+    // resolveCollisions cleared state.marked already. Defensive
+    // re-check that the index is still alive.
+    if (!state.invaders[m.idx] || !state.invaders[m.idx].alive) {
+      state.marked = null;
+      state.markedSpawnIn = nextMarkedGap(aliveIdxs.length);
+      return;
+    }
+    m.untilSec = Math.max(0, m.untilSec - dt);
+    const t = 1 - (m.untilSec / MARKED_DURATION_SEC);
+    const inv = state.invaders[m.idx];
+    // Vertical: cosine ease 0→1→0 over the duration. Capped so the
+    // swoop doesn't crowd the shield row / collide with the ship at
+    // peak dive (SHIP_Y - INV_H - MARKED_SWOOP_GUARD is the floor).
+    const easeV = 0.5 - 0.5 * Math.cos(t * Math.PI * 2);
+    const swoopAmount = Math.min(
+      MARKED_SWOOP_AMOUNT_MAX,
+      Math.max(0, SHIP_Y - inv.y - INV_H - MARKED_SWOOP_GUARD),
+    );
+    m.swoopDY = easeV * swoopAmount;
+    // Horizontal: 2.5 cycles of sine over the duration → loop-de-loop
+    // shape. Waggle amplitude fades with the same envelope so the
+    // invader sits still at start + end (otherwise the snap-back to
+    // its grid slot would have a visible horizontal jump).
+    m.swoopDX = Math.sin(t * Math.PI * 5) * MARKED_WAGGLE_AMP * easeV;
+    if (m.untilSec === 0) {
+      state.marked = null;
+      state.markedSpawnIn = nextMarkedGap(aliveIdxs.length);
+    }
+    return;
+  }
+  state.markedSpawnIn = Math.max(0, state.markedSpawnIn - dt);
+  if (state.markedSpawnIn === 0) {
+    state.marked = {
+      idx: aliveIdxs[Math.floor(Math.random() * aliveIdxs.length)],
+      untilSec: MARKED_DURATION_SEC,
+      swoopDX: 0,
+      swoopDY: 0,
+    };
+  }
 }
 
 // Chip the shared shield bitmap where a bullet AABB overlaps.
@@ -850,7 +971,13 @@ function resolveCollisions(state, occupied) {
     for (let i = 0; i < state.invaders.length; i++) {
       const inv = state.invaders[i];
       if (!inv.alive) continue;
-      if (!overlap(b.x, b.y, bw, bh, inv.x, inv.y, INV_W, INV_H)) continue;
+      // Marked invader collides at its swoop position, NOT its grid
+      // slot — that's the whole point of the swoop. Compute the
+      // effective hit box for this invader for the overlap test.
+      const isMarked = state.marked && state.marked.idx === i;
+      const ix = isMarked ? inv.x + state.marked.swoopDX : inv.x;
+      const iy = isMarked ? inv.y + state.marked.swoopDY : inv.y;
+      if (!overlap(b.x, b.y, bw, bh, ix, iy, INV_W, INV_H)) continue;
       inv.alive = false;
       const owner = b.owner && state.ships[b.owner];
       if (owner) {
@@ -858,17 +985,21 @@ function resolveCollisions(state, occupied) {
         owner.comboDecayIn = COMBO_WINDOW_SEC;
         const basePts = ROW_POINTS[Math.floor(i / INV_COLS)] || 0;
         const mult = comboMultiplier(owner.combo);
-        const pts = basePts * mult;
+        let pts = basePts * mult;
+        // Marked bonus is FLAT (not combo-scaled — matches SP).
+        // Yellow popup + bigger text to celebrate the rare hit.
+        const markedHit = isMarked;
+        if (markedHit) pts += MARKED_BONUS;
         owner.score += pts;
-        // Floating score popup: "+30" for a vanilla kill, "x3 +60"
-        // when a multiplier's active. Drawn at the killed invader's
-        // position, drifts up and fades.
-        const text = mult > 1 ? `x${mult} +${pts}` : `+${pts}`;
+        let text;
+        if (markedHit)     text = `+${pts}!`;
+        else if (mult > 1) text = `x${mult} +${pts}`;
+        else               text = `+${pts}`;
         state.popups.push({
-          x: inv.x + INV_W / 2,
-          y: inv.y,
+          x: ix + INV_W / 2,
+          y: iy,
           text: text,
-          col: '#ffffff',
+          col: markedHit ? '#ffd84a' : '#ffffff',
           life: POPUP_LIFE_SEC,
         });
         // Earned-ammo threshold crossings — bump the threshold even
@@ -877,6 +1008,12 @@ function resolveCollisions(state, occupied) {
           if (owner.superAmmo < SUPER_SHOT_MAX) owner.superAmmo++;
           owner.nextSuperAt += SUPER_SCORE_INTERVAL;
         }
+      }
+      if (isMarked) {
+        // Clear the mark so stepMarked can schedule the next one
+        // next tick. We don't reset markedSpawnIn here — stepMarked
+        // does that with the correct alive-count.
+        state.marked = null;
       }
       if (!b.charged) { b.y = -999; break; }
       // charged: keep checking other invaders this tick
@@ -931,7 +1068,7 @@ function resolveCollisions(state, occupied) {
       const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
       const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
       if (b.y < -bh) continue;
-      if (!overlap(b.x, b.y, bw, bh, bs.x, BOSS_Y, BOSS_W, BOSS_H)) continue;
+      if (!overlap(b.x, b.y, bw, bh, bs.x, bs.y, BOSS_W, BOSS_H)) continue;
       const dmg = b.charged ? 3 : 1;
       bs.hp = Math.max(0, bs.hp - dmg);
       const owner = b.owner && state.ships[b.owner];
@@ -939,7 +1076,7 @@ function resolveCollisions(state, occupied) {
         owner.score += BOSS_HIT_SCORE;
         state.popups.push({
           x: bs.x + BOSS_W / 2,
-          y: BOSS_Y,
+          y: bs.y,
           text: `-${dmg}`,
           col: '#ff7a7a',
           life: POPUP_LIFE_SEC,
@@ -948,7 +1085,7 @@ function resolveCollisions(state, occupied) {
           owner.score += BOSS_DEFEAT_SCORE;
           state.popups.push({
             x: bs.x + BOSS_W / 2,
-            y: BOSS_Y + BOSS_H / 2,
+            y: bs.y + BOSS_H / 2,
             text: `+${BOSS_DEFEAT_SCORE}`,
             col: '#ffd84a',
             life: POPUP_LIFE_SEC * 2,
@@ -1206,6 +1343,9 @@ export function snapshotForClient(state) {
     phase:          state.phase,
     boss:           state.boss ? {
       x:    round(state.boss.x),
+      // Descent — `y` is server-authoritative now (was a constant).
+      // Older clients fall back to BOSS_Y if missing.
+      y:    round(state.boss.y),
       hp:   state.boss.hp,
       hpMax: state.boss.hpMax,
       type: state.boss.type | 0,
@@ -1216,5 +1356,14 @@ export function snapshotForClient(state) {
     // gate leaderboard submission so cheated runs don't pollute the
     // hi-score table.
     cheated:        !!state.cheated,
+    // Marked invader — { i, dx, dy } where i is the index into the
+    // invaders array and dx/dy are the swoop offsets (added on top
+    // of the invader's grid position by the renderer + collision).
+    // null when no mark is active.
+    marked:         state.marked ? {
+      i:  state.marked.idx,
+      dx: round(state.marked.swoopDX),
+      dy: round(state.marked.swoopDY),
+    } : null,
   };
 }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -581,6 +581,60 @@
     mutedKey:  'oyster-arcade-sfx-muted',
   });
 
+  // Synth — small WebAudio helper for the iconic Invaders sounds
+  // that aren't MP3-sampled: the march heartbeat (4-note loop that
+  // speeds up with the swarm) and the UFO warble. Ported verbatim
+  // from SP's `synth` IIFE (sp index.html ~L313). Uses the shared
+  // Arcade.Audio master volume so the cabinet's mute switch works.
+  const synth = (function () {
+    let actx = null;
+    function ensure() {
+      if (actx) { if (actx.state === 'suspended') actx.resume().catch(()=>{}); return actx; }
+      try {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return null;
+        actx = new Ctx();
+      } catch (_) { return null; }
+      return actx;
+    }
+    function masterVol() {
+      return (window.Arcade && Arcade.Audio && Arcade.Audio.getVolume) ? Arcade.Audio.getVolume() : 1;
+    }
+    function blip(freqStart, freqEnd, durMs, gain, type) {
+      const c = ensure(); if (!c) return;
+      const v = masterVol() * (gain || 0.25);
+      if (v <= 0) return;
+      const t = c.currentTime;
+      const dur = durMs / 1000;
+      const osc = c.createOscillator();
+      osc.type = type || 'square';
+      osc.frequency.setValueAtTime(freqStart, t);
+      osc.frequency.linearRampToValueAtTime(freqEnd, t + dur);
+      const g = c.createGain();
+      g.gain.setValueAtTime(v, t);
+      g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+      osc.connect(g).connect(c.destination);
+      osc.start(t);
+      osc.stop(t + dur);
+    }
+    // March heartbeat — four notes E2, D2, C2, B1 looped, advancing
+    // by one beat each call. Caller schedules calls at the march
+    // tempo (sped up by the swarm thinning).
+    const MARCH_NOTES = [82.41, 73.42, 65.41, 61.74];
+    let marchIdx = 0;
+    function march() { blip(MARCH_NOTES[marchIdx % 4], MARCH_NOTES[marchIdx % 4], 110, 0.18, 'square'); marchIdx++; }
+    function marchReset() { marchIdx = 0; }
+    // UFO siren — sine sweep up-down, called every ~100 ms while
+    // a UFO is on screen. `t` is the UFO's progress across the
+    // playfield (0..1) — drives a subtle pitch wobble on top of
+    // the carrier wobble inside.
+    function ufoWarble(t) {
+      const f = 480 + Math.sin(t * Math.PI * 8) * 90;
+      blip(f, f, 100, 0.13, 'sine');
+    }
+    return { ensure, march, marchReset, ufoWarble };
+  })();
+
   // Leaderboard — same `'invaders'` game key as SP so MP per-player
   // scores share one hi-score table with any legacy SP scores. Top
   // 10 displayed. `qualifies()` reads the local mirror; `submit()`
@@ -605,7 +659,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 29;
+  const NETCODE_VERSION = 30;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1285,6 +1339,19 @@
           // of having to spot a quiet number change while shooting.
           livesFlashUntil = performance.now() + LIVES_FLASH_MS;
         }
+        // March heartbeat — fires on each authoritative shuffle-frame
+        // flip, so the iconic 4-note loop speeds up exactly when the
+        // swarm does (engine's iFrame advances by horizontal distance
+        // travelled). Only during grid phase + actually running.
+        if (msg.status === 'running' && msg.phase === 'grid'
+            && typeof msg.iFrame === 'number' && msg.iFrame !== prev.iFrame) {
+          synth.march();
+        }
+        // Restart of a new run — reset the march sequence so it
+        // always opens on the E2 (the canonical first beat).
+        if (msg.status === 'running' && prev.status !== 'running') {
+          synth.marchReset();
+        }
       }
       lastState = msg;
       snapBuffer.push(msg);
@@ -1583,8 +1650,12 @@
 
   startBtn.addEventListener('click', () => {
     // iOS needs the AudioContext created/resumed inside a real user
-    // gesture. Start is the first guaranteed tap, so do it here.
+    // gesture. Start is the first guaranteed tap, so do it here for
+    // both the shared Arcade.Audio (sfx-* samples) AND our local
+    // WebAudio synth (march heartbeat + UFO warble). Each owns its
+    // own AudioContext under the hood.
     Arcade.Audio.ensureCtx();
+    synth.ensure();
     // Block restart while initials are open — otherwise tapping
     // START mid-submission loses the score without writing it to
     // the leaderboard. The player can either finish entering
@@ -1993,15 +2064,31 @@
     // 6 PF right-padding gap; squid (9 PF wide) gets the SP-style
     // +2 PF rightward nudge to align columns under the wider rows.
     const SPRITE_SCALE = 1.5;
+    // Marked-invader swoop offset — if any invader is the marked one,
+    // its render position is the grid slot PLUS the server-computed
+    // swoop offset (dx/dy). Pulse colour white ↔ row palette at
+    // ~12.5 Hz so it reads as "this one is special". Server flips
+    // the mark to null on kill / expiry, so this branch quietly
+    // turns off when there's nothing to swoop.
+    const marked = latestSnap.marked || null;
+    const markedFlashWhite = marked
+      ? (Math.floor(performance.now() / 80) % 2 === 0)
+      : false;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide
       const row = Math.floor(i / SPRITE_COLS);
       const { frames, w } = spriteForRow(row);
       const ox = row === 0 ? 2 : 0;
-      const cellX = Math.round(lerp(ia.x, ib.x) + ox);
-      const cellY = Math.round(lerp(ia.y, ib.y));
-      paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, ROW_COLORS[row] || '#ffffff');
+      const isMarked = marked && marked.i === i;
+      const dx = isMarked ? (marked.dx || 0) : 0;
+      const dy = isMarked ? (marked.dy || 0) : 0;
+      const cellX = Math.round(lerp(ia.x, ib.x) + ox + dx);
+      const cellY = Math.round(lerp(ia.y, ib.y) + dy);
+      const colour = (isMarked && markedFlashWhite)
+        ? '#ffffff'
+        : (ROW_COLORS[row] || '#ffffff');
+      paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, colour);
     }
 
     // Shields — decode the packed bitmap from the snapshot once when
@@ -2040,8 +2127,12 @@
       const ratio = Math.max(0, Math.min(1, hp / hpMax));
       // Body colour darkens as the boss bleeds — SP's 3-step palette.
       const bandIndex = ratio > 0.66 ? 0 : ratio > 0.33 ? 1 : 2;
-      paintBoss(ctx, latestSnap.boss.x, BOSS_Y, 5, bf, latestSnap.boss.type || 0, bandIndex);
-      const barY = BOSS_Y - 4;
+      // v30: boss descends — y is server-authoritative now. Fall
+      // back to the old BOSS_Y constant for pre-v30 snapshots so
+      // a mid-deploy client doesn't render the boss at (x, undef).
+      const bossY = (latestSnap.boss.y != null) ? latestSnap.boss.y : BOSS_Y;
+      paintBoss(ctx, latestSnap.boss.x, bossY, 5, bf, latestSnap.boss.type || 0, bandIndex);
+      const barY = bossY - 4;
       ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
       ctx.fillRect(latestSnap.boss.x, barY, BOSS_W, 2);
       ctx.fillStyle = ratio > 0.6 ? '#6bff8c' : ratio > 0.3 ? '#ffd84a' : '#ff6666';
@@ -2494,9 +2585,27 @@
     }
   }
 
+  // UFO warble — fires every UFO_WARBLE_MS while a UFO is on-screen.
+  // Tracked client-side (server doesn't drive audio) so each device
+  // hears its own warble in time. Reset accumulator when no UFO so a
+  // fresh spawn starts on the first frame.
+  const UFO_WARBLE_MS = 100;
+  let ufoWarbleAt = 0;
+  function tickUfoWarble(now) {
+    const snap = snapBuffer[snapBuffer.length - 1];
+    if (!snap || !snap.ufo) { ufoWarbleAt = 0; return; }
+    if (now >= ufoWarbleAt) {
+      const progress = Math.max(0, Math.min(1, snap.ufo.x / PF_W));
+      synth.ufoWarble(progress);
+      ufoWarbleAt = now + UFO_WARBLE_MS;
+    }
+  }
+
   function rafLoop(now) {
-    stepLocal(now || performance.now());
+    const t = now || performance.now();
+    stepLocal(t);
     renderInterpolated();
+    tickUfoWarble(t);
     requestAnimationFrame(rafLoop);
   }
   requestAnimationFrame(rafLoop);

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -156,8 +156,9 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        - Boss descent: state.boss now has `y` (was a constant);
 //          drops slowly toward the shield row during the fight.
 //          New wire field boss.y.
-//        - Invader fire interval shrinks per set (1.4 → 0.55 s)
-//          so endgame stages feel urgent.
+//        - Invader fire interval shrinks per set: set 1 = 1.4 s,
+//          set 4 = 0.65 s (with a 0.55 s floor that the 4-set game
+//          never actually reaches) so endgame stages feel urgent.
 //        - Client-only: march-heartbeat synth + UFO warble synth.
 const NETCODE_VERSION = 30;
 

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -148,7 +148,18 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //        per-player scores from submission. Also fixes the charged-
 //        bullet-vs-boss bug (boss now consumes bullets on hit like
 //        SP — was dealing ~24 dmg per hold-release).
-const NETCODE_VERSION = 29;
+// v30 — "Game feels alive" bundle (SP-parity polish):
+//        - Marked invader: one random invader periodically breaks
+//          formation, loop-de-loops toward the player + returns;
+//          kill for flat +200 bonus. New wire field state.marked
+//          { i, dx, dy } | null.
+//        - Boss descent: state.boss now has `y` (was a constant);
+//          drops slowly toward the shield row during the fight.
+//          New wire field boss.y.
+//        - Invader fire interval shrinks per set (1.4 → 0.55 s)
+//          so endgame stages feel urgent.
+//        - Client-only: march-heartbeat synth + UFO warble synth.
+const NETCODE_VERSION = 30;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Bundled SP-parity polish you flagged in the audit. Five gaps, all targeting the same problem: the MP port felt sterile compared to SP. ~150 lines total.

### 1. Marked invader (the one you spotted)
One random alive invader periodically breaks formation, dives toward the player in a **loop-de-loop swoop** (cosine ease + sin waggle), then snaps back to its grid slot. Kill it before the timer expires for a flat **+200** bonus (NOT combo-scaled — matches SP). Pulses white at ~12.5 Hz so it reads as "special". Last-invader endgame: the loner panics with 0.4–0.9 s gaps between marks instead of 5–15 s. Mark clears on stage change / boss / cutscene. [SP ~L1666-1713]

### 2. March heartbeat synth
The iconic 4-note loop `E2 D2 C2 B1` (~SP L350). Fires on each authoritative shuffle-frame flip (engine's `iFrame`), so it speeds up exactly when the swarm does. Game now sounds like Invaders.

### 3. UFO warble synth
Sine sweep `480 ± 90 Hz` every 100 ms while a UFO is on-screen. Client-side tracking off the latest snapshot's `ufo.x` for progress. The bonus saucer is no longer sonically invisible.

### 4. Boss descent
Boss now has `y` on state (was a fixed constant). Descends at `1.6 + (setNum-1)*0.8` PF/sec, floored just above the shield row. Removes the "grind it down forever" problem — sets 3 + 4 now have real time pressure. Server-authoritative; renderer reads `boss.y` from the wire.

### 5. Invader fire-interval scaling
Per-set shrink: set 1 = 1.4 s → set 4 = 0.65 s, floored above the boss interval so the swarm doesn't out-spam its own boss. SP achieves the same difficulty curve via a fire-chance ramp; we shrink the interval since MP fires deterministically.

## Wire change

| New field           | Shape                                          |
|---------------------|------------------------------------------------|
| `state.marked`      | `{ i: number, dx: number, dy: number } \| null` |
| `boss.y`            | `number` (was a constant client-side)          |

Pre-v30 clients fall back to `BOSS_Y` constant if `boss.y` is missing — non-fatal mid-deploy.

Netcode **v29 → v30**.

## Test plan

- [ ] Start a normal stage → after 5-15 s, one invader breaks formation and loops down toward the ship + back. Pulses white. Tag it → yellow `+(score)!` popup, big bonus to your personal score.
- [ ] Last invader of a stage → it panics with very short gaps between swoops.
- [ ] Marked invader expires un-shot → snaps back to its grid slot smoothly (no jump).
- [ ] Charged shot pierces marked invader → kills it + continues to other invaders.
- [ ] Marching swarm sounds like the iconic Invaders heartbeat. Speeds up as the swarm thins.
- [ ] UFO crossing the screen → soft sine warble audible throughout. Silent again once it leaves / dies.
- [ ] Boss fight: the boss slowly drops over the course of the fight. By the time it's near the shields you should feel pressured to finish it.
- [ ] Set 4 (JADE SKULL) fires noticeably faster than set 1 (CRIMSON OCTOPUS). Set 4 grid stage (4-1, 4-2, 4-3) also fires noticeably faster than 1-1.
- [ ] Score popups still work in all combinations: combo `x3 +60`, marked yellow `+260!`, normal `+30`.
- [ ] Restart cleanly resets the march beat sequence (always opens on the E2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)