### PR TITLE
arcade(shared): extract leaderboard CSS + add DOM-contract README

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../shared/touch.css">
 <link rel="stylesheet" href="../shared/overlays.css">
 <link rel="stylesheet" href="../shared/splash.css">
+<link rel="stylesheet" href="../shared/leaderboard.css">
 <style>
   /* Invaders-specific splash + game-over palette. Shell, .splash-main,
      .start, .controls, .credit, .hiscore-row, and the prefers-reduced-
@@ -51,36 +52,8 @@
   /* Splash-view cycling (.splash-view + .is-active) lives in
      ../shared/splash.css. The cycler itself (Arcade.Splash.startCycle)
      lives in ../shared/splash.js. */
-  .leaderboard {
-    color: #fff;
-    font-family: 'Press Start 2P', ui-monospace, monospace;
-  }
-  .leaderboard .lb-title {
-    font-size: clamp(18px, 3.5vw, 32px);
-    color: #ffd84a;
-    letter-spacing: 0.12em;
-    text-shadow: 3px 3px 0 #ff3aa1, 5px 5px 0 #2dd4ff;
-    margin-bottom: clamp(8px, 1.5vw, 16px);
-  }
-  .leaderboard .lb-list {
-    list-style: none; padding: 0; margin: 0;
-    display: grid;
-    grid-template-columns: auto auto auto;
-    gap: 6px 22px;
-    font-size: clamp(10px, 1.5vw, 14px);
-    letter-spacing: 0.14em;
-    align-items: center;
-  }
-  .leaderboard .lb-list li { display: contents; }
-  .leaderboard .lb-rank     { color: #ff3aa1; text-align: right; }
-  .leaderboard .lb-initials { color: #2dd4ff; text-align: left; letter-spacing: 0.2em; }
-  .leaderboard .lb-score    { color: #ffd84a; text-align: right; }
-  .leaderboard .lb-empty {
-    font-size: clamp(10px, 1.4vw, 12px);
-    color: rgba(255, 255, 255, 0.55);
-    grid-column: 1 / -1;
-    text-align: center;
-  }
+  /* Splash leaderboard view (.leaderboard + .lb-*) lives in
+     ../shared/leaderboard.css. Invaders uses the default heading size. */
   /* @keyframes arcade-blink + splash-poweron live in shared/cabinet.css */
 
   /* Per-button touch overrides — FIRE button is pink to set it apart from

--- a/docs/arcade/shared/README.md
+++ b/docs/arcade/shared/README.md
@@ -43,11 +43,17 @@ modules read another's API at call time. Use this order.
 <script src="../shared/initials.js"></script>
 <script src="../shared/end-overlay.js"></script>
 <script src="../shared/splash.js"></script>
-<!-- …then your game's own <script> last -->
 ```
 
 Skip any module you don't need — but mind the noted dependencies (`pause`
 wants `audio` loaded first; `iframe-host` checks for `pause`).
+
+**Your game's own script goes at the *end* of `<body>`, after the markup** — not
+up here with the shared modules. The shared modules just define `window.Arcade.*`
+and do no DOM lookups at load, but your init code calls `Arcade.Splash.mount()` /
+`paintList()` / etc., which need `#splash`, `#lb-list`, `#gameover` … to already
+exist. Run it at body-top and it silently no-ops on the missing elements. (Or
+give your script `defer`, or wrap init in `DOMContentLoaded`.)
 
 ---
 
@@ -84,7 +90,9 @@ SFX/BGM lists, the title art, and the control hints with your own.
 ```html
 <!-- <head>: the six <link>s from "Load order" above -->
 <body>
-  <!-- the nine <script>s from "Load order", then your game script -->
+  <!-- the nine shared <script>s from "Load order" go here at body-top;
+       your game's OWN script goes at the end of <body> (see bottom) -->
+
 
   <!-- SFX: id MUST match the key in Arcade.Audio.init({sfx}) -->
   <audio id="sfx-shoot" src="sfx-shoot.mp3" preload="auto"></audio>
@@ -151,10 +159,14 @@ SFX/BGM lists, the title art, and the control hints with your own.
       </div>
     </div>
   </div>
+
+  <!-- Your game's own script goes HERE — after the markup — so its
+       Arcade.*.mount() / paintList() calls can find the elements above. -->
+  <script src="your-game.js"></script>
 </body>
 ```
 
-### Wiring (in your game's `<script>`, after the shared scripts)
+### Wiring (in your game's `<script>`, placed at the end of `<body>` after the markup)
 
 ```js
 Arcade.Audio.init({ sfx: { 'sfx-shoot': 'sfx-shoot.mp3' }, volumeKey: 'oyster-arcade-sfx-volume' });

--- a/docs/arcade/shared/README.md
+++ b/docs/arcade/shared/README.md
@@ -1,0 +1,232 @@
+# Arcade shared framework — DOM contract & wiring guide
+
+Everything in `docs/arcade/shared/` is the common cabinet for the arcade games
+(`invaders/`, `space-jumper/`, …). The JS modules attach to a single global
+`window.Arcade.*` namespace; the CSS sheets style a fixed set of class/id names.
+
+**The one gotcha:** every module is **selector-driven with silent defaults**.
+If your markup doesn't use the exact ids/classes a module expects, the module
+no-ops quietly — no error, just a dead button or an unstyled panel. This file
+is the source of truth for those selectors so a new game (or an agent building
+one) can be scaffolded correctly the first time.
+
+Each module is a plain IIFE — no build step, no imports. Drop the `<script>`
+tags in and the `window.Arcade.*` objects appear.
+
+---
+
+## Load order
+
+Order matters: stylesheets reference each other's `@keyframes`, and a few JS
+modules read another's API at call time. Use this order.
+
+**In `<head>` — stylesheets:**
+
+```html
+<link rel="stylesheet" href="../shared/pixel-font.css">  <!-- 1st: @font-face + body reset -->
+<link rel="stylesheet" href="../shared/cabinet.css">     <!-- defines the @keyframes the others use -->
+<link rel="stylesheet" href="../shared/touch.css">
+<link rel="stylesheet" href="../shared/overlays.css">    <!-- game-over overlay -->
+<link rel="stylesheet" href="../shared/splash.css">      <!-- title/attract screen -->
+<link rel="stylesheet" href="../shared/leaderboard.css"> <!-- splash leaderboard view -->
+```
+
+**At the top of `<body>` — scripts (load only what you use, in this order):**
+
+```html
+<script src="../shared/audio.js"></script>       <!-- before pause.js (pause reads Arcade.Audio) -->
+<script src="../shared/music.js"></script>
+<script src="../shared/pause.js"></script>
+<script src="../shared/touch.js"></script>
+<script src="../shared/iframe-host.js"></script> <!-- after pause.js (checks Arcade.Pause for ESC) -->
+<script src="../shared/leaderboard.js"></script>
+<script src="../shared/initials.js"></script>
+<script src="../shared/end-overlay.js"></script>
+<script src="../shared/splash.js"></script>
+<!-- …then your game's own <script> last -->
+```
+
+Skip any module you don't need — but mind the noted dependencies (`pause`
+wants `audio` loaded first; `iframe-host` checks for `pause`).
+
+---
+
+## Module reference
+
+| Module | `window.Arcade.*` | Required DOM / selectors | Notes |
+|---|---|---|---|
+| `audio.js` | `Audio` | `<audio id="…">` for each SFX key passed to `init({sfx})` | Web Audio SFX. The `<audio>` element is only the pre-decode fallback; ids **must** match the `sfx` keys. Call `ensureCtx()` on the first user gesture (iOS unlock). |
+| `music.js` | `Music` | `<audio id="bgm…">` — **any id starting with `bgm`** | BGM. One track at a time; `play('bgm-x', {gain})` pauses the rest. New tracks **must** be named `bgm` / `bgm-*` or neither `Music` nor the pause slider will manage them. |
+| `pause.js` | `Pause` | none — injects its own overlay + styles | P / ESC toggles a pause card with MUSIC + SFX volume sliders. Reads `audio[id^="bgm"]`. Gate your loop with `if (Arcade.Pause.isPaused()) return;`. Optional `Arcade.Pause.canPause = () => …`. |
+| `touch.js` | `Touch` | you pass element refs; convention: `.touch-controls` with `.tc-btn` buttons | `bind(btn,onDown,onUp)` for a hold button; `movePad(left,right,…)` for a ◀▶ analog d-pad. Also installs a coarse-pointer `contextmenu` guard. Touch controls only show once `.tube.is-ready`. |
+| `iframe-host.js` | *(self-installs)* | none | Adds `.is-embedded` to `<body>` when iframed; ESC posts a close message to the parent — unless `Arcade.Pause` is loaded, which then owns ESC. No API. |
+| `leaderboard.js` | `Leaderboard` | `paintList({listSelector})` → an `<ol>` (conventionally `#lb-list`); `paintHiScoreRow({valueSelector, initialsSelector, rowSelector})` | Cloud (`/api/leaderboard`) + localStorage mirror. `init({game, max})` — `game` must be in the worker allowlist (`infra/leaderboard-worker/src/worker.ts`). Mirror key: `oyster-arcade-leaderboard-<game>`. |
+| `initials.js` | `Initials` | `#go-initials` container, `#go-initials .go-slot` cells each with `data-slot="N"`, `#go-prompt` | High-score initials state machine (keyboard + touch). `mount({onSubmit, fireButton})`, `open()`. Gate your restart listeners on `if (Arcade.Initials.isActive()) return;`. |
+| `end-overlay.js` | `EndOverlay` | `#gameover` root + `#go-title`, `#go-score-val`, `#go-hiscore`, `#go-prompt` (toggles `.is-visible`) | Game-over/complete overlay + the grace-window + "next keypress restarts" gate. `show({score, title, titleClass, hiscore, graceMs, qualifies})`, `acceptsInput()`, `consumePending()`. `mount()` is optional (defaults match the ids above). |
+| `splash.js` | `Splash` | `#splash`, `#splash .splash-view` (index 0 = title, 1 = leaderboard), `.tube` | Full attract-mode lifecycle: booting → title → playing → attract. `mount({onTitle, onPlay, onLeaderboardShow, unlockAudio, isBusy})`, `enterAttract()`. Gate your loop with `if (!Arcade.Splash.isPlaying()) return;`. Toggles `.tube.is-ready` and `body.is-ingame`. |
+
+### Stylesheet class contracts
+
+- **`pixel-font.css`** — `@font-face` for *Press Start 2P* (self-hosted from `../../assets/PressStart2P-Regular.ttf`; the Google subset drops the ★ ♪ ← → glyphs) + a full-screen body reset that locks scroll/zoom/selection. Load first.
+- **`cabinet.css`** — the bezel/tube/CRT shell: `.screen` › `.tube` › (`canvas`, `.overlay`, `.vignette`). `.tube.is-ready` reveals the canvas + touch controls; `.tube.is-shaking` plays a crash shake. Owns the shared `@keyframes`: `splash-poweron`, `crt-shutoff`, `crt-shake`, `arcade-blink`. References `../../assets/crt.png`.
+- **`overlays.css`** — `.gameover` (`.is-visible`) and `.go-*` children (`.go-title` with `.is-win`/`.is-loss`, `.go-score`, `.go-hiscore`, `.go-prompt`, `.go-initials`, `.go-initials-label`, `.go-initials-slots`, `.go-slot` w/ `.is-active`, `.go-initials-hint`). Retint via `--go-*` CSS vars — don't restate geometry.
+- **`splash.css`** — `.splash` (`.is-hidden`), `.splash-main`, `.start`, `.controls` (`.key`/`.desc`), `.credit`, `.hiscore-row` (`.hs-val`/`.hs-initials`), and `.splash-view` (`.is-active`). Background via `--splash-bg`. **Per-game (not here):** `.splash .title` marquee.
+- **`touch.css`** — `.touch-controls` › `.tc-group` › `.tc-btn` (`.is-pressed`). Plus the `.key-only` / `.touch-only` utility pair that swaps keyboard vs touch hint copy on coarse pointers.
+- **`leaderboard.css`** — `.leaderboard` › `.lb-title` / `.lb-list` (`li`) / `.lb-rank` / `.lb-initials` / `.lb-score` / `.lb-empty`. Tune just the heading via `--lb-title-size` (set it on `.leaderboard`; it inherits to `.lb-title`).
+
+---
+
+## Minimal game skeleton
+
+Real, working markup trimmed to the essentials (from `invaders/`). Replace the
+SFX/BGM lists, the title art, and the control hints with your own.
+
+```html
+<!-- <head>: the six <link>s from "Load order" above -->
+<body>
+  <!-- the nine <script>s from "Load order", then your game script -->
+
+  <!-- SFX: id MUST match the key in Arcade.Audio.init({sfx}) -->
+  <audio id="sfx-shoot" src="sfx-shoot.mp3" preload="auto"></audio>
+  <!-- BGM: id MUST start with "bgm" -->
+  <audio id="bgm"       src="bgm.mp3"       preload="auto" loop></audio>
+  <audio id="bgm-title" src="bgm-title.mp3" preload="auto" loop></audio>
+
+  <div class="screen">
+    <div class="tube">
+      <canvas id="c"></canvas>
+      <div class="overlay"></div>
+      <div class="vignette"></div>
+
+      <!-- Touch controls (auto-shown on coarse pointers once .tube.is-ready) -->
+      <div class="touch-controls">
+        <div class="tc-group">
+          <button type="button" class="tc-btn" id="tc-left"  aria-label="Move left"  tabindex="-1">◀</button>
+          <button type="button" class="tc-btn" id="tc-right" aria-label="Move right" tabindex="-1">▶</button>
+        </div>
+        <div class="tc-group">
+          <button type="button" class="tc-btn" id="tc-fire" aria-label="Fire" tabindex="-1">FIRE</button>
+        </div>
+      </div>
+
+      <!-- Game-over overlay (EndOverlay + Initials) -->
+      <div class="gameover" id="gameover" aria-hidden="true">
+        <div class="go-title" id="go-title">GAME OVER</div>
+        <div class="go-score">SCORE <span id="go-score-val">0</span></div>
+        <div class="go-hiscore" id="go-hiscore"></div>
+        <div class="go-prompt" id="go-prompt">
+          <span class="key-only">PRESS ANY KEY TO CONTINUE</span>
+          <span class="touch-only">TAP TO CONTINUE</span>
+        </div>
+        <div class="go-initials" id="go-initials" hidden>
+          <div class="go-initials-label">NEW HIGH SCORE — ENTER INITIALS</div>
+          <div class="go-initials-slots">
+            <span class="go-slot is-active" data-slot="0">A</span>
+            <span class="go-slot"           data-slot="1">A</span>
+            <span class="go-slot"           data-slot="2">A</span>
+          </div>
+          <div class="go-initials-hint">
+            <span class="key-only">↑↓ LETTER · ←→ SLOT · ENTER SAVE</span>
+            <span class="touch-only">TAP SLOT · SWIPE LETTER · SELECT SAVES</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Splash: title card ↔ leaderboard, auto-cycled by Arcade.Splash -->
+      <div class="splash" id="splash">
+        <div class="splash-main">
+          <div class="title-card splash-view is-active">
+            <div class="title">YOUR GAME</div>
+            <div class="start"><span class="key-only">INSERT COIN TO PLAY</span><span class="touch-only">TAP TO PLAY</span></div>
+            <div class="hiscore-row" id="hiscore-row">HIGH SCORE
+              <span class="hs-val" id="hs-val-splash">0000</span>
+              <span class="hs-initials" id="hs-initials-splash">---</span>
+            </div>
+          </div>
+          <div class="leaderboard splash-view">
+            <div class="lb-title">HIGH SCORES</div>
+            <ol class="lb-list" id="lb-list"></ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+```
+
+### Wiring (in your game's `<script>`, after the shared scripts)
+
+```js
+Arcade.Audio.init({ sfx: { 'sfx-shoot': 'sfx-shoot.mp3' }, volumeKey: 'oyster-arcade-sfx-volume' });
+Arcade.Leaderboard.init({ game: 'your-game', max: 10 });   // 'your-game' must be in the worker allowlist
+Arcade.Leaderboard.refresh();
+
+Arcade.Initials.mount({
+  fireButton: '#tc-fire',
+  onSubmit: (initials) => {
+    Arcade.Leaderboard.submit(score, initials);
+    Arcade.EndOverlay.extendGrace(800);     // beat before the next key restarts
+  },
+});
+
+Arcade.Splash.mount({
+  onTitle:           () => Arcade.Music.play('bgm-title', { gain: 0.4 }),
+  onPlay:            () => { Arcade.Music.play('bgm', { gain: 0.35 }); startRun(); },
+  onLeaderboardShow: () => Arcade.Leaderboard.paintList({ listSelector: '#lb-list' }),
+  unlockAudio:       () => { Arcade.Audio.ensureCtx(); Arcade.Music.retryPending(); },  // first-gesture iOS unlock
+  isBusy:            () => Arcade.Initials.isActive(),
+});
+
+// On game over:
+function endRun() {
+  Arcade.EndOverlay.show({
+    score,
+    title:     win ? 'GAME COMPLETE' : 'GAME OVER',
+    titleClass: win ? 'is-win' : '',
+    hiscore:   Arcade.Leaderboard.getHighScore(),
+    qualifies: Arcade.Leaderboard.qualifies(score),
+    graceMs:   1200,
+  });
+}
+
+// Restart listener (keyboard/tap):
+function onRestartKey() {
+  if (Arcade.Initials.isActive()) return;
+  if (!Arcade.EndOverlay.acceptsInput()) return;            // inside the grace window
+  if (Arcade.EndOverlay.consumePending()) { Arcade.Initials.open(); return; }  // qualified → enter initials
+  Arcade.EndOverlay.hide();
+  Arcade.Splash.enterAttract();
+}
+
+// Game loop:
+function tick(now) {
+  requestAnimationFrame(tick);
+  if (!Arcade.Splash.isPlaying()) return;   // frozen on title/attract
+  if (Arcade.Pause.isPaused()) { draw(); return; }
+  update(dt);
+  draw();
+}
+```
+
+---
+
+## Conventions
+
+- **SFX ids** = the keys in `Arcade.Audio.init({sfx})`. The matching `<audio>`
+  element is just the pre-decode fallback.
+- **BGM ids** must start with `bgm` (`bgm`, `bgm-title`, `bgm-boss`, …). That
+  prefix is how both `Arcade.Music` and the pause MUSIC slider find tracks.
+- **Leaderboard `game` key** must be in the worker's `GAMES` allowlist
+  (`infra/leaderboard-worker/src/worker.ts`). Mirror lives at
+  `localStorage['oyster-arcade-leaderboard-<game>']`.
+- **Shared volume keys** (cabinet-wide, set by `pause.js`):
+  `oyster-arcade-music-volume`, `oyster-arcade-sfx-volume` (each `0..1`).
+- **Retint, don't restate.** Override per-game colour via the documented CSS
+  vars — `--splash-bg`, `--go-*` (overlays), `--lb-title-size` (leaderboard) —
+  rather than re-declaring the shared rules. The only block each game writes
+  from scratch is its own `.splash .title` marquee + bespoke title art.
+- **`.key-only` / `.touch-only`** swap keyboard vs touch hint copy automatically
+  on coarse pointers (from `touch.css`). Author both; the cabinet shows the right one.
+
+> Adding a new shared module or stylesheet? Update this file's reference table
+> and load-order list in the same change so the contract stays trustworthy.

--- a/docs/arcade/shared/leaderboard.css
+++ b/docs/arcade/shared/leaderboard.css
@@ -1,0 +1,39 @@
+/* Shared SPLASH leaderboard view — the title↔leaderboard attract-mode card.
+ * The list DOM is built by shared/leaderboard.js (Arcade.Leaderboard.paintList
+ * / paintHiScoreRow); this styles it. Lifted from the verbatim copies that
+ * lived inline in invaders/ and space-jumper/.
+ *
+ * --lb-title-size tunes just the heading scale (Space Jumper runs a smaller
+ * title than Invaders) — everything else is shared. Override it per game on
+ * the .leaderboard element; it inherits down to .lb-title.
+ */
+.leaderboard {
+  color: #fff;
+  font-family: 'Press Start 2P', ui-monospace, monospace;
+}
+.leaderboard .lb-title {
+  font-size: var(--lb-title-size, clamp(18px, 3.5vw, 32px));
+  color: #ffd84a;
+  letter-spacing: 0.12em;
+  text-shadow: 3px 3px 0 #ff3aa1, 5px 5px 0 #2dd4ff;
+  margin-bottom: clamp(8px, 1.5vw, 16px);
+}
+.leaderboard .lb-list {
+  list-style: none; padding: 0; margin: 0;
+  display: grid;
+  grid-template-columns: auto auto auto;
+  gap: 6px 22px;
+  font-size: clamp(10px, 1.5vw, 14px);
+  letter-spacing: 0.14em;
+  align-items: center;
+}
+.leaderboard .lb-list li { display: contents; }
+.leaderboard .lb-rank     { color: #ff3aa1; text-align: right; }
+.leaderboard .lb-initials { color: #2dd4ff; text-align: left; letter-spacing: 0.2em; }
+.leaderboard .lb-score    { color: #ffd84a; text-align: right; }
+.leaderboard .lb-empty {
+  font-size: clamp(10px, 1.4vw, 12px);
+  color: rgba(255, 255, 255, 0.55);
+  grid-column: 1 / -1;
+  text-align: center;
+}

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="../shared/touch.css">
 <link rel="stylesheet" href="../shared/overlays.css">
 <link rel="stylesheet" href="../shared/splash.css">
+<link rel="stylesheet" href="../shared/leaderboard.css">
 <style>
   /* Platformer-specific styles. Cabinet, pixel font, and touch base styles
      come from ../shared/ — see <link> tags above. */
@@ -44,33 +45,10 @@
       4px 4px 0 #2dd4ff,
       0 0 24px rgba(255, 216, 74, 0.35);
   }
-  /* Splash leaderboard view (title ↔ leaderboard cycle). Palette matches the
-     title; can move to shared/ once Invaders + Rocket Ship adopt the shared
-     splash lifecycle. */
-  .leaderboard { color: #fff; font-family: 'Press Start 2P', ui-monospace, monospace; }
-  .leaderboard .lb-title {
-    font-size: clamp(16px, 3vw, 28px);
-    color: #ffd84a;
-    letter-spacing: 0.12em;
-    text-shadow: 3px 3px 0 #ff3aa1, 5px 5px 0 #2dd4ff;
-    margin-bottom: clamp(8px, 1.5vw, 16px);
-  }
-  .leaderboard .lb-list {
-    list-style: none; padding: 0; margin: 0;
-    display: grid; grid-template-columns: auto auto auto;
-    gap: 6px 22px;
-    font-size: clamp(10px, 1.5vw, 14px);
-    letter-spacing: 0.14em; align-items: center;
-  }
-  .leaderboard .lb-list li { display: contents; }
-  .leaderboard .lb-rank     { color: #ff3aa1; text-align: right; }
-  .leaderboard .lb-initials { color: #2dd4ff; text-align: left; letter-spacing: 0.2em; }
-  .leaderboard .lb-score    { color: #ffd84a; text-align: right; }
-  .leaderboard .lb-empty {
-    font-size: clamp(10px, 1.4vw, 12px);
-    color: rgba(255, 255, 255, 0.55);
-    grid-column: 1 / -1; text-align: center;
-  }
+  /* Splash leaderboard view (.leaderboard + .lb-*) lives in
+     ../shared/leaderboard.css. Space Jumper runs a smaller heading than the
+     shared default — override just that via the --lb-title-size var. */
+  .leaderboard { --lb-title-size: clamp(16px, 3vw, 28px); }
   /* ── Title scene: Rogers jetpacking through space ──────────────────────
      A deep-space backdrop behind the splash — nebula glow, twinkling stars, a
      planet and floating platforms, with Rogers hovering on his jetpack (flame


### PR DESCRIPTION
First slice of the arcade-framework DRY pass — pure de-duplication + docs, **no behaviour change**.

## What & why
The `.leaderboard .lb-*` splash-view CSS was copy-pasted near-verbatim in `invaders/` and `space-jumper/`, even though the list DOM is already built by the shared `Arcade.Leaderboard.paintList()`. The only difference between the two copies was the heading font-size.

### `shared/leaderboard.css` (new)
- Canonical `.leaderboard .lb-*` block; inline copies removed from both games (−57 lines).
- Per-game heading size preserved via a `--lb-title-size` var: Invaders uses the default `clamp(18px, 3.5vw, 32px)`; Space Jumper overrides to `clamp(16px, 3vw, 28px)` in one line.
- `invaders-mp` left untouched — its game-over screen uses a different `.es-lb-*` table.

### `shared/README.md` (new)
DOM-contract & wiring guide for the whole `Arcade.*` framework: load order, per-module required selectors, stylesheet class names, a minimal copy-paste game skeleton, and the init/loop wiring sequence. Modules are selector-driven with silent defaults, so this is what lets a new game (or an agent) be scaffolded without copying a sibling and hitting a quiet no-op.

## Verification
Served the branch and forced both leaderboard views with seeded scores:
- `leaderboard.css` loads in both games.
- `.lb-title` resolves to **32px** (Invaders) vs **28px** (Space Jumper) — each game's original heading preserved exactly.
- Ranks/initials/scores/empty-state/special glyphs render identically to before.

All asset/worker paths referenced in the README verified to exist.

No CHANGELOG entry (arcade changes are out of scope for the consumer changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)