### PR TITLE
arcade(invaders-mp): polish pack — Claude egg + grid drop scaling + CRT shake

### DIFF
--- a/docs/arcade/invaders-mp/engine.d.ts
+++ b/docs/arcade/invaders-mp/engine.d.ts
@@ -155,6 +155,8 @@ export interface GameState {
   marked: MarkedInvader | null;
   /** Seconds until the next mark-spawn attempt while none is active. */
   markedSpawnIn: number;
+  /** Row-3 column index for the Claude easter egg this grid (0..INV_COLS-1). */
+  claudeCol: number;
 }
 
 export interface WireSnapshot {
@@ -210,6 +212,8 @@ export interface WireSnapshot {
   cheated: boolean;
   /** Currently-swooping marked invader, or null. `i` indexes the invaders array; dx/dy are swoop offsets added to the invader's grid position. */
   marked: { i: number; dx: number; dy: number } | null;
+  /** Row-3 column index for the Claude easter egg this grid. */
+  claudeCol: number;
   /**
    * Per-seat occupancy. Set by the transport layer (room.ts on the
    * server, hostTick on the client) after snapshotForClient returns,

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -438,9 +438,8 @@ function waveTotal(setNum, stageNum) {
 // `dropRows` (0..3) starts the swarm that many rows lower so later
 // waves give less reaction room — matches SP's `dropRows = min(3,
 // waveNum - 1)`. Caller computes via waveTotal(stageSet, stageNum).
-// `claudeCol` (0..INV_COLS-1) picks which row-3 cell renders as the
-// terracotta Claude easter egg (cosmetic only — same point value
-// as any other row-3 octopus). Re-rolled per grid spawn.
+// Claude easter-egg column lives on state.claudeCol (re-rolled in
+// checkStageClear), not here — buildGrid only owns invader positions.
 function buildGrid(dropRows = 0) {
   const out = [];
   const yOffset = dropRows * INV_GAP_Y;

--- a/docs/arcade/invaders-mp/engine.js
+++ b/docs/arcade/invaders-mp/engine.js
@@ -400,6 +400,10 @@ export function initState() {
     // gap so the first stage gets a few seconds of "normal" before
     // the first swoop. Updated by stepMarked + nextMarkedGap.
     markedSpawnIn: MARKED_GAP_MIN_SEC,
+    // Which row-3 column renders as the Claude easter egg this grid.
+    // Cosmetic — the cell still scores like a normal row-3 octopus.
+    // Re-rolled in checkStageClear whenever a new grid spawns.
+    claudeCol: pickClaudeCol(),
     // 2-frame "shuffle" animation. Advances by horizontal distance
     // travelled, mirroring SP's discrete-step flip (~2 units per
     // beat) — so the animation cadence is tied to march speed and
@@ -423,19 +427,35 @@ export function initState() {
   };
 }
 
-function buildGrid() {
+// Total waves elapsed across all sets, used to scale grid difficulty.
+// 1-1 = 1, 1-2 = 2, ..., 2-1 = 4, 2-3 = 6, ... Pure derivation from
+// state — no separate counter needed.
+const GRID_DROP_ROWS_MAX = 3;
+function waveTotal(setNum, stageNum) {
+  return (setNum - 1) * STAGES_PER_SET + stageNum;
+}
+
+// `dropRows` (0..3) starts the swarm that many rows lower so later
+// waves give less reaction room — matches SP's `dropRows = min(3,
+// waveNum - 1)`. Caller computes via waveTotal(stageSet, stageNum).
+// `claudeCol` (0..INV_COLS-1) picks which row-3 cell renders as the
+// terracotta Claude easter egg (cosmetic only — same point value
+// as any other row-3 octopus). Re-rolled per grid spawn.
+function buildGrid(dropRows = 0) {
   const out = [];
+  const yOffset = dropRows * INV_GAP_Y;
   for (let row = 0; row < INV_ROWS; row++) {
     for (let col = 0; col < INV_COLS; col++) {
       out.push({
         x: INV_ORIGIN_X + col * INV_GAP_X,
-        y: INV_ORIGIN_Y + row * INV_GAP_Y,
+        y: INV_ORIGIN_Y + row * INV_GAP_Y + yOffset,
         alive: true,
       });
     }
   }
   return out;
 }
+function pickClaudeCol() { return Math.floor(Math.random() * INV_COLS); }
 
 // === Step ===
 
@@ -659,7 +679,8 @@ function checkStageClear(state) {
     state.boss = null;
     state.stageSet += 1;
     state.stageNum = 1;
-    state.invaders = buildGrid();
+    state.invaders = buildGrid(Math.min(GRID_DROP_ROWS_MAX, waveTotal(state.stageSet, state.stageNum) - 1));
+    state.claudeCol = pickClaudeCol();
     state.invaderDir = 1;
     state.invaderDropRemaining = 0;
     state.invaderFireAccum = 0;
@@ -682,7 +703,8 @@ function checkStageClear(state) {
     state.stageAnnounceIn = STAGE_ANNOUNCE_SEC;
     return;
   }
-  state.invaders = buildGrid();
+  state.invaders = buildGrid(Math.min(GRID_DROP_ROWS_MAX, waveTotal(state.stageSet, state.stageNum) - 1));
+  state.claudeCol = pickClaudeCol();
   state.invaderDir = 1;
   state.invaderDropRemaining = 0;
   state.invaderFireAccum = 0;
@@ -1374,5 +1396,9 @@ export function snapshotForClient(state) {
       dx: round(state.marked.swoopDX),
       dy: round(state.marked.swoopDY),
     } : null,
+    // Which row-3 column renders as the Claude easter egg this grid.
+    // Re-rolled on each new grid spawn. Client-side cosmetic only —
+    // collision / scoring are unchanged.
+    claudeCol:      state.claudeCol | 0,
   };
 }

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -559,7 +559,8 @@
   const UFO_W = UFO_W_EXPORT ?? 16;
   const UFO_H = UFO_H_EXPORT ?? 7;
   const UFO_Y = UFO_Y_EXPORT ?? 12;
-  import { ROW_COLORS, spriteForRow, paintPixels, paintShip, paintBoss } from './sprites.js';
+  import { ROW_COLORS, spriteForRow, paintPixels, paintShip, paintBoss, paintClaude, CLAUDE_COLOUR } from './sprites.js';
+  const CLAUDE_ROW = 3;  // 0-indexed; row 3 + 4 are octopus, Claude rides the upper octopus row
   // Renderer uses INV_COLS to map invader array index → grid row. It
   // happens to equal 11 in the current engine; mirror as a const so a
   // future engine.INV_COLS change forces an audit here rather than
@@ -659,7 +660,7 @@
   // Welcome from the server includes its own value so we can flag a
   // mismatch (usually means one side is still on a stale deploy or the
   // browser is showing a cached HTML). See server room.ts for history.
-  const NETCODE_VERSION = 30;
+  const NETCODE_VERSION = 31;
 
   // --------------------------------------------------------------------
   // Room code — 4 letters that identifies this room's DO instance.
@@ -1328,6 +1329,18 @@
           // msg.status would swallow the explosion on round-ending
           // deaths. The lose jingle still fires separately below.
           Arcade.Audio.play('sfx-explosion', 0.6);
+          // CRT shake — own-ship death is the right drama beat to
+          // jolt the cabinet. Other players' deaths don't shake
+          // this client (their cabinet shakes on its own snapshot).
+          shakeTube();
+        }
+        // CRT shake on boss defeat too. Detect transition: prev had
+        // a boss alive, msg has no boss (cleared in checkStageClear
+        // when hp hits 0). Guard on prev.boss truthiness so a
+        // mid-deploy snapshot without `boss` doesn't false-fire.
+        if (prev.boss && prev.boss.hp > 0 && (!msg.boss || msg.boss.hp === 0)
+            && prev.phase === 'boss') {
+          shakeTube();
         }
         if (msg.status === 'gameover' && prev.status !== 'gameover' && !msg.won) {
           Arcade.Audio.play('sfx-lose', 0.6);
@@ -1379,6 +1392,29 @@
   // prescreen fade (our `.tube.is-ready #prescreen` rule). Single
   // class flip = entire UI transition.
   const tube = document.querySelector('.tube');
+
+  // CRT shake — toggles the shared `.tube.is-shaking` keyframe in
+  // cabinet.css for ~550 ms. Triggered on dramatic moments only
+  // (boss defeat, own-ship death) so it stays a treat, not a
+  // distraction. Re-entrant: a second trigger before the first
+  // ends restarts the animation cleanly.
+  const SHAKE_MS = 600;
+  let shakeUntil = 0;
+  function shakeTube() {
+    if (!tube) return;
+    // Force a reflow if already shaking so the keyframe restarts
+    // from frame 0 rather than continuing wherever it was.
+    if (tube.classList.contains('is-shaking')) {
+      tube.classList.remove('is-shaking');
+      // Read offsetWidth to flush the layout change before re-adding.
+      void tube.offsetWidth;
+    }
+    tube.classList.add('is-shaking');
+    shakeUntil = performance.now() + SHAKE_MS;
+    setTimeout(() => {
+      if (performance.now() >= shakeUntil) tube.classList.remove('is-shaking');
+    }, SHAKE_MS + 50);
+  }
 
   // Player slot elements, indexed by seat position. Filled from
   // refreshPlayerSlots on every snapshot.
@@ -2074,21 +2110,35 @@
     const markedFlashWhite = marked
       ? (Math.floor(performance.now() / 80) % 2 === 0)
       : false;
+    // Claude easter egg — row-3 cell at column `latestSnap.claudeCol`
+    // gets the Claude sprite + terracotta colour instead of the
+    // usual octopus. Re-rolled per grid by the engine; client just
+    // honours whatever column the snapshot specifies.
+    const claudeCol = (latestSnap.claudeCol != null) ? latestSnap.claudeCol : -1;
     for (let i = 0; i < n; i++) {
       const ia = a.invaders[i], ib = b.invaders[i];
       if (!ib.a || !ia.a) continue;            // dead either side → hide
       const row = Math.floor(i / SPRITE_COLS);
+      const col = i % SPRITE_COLS;
+      const isMarked = marked && marked.i === i;
+      const isClaude = row === CLAUDE_ROW && col === claudeCol;
       const { frames, w } = spriteForRow(row);
       const ox = row === 0 ? 2 : 0;
-      const isMarked = marked && marked.i === i;
       const dx = isMarked ? (marked.dx || 0) : 0;
       const dy = isMarked ? (marked.dy || 0) : 0;
       const cellX = Math.round(lerp(ia.x, ib.x) + ox + dx);
       const cellY = Math.round(lerp(ia.y, ib.y) + dy);
-      const colour = (isMarked && markedFlashWhite)
-        ? '#ffffff'
-        : (ROW_COLORS[row] || '#ffffff');
-      paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, colour);
+      if (isClaude) {
+        // Claude pulses white when marked (same flash cadence) so the
+        // easter egg + the marked-invader bonus both still read.
+        const claudeColour = (isMarked && markedFlashWhite) ? '#ffffff' : CLAUDE_COLOUR;
+        paintClaude(ctx, cellX, cellY, SPRITE_SCALE, frame, claudeColour);
+      } else {
+        const colour = (isMarked && markedFlashWhite)
+          ? '#ffffff'
+          : (ROW_COLORS[row] || '#ffffff');
+        paintPixels(ctx, cellX, cellY, frames[frame], SPRITE_SCALE, colour);
+      }
     }
 
     // Shields — decode the packed bitmap from the snapshot once when

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -559,7 +559,17 @@
   const UFO_W = UFO_W_EXPORT ?? 16;
   const UFO_H = UFO_H_EXPORT ?? 7;
   const UFO_Y = UFO_Y_EXPORT ?? 12;
-  import { ROW_COLORS, spriteForRow, paintPixels, paintShip, paintBoss, paintClaude, CLAUDE_COLOUR } from './sprites.js';
+  // Namespace import + destructure for the same reason as engine.js
+  // above — a stale cached sprites.js mid-deploy that's missing the
+  // new exports (paintClaude / CLAUDE_COLOUR landed in #599) would
+  // hard-fail the module link and white-screen the page. With the
+  // namespace form, missing members are just `undefined` and the
+  // affected feature (Claude render) silently no-ops.
+  import * as sprites from './sprites.js';
+  const {
+    ROW_COLORS, spriteForRow, paintPixels, paintShip, paintBoss,
+    paintClaude, CLAUDE_COLOUR,
+  } = sprites;
   const CLAUDE_ROW = 3;  // 0-indexed; row 3 + 4 are octopus, Claude rides the upper octopus row
   // Renderer uses INV_COLS to map invader array index → grid row. It
   // happens to equal 11 in the current engine; mirror as a const so a
@@ -1394,11 +1404,14 @@
   const tube = document.querySelector('.tube');
 
   // CRT shake — toggles the shared `.tube.is-shaking` keyframe in
-  // cabinet.css for ~550 ms. Triggered on dramatic moments only
-  // (boss defeat, own-ship death) so it stays a treat, not a
-  // distraction. Re-entrant: a second trigger before the first
-  // ends restarts the animation cleanly.
-  const SHAKE_MS = 600;
+  // cabinet.css. Triggered on dramatic moments only (boss defeat,
+  // own-ship death) so it stays a treat, not a distraction.
+  // Re-entrant: a second trigger before the first ends restarts the
+  // animation cleanly. SHAKE_MS matches the keyframe duration in
+  // cabinet.css (.tube.is-shaking → 0.55 s) so the class lifetime
+  // and the animation track exactly; out-of-sync values would let
+  // the next trigger fire mid-animation or strip the class early.
+  const SHAKE_MS = 550;
   let shakeUntil = 0;
   function shakeTube() {
     if (!tube) return;
@@ -2128,10 +2141,14 @@
       const dy = isMarked ? (marked.dy || 0) : 0;
       const cellX = Math.round(lerp(ia.x, ib.x) + ox + dx);
       const cellY = Math.round(lerp(ia.y, ib.y) + dy);
-      if (isClaude) {
+      if (isClaude && paintClaude) {
         // Claude pulses white when marked (same flash cadence) so the
         // easter egg + the marked-invader bonus both still read.
-        const claudeColour = (isMarked && markedFlashWhite) ? '#ffffff' : CLAUDE_COLOUR;
+        // Guard on paintClaude being defined — a stale sprites.js
+        // mid-deploy might lack the export, in which case we fall
+        // through to the normal octopus render and the easter egg
+        // is silently hidden until the cache refreshes.
+        const claudeColour = (isMarked && markedFlashWhite) ? '#ffffff' : (CLAUDE_COLOUR || '#d97757');
         paintClaude(ctx, cellX, cellY, SPRITE_SCALE, frame, claudeColour);
       } else {
         const colour = (isMarked && markedFlashWhite)

--- a/docs/arcade/invaders-mp/sprites.js
+++ b/docs/arcade/invaders-mp/sprites.js
@@ -138,3 +138,40 @@ export function paintBoss(ctx, x, y, scale, frame, type, bandIndex) {
     }
   }
 }
+
+// Claude easter egg — one row-3 octopus cell renders as a tiny
+// Claude creature in terracotta `#d97757`. Ported from SP — pure
+// cosmetic, scores like any other row-3 octopus (10 pts × combo).
+// 9×6 body plus 4 separate "feet" rectangles below; the feet
+// stretch slightly on frame 1 so it looks like the creature is
+// marching with the swarm. Painted at scale 1.5 to match the grid
+// invader pipeline; the body sits one PF to the left so the wider
+// silhouette stays centred in the 18 PF grid cell.
+export const CLAUDE_COLOUR = '#d97757';
+const CLAUDE_BODY = [
+  '..XXXXX..',
+  '.XXXXXXX.',
+  '.X.XXX.X.',
+  '.XXXXXXX.',
+  'XXXXXXXXX',
+  '.XXXXXXX.',
+];
+export function paintClaude(ctx, x, y, scale, frame, color) {
+  ctx.fillStyle = color || CLAUDE_COLOUR;
+  const ox = -1;                                 // SP-matching nudge
+  for (let row = 0; row < CLAUDE_BODY.length; row++) {
+    const cells = CLAUDE_BODY[row];
+    const py = y + row * scale;
+    for (let col = 0; col < cells.length; col++) {
+      if (cells[col] === 'X') ctx.fillRect(x + (col + ox) * scale, py, scale, scale);
+    }
+  }
+  // 4 marching legs — pairs at the body edges with a centre gap so
+  // it reads as ▘▘ ▝▝. Frame 1 stretches them to ~1.5× height so the
+  // creature animates "stepping" along with the swarm's shuffle.
+  const legY = y + CLAUDE_BODY.length * scale;
+  const legH = (frame & 1 ? 1.5 : 1) * scale;
+  for (const u of [1, 2.5, 5.5, 7]) {
+    ctx.fillRect(x + (u + ox) * scale, legY, scale, legH);
+  }
+}

--- a/infra/oyster-arcade-mp/src/room.ts
+++ b/infra/oyster-arcade-mp/src/room.ts
@@ -160,7 +160,14 @@ const MAX_WS_MESSAGE_CHARS = 4096;
 //          set 4 = 0.65 s (with a 0.55 s floor that the 4-set game
 //          never actually reaches) so endgame stages feel urgent.
 //        - Client-only: march-heartbeat synth + UFO warble synth.
-const NETCODE_VERSION = 30;
+// v31 — Polish pack: grid drop-rows scale per wave (later stages
+//        start the swarm one row lower, capped at 3 — partner to
+//        v30's fire-interval ramp); Claude easter egg (one row-3
+//        cell per grid renders as a terracotta Claude creature,
+//        cosmetic only); CRT screen shake on boss defeat + local-
+//        player death (client only, no wire change). New wire
+//        field: state.claudeCol.
+const NETCODE_VERSION = 31;
 
 type ClientMessage =
   | { type: 'ping';   t: number }


### PR DESCRIPTION
## Summary

Three polish items from the SP audit, bundled because each is small and they're all low-risk.

### Claude easter egg
One row-3 octopus per grid renders as a tiny terracotta Claude creature (`#d97757`) — 9×6 body + 4 marching feet (stretch on frame 1 so it shuffles with the swarm). Cosmetic only — same point value as any other row-3 octopus. Position re-rolled on every new grid spawn so it moves around between stages.

### Grid drop-rows per wave
Partner to v30's fire-interval ramp. Each wave starts the swarm one row lower than the previous, capped at 3 — by stage 2-1+ the swarm is at the lowest start position. Total wave count = `(stageSet - 1) * STAGES_PER_SET + stageNum`, drop = `min(3, waveTotal - 1)`. So:
- 1-1 → drop 0
- 1-2 → drop 1
- 1-3 → drop 2
- 2-1+ → drop 3 (capped)

`buildGrid()` now accepts a `dropRows` arg; `checkStageClear` computes it before each grid spawn.

### CRT screen shake
Client-only. Toggles the shared `.tube.is-shaking` keyframe (already in `cabinet.css` but never wired in any arcade game until now). Fires on:
- **Boss defeat** — transition: `prev.boss.hp > 0 && (!msg.boss || msg.boss.hp === 0) && prev.phase === 'boss'`
- **Local player death** — transition: my player.alive true → false while running

Other players' deaths don't shake this client — each cabinet shakes on its own snapshot. Re-entrant: a second trigger restarts the keyframe cleanly.

## Wire change

New field: `state.claudeCol: number` (0..INV_COLS-1, the column whose row-3 cell renders as Claude).

Netcode **v30 → v31**.

## Test plan

- [ ] Start a stage — look for the row-3 octopus column with the terracotta Claude creature with the 4 little feet. Position changes each new grid.
- [ ] Killing Claude scores normally (10 × combo) — no special bonus, just visual.
- [ ] 1-1 starts at the usual top position; 2-1 starts noticeably lower (less reaction room).
- [ ] Boss defeat → screen shakes briefly.
- [ ] Local ship dies → screen shakes briefly.
- [ ] Other player dies (multiplayer test) → no shake on my cabinet (only theirs).
- [ ] Two boss deaths in quick succession — shake restarts cleanly each time.
- [ ] No regressions on marked invader (Claude can also be marked → pulses white at swoop position).

🤖 Generated with [Claude Code](https://claude.com/claude-code)