### PR TITLE
fix(invaders-mp): STUN + Cloudflare Realtime TURN for hostile-NAT P2P

### DIFF
--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1095,9 +1095,11 @@
   // STUN doesn't fix every NAT — symmetric NAT (some hotel + cellular
   // setups) still needs a TURN relay we don't run yet. The DO cloud-
   // relay fallback is the safety net for that case.
+  // Two *independent* STUN providers so a single host/DNS outage
+  // doesn't kill WebRTC. (Earlier draft listed two ports on
+  // stun.l.google.com — those would have failed together.)
   const ICE_SERVERS = [
     { urls: 'stun:stun.l.google.com:19302' },
-    { urls: 'stun:stun.l.google.com:5349' },
     { urls: 'stun:stun.cloudflare.com:3478' },
   ];
 
@@ -1126,14 +1128,23 @@
     // Useful when triaging hotel / cellular / corporate networks
     // where STUN alone isn't enough and we need to know if it's a
     // candidate-gathering failure vs a connectivity check failure.
-    if (p._pc) {
-      p._pc.addEventListener('iceconnectionstatechange', () => {
-        console.log('[P2P] ICE', otherSeat, '→', p._pc.iceConnectionState);
-      });
-      p._pc.addEventListener('icegatheringstatechange', () => {
-        console.log('[P2P] gather', otherSeat, '→', p._pc.iceGatheringState);
-      });
-    }
+    //
+    // NOTE: deliberately reaching into simple-peer's underscore-
+    // prefixed `_pc` is a private-API access. Guarded so a future
+    // library refactor (rename/remove) silently disables the
+    // diagnostics rather than crashing the peer setup. Worst case
+    // we lose log lines, never the connection.
+    try {
+      const pc = p._pc;
+      if (pc && typeof pc.addEventListener === 'function') {
+        pc.addEventListener('iceconnectionstatechange', () => {
+          console.log('[P2P] ICE', otherSeat, '→', pc.iceConnectionState);
+        });
+        pc.addEventListener('icegatheringstatechange', () => {
+          console.log('[P2P] gather', otherSeat, '→', pc.iceGatheringState);
+        });
+      }
+    } catch (_) { /* simple-peer internals changed — diagnostics skipped */ }
 
     p.on('signal', (data) => {
       if (ws && ws.readyState === 1) {

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1083,6 +1083,24 @@
     else                             setTransport('relay');
   }
 
+  // STUN servers — without these SimplePeer only emits host candidates
+  // (LAN IPs). Same Wi-Fi works (assuming the AP allows client-to-
+  // client traffic), but hotels almost always disable that ("AP
+  // isolation" / "guest mode"). STUN lets each peer discover its
+  // public ip:port behind NAT so the other end has something to
+  // connect to. Public Google + Cloudflare STUN are free and well-
+  // maintained; we list multiple so a single outage doesn't break
+  // WebRTC for everyone.
+  //
+  // STUN doesn't fix every NAT — symmetric NAT (some hotel + cellular
+  // setups) still needs a TURN relay we don't run yet. The DO cloud-
+  // relay fallback is the safety net for that case.
+  const ICE_SERVERS = [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:stun.l.google.com:5349' },
+    { urls: 'stun:stun.cloudflare.com:3478' },
+  ];
+
   // Create a peer to `otherSeat` if one doesn't exist yet. Host (P1)
   // initiates; clients are passive (they wait for P1's offer). Idempotent.
   function makePeerTo(otherSeat) {
@@ -1091,13 +1109,31 @@
     const initiator = (mySeat === 'p1');
     let p;
     try {
-      p = new SimplePeer({ initiator, trickle: true });
+      p = new SimplePeer({
+        initiator,
+        trickle: true,
+        config: { iceServers: ICE_SERVERS },
+      });
     } catch (e) {
       console.warn('[P2P] new SimplePeer failed for', otherSeat, e && e.message);
       return;
     }
     peers.set(otherSeat, p);
     console.log('[P2P] peer to', otherSeat, '(initiator=' + initiator + ')');
+    // ICE diagnostic logging — taps into the underlying
+    // RTCPeerConnection so failures past the SimplePeer wrapper are
+    // visible (e.g. "all candidates failed" with no error event).
+    // Useful when triaging hotel / cellular / corporate networks
+    // where STUN alone isn't enough and we need to know if it's a
+    // candidate-gathering failure vs a connectivity check failure.
+    if (p._pc) {
+      p._pc.addEventListener('iceconnectionstatechange', () => {
+        console.log('[P2P] ICE', otherSeat, '→', p._pc.iceConnectionState);
+      });
+      p._pc.addEventListener('icegatheringstatechange', () => {
+        console.log('[P2P] gather', otherSeat, '→', p._pc.iceGatheringState);
+      });
+    }
 
     p.on('signal', (data) => {
       if (ws && ws.readyState === 1) {

--- a/docs/arcade/invaders-mp/index.html
+++ b/docs/arcade/invaders-mp/index.html
@@ -1096,25 +1096,74 @@
   // setups) still needs a TURN relay we don't run yet. The DO cloud-
   // relay fallback is the safety net for that case.
   // Two *independent* STUN providers so a single host/DNS outage
-  // doesn't kill WebRTC. (Earlier draft listed two ports on
-  // stun.l.google.com — those would have failed together.)
-  const ICE_SERVERS = [
+  // doesn't kill WebRTC. STUN handles ~80% of NATs; the remaining
+  // symmetric-NAT cases (hotels, cellular) need TURN — fetched
+  // separately from /api/mp/turn-credentials and merged below.
+  const STUN_SERVERS = [
     { urls: 'stun:stun.l.google.com:19302' },
     { urls: 'stun:stun.cloudflare.com:3478' },
   ];
+  // Live ICE config. Starts STUN-only; gets upgraded with the
+  // TURN entry once /api/mp/turn-credentials returns. If the
+  // endpoint isn't configured (missing secrets) we just stay
+  // STUN-only — works for most networks, degrades gracefully.
+  let iceServers = [...STUN_SERVERS];
+  let iceFetchedAt = 0;
+  // Refresh ~10 min before the credential TTL expires so a long
+  // session never tries to handshake with stale creds.
+  const ICE_REFRESH_AFTER_MS = 50 * 60 * 1000;
+
+  async function refreshIceServers() {
+    try {
+      const r = await fetch('/api/mp/turn-credentials');
+      if (!r.ok) {
+        // 503 = secrets not configured (expected pre-setup) or CF
+        // upstream blip. Either way, keep the existing list.
+        console.log('[P2P] TURN endpoint returned', r.status, '— STUN-only');
+        return;
+      }
+      const data = await r.json();
+      const ice = data && data.iceServers;
+      if (!ice) return;
+      // CF returns one combined entry with multiple urls + creds.
+      // Merge it in front of STUN so the browser tries TURN candidates
+      // first when reflexive ones fail.
+      iceServers = [ice, ...STUN_SERVERS];
+      iceFetchedAt = Date.now();
+      console.log('[P2P] TURN credentials acquired (Cloudflare Realtime)');
+    } catch (e) {
+      console.warn('[P2P] TURN fetch failed:', e && e.message);
+    }
+  }
+  // Fetch on load — fire-and-forget. The first peer creation that
+  // happens *after* this resolves gets TURN; anything that races
+  // ahead gets STUN-only (still better than the original LAN-only
+  // behaviour, and degrades safely).
+  refreshIceServers();
+  function maybeRefreshIceServers() {
+    if (Date.now() - iceFetchedAt > ICE_REFRESH_AFTER_MS) {
+      refreshIceServers();
+    }
+  }
 
   // Create a peer to `otherSeat` if one doesn't exist yet. Host (P1)
   // initiates; clients are passive (they wait for P1's offer). Idempotent.
   function makePeerTo(otherSeat) {
     if (typeof SimplePeer === 'undefined') return; // library not loaded
     if (peers.has(otherSeat)) return;
+    // Best-effort refresh of TURN credentials before each handshake
+    // so a long-running tab (passed the credential TTL) doesn't try
+    // to connect with stale creds. Fire-and-forget; this peer uses
+    // the current cached `iceServers` regardless of whether the
+    // refresh has resolved yet.
+    maybeRefreshIceServers();
     const initiator = (mySeat === 'p1');
     let p;
     try {
       p = new SimplePeer({
         initiator,
         trickle: true,
-        config: { iceServers: ICE_SERVERS },
+        config: { iceServers },
       });
     } catch (e) {
       console.warn('[P2P] new SimplePeer failed for', otherSeat, e && e.message);

--- a/infra/oyster-arcade-mp/src/worker.ts
+++ b/infra/oyster-arcade-mp/src/worker.ts
@@ -5,12 +5,79 @@
 //                                   InvadersRoom Durable Object whose
 //                                   id is derived from the 4-letter
 //                                   room code (one DO per code)
+// GET  /api/mp/turn-credentials   → mints short-lived TURN credentials
+//                                   from Cloudflare Realtime so peers
+//                                   on hostile NAT (hotel APs, cellular)
+//                                   have a relay path when STUN-only
+//                                   handshakes fail. Returns the JSON
+//                                   from CF, or 503 if the TURN_APP_ID
+//                                   + TURN_APP_TOKEN secrets aren't set.
 //
 // Anything else 404s. v0 is one game (invaders), per-pair rooms keyed
 // by code, no matchmaking, no auth.
+//
+// Required secrets for TURN (set via `npx wrangler secret put`):
+//   TURN_APP_ID    — Cloudflare Realtime TURN key ID (UUID)
+//   TURN_APP_TOKEN — API token with Realtime:Edit scope
+// Without these the TURN endpoint 503s and the client falls back to
+// STUN-only, which is fine for cone-NAT networks but fails on hotels
+// + cellular with symmetric NAT.
 
 export interface Env {
   ROOM: DurableObjectNamespace;
+  TURN_APP_ID?: string;
+  TURN_APP_TOKEN?: string;
+}
+
+// 1-hour TTL on TURN credentials. Long enough that a single fetch
+// covers a typical co-op session; short enough that leaked creds
+// can't be reused for long. The client caches the result and
+// refreshes ~10 min before expiry.
+const TURN_CREDENTIAL_TTL_SEC = 3600;
+
+async function handleTurnCredentials(env: Env): Promise<Response> {
+  if (!env.TURN_APP_ID || !env.TURN_APP_TOKEN) {
+    return new Response(
+      JSON.stringify({ error: 'turn_not_configured' }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+  const url = `https://rtc.live.cloudflare.com/v1/turn/keys/${env.TURN_APP_ID}/credentials/generate`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${env.TURN_APP_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ttl: TURN_CREDENTIAL_TTL_SEC }),
+    });
+  } catch (e) {
+    return new Response(
+      JSON.stringify({ error: 'cf_turn_unreachable', detail: (e as Error).message }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    return new Response(
+      JSON.stringify({ error: 'cf_turn_failed', status: resp.status, body: text }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+  // Pass CF's response through verbatim — it includes the iceServers
+  // object the client splices straight into its WebRTC config.
+  // Cache at the edge briefly so a flurry of joiners doesn't fan
+  // out one CF API call per client (creds are still per-session
+  // distinct, just on the same TTL window).
+  const body = await resp.text();
+  return new Response(body, {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'private, max-age=60',
+    },
+  });
 }
 
 export default {
@@ -21,6 +88,10 @@ export default {
       return new Response('ok', {
         headers: { 'content-type': 'text/plain; charset=utf-8' },
       });
+    }
+
+    if (url.pathname === '/api/mp/turn-credentials') {
+      return handleTurnCredentials(env);
     }
 
     if (url.pathname === '/api/mp/invaders/ws') {


### PR DESCRIPTION
## Summary

Your hotel was a smoking gun. The \`SimplePeer\` constructor had no \`iceServers\` config — meaning WebRTC could only emit *host candidates* (LAN IPs). Same-Wi-Fi works at home because the AP allows client-to-client traffic, but hotels almost always disable it ("AP isolation" / "guest mode"). So host candidates went out, the other end couldn't reach them, no handshake, badge stuck at \`P2P…\` forever.

Fix: add free public STUN (Google + Cloudflare, three endpoints so a single outage doesn't break everyone). Peers can now discover their public ip:port and the other end gets something reachable.

```js
config: { iceServers: [
  { urls: 'stun:stun.l.google.com:19302' },
  { urls: 'stun:stun.l.google.com:5349' },
  { urls: 'stun:stun.cloudflare.com:3478' },
] }
```

Also wired diagnostic \`console.log\` for ICE connection + gathering state transitions on the underlying \`RTCPeerConnection\`, so if it *still* fails at some particular network we'll see exactly where (\`gather → complete\` but \`ICE → failed\` = symmetric NAT, needs TURN; \`gather → gathering\` stuck = STUN unreachable, etc).

## What this doesn't fix

**Symmetric NAT** — some hotels and most cellular networks rewrite the public port unpredictably per destination, so the STUN-discovered \`ip:port\` is wrong by the time the other peer tries it. Needs a TURN relay (which we don't run yet). Cloudflare Calls has a free-ish tier for this; worth a follow-up if STUN alone isn't enough.

For symmetric-NAT cases the cloud-relay via the DO WebSocket is the existing safety net — but with \`solo-skips-do\` in play, the host stays in local-host mode and never tells the DO 'start', so the joiner sees \`waiting\` forever. That's a separate problem; we can add a "P2P timeout → fall back to DO" detection if STUN doesn't carry the day.

## Test plan

- [ ] Open \`https://arcade.oyster.to/invaders-mp/\` on the hotel laptop. Tap START → solo runs (badge \`SOLO\`).
- [ ] iPad joins via QR. Badge on both should flip \`P2P… → P2P\` within a few seconds.
- [ ] If it doesn't connect: open the browser console on both devices and share the \`[P2P] ICE\` / \`[P2P] gather\` lines. They'll tell us exactly which stage of the handshake stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)