### PR TITLE
Artefacts: kind filter + table column headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Find sessions by the files they touched.** Search (Cmd+K) now matches a session by any file name your agent read or edited — search `App.jsx` to surface every session that worked on it, even when the name never appears in the conversation.
 - **Move a project between spaces — or out of one.** A project's ⋯ menu now offers "Move to space…": relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects collect under the Unassigned pill, ready to re-file.
 - **Ask to see a past session, and Oyster opens it.** Say "show me the session about X" and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.
+- **Filter artefacts by kind.** The Artefacts section gains a Kind row — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.
 
 ### Changed
 
@@ -18,6 +19,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 ### Fixed
 
 - **Onboarding reflects what you've actually done.** "Publish your first artefact" now ticks only when you have a live publication (and un-ticks if you unpublish), and the setup icon fills as a progress ring — becoming the 🦪 only once every step is done.
+- **Artefacts table view has column headers.** The table view now labels its columns (Name · Space · Kind · Created), matching the sessions list.
 
 ## [0.10.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Find sessions by the files they touched.** Search (Cmd+K) now matches a session by any file name your agent read or edited — search `App.jsx` to surface every session that worked on it, even when the name never appears in the conversation.
 - **Move a project between spaces — or out of one.** A project's ⋯ menu now offers "Move to space…": relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects collect under the Unassigned pill, ready to re-file.
 - **Ask to see a past session, and Oyster opens it.** Say "show me the session about X" and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.
-- **Filter artefacts by kind.** The Artefacts section gains a Kind row — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.
+- **Filter artefacts by kind.** The Artefacts section gains a Kind filter — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.
 
 ### Changed
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -311,6 +311,7 @@
 <li><strong>Find sessions by the files they touched.</strong> Search (Cmd+K) now matches a session by any file name your agent read or edited — search <code>App.jsx</code> to surface every session that worked on it, even when the name never appears in the conversation.</li>
 <li><strong>Move a project between spaces — or out of one.</strong> A project&#39;s ⋯ menu now offers &quot;Move to space…&quot;: relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects collect under the Unassigned pill, ready to re-file.</li>
 <li><strong>Ask to see a past session, and Oyster opens it.</strong> Say &quot;show me the session about X&quot; and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.</li>
+<li><strong>Filter artefacts by kind.</strong> The Artefacts section gains a Kind row — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.</li>
 </ul>
 <h3>Changed</h3>
 <ul>
@@ -319,6 +320,7 @@
 <h3>Fixed</h3>
 <ul>
 <li><strong>Onboarding reflects what you&#39;ve actually done.</strong> &quot;Publish your first artefact&quot; now ticks only when you have a live publication (and un-ticks if you unpublish), and the setup icon fills as a progress ring — becoming the 🦪 only once every step is done.</li>
+<li><strong>Artefacts table view has column headers.</strong> The table view now labels its columns (Name · Space · Kind · Created), matching the sessions list.</li>
 </ul>
 <h2 id="v-0-10-0"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.9.8...v0.10.0" rel="noopener noreferrer"><span class="release-version">0.10.0</span></a><span class="release-date"> — 2026-05-24</span></h2>
 <h3>Added</h3>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -311,7 +311,7 @@
 <li><strong>Find sessions by the files they touched.</strong> Search (Cmd+K) now matches a session by any file name your agent read or edited — search <code>App.jsx</code> to surface every session that worked on it, even when the name never appears in the conversation.</li>
 <li><strong>Move a project between spaces — or out of one.</strong> A project&#39;s ⋯ menu now offers &quot;Move to space…&quot;: relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects collect under the Unassigned pill, ready to re-file.</li>
 <li><strong>Ask to see a past session, and Oyster opens it.</strong> Say &quot;show me the session about X&quot; and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.</li>
-<li><strong>Filter artefacts by kind.</strong> The Artefacts section gains a Kind row — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.</li>
+<li><strong>Filter artefacts by kind.</strong> The Artefacts section gains a Kind filter — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.</li>
 </ul>
 <h3>Changed</h3>
 <ul>

--- a/web/src/components/Home/ArtefactTable.tsx
+++ b/web/src/components/Home/ArtefactTable.tsx
@@ -66,6 +66,12 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
   return (
     <div className="home-table-wrap">
       <div className="home-table">
+        <div className="home-artefact-row home-artefact-row--header" role="row">
+          <span role="columnheader">Name</span>
+          <span role="columnheader">Space</span>
+          <span role="columnheader">Kind</span>
+          <span role="columnheader">Created</span>
+        </div>
         {sorted.map((art) => {
           const space = spaces.find((s) => s.id === art.spaceId);
           return (

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -209,7 +209,15 @@
 
 /* Artefact KIND filter — a compact dropdown on the right of the section head.
    Trigger reuses the .stat-btn vocabulary; the menu drops below it. */
-.home-kind-filter { position: relative; display: inline-flex; }
+.home-kind-filter { position: relative; display: inline-flex; align-items: center; gap: 8px; }
+.home-kind-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  opacity: 0.6;
+}
 .home-kind-trigger {
   display: inline-flex;
   align-items: center;
@@ -231,8 +239,6 @@
   border-color: var(--home-border-accent);
   color: var(--home-accent-bright);
 }
-.home-kind-icon { flex: 0 0 auto; opacity: 0.8; }
-.home-kind-trigger-label { opacity: 0.6; text-transform: uppercase; }
 .home-kind-caret { font-size: 9px; opacity: 0.7; }
 
 .home-kind-menu {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -207,6 +207,27 @@
   color: var(--home-accent-bright);
 }
 
+/* Second filter row — artefact KIND pills. Aligns with .home-section-head's
+   width/gutter; tucks just under the source-pill row. Reuses .stat-btn. */
+.home-section-kinds {
+  max-width: 1100px;
+  margin: -6px auto 14px;
+  padding: 0 32px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+.home-kind-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  opacity: 0.6;
+  margin-right: 4px;
+}
+
 /* ── State pips ── */
 .pip {
   width: 6px;
@@ -585,6 +606,21 @@
   background: rgba(124, 107, 255, 0.05);
 }
 .home-artefact-row:last-child { border-bottom: none; }
+
+/* Column-header row for the artefacts table (mirrors .home-row--header on the
+   sessions table). Reuses .home-artefact-row's grid; just restyles + disables
+   the row affordances. */
+.home-artefact-row--header {
+  cursor: default;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  opacity: 0.6;
+}
+.home-artefact-row--header:hover { background: transparent; }
+.home-artefact-row--header > :last-child { text-align: right; }
 
 .home-artefact-row-title {
   font-size: 13px;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -207,26 +207,64 @@
   color: var(--home-accent-bright);
 }
 
-/* Second filter row — artefact KIND pills. Aligns with .home-section-head's
-   width/gutter; tucks just under the source-pill row. Reuses .stat-btn. */
-.home-section-kinds {
-  max-width: 1100px;
-  margin: -6px auto 14px;
-  padding: 0 32px;
-  display: flex;
-  flex-wrap: wrap;
+/* Artefact KIND filter — a compact dropdown on the right of the section head.
+   Trigger reuses the .stat-btn vocabulary; the menu drops below it. */
+.home-kind-filter { position: relative; display: inline-flex; }
+.home-kind-trigger {
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
-}
-.home-kind-label {
+  gap: 6px;
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 11px;
   color: var(--text-dim);
-  opacity: 0.6;
-  margin-right: 4px;
+  background: var(--home-surface);
+  border: 1px solid var(--home-border);
+  padding: 3px 10px;
+  border-radius: 9999px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
+.home-kind-trigger:hover { background: rgba(255, 255, 255, 0.06); color: var(--text); }
+.home-kind-trigger.active {
+  background: rgba(124, 107, 255, 0.18);
+  border-color: var(--home-border-accent);
+  color: var(--home-accent-bright);
+}
+.home-kind-trigger-label { opacity: 0.6; text-transform: uppercase; }
+.home-kind-caret { font-size: 9px; opacity: 0.7; }
+
+.home-kind-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  min-width: 160px;
+  padding: 4px;
+  background: rgba(20, 21, 40, 0.98);
+  border: 1px solid var(--home-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+.home-kind-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  cursor: pointer;
+  text-align: left;
+}
+.home-kind-item:hover { background: rgba(255, 255, 255, 0.06); color: var(--text); }
+.home-kind-item.active { background: rgba(124, 107, 255, 0.18); color: var(--home-accent-bright); }
+.home-kind-count { color: var(--home-text-muted); font-variant-numeric: tabular-nums; }
 
 /* ── State pips ── */
 .pip {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -231,6 +231,7 @@
   border-color: var(--home-border-accent);
   color: var(--home-accent-bright);
 }
+.home-kind-icon { flex: 0 0 auto; opacity: 0.8; }
 .home-kind-trigger-label { opacity: 0.6; text-transform: uppercase; }
 .home-kind-caret { font-size: 9px; opacity: 0.7; }
 

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
-import { Folder, FolderPlus, Shield } from "lucide-react";
+import { Filter, Folder, FolderPlus, Shield } from "lucide-react";
 import type { Session, SessionState, DisplayState } from "../../data/sessions-api";
 import { ARTIFACT_KINDS, type Artifact, type ArtifactKind, type Space } from "../../../../shared/types";
 import { useMemories } from "../../hooks/useMemories";
@@ -1297,7 +1297,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         </section>
 
         <section className="home-section">
-          <div className="home-section-head">
+          <div className="home-section-head" style={kindMenuOpen ? { zIndex: 40 } : undefined}>
             <span className="home-section-label">Artefacts</span>
             <span className="home-section-stats">
               {ARTEFACT_SOURCE_ORDER.map((src) => {
@@ -1330,6 +1330,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   aria-expanded={kindMenuOpen}
                   title="Filter artefacts by kind"
                 >
+                  <Filter size={12} aria-hidden="true" className="home-kind-icon" />
                   <span className="home-kind-trigger-label">Kind:</span>
                   {artefactKind === "all" ? "all" : artefactKind}
                   <span className="home-kind-caret" aria-hidden="true">▾</span>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -564,15 +564,27 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     [artefactKindCounts],
   );
 
-  // Close the kind-filter dropdown on any click outside it.
+  // Close the kind-filter dropdown on any click outside it. `e.target` is an
+  // EventTarget, not necessarily an Element, so guard before calling .closest().
   useEffect(() => {
     if (!kindMenuOpen) return;
     const onDocClick = (e: MouseEvent) => {
-      if (!(e.target as HTMLElement)?.closest(".home-kind-filter")) setKindMenuOpen(false);
+      const t = e.target;
+      if (!(t instanceof Element) || !t.closest(".home-kind-filter")) setKindMenuOpen(false);
     };
     document.addEventListener("click", onDocClick);
     return () => document.removeEventListener("click", onDocClick);
   }, [kindMenuOpen]);
+
+  // If the selected kind leaves the current scope (its last artefact is
+  // removed/moved, or the scope changes), fall back to "all". Otherwise the
+  // dropdown can hide while still filtering to an absent kind — stranding an
+  // empty list with no visible control to reset.
+  useEffect(() => {
+    if (artefactKind !== "all" && !presentKinds.includes(artefactKind)) {
+      setArtefactKind("all");
+    }
+  }, [artefactKind, presentKinds]);
 
   const [projectsExpanded, setProjectsExpanded] = useState(false);
 

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -235,6 +235,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // Artefact KIND filter — orthogonal to source; the two combine. "all" = no
   // kind narrowing. Reset on scope change alongside the source filter.
   const [artefactKind, setArtefactKind] = useState<ArtifactKind | "all">("all");
+  const [kindMenuOpen, setKindMenuOpen] = useState(false);
   const [artefactsLimit, setArtefactsLimit] = useState(ARTEFACTS_PREVIEW);
   // Cwd-based tile filter: drives session narrowing on both Home default
   // and showElsewhere. Lives alongside selectedProjectId; resets when scope changes.
@@ -562,6 +563,16 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     () => ARTIFACT_KINDS.filter((k) => (artefactKindCounts[k] ?? 0) > 0),
     [artefactKindCounts],
   );
+
+  // Close the kind-filter dropdown on any click outside it.
+  useEffect(() => {
+    if (!kindMenuOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!(e.target as HTMLElement)?.closest(".home-kind-filter")) setKindMenuOpen(false);
+    };
+    document.addEventListener("click", onDocClick);
+    return () => document.removeEventListener("click", onDocClick);
+  }, [kindMenuOpen]);
 
   const [projectsExpanded, setProjectsExpanded] = useState(false);
 
@@ -1309,6 +1320,49 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               })}
             </span>
             <span className="home-section-rule" />
+            {presentKinds.length > 1 && (
+              <div className="home-kind-filter">
+                <button
+                  type="button"
+                  className={`home-kind-trigger${artefactKind !== "all" ? " active" : ""}`}
+                  onClick={() => setKindMenuOpen((v) => !v)}
+                  aria-haspopup="menu"
+                  aria-expanded={kindMenuOpen}
+                  title="Filter artefacts by kind"
+                >
+                  <span className="home-kind-trigger-label">Kind:</span>
+                  {artefactKind === "all" ? "all" : artefactKind}
+                  <span className="home-kind-caret" aria-hidden="true">▾</span>
+                </button>
+                {kindMenuOpen && (
+                  <div className="home-kind-menu" role="menu">
+                    <button
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={artefactKind === "all"}
+                      className={`home-kind-item${artefactKind === "all" ? " active" : ""}`}
+                      onClick={() => { setArtefactKind("all"); setKindMenuOpen(false); }}
+                    >
+                      <span>All kinds</span>
+                      <span className="home-kind-count">{artefactSourceCounts.all}</span>
+                    </button>
+                    {presentKinds.map((kind) => (
+                      <button
+                        key={kind}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={artefactKind === kind}
+                        className={`home-kind-item${artefactKind === kind ? " active" : ""}`}
+                        onClick={() => { setArtefactKind(kind); setKindMenuOpen(false); }}
+                      >
+                        <span>{kind}</span>
+                        <span className="home-kind-count">{artefactKindCounts[kind] ?? 0}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
             <div className="home-view-toggle">
               <button
                 className={`view-btn${artefactsView === "icons" ? " active" : ""}`}
@@ -1337,26 +1391,6 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               </button>
             </div>
           </div>
-          {presentKinds.length > 1 && (
-            <div className="home-section-kinds">
-              <span className="home-kind-label">Kind</span>
-              <button
-                className={`stat-btn${artefactKind === "all" ? " active" : ""}`}
-                onClick={() => setArtefactKind("all")}
-              >
-                all
-              </button>
-              {presentKinds.map((kind) => (
-                <button
-                  key={kind}
-                  className={`stat-btn${artefactKind === kind ? " active" : ""}`}
-                  onClick={() => setArtefactKind(kind)}
-                >
-                  {artefactKindCounts[kind]} {kind}
-                </button>
-              ))}
-            </div>
-          )}
           {artefactSource === "published" && filteredArtefactsTotal === 0 ? (
             <div className="home-empty">
               {signedIn === null ? (

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
-import { Filter, Folder, FolderPlus, Shield } from "lucide-react";
+import { Folder, FolderPlus, Shield } from "lucide-react";
 import type { Session, SessionState, DisplayState } from "../../data/sessions-api";
 import { ARTIFACT_KINDS, type Artifact, type ArtifactKind, type Space } from "../../../../shared/types";
 import { useMemories } from "../../hooks/useMemories";
@@ -1322,16 +1322,16 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             <span className="home-section-rule" />
             {presentKinds.length > 1 && (
               <div className="home-kind-filter">
+                <span className="home-kind-label">Kind</span>
                 <button
                   type="button"
                   className={`home-kind-trigger${artefactKind !== "all" ? " active" : ""}`}
                   onClick={() => setKindMenuOpen((v) => !v)}
                   aria-haspopup="menu"
                   aria-expanded={kindMenuOpen}
+                  aria-label="Filter artefacts by kind"
                   title="Filter artefacts by kind"
                 >
-                  <Filter size={12} aria-hidden="true" className="home-kind-icon" />
-                  <span className="home-kind-trigger-label">Kind:</span>
                   {artefactKind === "all" ? "all" : artefactKind}
                   <span className="home-kind-caret" aria-hidden="true">▾</span>
                 </button>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LayoutGroup, motion } from "framer-motion";
 import { Folder, FolderPlus, Shield } from "lucide-react";
 import type { Session, SessionState, DisplayState } from "../../data/sessions-api";
-import type { Artifact, Space } from "../../../../shared/types";
+import { ARTIFACT_KINDS, type Artifact, type ArtifactKind, type Space } from "../../../../shared/types";
 import { useMemories } from "../../hooks/useMemories";
 import { useAuthSignedIn } from "../../hooks/useAuthSignedIn";
 import { useMyDeviceId } from "../../hooks/useMyDeviceId";
@@ -232,6 +232,9 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // Artefact source filter (#280) + 3-row collapse. Reset on scope change
   // so each space starts compact and at "all".
   const [artefactSource, setArtefactSource] = useState<ArtefactSource>("all");
+  // Artefact KIND filter — orthogonal to source; the two combine. "all" = no
+  // kind narrowing. Reset on scope change alongside the source filter.
+  const [artefactKind, setArtefactKind] = useState<ArtifactKind | "all">("all");
   const [artefactsLimit, setArtefactsLimit] = useState(ARTEFACTS_PREVIEW);
   // Cwd-based tile filter: drives session narrowing on both Home default
   // and showElsewhere. Lives alongside selectedProjectId; resets when scope changes.
@@ -301,6 +304,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     setArtefactsLimit(ARTEFACTS_PREVIEW);
     setSessionsLimit(SESSIONS_PREVIEW);
     setArtefactSource("all");
+    setArtefactKind("all");
     if (pendingFolderSelection.current) {
       setSelectedProjectId(pendingFolderSelection.current);
       pendingFolderSelection.current = null;
@@ -543,6 +547,22 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     return counts;
   }, [effectiveDesktopProps.artifacts]);
 
+  // Per-kind counts over the active scope — independent of the source filter,
+  // matching how the source pills count the scope total. Drives the Kind row.
+  const artefactKindCounts = useMemo(() => {
+    const counts: Partial<Record<ArtifactKind, number>> = {};
+    for (const a of effectiveDesktopProps.artifacts) {
+      counts[a.artifactKind] = (counts[a.artifactKind] ?? 0) + 1;
+    }
+    return counts;
+  }, [effectiveDesktopProps.artifacts]);
+  // Kinds actually present in this scope, in canonical order. The Kind row only
+  // renders when there's more than one — no point filtering a single-kind scope.
+  const presentKinds = useMemo(
+    () => ARTIFACT_KINDS.filter((k) => (artefactKindCounts[k] ?? 0) > 0),
+    [artefactKindCounts],
+  );
+
   const [projectsExpanded, setProjectsExpanded] = useState(false);
 
   // Collapsed, the Projects strip shows exactly one row. The grid is
@@ -645,6 +665,10 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     } else if (artefactSource !== "all") {
       list = list.filter((a) => (a.sourceOrigin ?? "manual") === artefactSource);
     }
+    // KIND filter combines with the source filter above.
+    if (artefactKind !== "all") {
+      list = list.filter((a) => a.artifactKind === artefactKind);
+    }
     // Pinned-first within the active scope (#387), then most-recent
     // first. Sorting by createdAt here (not just inside ArtefactTable)
     // means the artefactsLimit slice picks the freshest rows; each
@@ -659,7 +683,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
       return (Number.isFinite(tb) ? tb : 0) - (Number.isFinite(ta) ? ta : 0);
     });
     return list;
-  }, [effectiveDesktopProps.artifacts, artefactSource, selectedProjectId]);
+  }, [effectiveDesktopProps.artifacts, artefactSource, artefactKind, selectedProjectId]);
   const visibleArtefacts = useMemo(
     () => filteredArtefacts.slice(0, artefactsLimit),
     [filteredArtefacts, artefactsLimit],
@@ -1313,6 +1337,26 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               </button>
             </div>
           </div>
+          {presentKinds.length > 1 && (
+            <div className="home-section-kinds">
+              <span className="home-kind-label">Kind</span>
+              <button
+                className={`stat-btn${artefactKind === "all" ? " active" : ""}`}
+                onClick={() => setArtefactKind("all")}
+              >
+                all
+              </button>
+              {presentKinds.map((kind) => (
+                <button
+                  key={kind}
+                  className={`stat-btn${artefactKind === kind ? " active" : ""}`}
+                  onClick={() => setArtefactKind(kind)}
+                >
+                  {artefactKindCounts[kind]} {kind}
+                </button>
+              ))}
+            </div>
+          )}
           {artefactSource === "published" && filteredArtefactsTotal === 0 ? (
             <div className="home-empty">
               {signedIn === null ? (


### PR DESCRIPTION
## Summary

Two improvements to the **Artefacts** section on Home:

- **Filter by kind.** A labelled dropdown (`Kind  [ all ▾ ]`) on the right of the section head lets you narrow the list to a single kind — app / deck / diagram / map / notes / table / wireframe — with per-kind counts. It's **orthogonal to the existing source pills** (mine / from agents / linked / …) and combines with them. The control only appears when the current scope holds more than one kind, and resets to "all" on scope change. Applies to both the icon and table views.
- **Table view column headers.** The table view now has a header row (Name · Space · Kind · Created), mirroring the sessions table's `role="columnheader"` pattern — it previously had none.

## Notes

- The kind filter is read-time only — no new state persisted, no API changes. It reuses the existing `filteredArtefacts` pipeline (one extra `.filter()` clause) and the `.stat-btn` visual vocabulary.
- The dropdown design was chosen over a second pill row after comparing mockups — two pill rows read as overwhelming at the existing pill count.
- Investigation confirmed there was **no leftover type-filter code** from the old 0.4/0.5 artifact-only surface to revive; this is built fresh.

## Test plan

- [x] `cd web && npx tsc --noEmit` — clean
- [x] Verified live (dev server): Kind dropdown lists present kinds + counts, filters correctly, combines with source pills, menu paints above the artefact cards; table headers render and align with the columns
- [ ] Reviewer: confirm the dropdown placement/label reads clearly as a filter, and headers look right in both light/dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)