### PR TITLE
arcade(space-jumper): flash the player's row on the leaderboard

### DIFF
--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -486,12 +486,16 @@ Arcade.Leaderboard.init({ game: 'space-jumper', max: 10 });
 // extra letter prev/next keys (matches Space Jumper's WASD movement scheme).
 // onSubmit handles the per-game UX (SCORE SAVED text, restart grace, server
 // submit + splash repaint).
+// The player's most-recently-saved { score, initials } so the leaderboard can
+// flash the row they just landed on (shared paintList highlight). Null until a save.
+let lastEntry = null;
 Arcade.Initials.mount({
   fireButton: '#tc-jump',
   fireLabel:  { idle: 'JUMP', select: 'SELECT' },
   extraKeys:  { 'letter-prev': ['w', 'W'], 'letter-next': ['s', 'S'] },
   onSubmit: (initials) => {
     hideEndOverlay();
+    lastEntry = { score, initials };   // flash this row when the board shows
     Arcade.Leaderboard.submit(score, initials).then(res => {
       if (!res.ok) console.warn('leaderboard submit failed:', res.error);
       refreshLeaderboard(true);   // pull fresh so the just-saved score shows
@@ -516,7 +520,7 @@ function paintSplashHiScore() {
 // Top-10 list for the splash's leaderboard view (3-digit pad, legacy from
 // when scores capped at 999).
 function paintLeaderboard() {
-  Arcade.Leaderboard.paintList({ listSelector: '#lb-list', pad: 3 });
+  Arcade.Leaderboard.paintList({ listSelector: '#lb-list', pad: 3, highlight: lastEntry });
 }
 // Pull live scores from the DB whenever the board is shown — so the splash
 // stays current (including the score you just saved), not just at boot.


### PR DESCRIPTION
## Summary

Space Jumper opts into the shared leaderboard **row highlight** (added canonically in #600): on a saved high score it remembers `{ score, initials }` and passes it as `paintList`'s `highlight`, so the player's row **flashes then pulses** on the board when it appears — same as rocket-ship.

~3 lines: the CSS (`.lb-list li.is-you`) and the `paintList({ highlight })` option are already in the shared modules; this is just the per-game opt-in. Space Jumper stays 3-column (no `since`); the optimistic-insert it already inherited means the row shows instantly.

**Scope note (the original follow-up was "invaders + space-jumper"):** SP `/invaders/` now 301-redirects to `/invaders-mp/`, so wiring it would be dead code; and invaders-mp uses its own per-player MP endscreen table, not the shared `paintList`, so the shared highlight doesn't apply there without separate MP-1-adjacent work. So this is space-jumper only.

## Test Plan

- `node docs/arcade/shared/{music,touch,splash}.test.cjs` → `ALL PASS` (shared modules unchanged).
- [ ] Browser: in Space Jumper, score high enough to qualify → enter initials → the board appears with **your row flashing then pulsing cyan↔gold**; non-qualifying play shows no highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)