### PR TITLE
arcade(shared): Arcade.Engine pure primitives + adoption (slice 1)

### DIFF
--- a/docs/arcade/invaders/index.html
+++ b/docs/arcade/invaders/index.html
@@ -91,6 +91,7 @@
 <script src="../shared/initials.js"></script>
 <script src="../shared/end-overlay.js"></script>
 <script src="../shared/splash.js"></script>
+<script src="../shared/engine.js"></script>
 <audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
 <audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
 <audio id="sfx-shoot"     src="sfx-shoot.mp3"               preload="auto"></audio>
@@ -185,9 +186,12 @@ const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
 let W, H, bgGradient;
 function resize() {
-  const rect = canvas.getBoundingClientRect();
-  W = canvas.width = rect.width;
-  H = canvas.height = rect.height;
+  // Arcade.Engine.canvas.configure sizes the backing store + normalises the
+  // transform; default maxDpr:1 keeps this rendering-equivalent. W/H stay in
+  // CSS pixels (the playfield letterbox + sprites map from these).
+  const surface = Arcade.Engine.canvas.configure(canvas);
+  W = surface.cssWidth;
+  H = surface.cssHeight;
   // Build the washed navy gradient once per resize — matches the splash.
   bgGradient = ctx.createLinearGradient(0, 0, 0, H);
   bgGradient.addColorStop(0, '#0d1a60');

--- a/docs/arcade/shared/README.md
+++ b/docs/arcade/shared/README.md
@@ -49,6 +49,7 @@ modules read another's API at call time. Use this order.
 <script src="../shared/initials.js"></script>
 <script src="../shared/end-overlay.js"></script>
 <script src="../shared/splash.js"></script>
+<script src="../shared/engine.js"></script>     <!-- game primitives; pure, no deps, order-independent -->
 ```
 
 Skip any module you don't need — but mind the noted dependencies (`pause`

--- a/docs/arcade/shared/README.md
+++ b/docs/arcade/shared/README.md
@@ -4,6 +4,12 @@ Everything in `docs/arcade/shared/` is the common cabinet for the arcade games
 (`invaders/`, `space-jumper/`, …). The JS modules attach to a single global
 `window.Arcade.*` namespace; the CSS sheets style a fixed set of class/id names.
 
+The framework has **two layers**. The modules below are *cabinet chrome* —
+`Audio`, `Music`, `Splash`, `Pause`, `Touch`, `Initials`, `Leaderboard`,
+`EndOverlay`. `engine.js` adds the *game-primitive* layer under `Arcade.Engine`
+(canvas backing-store, rect overlap, stable PRNG, pixel draw) — the building
+blocks of a game's own simulation and rendering, not the surrounding cabinet.
+
 **The one gotcha:** every module is **selector-driven with silent defaults**.
 If your markup doesn't use the exact ids/classes a module expects, the module
 no-ops quietly — no error, just a dead button or an unstyled panel. This file
@@ -70,6 +76,7 @@ give your script `defer`, or wrap init in `DOMContentLoaded`.)
 | `initials.js` | `Initials` | `#go-initials` container, `#go-initials .go-slot` cells each with `data-slot="N"`, `#go-prompt` | High-score initials state machine (keyboard + touch). `mount({onSubmit, fireButton})`, `open()`. Gate your restart listeners on `if (Arcade.Initials.isActive()) return;`. |
 | `end-overlay.js` | `EndOverlay` | `#gameover` root + `#go-title`, `#go-score-val`, `#go-hiscore`, `#go-prompt` (toggles `.is-visible`) | Game-over/complete overlay + the grace-window + "next keypress restarts" gate. `show({score, title, titleClass, hiscore, graceMs, qualifies})`, `acceptsInput()`, `consumePending()`. `mount()` is optional (defaults match the ids above). |
 | `splash.js` | `Splash` | `#splash`, `#splash .splash-view` (index 0 = title, 1 = leaderboard), `.tube` | Full attract-mode lifecycle: booting → title → playing → attract. `mount({onTitle, onPlay, onLeaderboardShow, unlockAudio, isBusy})`, `enterAttract()`. Gate your loop with `if (!Arcade.Splash.isPlaying()) return;`. Toggles `.tube.is-ready` and `body.is-ingame`. |
+| `engine.js` | `Engine` | none — pure helpers, no DOM lookups at load | Game primitives (the layer below the chrome above): `canvas.configure(canvas,{maxDpr})` (backing store + capped DPR transform, returns `{ctx,cssWidth,cssHeight,dpr,pixelWidth,pixelHeight}`); `rectsOverlap(...)` (strict AABB); `rand.tileHash(i)`; `draw.circle(ctx,cx,cy,r)`. **`canvas.configure` resets the 2D transform on every call — call it on resize, not per-frame.** |
 
 ### Stylesheet class contracts
 

--- a/docs/arcade/shared/engine.js
+++ b/docs/arcade/shared/engine.js
@@ -27,10 +27,15 @@
     const rect = canvas.getBoundingClientRect();
     const cssWidth = rect.width;
     const cssHeight = rect.height;
-    const pixelWidth = Math.round(cssWidth * dpr);
-    const pixelHeight = Math.round(cssHeight * dpr);
-    canvas.width = pixelWidth;
-    canvas.height = pixelHeight;
+    // Assign css*dpr and read the value back: the canvas width/height
+    // attributes coerce to integers by truncation, so the read-back is the
+    // TRUE backing-store size. This matches the prior `canvas.width = rect.width`
+    // exactly at dpr 1 (no Math.round drift when getBoundingClientRect returns
+    // fractional CSS pixels) and guarantees the returned facts equal reality.
+    canvas.width = cssWidth * dpr;
+    canvas.height = cssHeight * dpr;
+    const pixelWidth = canvas.width;
+    const pixelHeight = canvas.height;
     const ctx = canvas.getContext('2d');
     if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     return { ctx, cssWidth, cssHeight, dpr, pixelWidth, pixelHeight };

--- a/docs/arcade/shared/engine.js
+++ b/docs/arcade/shared/engine.js
@@ -1,0 +1,71 @@
+// Arcade.Engine — pure game primitives.
+//
+// The "game primitive" layer of the arcade framework, distinct from the
+// cabinet chrome (Arcade.Audio / Music / Splash / Pause / Touch / Initials /
+// Leaderboard / EndOverlay). Everything here is pure (no DOM lookups at load,
+// no module state); a game includes engine.js and calls the helpers directly.
+//
+//   Arcade.Engine.canvas.configure(canvas, { maxDpr })  -> backing store + DPR transform; returns facts
+//   Arcade.Engine.rectsOverlap(ax,ay,aw,ah, bx,by,bw,bh) -> strict AABB overlap (touching edges => false)
+//   Arcade.Engine.rand.tileHash(i)                       -> stable pseudo-random in [0,1) keyed by index
+//   Arcade.Engine.draw.circle(ctx, cx, cy, r)            -> filled disc via integer scanlines
+
+(function () {
+  // canvas.configure — owns ONLY the backing store + 2D transform, never layout
+  // (no letterboxing / tile sizing / camera; the game maps its world from the
+  // returned facts). DPR is opt-in and capped: maxDpr defaults to 1, so the
+  // default is rendering-equivalent to a plain `canvas.width = cssWidth`.
+  //
+  // FOOTGUN: this resets the 2D transform on every call — to (dpr,0,0,dpr,0,0),
+  // i.e. identity when dpr === 1. Call it on resize, NOT per-frame (setting
+  // canvas.width clears the canvas). A game that applies its own persistent
+  // transform must re-apply it after configure().
+  function configure(canvas, opts) {
+    opts = opts || {};
+    const maxDpr = Math.max(1, Number(opts.maxDpr) || 1);   // guards 0 / null / NaN / negative
+    const dpr = Math.min(window.devicePixelRatio || 1, maxDpr);
+    const rect = canvas.getBoundingClientRect();
+    const cssWidth = rect.width;
+    const cssHeight = rect.height;
+    const pixelWidth = Math.round(cssWidth * dpr);
+    const pixelHeight = Math.round(cssHeight * dpr);
+    canvas.width = pixelWidth;
+    canvas.height = pixelHeight;
+    const ctx = canvas.getContext('2d');
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    return { ctx, cssWidth, cssHeight, dpr, pixelWidth, pixelHeight };
+  }
+
+  // Strict axis-aligned bounding-box overlap. Touching edges return false
+  // (named rectsOverlap rather than aabb so it reads for non-game-dev callers).
+  function rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
+    return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+  }
+
+  // Stable per-index pseudo-random in [0,1). Keyed off the index (not a
+  // per-frame value), so whatever it drives is stable across frames.
+  function tileHash(i) {
+    let x = ((i | 0) + 100000) >>> 0;
+    x = (x * 9301 + 49297) % 233280;
+    return x / 233280;
+  }
+
+  // Filled disc via integer scanlines. Caller sets ctx.fillStyle first; pass
+  // any 2D context (main or offscreen). Top/bottom rows (y = ±r) round to w=0
+  // → zero-width no-op rects, giving small discs a slight flat cap; this is the
+  // verbatim algorithm the games already ship, kept as-is for rendering parity.
+  function circle(ctx, cx, cy, r) {
+    for (let y = -r; y <= r; y++) {
+      const w = Math.round(Math.sqrt(r * r - y * y));
+      ctx.fillRect(Math.round(cx - w), Math.round(cy + y), w * 2, 1);
+    }
+  }
+
+  window.Arcade = window.Arcade || {};
+  window.Arcade.Engine = {
+    canvas: { configure },
+    rectsOverlap,
+    rand: { tileHash },
+    draw: { circle },
+  };
+})();

--- a/docs/arcade/shared/engine.test.cjs
+++ b/docs/arcade/shared/engine.test.cjs
@@ -33,8 +33,13 @@ function makeCanvas(cssW, cssH) {
     fillRect(x, y, w, h) { this._rects.push([x, y, w, h]); },
   };
   return {
-    width: 0,
-    height: 0,
+    // Emulate the browser: assigning the canvas width/height attribute coerces
+    // to an unsigned integer (truncation), so reads return the real backing size.
+    _w: 0, _h: 0,
+    get width() { return this._w; },
+    set width(v) { this._w = Math.floor(v); },
+    get height() { return this._h; },
+    set height(v) { this._h = Math.floor(v); },
     getBoundingClientRect() { return { width: cssW, height: cssH }; },
     getContext() { return ctx; },
   };
@@ -66,6 +71,15 @@ for (const bad of [0, null, NaN, -2]) {
   const ss = E.canvas.configure(cc, { maxDpr: bad });
   check(`invalid maxDpr ${String(bad)} => dpr 1`, ss.dpr, 1);
 }
+
+// Fractional CSS size: the browser truncates the backing store, so configure
+// must NOT round (that would drift 1px and break parity). pixelWidth/Height are
+// read back from the canvas, so they equal the true (truncated) backing size.
+sandbox.devicePixelRatio = 1;
+const cf = makeCanvas(1396.5, 700.5);
+const sf = E.canvas.configure(cf);
+check('fractional css truncates backing (parity, not rounded)', [cf.width, cf.height], [1396, 700]);
+check('pixelWidth/Height read back from real backing', [sf.pixelWidth, sf.pixelHeight], [1396, 700]);
 
 // ---- rectsOverlap (strict AABB) ------------------------------------------
 check('overlapping rects => true', E.rectsOverlap(0, 0, 10, 10, 5, 5, 10, 10), true);

--- a/docs/arcade/shared/engine.test.cjs
+++ b/docs/arcade/shared/engine.test.cjs
@@ -1,0 +1,90 @@
+// Tests for Arcade.Engine — run with `node engine.test.cjs`.
+// Loads the real shared/engine.js into a DOM stub, then checks canvas.configure
+// (DPR cap + clamp + backing-store sizing + transform reset + returned facts),
+// rectsOverlap (strict AABB), rand.tileHash (stable PRNG), and draw.circle
+// (integer scanline spans).
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const sandbox = { console };
+sandbox.window = sandbox;
+sandbox.devicePixelRatio = 1;
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(__dirname, 'engine.js'), 'utf8'), sandbox);
+const E = sandbox.Arcade.Engine;
+
+let failures = 0;
+function check(label, got, want) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  if (!ok) failures++;
+}
+function checkTrue(label, cond) { check(label, !!cond, true); }
+
+// ---- mock canvas + 2D context --------------------------------------------
+function makeCanvas(cssW, cssH) {
+  const ctx = {
+    _transform: null,
+    _rects: [],
+    fillStyle: '',
+    setTransform(a, b, c, d, e, f) { this._transform = [a, b, c, d, e, f]; },
+    fillRect(x, y, w, h) { this._rects.push([x, y, w, h]); },
+  };
+  return {
+    width: 0,
+    height: 0,
+    getBoundingClientRect() { return { width: cssW, height: cssH }; },
+    getContext() { return ctx; },
+  };
+}
+
+// ---- canvas.configure -----------------------------------------------------
+// maxDpr omitted => dpr 1 even on a high-density device.
+sandbox.devicePixelRatio = 2;
+let c = makeCanvas(800, 600);
+let s = E.canvas.configure(c);
+check('maxDpr omitted => dpr 1', s.dpr, 1);
+check('omitted: backing width = css*1', c.width, 800);
+check('omitted: backing height = css*1', c.height, 600);
+
+// devicePixelRatio 3 + maxDpr 2 => dpr 2, backing = css*2.
+sandbox.devicePixelRatio = 3;
+c = makeCanvas(800, 600);
+s = E.canvas.configure(c, { maxDpr: 2 });
+check('dpr capped at maxDpr', s.dpr, 2);
+check('backing width = css*dpr', c.width, 1600);
+check('backing height = css*dpr', c.height, 1200);
+check('transform reset to (dpr,0,0,dpr,0,0)', c.getContext()._transform, [2, 0, 0, 2, 0, 0]);
+check('returns the five facts + ctx', [s.cssWidth, s.cssHeight, s.dpr, s.pixelWidth, s.pixelHeight, !!s.ctx], [800, 600, 2, 1600, 1200, true]);
+
+// invalid maxDpr values are clamped to 1.
+sandbox.devicePixelRatio = 2;
+for (const bad of [0, null, NaN, -2]) {
+  const cc = makeCanvas(100, 100);
+  const ss = E.canvas.configure(cc, { maxDpr: bad });
+  check(`invalid maxDpr ${String(bad)} => dpr 1`, ss.dpr, 1);
+}
+
+// ---- rectsOverlap (strict AABB) ------------------------------------------
+check('overlapping rects => true', E.rectsOverlap(0, 0, 10, 10, 5, 5, 10, 10), true);
+check('disjoint rects => false', E.rectsOverlap(0, 0, 10, 10, 20, 20, 5, 5), false);
+check('edge-touching => false (strict)', E.rectsOverlap(0, 0, 10, 10, 10, 0, 10, 10), false);
+
+// ---- rand.tileHash --------------------------------------------------------
+check('tileHash deterministic', E.rand.tileHash(7), E.rand.tileHash(7));
+checkTrue('tileHash in [0,1)', E.rand.tileHash(7) >= 0 && E.rand.tileHash(7) < 1);
+checkTrue('tileHash varies by index', E.rand.tileHash(1) !== E.rand.tileHash(2));
+checkTrue('tileHash(0) known value ~0.2655', Math.abs(E.rand.tileHash(0) - 0.2655) < 1e-3);
+
+// ---- draw.circle (integer scanlines) -------------------------------------
+const dctx = makeCanvas(10, 10).getContext();
+E.draw.circle(dctx, 10, 10, 2);
+// Poles (y = ±r) round to w=0 → zero-width (no-op) rects; expected here to pin
+// the exact scanline output of the source algorithm (kept verbatim for parity).
+check('draw.circle scanline spans (r=2 at 10,10)', dctx._rects,
+  [[10, 8, 0, 1], [8, 9, 4, 1], [8, 10, 4, 1], [8, 11, 4, 1], [10, 12, 0, 1]]);
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/docs/arcade/space-jumper/index.html
+++ b/docs/arcade/space-jumper/index.html
@@ -252,6 +252,7 @@
 <script src="../shared/splash.js"></script>
 <script src="../shared/initials.js"></script>
 <script src="../shared/end-overlay.js"></script>
+<script src="../shared/engine.js"></script>
 <audio id="sfx-powerup"   src="../shared/sfx-powerup.mp3"   preload="auto"></audio>
 <audio id="sfx-explosion" src="../shared/sfx-explosion.mp3" preload="auto"></audio>
 <audio id="sfx-lose"      src="../shared/sfx-lose.mp3"      preload="auto"></audio>
@@ -377,9 +378,12 @@ const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
 let W, H;
 function resize() {
-  const rect = canvas.getBoundingClientRect();
-  W = canvas.width = rect.width;
-  H = canvas.height = rect.height;
+  // Arcade.Engine.canvas.configure sizes the backing store + normalises the
+  // transform; default maxDpr:1 keeps this rendering-equivalent. W/H stay in
+  // CSS pixels (the game's drawing coordinate space).
+  const surface = Arcade.Engine.canvas.configure(canvas);
+  W = surface.cssWidth;
+  H = surface.cssHeight;
 }
 resize();
 window.addEventListener('resize', resize);
@@ -934,8 +938,10 @@ let gameOver = false;
 let gameOverAt = 0;
 const enemies = [];
 
+// Forwards to the shared primitive (single source of truth). Same signature,
+// so existing call sites are unchanged.
 function aabbOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
-  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+  return Arcade.Engine.rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh);
 }
 
 function initEnemies() {
@@ -1906,18 +1912,10 @@ function drawHUD() {
 
 // ---------- Background helpers ----------
 // Crisp pixel-style disc via small rectangles. Cheap, no canvas arcs.
-function fillCircle(cx, cy, r) {
-  for (let y = -r; y <= r; y++) {
-    const w = Math.round(Math.sqrt(r * r - y * y));
-    ctx.fillRect(Math.round(cx - w), Math.round(cy + y), w * 2, 1);
-  }
-}
-function fillCircleOn(c, cx, cy, r) {
-  for (let y = -r; y <= r; y++) {
-    const w = Math.round(Math.sqrt(r * r - y * y));
-    c.fillRect(Math.round(cx - w), Math.round(cy + y), w * 2, 1);
-  }
-}
+// Forward to the shared scanline disc. fillCircle draws on the main ctx;
+// fillCircleOn takes an explicit context (offscreen moon canvas, etc.).
+function fillCircle(cx, cy, r) { Arcade.Engine.draw.circle(ctx, cx, cy, r); }
+function fillCircleOn(c, cx, cy, r) { Arcade.Engine.draw.circle(c, cx, cy, r); }
 
 // Moon is static art rendered into an offscreen canvas once, then
 // blitted via drawImage each frame — saves ~70 sqrt() calls + 70
@@ -1952,9 +1950,7 @@ function getMoonCanvas() {
 // the per-frame screen x), so a tile's hash — and therefore the shape
 // + position of whatever's drawn on it — never changes between frames.
 function tileHash(i) {
-  let x = ((i | 0) + 100000) >>> 0;
-  x = (x * 9301 + 49297) % 233280;
-  return x / 233280;
+  return Arcade.Engine.rand.tileHash(i);
 }
 
 // Distant pixel-city silhouette. Each "tile" along the strip hosts one

--- a/docs/superpowers/plans/2026-05-26-arcade-engine-primitives.md
+++ b/docs/superpowers/plans/2026-05-26-arcade-engine-primitives.md
@@ -164,10 +164,14 @@ Create `docs/arcade/shared/engine.js` with exactly this content:
     const rect = canvas.getBoundingClientRect();
     const cssWidth = rect.width;
     const cssHeight = rect.height;
-    const pixelWidth = Math.round(cssWidth * dpr);
-    const pixelHeight = Math.round(cssHeight * dpr);
-    canvas.width = pixelWidth;
-    canvas.height = pixelHeight;
+    // Assign css*dpr and read back: the canvas width/height attributes coerce
+    // to integers by truncation, so the read-back is the TRUE backing-store size.
+    // Matches `canvas.width = rect.width` exactly at dpr 1 (no Math.round drift on
+    // fractional CSS pixels) and makes the returned facts equal reality.
+    canvas.width = cssWidth * dpr;
+    canvas.height = cssHeight * dpr;
+    const pixelWidth = canvas.width;
+    const pixelHeight = canvas.height;
     const ctx = canvas.getContext('2d');
     if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     return { ctx, cssWidth, cssHeight, dpr, pixelWidth, pixelHeight };

--- a/docs/superpowers/plans/2026-05-26-arcade-engine-primitives.md
+++ b/docs/superpowers/plans/2026-05-26-arcade-engine-primitives.md
@@ -1,0 +1,503 @@
+# Arcade Engine Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `shared/engine.js` module (`Arcade.Engine`) holding four pure game primitives — `canvas.configure`, `rectsOverlap`, `rand.tileHash`, `draw.circle` — and adopt them in the single-player games with no rendering change.
+
+**Architecture:** A plain IIFE in `docs/arcade/shared/`, same pattern as the existing chrome modules (audio/music/splash/…), exposing one namespace `window.Arcade.Engine`. The games adopt it by replacing their local definitions with thin forwarders (so existing call sites are untouched), keeping the change mechanical and rendering-equivalent. DPR support is opt-in and capped; the default reproduces today's behaviour.
+
+**Tech Stack:** Vanilla browser JS (no build step). Node-based unit tests via `vm` (`*.test.cjs`), run with `node <file>`. Manual browser parity check via `python3 -m http.server`.
+
+**Spec:** `docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md`
+
+**Scope note:** Per spec, this slice is **pure helpers only**. The game loop, tilemap collision resolver, and `draw.pixels` are explicitly out of scope. Per a follow-up scoping decision, **Invaders adopts `canvas.configure` only** this slice — converting its inline collision conditionals to `rectsOverlap` is deferred (a higher-risk hand-rewrite; `rectsOverlap` is already proven by Space Jumper). No CHANGELOG entry (arcade is out of consumer-changelog scope).
+
+---
+
+## File structure
+
+- **Create** `docs/arcade/shared/engine.js` — the `Arcade.Engine` module.
+- **Create** `docs/arcade/shared/engine.test.cjs` — node unit tests for all four helpers.
+- **Modify** `docs/arcade/space-jumper/index.html` — add the `<script>` tag; adopt `canvas.configure` + forward `aabbOverlap`/`tileHash`/`fillCircle`/`fillCircleOn` to the shared helpers.
+- **Modify** `docs/arcade/invaders/index.html` — add the `<script>` tag; adopt `canvas.configure` in `resize()`.
+- **Modify** `docs/arcade/shared/README.md` — document the module (table row + two-layer note + the `configure` transform footgun).
+
+---
+
+## Task 1: Create the `Arcade.Engine` module (TDD)
+
+**Files:**
+- Create: `docs/arcade/shared/engine.js`
+- Test: `docs/arcade/shared/engine.test.cjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `docs/arcade/shared/engine.test.cjs` with exactly this content:
+
+```js
+// Tests for Arcade.Engine — run with `node engine.test.cjs`.
+// Loads the real shared/engine.js into a DOM stub, then checks canvas.configure
+// (DPR cap + clamp + backing-store sizing + transform reset + returned facts),
+// rectsOverlap (strict AABB), rand.tileHash (stable PRNG), and draw.circle
+// (integer scanline spans).
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const sandbox = { console };
+sandbox.window = sandbox;
+sandbox.devicePixelRatio = 1;
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(path.join(__dirname, 'engine.js'), 'utf8'), sandbox);
+const E = sandbox.Arcade.Engine;
+
+let failures = 0;
+function check(label, got, want) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  if (!ok) failures++;
+}
+function checkTrue(label, cond) { check(label, !!cond, true); }
+
+// ---- mock canvas + 2D context --------------------------------------------
+function makeCanvas(cssW, cssH) {
+  const ctx = {
+    _transform: null,
+    _rects: [],
+    fillStyle: '',
+    setTransform(a, b, c, d, e, f) { this._transform = [a, b, c, d, e, f]; },
+    fillRect(x, y, w, h) { this._rects.push([x, y, w, h]); },
+  };
+  return {
+    width: 0,
+    height: 0,
+    getBoundingClientRect() { return { width: cssW, height: cssH }; },
+    getContext() { return ctx; },
+  };
+}
+
+// ---- canvas.configure -----------------------------------------------------
+// maxDpr omitted => dpr 1 even on a high-density device.
+sandbox.devicePixelRatio = 2;
+let c = makeCanvas(800, 600);
+let s = E.canvas.configure(c);
+check('maxDpr omitted => dpr 1', s.dpr, 1);
+check('omitted: backing width = css*1', c.width, 800);
+check('omitted: backing height = css*1', c.height, 600);
+
+// devicePixelRatio 3 + maxDpr 2 => dpr 2, backing = css*2.
+sandbox.devicePixelRatio = 3;
+c = makeCanvas(800, 600);
+s = E.canvas.configure(c, { maxDpr: 2 });
+check('dpr capped at maxDpr', s.dpr, 2);
+check('backing width = css*dpr', c.width, 1600);
+check('backing height = css*dpr', c.height, 1200);
+check('transform reset to (dpr,0,0,dpr,0,0)', c.getContext()._transform, [2, 0, 0, 2, 0, 0]);
+check('returns the five facts + ctx', [s.cssWidth, s.cssHeight, s.dpr, s.pixelWidth, s.pixelHeight, !!s.ctx], [800, 600, 2, 1600, 1200, true]);
+
+// invalid maxDpr values are clamped to 1.
+sandbox.devicePixelRatio = 2;
+for (const bad of [0, null, NaN, -2]) {
+  const cc = makeCanvas(100, 100);
+  const ss = E.canvas.configure(cc, { maxDpr: bad });
+  check(`invalid maxDpr ${JSON.stringify(bad)} => dpr 1`, ss.dpr, 1);
+}
+
+// ---- rectsOverlap (strict AABB) ------------------------------------------
+check('overlapping rects => true', E.rectsOverlap(0, 0, 10, 10, 5, 5, 10, 10), true);
+check('disjoint rects => false', E.rectsOverlap(0, 0, 10, 10, 20, 20, 5, 5), false);
+check('edge-touching => false (strict)', E.rectsOverlap(0, 0, 10, 10, 10, 0, 10, 10), false);
+
+// ---- rand.tileHash --------------------------------------------------------
+check('tileHash deterministic', E.rand.tileHash(7), E.rand.tileHash(7));
+checkTrue('tileHash in [0,1)', E.rand.tileHash(7) >= 0 && E.rand.tileHash(7) < 1);
+checkTrue('tileHash varies by index', E.rand.tileHash(1) !== E.rand.tileHash(2));
+checkTrue('tileHash(0) known value ~0.2655', Math.abs(E.rand.tileHash(0) - 0.2655) < 1e-3);
+
+// ---- draw.circle (integer scanlines) -------------------------------------
+const dctx = makeCanvas(10, 10).getContext();
+E.draw.circle(dctx, 10, 10, 2);
+check('draw.circle scanline spans (r=2 at 10,10)', dctx._rects,
+  [[10, 8, 0, 1], [8, 9, 4, 1], [8, 10, 4, 1], [8, 11, 4, 1], [10, 12, 0, 1]]);
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd docs/arcade/shared && node engine.test.cjs`
+Expected: throws `ENOENT: no such file or directory, open '.../engine.js'` (module doesn't exist yet).
+
+- [ ] **Step 3: Write the module**
+
+Create `docs/arcade/shared/engine.js` with exactly this content:
+
+```js
+// Arcade.Engine — pure game primitives.
+//
+// The "game primitive" layer of the arcade framework, distinct from the
+// cabinet chrome (Arcade.Audio / Music / Splash / Pause / Touch / Initials /
+// Leaderboard / EndOverlay). Everything here is pure (no DOM lookups at load,
+// no module state); a game includes engine.js and calls the helpers directly.
+//
+//   Arcade.Engine.canvas.configure(canvas, { maxDpr })  -> backing store + DPR transform; returns facts
+//   Arcade.Engine.rectsOverlap(ax,ay,aw,ah, bx,by,bw,bh) -> strict AABB overlap (touching edges => false)
+//   Arcade.Engine.rand.tileHash(i)                       -> stable pseudo-random in [0,1) keyed by index
+//   Arcade.Engine.draw.circle(ctx, cx, cy, r)            -> filled disc via integer scanlines
+
+(function () {
+  // canvas.configure — owns ONLY the backing store + 2D transform, never layout
+  // (no letterboxing / tile sizing / camera; the game maps its world from the
+  // returned facts). DPR is opt-in and capped: maxDpr defaults to 1, so the
+  // default is rendering-equivalent to a plain `canvas.width = cssWidth`.
+  //
+  // FOOTGUN: this resets the 2D transform on every call — to (dpr,0,0,dpr,0,0),
+  // i.e. identity when dpr === 1. Call it on resize, NOT per-frame (setting
+  // canvas.width clears the canvas). A game that applies its own persistent
+  // transform must re-apply it after configure().
+  function configure(canvas, opts) {
+    opts = opts || {};
+    const maxDpr = Math.max(1, Number(opts.maxDpr) || 1);   // guards 0 / null / NaN / negative
+    const dpr = Math.min(window.devicePixelRatio || 1, maxDpr);
+    const rect = canvas.getBoundingClientRect();
+    const cssWidth = rect.width;
+    const cssHeight = rect.height;
+    const pixelWidth = Math.round(cssWidth * dpr);
+    const pixelHeight = Math.round(cssHeight * dpr);
+    canvas.width = pixelWidth;
+    canvas.height = pixelHeight;
+    const ctx = canvas.getContext('2d');
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    return { ctx, cssWidth, cssHeight, dpr, pixelWidth, pixelHeight };
+  }
+
+  // Strict axis-aligned bounding-box overlap. Touching edges return false
+  // (named rectsOverlap rather than aabb so it reads for non-game-dev callers).
+  function rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
+    return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+  }
+
+  // Stable per-index pseudo-random in [0,1). Keyed off the index (not a
+  // per-frame value), so whatever it drives is stable across frames.
+  function tileHash(i) {
+    let x = ((i | 0) + 100000) >>> 0;
+    x = (x * 9301 + 49297) % 233280;
+    return x / 233280;
+  }
+
+  // Filled disc via integer scanlines. Caller sets ctx.fillStyle first; pass
+  // any 2D context (main or offscreen).
+  function circle(ctx, cx, cy, r) {
+    for (let y = -r; y <= r; y++) {
+      const w = Math.round(Math.sqrt(r * r - y * y));
+      ctx.fillRect(Math.round(cx - w), Math.round(cy + y), w * 2, 1);
+    }
+  }
+
+  window.Arcade = window.Arcade || {};
+  window.Arcade.Engine = {
+    canvas: { configure },
+    rectsOverlap,
+    rand: { tileHash },
+    draw: { circle },
+  };
+})();
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd docs/arcade/shared && node engine.test.cjs`
+Expected: every line `PASS`, final line `ALL PASS`, exit code 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/arcade/shared/engine.js docs/arcade/shared/engine.test.cjs
+git commit -m "arcade(shared): add Arcade.Engine pure primitives (canvas/rectsOverlap/rand/draw)
+
+New shared/engine.js — the game-primitive layer alongside the cabinet chrome.
+canvas.configure owns backing-store + capped DPR transform and returns facts
+(never layout); rectsOverlap is a strict AABB test; rand.tileHash is the stable
+per-index PRNG; draw.circle is the integer-scanline disc. Node tests in
+engine.test.cjs cover DPR cap/clamp, transform reset, strict overlap, PRNG
+determinism, and scanline spans.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Adopt in Space Jumper
+
+Space Jumper gets `canvas.configure` plus forwarders for all four of its local
+helpers. Forwarders keep the exact signatures, so the 13 `tileHash`, 5
+`aabbOverlap`, 1 `fillCircle`, and 4 `fillCircleOn` call sites are untouched.
+
+**Files:**
+- Modify: `docs/arcade/space-jumper/index.html`
+
+- [ ] **Step 1: Add the `<script>` tag**
+
+In `docs/arcade/space-jumper/index.html`, after the last shared script tag
+(`<script src="../shared/end-overlay.js"></script>`, line ~254), add:
+
+```html
+<script src="../shared/engine.js"></script>
+```
+
+So the block reads:
+```html
+<script src="../shared/end-overlay.js"></script>
+<script src="../shared/engine.js"></script>
+```
+
+- [ ] **Step 2: Adopt `canvas.configure` in `resize()`**
+
+Replace the `resize()` function (currently):
+```js
+function resize() {
+  const rect = canvas.getBoundingClientRect();
+  W = canvas.width = rect.width;
+  H = canvas.height = rect.height;
+}
+```
+with:
+```js
+function resize() {
+  // Arcade.Engine.canvas.configure sizes the backing store + normalises the
+  // transform; default maxDpr:1 keeps this rendering-equivalent. W/H stay in
+  // CSS pixels (the game's drawing coordinate space).
+  const surface = Arcade.Engine.canvas.configure(canvas);
+  W = surface.cssWidth;
+  H = surface.cssHeight;
+}
+```
+
+- [ ] **Step 3: Forward `aabbOverlap` to the shared helper**
+
+Replace the `aabbOverlap` definition (currently):
+```js
+function aabbOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
+  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+}
+```
+with:
+```js
+// Forwards to the shared primitive (single source of truth). Same signature,
+// so existing call sites are unchanged.
+function aabbOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
+  return Arcade.Engine.rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh);
+}
+```
+
+- [ ] **Step 4: Forward `tileHash` to the shared helper**
+
+Replace the `tileHash` definition (currently):
+```js
+function tileHash(i) {
+  let x = ((i | 0) + 100000) >>> 0;
+  x = (x * 9301 + 49297) % 233280;
+  return x / 233280;
+}
+```
+with (keep the explanatory comment block above it intact):
+```js
+function tileHash(i) {
+  return Arcade.Engine.rand.tileHash(i);
+}
+```
+
+- [ ] **Step 5: Forward `fillCircle` and `fillCircleOn` to the shared helper**
+
+Replace both definitions (currently):
+```js
+function fillCircle(cx, cy, r) {
+  for (let y = -r; y <= r; y++) {
+    const w = Math.round(Math.sqrt(r * r - y * y));
+    ctx.fillRect(Math.round(cx - w), Math.round(cy + y), w * 2, 1);
+  }
+}
+function fillCircleOn(c, cx, cy, r) {
+  for (let y = -r; y <= r; y++) {
+    const w = Math.round(Math.sqrt(r * r - y * y));
+    c.fillRect(Math.round(cx - w), Math.round(cy + y), w * 2, 1);
+  }
+}
+```
+with:
+```js
+// Forward to the shared scanline disc. fillCircle draws on the main ctx;
+// fillCircleOn takes an explicit context (offscreen moon canvas, etc.).
+function fillCircle(cx, cy, r) { Arcade.Engine.draw.circle(ctx, cx, cy, r); }
+function fillCircleOn(c, cx, cy, r) { Arcade.Engine.draw.circle(c, cx, cy, r); }
+```
+
+- [ ] **Step 6: Browser parity check**
+
+Run a local server from the worktree's `docs/`:
+```bash
+python3 -m http.server 8012 --directory docs
+```
+Open `http://localhost:8012/arcade/space-jumper/index.html`. Verify:
+- Title screen renders (the planet/moon disc — exercises `draw.circle` via `fillCircleOn`).
+- No errors in the browser console (e.g. `Arcade.Engine is undefined`).
+- Start a run: the player moves/jumps, enemies walk, coins/jetpacks/goal render, collision feels identical (stomp, walls, jetpack refuel on landing — exercises `aabbOverlap` and the unchanged collision code).
+- Background props (city/pines/etc.) render stably across frames (exercises `tileHash`).
+
+Stop the server (`Ctrl-C` or `pkill -f "http.server 8012"`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/arcade/space-jumper/index.html
+git commit -m "arcade(space-jumper): adopt Arcade.Engine primitives
+
+resize() uses Arcade.Engine.canvas.configure (default maxDpr:1, rendering-
+equivalent); aabbOverlap/tileHash/fillCircle/fillCircleOn become thin forwarders
+to the shared helpers so call sites are untouched. Verified in-browser: title,
+gameplay, collision, and per-tile background art render identically.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Adopt in Invaders (`canvas.configure` only)
+
+Invaders adopts `canvas.configure`; its inline collision conditionals are left
+as-is this slice (deferred per the scope note).
+
+**Files:**
+- Modify: `docs/arcade/invaders/index.html`
+
+- [ ] **Step 1: Add the `<script>` tag**
+
+In `docs/arcade/invaders/index.html`, after the last shared script tag
+(`<script src="../shared/splash.js"></script>`, line ~93), add:
+
+```html
+<script src="../shared/engine.js"></script>
+```
+
+So the block reads:
+```html
+<script src="../shared/splash.js"></script>
+<script src="../shared/engine.js"></script>
+```
+
+- [ ] **Step 2: Adopt `canvas.configure` in `resize()`**
+
+Replace the `resize()` function (currently):
+```js
+function resize() {
+  const rect = canvas.getBoundingClientRect();
+  W = canvas.width = rect.width;
+  H = canvas.height = rect.height;
+  // Build the washed navy gradient once per resize — matches the splash.
+  bgGradient = ctx.createLinearGradient(0, 0, 0, H);
+  bgGradient.addColorStop(0, '#0d1a60');
+  bgGradient.addColorStop(1, '#050a30');
+}
+```
+with:
+```js
+function resize() {
+  // Arcade.Engine.canvas.configure sizes the backing store + normalises the
+  // transform; default maxDpr:1 keeps this rendering-equivalent. W/H stay in
+  // CSS pixels (the playfield letterbox + sprites map from these).
+  const surface = Arcade.Engine.canvas.configure(canvas);
+  W = surface.cssWidth;
+  H = surface.cssHeight;
+  // Build the washed navy gradient once per resize — matches the splash.
+  bgGradient = ctx.createLinearGradient(0, 0, 0, H);
+  bgGradient.addColorStop(0, '#0d1a60');
+  bgGradient.addColorStop(1, '#050a30');
+}
+```
+
+- [ ] **Step 3: Browser parity check**
+
+Run a local server from the worktree's `docs/`:
+```bash
+python3 -m http.server 8012 --directory docs
+```
+Open `http://localhost:8012/arcade/invaders/index.html`. Verify:
+- Title/leaderboard splash renders; no console errors (e.g. `Arcade.Engine is undefined`).
+- Start a run: the invader grid, player, bullets, shields, and the navy background gradient render and animate identically; the playfield fills the tube the same as before.
+
+Stop the server (`Ctrl-C` or `pkill -f "http.server 8012"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/arcade/invaders/index.html
+git commit -m "arcade(invaders): adopt Arcade.Engine.canvas.configure in resize()
+
+resize() uses the shared canvas helper (default maxDpr:1, rendering-equivalent);
+the bgGradient build is unchanged. Inline collision tests are left for a later
+pass. Verified in-browser: splash + gameplay render identically.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Document `engine.js` in the shared README
+
+**Files:**
+- Modify: `docs/arcade/shared/README.md`
+
+- [ ] **Step 1: Add the module to the "Module reference" table**
+
+In `docs/arcade/shared/README.md`, in the `## Module reference` table, add this
+row after the `splash.js` row (the last data row before the `### Stylesheet
+class contracts` heading):
+
+```md
+| `engine.js` | `Engine` | none — pure helpers, no DOM lookups at load | Game primitives (the layer below the chrome above): `canvas.configure(canvas,{maxDpr})` (backing store + capped DPR transform, returns `{ctx,cssWidth,cssHeight,dpr,pixelWidth,pixelHeight}`); `rectsOverlap(...)` (strict AABB); `rand.tileHash(i)`; `draw.circle(ctx,cx,cy,r)`. **`canvas.configure` resets the 2D transform on every call — call it on resize, not per-frame.** |
+```
+
+- [ ] **Step 2: Add the two-layer note**
+
+In `docs/arcade/shared/README.md`, immediately after the first paragraph
+(the line ending "…the CSS sheets style a fixed set of class/id names.") add:
+
+```md
+The framework has **two layers**. The modules above are *cabinet chrome* —
+`Audio`, `Music`, `Splash`, `Pause`, `Touch`, `Initials`, `Leaderboard`,
+`EndOverlay`. `engine.js` adds the *game-primitive* layer under `Arcade.Engine`
+(canvas backing-store, rect overlap, stable PRNG, pixel draw) — the building
+blocks of a game's own simulation and rendering, not the surrounding cabinet.
+```
+
+(If the exact opening wording differs, place this note as its own paragraph
+directly after the first paragraph of the file.)
+
+- [ ] **Step 3: Verify it renders sensibly**
+
+Run: `cd docs/arcade/shared && node -e "const t=require('fs').readFileSync('README.md','utf8'); if(!t.includes('engine.js')||!t.includes('two layers')) { console.error('README missing engine.js/two-layer note'); process.exit(1);} console.log('README OK');"`
+Expected: `README OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/arcade/shared/README.md
+git commit -m "docs(arcade): document engine.js + the chrome/engine two-layer split
+
+Add the engine.js row to the shared module reference (incl. the canvas.configure
+transform-reset footgun) and a note framing the two framework layers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] `cd docs/arcade/shared && node engine.test.cjs` → `ALL PASS`.
+- [ ] Both games open and play identically to pre-change (Tasks 2 & 3 checks).
+- [ ] `git log --oneline` shows four commits (module+tests, space-jumper, invaders, README).
+- [ ] No CHANGELOG edit (arcade out of scope).
+- [ ] Ready to push and open a PR for review.

--- a/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
+++ b/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
@@ -72,8 +72,11 @@ veto point left for the reviewer.)*
 - `maxDpr = Math.max(1, Number(maxDpr) || 1)` — guards `0` / `null` / `NaN` / negative
   so a bad value can't produce a zero-size or broken canvas.
 - `dpr = min(window.devicePixelRatio || 1, maxDpr)`.
-- `pixelWidth = round(cssWidth * dpr)`, `pixelHeight = round(cssHeight * dpr)`.
-- Sets `canvas.width = pixelWidth`, `canvas.height = pixelHeight`.
+- Sets `canvas.width = cssWidth * dpr` (same for height) and reads it back: the
+  canvas attributes coerce to integers by truncation, so the read-back is the true
+  backing-store size. `pixelWidth = canvas.width`, `pixelHeight = canvas.height`.
+  (No `Math.round` — truncation matches the prior `canvas.width = rect.width`
+  exactly at dpr 1, with no 1px drift on fractional CSS sizes.)
 - Grabs `ctx = canvas.getContext('2d')` and **always** normalises the transform:
   `ctx.setTransform(dpr, 0, 0, dpr, 0, 0)` (identity when `dpr === 1`), so game code keeps
   drawing in CSS-pixel coordinates regardless of DPR.
@@ -173,7 +176,8 @@ Node-based, modelled on the existing `music.test.cjs` / `splash.test.cjs` (mock
 - **`canvas.configure`:**
   - `maxDpr` omitted ⇒ `dpr === 1`.
   - `devicePixelRatio = 3`, `{ maxDpr: 2 }` ⇒ `dpr === 2`.
-  - `canvas.width === round(cssWidth * dpr)`, `canvas.height === round(cssHeight * dpr)`.
+  - `canvas.width` reads back the truncated `cssWidth * dpr` (same for height); a
+    fractional CSS size (e.g. 1396.5 → 1396) truncates, matching the old behaviour.
   - `ctx.setTransform` called with `(dpr, 0, 0, dpr, 0, 0)` after the call (transform
     reset / normalised).
   - invalid `maxDpr` (`0`, `null`, `NaN`, `-2`) ⇒ clamped, `dpr === 1`.

--- a/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
+++ b/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
@@ -18,7 +18,7 @@ the same shape.
 
 ```
 Arcade.Audio / Music / Splash / Pause / Touch / Initials / Leaderboard / EndOverlay   ← cabinet chrome
-Arcade.Engine.{ canvas, aabb, rand, draw }                                            ← game primitives (NEW)
+Arcade.Engine.{ canvas, rectsOverlap, rand, draw }                                    ← game primitives (NEW)
 ```
 
 This directly serves the framework ambition (`shared/` as a target an agent can build
@@ -58,7 +58,7 @@ or agent — two clean buckets instead of one flat bag of ~30 helpers.
 ### `Arcade.Engine.canvas`
 
 ```js
-const view = Arcade.Engine.canvas.configure(canvas, { maxDpr = 1 } = {});
+const surface = Arcade.Engine.canvas.configure(canvas, { maxDpr = 1 } = {});
 // → { ctx, cssWidth, cssHeight, dpr, pixelWidth, pixelHeight }
 ```
 
@@ -69,6 +69,8 @@ veto point left for the reviewer.)*
 
 **Behaviour:**
 - Reads the CSS box via `canvas.getBoundingClientRect()` → `cssWidth`, `cssHeight`.
+- `maxDpr = Math.max(1, Number(maxDpr) || 1)` — guards `0` / `null` / `NaN` / negative
+  so a bad value can't produce a zero-size or broken canvas.
 - `dpr = min(window.devicePixelRatio || 1, maxDpr)`.
 - `pixelWidth = round(cssWidth * dpr)`, `pixelHeight = round(cssHeight * dpr)`.
 - Sets `canvas.width = pixelWidth`, `canvas.height = pixelHeight`.
@@ -80,9 +82,9 @@ veto point left for the reviewer.)*
 **Does NOT:** letterbox, derive tile sizes, set up a camera, or otherwise map the game
 world. The game does that from the returned facts, e.g.:
 ```js
-const v = Arcade.Engine.canvas.configure(canvas);
-letterboxFixedPlayfield(v, 260, 280);   // Invaders
-deriveTileSize(v);                       // Space Jumper
+const surface = Arcade.Engine.canvas.configure(canvas);
+letterboxFixedPlayfield(surface, 260, 280);   // Invaders
+deriveTileSize(surface);                       // Space Jumper
 ```
 
 **Footgun (must be documented in the header + README, and tested):** `configure` resets
@@ -94,15 +96,19 @@ game-applied persistent transform to survive it — re-apply after `configure` i
 transform ⇒ rendering-equivalent to today's `resize()`. DPR crispness is strictly
 opt-in (`{ maxDpr: 2 }`) because both games repaint the full screen every frame, so a
 higher backing store is ~`dpr²`× the fill cost — a real hit on phones/tablets. Opting
-in later is a one-flag change with no game-code change (the transform handles scaling),
-and the cost can be measured per game.
+in later should be a one-flag change for games that draw in CSS-pixel coordinates; games
+with custom transforms, cached gradients/image buffers, or pixel-perfect assumptions may
+still need local work. The cost can be measured per game.
 
-### `Arcade.Engine.aabb`
+### `Arcade.Engine.rectsOverlap`
 
 ```js
-Arcade.Engine.aabb(ax, ay, aw, ah, bx, by, bw, bh);  // → boolean
-// strict overlap: touching edges returns false
+Arcade.Engine.rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh);  // → boolean
+// AABB test; strict overlap — touching edges return false
 ```
+
+Named `rectsOverlap` (not `aabb`) so it reads for a reader who isn't game-engine fluent;
+the comment keeps the AABB term discoverable.
 
 The pure axis-aligned box-overlap test (Space Jumper's `aabbOverlap`, verbatim
 semantics: `ax < bx+bw && ax+aw > bx && ay < by+bh && ay+ah > by`). Documented as
@@ -143,7 +149,7 @@ change. Each swap is mechanical and individually parity-checkable.
 | Helper | `invaders/index.html` | `space-jumper/index.html` |
 |---|---|---|
 | `canvas.configure` | `resize()` backing-store lines (keeps building `bgGradient` locally) | `resize()` backing-store lines |
-| `aabb` | inline overlap tests in `resolveCollisions` | `aabbOverlap` definition + call sites |
+| `rectsOverlap` | inline overlap tests in `resolveCollisions` | `aabbOverlap` definition + call sites |
 | `rand.tileHash` | — | `tileHash` definition + call sites |
 | `draw.circle` | — | `fillCircle` + `fillCircleOn` definitions + call sites |
 
@@ -151,7 +157,7 @@ change. Each swap is mechanical and individually parity-checkable.
 canvas game in the same shape).
 
 Note on `canvas.configure` adoption: today both games do `W = canvas.width = rect.width`.
-After adoption, geometry uses `view.cssWidth`/`view.cssHeight`; with the default
+After adoption, geometry uses `surface.cssWidth`/`surface.cssHeight`; with the default
 `maxDpr: 1` these equal the pixel dimensions, so the change is rendering-equivalent.
 
 ## Tests — `docs/arcade/shared/engine.test.cjs`
@@ -165,8 +171,9 @@ Node-based, modelled on the existing `music.test.cjs` / `splash.test.cjs` (mock
   - `canvas.width === round(cssWidth * dpr)`, `canvas.height === round(cssHeight * dpr)`.
   - `ctx.setTransform` called with `(dpr, 0, 0, dpr, 0, 0)` after the call (transform
     reset / normalised).
+  - invalid `maxDpr` (`0`, `null`, `NaN`, `-2`) ⇒ clamped, `dpr === 1`.
   - return object exposes `ctx` + all five facts.
-- **`aabb`:** overlapping boxes ⇒ `true`; disjoint ⇒ `false`; **edge-touching ⇒ `false`**
+- **`rectsOverlap`:** overlapping boxes ⇒ `true`; disjoint ⇒ `false`; **edge-touching ⇒ `false`**
   (named test, pins the strict-overlap contract).
 - **`rand.tileHash`:** deterministic for a fixed `i`; result in `[0, 1)`; a known
   fixed value for a known `i`.
@@ -199,12 +206,12 @@ Layered onto `Arcade.Engine` later, none requiring a reshape of this slice:
 |---|---|
 | Adoption silently changes rendering | `maxDpr: 1` default = rendering-equivalent; unit tests + browser parity check both games |
 | `setTransform` reset surprises a later contributor | Documented in header + README; asserted in tests |
-| "Engine" overpromises while the surface is small | Acceptable — it's the deliberate home for the loop/collision work to come; draw/rand/aabb/canvas already cohere as primitives |
+| "Engine" overpromises while the surface is small | Acceptable — it's the deliberate home for the loop/collision work to come; draw/rand/rectsOverlap/canvas already cohere as primitives |
 | Over-fragmentation | Single `engine.js`, single namespace — one script tag, one row in the README |
 
 ## Acceptance criteria
 
-- `shared/engine.js` defines `Arcade.Engine` with `canvas.configure`, `aabb`,
+- `shared/engine.js` defines `Arcade.Engine` with `canvas.configure`, `rectsOverlap`,
   `rand.tileHash`, `draw.circle` exactly as specified.
 - Both single-player games adopt all applicable helpers; their inline copies are removed.
 - `shared/engine.test.cjs` passes, covering the cases above.

--- a/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
+++ b/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
@@ -149,12 +149,17 @@ change. Each swap is mechanical and individually parity-checkable.
 | Helper | `invaders/index.html` | `space-jumper/index.html` |
 |---|---|---|
 | `canvas.configure` | `resize()` backing-store lines (keeps building `bgGradient` locally) | `resize()` backing-store lines |
-| `rectsOverlap` | inline overlap tests in `resolveCollisions` | `aabbOverlap` definition + call sites |
+| `rectsOverlap` | *(deferred this slice — see note below)* | `aabbOverlap` definition + call sites |
 | `rand.tileHash` | — | `tileHash` definition + call sites |
 | `draw.circle` | — | `fillCircle` + `fillCircleOn` definitions + call sites |
 
 `invaders-mp` is **out of scope** (separate engine/netcode path; not a single-player
 canvas game in the same shape).
+
+**Invaders `rectsOverlap` deferred (scoping decision):** converting Invaders' 5 bespoke
+inline collision conditionals to `rectsOverlap` is a higher-risk hand-rewrite of live
+gameplay logic, and `rectsOverlap` is already proven by Space Jumper's adoption. Invaders
+adopts `canvas.configure` only this slice; the collision conversion is a fast-follow.
 
 Note on `canvas.configure` adoption: today both games do `W = canvas.width = rect.width`.
 After adoption, geometry uses `surface.cssWidth`/`surface.cssHeight`; with the default

--- a/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
+++ b/docs/superpowers/specs/2026-05-26-arcade-engine-primitives-design.md
@@ -1,0 +1,214 @@
+# Arcade engine primitives — `Arcade.Engine` (slice 1)
+
+**Date:** 2026-05-26
+**Status:** design — approved direction, pending written-spec review
+**Scope:** item #3 of the 2026-05-25 arcade-framework audit
+
+## Motivation
+
+`docs/arcade/shared/` currently centralises the **cabinet chrome** — `Arcade.Audio`,
+`Music`, `Splash`, `Pause`, `Touch`, `Initials`, `Leaderboard`, `EndOverlay`. It has
+**zero engine layer**: every game re-implements canvas setup, box-overlap tests, a
+stable per-tile PRNG, and pixel-drawing helpers inline.
+
+This slice introduces a second, clearly-named layer for the building blocks of a
+game's own simulation and rendering, without touching the riskier shared concerns
+(game loop, collision resolution) that the games have **not** yet proven to need in
+the same shape.
+
+```
+Arcade.Audio / Music / Splash / Pause / Touch / Initials / Leaderboard / EndOverlay   ← cabinet chrome
+Arcade.Engine.{ canvas, aabb, rand, draw }                                            ← game primitives (NEW)
+```
+
+This directly serves the framework ambition (`shared/` as a target an agent can build
+a new game against): naming the chrome-vs-engine boundary gives a future reader — human
+or agent — two clean buckets instead of one flat bag of ~30 helpers.
+
+## Principles guiding the slice
+
+1. **Restraint over reuse.** Extract only pure, generic helpers with a real adopter
+   today. A primitive nobody uses is dead weight.
+2. **No hidden coupling smuggled into shared code.** Space Jumper's `resolveX`/`resolveY`
+   mutate the `player` object and refuel the jetpack on landing; Invaders' `paintPixels`
+   is welded to its playfield→canvas letterbox transform. Extracting either would drag
+   game-world-mapping policy into the engine layer. Both are deferred.
+3. **Parity first.** Adopting a helper must be rendering-equivalent — no gameplay or
+   visual change in this slice. Verified by unit tests + a browser spot-check of both
+   games.
+4. **Separation of concerns in the API.** Backing-store sizing (DPR/crispness/perf),
+   viewport/layout (size, safe area, aspect), and world mapping (playfield, camera, tile
+   size) are three different jobs. The engine owns only the first; the game keeps the
+   other two.
+5. **Names must be unambiguous to a future agent.** Prefer a name that says exactly what
+   the function touches over a short name that implies more than it does.
+
+## Module
+
+- New file: `docs/arcade/shared/engine.js` (plain IIFE, no build step).
+- Exposes a single namespace `window.Arcade.Engine` — preserving the shared/ "one file →
+  one `Arcade.*` namespace" convention; the sub-objects are structure within it.
+- Load order: a `<script src="../shared/engine.js"></script>` alongside the other shared
+  modules at body-top (no inter-module dependencies; it only defines functions).
+- `docs/arcade/shared/README.md` gains: an `engine.js` row in the module table, and a
+  short note framing the two layers (chrome vs engine).
+
+## API surface (slice 1)
+
+### `Arcade.Engine.canvas`
+
+```js
+const view = Arcade.Engine.canvas.configure(canvas, { maxDpr = 1 } = {});
+// → { ctx, cssWidth, cssHeight, dpr, pixelWidth, pixelHeight }
+```
+
+**Name:** `configure` — chosen to avoid the "make it fit the screen" layout implication
+of `fit`, and to signal it owns the canvas's backing-store + transform setup as a bundle.
+*(Open alternative: `resizeBackingStore` if a maximally-literal name is preferred. One
+veto point left for the reviewer.)*
+
+**Behaviour:**
+- Reads the CSS box via `canvas.getBoundingClientRect()` → `cssWidth`, `cssHeight`.
+- `dpr = min(window.devicePixelRatio || 1, maxDpr)`.
+- `pixelWidth = round(cssWidth * dpr)`, `pixelHeight = round(cssHeight * dpr)`.
+- Sets `canvas.width = pixelWidth`, `canvas.height = pixelHeight`.
+- Grabs `ctx = canvas.getContext('2d')` and **always** normalises the transform:
+  `ctx.setTransform(dpr, 0, 0, dpr, 0, 0)` (identity when `dpr === 1`), so game code keeps
+  drawing in CSS-pixel coordinates regardless of DPR.
+- Returns the facts object (incl. `ctx`).
+
+**Does NOT:** letterbox, derive tile sizes, set up a camera, or otherwise map the game
+world. The game does that from the returned facts, e.g.:
+```js
+const v = Arcade.Engine.canvas.configure(canvas);
+letterboxFixedPlayfield(v, 260, 280);   // Invaders
+deriveTileSize(v);                       // Space Jumper
+```
+
+**Footgun (must be documented in the header + README, and tested):** `configure` resets
+the 2D transform on every call. Call it on resize, **not** per-frame (setting
+`canvas.width` clears the canvas and costs a reallocation), and don't expect a
+game-applied persistent transform to survive it — re-apply after `configure` if needed.
+
+**Parity:** default `maxDpr: 1` ⇒ `dpr = 1` ⇒ backing store in CSS pixels + identity
+transform ⇒ rendering-equivalent to today's `resize()`. DPR crispness is strictly
+opt-in (`{ maxDpr: 2 }`) because both games repaint the full screen every frame, so a
+higher backing store is ~`dpr²`× the fill cost — a real hit on phones/tablets. Opting
+in later is a one-flag change with no game-code change (the transform handles scaling),
+and the cost can be measured per game.
+
+### `Arcade.Engine.aabb`
+
+```js
+Arcade.Engine.aabb(ax, ay, aw, ah, bx, by, bw, bh);  // → boolean
+// strict overlap: touching edges returns false
+```
+
+The pure axis-aligned box-overlap test (Space Jumper's `aabbOverlap`, verbatim
+semantics: `ax < bx+bw && ax+aw > bx && ay < by+bh && ay+ah > by`). Documented as
+**strict overlap** — edges that merely touch do not count — because a future caller will
+eventually assume the opposite.
+
+### `Arcade.Engine.rand`
+
+```js
+Arcade.Engine.rand.tileHash(i);  // → number in [0, 1)
+```
+
+Space Jumper's stable per-index PRNG, verbatim algorithm:
+`x = ((i|0)+100000)>>>0; x = (x*9301+49297) % 233280; return x/233280;`
+Deterministic for a given `i` — used to keep per-tile art stable across frames.
+
+### `Arcade.Engine.draw`
+
+```js
+Arcade.Engine.draw.circle(ctx, cx, cy, r);  // filled disc via integer scanlines
+```
+
+The scanline disc fill (`for y in -r..r: w = round(√(r²−y²)); ctx.fillRect(round(cx−w),
+round(cy+y), w*2, 1)`). Takes an explicit `ctx`, so it unifies Space Jumper's `fillCircle`
+(main ctx) **and** `fillCircleOn` (offscreen ctx) into one helper. Caller sets
+`ctx.fillStyle` before calling.
+
+**Deferred — not in this slice:** `draw.pixels` (the 'X' string-art sprite painter).
+Invaders' `paintPixels` routes through its `drawRect`/`pfToCanvas` letterbox transform, so
+a generic version has no clean adopter today; extracting it now would smuggle
+world-mapping policy into `Engine.draw`. Added when a second game needs it.
+
+## Adoption plan (same PR)
+
+A helper nobody calls is dead weight, so both single-player games adopt in the same
+change. Each swap is mechanical and individually parity-checkable.
+
+| Helper | `invaders/index.html` | `space-jumper/index.html` |
+|---|---|---|
+| `canvas.configure` | `resize()` backing-store lines (keeps building `bgGradient` locally) | `resize()` backing-store lines |
+| `aabb` | inline overlap tests in `resolveCollisions` | `aabbOverlap` definition + call sites |
+| `rand.tileHash` | — | `tileHash` definition + call sites |
+| `draw.circle` | — | `fillCircle` + `fillCircleOn` definitions + call sites |
+
+`invaders-mp` is **out of scope** (separate engine/netcode path; not a single-player
+canvas game in the same shape).
+
+Note on `canvas.configure` adoption: today both games do `W = canvas.width = rect.width`.
+After adoption, geometry uses `view.cssWidth`/`view.cssHeight`; with the default
+`maxDpr: 1` these equal the pixel dimensions, so the change is rendering-equivalent.
+
+## Tests — `docs/arcade/shared/engine.test.cjs`
+
+Node-based, modelled on the existing `music.test.cjs` / `splash.test.cjs` (mock
+`canvas`/`ctx`/`devicePixelRatio`; no real DOM).
+
+- **`canvas.configure`:**
+  - `maxDpr` omitted ⇒ `dpr === 1`.
+  - `devicePixelRatio = 3`, `{ maxDpr: 2 }` ⇒ `dpr === 2`.
+  - `canvas.width === round(cssWidth * dpr)`, `canvas.height === round(cssHeight * dpr)`.
+  - `ctx.setTransform` called with `(dpr, 0, 0, dpr, 0, 0)` after the call (transform
+    reset / normalised).
+  - return object exposes `ctx` + all five facts.
+- **`aabb`:** overlapping boxes ⇒ `true`; disjoint ⇒ `false`; **edge-touching ⇒ `false`**
+  (named test, pins the strict-overlap contract).
+- **`rand.tileHash`:** deterministic for a fixed `i`; result in `[0, 1)`; a known
+  fixed value for a known `i`.
+- **`draw.circle`:** against a mock `ctx`, the emitted `fillRect` scanline spans match
+  `w = round(√(r²−y²))` for a small `r`.
+
+## Parity verification (beyond unit tests)
+
+Serve the worktree and spot-check both games in the browser (same method as the #1
+leaderboard PR): title/leaderboard render + a short play loop. With `maxDpr: 1` the
+canvas backing store and transform are unchanged, so this confirms the refactor is
+rendering-equivalent rather than relying on inspection alone.
+
+## Out of scope (explicit boundary)
+
+Layered onto `Arcade.Engine` later, none requiring a reshape of this slice:
+
+- **Game loop** — the two games use genuinely different models (Invaders: `dt`-based,
+  pause-checked inside, always repaints bg; Space Jumper: fixed-step, gated on
+  `Splash.isPlaying()`). Unifying changes one game's feel.
+- **Tilemap collision resolver** (`resolveX`/`resolveY`) — coupled to the player object
+  and jetpack refuel; a real refactor, not a lift.
+- **`draw.pixels`** — coupled to Invaders' letterbox transform (see above).
+- **DPR-by-default** and a **fixed-internal-resolution** render mode — both possible
+  future `canvas` options.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Adoption silently changes rendering | `maxDpr: 1` default = rendering-equivalent; unit tests + browser parity check both games |
+| `setTransform` reset surprises a later contributor | Documented in header + README; asserted in tests |
+| "Engine" overpromises while the surface is small | Acceptable — it's the deliberate home for the loop/collision work to come; draw/rand/aabb/canvas already cohere as primitives |
+| Over-fragmentation | Single `engine.js`, single namespace — one script tag, one row in the README |
+
+## Acceptance criteria
+
+- `shared/engine.js` defines `Arcade.Engine` with `canvas.configure`, `aabb`,
+  `rand.tileHash`, `draw.circle` exactly as specified.
+- Both single-player games adopt all applicable helpers; their inline copies are removed.
+- `shared/engine.test.cjs` passes, covering the cases above.
+- Browser spot-check: both games render and play identically to pre-change.
+- `shared/README.md` documents `engine.js` (module row + two-layer note + the
+  `configure` transform footgun).
+- No CHANGELOG entry (arcade is out of consumer-changelog scope).


### PR DESCRIPTION
First slice of the arcade engine layer (audit item #3) — pure helpers only, **rendering-equivalent**, no gameplay change.

## Summary
- **New `shared/engine.js` (`Arcade.Engine`)** — the *game-primitive* layer alongside the cabinet chrome (`Audio`/`Splash`/`Pause`/…):
  - `canvas.configure(canvas,{maxDpr})` — sizes the backing store + normalises the 2D transform, returns `{ctx,cssWidth,cssHeight,dpr,pixelWidth,pixelHeight}`. Owns **only** backing-store + DPR, never layout. DPR is opt-in and capped; default `maxDpr:1` reproduces today's behaviour. (Resets the transform on every call — call on resize, not per-frame.)
  - `rectsOverlap(...)` — strict AABB (touching edges → false).
  - `rand.tileHash(i)` — stable per-index PRNG in [0,1).
  - `draw.circle(ctx,cx,cy,r)` — integer-scanline disc.
- **Adoption (mechanical):** Space Jumper + Invaders use `canvas.configure` in `resize()`; Space Jumper's `aabbOverlap`/`tileHash`/`fillCircle`/`fillCircleOn` become signature-preserving forwarders (call sites untouched). Invaders' inline collision conversion is intentionally deferred (higher-risk hand-rewrite; `rectsOverlap` is proven by Space Jumper).
- **`shared/README.md`** documents the module + the chrome/engine two-layer split.
- Design spec + implementation plan under `docs/superpowers/`.

Deliberately **out of scope** (deferred): game loop, tilemap collision resolver, `draw.pixels`, DPR-by-default.

## Test Plan
- [x] `node docs/arcade/shared/engine.test.cjs` → ALL PASS (DPR cap + invalid-value clamp, transform reset, strict overlap, PRNG determinism/known value, scanline spans)
- [x] Space Jumper: title + gameplay render, no console errors, `canvas.width` == CSS px at `devicePixelRatio` 2 (parity, not the 2× path)
- [x] Invaders: splash + gameplay render, no console errors, backing store == CSS px
- [ ] Reviewer: confirm no visual change vs `main`

No CHANGELOG entry (arcade is out of consumer-changelog scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)