### PR TITLE
arcade(invaders): import rectsOverlap from shared/geometry.js

### DIFF
--- a/docs/arcade/invaders/engine.js
+++ b/docs/arcade/invaders/engine.js
@@ -10,6 +10,12 @@
 // room.ts gets full TypeScript type-checking against this file
 // without an allowJs build flag.
 
+// Strict AABB primitive imported from shared/geometry.js — same
+// one-liner that lives inline in shared/engine.js's Arcade.Engine,
+// re-exported here so the server-authoritative sim and the browser
+// share one source of truth without depending on `window.Arcade`.
+import { rectsOverlap } from '../shared/geometry.js';
+
 // === Playfield ===
 // Widened from 240 in Phase D to match SP and host the 11-column
 // invader grid. With 4 ships at SHIP_W=16, the spawn margin is now
@@ -1006,7 +1012,7 @@ function resolveCollisions(state, occupied) {
       const isMarked = state.marked && state.marked.idx === i;
       const ix = isMarked ? inv.x + state.marked.swoopDX : inv.x;
       const iy = isMarked ? inv.y + state.marked.swoopDY : inv.y;
-      if (!overlap(b.x, b.y, bw, bh, ix, iy, INV_W, INV_H)) continue;
+      if (!rectsOverlap(b.x, b.y, bw, bh, ix, iy, INV_W, INV_H)) continue;
       inv.alive = false;
       const owner = b.owner && state.ships[b.owner];
       if (owner) {
@@ -1070,7 +1076,7 @@ function resolveCollisions(state, occupied) {
       if (b.y < -bh) continue;
       for (const a of state.boss.adds) {
         if (!a.alive) continue;
-        if (!overlap(b.x, b.y, bw, bh, a.x, a.y, BOSS_ADD_W, BOSS_ADD_H)) continue;
+        if (!rectsOverlap(b.x, b.y, bw, bh, a.x, a.y, BOSS_ADD_W, BOSS_ADD_H)) continue;
         a.alive = false;
         a.respawnIn = BOSS_ADD_RESPAWN_SEC;
         const owner = b.owner && state.ships[b.owner];
@@ -1104,7 +1110,7 @@ function resolveCollisions(state, occupied) {
       const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
       const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
       if (b.y < -bh) continue;
-      if (!overlap(b.x, b.y, bw, bh, bs.x, bs.y, BOSS_W, BOSS_H)) continue;
+      if (!rectsOverlap(b.x, b.y, bw, bh, bs.x, bs.y, BOSS_W, BOSS_H)) continue;
       const dmg = b.charged ? 3 : 1;
       bs.hp = Math.max(0, bs.hp - dmg);
       const owner = b.owner && state.ships[b.owner];
@@ -1149,7 +1155,7 @@ function resolveCollisions(state, occupied) {
       const bw = b.charged ? CHARGED_BULLET_W : BULLET_W;
       const bh = b.charged ? CHARGED_BULLET_H : BULLET_H;
       if (b.y < -bh) continue;
-      if (overlap(b.x, b.y, bw, bh, state.ufo.x, UFO_Y, UFO_W, UFO_H)) {
+      if (rectsOverlap(b.x, b.y, bw, bh, state.ufo.x, UFO_Y, UFO_W, UFO_H)) {
         // Progress = distance travelled from the spawn edge, so left-
         // and right-spawning UFOs both pay 0 at their spawn point and
         // ramp up to the max as they approach the despawn edge —
@@ -1203,7 +1209,7 @@ function resolveCollisions(state, occupied) {
     for (const seat of SEATS) {
       const ship = state.ships[seat];
       if (!ship.alive || !occupied[seat] || ship.invulnFor > 0) continue;
-      if (overlap(b.x, b.y, BULLET_W, BULLET_H, ship.x, SHIP_Y, SHIP_W, SHIP_H)) {
+      if (rectsOverlap(b.x, b.y, BULLET_W, BULLET_H, ship.x, SHIP_Y, SHIP_W, SHIP_H)) {
         ship.alive = false;
         if (state.lives > 0) {
           state.lives--;
@@ -1240,10 +1246,6 @@ function checkEnd(state, occupied) {
   // a boss interrupts (Phase H) or you lose to breach/wipe.
   // checkStageClear (called before this in step()) handles the
   // grid-clear case by rebuilding the next stage.
-}
-
-function overlap(ax, ay, aw, ah, bx, by, bw, bh) {
-  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
 }
 
 // === Debug cheats ===

--- a/docs/arcade/invaders/engine.js
+++ b/docs/arcade/invaders/engine.js
@@ -10,10 +10,11 @@
 // room.ts gets full TypeScript type-checking against this file
 // without an allowJs build flag.
 
-// Strict AABB primitive imported from shared/geometry.js — same
-// one-liner that lives inline in shared/engine.js's Arcade.Engine,
-// re-exported here so the server-authoritative sim and the browser
-// share one source of truth without depending on `window.Arcade`.
+// Strict AABB primitive — same one-liner that lives inline in
+// shared/engine.js's Arcade.Engine. Pulled in via ESM (not via
+// window.Arcade) so this file works identically when bundled into
+// the Cloudflare Worker, where there is no DOM and no Arcade global.
+// Used internally; not re-exported.
 import { rectsOverlap } from '../shared/geometry.js';
 
 // === Playfield ===

--- a/docs/arcade/shared/README.md
+++ b/docs/arcade/shared/README.md
@@ -10,6 +10,14 @@ The framework has **two layers**. The modules below are *cabinet chrome* —
 (canvas backing-store, rect overlap, stable PRNG, pixel draw) — the building
 blocks of a game's own simulation and rendering, not the surrounding cabinet.
 
+**Separately,** `geometry.js` is a tiny ESM module (`export function rectsOverlap`)
+for simulation-safe primitives — no DOM, no globals, no `window.Arcade` attach.
+It exists so a game's simulation code that runs in **both** the browser and a
+Cloudflare Worker (e.g. `invaders/engine.js`, imported by `room.ts`) can share
+the primitive without depending on a browser-only surface. `Arcade.Engine` keeps
+its own inline copy of the same one-liner so the cabinet's IIFE loading stays
+synchronous; both paths are byte-equivalent.
+
 **The one gotcha:** every module is **selector-driven with silent defaults**.
 If your markup doesn't use the exact ids/classes a module expects, the module
 no-ops quietly — no error, just a dead button or an unstyled panel. This file

--- a/docs/arcade/shared/README.md
+++ b/docs/arcade/shared/README.md
@@ -24,8 +24,10 @@ no-ops quietly — no error, just a dead button or an unstyled panel. This file
 is the source of truth for those selectors so a new game (or an agent building
 one) can be scaffolded correctly the first time.
 
-Each module is a plain IIFE — no build step, no imports. Drop the `<script>`
-tags in and the `window.Arcade.*` objects appear.
+Each cabinet/engine module is a plain IIFE — no build step, no imports. Drop
+the `<script>` tags in and the `window.Arcade.*` objects appear. (`geometry.js`
+is the lone exception: it's ESM-only and consumed via `import`, not a
+`<script>` tag. See the "Separately" paragraph above.)
 
 ---
 

--- a/docs/arcade/shared/geometry.js
+++ b/docs/arcade/shared/geometry.js
@@ -1,0 +1,20 @@
+// Simulation-safe geometry primitives — pure functions with no DOM, no
+// globals, no environment assumptions. Safe to import from both the
+// browser (game code) and Cloudflare Workers (server-authoritative
+// simulation).
+//
+// Distinct from `shared/engine.js`, which owns the browser-facing
+// `Arcade.Engine` surface (canvas configuration, render helpers,
+// chrome-adjacent primitives). This module is the simulation layer's
+// own primitive — narrower, dependency-free, ESM-only.
+//
+// The browser-facing `Arcade.Engine.rectsOverlap` (in shared/engine.js)
+// keeps an inline copy of the same one-liner so the IIFE attach pattern
+// stays synchronous; both paths return identical results.
+
+// Strict AABB overlap test — touching edges do NOT count as overlapping.
+// Args are flat scalars (not objects) so callsites pass whatever shape
+// of rect they hold without allocating.
+export function rectsOverlap(ax, ay, aw, ah, bx, by, bw, bh) {
+  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+}

--- a/docs/arcade/shared/geometry.test.mjs
+++ b/docs/arcade/shared/geometry.test.mjs
@@ -1,0 +1,46 @@
+// Tests for shared/geometry.js — run with `node geometry.test.mjs`.
+//
+// geometry.js is the ESM-only source of truth for the rectsOverlap
+// primitive used by simulation code that runs in both the browser
+// (game host-mode client) and a Cloudflare Worker (server-authoritative
+// sim). The IIFE copy on `Arcade.Engine.rectsOverlap` in
+// shared/engine.js is exercised separately by engine.test.cjs; this
+// file locks the ESM copy so the two paths can't silently drift.
+
+import { rectsOverlap } from './geometry.js';
+
+let failures = 0;
+function check(label, got, want) {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  if (!ok) failures++;
+}
+
+// Clear overlap — A's right edge crosses into B.
+check('overlapping rects', rectsOverlap(0, 0, 10, 10, 5, 5, 10, 10), true);
+
+// Disjoint along x.
+check('disjoint along x', rectsOverlap(0, 0, 5, 5, 10, 0, 5, 5), false);
+
+// Disjoint along y.
+check('disjoint along y', rectsOverlap(0, 0, 5, 5, 0, 10, 5, 5), false);
+
+// A fully contains B.
+check('containment', rectsOverlap(0, 0, 20, 20, 5, 5, 5, 5), true);
+
+// Strict edge-touching — A's right edge (x=10) meets B's left edge
+// (x=10). Touching does NOT count as overlapping. This is the
+// load-bearing property that distinguishes rectsOverlap from a
+// non-strict variant; bullets that just barely kiss an invader's
+// edge should not register a hit.
+check('edge-touching x (strict)', rectsOverlap(0, 0, 10, 10, 10, 0, 10, 10), false);
+check('edge-touching y (strict)', rectsOverlap(0, 0, 10, 10, 0, 10, 10, 10), false);
+
+// One-pixel overlap on the x edge.
+check('1-pixel overlap x', rectsOverlap(0, 0, 11, 10, 10, 0, 10, 10), true);
+
+if (failures) {
+  console.log(`\n${failures} FAIL`);
+  process.exit(1);
+}
+console.log('\nALL PASS');


### PR DESCRIPTION
## Summary

Extracts the strict-AABB primitive into a tiny ESM-only module — `docs/arcade/shared/geometry.js` — so the server-authoritative sim and its browser twin (both living in `docs/arcade/invaders/engine.js`) share one source of truth without depending on the browser-only `window.Arcade.Engine` surface.

The honest version of \"gets the primitive a second user\" called out in the audit follow-up: the Cloudflare Worker bundling `invaders/engine.js` and the browser host-mode client loading the same file now BOTH consume `rectsOverlap` from `shared/geometry.js`. `shared/engine.js` still exposes the same primitive on `Arcade.Engine` for non-simulation game code (space-jumper renderer, etc.) that doesn't run inside a Worker.

## What's in this PR

### New: `docs/arcade/shared/geometry.js`
A 5-line ESM module — `export function rectsOverlap(...)`. Pure, no DOM, no globals, no environment assumptions. Safe to import from both the browser and a Cloudflare Worker. **Deliberately not `shared/engine.js`-shaped** — no IIFE, no `Arcade.*` attach. That boundary is the point: simulation-safe primitives live here; browser-chrome primitives stay in `shared/engine.js`.

### Modified: `docs/arcade/invaders/engine.js`
- Adds `import { rectsOverlap } from '../shared/geometry.js'`.
- Deletes the local `overlap(...)` helper (byte-identical impl).
- Retargets the 5 callsites (grid / boss minions / boss / UFO / ship) from `overlap(...)` to `rectsOverlap(...)`.

### Modified: `docs/arcade/shared/README.md`
Adds a short paragraph marking `geometry.js` as a separate kind of file from the IIFE chrome modules.

### Unchanged: `docs/arcade/shared/engine.js`
Keeps its own inline copy of the same one-liner inside `Arcade.Engine`. The cabinet's IIFE attach pattern stays synchronous; classic-script load order across all three games is untouched. Both paths return identical results.

## Why this shape (vs. the alternatives)

We considered:

- **B: rename `overlap` → `rectsOverlap` in-place.** Naming alignment, no architectural change. Honest but cosmetic — `Arcade.Engine.rectsOverlap` would still only have space-jumper as a code-level user.
- **C-full: convert `shared/engine.js` to ESM** so it imports from `geometry.js`. Single source of truth everywhere. Requires `type=\"module\"` on all 3 game HTMLs and rewires `engine.test.cjs` — broader than the task warrants.
- **C-lean (this PR): tiny shared ESM file, leave `shared/engine.js` untouched.** Gets the dedup at the layer that matters (cross-platform `engine.js`) without touching the browser load model.

## Test plan

- ✅ `infra/oyster-arcade-mp` typecheck passes (Worker imports `invaders/engine.js` which now imports `shared/geometry.js`).
- ✅ `npx wrangler deploy --dry-run` from `infra/oyster-arcade-mp` succeeds — esbuild bundles the cross-folder import cleanly (final bundle 46.18 KiB).
- ✅ `npx wrangler dev` from `infra/oyster-arcade-site` serves `/shared/geometry.js` with 200; `/invaders/engine.js` still 200 and includes the new import in the served bytes.
- ✅ `docs/arcade/shared/*.test.cjs` all pass (none touch geometry.js directly; `shared/engine.js`'s own `rectsOverlap` is unchanged).
- 🎮 Manual smoke once deployed:
  - [ ] Solo Invaders round: bullets hit invaders / boss / UFO / ship; respawns, scoring, lives all work.
  - [ ] Two devices, room code in URL — server-authoritative collision still matches client expectations.

## Closes

The \"convert Invaders' inline collision conditionals to `rectsOverlap`\" fast-follow tracked in the engine-primitives memory after #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)