### PR TITLE
Unified scope UX (PR 1): tabs, vault card, repo-named sessions, URL project scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 - **Sessions show what they produced.** Each session now lists the docs, decks, tables, and diagrams it created or worked on — filled in automatically from your agent's activity, with no manual tagging.
 - **Find sessions by the files they touched.** Search (Cmd+K) now matches a session by any file name your agent read or edited — search `App.jsx` to surface every session that worked on it, even when the name never appears in the conversation.
-- **Move a project between spaces — or out of one.** A project's ⋯ menu now offers "Move to space…": relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects collect under the Unassigned pill, ready to re-file.
+- **Move a project between spaces — or out of one.** A project's ⋯ menu now offers "Move to space…": relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects stay on Home, ready to re-file.
 - **Ask to see a past session, and Oyster opens it.** Say "show me the session about X" and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.
 - **Filter artefacts by kind.** The Artefacts section gains a Kind filter — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **One surface, three tabs** — Sessions, Artefacts and Memories now sit in tabs below your projects, scoped by the selected space and project, with a scope crumb showing where you are.
+- **Vault joins the project grid** — artefacts created in Oyster itself appear under a Vault card on Home, alongside your repos.
+- **Unassigned pill retired** — projects without a space now appear on Home with everything else.
 - **Projects collapse to a single row.** The home Projects strip now shows just the top row by default, with "Show all" to expand — less scrolling to reach your sessions.
 
 ### Fixed
 
+- **Sessions table names the repo** — the project column shows the repository name instead of the space, and steps aside when a project is selected.
 - **Onboarding reflects what you've actually done.** "Publish your first artefact" now ticks only when you have a live publication (and un-ticks if you unpublish), and the setup icon fills as a progress ring — becoming the 🦪 only once every step is done.
 - **Artefacts table view has column headers.** The table view now labels its columns (Name · Space · Kind · Created), matching the sessions list.
 

--- a/docs/superpowers/plans/2026-06-05-unified-scope-ux-pr1.md
+++ b/docs/superpowers/plans/2026-06-05-unified-scope-ux-pr1.md
@@ -113,8 +113,10 @@ In `index.tsx`, the SessionRow callsite (inside `visibleSessions.slice(0, sessio
 
 ```tsx
                       projectName={session.projectId ? projectNameById[session.projectId] ?? null : null}
-                      hideProject={selectedProjectId !== null}
+                      hideProject={selectedProjectId !== null && selectedProjectId !== VAULT}
 ```
+
+(Not at VAULT scope: vault sessions are no-project orphans, so the column's cwd-basename fallback is the only signal of where each ran — keep it visible there.)
 
 The table header row above it — make the Project columnheader conditional and add a modifier class to the table. Replace:
 
@@ -130,10 +132,10 @@ with:
 
 ```tsx
               <div className="home-table-wrap">
-                <div className={`home-table${selectedProjectId !== null ? " home-table--no-project" : ""}`}>
+                <div className={`home-table${selectedProjectId !== null && selectedProjectId !== VAULT ? " home-table--no-project" : ""}`}>
                   <div className="home-row home-row--header" role="row">
                     <span aria-hidden="true" />
-                    {selectedProjectId === null && <span role="columnheader">Project</span>}
+                    {(selectedProjectId === null || selectedProjectId === VAULT) && <span role="columnheader">Project</span>}
 ```
 
 - [ ] **Step 5: Grid variant in Home.css**
@@ -207,10 +209,16 @@ After the `activeSpaceRow` / `eyebrow` lines (~line 817), add:
     ? "vault"
     : selectedProject
       ? `${selectedProject.spaceId ? (spaces.find((s) => s.id === selectedProject.spaceId)?.displayName ?? selectedProject.spaceId) + " › " : ""}${selectedProject.name}`
+      : isArchivedView
+        ? "archived"
+      : isAllView
+        ? "all"
       : scopedSpace
         ? (activeSpaceRow?.displayName ?? scopedSpace)
         : "everything";
 ```
+
+(Meta views aren't a wider "everything" — Archived in particular is a different dataset; the crumb must say so.)
 
 - [ ] **Step 2: Insert the strip, wrap the sections**
 
@@ -362,6 +370,20 @@ with:
 - [ ] **Step 2: Orphan-cwd tiles compute on Home unconditionally**
 
 In the `orphanCwdGroups` memo (~line 432), replace `if (!showElsewhere || !isHomeView) return [];` with `if (!isHomeView) return [];` and remove `showElsewhere` from its dep array.
+
+Also fix a duplicate-tile bug this surfaces: a session in an *unassigned project* has `spaceId === null` but a real `projectId` — its project renders as a normal card now, so it must not also spawn an orphan-folder tile for the same directory. In the same memo, replace the skip condition:
+
+```ts
+      if (s.spaceId !== null || !s.cwd) continue;
+```
+
+with:
+
+```ts
+      // Project-bound sessions render via their project card — only truly
+      // unclaimed folders (no project, no space) get an orphan tile.
+      if (s.projectId || s.spaceId !== null || !s.cwd) continue;
+```
 
 - [ ] **Step 3: Vault tile + orphan tiles inside the Home projects grid**
 

--- a/docs/superpowers/plans/2026-06-05-unified-scope-ux-pr1.md
+++ b/docs/superpowers/plans/2026-06-05-unified-scope-ux-pr1.md
@@ -1,0 +1,657 @@
+# Unified Scope UX — PR 1 (Structural Unification) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One page shape with scope: the Sessions/Artefacts/Memories sections become tabs scoped by space pill + project card selection; the sessions table names the repo (never the space); Vault and orphan folders join the Home project grid; the Unassigned pill and Elsewhere view retire; project scope becomes URL-addressable.
+
+**Architecture:** All UI work. `Home/index.tsx` is the single always-mounted surface (Desktop already renders *inside* its Artefacts section — there is no separate Desktop route to retire). We restructure Home's three stacked sections into a tab panel, fix the session project label, widen the Home grid to all projects + Vault + orphan-cwd tiles, delete the Elsewhere/Unassigned code paths, and lift `selectedProjectId` to App for `/s/<space>/p/<project>` routing. No server or schema changes. ChatBar untouched.
+
+**Tech Stack:** React 18 + TypeScript (web/), Vite. **No web test runner exists** (server has vitest; web has only `tsc -b` + `eslint`). Per codebase convention, verification is: typecheck + lint + build + explicit manual browser checks listed in each task. Do not introduce a test framework in this PR.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-unified-scope-ux-design.md`
+
+**Branch / worktree:** Branch `unified-scope-ux` exists (holds the spec). Per user preference, execute in a worktree: `git worktree add ~/Dev/oyster.worktrees/unified-scope-ux unified-scope-ux`, copy `.env` into it, run `npm install` in `web/` and `server/` (or symlink node_modules — Vite may glitch on first load with symlinks). Dev/installed servers share `~/Oyster` — if the dev server won't start, check for a stale `~/Oyster/.oyster.lock`.
+
+**Manual-check harness:** `npm run dev` at the repo root → web at `http://localhost:7337`, server at 3333. All manual steps below assume this is running.
+
+---
+
+### Task 1: Session rows name the repo, never the space
+
+The PROJECT column currently shows the *space* displayName whenever `session.spaceId` is set (`spaceLabel ?? cwdBasename`), which makes two repos in one space indistinguishable. Show the project (repo) name via the projects registry, falling back to the cwd basename. Also hide the column entirely when a project is selected (the scope already says it).
+
+**Files:**
+- Modify: `web/src/components/Home/SessionRow.tsx` (label logic ~lines 56–68, render ~line 107, props interface near top)
+- Modify: `web/src/components/Home/index.tsx` (allProjects fetch ~line 195–202, new memo, SessionRow callsite ~line 1274–1288, table header ~line 1264–1273)
+- Modify: `web/src/components/Home/Home.css` (no-project grid variant, after the `.home-row` block ~line 513)
+
+- [ ] **Step 1: Always fetch allProjects**
+
+In `web/src/components/Home/index.tsx`, the `useFetched(fetchAllProjects, …)` call is gated `enabled: isMetaScope`. Session-row labels now need the registry in every scope. Change:
+
+```ts
+    { enabled: isMetaScope, ssEvent: "session_changed" },
+```
+
+to:
+
+```ts
+    // Always fetched: feeds session-row project labels in every scope,
+    // plus the Home tile strip.
+    { enabled: true, ssEvent: "session_changed" },
+```
+
+Also update the comment above the hook (it says "Only fetched when on Home").
+
+- [ ] **Step 2: Add the projectNameById memo**
+
+In `index.tsx`, immediately after the `useFetched` block for `allProjects`:
+
+```ts
+  // Repo names for session-row labels — never the space displayName
+  // (scope already says the space; two repos in one space must stay
+  // distinguishable). Falls back to cwd basename inside SessionRow.
+  const projectNameById = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const p of allProjects) out[p.id] = p.name;
+    return out;
+  }, [allProjects]);
+```
+
+- [ ] **Step 3: Rework SessionRow's label**
+
+In `web/src/components/Home/SessionRow.tsx`:
+
+(a) Add to the `SessionRowProps` interface (it's the type the component destructures from — near the top of the file):
+
+```ts
+  /** Repo name from the projects registry; null/undefined = unknown. */
+  projectName?: string | null;
+  /** Project scope is active — the column is redundant, hide it. */
+  hideProject?: boolean;
+```
+
+(b) Add `projectName` and `hideProject` to the destructured params.
+
+(c) Replace the label block:
+
+```ts
+  // Prefer space label when the session belongs to a registered space.
+  const spaceLabel = session.spaceId
+    ? (spaces.find((s) => s.id === session.spaceId)?.displayName ?? null)
+    : null;
+  const projectLabel = (spaceLabel ?? cwdBasename) || "—";
+```
+
+with:
+
+```ts
+  // Repo name via the projects registry; cwd basename for orphans.
+  // Never the space name — the scope/space pill already says that.
+  const projectLabel = (projectName ?? cwdBasename) || "—";
+```
+
+(d) Make the column conditional. Replace:
+
+```tsx
+        <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
+```
+
+with:
+
+```tsx
+        {!hideProject && (
+          <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
+        )}
+```
+
+(e) The `spaces` prop may now be unused in SessionRow — check with eslint (Step 6). If unused, remove it from `SessionRowProps`, the destructure, and the callsite in `index.tsx`. If it's still used elsewhere in the file (e.g. chips), leave it.
+
+- [ ] **Step 4: Thread props at the callsite + conditional header column**
+
+In `index.tsx`, the SessionRow callsite (inside `visibleSessions.slice(0, sessionsLimit).map(…)`), add:
+
+```tsx
+                      projectName={session.projectId ? projectNameById[session.projectId] ?? null : null}
+                      hideProject={selectedProjectId !== null}
+```
+
+The table header row above it — make the Project columnheader conditional and add a modifier class to the table. Replace:
+
+```tsx
+              <div className="home-table-wrap">
+                <div className="home-table">
+                  <div className="home-row home-row--header" role="row">
+                    <span aria-hidden="true" />
+                    <span role="columnheader">Project</span>
+```
+
+with:
+
+```tsx
+              <div className="home-table-wrap">
+                <div className={`home-table${selectedProjectId !== null ? " home-table--no-project" : ""}`}>
+                  <div className="home-row home-row--header" role="row">
+                    <span aria-hidden="true" />
+                    {selectedProjectId === null && <span role="columnheader">Project</span>}
+```
+
+- [ ] **Step 5: Grid variant in Home.css**
+
+After the `.home-row { … }` block (~line 513, template `18px 130px 1fr 130px 150px 130px`):
+
+```css
+/* Project scope active — the project column is hidden (the scope crumb
+   names it), so the title takes its track. */
+.home-table--no-project .home-row {
+  grid-template-columns: 18px 1fr 130px 150px 130px;
+}
+```
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `cd web && npx tsc -b && npm run lint`
+Expected: both clean. If eslint flags `spaces` unused in SessionRow.tsx, remove it per Step 3(e) and re-run.
+
+- [ ] **Step 7: Manual check**
+
+With dev running, on `http://localhost:7337/s/home`: every sessions-table row shows a *repo* name (e.g. `oyster-dev`), not a space name, even for sessions in spaces. Click a project tile: the Project column (and header) disappears and the table re-flows; deselect: it returns.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/components/Home/SessionRow.tsx web/src/components/Home/index.tsx web/src/components/Home/Home.css
+git commit -m "home: session rows name the repo, hide column at project scope"
+```
+
+---
+
+### Task 2: Tab strip — Sessions | Artefacts | Memories + scope crumb
+
+The three stacked `<section>`s become one tab panel. Filters/toggles stay inside their tab. A scope crumb on the right of the strip names the active scope and clears project selection.
+
+**Files:**
+- Modify: `web/src/components/Home/index.tsx` (new state + memos near the other view state ~line 208; markup around the three sections ~lines 1212–1587)
+- Modify: `web/src/components/Home/Home.css` (tab styles)
+
+- [ ] **Step 1: Tab state + counts + crumb**
+
+In `index.tsx`, next to the `sessionsView` sticky state (~line 208), add:
+
+```ts
+  const [activeTab, setActiveTab] = useStickyView("oyster.home.activeTab", "sessions", ["sessions", "artefacts", "memories"] as const);
+```
+
+After the `projectArtefactCounts` memo (~line 664), add:
+
+```ts
+  // Scope-only artefact total for the tab count (source/kind filters are
+  // tab-internal and shouldn't change the tab's headline number).
+  const scopedArtefactsTotal = useMemo(() => {
+    const list = effectiveDesktopProps.artifacts;
+    if (selectedProjectId === VAULT) return list.filter((a) => !a.projectId).length;
+    if (selectedProjectId) return list.filter((a) => a.projectId === selectedProjectId).length;
+    return list.length;
+  }, [effectiveDesktopProps.artifacts, selectedProjectId]);
+```
+
+(Note: Task 3 renames `effectiveDesktopProps` → `desktopProps`; the replace_all there will update this too.)
+
+After the `activeSpaceRow` / `eyebrow` lines (~line 817), add:
+
+```ts
+  const selectedProject = selectedProjectId && selectedProjectId !== VAULT
+    ? allProjects.find((p) => p.id === selectedProjectId) ?? null
+    : null;
+  const scopeCrumb = selectedProjectId === VAULT
+    ? "vault"
+    : selectedProject
+      ? `${selectedProject.spaceId ? (spaces.find((s) => s.id === selectedProject.spaceId)?.displayName ?? selectedProject.spaceId) + " › " : ""}${selectedProject.name}`
+      : scopedSpace
+        ? (activeSpaceRow?.displayName ?? scopedSpace)
+        : "everything";
+```
+
+- [ ] **Step 2: Insert the strip, wrap the sections**
+
+Directly above the Sessions `<section className="home-section">` (~line 1212), insert:
+
+```tsx
+        <div className="home-tabs" role="tablist" aria-label="Scoped content">
+          {(["sessions", "artefacts", "memories"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === t}
+              className={`home-tab${activeTab === t ? " active" : ""}`}
+              onClick={() => setActiveTab(t)}
+            >
+              {t === "sessions" ? "Sessions" : t === "artefacts" ? "Artefacts" : "Memories"}
+              <span className="home-tab-count">
+                {t === "sessions" ? stateCounts.all : t === "artefacts" ? scopedArtefactsTotal : scopedMemories.length}
+              </span>
+            </button>
+          ))}
+          <span className="home-tab-scope">
+            scope: {scopeCrumb}
+            {selectedProjectId !== null && (
+              <button
+                type="button"
+                className="home-tab-scope-clear"
+                onClick={() => setSelectedProjectId(null)}
+                aria-label="Clear project scope"
+              >
+                ✕
+              </button>
+            )}
+          </span>
+        </div>
+```
+
+Then wrap each of the three sections in its tab conditional:
+- Sessions section (~1212–1309): `{activeTab === "sessions" && ( <section …> … </section> )}`
+- Artefacts section (~1311–1501): `{activeTab === "artefacts" && ( … )}`
+- Memories section (~1503–1587): `{activeTab === "memories" && ( … )}`
+
+- [ ] **Step 3: De-duplicate section labels**
+
+The tab is now the label. Inside each wrapped section's `home-section-head`:
+- Sessions: delete `<span className="home-section-label">Sessions</span>`
+- Artefacts: delete `<span className="home-section-label">Artefacts</span>`
+- Memories: delete `<span className="home-section-label">Memories</span>` **and** `<span className="home-artefacts-count">{scopedMemories.length}</span>` (count lives in the tab now)
+
+- [ ] **Step 4: Tab CSS**
+
+In `Home.css`, after the `.home-section-head` block (~line 143):
+
+```css
+/* Scoped-content tab strip (Sessions | Artefacts | Memories). */
+.home-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 36px;
+  border-bottom: 1px solid var(--home-border);
+}
+.home-tab {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 14px;
+  font-size: 13px;
+  color: var(--text-dim);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.home-tab:hover { color: var(--text); }
+.home-tab.active { color: var(--text); border-bottom-color: #7c6bff; font-weight: 600; }
+.home-tab-count {
+  margin-left: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+.home-tab-scope {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  padding-right: 4px;
+}
+.home-tab-scope-clear {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0 2px;
+}
+.home-tab-scope-clear:hover { color: var(--text); }
+```
+
+(`#7c6bff` is the accent already used by `.home-row:hover`'s rgba(124, 107, 255, …) and App's bolt gradient. If Home.css defines an accent custom property, prefer it.)
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `cd web && npx tsc -b && npm run lint`
+Expected: clean. Likely tripwires: `scopedMemories` is declared ~line 500, *before* the crumb memos — the tab strip JSX uses both, which is fine, but `selectedProject` (Step 1) must be declared **after** `allProjects` and **before** the JSX. If tsc complains about use-before-declaration, move the Step 1 blocks below all data memos.
+
+- [ ] **Step 6: Manual check**
+
+On `/s/home`: one tab strip with three tabs + counts; clicking tabs swaps content; filters (live/waiting/done, FULL/COMPACT, source/kind, icon/table) all still work inside their tabs; crumb reads `scope: everything`. Click the `oyster` space pill → crumb shows the space name; select a project tile → crumb shows `space › project` with ✕; ✕ clears. Reload → active tab persists. Click the shield pill → VaultInfo page still renders without the strip.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/Home/index.tsx web/src/components/Home/Home.css
+git commit -m "home: sessions/artefacts/memories become scoped tabs with scope crumb"
+```
+
+---
+
+### Task 3: Home grid = all projects + Vault card + orphan folders; retire Unassigned/Elsewhere
+
+Unassigned projects join the main Home grid (no more negative-space pill); the Vault tile (today space-view-only, in ProjectTileGrid) gets a Home twin; orphan-cwd tiles move from Elsewhere onto Home; the `showElsewhere` state and every branch of it is deleted.
+
+**Files:**
+- Modify: `web/src/components/Home/index.tsx` (grid sections ~lines 1002–1143, pill block ~lines 940–967, state + memos throughout)
+
+- [ ] **Step 1: All projects in the Home sort**
+
+In the `sortedProjects` memo (~line 644), replace:
+
+```ts
+    // Filed projects only — those detached from every space (space_id null)
+    // live under the Unassigned pill, mirroring how orphan sessions are
+    // segregated out of the Home view.
+    return allProjects.filter((p) => p.spaceId != null).sort((a, b) => {
+```
+
+with:
+
+```ts
+    // Every project — assigned or not. Unassigned projects are ordinary
+    // cards on Home now; the Unassigned pill is retired.
+    return [...allProjects].sort((a, b) => {
+```
+
+- [ ] **Step 2: Orphan-cwd tiles compute on Home unconditionally**
+
+In the `orphanCwdGroups` memo (~line 432), replace `if (!showElsewhere || !isHomeView) return [];` with `if (!isHomeView) return [];` and remove `showElsewhere` from its dep array.
+
+- [ ] **Step 3: Vault tile + orphan tiles inside the Home projects grid**
+
+In the Home projects section (~line 1002), the gate and grid become:
+
+```tsx
+        {isHomeView && (sortedProjects.length > 0 || orphanCwdGroups.length > 0 || (projectArtefactCounts[VAULT] ?? 0) > 0) && (
+```
+
+Inside `<div className="home-projects-grid" ref={projectsGridRef}>`, **before** `{visibleProjects.map(…)}`, add the Vault card (Shield is already imported):
+
+```tsx
+              {(projectArtefactCounts[VAULT] ?? 0) > 0 && (
+                <div className={`home-projects-strip-tile home-project-tile--vault${selectedProjectId === VAULT ? " selected" : ""}`}>
+                  <button
+                    type="button"
+                    className="home-projects-strip-tile-body"
+                    onClick={() => setSelectedProjectId(selectedProjectId === VAULT ? null : VAULT)}
+                    title="Artefacts created in Oyster itself — not tied to a repo"
+                  >
+                    <div className="home-projects-strip-name">
+                      <Shield size={14} strokeWidth={1.75} aria-hidden="true" />
+                      <span>Vault</span>
+                    </div>
+                    <div className="home-projects-strip-counts">
+                      <span className="signal"><span className="pip pip-dim" />{projectArtefactCounts[VAULT]} {(projectArtefactCounts[VAULT] ?? 0) === 1 ? "artefact" : "artefacts"}</span>
+                    </div>
+                  </button>
+                </div>
+              )}
+```
+
+Then move the orphan-cwd tiles: take the entire `{orphanCwdGroups.map((p) => { … })}` block out of the `isHomeView && showElsewhere && orphanCwdGroups.length > 0` section (~lines 1086–1143) and paste it **after** `{visibleProjects.map(…)}` inside the main grid. Delete the now-empty Elsewhere orphan section wrapper.
+
+- [ ] **Step 4: Delete the Elsewhere/Unassigned code paths**
+
+In `index.tsx`, remove in this order (each removal unblocks the next lint pass):
+
+1. The Unassigned breadcrumb pill block (`{(orphanCounts.total > 0 || unassignedProjects.length > 0) && realSpaces.length > 0 && ( <button … Unassigned … /> )}`, ~lines 940–967).
+2. The `isHomeView && showElsewhere && unassignedProjects.length > 0` projects section (~lines 1062–1084) — those projects render in the main grid now.
+3. The `unassignedProjects` memo (~line 523).
+4. The `showElsewhere` state (~line 217) and every remaining read/write:
+   - the reset effect (~line 286–291) keeps only `setShowVault(false)`,
+   - `scopedSessions` (~line 328) becomes `return scopedSpace ? sessions.filter((s) => s.spaceId === scopedSpace) : sessions;`,
+   - `scopedMemories` (~line 500) drops its Elsewhere branch (keep the rest — Task 4 reworks it),
+   - `effectiveDesktopProps` (~line 527): delete the memo entirely and replace every `effectiveDesktopProps` usage with `desktopProps` (replace-all; ~5 usages incl. Task 2's `scopedArtefactsTotal`),
+   - the scope-reset effect dep array (~line 316) drops `showElsewhere`,
+   - the `eyebrow` line (~818) becomes `const eyebrow = isHomeView ? "Home" : isAllView ? "All" : isArchivedView ? "Archived" : activeSpaceRow?.displayName ?? scopedSpace ?? "";`,
+   - the `<h1>` (~992) becomes `{isHomeView ? "Your work." : eyebrow}` (Task 4 finishes it),
+   - Home/Vault pill onClick handlers drop `setShowElsewhere(false)`,
+   - the sessions empty-state conditions (~1260, ~1301) drop `&& !showElsewhere`.
+5. `realSpaceIds` memo (~line 514) if now unused (it fed `effectiveDesktopProps`); eslint will confirm.
+6. In the space-delete ConfirmModal copy (~lines 1680–1682), replace the two "→ Elsewhere" strings with "→ Home" (sessions/memories unbound from a deleted space surface on Home now).
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `cd web && npx tsc -b && npm run lint`
+Expected: clean — in particular zero remaining references to `showElsewhere`, `unassignedProjects`, `effectiveDesktopProps`. `orphanCounts` is still used (Home pill tooltip totals) — leave it.
+
+- [ ] **Step 6: Manual check**
+
+On `/s/home`: unassigned projects (e.g. `Dev`, `sober-o-matic`) now appear as ordinary cards in the grid; a **Vault** card appears iff no-project artefacts exist — clicking it scopes all three tabs (Artefacts = native ones, Sessions = no-project ones, crumb = `vault`); orphan-folder tiles render in the same grid with working FolderPlus → attach popover; the topbar has **no Unassigned pill**; deleting a test space says "→ Home".
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/Home/index.tsx
+git commit -m "home: all projects + vault + orphan folders in one grid; retire Unassigned/Elsewhere"
+```
+
+---
+
+### Task 4: Scope-aware title + memory scoping at project/Vault scope
+
+**Files:**
+- Modify: `web/src/components/Home/index.tsx` (h1 ~line 992, `scopedMemories` memo ~line 500)
+
+- [ ] **Step 1: Title reflects project scope**
+
+Replace the `<h1>`:
+
+```tsx
+          <h1 className="home-title">{isHomeView ? "Your work." : eyebrow}</h1>
+```
+
+with:
+
+```tsx
+          <h1 className="home-title">
+            {selectedProjectId === VAULT ? "Vault."
+              : selectedProject ? selectedProject.name
+              : isHomeView ? "Your work."
+              : eyebrow}
+          </h1>
+```
+
+(`selectedProject` is the Task 2 memo. If Task 2's declaration sits below the JSX-needed point, it already had to be moved above — same constraint here.)
+
+- [ ] **Step 2: Memories follow project/Vault scope**
+
+Replace the `scopedMemories` memo (post-Task-3 shape) with:
+
+```ts
+  // Memories scope mirrors the server `list(space_id)` semantics: a space
+  // includes both its own memories AND globals. There is no project-level
+  // memory in the model (yet) — at project scope show the project's space
+  // + globals; at Vault scope, globals only.
+  const scopedMemories = useMemo(() => {
+    if (selectedProjectId === VAULT) return memories.filter((m) => !m.space_id);
+    const spaceForScope = selectedProject?.spaceId ?? scopedSpace;
+    return spaceForScope
+      ? memories.filter((m) => !m.space_id || m.space_id === spaceForScope)
+      : memories;
+  }, [memories, scopedSpace, selectedProject, selectedProjectId]);
+```
+
+Declaration-order constraint: this memo now depends on `selectedProject`, so `selectedProject` (and therefore the `allProjects` fetch) must be declared above it. Move the `selectedProject`/`scopeCrumb` block up next to the other scope derivations if tsc complains.
+
+- [ ] **Step 3: Typecheck + lint + manual check**
+
+Run: `cd web && npx tsc -b && npm run lint` → clean.
+Manual: select a project in a space that has space-scoped memories → Memories tab shows that space's + globals, title is the project name; select Vault → globals only, title "Vault."; deselect on Home → all memories, "Your work.".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/index.tsx
+git commit -m "home: project-scoped title and memories"
+```
+
+---
+
+### Task 5: Project scope in the URL — `/s/<space>/p/<project>`
+
+Lift `selectedProjectId` from Home to App so selection is URL-addressable and survives back/forward.
+
+**Files:**
+- Modify: `web/src/App.tsx` (getUrlState ~lines 52–63, state ~line 65, popstate ~lines 247–267, handleSpaceChange ~line 270, reveal/SSE handlers ~lines 183, 201–210, Home props ~line 609)
+- Modify: `web/src/components/Home/index.tsx` (Props interface, remove local state, rewire setters)
+
+- [ ] **Step 1: Parse the project URL in App**
+
+In `getUrlState`, add a `projectId` field. Insert the project match **before** the bare-space match and add `projectId: null` to the other returns:
+
+```ts
+  const getUrlState = useCallback((): { space: string; artifactId: string | null; groupName: string | null; hash: string; projectId: string | null } => {
+    const artifactMatch = window.location.pathname.match(/^\/s\/([^/]+)\/a\/([^/]+)$/);
+    if (artifactMatch) {
+      return { space: artifactMatch[1], artifactId: artifactMatch[2], groupName: null, hash: window.location.hash || "", projectId: null };
+    }
+    const groupMatch = window.location.pathname.match(/^\/s\/([^/]+)\/g\/([^/]+)$/);
+    if (groupMatch) {
+      return { space: groupMatch[1], artifactId: null, groupName: decodeURIComponent(groupMatch[2]), hash: "", projectId: null };
+    }
+    const projectMatch = window.location.pathname.match(/^\/s\/([^/]+)\/p\/([^/]+)$/);
+    if (projectMatch) {
+      return { space: projectMatch[1], artifactId: null, groupName: null, hash: "", projectId: decodeURIComponent(projectMatch[2]) };
+    }
+    const spaceMatch = window.location.pathname.match(/^\/s\/([^/]+?)\/?$/);
+    return { space: spaceMatch ? spaceMatch[1] : "home", artifactId: null, groupName: null, hash: "", projectId: null };
+  }, []);
+```
+
+- [ ] **Step 2: App-level scope state + handler**
+
+After the `activeSpace` state (~line 65):
+
+```ts
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(() => getUrlState().projectId);
+
+  // Project scope is URL-addressable: /s/<space>/p/<projectId> (VAULT's
+  // sentinel "__vault__" rides along unescaped-safe via encodeURIComponent).
+  const handleProjectScopeChange = useCallback((projectId: string | null) => {
+    setActiveProjectId(projectId);
+    const target = projectId
+      ? `/s/${activeSpace}/p/${encodeURIComponent(projectId)}`
+      : `/s/${activeSpace}`;
+    if (window.location.pathname !== target) {
+      window.history.pushState(null, "", target);
+    }
+  }, [activeSpace]);
+```
+
+In `handleSpaceChange` (~line 270) add `setActiveProjectId(null);` after `setActiveSpace(space);`.
+
+In `handlePopState` (~line 248), destructure `projectId` from `getUrlState()` and add `setActiveProjectId(projectId);`.
+
+The three handlers that push a space URL directly also clear project scope — add `setActiveProjectId(null);` to: the `pendingReveal` branch (~line 183), the `open_artifact` SSE branch (~line 201), and the `switch_space` SSE branch (~line 208).
+
+- [ ] **Step 3: Pass to Home**
+
+In the `<Home …>` element add:
+
+```tsx
+        selectedProjectId={activeProjectId}
+        onSelectProject={handleProjectScopeChange}
+```
+
+- [ ] **Step 4: Home consumes the lifted state**
+
+In `Home/index.tsx`:
+
+(a) Props interface adds:
+
+```ts
+  /** Project scope (a project id or the VAULT sentinel) — owned by App
+   *  so it's URL-addressable. */
+  selectedProjectId: string | null;
+  onSelectProject: (projectId: string | null) => void;
+```
+
+(b) Add both to the destructured params. Delete the local state (~line 261):
+
+```ts
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+```
+
+(c) Replace every `setSelectedProjectId(X)` call with `onSelectProject(X)` (grid tiles, Vault tile, scope-crumb ✕, and the `setSelectedProjectId` prop passed to `ProjectTileGrid` becomes `setSelectedProjectId={onSelectProject}`).
+
+(d) The scope-reset effect (~lines 302–316): App now owns clearing project scope on space change, so remove the `selectedProjectId` handling — delete the `pendingFolderSelection` ref (it is never written; dead) and the `if (pendingFolderSelection.current) … else { setSelectedProjectId(null); }` block, keeping the limit/filter resets:
+
+```ts
+  useEffect(() => {
+    setMemoriesLimit(MEMORIES_PREVIEW);
+    setArtefactsLimit(ARTEFACTS_PREVIEW);
+    setSessionsLimit(SESSIONS_PREVIEW);
+    setArtefactSource("all");
+    setArtefactKind("all");
+    setSelectedCwd(null);
+  }, [scopedSpace, isHomeView]);
+```
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `cd web && npx tsc -b && npm run lint`
+Expected: clean; no remaining `setSelectedProjectId` identifier in Home (the ProjectTileGrid *prop name* stays — only Home's local setter is gone).
+
+- [ ] **Step 6: Manual check**
+
+Select a project on Home → URL becomes `/s/home/p/<id>`; reload → scope (title, crumb, hidden column) restores; back button → returns to `/s/home` unscoped; click a space pill while project-scoped → project clears; `/s/home/p/__vault__` reloads into Vault scope. Artifact deep-links (`/s/<space>/a/<id>`) and group popups still open.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/App.tsx web/src/components/Home/index.tsx
+git commit -m "app: project scope is URL-addressable (/s/<space>/p/<project>)"
+```
+
+---
+
+### Task 6: Changelog + full build
+
+**Files:**
+- Modify: `CHANGELOG.md` (top `[Unreleased]` section — read the file head first and match its exact heading style)
+
+- [ ] **Step 1: Changelog entry**
+
+Under `[Unreleased]` (create the section if absent, mirroring the existing release-section format):
+
+```md
+### Changed
+- **One surface, three tabs** — Sessions, Artefacts and Memories now sit in tabs below your projects, scoped by the selected space and project, with a scope crumb showing where you are.
+- **Vault joins the project grid** — artefacts created in Oyster itself appear under a Vault card on Home, alongside your repos.
+- **Unassigned pill retired** — projects without a space now appear on Home with everything else.
+
+### Fixed
+- **Sessions table names the repo** — the project column shows the repository name instead of the space, and steps aside when a project is selected.
+```
+
+- [ ] **Step 2: Full build + lint sweep**
+
+Run from the repo root: `npm run build`
+Expected: web tsc + vite build and server tsc all pass.
+Run: `cd web && npm run lint` → clean.
+
+- [ ] **Step 3: Final manual sweep**
+
+One pass through: Home unscoped → space pill → project tile → each tab → Vault card → shield page → ⌘K Spotlight → ChatBar message box renders untouched at the bottom → New session pill. Nothing visually broken, no console errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "changelog: unified scope tabs, vault card, repo-named sessions"
+```
+
+---
+
+## Out of scope (PR 2/3 per spec)
+
+- Ask Oyster slide-over panel; ChatBar demotion/removal.
+- SpotlightSearch "ask" row.
+- `memories.project_id`, dropping `sessions.space_id`, any server change.

--- a/docs/superpowers/specs/2026-06-05-unified-scope-ux-design.md
+++ b/docs/superpowers/specs/2026-06-05-unified-scope-ux-design.md
@@ -1,0 +1,151 @@
+# Unified scope UX — design
+
+**Status:** Draft for review · 2026-06-05 · branch `unified-scope-ux`
+
+## Goal
+
+One page shape for the whole app. Spaces, projects, and the three content
+types (sessions, artefacts, memories) stop being separate worlds and become
+**one surface with a scope**: pills scope to a space, cards scope to a
+project, a tab strip shows the scoped content.
+
+Interactive prototype from the brainstorm:
+`.superpowers/brainstorm/41975-1780637235/content/structure-interactive.html`
+
+## Premises
+
+- Target user already runs agents daily. First-run is data-rich (discovered
+  projects, backfilled sessions/artefacts) — there is no empty-state problem.
+  Judge the UX by its *transitions* (e.g. organise-into-spaces), not arrival.
+- Chat does not take centre stage. "Ask Oyster" is an affordance on the
+  surface, not the front door.
+
+## Problem
+
+The schema is project-centric (sessions, artefacts, and paths all hang off
+`projects`; spaces merely group them), but the UX is space-centric and
+split into two genres:
+
+- Home is a dashboard of four stacked flat lists; a space is a different
+  world (the Desktop tile canvas). Project — the hub entity — has no view.
+- The sessions table's PROJECT column shows the *space* name once a session
+  has a `space_id` (`SessionRow.tsx`: `spaceLabel ?? cwdBasename`), so
+  running "Organise into spaces" coarsens the table — two repos in one
+  space become indistinguishable exactly when the user gains structure.
+- Null relations are promoted to destinations (Unassigned pill) while real
+  relations (which repo owns this session) are demoted to tooltips.
+- "Vault" names two unconnected surfaces: the Pro/inventory page and the
+  no-project-artefacts tile in the projects grid — which are in fact the
+  same concept (what lives in `~/Oyster`) at different zoom levels, with
+  nothing in the UI connecting them.
+
+## Design
+
+### Structure
+
+```
+[ ⌂ Home | <space pills> | + ]                  [+ New session] [shield] [oyster]
+
+  {Scope title}            "Your work." / "<space>." / "<project>  in <space>"
+
+  PROJECTS                 cards: repo projects + Vault card (when non-empty)
+  [client-portal] [website] [Vault] …
+
+  [ Sessions | Artefacts | Memories ]     scope: everything ▸ <space> ▸ <project>
+  ─────────────────────────────────────
+  (active tab's content, scoped)
+```
+
+### Scoping rules
+
+- **Space pill click** = scope to space. Cards narrow to its projects,
+  tabs narrow to its content, title becomes the space name.
+- **Project card click** = scope to project (sets space implicitly from the
+  project). Click again, or the ✕ on the scope crumb, to deselect.
+- **Selection, not navigation** — but URL-addressable: `/s/<space>` and
+  `/s/<space>/p/<project>` map onto scope state. Existing artifact/group
+  deep links (`/s/<id>/a/<artifactId>`, `/g/<group>`) keep working.
+- **Scope is law.** Every tab shows exactly what the schema places in scope:
+  sessions and artefacts via `project_id`, memories via the project's space
+  (plus global). Redundant columns disappear when scope implies them — the
+  PROJECT column is hidden at project scope.
+- Scope derivation is one-directional: Project → Space. The UI never reads
+  `sessions.space_id` for display again.
+
+### Tabs
+
+- **Sessions** (default tab) — existing table + filter chips
+  (live/waiting/done/all) + FULL/COMPACT toggle, moved inside the tab.
+  The project column always shows the *repo* name, never the space.
+- **Artefacts** — absorbs the Desktop surface: icon-grid view with groups
+  and pins, plus the existing table view and source/kind filters. Pinned
+  artefacts float first, groups render as folders, exactly as Desktop does
+  today — just scoped and inside a tab.
+- **Memories** — existing list with a scope badge per row (`<space>` /
+  `global`). At project scope shows the project's space memories + global.
+- Tab counts render in the strip. Active tab persists per scope level in
+  localStorage (like `oyster.home.sessionsView` today).
+
+### Vault
+
+One concept at two zoom levels — both keep the name:
+
+- **Vault card** in the projects grid (exists today, `ProjectTileGrid.tsx`):
+  the *working* zoom — artefacts whose files live in `~/Oyster` rather than
+  a repo. Scopes like any project card: native artefacts, orphan sessions,
+  global memories. Links to the shield page.
+- **Shield page** (Pro teaser + `vault-inventory.ts`): the *system* zoom —
+  everything `~/Oyster` holds. Untouched by this redesign.
+
+Every card in the projects grid now answers the same question — "where does
+this work live?" — your repos, plus Oyster's own vault.
+
+### Retired
+
+- **Desktop as a route/destination.** Its rendering moves into the Artefacts
+  tab; `/s/<spaceId>` now lands on the unified page scoped to the space.
+- **Unassigned pill + Elsewhere view.** Unassigned projects are ordinary
+  cards at Home scope; orphan sessions are visible at Home scope. Absence of
+  a relation is no longer a place.
+
+### Unchanged
+
+- Project cards (`ProjectTile`), `SessionRow`, `ArtefactTable`, `MemoryCard`,
+  space pills with status pips, "Organise into spaces ✨" flow, inspector,
+  session resume/connect, `+ New session`.
+- No SQLite schema changes. `sessions.space_id` stays (flagged for eventual
+  cleanup); `memories.project_id` is a noted future enhancement, not built.
+
+## Ask Oyster
+
+**Decision: topbar `✦ Ask` button opening a slide-over panel** (option A of
+the placement study). The panel hosts the conversation beside the surface,
+inherits the current scope (shown as a chip in its header), and reuses
+ChatBar's input/slash-command/streaming logic re-homed. The bottom ChatBar
+is removed when the panel ships.
+
+**Later, not now:** the existing ⌘K palette (`SpotlightSearch.tsx`) gains an
+"ask" row that opens the panel pre-filled — palette as launcher, panel as
+surface. They compose; neither blocks the other.
+
+**Rejected:** keeping a demoted bottom bar — it permanently spends vertical
+space, preserves the chat-at-centre signal this design retires, and still
+needs the panel to render answers.
+
+## Delivery
+
+Three PRs, each leaving the app fully working:
+
+1. **Structural unification.** Tab strip + scope state, Artefacts tab
+   absorbs Desktop, retire Unassigned pill/Elsewhere/Desktop route, project
+   labelling fix, Vault card scoping. Bottom ChatBar untouched.
+2. **Ask Oyster panel.** Slide-over panel + `✦ Ask` button + scope chip;
+   ChatBar guts move in; bottom bar removed. Mostly code-motion.
+3. **Palette integration** (when wanted). "Ask" row in SpotlightSearch →
+   opens panel pre-filled.
+
+## Out of scope / future
+
+- `memories.project_id` (project-scoped memory).
+- Dropping `sessions.space_id`.
+- Any change to the shield/Pro page, publishing, sync, or MCP surface.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -286,7 +286,10 @@ export default function App() {
     }
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [getUrlState]);
+    // `artifacts` in deps: the handler resolves /a/<id> URLs against it, so a
+    // once-registered listener would hold the first render's empty array and
+    // never reopen a viewer on back/forward. Re-registering per update is cheap.
+  }, [getUrlState, artifacts]);
 
   // Push URL when space changes via pill click
   const handleSpaceChange = useCallback((space: string) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,20 +49,38 @@ export default function App() {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [publishingArtifact, setPublishingArtifact] = useState<Artifact | null>(null);
-  const getUrlState = useCallback((): { space: string; artifactId: string | null; groupName: string | null; hash: string } => {
+  const getUrlState = useCallback((): { space: string; artifactId: string | null; groupName: string | null; hash: string; projectId: string | null } => {
     const artifactMatch = window.location.pathname.match(/^\/s\/([^/]+)\/a\/([^/]+)$/);
     if (artifactMatch) {
-      return { space: artifactMatch[1], artifactId: artifactMatch[2], groupName: null, hash: window.location.hash || "" };
+      return { space: artifactMatch[1], artifactId: artifactMatch[2], groupName: null, hash: window.location.hash || "", projectId: null };
     }
     const groupMatch = window.location.pathname.match(/^\/s\/([^/]+)\/g\/([^/]+)$/);
     if (groupMatch) {
-      return { space: groupMatch[1], artifactId: null, groupName: decodeURIComponent(groupMatch[2]), hash: "" };
+      return { space: groupMatch[1], artifactId: null, groupName: decodeURIComponent(groupMatch[2]), hash: "", projectId: null };
+    }
+    const projectMatch = window.location.pathname.match(/^\/s\/([^/]+)\/p\/([^/]+)$/);
+    if (projectMatch) {
+      return { space: projectMatch[1], artifactId: null, groupName: null, hash: "", projectId: decodeURIComponent(projectMatch[2]) };
     }
     const spaceMatch = window.location.pathname.match(/^\/s\/([^/]+?)\/?$/);
-    return { space: spaceMatch ? spaceMatch[1] : "home", artifactId: null, groupName: null, hash: "" };
+    return { space: spaceMatch ? spaceMatch[1] : "home", artifactId: null, groupName: null, hash: "", projectId: null };
   }, []);
 
   const [activeSpace, setActiveSpace] = useState<string>(() => getUrlState().space);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(() => getUrlState().projectId);
+
+  // Project scope is URL-addressable: /s/<space>/p/<projectId> (VAULT's
+  // sentinel "__vault__" rides along unescaped-safe via encodeURIComponent).
+  const handleProjectScopeChange = useCallback((projectId: string | null) => {
+    setActiveProjectId(projectId);
+    const target = projectId
+      ? `/s/${activeSpace}/p/${encodeURIComponent(projectId)}`
+      : `/s/${activeSpace}`;
+    if (window.location.pathname !== target) {
+      window.history.pushState(null, "", target);
+    }
+  }, [activeSpace]);
+
   const [spotlightOpen, setSpotlightOpen] = useState(false);
 
   // Global keyboard shortcuts
@@ -181,6 +199,7 @@ export default function App() {
         const revealed = arts.find((a) => a.pendingReveal);
         if (revealed) {
           setActiveSpace(revealed.spaceId);
+          setActiveProjectId(null);
           window.history.pushState(null, "", `/s/${revealed.spaceId}`);
           if (revealed.groupName) setOpenGroup(revealed.groupName);
           setRevealId(revealed.id);
@@ -199,6 +218,7 @@ export default function App() {
     if (event.command === "open_artifact") {
       const { spaceId, label, url, artifactKind, id } = event.payload as { spaceId: string; label: string; url: string; artifactKind: ArtifactKind; id: string };
       setActiveSpace(spaceId);
+      setActiveProjectId(null);
       window.history.pushState(null, "", `/s/${spaceId}/a/${id}`);
       dispatch({ type: "CLOSE_ALL_VIEWERS" });
       dispatch({ type: "OPEN_VIEWER", title: label, path: url, fullscreen: shouldOpenFullscreen(artifactKind) });
@@ -206,6 +226,7 @@ export default function App() {
     if (event.command === "switch_space") {
       const { spaceId } = event.payload as { spaceId: string };
       setActiveSpace(spaceId);
+      setActiveProjectId(null);
       window.history.pushState(null, "", `/s/${spaceId}`);
       dispatch({ type: "CLOSE_ALL_VIEWERS" });
     }
@@ -246,8 +267,9 @@ export default function App() {
   // Sync state from browser back/forward
   useEffect(() => {
     function handlePopState() {
-      const { space, artifactId, groupName } = getUrlState();
+      const { space, artifactId, groupName, projectId } = getUrlState();
       setActiveSpace(space);
+      setActiveProjectId(projectId);
       setOpenGroup(groupName);
       if (!artifactId) {
         dispatch({ type: "CLOSE_ALL_VIEWERS" });
@@ -273,6 +295,7 @@ export default function App() {
       window.history.pushState(null, "", target);
     }
     setActiveSpace(space);
+    setActiveProjectId(null);
     setOpenGroup(null);
   }, []);
 
@@ -610,6 +633,8 @@ export default function App() {
         activeSpace={activeSpace}
         spaces={spaces}
         onSpaceChange={handleSpaceChange}
+        selectedProjectId={activeProjectId}
+        onSelectProject={handleProjectScopeChange}
         onPromoteFolderToSpace={handlePromoteFolderToSpace}
         onSpaceDelete={handleSpaceDelete}
         onSpaceUpdate={handleSpaceUpdate}

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -154,6 +154,56 @@
   font-size: 12px;
 }
 
+/* Scoped-content tab strip (Sessions | Artefacts | Memories). */
+.home-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 36px;
+  border-bottom: 1px solid var(--home-border);
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 32px;
+}
+.home-tab {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 14px;
+  font-size: 13px;
+  color: var(--text-dim);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.home-tab:hover { color: var(--text); }
+.home-tab.active { color: var(--text); border-bottom-color: var(--accent); font-weight: 600; }
+.home-tab-count {
+  margin-left: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+.home-tab-scope {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  padding-right: 4px;
+}
+.home-tab-scope-clear {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0 2px;
+}
+.home-tab-scope-clear:hover { color: var(--text); }
+
 .home-section-label {
   color: var(--text);
 }

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -111,15 +111,6 @@
   padding: 80px 32px 24px;
 }
 
-.home-eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--home-accent-bright);
-  margin-bottom: 8px;
-}
-
 .home-title {
   font-size: 2.6rem;
   font-weight: 600;
@@ -212,12 +203,6 @@
    already draws the divider, so no second hairline. */
 .home-section-spacer {
   flex: 1;
-}
-
-.home-artefacts-count {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--home-text-muted);
 }
 
 /* ── Stat / filter chips (the same buttons act as both) ── */
@@ -1432,9 +1417,6 @@
 .home-breadcrumb-pill--home,
 .home-breadcrumb-pill--vault {
   padding: 5px 9px;
-}
-.home-breadcrumb-pill--elsewhere .home-breadcrumb-pill-label {
-  font-style: italic;
 }
 .home-breadcrumb-pill--add > [aria-hidden="true"] {
   color: var(--home-accent-bright);

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -523,6 +523,12 @@
 .home-row:hover { background: rgba(124, 107, 255, 0.05); }
 .home-row:last-child { border-bottom: none; }
 
+/* Project scope active — the project column is hidden (the scope crumb
+   names it), so the title takes its track. */
+.home-table--no-project .home-row {
+  grid-template-columns: 18px 1fr 130px 150px 130px;
+}
+
 .home-row-status {
   width: 8px;
   height: 8px;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1573,21 +1573,22 @@
   gap: 5px;
   color: rgba(232, 233, 240, 0.78);
 }
-/* Folder treatment for orphan tile names: muted text + folder glyph. */
+/* Tile name row: flex so any leading icon aligns with the label. */
 .home-projects-strip-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-family: var(--font-mono);
   font-size: 13px;
   color: var(--home-accent-bright);
   margin-bottom: 8px;
 }
-.home-projects-strip-name--folder {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--home-text-muted);
-}
-.home-projects-strip-name--folder svg {
+.home-projects-strip-name svg {
   flex-shrink: 0;
+}
+/* Orphan-folder tiles: muted colour override only. */
+.home-projects-strip-name--folder {
+  color: var(--home-text-muted);
 }
 
 /* Vault info page (cloud-sync teaser) — selected via the Shield pill in

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -208,12 +208,6 @@
   color: var(--text);
 }
 
-.home-section-rule {
-  flex: 1;
-  height: 1px;
-  background: var(--home-border);
-}
-
 /* Invisible flex spacer for tab-section heads — the tab strip above
    already draws the divider, so no second hairline. */
 .home-section-spacer {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -1495,7 +1495,7 @@
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 10px;
 }
-/* Orphan-cwd tiles (Elsewhere / Unassigned view). Same two-piece pattern
+/* Orphan-cwd tiles (unclaimed folders on Home). Same two-piece pattern
    as ProjectTile: outer div is the chrome + jump-button anchor; inner
    <button> covers the body click target. */
 .home-projects-strip-tile {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -214,6 +214,12 @@
   background: var(--home-border);
 }
 
+/* Invisible flex spacer for tab-section heads — the tab strip above
+   already draws the divider, so no second hairline. */
+.home-section-spacer {
+  flex: 1;
+}
+
 .home-artefacts-count {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -2016,7 +2016,6 @@
   justify-content: center;
   margin-top: 14px;
   padding-top: 14px;
-  border-top: 1px solid var(--home-border);
 }
 .home-projects-show-more {
   font-family: var(--font-mono);

--- a/web/src/components/Home/ProjectTile.tsx
+++ b/web/src/components/Home/ProjectTile.tsx
@@ -262,7 +262,7 @@ export function ProjectTile({
                 className="home-project-tile-menu-item"
                 disabled={busy}
                 onClick={() => performMove(null)}
-                title="Detach from its space — the project moves to Unassigned."
+                title="Detach from its space — the project stays on Home."
               >
                 — Remove from space —
               </button>

--- a/web/src/components/Home/SessionRow.tsx
+++ b/web/src/components/Home/SessionRow.tsx
@@ -10,7 +10,6 @@
 // create/modify only, top 3, whenAt DESC). Absent on remote sessions, in
 // which case the row degrades to the COMPACT layout (no extra line).
 import type { Session } from "../../data/sessions-api";
-import type { Space } from "../../../../shared/types";
 import {
   AGENT_PIP_CLASS, activeWriterChipFor, formatRelative,
   originDeviceChipFor,
@@ -22,7 +21,10 @@ export type SessionRowView = "full" | "compact";
 interface SessionRowProps {
   session: Session;
   view: SessionRowView;
-  spaces: Space[];
+  /** Repo name from the projects registry; null/undefined = unknown. */
+  projectName?: string | null;
+  /** Project scope is active — the column is redundant, hide it. */
+  hideProject?: boolean;
   /** Local device id; drives the cross-device chip. See SessionTile. */
   myDeviceId: string | null;
   /** Presence info from useTerminalPresence; undefined when no live terminal. */
@@ -41,7 +43,8 @@ interface SessionRowProps {
 export function SessionRow({
   session,
   view,
-  spaces,
+  projectName,
+  hideProject,
   myDeviceId,
   livePresence,
   onOpen,
@@ -61,11 +64,9 @@ export function SessionRow({
 
   const handleRowActivate = () => { if (onOpen) onOpen(session.id); };
 
-  // Prefer space label when the session belongs to a registered space.
-  const spaceLabel = session.spaceId
-    ? (spaces.find((s) => s.id === session.spaceId)?.displayName ?? null)
-    : null;
-  const projectLabel = (spaceLabel ?? cwdBasename) || "—";
+  // Repo name via the projects registry; cwd basename for orphans.
+  // Never the space name — the scope/space pill already says that.
+  const projectLabel = (projectName ?? cwdBasename) || "—";
   const isManual = session.assignmentMode === "manual";
   const rowExtraClass = livePresence
     ? (livePresence.state === "attached" ? " sr--attached" : " sr--running")
@@ -104,7 +105,9 @@ export function SessionRow({
         tabIndex={onOpen ? 0 : undefined}
       >
         <span className={`home-row-status ${statusDotClass}`} title={session.displayReason || undefined} />
-        <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
+        {!hideProject && (
+          <span className="home-row-space" title={session.cwd ?? undefined}>{projectLabel}</span>
+        )}
         <span className="home-row-title">
           <span className="home-row-title-inner" title={title}>
             {remoteChip && (

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -216,6 +216,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   useEffect(() => { setShowAttachForm(false); }, [projectsSpaceId]);
   const [stateFilter, setStateFilter] = useState<StateFilter>("all");
   const [sessionsView, setSessionsView] = useStickyView("oyster.home.sessionsView", "full", ["full", "compact"] as const);
+  const [activeTab, setActiveTab] = useStickyView("oyster.home.activeTab", "sessions", ["sessions", "artefacts", "memories"] as const);
   const [artefactsView, setArtefactsView] = useStickyView("oyster.home.artefactsView", "icons", ["icons", "table"] as const);
   const [activePanel, setActivePanel] = useState<ActivePanel | null>(null);
   const [pendingMemoryDelete, setPendingMemoryDelete] = useState<Memory | null>(null);
@@ -680,6 +681,15 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     return counts;
   }, [effectiveDesktopProps.artifacts]);
 
+  // Scope-only artefact total for the tab count (source/kind filters are
+  // tab-internal and shouldn't change the tab's headline number).
+  const scopedArtefactsTotal = useMemo(() => {
+    const list = effectiveDesktopProps.artifacts;
+    if (selectedProjectId === VAULT) return list.filter((a) => !a.projectId).length;
+    if (selectedProjectId) return list.filter((a) => a.projectId === selectedProjectId).length;
+    return list.length;
+  }, [effectiveDesktopProps.artifacts, selectedProjectId]);
+
   // Filter + collapse to an incremental preview. Each "Show more" click
   // grows artefactsLimit by ARTEFACTS_PREVIEW; the cap applies to both
   // icon and table views so busy spaces don't push later sections far
@@ -829,6 +839,21 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     : isAllView ? "All"
     : isArchivedView ? "Archived"
     : activeSpaceRow?.displayName ?? scopedSpace ?? "";
+
+  const selectedProject = selectedProjectId && selectedProjectId !== VAULT
+    ? allProjects.find((p) => p.id === selectedProjectId) ?? null
+    : null;
+  const scopeCrumb = selectedProjectId === VAULT
+    ? "vault"
+    : selectedProject
+      ? `${selectedProject.spaceId ? (spaces.find((s) => s.id === selectedProject.spaceId)?.displayName ?? selectedProject.spaceId) + " › " : ""}${selectedProject.name}`
+      : isArchivedView
+        ? "archived"
+      : isAllView
+        ? "all"
+      : scopedSpace
+        ? (activeSpaceRow?.displayName ?? scopedSpace)
+        : "everything";
 
   return (
     <div className="home">
@@ -1219,9 +1244,40 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
           )
         )}
 
+        <div className="home-tabs" role="tablist" aria-label="Scoped content">
+          {(["sessions", "artefacts", "memories"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === t}
+              className={`home-tab${activeTab === t ? " active" : ""}`}
+              onClick={() => setActiveTab(t)}
+            >
+              {t === "sessions" ? "Sessions" : t === "artefacts" ? "Artefacts" : "Memories"}
+              <span className="home-tab-count">
+                {t === "sessions" ? stateCounts.all : t === "artefacts" ? scopedArtefactsTotal : scopedMemories.length}
+              </span>
+            </button>
+          ))}
+          <span className="home-tab-scope">
+            scope: {scopeCrumb}
+            {selectedProjectId !== null && (
+              <button
+                type="button"
+                className="home-tab-scope-clear"
+                onClick={() => setSelectedProjectId(null)}
+                aria-label="Clear project scope"
+              >
+                ✕
+              </button>
+            )}
+          </span>
+        </div>
+
+        {activeTab === "sessions" && (
         <section className="home-section">
           <div className="home-section-head">
-            <span className="home-section-label">Sessions</span>
             <span className="home-section-stats">
               {FILTER_ORDER.map((f) => {
                 const count = stateCounts[f];
@@ -1318,10 +1374,11 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             </div>
           )}
         </section>
+        )}
 
+        {activeTab === "artefacts" && (
         <section className="home-section">
           <div className="home-section-head" style={kindMenuOpen ? { zIndex: 40 } : undefined}>
-            <span className="home-section-label">Artefacts</span>
             <span className="home-section-stats">
               {ARTEFACT_SOURCE_ORDER.map((src) => {
                 const count = artefactSourceCounts[src];
@@ -1510,11 +1567,11 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             </>
           )}
         </section>
+        )}
 
+        {activeTab === "memories" && (
         <section className="home-section">
           <div className="home-section-head">
-            <span className="home-section-label">Memories</span>
-            <span className="home-artefacts-count">{scopedMemories.length}</span>
             <span className="home-section-rule" />
             <button
               type="button"
@@ -1596,6 +1653,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             </div>
           )}
         </section>
+        )}
         </>)}
       </div>
       <InspectorPanel active={activePanel} onClose={() => setActivePanel(null)}>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -301,6 +301,12 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     }
   }, [isHomeView]);
 
+  // AddMemoryForm unmounts with its tab and would lose its draft — close
+  // it on tab switch so it doesn't reappear surprisingly empty.
+  useEffect(() => {
+    if (activeTab !== "memories") setShowAddMemory(false);
+  }, [activeTab]);
+
   const showVaultPage = showVault && isHomeView;
 
   // Collapse limits + filter reset on scope change — switching from a

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -190,16 +190,26 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     error: spaceProjectsError,
     refresh: refreshSpaceProjects,
   } = useSpaceProjects(projectsSpaceId);
-  // All projects across all spaces — used by the Home-view tile strip.
-  // Only fetched when on Home (enabled when isMetaScope and not Elsewhere).
+  // All projects across all spaces — used by the Home-view tile strip and
+  // session-row project labels in every scope.
   const {
     data: allProjects,
     refresh: refreshAllProjects,
   } = useFetched<import("../../data/projects-api").Project[]>(
     fetchAllProjects,
     [],
-    { enabled: isMetaScope, ssEvent: "session_changed" },
+    // Always fetched: feeds session-row project labels in every scope,
+    // plus the Home tile strip.
+    { enabled: true, ssEvent: "session_changed" },
   );
+  // Repo names for session-row labels — never the space displayName
+  // (scope already says the space; two repos in one space must stay
+  // distinguishable). Falls back to cwd basename inside SessionRow.
+  const projectNameById = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const p of allProjects) out[p.id] = p.name;
+    return out;
+  }, [allProjects]);
   const [showAttachForm, setShowAttachForm] = useState(false);
   // Reset the attach form whenever scope changes so it doesn't carry
   // across spaces.
@@ -1262,10 +1272,10 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
           ) : (
             <>
               <div className="home-table-wrap">
-                <div className="home-table">
+                <div className={`home-table${selectedProjectId !== null && selectedProjectId !== VAULT ? " home-table--no-project" : ""}`}>
                   <div className="home-row home-row--header" role="row">
                     <span aria-hidden="true" />
-                    <span role="columnheader">Project</span>
+                    {(selectedProjectId === null || selectedProjectId === VAULT) && <span role="columnheader">Project</span>}
                     <span role="columnheader">Title</span>
                     <span role="columnheader">Agent</span>
                     <span role="columnheader">Reason</span>
@@ -1276,9 +1286,10 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                       key={session.id}
                       session={session}
                       view={sessionsView}
-                      spaces={spaces}
                       myDeviceId={myDeviceId}
                       livePresence={presence.byId[session.id]}
+                      projectName={session.projectId ? projectNameById[session.projectId] ?? null : null}
+                      hideProject={selectedProjectId !== null && selectedProjectId !== VAULT}
                       onOpen={(id) => setActivePanel({ kind: "session", id })}
                       onTerminalFocus={onTerminalFocus}
                       onTerminalRestore={onTerminalRestore}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1183,6 +1183,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               key={t}
               type="button"
               role="tab"
+              id={`home-tab-${t}`}
+              aria-controls={`home-tabpanel-${t}`}
               aria-selected={activeTab === t}
               className={`home-tab${activeTab === t ? " active" : ""}`}
               onClick={() => setActiveTab(t)}
@@ -1211,7 +1213,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         </div>
 
         {activeTab === "sessions" && (
-        <section className="home-section">
+        <section className="home-section" role="tabpanel" id="home-tabpanel-sessions" aria-labelledby="home-tab-sessions">
           <div className="home-section-head">
             <span className="home-section-stats">
               {FILTER_ORDER.map((f) => {
@@ -1312,7 +1314,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         )}
 
         {activeTab === "artefacts" && (
-        <section className="home-section">
+        <section className="home-section" role="tabpanel" id="home-tabpanel-artefacts" aria-labelledby="home-tab-artefacts">
           <div className="home-section-head" style={kindMenuOpen ? { zIndex: 40 } : undefined}>
             <span className="home-section-stats">
               {ARTEFACT_SOURCE_ORDER.map((src) => {
@@ -1505,7 +1507,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         )}
 
         {activeTab === "memories" && (
-        <section className="home-section">
+        <section className="home-section" role="tabpanel" id="home-tabpanel-memories" aria-labelledby="home-tab-memories">
           <div className="home-section-head">
             <span className="home-section-spacer" />
             <button

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -1185,9 +1185,11 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               </span>
             </button>
           ))}
-          <span className="home-tab-scope">
-            scope: {scopeCrumb}
-            {selectedProjectId !== null && (
+          {/* Crumb only when a project/Vault narrows the scope — at plain
+              space scope it would just echo the selected pill and title. */}
+          {selectedProjectId !== null && (
+            <span className="home-tab-scope">
+              scope: {scopeCrumb}
               <button
                 type="button"
                 className="home-tab-scope-clear"
@@ -1196,8 +1198,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               >
                 ✕
               </button>
-            )}
-          </span>
+            </span>
+          )}
         </div>
 
         {activeTab === "sessions" && (
@@ -1227,7 +1229,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                 );
               })}
             </span>
-            <span className="home-section-rule" />
+            <span className="home-section-spacer" />
             <div className="view-toggle-text">
               <button
                 type="button"
@@ -1324,7 +1326,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                 );
               })}
             </span>
-            <span className="home-section-rule" />
+            <span className="home-section-spacer" />
             {presentKinds.length > 1 && (
               <div className="home-kind-filter">
                 <span className="home-kind-label">Kind</span>
@@ -1497,7 +1499,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         {activeTab === "memories" && (
         <section className="home-section">
           <div className="home-section-head">
-            <span className="home-section-rule" />
+            <span className="home-section-spacer" />
             <button
               type="button"
               className="home-memories-refresh-btn"

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -89,6 +89,10 @@ interface Props {
    *  computes it from the unscoped artefact pile so a space pill can't
    *  hide a publication that lives in another space. */
   publishedCount?: number;
+  /** Project scope (a project id or the VAULT sentinel) — owned by App
+   *  so it's URL-addressable. */
+  selectedProjectId: string | null;
+  onSelectProject: (projectId: string | null) => void;
 }
 
 const ARTEFACT_SOURCE_ORDER: ArtefactSource[] = ["all", "manual", "ai_generated", "discovered", "published", "pinned"];
@@ -167,7 +171,7 @@ const FILTER_LABELS: Record<StateFilter, string> = {
   all: "all",
 };
 
-export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop, onOpenArtifact, onOpenNewSession, onConnectSession, sessions, sessionsLoading: loading, sessionsError: error, userSpaceCount, publishedCount }: Props) {
+export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop, onOpenArtifact, onOpenNewSession, onConnectSession, sessions, sessionsLoading: loading, sessionsError: error, userSpaceCount, publishedCount, selectedProjectId, onSelectProject }: Props) {
   const presence = useTerminalPresence(sessions, terminalWindows ?? []);
   const signedIn = useAuthSignedIn();
   const myDevice = useMyDeviceId();
@@ -260,10 +264,6 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // Right-click context menu on a breadcrumb pill — owns rename / color /
   // delete entry points. Anchored by the clicked pill's bounding rect.
   const [pillCtx, setPillCtx] = useState<{ spaceId: string; rect: DOMRect } | null>(null);
-  // Project-tile filter: null = "All" (no folder scope), "__vault__" =
-  // native artefacts, otherwise a source_id. The tile grid is the canonical
-  // surface for switching between folders; selection is exclusive.
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const selectedProject = selectedProjectId && selectedProjectId !== VAULT
     ? allProjects.find((p) => p.id === selectedProjectId) ?? null
     : null;
@@ -306,24 +306,15 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
 
   // Collapse limits + filter reset on scope change — switching from a
   // 60-item Home view to a single-space view shouldn't carry over either
-  // the "show more" depth, source filter, or tile selection. Exception:
-  // the Active-projects jump arrow lets the user "open this space with
-  // this project pre-selected" — the click stashes a source_id in the
-  // pending ref before triggering onSpaceChange, and this effect honours
-  // it instead of the default null reset.
-  const pendingFolderSelection = useRef<string | null>(null);
+  // the "show more" depth, source filter, or tile selection. Project scope
+  // (selectedProjectId) is now URL-addressable and owned by App; App clears
+  // it on space change via handleSpaceChange, so this effect doesn't touch it.
   useEffect(() => {
     setMemoriesLimit(MEMORIES_PREVIEW);
     setArtefactsLimit(ARTEFACTS_PREVIEW);
     setSessionsLimit(SESSIONS_PREVIEW);
     setArtefactSource("all");
     setArtefactKind("all");
-    if (pendingFolderSelection.current) {
-      setSelectedProjectId(pendingFolderSelection.current);
-      pendingFolderSelection.current = null;
-    } else {
-      setSelectedProjectId(null);
-    }
     setSelectedCwd(null);
   }, [scopedSpace, isHomeView]);
 
@@ -1001,7 +992,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   <button
                     type="button"
                     className="home-projects-strip-tile-body"
-                    onClick={() => { setSelectedCwd(null); setSelectedProjectId(selectedProjectId === VAULT ? null : VAULT); }}
+                    onClick={() => { setSelectedCwd(null); onSelectProject(selectedProjectId === VAULT ? null : VAULT); }}
                     title="Artefacts created in Oyster itself — not tied to a repo"
                   >
                     <div className="home-projects-strip-name">
@@ -1023,7 +1014,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   artefactCount={projectArtefactCounts[p.id] ?? 0}
                   sessionCounts={sessionCountsByProject[p.id]}
                   selected={selectedProjectId === p.id}
-                  onSelect={() => { setSelectedCwd(null); setSelectedProjectId(selectedProjectId === p.id ? null : p.id); }}
+                  onSelect={() => { setSelectedCwd(null); onSelectProject(selectedProjectId === p.id ? null : p.id); }}
                   onChanged={refreshAllProjects}
                   isLastProject={false}
                   spaceTotalSessions={0}
@@ -1047,7 +1038,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                     <button
                       type="button"
                       className="home-projects-strip-tile-body"
-                      onClick={() => { setSelectedProjectId(null); setSelectedCwd(isSelected ? null : p.cwd); }}
+                      onClick={() => { onSelectProject(null); setSelectedCwd(isSelected ? null : p.cwd); }}
                       title={p.cwd}
                     >
                       <div className="home-projects-strip-name home-projects-strip-name--folder">
@@ -1166,7 +1157,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               projectArtefactCounts={projectArtefactCounts}
               sessionCountsByProject={sessionCountsByProject}
               selectedProjectId={selectedProjectId}
-              setSelectedProjectId={setSelectedProjectId}
+              setSelectedProjectId={onSelectProject}
               spaceTotalSessions={scopedSessions.length}
               spaces={moveSpaceOptions}
               showAttachForm={showAttachForm}
@@ -1200,7 +1191,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               <button
                 type="button"
                 className="home-tab-scope-clear"
-                onClick={() => setSelectedProjectId(null)}
+                onClick={() => onSelectProject(null)}
                 aria-label="Clear project scope"
               >
                 ✕

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -221,14 +221,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   const [activePanel, setActivePanel] = useState<ActivePanel | null>(null);
   const [pendingMemoryDelete, setPendingMemoryDelete] = useState<Memory | null>(null);
 
-  // Local "Elsewhere" scope: filters Sessions to those whose spaceId is null
-  // (claude/codex sessions started in folders that aren't attached to any
-  // registered space). Only applies in Home view; navigating to a real space
-  // resets it.
-  const [showElsewhere, setShowElsewhere] = useState(false);
   // Vault info page (cloud-sync teaser). Sits next to Home in the breadcrumb;
-  // mutually exclusive with showElsewhere and resets when navigating away
-  // from Home, same lifecycle as showElsewhere.
+  // resets when navigating away from Home.
   const [showVault, setShowVault] = useState(false);
   // Memories collapse: long lists are noisy on Home. Default to 5 rows;
   // "Show all" expands. Resets when the user changes scope so a different
@@ -292,11 +286,9 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   const isMetaView = isHomeView || isAllView || isArchivedView;
   const scopedSpace = !isMetaView ? activeSpace : null;
 
-  // Reset Elsewhere scope when we navigate away from Home (e.g. user clicks
-  // a real space card or chat-bar pill).
+  // Reset Vault page when we navigate away from Home.
   useEffect(() => {
     if (!isHomeView) {
-      setShowElsewhere(false);
       setShowVault(false);
     }
   }, [isHomeView]);
@@ -330,7 +322,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
       setSelectedProjectId(null);
     }
     setSelectedCwd(null);
-  }, [scopedSpace, showElsewhere, isHomeView]);
+  }, [scopedSpace, isHomeView]);
 
   // Auto-reset the live-terminals filter if there are no live terminals
   // (e.g. the last terminal was stopped, or the user switched to a space
@@ -343,9 +335,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   }, [stateFilter, presence.totalLive]);
 
   const scopedSessions = useMemo(() => {
-    if (showElsewhere && isHomeView) return sessions.filter((s) => s.spaceId === null);
     return scopedSpace ? sessions.filter((s) => s.spaceId === scopedSpace) : sessions;
-  }, [sessions, scopedSpace, showElsewhere, isHomeView]);
+  }, [sessions, scopedSpace]);
 
   // Folder-narrowed sessions: when a project tile is selected, sessions
   // filter to that source (or sessions without a source for VAULT, or
@@ -392,7 +383,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // spaceId === null) + a grand total for the Home card. Buckets by
   // `displayState` so dormant rows fold into `done` — matches the home
   // chip semantics where `disconnected` means the 30min–8h band only.
-  const { sessionCountsBySpace, orphanCounts, totalCounts } = useMemo(() => {
+  const { sessionCountsBySpace, totalCounts } = useMemo(() => {
     const bySpace: Record<string, { total: number; running: number; active: number; waiting: number; disconnected: number; done: number }> = {};
     const orphans = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     const total = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
@@ -442,19 +433,21 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     return out;
   }, [sessions, presence.byId]);
 
-  // Orphan-cwd "projects" on Elsewhere — sessions whose cwd doesn't
+  // Orphan-cwd "projects" on Home — sessions whose cwd doesn't
   // match any registered source still came from somewhere. Group by
   // cwd so the user can see at a glance which rogue folders have
   // activity, not just an undifferentiated session list.
   const orphanCwdGroups = useMemo(() => {
-    if (!showElsewhere || !isHomeView) return [];
+    if (!isHomeView) return [];
     const map = new Map<string, {
       cwd: string;
       counts: { active: number; waiting: number; disconnected: number; done: number };
       lastEventAt: number;
     }>();
     for (const s of sessions) {
-      if (s.spaceId !== null || !s.cwd) continue;
+      // Project-bound sessions render via their project card — only truly
+      // unclaimed folders (no project, no space) get an orphan tile.
+      if (s.projectId || s.spaceId !== null || !s.cwd) continue;
       // Group separator-equivalent Windows paths under one tile: local
       // sessions write forward-slashed cwds while remote_sessions can hold
       // the raw backslash form pushed from the origin device, so the same
@@ -478,7 +471,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
       if (Number.isFinite(t) && t > entry.lastEventAt) entry.lastEventAt = t;
     }
     return [...map.values()].sort((a, b) => b.lastEventAt - a.lastEventAt);
-  }, [sessions, showElsewhere, isHomeView]);
+  }, [sessions, isHomeView]);
 
   // Drop meta-spaces from the Spaces summary cards: the chat bar already
   // renders Home as its own pill, so a `home` row in the spaces table would
@@ -512,68 +505,41 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // global memories (no space_id) — globals are meant to apply everywhere,
   // and the agent's `recall(query, space_id)` already returns scope+global,
   // so the human-browsing surface should match.
-  // Elsewhere narrows to memories not bound to any currently-known space
-  // (orphans + memories pointing at deleted spaces).
   const scopedMemories = useMemo(() => {
-    if (showElsewhere && isHomeView) {
-      const real = new Set(spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__").map((s) => s.id));
-      return memories.filter((m) => !m.space_id || !real.has(m.space_id));
-    }
     return scopedSpace
       ? memories.filter((m) => !m.space_id || m.space_id === scopedSpace)
       : memories;
-  }, [memories, scopedSpace, showElsewhere, isHomeView, spaces]);
+  }, [memories, scopedSpace]);
 
-  // When scoped to Elsewhere, artefacts should mirror the sessions filter:
-  // anything not attributed to a known real space (null spaceId or a stale
-  // pointer to a deleted space). App.tsx hands us all artefacts on home —
-  // we narrow them locally so artefacts and sessions tell the same story.
-  const realSpaceIds = useMemo(() => new Set(realSpaces.map((s) => s.id)), [realSpaces]);
   // Destination options for a project tile's "Move to space…" picker.
   const moveSpaceOptions = useMemo(
     () => realSpaces.map((s) => ({ id: s.id, name: s.displayName })),
     [realSpaces],
   );
-  // Projects detached from every space (space_id = null) — surfaced under the
-  // Unassigned pill so a "removed from space" project stays findable and can
-  // be re-filed from its own Move-to-space menu.
-  const unassignedProjects = useMemo(
-    () => allProjects.filter((p) => p.spaceId == null),
-    [allProjects],
-  );
-  const effectiveDesktopProps = useMemo(() => {
-    if (showElsewhere && isHomeView) {
-      return {
-        ...desktopProps,
-        artifacts: desktopProps.artifacts.filter((a) => !a.spaceId || !realSpaceIds.has(a.spaceId)),
-      };
-    }
-    return desktopProps;
-  }, [showElsewhere, isHomeView, desktopProps, realSpaceIds]);
 
   // Source-origin counts over the scoped artefacts (so the chip totals
   // reflect the current space pill, not the global pile).
   const artefactSourceCounts = useMemo(() => {
     const counts: Record<ArtefactSource, number> = { all: 0, manual: 0, ai_generated: 0, discovered: 0, published: 0, pinned: 0 };
-    counts.all = effectiveDesktopProps.artifacts.length;
-    for (const a of effectiveDesktopProps.artifacts) {
+    counts.all = desktopProps.artifacts.length;
+    for (const a of desktopProps.artifacts) {
       const o = a.sourceOrigin ?? "manual";
       if (o === "manual" || o === "ai_generated" || o === "discovered") counts[o]++;
       if (isLivePublication(a)) counts.published++;
       if (a.pinnedAt != null) counts.pinned++;
     }
     return counts;
-  }, [effectiveDesktopProps.artifacts]);
+  }, [desktopProps.artifacts]);
 
   // Per-kind counts over the active scope — independent of the source filter,
   // matching how the source pills count the scope total. Drives the Kind row.
   const artefactKindCounts = useMemo(() => {
     const counts: Partial<Record<ArtifactKind, number>> = {};
-    for (const a of effectiveDesktopProps.artifacts) {
+    for (const a of desktopProps.artifacts) {
       counts[a.artifactKind] = (counts[a.artifactKind] ?? 0) + 1;
     }
     return counts;
-  }, [effectiveDesktopProps.artifacts]);
+  }, [desktopProps.artifacts]);
   // Kinds actually present in this scope, in canonical order. The Kind row only
   // renders when there's more than one — no point filtering a single-kind scope.
   const presentKinds = useMemo(
@@ -655,10 +621,9 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         total: sessionTotalsByProject[id] ?? 0,
       };
     };
-    // Filed projects only — those detached from every space (space_id null)
-    // live under the Unassigned pill, mirroring how orphan sessions are
-    // segregated out of the Home view.
-    return allProjects.filter((p) => p.spaceId != null).sort((a, b) => {
+    // Every project — assigned or not. Unassigned projects are ordinary
+    // cards on Home now; the Unassigned pill is retired.
+    return [...allProjects].sort((a, b) => {
       const sa = score(a.id);
       const sb = score(b.id);
       if (sa.hasLive !== sb.hasLive) return sb.hasLive - sa.hasLive;
@@ -680,28 +645,28 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // when the artefact list is empty.
   const projectArtefactCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    for (const a of effectiveDesktopProps.artifacts) {
+    for (const a of desktopProps.artifacts) {
       const key = a.projectId ?? VAULT;
       counts[key] = (counts[key] ?? 0) + 1;
     }
     return counts;
-  }, [effectiveDesktopProps.artifacts]);
+  }, [desktopProps.artifacts]);
 
   // Scope-only artefact total for the tab count (source/kind filters are
   // tab-internal and shouldn't change the tab's headline number).
   const scopedArtefactsTotal = useMemo(() => {
-    const list = effectiveDesktopProps.artifacts;
+    const list = desktopProps.artifacts;
     if (selectedProjectId === VAULT) return list.filter((a) => !a.projectId).length;
     if (selectedProjectId) return list.filter((a) => a.projectId === selectedProjectId).length;
     return list.length;
-  }, [effectiveDesktopProps.artifacts, selectedProjectId]);
+  }, [desktopProps.artifacts, selectedProjectId]);
 
   // Filter + collapse to an incremental preview. Each "Show more" click
   // grows artefactsLimit by ARTEFACTS_PREVIEW; the cap applies to both
   // icon and table views so busy spaces don't push later sections far
   // below the fold.
   const filteredArtefacts = useMemo(() => {
-    let list = effectiveDesktopProps.artifacts;
+    let list = desktopProps.artifacts;
     if (selectedProjectId === VAULT) {
       list = list.filter((a) => !a.projectId);
     } else if (selectedProjectId) {
@@ -732,7 +697,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
       return (Number.isFinite(tb) ? tb : 0) - (Number.isFinite(ta) ? ta : 0);
     });
     return list;
-  }, [effectiveDesktopProps.artifacts, artefactSource, artefactKind, selectedProjectId]);
+  }, [desktopProps.artifacts, artefactSource, artefactKind, selectedProjectId]);
   const visibleArtefacts = useMemo(
     () => filteredArtefacts.slice(0, artefactsLimit),
     [filteredArtefacts, artefactsLimit],
@@ -841,7 +806,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   }, []);
 
   const activeSpaceRow = scopedSpace ? spaces.find((s) => s.id === scopedSpace) : null;
-  const eyebrow = isHomeView ? (showElsewhere ? "Unassigned" : "Home")
+  const eyebrow = isHomeView ? "Home"
     : isAllView ? "All"
     : isArchivedView ? "Archived"
     : activeSpaceRow?.displayName ?? scopedSpace ?? "";
@@ -883,12 +848,12 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             <AuthBadge />
             <button
               type="button"
-              className={`home-breadcrumb-pill home-breadcrumb-pill--home${isHomeView && !showElsewhere && !showVault ? " selected" : ""}`}
-              onClick={() => { onSpaceChange("home"); setShowElsewhere(false); setShowVault(false); }}
+              className={`home-breadcrumb-pill home-breadcrumb-pill--home${isHomeView && !showVault ? " selected" : ""}`}
+              onClick={() => { onSpaceChange("home"); setShowVault(false); }}
               onContextMenu={(e) => e.preventDefault()}
               title={`${totalCounts.active} active · ${totalCounts.waiting} waiting · ${totalCounts.disconnected} disconnected · ${totalCounts.done} done`}
             >
-              {isHomeView && !showElsewhere && !showVault && (
+              {isHomeView && !showVault && (
                 <motion.span
                   layoutId="home-breadcrumb-bg"
                   className="home-breadcrumb-pill-bg"
@@ -902,7 +867,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             <button
               type="button"
               className={`home-breadcrumb-pill home-breadcrumb-pill--vault${showVaultPage ? " selected" : ""}`}
-              onClick={() => { onSpaceChange("home"); setShowElsewhere(false); setShowVault(true); }}
+              onClick={() => { onSpaceChange("home"); setShowVault(true); }}
               onContextMenu={(e) => e.preventDefault()}
               title="Oyster Pro — coming soon"
               aria-label="Oyster Pro"
@@ -978,34 +943,6 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                 <span aria-hidden="true">+</span>
               )}
             </button>
-            {(orphanCounts.total > 0 || unassignedProjects.length > 0) && realSpaces.length > 0 && (
-              <button
-                type="button"
-                className={`home-breadcrumb-pill home-breadcrumb-pill--elsewhere${showElsewhere && isHomeView ? " selected" : ""}`}
-                onClick={() => { onSpaceChange("home"); setShowElsewhere(true); setShowVault(false); }}
-                onContextMenu={(e) => e.preventDefault()}
-                title={[
-                  orphanCounts.running > 0 && `${orphanCounts.running} running`,
-                  orphanCounts.active > 0 && `${orphanCounts.active} active`,
-                  orphanCounts.waiting > 0 && `${orphanCounts.waiting} waiting`,
-                  orphanCounts.done > 0 && `${orphanCounts.done} done`,
-                ].filter(Boolean).join(" · ") || "Projects and sessions not filed into a space"}
-              >
-                {showElsewhere && isHomeView && (
-                  <motion.span
-                    layoutId="home-breadcrumb-bg"
-                    className="home-breadcrumb-pill-bg"
-                    transition={{ type: "spring", stiffness: 400, damping: 35 }}
-                  />
-                )}
-                {(orphanCounts.running > 0 || orphanCounts.active > 0 || orphanCounts.waiting > 0) && (
-                  <span className="home-breadcrumb-badges">
-                    {renderPipCounts(orphanCounts)}
-                  </span>
-                )}
-                <span className="home-breadcrumb-pill-label">Unassigned</span>
-              </button>
-            )}
             </div>
             <div className="home-breadcrumb-inner home-breadcrumb-inner--right-cluster">
               {onTerminalFocus && onTerminalRestore && onTerminalStop && presence.totalLive > 0 && (
@@ -1030,7 +967,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
           {/* Eyebrow dropped — the breadcrumb above already shows the
               active scope, so a separate "HOME" / "OYSTER" label is
               redundant. */}
-          <h1 className="home-title">{isHomeView ? (showElsewhere ? "Unassigned." : "Your work.") : eyebrow}</h1>
+          <h1 className="home-title">{isHomeView ? "Your work." : eyebrow}</h1>
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 
@@ -1040,7 +977,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             home-space-card / home-spaces-section CSS is kept around in
             case the cards return as a settings or dashboard surface. */}
 
-        {isHomeView && !showElsewhere && sortedProjects.length > 0 && (
+        {isHomeView && (sortedProjects.length > 0 || orphanCwdGroups.length > 0 || (projectArtefactCounts[VAULT] ?? 0) > 0) && (
           <div className="home-section home-projects-section">
             <div className="home-section-head">
               <span className="home-section-label">Projects</span>
@@ -1055,6 +992,24 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               <span className="home-section-rule" />
             </div>
             <div className="home-projects-grid" ref={projectsGridRef}>
+              {(projectArtefactCounts[VAULT] ?? 0) > 0 && (
+                <div className={`home-projects-strip-tile home-project-tile--vault${selectedProjectId === VAULT ? " selected" : ""}`}>
+                  <button
+                    type="button"
+                    className="home-projects-strip-tile-body"
+                    onClick={() => setSelectedProjectId(selectedProjectId === VAULT ? null : VAULT)}
+                    title="Artefacts created in Oyster itself — not tied to a repo"
+                  >
+                    <div className="home-projects-strip-name">
+                      <Shield size={14} strokeWidth={1.75} aria-hidden="true" />
+                      <span>Vault</span>
+                    </div>
+                    <div className="home-projects-strip-counts">
+                      <span className="signal"><span className="pip pip-dim" />{projectArtefactCounts[VAULT]} {(projectArtefactCounts[VAULT] ?? 0) === 1 ? "artefact" : "artefacts"}</span>
+                    </div>
+                  </button>
+                </div>
+              )}
               {visibleProjects.map((p) => (
                 // onSpaceDelete intentionally omitted — Home strip can't collapse spaces.
                 // isLastProject/spaceTotalSessions are inert here (willCollapseSpace = false).
@@ -1074,59 +1029,6 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   onLaunchClaude={onLaunchClaude}
                 />
               ))}
-            </div>
-            {hiddenCount > 0 && !projectsExpanded && (
-              <div className="home-projects-footer">
-                <button
-                  type="button"
-                  className="home-projects-show-more"
-                  onClick={() => setProjectsExpanded(true)}
-                >
-                  Show all {sortedProjects.length} projects ▾
-                </button>
-              </div>
-            )}
-            {projectsExpanded && sortedProjects.length > projectColumns && (
-              <div className="home-projects-footer">
-                <button
-                  type="button"
-                  className="home-projects-show-more home-projects-show-more--collapse"
-                  onClick={() => setProjectsExpanded(false)}
-                >
-                  Show less ▴
-                </button>
-              </div>
-            )}
-          </div>
-        )}
-
-        {isHomeView && showElsewhere && unassignedProjects.length > 0 && (
-          <div className="home-section home-projects-section">
-            <div className="home-projects-grid">
-              {unassignedProjects.map((p) => (
-                <ProjectTile
-                  key={p.id}
-                  project={p}
-                  artefactCount={projectArtefactCounts[p.id] ?? 0}
-                  sessionCounts={sessionCountsByProject[p.id]}
-                  selected={selectedProjectId === p.id}
-                  onSelect={() => setSelectedProjectId(selectedProjectId === p.id ? null : p.id)}
-                  onChanged={refreshAllProjects}
-                  isLastProject={false}
-                  spaceTotalSessions={0}
-                  // No merge target across the unassigned pool; move-to-space re-files it.
-                  otherProjects={[]}
-                  spaces={moveSpaceOptions}
-                  onLaunchClaude={onLaunchClaude}
-                />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {isHomeView && showElsewhere && orphanCwdGroups.length > 0 && (
-          <div className="home-section home-projects-section">
-            <div className="home-projects-grid">
               {orphanCwdGroups.map((p) => {
                 const isSelected = selectedCwd === p.cwd;
                 // Disable every promote button while *any* promotion is in
@@ -1180,6 +1082,28 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                 );
               })}
             </div>
+            {hiddenCount > 0 && !projectsExpanded && (
+              <div className="home-projects-footer">
+                <button
+                  type="button"
+                  className="home-projects-show-more"
+                  onClick={() => setProjectsExpanded(true)}
+                >
+                  Show all {sortedProjects.length} projects ▾
+                </button>
+              </div>
+            )}
+            {projectsExpanded && sortedProjects.length > projectColumns && (
+              <div className="home-projects-footer">
+                <button
+                  type="button"
+                  className="home-projects-show-more home-projects-show-more--collapse"
+                  onClick={() => setProjectsExpanded(false)}
+                >
+                  Show less ▴
+                </button>
+              </div>
+            )}
           </div>
         )}
 
@@ -1196,7 +1120,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             <div className="home-spaces-section">
               <div className="home-folders-empty">
                 <strong>No projects in this space yet.</strong>{" "}
-                Sessions started in unclaimed folders land in Elsewhere
+                Sessions started in unclaimed folders appear on Home
                 until you claim them into a project.{" "}
                 <span className="home-folders-empty-hint">
                   <button
@@ -1329,7 +1253,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
 
           {loading && sessions.length === 0 ? (
             <div className="home-empty">Loading sessions…</div>
-          ) : visibleSessions.length === 0 && !(stateCounts.all === 0 && isHomeView && !showElsewhere) ? (
+          ) : visibleSessions.length === 0 && !(stateCounts.all === 0 && isHomeView) ? (
             <div className="home-empty">No sessions match this filter yet.</div>
           ) : (
             <>
@@ -1371,7 +1295,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               )}
             </>
           )}
-          {stateCounts.all === 0 && isHomeView && !showElsewhere && !loading && (
+          {stateCounts.all === 0 && isHomeView && !loading && (
             <div className="home-empty-state">
               <div className="home-empty-state-title">No sessions found yet.</div>
               <div className="home-empty-state-body">
@@ -1521,7 +1445,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             <>
               <div className="home-artefacts">
                 <Desktop
-                  {...effectiveDesktopProps}
+                  {...desktopProps}
                   artifacts={visibleArtefacts}
                   isHero={false}
                   showMeta
@@ -1752,9 +1676,9 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         const memoryCount = memories.filter((m) => m.space_id === targetId).length;
         const plural = (n: number, one: string, many: string) => n === 1 ? `1 ${one}` : `${n} ${many}`;
         const lines: React.ReactNode[] = [];
-        if (sessionCount > 0) lines.push(<>{plural(sessionCount, "session", "sessions")} → Elsewhere</>);
+        if (sessionCount > 0) lines.push(<>{plural(sessionCount, "session", "sessions")} → Home</>);
         if (artefactCount > 0) lines.push(<>{plural(artefactCount, "artefact", "artefacts")} → Home, grouped under <strong>{displayName}</strong></>);
-        if (memoryCount > 0) lines.push(<>{plural(memoryCount, "memory", "memories")} → Elsewhere (unbound from this space)</>);
+        if (memoryCount > 0) lines.push(<>{plural(memoryCount, "memory", "memories")} → Home (unbound from this space)</>);
         return (
           <ConfirmModal
             open={true}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -984,7 +984,6 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               >
                 Organise into spaces ✨
               </button>
-              <span className="home-section-rule" />
             </div>
             <div className="home-projects-grid" ref={projectsGridRef}>
               {(projectArtefactCounts[VAULT] ?? 0) > 0 && (

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -179,8 +179,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     error: memoriesError,
     refresh: refreshMemories,
   } = useMemories();
-  // Space sources only fetch when scoped to a real space — Home / Elsewhere
-  // / All / Archived don't have a single source list. Identifies the
+  // Space sources only fetch when scoped to a real space — Home / All /
+  // Archived don't have a single source list. Identifies the
   // "zero sources attached" pitfall (#266) at a glance.
   const isMetaScope = activeSpace === "home" || activeSpace === "__all__" || activeSpace === "__archived__";
   const projectsSpaceId = !isMetaScope ? activeSpace : null;
@@ -242,8 +242,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   const [artefactKind, setArtefactKind] = useState<ArtifactKind | "all">("all");
   const [kindMenuOpen, setKindMenuOpen] = useState(false);
   const [artefactsLimit, setArtefactsLimit] = useState(ARTEFACTS_PREVIEW);
-  // Cwd-based tile filter: drives session narrowing on both Home default
-  // and showElsewhere. Lives alongside selectedProjectId; resets when scope changes.
+  // Cwd-based tile filter: drives session narrowing for orphan-folder tiles
+  // on Home. Lives alongside selectedProjectId; resets when scope changes.
   const [selectedCwd, setSelectedCwd] = useState<string | null>(null);
   // Cwd of the orphan tile currently mid-promotion (or mid-attach). Disables
   // every FolderPlus button so a slow server response can't kick off a
@@ -340,7 +340,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
 
   // Folder-narrowed sessions: when a project tile is selected, sessions
   // filter to that source (or sessions without a source for VAULT, or
-  // by cwd when a cwd-based tile is picked on Home or showElsewhere).
+  // by cwd when an orphan-folder tile is picked on Home).
   const folderScopedSessions = useMemo(() => {
     if (selectedCwd) return scopedSessions.filter((s) => s.cwd === selectedCwd);
     if (selectedProjectId === VAULT) return scopedSessions.filter((s) => !s.projectId);
@@ -477,9 +477,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // renders Home as its own pill, so a `home` row in the spaces table would
   // surface a redundant card. __all__ and __archived__ are similar.
   // Sort by most recent session activity desc; spaces with no sessions
-  // fall to the bottom in their original (alphabetical) order. Home and
-  // Elsewhere cards are rendered around this list — always first / always
-  // last regardless of activity.
+  // fall to the bottom in their original (alphabetical) order.
   // Stable breadcrumb order: bucket by strongest signal (green → amber →
   // red → quiet), then alphabetise within each bucket. Sorting by
   // last-activity caused pill order to flip every time a session updated,
@@ -704,10 +702,10 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   );
   const filteredArtefactsTotal = filteredArtefacts.length;
 
-  // Resolve the active artefact against the FULL artifact list, not the
-  // showElsewhere-filtered one. Cross-navigating from a session inspector
-  // to an artefact in a different scope (e.g. clicking a registered-space
-  // artefact while the user is in Elsewhere mode) shouldn't close the panel.
+  // Resolve the active artefact against the FULL artifact list so
+  // cross-scope navigation from a session inspector (e.g. clicking a
+  // registered-space artefact while in a different scope) doesn't
+  // close the panel.
   const activeArtefact = activePanel?.kind === "artefact"
     ? desktopProps.artifacts.find((a) => a.id === activePanel.id)
     : null;

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -318,6 +318,14 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     setSelectedCwd(null);
   }, [scopedSpace, isHomeView]);
 
+  // URL-driven project scope (deep link, back/forward) must beat the
+  // Home-local folder filter — folderScopedSessions checks selectedCwd
+  // first, so a surviving cwd would silently shadow the project in the URL.
+  // Tile clicks already cross-clear; this covers the popstate path.
+  useEffect(() => {
+    if (selectedProjectId !== null) setSelectedCwd(null);
+  }, [selectedProjectId]);
+
   // Auto-reset the live-terminals filter if there are no live terminals
   // (e.g. the last terminal was stopped, or the user switched to a space
   // with none). Without this the pill disappears but the filter sticks,
@@ -373,13 +381,11 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     });
   }, [folderScopedSessions, stateFilter, presence.byId]);
 
-  // Per-space session counts + a separate orphan tally (sessions with
-  // spaceId === null) + a grand total for the Home card. Buckets by
+  // Per-space session counts + a grand total for the Home card. Buckets by
   // `displayState` so dormant rows fold into `done` — matches the home
   // chip semantics where `disconnected` means the 30min–8h band only.
   const { sessionCountsBySpace, totalCounts } = useMemo(() => {
     const bySpace: Record<string, { total: number; running: number; active: number; waiting: number; disconnected: number; done: number }> = {};
-    const orphans = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     const total = { total: 0, running: 0, active: 0, waiting: 0, disconnected: 0, done: 0 };
     const bump = (c: { active: number; waiting: number; disconnected: number; done: number }, ds: DisplayState) => {
       if (ds === "dormant") c.done++;
@@ -395,13 +401,9 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
         bump(c, s.displayState);
         if (presence.byId[s.id]) c.running++;
         bySpace[s.spaceId] = c;
-      } else {
-        orphans.total++;
-        bump(orphans, s.displayState);
-        if (presence.byId[s.id]) orphans.running++;
       }
     }
-    return { sessionCountsBySpace: bySpace, orphanCounts: orphans, totalCounts: total };
+    return { sessionCountsBySpace: bySpace, totalCounts: total };
   }, [sessions, presence.byId]);
 
   // Per-project live-session counts, keyed by project_id. Used by
@@ -498,9 +500,15 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // + globals; at Vault scope, globals only.
   const scopedMemories = useMemo(() => {
     if (selectedProjectId === VAULT) return memories.filter((m) => !m.space_id);
-    const spaceForScope = selectedProject?.spaceId ?? scopedSpace;
-    return spaceForScope
-      ? memories.filter((m) => !m.space_id || m.space_id === spaceForScope)
+    if (selectedProjectId) {
+      // Project scope: its space + globals. When the space can't resolve
+      // (registry still loading, or the project is unassigned) show globals
+      // only — never the whole pile under a project's title.
+      const sp = selectedProject?.spaceId ?? null;
+      return memories.filter((m) => !m.space_id || (sp !== null && m.space_id === sp));
+    }
+    return scopedSpace
+      ? memories.filter((m) => !m.space_id || m.space_id === scopedSpace)
       : memories;
   }, [memories, scopedSpace, selectedProject, selectedProjectId]);
 
@@ -646,13 +654,12 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   }, [desktopProps.artifacts]);
 
   // Scope-only artefact total for the tab count (source/kind filters are
-  // tab-internal and shouldn't change the tab's headline number).
-  const scopedArtefactsTotal = useMemo(() => {
-    const list = desktopProps.artifacts;
-    if (selectedProjectId === VAULT) return list.filter((a) => !a.projectId).length;
-    if (selectedProjectId) return list.filter((a) => a.projectId === selectedProjectId).length;
-    return list.length;
-  }, [desktopProps.artifacts, selectedProjectId]);
+  // tab-internal and shouldn't change the tab's headline number). Derived
+  // from projectArtefactCounts — same VAULT/projectId bucketing — so the
+  // badge and the tile counts can't drift apart.
+  const scopedArtefactsTotal = selectedProjectId
+    ? (projectArtefactCounts[selectedProjectId] ?? 0)
+    : desktopProps.artifacts.length;
 
   // Filter + collapse to an incremental preview. Each "Show more" click
   // grows artefactsLimit by ARTEFACTS_PREVIEW; the cap applies to both
@@ -808,6 +815,8 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     ? "vault"
     : selectedProject
       ? `${selectedProject.spaceId ? (spaces.find((s) => s.id === selectedProject.spaceId)?.displayName ?? selectedProject.spaceId) + " › " : ""}${selectedProject.name}`
+    : selectedCwd
+      ? homeRelative(selectedCwd)
       : isArchivedView
         ? "archived"
       : isAllView
@@ -1184,16 +1193,16 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
               </span>
             </button>
           ))}
-          {/* Crumb only when a project/Vault narrows the scope — at plain
-              space scope it would just echo the selected pill and title. */}
-          {selectedProjectId !== null && (
+          {/* Crumb only when a project/Vault/folder narrows the scope — at
+              plain space scope it would just echo the selected pill and title. */}
+          {(selectedProjectId !== null || selectedCwd !== null) && (
             <span className="home-tab-scope">
               scope: {scopeCrumb}
               <button
                 type="button"
                 className="home-tab-scope-clear"
-                onClick={() => onSelectProject(null)}
-                aria-label="Clear project scope"
+                onClick={() => { onSelectProject(null); setSelectedCwd(null); }}
+                aria-label="Clear scope"
               >
                 ✕
               </button>

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -995,7 +995,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   <button
                     type="button"
                     className="home-projects-strip-tile-body"
-                    onClick={() => setSelectedProjectId(selectedProjectId === VAULT ? null : VAULT)}
+                    onClick={() => { setSelectedCwd(null); setSelectedProjectId(selectedProjectId === VAULT ? null : VAULT); }}
                     title="Artefacts created in Oyster itself — not tied to a repo"
                   >
                     <div className="home-projects-strip-name">
@@ -1017,7 +1017,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   artefactCount={projectArtefactCounts[p.id] ?? 0}
                   sessionCounts={sessionCountsByProject[p.id]}
                   selected={selectedProjectId === p.id}
-                  onSelect={() => setSelectedProjectId(selectedProjectId === p.id ? null : p.id)}
+                  onSelect={() => { setSelectedCwd(null); setSelectedProjectId(selectedProjectId === p.id ? null : p.id); }}
                   onChanged={refreshAllProjects}
                   isLastProject={false}
                   spaceTotalSessions={0}
@@ -1041,7 +1041,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                     <button
                       type="button"
                       className="home-projects-strip-tile-body"
-                      onClick={() => setSelectedCwd(isSelected ? null : p.cwd)}
+                      onClick={() => { setSelectedProjectId(null); setSelectedCwd(isSelected ? null : p.cwd); }}
                       title={p.cwd}
                     >
                       <div className="home-projects-strip-name home-projects-strip-name--folder">

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -264,6 +264,9 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
   // native artefacts, otherwise a source_id. The tile grid is the canonical
   // surface for switching between folders; selection is exclusive.
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const selectedProject = selectedProjectId && selectedProjectId !== VAULT
+    ? allProjects.find((p) => p.id === selectedProjectId) ?? null
+    : null;
   const [addSpaceOpen, setAddSpaceOpen] = useState(false);
 
   const triggerSetupScan = useCallback(async () => {
@@ -498,16 +501,17 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     });
   }, [spaces, sessionCountsBySpace]);
 
-  // Memories scope mirrors the server `list(space_id)` semantics: a real
-  // space includes both memories explicitly tagged with that space AND
-  // global memories (no space_id) — globals are meant to apply everywhere,
-  // and the agent's `recall(query, space_id)` already returns scope+global,
-  // so the human-browsing surface should match.
+  // Memories scope mirrors the server `list(space_id)` semantics: a space
+  // includes both its own memories AND globals. There is no project-level
+  // memory in the model (yet) — at project scope show the project's space
+  // + globals; at Vault scope, globals only.
   const scopedMemories = useMemo(() => {
-    return scopedSpace
-      ? memories.filter((m) => !m.space_id || m.space_id === scopedSpace)
+    if (selectedProjectId === VAULT) return memories.filter((m) => !m.space_id);
+    const spaceForScope = selectedProject?.spaceId ?? scopedSpace;
+    return spaceForScope
+      ? memories.filter((m) => !m.space_id || m.space_id === spaceForScope)
       : memories;
-  }, [memories, scopedSpace]);
+  }, [memories, scopedSpace, selectedProject, selectedProjectId]);
 
   // Destination options for a project tile's "Move to space…" picker.
   const moveSpaceOptions = useMemo(
@@ -809,9 +813,6 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
     : isArchivedView ? "Archived"
     : activeSpaceRow?.displayName ?? scopedSpace ?? "";
 
-  const selectedProject = selectedProjectId && selectedProjectId !== VAULT
-    ? allProjects.find((p) => p.id === selectedProjectId) ?? null
-    : null;
   const scopeCrumb = selectedProjectId === VAULT
     ? "vault"
     : selectedProject
@@ -965,7 +966,12 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
           {/* Eyebrow dropped — the breadcrumb above already shows the
               active scope, so a separate "HOME" / "OYSTER" label is
               redundant. */}
-          <h1 className="home-title">{isHomeView ? "Your work." : eyebrow}</h1>
+          <h1 className="home-title">
+            {selectedProjectId === VAULT ? "Vault."
+              : selectedProject ? selectedProject.name
+              : isHomeView ? "Your work."
+              : eyebrow}
+          </h1>
           {error && <div className="home-error">Couldn't load sessions: {error.message}</div>}
         </header>
 


### PR DESCRIPTION
## Summary

PR 1 of the unified-scope redesign ([spec](docs/superpowers/specs/2026-06-05-unified-scope-ux-design.md), [plan](docs/superpowers/plans/2026-06-05-unified-scope-ux-pr1.md)): one page shape with scope — pills scope to a space, cards scope to a project, tabs show the scoped content.

- **Sessions | Artefacts | Memories become tabs** below the projects grid, with counts and a scope crumb (+ ✕ to clear). All existing filters/toggles live on inside their tab.
- **Sessions table names the repo**, never the space (`projectNameById` via the projects registry, cwd-basename fallback); the column steps aside when a project is selected.
- **One Home grid**: all projects (assigned + unassigned) + a Vault card (no-project artefacts) + orphan-folder tiles. The Unassigned pill and Elsewhere view are retired; tile selections are mutually exclusive.
- **Project scope is URL-addressable** — `/s/<space>/p/<project>` parses on load, pushes on select, syncs on popstate, clears on every space change.
- Scope-aware title + memories (project → its space + globals; Vault → globals only).
- ChatBar, shield/Pro page, Spotlight, inspector, publish flows untouched. No schema changes. `Home/index.tsx` nets −12 lines.

## Reviewer notes (known, deliberate non-fixes)

1. **Source/kind chip counts** in the Artefacts tab count the space/home pile while the tab badge is project-scoped — chip computation is pre-existing; scoping it is follow-up material.
2. **SSE reveal / `open_artifact` clears project scope** — matches existing space-switch behaviour; if scope should survive same-project reveals, that's a deliberate future change.
3. **Legacy `/s/__all__` view**: project-less sessions now show cwd/— instead of their space name (label rewrite). Only reachable via old bookmarks.
4. **Fresh install with only chat-native artefacts** renders the Projects section with just a Vault tile + "Organise into spaces" CTA — polish candidate.
5. Vault sentinel rides the project-id channel (`/p/__vault__`) and the per-space vault tile shares it — flagged in the spec for PR 2.

## Test plan

- [x] `npm run build` (web tsc + vite + server tsc) green; 613/613 server tests pass
- [x] Multi-agent review: per-task spec + quality reviews, final integration review, 7-angle recall review with verified findings fixed (`0bc1d30`)
- [ ] Manual: select space pill → project card → tabs scope, PROJECT column hides, URL `/s/<space>/p/<id>` survives reload + back
- [ ] Manual: orphan-folder tile shows crumb + ✕; Vault card scopes; no Unassigned pill
- [ ] Manual: FULL-view artefact chips alignment with project column hidden; narrow-viewport reflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)