### PR TITLE
Ask Oyster panel (PR 2): chat moves to a scoped slide-over, bottom bar retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Changed
 
+- **Ask Oyster moves to a side panel** — chat now opens from the ✦ Ask button in the top bar and slides in beside your work, instead of a bar pinned to the bottom of every page. It knows which space and project you're looking at.
+- **Bottom chat bar removed** — and with it, typing-anywhere-to-chat and the ⚡ terminal shortcut.
 - **One surface, three tabs** — Sessions, Artefacts and Memories now sit in tabs below your projects, scoped by the selected space and project, with a scope crumb showing where you are.
 - **Vault joins the project grid** — artefacts created in Oyster itself appear under a Vault card on Home, alongside your repos.
 - **Unassigned pill retired** — projects without a space now appear on Home with everything else.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Browser → http://localhost:4444
 
 ## Mental Models
 
-**Spaces** — organisational nodes. Each space has an ID, display name, optional repo path, and colour. Navigated via pills at the bottom of the chat bar, or via `#space` / `/s space` commands.
+**Spaces** — organisational nodes. Each space has an ID, display name, optional repo path, and colour. Navigated via pills in the top bar, or via `#space` / `/s space` commands in the Ask panel.
 
 **Artefacts** — typed outputs on the surface (app, notes, diagram, deck, wireframe, table, map). Registered in SQLite, files in `~/Oyster/spaces/<space-id>/` (user work) or `~/Oyster/apps/` (installed bundles). `source_origin` tracks provenance: `manual` | `discovered` | `ai_generated`.
 
@@ -53,7 +53,7 @@ Browser → http://localhost:4444
 - `opencode.json` — OpenCode config (model, MCP endpoints)
 - `web/src/App.tsx` — root component, state, SSE subscription
 - `web/src/components/Desktop.tsx` — surface grid, topbar, sort/filter/view
-- `web/src/components/ChatBar.tsx` — chat input, slash commands, space pills
+- `web/src/components/AskPanel.tsx` — Ask Oyster panel: chat input, slash commands, message thread
 
 ## How to build and run
 

--- a/docs/superpowers/plans/2026-06-05-ask-oyster-panel.md
+++ b/docs/superpowers/plans/2026-06-05-ask-oyster-panel.md
@@ -1,0 +1,427 @@
+# Ask Oyster Panel (PR 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The bottom ChatBar becomes a right-hand slide-over "Ask Oyster" panel opened from a topbar `✦ Ask` button; the agent learns the user's current scope; the omnikey handler and ⚡ terminal escape hatch are removed.
+
+**Architecture:** Convert `ChatBar.tsx` in place — rename to `AskPanel`, replace the fixed-bottom shell with a slide-over shell, keep all chat logic (slash commands, autocomplete, streaming, queueing, events) byte-identical. The panel is **always mounted** in App with an `open` prop toggling a CSS transform, so conversation state and the SSE stream survive close/reopen exactly as the always-mounted bar does today. Scope context is computed in App and threaded as two props (display label + message prefix).
+
+**Tech Stack:** React 18 + TypeScript (web/), no web test runner (per codebase; verification = `npx tsc -b` + `npm run lint` zero-new-errors + `npm run build` + manual checks). Lint baseline: ~45 pre-existing `react-hooks` errors repo-wide — gate is zero NEW errors on touched lines.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-ask-oyster-panel-design.md`
+
+**One noted spec deviation:** the spec says AI-error surfacing "moves into the panel", but App's `aiError` banner also serves non-chat errors (unpublish failure, App.tsx:559). Keep the `onAiError` → App-banner wiring exactly as today; the banner is the shared error surface. (Provider-status fallback already lives inside the component and moves with it.)
+
+**Branch / worktree:** Branch `ask-oyster-panel` exists (holds the spec). Execute in a worktree: `git worktree add ~/Dev/oyster.worktrees/ask-oyster-panel ask-oyster-panel`, copy `.env` in, symlink `node_modules` (root, web, server) from the main checkout. Manual checks: `npm run dev` from the worktree root → http://localhost:7337 (stop any running Oyster first; stale `~/Oyster/.oyster.lock` may need deleting).
+
+**Key facts an implementer needs (verified against main):**
+- `web/src/components/ChatBar.tsx` (691 lines) renders: messages panel (expands upward; bubbles, markdown via marked+DOMPurify, `ToolBlock`/`ReasoningBlock`, question options, copy button), slash autocomplete, ⚡ bolt div (`chatbar-oyster`, onClick=`onOpenTerminal`), status text, provider fallback, input + send.
+- `useChatSession` (web/src/hooks/useChatSession.ts) owns messages/sessionId/expanded + `/session/<id>` URL push + popstate reset. **Unchanged in this PR.**
+- `useChatEvents` streams SSE into messages. **Unchanged.**
+- App couplings (web/src/App.tsx): `chatInputRef` + printable-key focus handler (~lines 69-100), `handleOpenTerminal`/`confirmHardcore`/`showHardcoreGate` + gate modal JSX (only dispatchers of `OPEN_TERMINAL`), `<ChatBar …>` render (~line 854+), `useAllProjects(pickerOpen)` (data/all-projects).
+- OnboardingDock.tsx:259 dispatches `oyster:send-prompt`; ChatBar listens (lines 452-462) and the listener moves with the component — but the panel must also OPEN.
+- Home topbar right-cluster (web/src/components/Home/index.tsx, `home-breadcrumb-inner--right-cluster`) renders `RunningTerminalsPill` + `NewSessionPill` (`nsp-pill` class — reuse it for the Ask pill).
+- App.css: `.chatbar-wrapper/.chatbar-bar/.chatbar-messages(+expand/collapse)/.chatbar-oyster/.chatbar-collapse` are structural (replaced); `.chatbar-input/.chatbar-send/.chatbar-status/.chatbar-copy/.chatbar-add-provider/.slash-*/.chat-bubble/.chat-markdown/.question-options/.tool-block*` are position-independent (kept, classnames unchanged).
+
+---
+
+### Task 1: Convert ChatBar → AskPanel + App wiring + topbar pill + removals
+
+One atomic conversion commit: after it, the app has no bottom bar, a working slide-over, and no omnikey/hardcore code. (It can't be split without an intermediate broken state — the rename breaks App's import.)
+
+**Files:**
+- Rename: `web/src/components/ChatBar.tsx` → `web/src/components/AskPanel.tsx` (`git mv`)
+- Create: `web/src/components/Topbar/AskPill.tsx`
+- Modify: `web/src/App.tsx`, `web/src/components/Home/index.tsx`, `web/src/App.css`
+
+- [ ] **Step 1: `git mv web/src/components/ChatBar.tsx web/src/components/AskPanel.tsx`**
+
+- [ ] **Step 2: Rework the component shell (AskPanel.tsx)**
+
+(a) Props — replace the interface:
+
+```ts
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Crumb-shaped scope label for the header chip ("everything" / space / "space › project" / "vault"). */
+  scopeLabel: string;
+  /** Context line prepended to outbound messages; null at "everything" scope. (Wired in Task 2 — pass null until then.) */
+  scopeContext: string | null;
+  spaces?: Space[];
+  activeSpace?: string;
+  onSpaceChange?: (space: string) => void;
+  artifacts?: Artifact[];
+  onArtifactOpen?: (artifact: Artifact) => void;
+  onArtifactPublish?: (artifact: Artifact) => void;
+  onArtifactUnpublish?: (artifact: Artifact) => void;
+  onAiError?: (message: string | null) => void;
+}
+```
+
+Dropped: `onOpenTerminal` (button removed), `inputRef` (omnikey removed — keep only the internal `localInputRef`, delete the `externalInputRef` indirection: `const inputRef = useRef<HTMLInputElement>(null);`).
+
+(b) Rename the function `ChatBar` → `AskPanel`; destructure the new props.
+
+(c) Delete the ⚡ bolt block (the `<div className="chatbar-oyster" onClick={onOpenTerminal}>…</div>` with the bolt SVG).
+
+(d) Delete the click-outside-collapses effect (the `handleClickOutside` useEffect — the panel closes only via ✕) and the `wrapperRef` it used.
+
+(e) Replace the outer render shell. The old shape was `div.chatbar-wrapper > [messages panel, chatbar-bar]`. New shape:
+
+```tsx
+  return (
+    <div className={`ask-panel${open ? " open" : ""}`} aria-hidden={!open}>
+      <div className="ask-panel-header">
+        <span className="ask-panel-title">✦ Ask Oyster</span>
+        <span className="ask-panel-scope" title="Answers consider your current scope">{scopeLabel}</span>
+        <button type="button" className="ask-panel-close" onClick={onClose} aria-label="Close Ask Oyster">✕</button>
+      </div>
+
+      {/* Messages feed — same inner markup as before, new container class */}
+      <div className="ask-panel-messages">
+        {messages.length > 0 && (
+          <>
+            <div className="chatbar-actions">
+              <button className={`chatbar-copy ${copied ? "copied" : ""}`} onClick={handleCopyChat} title="Copy chat">
+                {copied ? "copied" : "copy"}
+              </button>
+            </div>
+            {/* …the existing messages.filter(...).map(...) block, UNCHANGED… */}
+            <div ref={bottomRef} />
+          </>
+        )}
+      </div>
+
+      {/* Input row — same inner markup as the old chatbar-bar, minus the bolt */}
+      <div className="ask-panel-inputrow">
+        {/* …existing slash-autocomplete block, status text, provider fallback,
+            input + send button, ALL UNCHANGED… */}
+      </div>
+    </div>
+  );
+```
+
+Concretely: keep every inner block byte-identical (autocomplete, status, provider fallback, input, send, bubbles, question options); only the containers change. The old `chatbar-collapse` (↓) button is deleted — the header ✕ replaces it. The `expanded`/`chat-expanded`/`chat-collapsed` class logic on the messages container is dropped (the feed is always visible inside an open panel); keep the `setExpanded(...)` calls elsewhere in the file untouched (they're harmless hook state and the `expanded` value still drives the autoscroll effect — change that effect's guard from `if (expanded)` to `if (open)` and its deps from `[messages, expanded]` to `[messages, open]`). Keep `slash-dimmed` by moving it onto `ask-panel-messages`: `` className={`ask-panel-messages${slashOpen ? " slash-dimmed" : ""}`} ``. The old `chatbar-bar` onClick expand handler is dropped.
+
+(f) The input's `onFocus` handler (`if (messages.length > 0) setExpanded(true)`) — delete it (no collapsed state to recover from).
+
+- [ ] **Step 3: AskPill**
+
+Create `web/src/components/Topbar/AskPill.tsx` (mirrors NewSessionPill, reuses its CSS):
+
+```tsx
+// "✦ Ask" pill. Sibling to NewSessionPill in the breadcrumb nav's
+// right-aligned cluster. Opens the Ask Oyster slide-over panel.
+
+export function AskPill({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="nsp-pill"
+      onClick={onClick}
+      title="Ask Oyster about your current scope"
+    >
+      <span aria-hidden="true">✦</span>
+      <span>Ask</span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Thread the pill through Home**
+
+In `web/src/components/Home/index.tsx`:
+- Props interface adds: `onOpenAsk?: () => void;` (doc comment: `/** Open the Ask Oyster panel — renders the ✦ Ask pill when provided. */`). Add to destructure.
+- Import: `import { AskPill } from "../Topbar/AskPill";`
+- In the right-cluster div (next to `{onOpenNewSession && <NewSessionPill …/>}`), add **before** the NewSessionPill:
+
+```tsx
+              {onOpenAsk && <AskPill onClick={onOpenAsk} />}
+```
+
+- [ ] **Step 5: App wiring + removals (web/src/App.tsx)**
+
+(a) Import swap: `import { ChatBar } from "./components/ChatBar";` → `import { AskPanel } from "./components/AskPanel";`
+
+(b) New state near the other UI state: `const [askOpen, setAskOpen] = useState(false);`
+
+(c) **Remove omnikey:** delete `const chatInputRef = useRef<HTMLInputElement>(null);` and, inside the global `handleKeyDown`, delete ONLY the printable-key block (the `const tag = …; if (tag !== "INPUT" && … && e.key.length === 1) { chatInputRef.current?.focus(); }` lines). Keep ⌘K Spotlight toggle and Escape handling intact. If `useRef` import becomes unused, eslint will say so — it won't (other refs exist).
+
+(d) **Remove the hardcore gate:** delete `handleOpenTerminal`, `confirmHardcore`, the `showHardcoreGate` state, and the entire `{showHardcoreGate && (…hardcore-gate-overlay…)}` JSX block. These were the only dispatchers of `OPEN_TERMINAL` (verified: windows.ts reducer case stays; the `terminalWindow` render block stays — it simply never mounts now, and removing the reducer/window machinery is out of scope).
+
+(e) Replace the `<ChatBar …/>` render with the always-mounted panel:
+
+```tsx
+      <AskPanel
+        open={askOpen}
+        onClose={() => setAskOpen(false)}
+        scopeLabel="everything"
+        scopeContext={null}
+        spaces={spaces}
+        activeSpace={activeSpace}
+        onSpaceChange={handleSpaceChange}
+        artifacts={artifacts}
+        onArtifactOpen={handleArtifactClick}
+        onArtifactPublish={handleArtifactPublish}
+        onArtifactUnpublish={handleArtifactUnpublish}
+        onAiError={setAiError}
+      />
+```
+
+(`scopeLabel`/`scopeContext` get real values in Task 2.)
+
+(f) Pass the opener to Home: add `onOpenAsk={() => setAskOpen(true)}` to the `<Home …>` props.
+
+- [ ] **Step 6: CSS (web/src/App.css)**
+
+Delete these structural blocks (grep each selector to find every occurrence — `.chatbar-messages` appears twice): `.chatbar-wrapper` (both), `.chatbar-bar`, `.chatbar-messages` (both, incl. `.chat-expanded`/`.chat-collapsed`/scrollbar variants), `.chatbar-oyster` (+ `:hover`/`:active`), `.chatbar-collapse` (+ hover; keep `.chatbar-actions .chatbar-collapse`? No — delete all `.chatbar-collapse` rules; the button is gone), `.chatbar-messages.slash-dimmed`. Also delete the now-orphaned `.hardcore-gate-overlay`/`.hardcore-gate`/`.hardcore-*` blocks (this change orphans them).
+
+KEEP unchanged: `.chatbar-input*`, `.chatbar-send*`, `.chatbar-status`, `.chatbar-copy*`, `.chatbar-actions`, `.chatbar-add-provider*`, `.slash-autocomplete*`, `.chat-bubble*`, `.chat-markdown*`, `.question-options*`, `.question-option-btn*`, `.tool-block*`.
+
+Add the panel block (after where `.chatbar-wrapper` was):
+
+```css
+/* ── Ask Oyster slide-over panel ── */
+.ask-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 420px;
+  max-width: 92vw;
+  display: flex;
+  flex-direction: column;
+  background: rgba(13, 14, 26, 0.97);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: -18px 0 48px rgba(0, 0, 0, 0.5);
+  transform: translateX(102%);
+  transition: transform 0.22s ease;
+  z-index: 200;
+}
+.ask-panel.open { transform: translateX(0); }
+
+.ask-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  flex: none;
+}
+.ask-panel-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #e8e8f2;
+}
+.ask-panel-scope {
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: rgba(220, 220, 240, 0.55);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 9999px;
+  padding: 2px 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+.ask-panel-close {
+  background: none;
+  border: none;
+  color: rgba(220, 220, 240, 0.55);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 4px;
+}
+.ask-panel-close:hover { color: #fff; }
+
+.ask-panel-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ask-panel-messages.slash-dimmed { opacity: 0.35; }
+.ask-panel-messages::-webkit-scrollbar { width: 8px; }
+.ask-panel-messages::-webkit-scrollbar-track { background: transparent; }
+.ask-panel-messages::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+}
+.ask-panel-messages::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.2); }
+
+.ask-panel-inputrow {
+  position: relative; /* anchors .slash-autocomplete */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  flex: none;
+}
+```
+
+Check `.slash-autocomplete`'s existing positioning: it floated above the bottom bar (likely `position:absolute; bottom:…`). With `.ask-panel-inputrow { position: relative }` as its anchor it should sit above the input inside the panel — verify visually and adjust its `left/right/bottom` offsets to fit the panel width if needed (e.g. `left: 8px; right: 8px; bottom: calc(100% + 6px);`).
+
+- [ ] **Step 7: Verify** — `cd web && npx tsc -b && npm run lint` (tsc clean; zero NEW lint errors). `grep -rn "ChatBar\|chatInputRef\|onOpenTerminal\|hardcore" web/src --include="*.tsx" --include="*.ts"` → only `windows.ts`'s reducer (allowed) and nothing else.
+
+- [ ] **Step 8: Manual check** — dev server: bottom bar gone (pages reclaim the space); `✦ Ask` pill next to `+ New session`; click opens slide-over with header/chip("everything")/✕; send a message → thread renders, streaming works; slash commands + autocomplete work inside the panel; `#1` switches space; close+reopen panel → thread intact; typing on the page does NOT focus anything; no ⚡ anywhere.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A web/src
+git commit -m "ask: ChatBar becomes the Ask Oyster slide-over panel"
+git log --oneline -1
+```
+
+---
+
+### Task 2: Real scope inheritance — chip + context prefix
+
+**Files:**
+- Modify: `web/src/App.tsx`, `web/src/components/AskPanel.tsx`
+
+- [ ] **Step 1: Compute scope in App**
+
+(a) Import the sentinel: `import { VAULT } from "./components/Home/types";`
+
+(b) The projects list: change `const { projects: allProjects, loading: allProjectsLoading } = useAllProjects(pickerOpen);` to enable when the panel is open too: `useAllProjects(pickerOpen || askOpen);`
+
+(c) Below `activeProjectId`/`askOpen` declarations:
+
+```ts
+  // Scope label + outbound-context line for the Ask panel. Label mirrors the
+  // Home crumb shapes; context is what the agent actually reads — omitted at
+  // "everything" so unscoped chats stay clean.
+  const askScope = useMemo((): { label: string; context: string | null } => {
+    if (activeProjectId === VAULT) {
+      return {
+        label: "vault",
+        context: `[Scope: the user is viewing the Vault — artefacts created in Oyster itself, not tied to a repo.]`,
+      };
+    }
+    const project = activeProjectId ? allProjects.find((p) => p.id === activeProjectId) ?? null : null;
+    const spaceId = project?.spaceId ?? (activeSpace !== "home" && activeSpace !== "__all__" && activeSpace !== "__archived__" ? activeSpace : null);
+    const spaceName = spaceId ? spaces.find((s) => s.id === spaceId)?.displayName ?? spaceId : null;
+    if (project) {
+      return {
+        label: `${spaceName ? spaceName + " › " : ""}${project.name}`,
+        context: `[Scope: ${spaceName ? `space "${spaceName}", ` : ""}project "${project.name}"${project.recentPath ? ` at ${project.recentPath}` : ""}.]`,
+      };
+    }
+    if (spaceName) {
+      return { label: spaceName, context: `[Scope: space "${spaceName}".]` };
+    }
+    return { label: "everything", context: null };
+  }, [activeProjectId, activeSpace, allProjects, spaces]);
+```
+
+(If `Project` has no `recentPath` field, check `web/src/data/all-projects.ts` for the actual field name and use it; omit the path clause if absent.)
+
+(d) Wire it: `scopeLabel={askScope.label}` and `scopeContext={askScope.context}` on `<AskPanel>` (replacing the Task 1 placeholders).
+
+- [ ] **Step 2: Prefix outbound messages in AskPanel**
+
+In `handleSend`, the non-command path currently does:
+
+```ts
+    setInput("");
+    setMessages((prev) => [...prev, { role: "user", content }]);
+    …
+    await sendMessage(sessionId, content);
+```
+
+Change ONLY the `sendMessage` line:
+
+```ts
+      // Scope context rides ahead of the user's text so the agent's MCP
+      // tools act where the user is looking. The displayed bubble stays raw.
+      await sendMessage(sessionId, scopeContext ? `${scopeContext}\n\n${content}` : content);
+```
+
+`scopeContext` must be added to the `handleSend` useCallback dep array. Slash/`#` commands are untouched (they return before this line and never reach the AI). The queued-prompt drain and `oyster:send-prompt` paths route through `handleSend`, so they inherit the prefix automatically.
+
+- [ ] **Step 3: Verify** — tsc + lint clean. Manual: scope to a project, open panel → chip shows `space › project`; send "what is this project?" → answer reflects the project (and the visible bubble shows only your text); switch to Home unscoped → chip "everything", sends carry no prefix (verify via the agent's view or a quick `console.log` removed before commit — or trust the code path).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/App.tsx web/src/components/AskPanel.tsx
+git commit -m "ask: panel inherits the active scope (chip + outbound context line)"
+```
+
+---
+
+### Task 3: Onboarding send-prompt opens the panel
+
+**Files:**
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1:** AskPanel's existing `oyster:send-prompt` listener sends the text, but the panel may be closed. App opens it — add near the other App-level effects:
+
+```ts
+  // OnboardingDock's "Set up Oyster" (and any oyster:send-prompt dispatcher)
+  // lands in the Ask panel — make sure the panel is visible when it does.
+  useEffect(() => {
+    const handler = () => setAskOpen(true);
+    window.addEventListener("oyster:send-prompt", handler);
+    return () => window.removeEventListener("oyster:send-prompt", handler);
+  }, []);
+```
+
+- [ ] **Step 2: Verify** — tsc + lint. Manual: trigger the OnboardingDock setup step (or `window.dispatchEvent(new CustomEvent("oyster:send-prompt", { detail: { text: "hello" } }))` from devtools) → panel opens and the message sends (including during the session-boot window — the pending-prompt queue inside AskPanel covers that, unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/App.tsx
+git commit -m "ask: open the panel when a cross-component prompt arrives"
+```
+
+---
+
+### Task 4: Changelog + docs + full build
+
+**Files:**
+- Modify: `CHANGELOG.md`, `CLAUDE.md`
+
+- [ ] **Step 1: Changelog** — read the head of CHANGELOG.md first; merge into the existing `[Unreleased]` sections (Keep-a-Changelog style, user-facing only):
+
+```md
+### Changed
+- **Ask Oyster moves to a side panel** — chat now opens from the ✦ Ask button in the top bar and slides in beside your work, instead of a bar pinned to the bottom of every page. It knows which space and project you're looking at.
+
+### Removed
+- **Bottom chat bar** — and with it, typing-anywhere-to-chat and the ⚡ terminal shortcut.
+```
+
+(If the file has no `### Removed` section precedent under Unreleased, fold the second bullet into Changed.)
+
+- [ ] **Step 2: CLAUDE.md touch-up** — two stale lines: "Navigated via pills at the bottom of the chat bar, or via `#space` / `/s space` commands" → "Navigated via pills in the top bar, or via `#space` / `/s space` commands in the Ask panel"; and the Key Files entry "`web/src/components/ChatBar.tsx` — chat input, slash commands, space pills" → "`web/src/components/AskPanel.tsx` — Ask Oyster panel: chat input, slash commands, message thread".
+
+- [ ] **Step 3: Full build** — root `npm run build` (web tsc + vite + server tsc all pass); `cd web && npm run lint` (baseline only).
+
+- [ ] **Step 4: Final manual sweep** — Home → space → project → open panel (chip correct at each scope) → send → close/reopen (thread intact) → `/o`, `/p`, `#1` from the panel → provider-fallback state (if testable) → `/session/<id>` URL appears on first message → no bottom bar on any view → viewer fix-error flow still posts (uses chat-api directly).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md CLAUDE.md
+git commit -m "changelog+docs: Ask Oyster side panel"
+```
+
+---
+
+## Out of scope (per spec)
+
+- PR 3: SpotlightSearch "ask" row.
+- Server-side session scoping; VAULT scope type; `selectedCwd` URL form.
+- `windows.ts` OPEN_TERMINAL reducer machinery (entry points removed; reducer untouched).

--- a/docs/superpowers/specs/2026-06-05-ask-oyster-panel-design.md
+++ b/docs/superpowers/specs/2026-06-05-ask-oyster-panel-design.md
@@ -1,0 +1,87 @@
+# Ask Oyster panel — design (PR 2 of unified scope UX)
+
+**Status:** Approved · 2026-06-05 · branch `ask-oyster-panel`
+
+## Goal
+
+Chat stops taking centre stage. The bottom ChatBar is removed; its input,
+slash commands, and message thread move into a right-hand **slide-over
+panel** opened from a `✦ Ask` button in the topbar. The panel inherits the
+user's current scope and tells the agent about it.
+
+Parent spec: `2026-06-05-unified-scope-ux-design.md` ("Ask Oyster" section —
+option A, panel now, palette launcher later).
+
+## Current state (verified)
+
+- `web/src/components/ChatBar.tsx` already renders the full conversation
+  inside itself (expands upward): bubbles, markdown (marked + DOMPurify),
+  tool/reasoning blocks, question options, copy button, slash autocomplete.
+  This PR is relocation, not a new chat UI.
+- Slash commands: `/s` switch space, `/o` open artifact, `/p` publish,
+  `/u` unpublish, `#space` quick-switch (+ positional `#N` variants).
+- Chat sessions are **unscoped**: `createSession()`/`sendMessage()` carry no
+  space/project; the agent doesn't know where the user is.
+- App couplings: global "any printable key focuses chat" handler
+  (`chatInputRef`), `onOpenTerminal` → hardcore-gate modal, `onAiError`
+  banner, provider-status fallback, OnboardingDock's `oyster:send-prompt`
+  event, `/session/<id>` URL push on first message (`useChatSession`).
+
+## Design
+
+### AskPanel
+
+New `web/src/components/AskPanel/` slide-over, right-hand side:
+
+- **Header:** `✦ Ask Oyster` · scope chip · ✕ close.
+- **Body:** ChatBar's message feed, moved (markdown, tool/reasoning blocks,
+  question options, copy chat, auto-scroll).
+- **Footer:** ChatBar's input, moved (slash commands, autocomplete,
+  keyboard navigation, placeholder rotation, provider-status fallback).
+- Conversation state survives close/reopen within the session (panel
+  unmount must not drop the thread — state lives in the panel's hook or
+  is lifted, decided at plan time).
+
+### Entry point
+
+One `✦ Ask` button in the topbar cluster next to `+ New session`. The only
+way in. Toggles the panel.
+
+### Scope inheritance (real)
+
+- Chip in the panel header reuses the unified-scope crumb shapes
+  (`everything` / space / `space › project` / `vault`).
+- Each sent message gets a client-side context prefix, e.g.
+  `[Scope: space "tokinvest", project "tokinvest-client-portal" at ~/Dev/tokinvest-client-portal]`
+  so the agent's MCP tools act in context. Omitted at `everything` scope.
+- No server or chat-API changes.
+
+### Removed
+
+- The bottom ChatBar render in App + ChatBar-specific fixed-bottom CSS
+  (~140 lines in App.css). Pages reclaim the bottom space.
+- The global "any printable key focuses chat" handler.
+- The ⚡ terminal button. If the hardcore-gate modal then has no caller,
+  it and `handleOpenTerminal`/`confirmHardcore` are deleted too (plan
+  verifies no other entry point exists).
+
+### Kept working
+
+- OnboardingDock's `oyster:send-prompt` → opens the panel and sends there.
+- AI-error surfacing and provider-status fallback move into the panel.
+- `/session/<id>` URL push on first message — unchanged behaviour, new home.
+- ViewerWindow's fix-error flow (uses chat-api directly; unaffected).
+
+## Out of scope
+
+- PR 3: "ask" row in SpotlightSearch (⌘K) opening the panel pre-filled.
+- Server-side session scoping (API-level spaceId/projectId).
+- VAULT-sentinel scope type and `selectedCwd`-in-URL seams (deferred from
+  PR 1 reviews; revisit when scope grows another consumer).
+
+## Decisions log
+
+- Type-anywhere-focuses-chat: **retired** (Matthew, 2026-06-05).
+- ⚡ terminal escape hatch: **removed** (Matthew, 2026-06-05).
+- Scope inheritance depth: **context prefix**, not display-only and not
+  API-level (Matthew, 2026-06-05).

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -654,7 +654,7 @@ body {
   box-shadow: -18px 0 48px rgba(0, 0, 0, 0.5);
   transform: translateX(102%);
   transition: transform 0.22s ease;
-  z-index: 200;
+  z-index: 5200;
 }
 .ask-panel.open { transform: translateX(0); }
 

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -632,25 +632,95 @@ body {
   to { transform: scale(1); opacity: 1; }
 }
 
-/* ── ChatBar ── */
-.chatbar-wrapper {
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── Ask Oyster slide-over panel ── */
+.ask-panel {
   position: fixed;
-  bottom: 16px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 640px;
-  max-width: calc(100% - 40px);
-  z-index: 90;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 420px;
+  max-width: 92vw;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  background: rgba(13, 14, 26, 0.97);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: -18px 0 48px rgba(0, 0, 0, 0.5);
+  transform: translateX(102%);
+  transition: transform 0.22s ease;
+  z-index: 200;
 }
+.ask-panel.open { transform: translateX(0); }
 
-/* Smooth transition back to bottom when artifacts appear */
-.chatbar-wrapper {
-  transition: bottom 0.5s ease, transform 0.5s ease, width 0.5s ease;
+.ask-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  flex: none;
 }
+.ask-panel-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #e8e8f2;
+}
+.ask-panel-scope {
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: rgba(220, 220, 240, 0.55);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 9999px;
+  padding: 2px 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+.ask-panel-close {
+  background: none;
+  border: none;
+  color: rgba(220, 220, 240, 0.55);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px 4px;
+}
+.ask-panel-close:hover { color: #fff; }
 
+.ask-panel-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ask-panel-messages.slash-dimmed { opacity: 0.35; }
+.ask-panel-messages::-webkit-scrollbar { width: 8px; }
+.ask-panel-messages::-webkit-scrollbar-track { background: transparent; }
+.ask-panel-messages::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+}
+.ask-panel-messages::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.2); }
+
+.ask-panel-inputrow {
+  position: relative; /* anchors .slash-autocomplete */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  flex: none;
+}
 
 .slash-autocomplete {
   position: absolute;
@@ -690,16 +760,6 @@ body {
   background: rgba(255, 255, 255, 0.08);
 }
 
-.chatbar-messages {
-  transition: opacity 0.2s ease, filter 0.2s ease;
-}
-
-.chatbar-messages.slash-dimmed {
-  opacity: 0.25;
-  pointer-events: none;
-  filter: blur(2px);
-}
-
 .slash-cmd {
   color: var(--accent);
   font-weight: 600;
@@ -714,43 +774,6 @@ body {
   color: rgba(255, 255, 255, 0.5);
   margin-left: auto;
   font-size: 12px;
-}
-
-.chatbar-bar {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
-  background: rgba(13, 14, 26, 0.9);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 9999px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  transition: padding 0.5s ease, gap 0.5s ease, border-color 0.5s ease;
-}
-
-.chatbar-oyster {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  background: var(--accent);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  flex-shrink: 0;
-  color: #fff;
-  transition: background 0.15s, transform 0.1s, width 0.5s ease, height 0.5s ease;
-}
-
-.chatbar-oyster:hover {
-  background: #6558d9;
-}
-
-.chatbar-oyster:active {
-  transform: scale(0.95);
 }
 
 .chatbar-input {
@@ -807,77 +830,6 @@ body {
   animation: pulse 1.5s ease-in-out infinite;
 }
 
-/* Chat messages panel */
-.chatbar-messages {
-  background: rgba(13, 14, 26, 0.7);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  margin-bottom: 8px;
-  padding: 20px;
-  max-height: 50vh;
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  position: relative;
-  transition: opacity 0.25s ease, transform 0.25s ease, max-height 0.3s ease;
-  transform-origin: bottom center;
-  -webkit-user-select: text;
-  user-select: text;
-  cursor: text;
-}
-
-.chatbar-messages::-webkit-scrollbar { width: 8px; }
-.chatbar-messages::-webkit-scrollbar-track { background: transparent; }
-.chatbar-messages::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.12);
-  border-radius: 4px;
-}
-.chatbar-messages::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.22);
-}
-
-.chatbar-messages.chat-expanded {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-  pointer-events: auto;
-}
-
-.chatbar-messages.chat-collapsed {
-  opacity: 0;
-  transform: translateY(12px) scale(0.97);
-  max-height: 0;
-  padding: 0 20px;
-  margin-bottom: 0;
-  overflow: hidden;
-  pointer-events: none;
-  border-color: transparent;
-  box-shadow: none;
-}
-
-.chatbar-collapse {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 0.75rem;
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  transition: color 0.15s;
-}
-
-.chatbar-collapse:hover {
-  color: var(--text);
-}
-
 .chatbar-actions {
   position: sticky;
   top: 0;
@@ -888,12 +840,7 @@ body {
   padding-bottom: 4px;
 }
 
-.chatbar-actions .chatbar-collapse {
-  position: static;
-}
-
-.chatbar-copy,
-.chatbar-actions .chatbar-collapse {
+.chatbar-copy {
   background: rgba(13, 14, 26, 0.8);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -906,8 +853,7 @@ body {
   transition: color 0.15s, background 0.15s;
 }
 
-.chatbar-copy:hover,
-.chatbar-actions .chatbar-collapse:hover {
+.chatbar-copy:hover {
   color: var(--text);
   background: rgba(255, 255, 255, 0.1);
 }
@@ -1894,119 +1840,6 @@ body {
   margin-left: auto;
   font-size: 11px;
   color: #6e7280;
-}
-
-/* ── Hardcore Gate Modal ── */
-
-.hardcore-gate-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(12px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  animation: fadeIn 0.25s ease;
-}
-
-.hardcore-gate {
-  background: rgba(22, 23, 42, 0.97);
-  border: none;
-  border-radius: 16px;
-  padding: 36px 36px 32px;
-  max-width: 340px;
-  text-align: center;
-  animation: gateSlideUp 0.35s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.hardcore-gate-icon {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 16px;
-}
-
-.hardcore-glow {
-  position: absolute;
-  width: 70px;
-  height: 70px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(33, 185, 129, 0.25), transparent 70%);
-  animation: glowPulse 2.5s ease-in-out infinite;
-}
-
-@keyframes glowPulse {
-  0%, 100% { opacity: 0.4; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.15); }
-}
-
-.hardcore-title {
-  font-family: var(--font-body);
-  font-weight: 600;
-  font-size: 20px;
-  margin: 0 0 10px;
-  letter-spacing: -0.02em;
-  color: var(--text);
-}
-
-.hardcore-gate p {
-  font-family: var(--font-body);
-  font-size: 14px;
-  color: var(--text-dim);
-  line-height: 1.6;
-  margin: 0 0 32px;
-}
-
-.hardcore-gate-actions {
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-}
-
-.hardcore-cancel {
-  font-family: var(--font-body);
-  font-size: 14px;
-  padding: 10px 24px;
-  border-radius: 999px;
-  border: none;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-dim);
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.hardcore-cancel:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: var(--text);
-}
-
-.hardcore-confirm {
-  font-family: var(--font-body);
-  font-size: 14px;
-  font-weight: 500;
-  padding: 10px 28px;
-  border-radius: 999px;
-  border: none;
-  background: var(--accent);
-  color: #ffffff;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.hardcore-confirm:hover {
-  filter: brightness(1.1);
-}
-
-@keyframes gateSlideUp {
-  from { opacity: 0; transform: translateY(16px) scale(0.97); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
 }
 
 /* ── Artifact error screen ── */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -279,8 +279,13 @@ export default function App() {
     function handlePopState() {
       // /session/<id> URLs carry no space/project — landing on one via
       // back/forward must not stomp the active scope (the thread that
-      // pushed it is still about wherever the user was).
-      if (window.location.pathname.startsWith("/session/")) return;
+      // pushed it is still about wherever the user was). It must, however,
+      // show the thread the URL refers to (mirrors the initial-load seed).
+      if (window.location.pathname.startsWith("/session/")) {
+        setAskOpen(true);
+        setAskEverOpened(true);
+        return;
+      }
       const { space, artifactId, groupName, projectId } = getUrlState();
       setActiveSpace(space);
       setActiveProjectId(projectId);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
         e.preventDefault();
         setSpotlightOpen((v) => !v);
       }
-      if (e.key === "Escape") setSpotlightOpen(false);
+      if (e.key === "Escape") { setSpotlightOpen(false); setAskOpen(false); }
     }
     document.addEventListener("keydown", handleKeyDown);
     // Prevent browser from opening dropped files/folders (but allow text drops)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Home } from "./components/Home";
 import { GroupPopup } from "./components/GroupPopup";
 import { AskPanel } from "./components/AskPanel";
@@ -27,6 +27,7 @@ import { recordRecentProjectId } from "./lib/new-session-recents";
 import { useSessions } from "./hooks/useSessions";
 import { NewSessionPicker } from "./components/NewSessionPicker";
 import { useAllProjects, fetchAllProjects } from "./data/all-projects";
+import { VAULT } from "./components/Home/types";
 import "./App.css";
 
 // `?onboarding=force` wipes the dock's persisted state and pretends this
@@ -352,7 +353,32 @@ export default function App() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerError, setPickerError] = useState<string | null>(null);
   const [initialPickerQuery, setInitialPickerQuery] = useState<string | undefined>(undefined);
-  const { projects: allProjects, loading: allProjectsLoading } = useAllProjects(pickerOpen);
+  const { projects: allProjects, loading: allProjectsLoading } = useAllProjects(pickerOpen || askOpen);
+
+  // Scope label + outbound-context line for the Ask panel. Label mirrors the
+  // Home crumb shapes; context is what the agent actually reads — omitted at
+  // "everything" so unscoped chats stay clean.
+  const askScope = useMemo((): { label: string; context: string | null } => {
+    if (activeProjectId === VAULT) {
+      return {
+        label: "vault",
+        context: `[Scope: the user is viewing the Vault — artefacts created in Oyster itself, not tied to a repo.]`,
+      };
+    }
+    const project = activeProjectId ? allProjects.find((p) => p.id === activeProjectId) ?? null : null;
+    const spaceId = project?.spaceId ?? (activeSpace !== "home" && activeSpace !== "__all__" && activeSpace !== "__archived__" ? activeSpace : null);
+    const spaceName = spaceId ? spaces.find((s) => s.id === spaceId)?.displayName ?? spaceId : null;
+    if (project) {
+      return {
+        label: `${spaceName ? spaceName + " › " : ""}${project.name}`,
+        context: `[Scope: ${spaceName ? `space "${spaceName}", ` : ""}project "${project.name}"${project.recentPath ? ` at ${project.recentPath}` : ""}.]`,
+      };
+    }
+    if (spaceName) {
+      return { label: spaceName, context: `[Scope: space "${spaceName}".]` };
+    }
+    return { label: "everything", context: null };
+  }, [activeProjectId, activeSpace, allProjects, spaces]);
 
   // Shared spawn path used by NewSessionPicker — same as
   // handleLaunchClaudeFromProject but renders errors in-modal instead
@@ -835,8 +861,8 @@ export default function App() {
       <AskPanel
         open={askOpen}
         onClose={() => setAskOpen(false)}
-        scopeLabel="everything"
-        scopeContext={null}
+        scopeLabel={askScope.label}
+        scopeContext={askScope.context}
         spaces={spaces}
         activeSpace={activeSpace}
         onSpaceChange={handleSpaceChange}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -83,7 +83,10 @@ export default function App() {
   }, [activeSpace]);
 
   const [spotlightOpen, setSpotlightOpen] = useState(false);
-  const [askOpen, setAskOpen] = useState(false);
+  // Open on /session/<id> loads: useChatSession restores that conversation
+  // into the panel, so the panel must be visible for the restore to mean
+  // anything ("refresh reloads this conversation").
+  const [askOpen, setAskOpen] = useState(() => window.location.pathname.startsWith("/session/"));
 
   // OnboardingDock's "Set up Oyster" (and any oyster:send-prompt dispatcher)
   // lands in the Ask panel — make sure the panel is visible when it does.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { Home } from "./components/Home";
 import { GroupPopup } from "./components/GroupPopup";
-import { ChatBar } from "./components/ChatBar";
+import { AskPanel } from "./components/AskPanel";
 import { PublishModal } from "./components/PublishModal";
 import { ViewerWindow } from "./components/ViewerWindow";
 import { TerminalWindow } from "./components/TerminalWindow";
@@ -82,9 +82,9 @@ export default function App() {
   }, [activeSpace]);
 
   const [spotlightOpen, setSpotlightOpen] = useState(false);
+  const [askOpen, setAskOpen] = useState(false);
 
   // Global keyboard shortcuts
-  const chatInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -92,12 +92,6 @@ export default function App() {
         setSpotlightOpen((v) => !v);
       }
       if (e.key === "Escape") setSpotlightOpen(false);
-      // Any printable key focuses chat bar when not already in an input
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "BUTTON" && !e.metaKey && !e.ctrlKey && !e.altKey && e.key.length === 1) {
-        chatInputRef.current?.focus();
-        // Don't preventDefault — let the character appear in the input
-      }
     }
     document.addEventListener("keydown", handleKeyDown);
     // Prevent browser from opening dropped files/folders (but allow text drops)
@@ -121,7 +115,6 @@ export default function App() {
   }, []);
   const [, setLoaded] = useState(false);
   const [revealId, setRevealId] = useState<string | null>(null);
-  const [showHardcoreGate, setShowHardcoreGate] = useState(false);
   const [openGroup, setOpenGroup] = useState<string | null>(() => getUrlState().groupName);
   // Auto-close the group popup when the group goes empty (e.g. the user
   // archived the last artifact from within it). Without this, the popup
@@ -475,21 +468,6 @@ export default function App() {
     }
   }
 
-  function handleOpenTerminal() {
-    const seen = localStorage.getItem("oyster-hardcore-seen");
-    if (!seen) {
-      setShowHardcoreGate(true);
-      return;
-    }
-    dispatch({ type: "OPEN_TERMINAL" });
-  }
-
-  function confirmHardcore() {
-    localStorage.setItem("oyster-hardcore-seen", "1");
-    setShowHardcoreGate(false);
-    dispatch({ type: "OPEN_TERMINAL" });
-  }
-
   async function handleArtifactStop(artifact: Artifact) {
     const appName = artifact.id.replace("app:", "");
     await stopAppApi(appName);
@@ -567,7 +545,6 @@ export default function App() {
     [],
   );
 
-  // T16-T18 will pass this to Desktop, ViewerWindow, and ChatBar.
   const handleArtifactPublish = useCallback((artifact: Artifact) => {
     if (artifact.builtin || artifact.plugin || artifact.status === "generating") return;
     setPublishingArtifact(artifact);
@@ -675,6 +652,7 @@ export default function App() {
           if (w) dispatch({ type: "CLOSE", id: w.id });
         }}
         onOpenNewSession={handleOpenNewSession}
+        onOpenAsk={() => setAskOpen(true)}
         onConnectSession={handleConnectSession}
         userSpaceCount={FORCE_ONBOARDING ? 0 : spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__").length}
         publishedCount={FORCE_ONBOARDING ? 0 : artifacts.filter((a) => a.publication != null && a.publication.unpublishedAt == null).length}
@@ -820,31 +798,6 @@ export default function App() {
         })}
       </div>
 
-      {showHardcoreGate && (
-        <div className="hardcore-gate-overlay" onClick={() => setShowHardcoreGate(false)}>
-          <div className="hardcore-gate" onClick={(e) => e.stopPropagation()}>
-            <div className="hardcore-gate-icon">
-              <div className="hardcore-glow" />
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none">
-                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" fill="url(#bolt-grad)" />
-                <defs>
-                  <linearGradient id="bolt-grad" x1="3" y1="2" x2="20" y2="22">
-                    <stop offset="0%" stopColor="#7c6bff" />
-                    <stop offset="100%" stopColor="#6366f1" />
-                  </linearGradient>
-                </defs>
-              </svg>
-            </div>
-            <h2 className="hardcore-title">Ultra Hardcore</h2>
-            <p>This opens the shell. You're talking directly to the engine — no guardrails, no undo, full control.</p>
-            <div className="hardcore-gate-actions">
-              <button className="hardcore-cancel" onClick={() => setShowHardcoreGate(false)}>I'll pass</button>
-              <button className="hardcore-confirm" onClick={confirmHardcore}>Game on</button>
-            </div>
-          </div>
-        </div>
-      )}
-
       {publishingArtifact && (() => {
         const fresh = artifacts.find((a) => a.id === publishingArtifact.id) ?? publishingArtifact;
         return <PublishModal artifact={fresh} onClose={() => setPublishingArtifact(null)} />;
@@ -879,12 +832,14 @@ export default function App() {
         );
       })()}
 
-      <ChatBar
-        onOpenTerminal={handleOpenTerminal}
+      <AskPanel
+        open={askOpen}
+        onClose={() => setAskOpen(false)}
+        scopeLabel="everything"
+        scopeContext={null}
         spaces={spaces}
         activeSpace={activeSpace}
         onSpaceChange={handleSpaceChange}
-        inputRef={chatInputRef}
         artifacts={artifacts}
         onArtifactOpen={handleArtifactClick}
         onArtifactPublish={handleArtifactPublish}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,6 +85,15 @@ export default function App() {
   const [spotlightOpen, setSpotlightOpen] = useState(false);
   const [askOpen, setAskOpen] = useState(false);
 
+  // OnboardingDock's "Set up Oyster" (and any oyster:send-prompt dispatcher)
+  // lands in the Ask panel — make sure the panel is visible when it does.
+  // AskPanel's own listener handles the actual send.
+  useEffect(() => {
+    const handler = () => setAskOpen(true);
+    window.addEventListener("oyster:send-prompt", handler);
+    return () => window.removeEventListener("oyster:send-prompt", handler);
+  }, []);
+
   // Global keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -87,12 +87,16 @@ export default function App() {
   // into the panel, so the panel must be visible for the restore to mean
   // anything ("refresh reloads this conversation").
   const [askOpen, setAskOpen] = useState(() => window.location.pathname.startsWith("/session/"));
+  // Latch: once the panel has opened, keep the projects list warm — the
+  // useFetched-backed hook resets to [] on disable, which would blank the
+  // scope chip/context for a beat on every reopen.
+  const [askEverOpened, setAskEverOpened] = useState(() => window.location.pathname.startsWith("/session/"));
 
   // OnboardingDock's "Set up Oyster" (and any oyster:send-prompt dispatcher)
   // lands in the Ask panel — make sure the panel is visible when it does.
   // AskPanel's own listener handles the actual send.
   useEffect(() => {
-    const handler = () => setAskOpen(true);
+    const handler = () => { setAskOpen(true); setAskEverOpened(true); };
     window.addEventListener("oyster:send-prompt", handler);
     return () => window.removeEventListener("oyster:send-prompt", handler);
   }, []);
@@ -273,6 +277,10 @@ export default function App() {
   // Sync state from browser back/forward
   useEffect(() => {
     function handlePopState() {
+      // /session/<id> URLs carry no space/project — landing on one via
+      // back/forward must not stomp the active scope (the thread that
+      // pushed it is still about wherever the user was).
+      if (window.location.pathname.startsWith("/session/")) return;
       const { space, artifactId, groupName, projectId } = getUrlState();
       setActiveSpace(space);
       setActiveProjectId(projectId);
@@ -351,12 +359,10 @@ export default function App() {
 
 
   const viewers = windows.filter((w) => w.type === "viewer");
-  const terminalWindow = windows.find((w) => w.type === "terminal");
   const claudeTerminals = windows.filter((w) => w.type === "claude_terminal");
   // Tabs in the fullscreen terminal toolbar list every open terminal so
   // the user can switch without leaving fullscreen.
   const liveTerminals: Array<{ id: string; title: string }> = [
-    ...(terminalWindow ? [{ id: terminalWindow.id, title: terminalWindow.title || "opencode" }] : []),
     ...claudeTerminals.map((t) => ({ id: t.id, title: t.title || "claude" })),
   ];
 
@@ -365,12 +371,15 @@ export default function App() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerError, setPickerError] = useState<string | null>(null);
   const [initialPickerQuery, setInitialPickerQuery] = useState<string | undefined>(undefined);
-  const { projects: allProjects, loading: allProjectsLoading } = useAllProjects(pickerOpen || askOpen);
+  const { projects: allProjects, loading: allProjectsLoading } = useAllProjects(pickerOpen || askOpen || askEverOpened);
 
   // Scope label + outbound-context line for the Ask panel. Label mirrors the
   // Home crumb shapes; context is what the agent actually reads — omitted at
   // "everything" so unscoped chats stay clean.
   const askScope = useMemo((): { label: string; context: string | null } => {
+    if (activeSpace === "__archived__") {
+      return { label: "archived", context: "[Scope: the user is browsing archived artefacts.]" };
+    }
     if (activeProjectId === VAULT) {
       return {
         label: "vault",
@@ -690,7 +699,7 @@ export default function App() {
           if (w) dispatch({ type: "CLOSE", id: w.id });
         }}
         onOpenNewSession={handleOpenNewSession}
-        onOpenAsk={() => setAskOpen(true)}
+        onOpenAsk={() => { setAskOpen(true); setAskEverOpened(true); }}
         onConnectSession={handleConnectSession}
         userSpaceCount={FORCE_ONBOARDING ? 0 : spaces.filter((s) => s.id !== "home" && s.id !== "__all__" && s.id !== "__archived__").length}
         publishedCount={FORCE_ONBOARDING ? 0 : artifacts.filter((a) => a.publication != null && a.publication.unpublishedAt == null).length}
@@ -778,21 +787,6 @@ export default function App() {
             />
           );
         })}
-        {terminalWindow && (
-          <TerminalWindow
-            key={terminalWindow.id}
-            id={terminalWindow.id}
-            defaultX={120}
-            defaultY={60}
-            zIndex={terminalWindow.zIndex}
-            onFocus={() => dispatch({ type: "FOCUS", id: terminalWindow.id })}
-            onClose={() => dispatch({ type: "MINIMISE", id: terminalWindow.id })}
-            fullscreen={terminalWindow.fullscreen}
-            onToggleFullscreen={() => dispatch({ type: "TOGGLE_FULLSCREEN", id: terminalWindow.id })}
-            liveTerminals={liveTerminals}
-            onSwitchTerminal={(targetId) => dispatch({ type: "SWITCH_FULLSCREEN_TERMINAL", id: targetId })}
-          />
-        )}
         {claudeTerminals.map((w, i) => {
           // PTY alive iff some session row reports this terminalId as live.
           // After Stop / natural exit / cross-tab kill, the server clears
@@ -870,6 +864,9 @@ export default function App() {
         );
       })()}
 
+      {/* Always mounted: the thread + SSE stream live in the panel's hooks,
+          and its oyster:send-prompt listener must exist before the panel is
+          opened. Conditional mounting would lose both. */}
       <AskPanel
         open={askOpen}
         onClose={() => setAskOpen(false)}

--- a/web/src/components/AskPanel.tsx
+++ b/web/src/components/AskPanel.tsx
@@ -94,7 +94,7 @@ interface Props {
   onAiError?: (message: string | null) => void;
 }
 
-export function AskPanel({ open, onClose, scopeLabel, spaces = [], activeSpace, onSpaceChange, artifacts = [], onArtifactOpen, onArtifactPublish, onArtifactUnpublish, onAiError }: Props) {
+export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [], activeSpace, onSpaceChange, artifacts = [], onArtifactOpen, onArtifactPublish, onArtifactUnpublish, onAiError }: Props) {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [statusText, setStatusText] = useState("");
@@ -410,7 +410,9 @@ export function AskPanel({ open, onClose, scopeLabel, spaces = [], activeSpace, 
     resetTracking();
 
     try {
-      await sendMessage(sessionId, content);
+      // Scope context rides ahead of the user's text so the agent's MCP
+      // tools act where the user is looking. The displayed bubble stays raw.
+      await sendMessage(sessionId, scopeContext ? `${scopeContext}\n\n${content}` : content);
     } catch (err) {
       console.error("Failed to send message:", err);
       setStreaming(false);
@@ -420,7 +422,7 @@ export function AskPanel({ open, onClose, scopeLabel, spaces = [], activeSpace, 
         : "Can't reach Oyster — check that the server is running";
       onAiError?.(msg);
     }
-  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts, onArtifactUnpublish, livePublications]);
+  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts, onArtifactUnpublish, livePublications, scopeContext]);
 
   // Drain any queued prompt as soon as the session is ready AND nothing
   // is streaming. handleSend's other guard is `streaming`; if we drained

--- a/web/src/components/AskPanel.tsx
+++ b/web/src/components/AskPanel.tsx
@@ -78,11 +78,15 @@ const SLASH_COMMANDS = [
 ];
 
 interface Props {
-  onOpenTerminal: () => void;
+  open: boolean;
+  onClose: () => void;
+  /** Crumb-shaped scope label for the header chip ("everything" / space / "space › project" / "vault"). */
+  scopeLabel: string;
+  /** Context line prepended to outbound messages; null at "everything" scope. (Wired in Task 2 — pass null until then.) */
+  scopeContext: string | null;
   spaces?: Space[];
   activeSpace?: string;
   onSpaceChange?: (space: string) => void;
-  inputRef?: React.RefObject<HTMLInputElement | null>;
   artifacts?: Artifact[];
   onArtifactOpen?: (artifact: Artifact) => void;
   onArtifactPublish?: (artifact: Artifact) => void;
@@ -90,16 +94,14 @@ interface Props {
   onAiError?: (message: string | null) => void;
 }
 
-export function ChatBar({ onOpenTerminal, spaces = [], activeSpace, onSpaceChange, inputRef: externalInputRef, artifacts = [], onArtifactOpen, onArtifactPublish, onArtifactUnpublish, onAiError }: Props) {
+export function AskPanel({ open, onClose, scopeLabel, spaces = [], activeSpace, onSpaceChange, artifacts = [], onArtifactOpen, onArtifactPublish, onArtifactUnpublish, onAiError }: Props) {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [statusText, setStatusText] = useState("");
   const [copied, setCopied] = useState(false);
   const [slashIndex, setSlashIndex] = useState(0);
   const bottomRef = useRef<HTMLDivElement>(null);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const localInputRef = useRef<HTMLInputElement>(null);
-  const inputRef = externalInputRef || localInputRef;
+  const inputRef = useRef<HTMLInputElement>(null);
   const [placeholder, setPlaceholder] = useState(() => placeholders[Math.floor(Math.random() * placeholders.length)]);
   const placeholderIndexRef = useRef(0);
   const [providerConfigured, setProviderConfigured] = useState<boolean | null>(null);
@@ -113,7 +115,7 @@ export function ChatBar({ onOpenTerminal, spaces = [], activeSpace, onSpaceChang
     return () => { cancelled = true; };
   }, []);
 
-  const { messages, setMessages, sessionId, expanded, setExpanded, pushSessionUrl } = useChatSession();
+  const { messages, setMessages, sessionId, setExpanded, pushSessionUrl } = useChatSession();
 
   // Compute slash autocomplete items
   const subseq = useCallback((query: string, target: string) => {
@@ -262,21 +264,10 @@ export function ChatBar({ onOpenTerminal, spaces = [], activeSpace, onSpaceChang
   }, [sessionId, onAiError]);
 
   useEffect(() => {
-    if (expanded) {
+    if (open) {
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
-  }, [messages, expanded]);
-
-  // Click outside chatbar collapses the messages panel
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (expanded && wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setExpanded(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [expanded, setExpanded]);
+  }, [messages, open]);
 
   // Queue for prompts dispatched before the chat session has finished
   // initialising. createSession() can take a few seconds while OpenCode
@@ -473,87 +464,84 @@ export function ChatBar({ onOpenTerminal, spaces = [], activeSpace, onSpaceChang
   }
 
   return (
-    <div ref={wrapperRef} className="chatbar-wrapper">
-      {/* Messages panel — expands upward */}
-      {messages.length > 0 && (
-        <div className={`chatbar-messages ${expanded ? "chat-expanded" : "chat-collapsed"}${slashOpen ? " slash-dimmed" : ""}`}>
-          <div className="chatbar-actions">
-            <button
-              className={`chatbar-copy ${copied ? "copied" : ""}`}
-              onClick={handleCopyChat}
-              title="Copy chat"
-            >
-              {copied ? "copied" : "copy"}
-            </button>
-            <button
-              className="chatbar-collapse"
-              onClick={() => setExpanded(false)}
-              title="Collapse"
-            >
-              ↓
-            </button>
-          </div>
-          {messages.filter((msg) => msg.content || msg.parts?.length || msg.question || msg.role === "user").map((msg, i) => (
-            <div key={msg.id || i} className={`chat-bubble ${msg.role}`}>
-              {msg.role === "assistant" && msg.parts && msg.parts.length > 0 ? (
-                msg.parts.map((part, pi) =>
-                  part.type === "text" && part.text ? (
-                    <div key={pi} className="chat-markdown" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(part.text) as string) }} />
-                  ) : part.type === "tool" && part.tool ? (
-                    <ToolBlock key={part.tool.id} tool={part.tool} />
-                  ) : part.type === "reasoning" && part.text ? (
-                    <ReasoningBlock key={pi} text={part.text} />
-                  ) : null
-                )
-              ) : msg.role === "assistant" && msg.content ? (
-                <div className="chat-markdown" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(msg.content) as string) }} />
-              ) : (
-                msg.content
-              )}
-              {msg.question && (
-                <div className="question-options">
-                  {msg.question.options.map((opt) => (
-                    <button
-                      key={opt.label}
-                      className="question-option-btn"
-                      onClick={async () => {
-                        const qId = msg.question!.id;
-                        setMessages((prev) =>
-                          prev.map((m) =>
-                            m.question?.id === qId
-                              ? { ...m, question: undefined }
-                              : m
-                          )
-                        );
-                        setMessages((prev) => [
-                          ...prev,
-                          { role: "user", content: opt.label },
-                        ]);
-                        setStreaming(true);
-                        setStatusText("thinking...");
-                        resetTracking();
-                        try {
-                          await replyToQuestion(qId, [[opt.label]]);
-                        } catch (err) {
-                          console.error("Failed to reply to question:", err);
-                          setStreaming(false);
-                          setStatusText("");
-                        }
-                      }}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
-          <div ref={bottomRef} />
-        </div>
-      )}
+    <div className={`ask-panel${open ? " open" : ""}`} aria-hidden={!open}>
+      <div className="ask-panel-header">
+        <span className="ask-panel-title">✦ Ask Oyster</span>
+        <span className="ask-panel-scope" title="Answers consider your current scope">{scopeLabel}</span>
+        <button type="button" className="ask-panel-close" onClick={onClose} aria-label="Close Ask Oyster">✕</button>
+      </div>
 
-      {/* Input bar */}
-      <div className="chatbar-bar" onClick={() => { if (messages.length > 0 && !expanded) setExpanded(true); }}>
+      {/* Messages feed — same inner markup as before, new container class */}
+      <div className={`ask-panel-messages${slashOpen ? " slash-dimmed" : ""}`}>
+        {messages.length > 0 && (
+          <>
+            <div className="chatbar-actions">
+              <button className={`chatbar-copy ${copied ? "copied" : ""}`} onClick={handleCopyChat} title="Copy chat">
+                {copied ? "copied" : "copy"}
+              </button>
+            </div>
+            {messages.filter((msg) => msg.content || msg.parts?.length || msg.question || msg.role === "user").map((msg, i) => (
+              <div key={msg.id || i} className={`chat-bubble ${msg.role}`}>
+                {msg.role === "assistant" && msg.parts && msg.parts.length > 0 ? (
+                  msg.parts.map((part, pi) =>
+                    part.type === "text" && part.text ? (
+                      <div key={pi} className="chat-markdown" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(part.text) as string) }} />
+                    ) : part.type === "tool" && part.tool ? (
+                      <ToolBlock key={part.tool.id} tool={part.tool} />
+                    ) : part.type === "reasoning" && part.text ? (
+                      <ReasoningBlock key={pi} text={part.text} />
+                    ) : null
+                  )
+                ) : msg.role === "assistant" && msg.content ? (
+                  <div className="chat-markdown" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(msg.content) as string) }} />
+                ) : (
+                  msg.content
+                )}
+                {msg.question && (
+                  <div className="question-options">
+                    {msg.question.options.map((opt) => (
+                      <button
+                        key={opt.label}
+                        className="question-option-btn"
+                        onClick={async () => {
+                          const qId = msg.question!.id;
+                          setMessages((prev) =>
+                            prev.map((m) =>
+                              m.question?.id === qId
+                                ? { ...m, question: undefined }
+                                : m
+                            )
+                          );
+                          setMessages((prev) => [
+                            ...prev,
+                            { role: "user", content: opt.label },
+                          ]);
+                          setStreaming(true);
+                          setStatusText("thinking...");
+                          resetTracking();
+                          try {
+                            await replyToQuestion(qId, [[opt.label]]);
+                          } catch (err) {
+                            console.error("Failed to reply to question:", err);
+                            setStreaming(false);
+                            setStatusText("");
+                          }
+                        }}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+            <div ref={bottomRef} />
+          </>
+        )}
+      </div>
+
+      {/* Input row — same inner markup as the old chatbar-bar, minus the bolt */}
+      <div className="ask-panel-inputrow">
         {/* Slash command autocomplete — floats above input */}
         {slashOpen && (
           <div className="slash-autocomplete">
@@ -578,20 +566,6 @@ export function ChatBar({ onOpenTerminal, spaces = [], activeSpace, onSpaceChang
             ))}
           </div>
         )}
-        <div
-          className="chatbar-oyster"
-          onClick={onOpenTerminal}
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            stroke="none"
-          >
-            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-          </svg>
-        </div>
         {streaming && statusText ? (
           <div className="chatbar-status">{statusText}</div>
         ) : null}
@@ -660,9 +634,6 @@ export function ChatBar({ onOpenTerminal, spaces = [], activeSpace, onSpaceChang
               if (e.key === "Escape") { setInput(""); return; }
             }
             if (e.key === "Enter") handleSend();
-          }}
-          onFocus={() => {
-            if (messages.length > 0) setExpanded(true);
           }}
           onBlur={() => {
             if (!input.trim()) {

--- a/web/src/components/AskPanel.tsx
+++ b/web/src/components/AskPanel.tsx
@@ -115,7 +115,7 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
     return () => { cancelled = true; };
   }, []);
 
-  const { messages, setMessages, sessionId, setExpanded, pushSessionUrl } = useChatSession();
+  const { messages, setMessages, sessionId, pushSessionUrl } = useChatSession();
 
   // Compute slash autocomplete items
   const subseq = useCallback((query: string, target: string) => {
@@ -269,6 +269,12 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
     }
   }, [messages, open]);
 
+  // The omnikey handler died with the bottom bar — focus the input when the
+  // panel opens so "click ✦, start typing" just works.
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
   // Queue for prompts dispatched before the chat session has finished
   // initialising. createSession() can take a few seconds while OpenCode
   // boots; without this, a prompt dispatched via the `oyster:send-prompt`
@@ -321,7 +327,6 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
       } else {
         const available = spaces.map(s => s.id).join(", ");
         setMessages(prev => [...prev, { role: "assistant", content: `No space matching "${q}". Available: ${available}` }]);
-        setExpanded(true);
       }
       return;
     }
@@ -347,7 +352,6 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
           } else {
             const available = spaces.map(s => s.id).join(", ");
             setMessages(prev => [...prev, { role: "assistant", content: `No space matching "${arg.trim()}". Available: ${available}` }]);
-            setExpanded(true);
           }
         }
 
@@ -356,7 +360,6 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
 
           if (scored.length === 0) {
             setMessages(prev => [...prev, { role: "assistant", content: `No artifact matching "${arg.trim()}"` }]);
-            setExpanded(true);
           } else if (scored.length === 1 || scored[0].score >= scored[1].score * 2) {
             onArtifactOpen(scored[0].a);
           } else {
@@ -370,7 +373,6 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
           const scored = scoreArtifacts(q).filter(({ a }) => allowed.has(a.id));
           if (scored.length === 0) {
             setMessages(prev => [...prev, { role: "assistant", content: `No artifact matching "${arg.trim()}"` }]);
-            setExpanded(true);
           } else if (scored.length === 1 || scored[0].score >= scored[1].score * 2) {
             onArtifactPublish(scored[0].a);
           } else {
@@ -384,7 +386,6 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
           const scored = scoreArtifacts(q).filter(({ a }) => allowed.has(a.id));
           if (scored.length === 0) {
             setMessages(prev => [...prev, { role: "assistant", content: `No live publication matching "${arg.trim()}"` }]);
-            setExpanded(true);
           } else if (scored.length === 1 || scored[0].score >= scored[1].score * 2) {
             onArtifactUnpublish(scored[0].a);
           } else {
@@ -399,7 +400,6 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
     setInput("");
     setMessages((prev) => [...prev, { role: "user", content }]);
     setStreaming(true);
-    setExpanded(true);
     setStatusText("thinking...");
     onAiError?.(null);
 
@@ -422,7 +422,7 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
         : "Can't reach Oyster — check that the server is running";
       onAiError?.(msg);
     }
-  }, [input, streaming, sessionId, setMessages, setExpanded, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts, onArtifactUnpublish, livePublications, scopeContext]);
+  }, [input, streaming, sessionId, setMessages, pushSessionUrl, resetTracking, spaces, onSpaceChange, subseq, artifacts, activeSpace, onArtifactOpen, scoreArtifacts, onAiError, onArtifactPublish, publishableArtifacts, onArtifactUnpublish, livePublications, scopeContext]);
 
   // Drain any queued prompt as soon as the session is ready AND nothing
   // is streaming. handleSend's other guard is `streaming`; if we drained
@@ -633,7 +633,7 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
                 else { setInput(item.label + ("args" in item && item.args ? " " : "")); }
                 return;
               }
-              if (e.key === "Escape") { setInput(""); return; }
+              if (e.key === "Escape") { e.stopPropagation(); setInput(""); return; }
             }
             if (e.key === "Enter") handleSend();
           }}

--- a/web/src/components/AskPanel.tsx
+++ b/web/src/components/AskPanel.tsx
@@ -464,7 +464,7 @@ export function AskPanel({ open, onClose, scopeLabel, spaces = [], activeSpace, 
   }
 
   return (
-    <div className={`ask-panel${open ? " open" : ""}`} aria-hidden={!open}>
+    <div className={`ask-panel${open ? " open" : ""}`} inert={!open || undefined}>
       <div className="ask-panel-header">
         <span className="ask-panel-title">✦ Ask Oyster</span>
         <span className="ask-panel-scope" title="Answers consider your current scope">{scopeLabel}</span>

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -81,11 +81,10 @@
   padding-bottom: 240px;
 }
 
-/* Soft fade behind the chat bar so content dissolves into the bg rather
-   than colliding with the pills. Matches docs/mockups/brain-prototype.html
-   exactly — bottom 30% solid (chat bar zone), then taper. Earlier pass
-   tapered too aggressively and washed the artefacts grid in a dark
-   rectangle. Sits above .home-scroll, below ChatBar. */
+/* Soft fade at the bottom so content dissolves into the bg rather than
+   running hard to the edge. Matches docs/mockups/brain-prototype.html
+   exactly — bottom 30% solid, then taper. Earlier pass tapered too
+   aggressively and washed the artefacts grid in a dark rectangle. */
 .home::before {
   content: "";
   position: fixed;

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -37,6 +37,7 @@ import { useTerminalPresence } from "../../hooks/useTerminalPresence";
 import type { WindowState } from "../../stores/windows";
 import { RunningTerminalsPill } from "../Topbar/RunningTerminalsPill";
 import { NewSessionPill } from "../Topbar/NewSessionPill";
+import { AskPill } from "../Topbar/AskPill";
 import { OnboardingDock } from "../OnboardingDock";
 import "./Home.css";
 
@@ -76,6 +77,8 @@ interface Props {
   /** Open the new-session palette. When omitted, the pill is hidden
    *  (e.g. in test contexts that don't wire it up). */
   onOpenNewSession?: () => void;
+  /** Open the Ask Oyster panel — renders the ✦ Ask pill when provided. */
+  onOpenAsk?: () => void;
   /** Focus / restore the live terminal for a session id. Threaded into
    *  SessionInspector so the primary action can read "Connect" when a
    *  live PTY exists. */
@@ -171,7 +174,7 @@ const FILTER_LABELS: Record<StateFilter, string> = {
   all: "all",
 };
 
-export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop, onOpenArtifact, onOpenNewSession, onConnectSession, sessions, sessionsLoading: loading, sessionsError: error, userSpaceCount, publishedCount, selectedProjectId, onSelectProject }: Props) {
+export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromoteFolderToSpace, onSpaceDelete, onSpaceUpdate, onLaunchClaude, onLaunchClaudeFromSession, onOpenRemoteInOyster, terminalWindows, onTerminalFocus, onTerminalRestore, onTerminalStop, onOpenArtifact, onOpenNewSession, onOpenAsk, onConnectSession, sessions, sessionsLoading: loading, sessionsError: error, userSpaceCount, publishedCount, selectedProjectId, onSelectProject }: Props) {
   const presence = useTerminalPresence(sessions, terminalWindows ?? []);
   const signedIn = useAuthSignedIn();
   const myDevice = useMyDeviceId();
@@ -953,6 +956,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
                   onStop={onTerminalStop}
                 />
               )}
+              {onOpenAsk && <AskPill onClick={onOpenAsk} />}
               {onOpenNewSession && <NewSessionPill onClick={onOpenNewSession} />}
             </div>
             <OnboardingDock userSpaceCount={userSpaceCount} publishedCount={publishedCount} />

--- a/web/src/components/InspectorPanel.css
+++ b/web/src/components/InspectorPanel.css
@@ -5,7 +5,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
-  /* Above ChatBar (90); below viewer windows (5100), Spotlight (5500),
+  /* Above Ask panel (200); below viewer windows (5100), Spotlight (5500),
      ConfirmModal (10000). Viewer sits above so an artefact opened from
      the inspector layers on top of the panel. */
   z-index: 4999;

--- a/web/src/components/InspectorPanel.css
+++ b/web/src/components/InspectorPanel.css
@@ -5,9 +5,10 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
-  /* Above Ask panel (200); below viewer windows (5100), Spotlight (5500),
-     ConfirmModal (10000). Viewer sits above so an artefact opened from
-     the inspector layers on top of the panel. */
+  /* Below viewer windows (5100), the Ask panel (5200), Spotlight (5500),
+     and ConfirmModal (10000). Viewer sits above so an artefact opened from
+     the inspector layers on top of the panel; Ask sits above so asking
+     while inspecting doesn't hide the answer. */
   z-index: 4999;
 }
 .inspector-backdrop.open {

--- a/web/src/components/OnboardingDock.tsx
+++ b/web/src/components/OnboardingDock.tsx
@@ -252,9 +252,9 @@ export function OnboardingDock({ userSpaceCount = 0, publishedCount = 0 }: Onboa
   }, []);
 
   const handleSetUpSpaces = useCallback(() => {
-    // Send the canonical setup prompt to the chat via the cross-component
-    // oyster:send-prompt event. ChatBar's listener routes it through the
-    // same handleSend path used for typed input.
+    // Send the canonical setup prompt via the cross-component
+    // oyster:send-prompt event. App opens the Ask panel; AskPanel's listener
+    // routes the text through the same handleSend path used for typed input.
     window.dispatchEvent(
       new CustomEvent("oyster:send-prompt", { detail: { text: "Set up Oyster" } }),
     );

--- a/web/src/components/Topbar/AskPill.tsx
+++ b/web/src/components/Topbar/AskPill.tsx
@@ -1,0 +1,16 @@
+// "✦ Ask" pill. Sibling to NewSessionPill in the breadcrumb nav's
+// right-aligned cluster. Opens the Ask Oyster slide-over panel.
+
+export function AskPill({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="nsp-pill"
+      onClick={onClick}
+      title="Ask Oyster about your current scope"
+    >
+      <span aria-hidden="true">✦</span>
+      <span>Ask</span>
+    </button>
+  );
+}

--- a/web/src/hooks/useChatSession.ts
+++ b/web/src/hooks/useChatSession.ts
@@ -42,10 +42,15 @@ function getSessionIdFromUrl(): string | null {
   return match ? match[1] : null;
 }
 
+// Outbound messages carry a "[Scope: …]\n\n" context prefix (AskPanel).
+// The live bubble shows the raw text; restored bubbles must match.
+function stripScopePrefix(text: string): string {
+  return text.replace(/^\[Scope:[^\]]*\]\n\n/, "");
+}
+
 export function useChatSession() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState(false);
   const hasPushedUrl = useRef(false);
 
   // Initialize session: fresh on home (/), restore on session URL (/session/:id)
@@ -63,13 +68,14 @@ export function useChatSession() {
           const restored: Message[] = [];
           for (const msg of existing) {
             const tp = msg.parts.filter((p: Record<string, unknown>) => p.type === "text" && p.text);
-            const content = tp.map((p: Record<string, unknown>) => p.text).join("");
+            const isUser = msg.info.role === "user";
+            const content = tp.map((p: Record<string, unknown>) => isUser ? stripScopePrefix(p.text as string) : p.text).join("");
 
             // Build ordered MessagePart[] from all text + tool parts
             const msgParts: MessagePart[] = [];
             for (const p of msg.parts) {
               if (p.type === "text" && p.text) {
-                msgParts.push({ type: "text", text: p.text as string });
+                msgParts.push({ type: "text", text: isUser ? stripScopePrefix(p.text as string) : p.text as string });
               } else if (p.type === "tool") {
                 const toolName = ((p.tool || p.toolName || p.name || "") as string).toLowerCase();
                 msgParts.push({
@@ -100,7 +106,6 @@ export function useChatSession() {
           }
           if (restored.length > 0) {
             setMessages(restored);
-            setExpanded(true);
           }
         } else {
           // Home — always create a fresh session
@@ -122,7 +127,6 @@ export function useChatSession() {
 
       // Navigating to home (/) or a space (/space/*) — reset chat to fresh state
       setMessages([]);
-      setExpanded(false);
       setSessionId(null);
       hasPushedUrl.current = false;
       createSession().then((s) => setSessionId(s.id)).catch(console.error);
@@ -142,5 +146,5 @@ export function useChatSession() {
     }
   }
 
-  return { messages, setMessages, sessionId, expanded, setExpanded, pushSessionUrl };
+  return { messages, setMessages, sessionId, pushSessionUrl };
 }

--- a/web/src/stores/windows.ts
+++ b/web/src/stores/windows.ts
@@ -26,7 +26,6 @@ export type WindowAction =
   | { type: "MINIMISE"; id: string }
   | { type: "CLOSE_ALL_VIEWERS" }
   | { type: "UPDATE_STATUS"; id: string; statusText: string }
-  | { type: "OPEN_TERMINAL" }
   | {
       type: "OPEN_CLAUDE_TERMINAL";
       terminalId: string;
@@ -129,27 +128,6 @@ export function windowsReducer(
       return state.map((w) =>
         w.id === action.id ? { ...w, statusText: action.statusText } : w
       );
-    case "OPEN_TERMINAL": {
-      const existing = state.find((w) => w.type === "terminal");
-      if (existing) {
-        topZ++;
-        return state.map((w) =>
-          w.id === existing.id ? { ...w, zIndex: topZ } : w
-        );
-      }
-      topZ++;
-      return [
-        ...state,
-        {
-          id: "terminal-" + nextId++,
-          type: "terminal",
-          title: "opencode",
-          statusText: "",
-          zIndex: topZ,
-          fullscreen: false,
-        },
-      ];
-    }
     case "OPEN_CLAUDE_TERMINAL": {
       // Always appends — multiple Claude terminals can coexist.
       topZ++;


### PR DESCRIPTION
## Summary

PR 2 of the unified-scope redesign ([spec](docs/superpowers/specs/2026-06-05-ask-oyster-panel-design.md), [plan](docs/superpowers/plans/2026-06-05-ask-oyster-panel.md)). Chat stops taking centre stage:

- **ChatBar → AskPanel**: the bottom bar becomes a right-hand slide-over opened from a `✦ Ask` topbar pill. All chat logic (slash commands, autocomplete, streaming, question options) relocated byte-identical. Always mounted — the thread and SSE stream survive close/reopen; `inert` when closed; Escape closes; opens automatically on `/session/<id>` loads so restored conversations are visible.
- **Real scope inheritance**: the panel header chips your current scope (`space › project` / `vault` / `archived` / `everything`) and prepends a `[Scope: …]` context line to outbound messages so the agent's MCP tools act where you're looking. Slash/`#` commands never reach the AI and carry no prefix; restored bubbles strip the prefix for display.
- **Removed**: the bottom bar (+~250 lines CSS), the global type-anywhere-focuses-chat handler, the ⚡ terminal button + hardcore-gate modal, and the now-unreachable `OPEN_TERMINAL` window machinery.
- **Kept working**: OnboardingDock's "Set up Oyster" prompt (opens the panel and sends), AI-error banner (deliberately stays App-level — it also serves non-chat errors), provider-status fallback, `/session/<id>` URL push.

## Reviewer notes (known, deliberate non-fixes)

1. **Chat thread resets on back/forward to non-`/session/` URLs** — pre-existing `useChatSession` behaviour (byte-identical on main); the panel now makes the reset visible where the old bar auto-collapsed. Rethinking chat-session lifecycle is its own piece of work.
2. **Scope chip doesn't know about orphan-folder (cwd) selection** — the deferred `selectedCwd` seam from PR 1; tracked for the scope-hygiene follow-up alongside the VAULT sentinel.
3. **Keyboard has no panel-open shortcut yet** — deliberate; PR 3 adds the ⌘K "ask" row as the keyboard entry.
4. Scope label logic exists in both Home's crumb and App's `askScope` — candidates for a shared selector when PR 3 touches this area.

## Test plan

- [x] `npm run build` green; 626/626 server tests pass
- [x] Multi-agent review: per-task spec + quality reviews, final integration review, 7-angle recall review — confirmed findings fixed (`94d1c84`, `2736966`, `de6e7d2`)
- [x] Manual: ✦ Ask opens panel; send/stream/slash/`#` inside it; close+reopen keeps thread; Escape closes (but not while slash dropdown open); focus lands in input on open
- [x] Manual: scope chip at each scope; agent answers reflect project scope; refresh a scoped `/session/` URL → thread restores, prefix not shown, scope retained
- [x] Manual: no bottom bar anywhere; onboarding "Set up Oyster" lands in the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)