### PR TITLE
Spotlight ask row (PR 3): ⌘K becomes the keyboard path to Ask Oyster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 - **Move a project between spaces — or out of one.** A project's ⋯ menu now offers "Move to space…": relocate it (and its sessions) to another space, or remove it from its space entirely. Removed projects stay on Home, ready to re-file.
 - **Ask to see a past session, and Oyster opens it.** Say "show me the session about X" and the agent finds it and opens it in the inspector — jumping straight to the relevant moment when it can. It can also list your recent sessions on request.
 - **Filter artefacts by kind.** The Artefacts section gains a Kind filter — narrow to apps, decks, diagrams, notes, tables, or wireframes, alongside the existing source filters.
+- **Ask from anywhere.** Search (Cmd+K) gains an "Ask Oyster" row — type a question, hit Enter, and the Ask panel opens with the answer streaming. No-result searches offer it too.
 
 ### Changed
 

--- a/docs/superpowers/specs/2026-06-05-spotlight-ask-row-design.md
+++ b/docs/superpowers/specs/2026-06-05-spotlight-ask-row-design.md
@@ -1,0 +1,33 @@
+# Spotlight "Ask Oyster" row — design (PR 3 of unified scope UX)
+
+**Status:** Approved · 2026-06-05 · branch `spotlight-ask-row`
+
+## Goal
+
+⌘K becomes the keyboard path to Ask Oyster. Whenever Spotlight has a
+non-empty query, an **"✦ Ask Oyster: \<query\>"** row appears as the last
+result (and as the action on the no-results state). Selecting it **sends
+immediately** — the panel opens with the answer streaming.
+
+Parent spec: `2026-06-05-ask-oyster-panel-design.md` (palette as launcher,
+panel as surface). Decision log: send-immediately chosen over the parent
+spec's loose "pre-filled" wording (Matthew, 2026-06-05) — matches launcher
+conventions and reuses the PR 2 plumbing wholesale.
+
+## Design
+
+- New `SpotlightHit` kind `"ask"`, appended to `flatHits` whenever
+  `query.trim()` is non-empty — so ArrowDown/Enter reach it with zero new
+  keyboard code.
+- Activating it dispatches the existing `oyster:send-prompt` event with the
+  query and closes Spotlight. App already opens the panel on that event;
+  AskPanel already sends through `handleSend` (scope prefix, session-boot
+  queueing). **No App/AskPanel changes.**
+- Render: last row of the results list; on the no-results state the row
+  renders beneath the "No results" message, so a dead end becomes an action.
+- No row on the empty-query recent feed (nothing to ask).
+
+## Out of scope
+
+Pre-fill/edit-before-send mechanism; any panel or App changes; the
+scope-hygiene seams.

--- a/docs/superpowers/specs/2026-06-05-spotlight-ask-row-design.md
+++ b/docs/superpowers/specs/2026-06-05-spotlight-ask-row-design.md
@@ -22,7 +22,11 @@ conventions and reuses the PR 2 plumbing wholesale.
 - Activating it dispatches the existing `oyster:send-prompt` event with the
   query and closes Spotlight. App already opens the panel on that event;
   AskPanel already sends through `handleSend` (scope prefix, session-boot
-  queueing). **No App/AskPanel changes.**
+  queueing). **No App changes.** One AskPanel change shipped with this PR
+  (review finding): `handleSend` now also queues prompts that arrive while a
+  response is streaming — ⌘K makes rapid re-asking a one-keystroke move, and
+  a mid-stream ask was previously dropped silently. The existing drain
+  effect fires the queued prompt when the stream ends.
 - Render: last row of the results list; on the no-results state the row
   renders beneath the "No results" message, so a dead end becomes an action.
 - No row on the empty-query recent feed (nothing to ask).

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1681,6 +1681,12 @@ body {
   justify-self: end;
 }
 
+/* Nested in the results container (no-results state) the container's own
+   top border does the dividing — drop the message's duplicate. */
+.spotlight-results .spotlight-empty {
+  border-top: none;
+}
+
 /* "Ask Oyster" launcher row — sits last in the list, faint divider above. */
 .spotlight-result--ask {
   border-top: 1px solid rgba(255, 255, 255, 0.06);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1681,6 +1681,23 @@ body {
   justify-self: end;
 }
 
+/* "Ask Oyster" launcher row — sits last in the list, faint divider above. */
+.spotlight-result--ask {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 0 0 12px 12px;
+  margin-top: 4px;
+}
+.spotlight-result-ask-glyph {
+  color: #7c6bff;
+  font-size: 12px;
+  line-height: 1;
+  justify-self: center;
+}
+.spotlight-result-ask-query {
+  color: rgba(232, 233, 240, 0.7);
+  font-style: italic;
+}
+
 .spotlight-result-space {
   font-size: 0.72rem;
   color: rgba(232, 233, 240, 0.3);

--- a/web/src/components/AskPanel.tsx
+++ b/web/src/components/AskPanel.tsx
@@ -285,9 +285,13 @@ export function AskPanel({ open, onClose, scopeLabel, scopeContext, spaces = [],
 
   const handleSend = useCallback(async (override?: string) => {
     const raw = override ?? input;
-    if (!raw.trim() || streaming) return;
-    if (!sessionId) {
-      // Session still booting — queue and let the drain effect fire it.
+    if (!raw.trim()) return;
+    if (!sessionId || streaming) {
+      // Session still booting, or a response mid-stream — queue and let the
+      // drain effect fire it when both clear. The streaming case is only
+      // reachable via event-driven sends (the input is disabled while
+      // streaming): e.g. a second ⌘K ask while the first answer streams —
+      // without the queue it would be silently dropped.
       pendingPromptRef.current = raw;
       return;
     }

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -43,7 +43,8 @@ const TYPE_OPTS: { value: 'session' | 'artefact' | 'memory'; color: string }[] =
 type SpotlightHit =
   | { kind: "artefact"; artifact: Artifact }
   | { kind: "transcript"; hit: TranscriptHit }
-  | { kind: "memory"; memory: Memory };
+  | { kind: "memory"; memory: Memory }
+  | { kind: "ask" };
 
 export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
   const [query, setQuery] = useState("");
@@ -236,11 +237,16 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       .slice(0, 10);
   }, [query, filter.type, filter.spaceId, artifacts]);
 
+  // Any non-empty query gets an "Ask Oyster" row as the final hit — ⌘K is
+  // the keyboard path to the Ask panel. No row on the empty-query recent
+  // feed (nothing to ask).
+  const askHit: SpotlightHit[] = query.trim() ? [{ kind: "ask" }] : [];
+
   // Whichever list is on screen drives keyboard nav. The recent feed only
   // shows when searchHits is empty AND query/filter are empty, so the two
   // never overlap.
-  const flatHits: SpotlightHit[] = searchHits.length > 0
-    ? searchHits
+  const flatHits: SpotlightHit[] = searchHits.length > 0 || askHit.length > 0
+    ? [...searchHits, ...askHit]
     : recentFeed.map((a): SpotlightHit => ({ kind: "artefact", artifact: a }));
 
   useEffect(() => {
@@ -255,6 +261,16 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
   }, [selected]);
 
   function activate(hit: SpotlightHit) {
+    if (hit.kind === "ask") {
+      // Reuses the Ask-panel plumbing wholesale: App opens the panel on
+      // this event; AskPanel routes the text through handleSend (scope
+      // prefix, session-boot queueing).
+      window.dispatchEvent(new CustomEvent("oyster:send-prompt", {
+        detail: { text: query.trim() },
+      }));
+      onClose();
+      return;
+    }
     if (hit.kind === "artefact") {
       onOpen(hit.artifact);
     } else if (hit.kind === "transcript") {
@@ -344,7 +360,10 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
   const showResults = artefactHits.length > 0
     || transcriptHits.length > 0 || transcriptsLoading
     || memoryHits.length > 0 || memoriesLoading;
-  const showEmpty = !!query.trim() && !transcriptsLoading && !memoriesLoading && flatHits.length === 0;
+  // "Empty" = no search results — the ask row still renders beneath the
+  // message (flatHits is never empty while a query exists), so keyboard
+  // state stays coherent and the dead end becomes an action.
+  const showEmpty = !!query.trim() && !transcriptsLoading && !memoriesLoading && searchHits.length === 0;
 
   return (
     <div className="spotlight-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
@@ -503,11 +522,28 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
                 </div>
               );
             })}
+
+            {askHit.length > 0 && (
+              <AskRow
+                query={query.trim()}
+                selected={selected === flatHits.length - 1}
+                onSelect={() => setSelected(flatHits.length - 1)}
+                onActivate={() => activate({ kind: "ask" })}
+              />
+            )}
           </div>
         )}
 
         {showEmpty && (
-          <div className="spotlight-empty">No results for "{query}"</div>
+          <div className="spotlight-results">
+            <div className="spotlight-empty">No results for "{query}"</div>
+            <AskRow
+              query={query.trim()}
+              selected={selected === flatHits.length - 1}
+              onSelect={() => setSelected(flatHits.length - 1)}
+              onActivate={() => activate({ kind: "ask" })}
+            />
+          </div>
         )}
 
         {!showResults && !showEmpty && recentFeed.length > 0 && (
@@ -533,6 +569,31 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/** The "Ask Oyster" launcher row — last hit whenever a query exists.
+ *  Selecting it fires the query at the Ask panel via oyster:send-prompt
+ *  and closes Spotlight. Rendered in both the results list and the
+ *  no-results state. */
+function AskRow({ query, selected, onSelect, onActivate }: {
+  query: string;
+  selected: boolean;
+  onSelect: () => void;
+  onActivate: () => void;
+}) {
+  return (
+    <div
+      className={`spotlight-result spotlight-result--ask${selected ? " spotlight-result--selected" : ""}`}
+      onMouseEnter={onSelect}
+      onClick={onActivate}
+    >
+      <span className="spotlight-result-ask-glyph" aria-hidden="true">✦</span>
+      <span className="spotlight-result-label">
+        Ask Oyster: <span className="spotlight-result-ask-query">{query}</span>
+      </span>
+      <span className="spotlight-result-badge">↵ ask</span>
     </div>
   );
 }

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -256,7 +256,10 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
   }, [query]);
 
   useEffect(() => {
-    const el = listRef.current?.children[selected] as HTMLElement | undefined;
+    // Look the highlighted row up by class rather than child index — the
+    // results container also holds section labels, loading rows, and the
+    // ask row, so children[selected] doesn't map onto hits.
+    const el = listRef.current?.querySelector<HTMLElement>(".spotlight-result--selected");
     el?.scrollIntoView({ block: "nearest" });
   }, [selected]);
 


### PR DESCRIPTION
## Summary

PR 3 (final) of the unified-scope redesign ([spec](docs/superpowers/specs/2026-06-05-spotlight-ask-row-design.md)): the palette becomes the launcher, the panel stays the surface.

- **"✦ Ask Oyster: \<query\>" row in ⌘K** — appended as the last result whenever a query exists; selecting it opens the Ask panel with the question sent immediately (scope-aware, via the existing send-prompt plumbing — zero App/panel API changes).
- **No-results becomes an action** — "No results for X" now offers the ask row instead of dead-ending.
- **Mid-stream asks queue instead of dropping** — review found that a second ask while an answer streams was silently lost (the input is disabled while streaming, but event-driven sends weren't); the existing boot-window queue now covers it, and the drain effect already fires when streaming ends.

## Reviewer notes

1. **Escape in Spotlight also closes a streaming Ask panel** — pre-existing from PR 2's global Escape handler (Spotlight doesn't stopPropagation); slightly easier to hit now. Candidate for the scope-hygiene follow-up rather than this PR.
2. The queued-prompt store keeps only the latest prompt (documented existing behaviour) — two rapid-fire asks during one stream keep the second.

## Test plan

- [x] tsc + lint baseline + full build green
- [x] Reviewed: keyboard index math (results, loading, and empty branches), showResults/showEmpty mutual exclusion, no double-dispatch
- [ ] Manual: ⌘K → type question → Enter on ask row → panel opens, answer streams; ask again mid-stream → second question follows the first
- [ ] Manual: no-results query → ask row works; empty-query recent feed shows no ask row

🤖 Generated with [Claude Code](https://claude.com/claude-code)