### PR TITLE
One SSE stream per tab — fixes multi-tab stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
-- **Multiple Oyster tabs no longer freeze the app.** Each tab held two permanent event streams, hitting the browser's per-site connection limit at three tabs — every request then stalled silently. One stream per tab now; open as many as you like.
+- **Multiple Oyster tabs no longer freeze the app.** Each tab held two permanent event streams, hitting the browser's per-site connection limit at three tabs — every request then stalled silently. One stream per tab now, so working across several tabs is comfortable.
 - **Sessions table names the repo** — the project column shows the repository name instead of the space, and steps aside when a project is selected.
 - **Onboarding reflects what you've actually done.** "Publish your first artefact" now ticks only when you have a live publication (and un-ticks if you unpublish), and the setup icon fills as a progress ring — becoming the 🦪 only once every step is done.
 - **Artefacts table view has column headers.** The table view now labels its columns (Name · Space · Kind · Created), matching the sessions list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Fixed
 
+- **Multiple Oyster tabs no longer freeze the app.** Each tab held two permanent event streams, hitting the browser's per-site connection limit at three tabs — every request then stalled silently. One stream per tab now; open as many as you like.
 - **Sessions table names the repo** — the project column shows the repository name instead of the space, and steps aside when a project is selected.
 - **Onboarding reflects what you've actually done.** "Publish your first artefact" now ticks only when you have a live publication (and un-ticks if you unpublish), and the setup icon fills as a progress ring — becoming the 🦪 only once every step is done.
 - **Artefacts table view has column headers.** The table view now labels its columns (Name · Space · Kind · Created), matching the sessions list.

--- a/docs/superpowers/specs/2026-06-05-sse-single-stream-design.md
+++ b/docs/superpowers/specs/2026-06-05-sse-single-stream-design.md
@@ -1,0 +1,46 @@
+# One SSE stream per tab — design
+
+**Status:** Approved · 2026-06-05 · branch `sse-single-stream`
+
+## Problem
+
+Chrome caps HTTP/1.1 at 6 connections per origin, shared across all tabs.
+Every Oyster tab held two permanent SSE streams (`/api/ui/events` +
+`/api/chat/events` via the always-mounted Ask panel; three during the
+viewer's fix-error flow) — so **three open Oyster tabs saturated the pool
+and every further fetch stalled forever**: no error, no banner, an
+eternally empty UI. Affects dev (7337) and the installed app (4444 is also
+HTTP/1.1). Diagnosed 2026-06-05 via `lsof` while testing #621.
+
+## Fix
+
+Chat events ride the existing `/api/ui/events` stream as a
+`{command: "chat", payload: <opencode event>}` envelope:
+
+- The server already held a **single internal subscription** to opencode's
+  `/global/event` (opencode-manager) and fanned out to a dedicated browser
+  client set. That set is deleted; `emitChatEvent()` now feeds
+  `broadcastUiEvent` through an injected sink (no circular import).
+- `broadcastUiEvent` gains the per-client buffer cap (1 MB) that the chat
+  broadcaster had — chat deltas are high-frequency and a stalled tab must
+  not grow Node's writable buffer unboundedly.
+- Client: `subscribeToEvents` (chat-api) delegates to the `ui-events`
+  singleton, filtering on `command === "chat"` — `useChatEvents` and
+  ViewerWindow keep their exact contracts. Chat inherits the singleton's
+  heartbeat-protected, visibility-aware reconnect (the old chat stream had
+  neither).
+- `/api/chat/events` route removed (UI and server ship together — no
+  version skew). The ui-events route carries the same local-origin gate,
+  so assistant output stays unreadable cross-origin.
+
+**Result:** one SSE per tab. Stall threshold moves from 3 tabs to 6+, with
+fetch headroom at every realistic count.
+
+## Rejected
+
+- **HTTP/2** — browsers refuse cleartext h2; localhost apps can't use it.
+- **BroadcastChannel leader election** (one stream per origin, any tab
+  count) — solves harder but adds failover complexity; revisit only if
+  6+ simultaneous tabs becomes a real pattern.
+- **Close streams on hidden tabs** — subsumed; the singleton already
+  handles visibility, and one stream per tab makes it unnecessary.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -767,7 +767,10 @@ function broadcastUiEvent(event: UiCommand) {
       // (open_artifact, switch_space) sent during the gap — accepted:
       // the cap only trips on an already-frozen tab, and steady state
       // self-heals (5s artifact/space poll; chat keeps streaming).
-      try { client.end(); } catch { /* best effort */ }
+      // destroy(), not end(): no point flushing 1MB to a frozen tab, and
+      // tearing the socket down makes the route's close handler fire
+      // promptly (clearing its heartbeat interval).
+      try { client.destroy(); } catch { /* best effort */ }
       uiClients.delete(client);
       continue;
     }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,7 +65,7 @@ import {
   startAutoApprover,
   proxyToOpenCode,
 } from "./opencode-manager.js";
-import { attachChatEventClient } from "./opencode-events.js";
+import { setChatEventSink } from "./opencode-events.js";
 import { sweepOrphanOpenCodeProcesses } from "./opencode-orphan-sweep.js";
 import { attachWebSocket, handleLegacyUpgrade } from "./pty-manager.js";
 import { ClaudePtyManager } from "./claude-pty-manager.js";
@@ -749,10 +749,21 @@ process.on("unhandledRejection", (err) => {
 
 const uiClients = new Set<ServerResponse>();
 
+// Cap per-client buffering: chat events ride this stream and can emit many
+// token deltas per second during a long assistant response — a stalled tab
+// would otherwise grow Node's internal writable buffer without bound. Drop
+// the laggard; its EventSource auto-reconnects.
+const MAX_CLIENT_BUFFER_BYTES = 1_000_000;
+
 function broadcastUiEvent(event: UiCommand) {
   const data = `data: ${JSON.stringify(event)}\n\n`;
   for (const client of uiClients) {
     if (client.writableEnded || client.destroyed) {
+      uiClients.delete(client);
+      continue;
+    }
+    if (client.writableLength > MAX_CLIENT_BUFFER_BYTES) {
+      try { client.end(); } catch { /* best effort */ }
       uiClients.delete(client);
       continue;
     }
@@ -763,6 +774,13 @@ function broadcastUiEvent(event: UiCommand) {
     }
   }
 }
+
+// Chat events (opencode + synthetic) ride the same stream as a
+// {command:"chat"} envelope — one SSE connection per tab. See
+// opencode-events.ts for why this is a sink injection.
+setChatEventSink((event) => {
+  broadcastUiEvent({ version: 1, command: "chat", payload: event });
+});
 
 // ── HTTP request handler ──
 
@@ -922,14 +940,10 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     return;
   }
 
-  // Chat SSE carries assistant output. Same origin gate as /api/ui/events:
-  // a cross-origin page in the same browser must not be able to open an
-  // EventSource against a running local Oyster and read the user's chat.
-  if (url === "/api/chat/events" || url.startsWith("/api/chat/events?")) {
-    if (rejectIfNonLocalOrigin()) return;
-    attachChatEventClient(req, res);
-    return;
-  }
+  // /api/chat/events retired: chat events now ride /api/ui/events as a
+  // {command:"chat"} envelope (one SSE per tab — connection-pool fix). The
+  // ui-events route carries the same local-origin gate, so assistant output
+  // remains unreadable to cross-origin pages.
 
   if (url === "/api/chat/doc") {
     await proxyToOpenCode(req, res, "/doc", getOpenCodePort());

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -763,6 +763,10 @@ function broadcastUiEvent(event: UiCommand) {
       continue;
     }
     if (client.writableLength > MAX_CLIENT_BUFFER_BYTES) {
+      // Dropping a laggard loses any imperative one-shot commands
+      // (open_artifact, switch_space) sent during the gap — accepted:
+      // the cap only trips on an already-frozen tab, and steady state
+      // self-heals (5s artifact/space poll; chat keeps streaming).
       try { client.end(); } catch { /* best effort */ }
       uiClients.delete(client);
       continue;
@@ -901,10 +905,11 @@ async function handleHttpRequest(req: IncomingMessage, res: ServerResponse) {
     startApp, stopApp, isPortOpen, waitForReady,
   })) return;
 
-  // GET /api/ui/events — SSE stream for UI commands.
-  // Local-origin only. The stream carries `mcp_client_connected` +
-  // `mcp_tool_called` events (connected-agent telemetry), which a
-  // cross-origin page in the same browser must not be able to observe
+  // GET /api/ui/events — SSE stream for UI commands AND chat events
+  // (the {command:"chat"} envelope — one connection per tab).
+  // Local-origin only. The stream carries connected-agent telemetry
+  // (`mcp_client_connected` + `mcp_tool_called`) and assistant output,
+  // neither of which a cross-origin page in the same browser may observe
   // by opening an EventSource against a running local Oyster.
   if (url === "/api/ui/events") {
     if (rejectIfNonLocalOrigin()) return;

--- a/server/src/opencode-events.ts
+++ b/server/src/opencode-events.ts
@@ -1,63 +1,28 @@
-// Browser-facing chat event stream. We maintain a single upstream subscription
-// to opencode's /event SSE endpoint (in opencode-manager) and fan out to N
-// registered browser clients. This lets us inject server-originated synthetic
-// events (e.g. from stderr pattern matches in #203) alongside proxied ones —
-// the previous per-client pass-through didn't allow that.
-
-import type { IncomingMessage, ServerResponse } from "node:http";
+// Chat event fan-out. We maintain a single upstream subscription to
+// opencode's /global/event SSE endpoint (in opencode-manager) and emit each
+// event into the shared /api/ui/events stream as a `{command:"chat"}`
+// envelope — one SSE connection per tab instead of a dedicated chat stream.
+// (Chrome caps HTTP/1.1 at 6 connections per origin; with two streams per
+// tab, three Oyster tabs stalled every fetch on the origin.) This module
+// also lets us inject server-originated synthetic events (e.g. from stderr
+// pattern matches in #203) alongside proxied ones.
 
 type SyntheticEvent = { type: string; properties?: Record<string, unknown> };
 
-const clients = new Set<ServerResponse>();
+// Injected by index.ts at startup (wraps broadcastUiEvent). Indirection
+// avoids a circular import — index.ts owns the ui-events client set.
+let sink: ((event: unknown) => void) | null = null;
 
-// Caller is responsible for the local-origin check (the same
-// rejectIfNonLocalOrigin gate used for /api/ui/events). Chat SSE
-// carries assistant output — a cross-origin page in the same browser
-// must not be able to open an EventSource against it. We also don't
-// set Access-Control-Allow-Origin here; the outer handler's wildcard
-// header would otherwise make this world-readable.
-export function attachChatEventClient(req: IncomingMessage, res: ServerResponse) {
-  res.writeHead(200, {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
-  clients.add(res);
-  req.on("close", () => {
-    clients.delete(res);
-  });
+export function setChatEventSink(fn: (event: unknown) => void) {
+  sink = fn;
 }
 
-// Mirror broadcastUiEvent's leak-safe pattern in index.ts: if close
-// doesn't fire cleanly, ended/destroyed responses would otherwise stay
-// in the set and we'd throw on every subsequent broadcast. We also
-// cap per-client buffering — chat SSE can emit many tokens per second
-// during a long assistant response, so a stalled tab could otherwise
-// grow Node's internal writable buffer without bound.
-const MAX_CLIENT_BUFFER_BYTES = 1_000_000;
-
-export function broadcastRaw(chunk: string) {
-  for (const res of clients) {
-    if (res.writableEnded || res.destroyed) {
-      clients.delete(res);
-      continue;
-    }
-    if (res.writableLength > MAX_CLIENT_BUFFER_BYTES) {
-      // Client can't keep up — drop rather than grow forever.
-      // EventSource in the browser will auto-reconnect.
-      try { res.end(); } catch { /* best effort */ }
-      clients.delete(res);
-      continue;
-    }
-    try {
-      res.write(chunk);
-    } catch {
-      clients.delete(res);
-    }
-  }
+/** Emit one opencode (or synthetic) chat event to all connected browsers
+ *  via the shared ui-events stream. No-op before the sink is wired. */
+export function emitChatEvent(event: unknown) {
+  sink?.(event);
 }
 
 export function broadcastSynthetic(event: SyntheticEvent) {
-  const payload = `data: ${JSON.stringify(event)}\n\n`;
-  broadcastRaw(payload);
+  emitChatEvent(event);
 }

--- a/server/src/opencode-manager.ts
+++ b/server/src/opencode-manager.ts
@@ -1,6 +1,6 @@
 import { type IncomingMessage, type ServerResponse } from "node:http";
 import { spawn, execSync } from "node:child_process";
-import { broadcastRaw, broadcastSynthetic } from "./opencode-events.js";
+import { emitChatEvent, broadcastSynthetic } from "./opencode-events.js";
 import { bootMark } from "./boot-timer.js";
 
 let shuttingDown = false;
@@ -211,19 +211,20 @@ export function startAutoApprover(
               try {
                 const wrapper = JSON.parse(line.slice(6));
                 // /global/event wraps every event in { payload, directory, project, workspace }.
-                // Unwrap so downstream consumers (the browser EventSource at
-                // /api/chat/events, and the permission/file checks below) see
-                // the same { type, properties } shape /event used to emit.
+                // Unwrap so downstream consumers (the browser, via the ui-events
+                // {command:"chat"} envelope, and the permission/file checks below)
+                // see the same { type, properties } shape /event used to emit.
                 const event = wrapper && typeof wrapper === "object" && "payload" in wrapper
                   ? wrapper.payload
                   : wrapper;
                 if (!event || typeof event !== "object") continue;
 
-                // Fan out the unwrapped event to any connected browser clients.
+                // Fan out the unwrapped event to any connected browser clients
+                // (rides the shared /api/ui/events stream as {command:"chat"}).
                 // A single upstream subscription avoids multiplying opencode load
                 // by the number of open tabs and gives us a place to inject
                 // server-originated synthetic events.
-                broadcastRaw(`data: ${JSON.stringify(event)}\n\n`);
+                emitChatEvent(event);
 
                 if (event.type === "permission.asked") {
                   const requestId = event.properties.id;

--- a/web/src/data/chat-api.ts
+++ b/web/src/data/chat-api.ts
@@ -1,3 +1,5 @@
+import { subscribeUiEvents } from "./ui-events";
+
 const SESSION_KEY = "oyster-session-id";
 
 export interface ChatSession {
@@ -112,22 +114,15 @@ export async function sendMessage(
 export function subscribeToEvents(
   onEvent: (event: ChatEvent) => void
 ): () => void {
-  const es = new EventSource("/api/chat/events");
-
-  es.onmessage = (e) => {
-    try {
-      const event: ChatEvent = JSON.parse(e.data);
-      onEvent(event);
-    } catch {
-      // ignore parse errors
-    }
-  };
-
-  es.onerror = () => {
-    // EventSource auto-reconnects
-  };
-
-  return () => es.close();
+  // Chat events ride the shared /api/ui/events stream as a
+  // {command:"chat"} envelope — one SSE connection per tab instead of a
+  // dedicated chat stream (Chrome caps HTTP/1.1 at 6 connections per
+  // origin; two streams per tab stalled every fetch at three tabs).
+  // Unwrap the envelope and preserve this function's callback contract.
+  return subscribeUiEvents((e) => {
+    if (e.command !== "chat") return;
+    onEvent(e.payload as ChatEvent);
+  });
 }
 
 export async function replyToQuestion(

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -34,10 +34,6 @@ export default defineConfig(({ mode }) => ({
   server: {
     port: 7337,
     proxy: {
-      '/api/chat/events': {
-        target,
-        headers: { Accept: 'text/event-stream' },
-      },
       '/api/ui/events': {
         target,
         headers: { Accept: 'text/event-stream' },


### PR DESCRIPTION
## Summary

Fixes the multi-tab freeze: Chrome caps HTTP/1.1 at **6 connections per origin**, and every Oyster tab held two permanent SSE streams (`/api/ui/events` + `/api/chat/events`, three during the viewer fix-flow) — so three open tabs saturated the pool and **every further request stalled silently** (no error, eternally empty UI). Affects dev and the installed app alike. Spec: [docs/superpowers/specs/2026-06-05-sse-single-stream-design.md](docs/superpowers/specs/2026-06-05-sse-single-stream-design.md).

- **Chat events ride the shared `/api/ui/events` stream** as a `{command:"chat", payload}` envelope. The server already held a single internal opencode subscription; it now feeds `broadcastUiEvent` via an injected sink (no import cycle).
- **`/api/chat/events` retired** (route, client EventSource, Vite proxy entry). UI + server ship together, so no version skew; the ui-events route carries the same local-origin gate, keeping assistant output unreadable cross-origin.
- **Client `subscribeToEvents` delegates to the ui-events singleton** — `useChatEvents`/ViewerWindow contracts untouched; chat inherits heartbeat + visibility-aware reconnect the old stream never had.
- **1 MB per-client buffer cap moves to `broadcastUiEvent`** (chat deltas are high-frequency; a frozen tab must not grow Node's writable buffer unboundedly).

**Result: one SSE per tab.** Stall threshold moves from 3 tabs to 6+, with fetch headroom at every realistic count.

## Reviewer notes

- Reviewed internally: module-init order (sink wired before opencode's first event can arrive), event-shape parity end-to-end incl. synthetic `session.error`, no subscription churn (`useChatEvents` deps stable, listener count never hits 0), per-token dispatch cost (~9 string compares), origin-gate parity.
- Known accepted trade-off (commented in code): a laggard tab dropped by the buffer cap loses one-shot nav commands sent during the gap; steady state self-heals via the 5s poll.
- Rejected alternatives in the spec: HTTP/2 (browsers refuse cleartext h2 on localhost), BroadcastChannel leader election (revisit if 6+ tabs becomes real).

## Test plan

- [x] Server tsc + 626/626 tests; web tsc + lint baseline; full build
- [x] Manual: chat streams in the panel (send → tokens render); two tabs open → both receive chat + session updates; `lsof -nP -i :7337 | grep -c ESTABLISHED` shows 2 connections per tab (1 SSE + 1 HMR) instead of 3
- [x] Manual: 4+ tabs open → app still loads data everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)