### PR TITLE
fix(groovebox): scope glow via two-pass stroke — shadowBlur was starving the audio scheduler

### DIFF
--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -301,11 +301,8 @@ export function makeViz(host, song, eng) {
     const data = eng.getScope(scopeSource);
     // Bright glowing trace — resolved via themeColors() (not CSS vars, which canvas can't read).
     const GAIN = 1.6;                              // amplify so quiet signals still read
-    ctx.lineWidth = 2.5;
     ctx.lineJoin = 'round';
     ctx.lineCap = 'round';
-    ctx.shadowColor = tc.scope;
-    ctx.shadowBlur = 10;
     ctx.strokeStyle = tc.scope;
     ctx.beginPath();
     if (!data || data.length === 0) {
@@ -319,8 +316,16 @@ export function makeViz(host, song, eng) {
         if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
       }
     }
+    // Two-pass glow instead of ctx.shadowBlur: a 60fps per-pixel gaussian on a
+    // 1024-point stroke was saturating the main thread and starving Tone's
+    // scheduler (events fired >1s late). A wide translucent pass under a bright
+    // core reads as a glow at a tiny fraction of the cost. Path reused — no rebuild.
+    ctx.globalAlpha = 0.22;
+    ctx.lineWidth = 7;
     ctx.stroke();
-    ctx.shadowBlur = 0;                            // reset so other draws don't glow
+    ctx.globalAlpha = 1;
+    ctx.lineWidth = 2.5;
+    ctx.stroke();
   }
 
   function startScopeLoop() {


### PR DESCRIPTION
## Summary
The scope view's waveform trace used `ctx.shadowBlur = 10` — a per-pixel gaussian recomputed on a 1024-point stroke at 60fps. On the default (Scope) view this saturated the main thread and starved Tone's lookahead scheduler until **every event fired in the past** (`[gbperf]` probe: `late 64/64`, scheduling lead −1.7s and growing), heard as stutter/dropouts during playback.

This replaces the gaussian with a two-pass stroke — a wide translucent pass under the bright core, reusing the already-built path — which reads as the same neon glow at a tiny fraction of the cost.

## Before / after (`?perf` probe, Scope view, M1 under load)
| | late | min lead |
|---|---|---|
| before | **64/64** | **−1700ms, runaway** |
| after | 0/64 | −165ms, stable |

## Notes
- Replaces #624, which was cut from the pre-squash `music-engine` branch and showed the whole already-merged groovebox as its diff (and was add/add-conflicting). This is the same 13-line fix cherry-picked onto main.
- 121/121 Vitest green. No CHANGELOG entry (arcade scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)