### PR TITLE
fix(arcade-site): run_worker_first — assets were shadowing the groovebox host rewrite

### DIFF
--- a/infra/oyster-arcade-site/wrangler.toml
+++ b/infra/oyster-arcade-site/wrangler.toml
@@ -12,6 +12,11 @@ compatibility_date = "2026-04-01"
 directory = "../../docs/arcade"
 binding = "ASSETS"
 not_found_handling = "404-page"
+# Route every request through the worker (assets would otherwise be served
+# directly when the path matches a file, so groovebox.oyster.to/ was getting
+# the arcade index.html before the host rewrite in worker.ts could run).
+# The worker proxies to ASSETS, so arcade.oyster.to behavior is unchanged.
+run_worker_first = true
 
 # Custom Domain (NOT a plain Workers Route): Cloudflare provisions the DNS
 # record AND the TLS cert automatically on first deploy. A plain route


### PR DESCRIPTION
## Summary
After deploying #626, `groovebox.oyster.to/` served the **arcade** index instead of the groovebox: Workers static assets are served directly when the request path matches a file, **before** the user worker runs — so the host rewrite never executed for `/` (or any other path that exists in the assets tree). Paths that miss the assets tree (e.g. `/vendor/tone.js`) reached the worker and rewrote correctly, which confirmed the diagnosis.

Fix: `run_worker_first = true` so every request invokes the worker; it proxies to ASSETS for everything else, so `arcade.oyster.to` behavior is unchanged. (Verified against the wrangler 4.93 config schema: `boolean | string[]`.)

## After merge
Re-run `wrangler deploy` from `infra/oyster-arcade-site/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)