### PR TITLE
arcade(groovebox): punch-in FX — five momentary performance pads on the master bus

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -249,6 +249,18 @@ export function createEngine() {
       Tone.Transport.stop();
       if (repeatId !== null) { Tone.Transport.clear(repeatId); repeatId = null; }
       step = 0; playing = false; pendingFill = null; activeFill = null; fillQueue = []; pendingTranspose = null;
+      // Punch pads release with the transport.
+      for (const k in _punchHeld) _punchHeld[k] = false;
+      _gateReturnPending = false;
+      if (started) {
+        const now = Tone.now();
+        punchGate.gain.cancelScheduledValues(now);      punchGate.gain.value = PUNCH_NEUTRAL.gateGain;
+        punchTape.delayTime.cancelScheduledValues(now); punchTape.delayTime.value = PUNCH_NEUTRAL.tapeDelay;
+        punchCrush.wet.rampTo(PUNCH_NEUTRAL.crushWet, 0.05);
+        punchFilter.frequency.rampTo(PUNCH_NEUTRAL.filterFreq, 0.05);
+        punchFilter.Q.rampTo(PUNCH_NEUTRAL.filterQ, 0.05);
+        punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, 0.05);
+      }
     },
     setTempo(bpm) { if (typeof bpm === 'number' && isFinite(bpm)) { tempo = bpm; Tone.Transport.bpm.value = bpm; } },
     onStep(cb) { onStepCb = cb; },
@@ -259,6 +271,52 @@ export function createEngine() {
     toggleMute(id)          { return song ? _toggleMute(song.lanes, id) : false; },
     toggleSolo(id)          { return song ? _soloExclusive(song.lanes, id) : false; },
     triggerFill(name)       { pendingFill = name; },
+    // Punch-in FX: momentary performance effects — punch(name, true) on press,
+    // punch(name, false) on release. Names: stutter|crush|dive|throw|stop.
+    punch(name, on) {
+      if (!started || _punchHeld[name] === undefined) return;
+      on = !!on;
+      if (_punchHeld[name] === on) return;          // ignore repeat echoes
+      _punchHeld[name] = on;
+      if (name === 'crush') punchCrush.wet.rampTo(on ? 1 : PUNCH_NEUTRAL.crushWet, 0.05);
+      else if (name === 'dive') {
+        punchFilter.frequency.rampTo(on ? 150 : PUNCH_NEUTRAL.filterFreq, 0.15);
+        punchFilter.Q.rampTo(on ? 8 : PUNCH_NEUTRAL.filterQ, 0.15);
+      }
+      else if (name === 'throw') {
+        if (on) punchThrow.wet.rampTo(0.6, 0.05);
+        else    punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, 1.5);   // tail rings out
+      }
+      else if (name === 'stop') {
+        const now = Tone.now();
+        if (on) {
+          // Slump: delayTime + gate fade over the same window — the gate sits
+          // before the tape delay, so the line keeps emitting the slowing audio.
+          _gateReturnPending = false;
+          punchGate.gain.cancelScheduledValues(now);
+          punchGate.gain.rampTo(0, 0.8);
+          punchTape.delayTime.cancelScheduledValues(now);
+          punchTape.delayTime.rampTo(0.6, 0.8);
+        } else {
+          // Strict release order (spec safeguard 2): gate down → reset delayTime
+          // (silent while the gate is at 0) → gate back up on-grid (the step
+          // callback consumes the flag).
+          punchGate.gain.cancelScheduledValues(now);
+          punchGate.gain.value = 0;
+          punchTape.delayTime.cancelScheduledValues(now);
+          punchTape.delayTime.value = PUNCH_NEUTRAL.tapeDelay;
+          _gateReturnPending = true;
+        }
+      }
+      else if (name === 'stutter') {
+        // Engagement is scheduled by the step callback (stutterAllowed gates it).
+        if (!on && !_punchHeld.stop) {
+          // STOP owns the gate (safeguard 1) — only restore when STOP isn't active.
+          punchGate.gain.cancelScheduledValues(Tone.now());
+          punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, 0.01);
+        }
+      }
+    },
     queueFill(name)         { fillQueue.push(name); return fillQueue.length; },
     unqueueAt(i)            { if (i >= 0 && i < fillQueue.length) fillQueue.splice(i, 1); return fillQueue.slice(); },
     clearQueue()            { fillQueue = []; },

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -258,13 +258,16 @@ export function createEngine() {
       Tone.Transport.stop();
       if (repeatId !== null) { Tone.Transport.clear(repeatId); repeatId = null; }
       step = 0; playing = false; pendingFill = null; activeFill = null; fillQueue = []; pendingTranspose = null;
-      // Punch pads release with the transport.
+      // Punch pads release with the transport. rampTo pins current values
+      // (no cancel-then-revert clicks); delayTime snaps back after the brief
+      // gate settle so any reverb tail doesn't doppler.
       for (const k in _punchHeld) _punchHeld[k] = false;
       _gateReturnPending = false;
       if (started) {
         const now = Tone.now();
-        punchGate.gain.cancelScheduledValues(now);      punchGate.gain.value = PUNCH_NEUTRAL.gateGain;
-        punchTape.delayTime.cancelScheduledValues(now); punchTape.delayTime.value = PUNCH_NEUTRAL.tapeDelay;
+        punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, 0.01);
+        punchTape.delayTime.cancelAndHoldAtTime(now);
+        punchTape.delayTime.setValueAtTime(PUNCH_NEUTRAL.tapeDelay, now + 0.015);
         punchCrush.wet.rampTo(PUNCH_NEUTRAL.crushWet, 0.05);
         punchFilter.frequency.rampTo(PUNCH_NEUTRAL.filterFreq, 0.05);
         punchFilter.Q.rampTo(PUNCH_NEUTRAL.filterQ, 0.05);
@@ -297,31 +300,31 @@ export function createEngine() {
         else    punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, 1.5);   // tail rings out
       }
       else if (name === 'stop') {
-        const now = Tone.now();
         if (on) {
           // Slump: delayTime + gate fade over the same window — the gate sits
           // before the tape delay, so the line keeps emitting the slowing audio.
+          // rampTo pins the current value (setRampPoint → cancelAndHoldAtTime),
+          // so it's safe mid-stutter / mid-anything — no explicit cancels.
           _gateReturnPending = false;
-          punchGate.gain.cancelScheduledValues(now);
           punchGate.gain.rampTo(0, 0.8);
-          punchTape.delayTime.cancelScheduledValues(now);
           punchTape.delayTime.rampTo(0.6, 0.8);
         } else {
-          // Strict release order (spec safeguard 2): gate down → reset delayTime
-          // (silent while the gate is at 0) → gate back up on-grid (the step
-          // callback consumes the flag).
-          punchGate.gain.cancelScheduledValues(now);
-          punchGate.gain.value = 0;
-          punchTape.delayTime.cancelScheduledValues(now);
-          punchTape.delayTime.value = PUNCH_NEUTRAL.tapeDelay;
+          // Strict release order (spec safeguard 2), click-free on quick taps:
+          // close the gate from wherever the slump got to (3ms), freeze the
+          // slump where it is, snap delayTime back only AFTER the gate is
+          // closed (silent), then gate back up on-grid (step callback flag).
+          const now = Tone.now();
+          punchGate.gain.rampTo(0, 0.003);
+          punchTape.delayTime.cancelAndHoldAtTime(now);
+          punchTape.delayTime.setValueAtTime(PUNCH_NEUTRAL.tapeDelay, now + 0.005);
           _gateReturnPending = true;
         }
       }
       else if (name === 'stutter') {
         // Engagement is scheduled by the step callback (stutterAllowed gates it).
         if (!on && !_punchHeld.stop) {
-          // STOP owns the gate (safeguard 1) — only restore when STOP isn't active.
-          punchGate.gain.cancelScheduledValues(Tone.now());
+          // STOP owns the gate (safeguard 1) — only restore when STOP isn't
+          // active. rampTo cancels the pending chop events itself.
           punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, 0.01);
         }
       }

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -204,6 +204,15 @@ export function createEngine() {
           const v = voices[ev.laneId];
           if (v) trigger(v, ev, t, sixteenth, barSeconds);
         }
+        // Punch-in: on-grid gate return after STOP release, then stutter chops.
+        if (_gateReturnPending) {
+          punchGate.gain.setValueAtTime(0, t);
+          punchGate.gain.linearRampToValueAtTime(PUNCH_NEUTRAL.gateGain, t + 0.003);
+          _gateReturnPending = false;
+        }
+        if (_punchHeld.stutter && stutterAllowed(_punchHeld)) {
+          for (const [at, v] of stutterEvents(t, sixteenth)) punchGate.gain.linearRampToValueAtTime(v, at);
+        }
         if (onStepCb) {
           const s = step; const sb = songBar; const qSnap = fillQueue.slice();
           Tone.Draw.schedule(() => {

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -4,6 +4,7 @@ import { eventsForStep } from './scheduler.js';
 import { createVoiceForType, trigger } from './voices.js';
 import { normalizeLanes, cachePoolsByType, laneByType, setLane as _setLane, toggleMute as _toggleMute, soloExclusive as _soloExclusive, captureScene as _captureScene, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { sectionAt } from './arrangement.js';
+import { PUNCH_NEUTRAL, stutterAllowed, stutterEvents } from './punch.js';
 
 export function createEngine() {
   let song = null, step = 0, started = false, repeatId = null, tempo = 120, playing = false, onStepCb = null, pendingFill = null, activeFill = null, fillQueue = [];
@@ -11,6 +12,10 @@ export function createEngine() {
   let keyQuantize = false, pendingTranspose = null;
   let masterComp = null, masterRev = null, masterVol = null, masterPan = null, masterWidth = null, masterEQ = null;
   let _widthOn = false;   // is the StereoWidener spliced into the master chain?
+  // Punch-in FX: pre-wired neutral insert chain (comp → punch → pan); momentary.
+  let punchGate = null, punchCrush = null, punchFilter = null, punchThrow = null, punchTape = null;
+  const _punchHeld = { stutter: false, crush: false, dive: false, throw: false, stop: false };
+  let _gateReturnPending = false;   // STOP released → gate returns on the next step boundary
   let meterL = null, meterR = null;
   let scopeMaster = null, scopeLane = {};
   // Per-lane keyed maps (by lane.id)
@@ -75,7 +80,16 @@ export function createEngine() {
     const masterTrim = new Tone.Gain(0.5).connect(out);
     masterVol  = new Tone.Gain(1).connect(masterTrim);
     masterPan  = new Tone.Panner(0).connect(masterVol);
-    masterComp = new Tone.Compressor({ threshold: 0, ratio: 1, attack: 0.01, release: 0.2 }).connect(masterPan);
+    // Punch-in FX insert (pre-wired, neutral — engaging a pad is param ramps only;
+    // spec: project-notes/oyster/po20/2026-06-08-punch-in-fx-spec.md). Between
+    // comp and pan: outside the EQ↔width↔reverb splice zone, after the reverb so
+    // punches chop/slur the full mix including tails.
+    punchTape   = new Tone.Delay({ delayTime: PUNCH_NEUTRAL.tapeDelay, maxDelay: 1 }).connect(masterPan);
+    punchThrow  = new Tone.FeedbackDelay({ delayTime: '8n.', feedback: 0.55, wet: PUNCH_NEUTRAL.throwWet }).connect(punchTape);
+    punchFilter = new Tone.Filter({ type: 'lowpass', frequency: PUNCH_NEUTRAL.filterFreq, Q: PUNCH_NEUTRAL.filterQ }).connect(punchThrow);
+    punchCrush  = new Tone.BitCrusher(4); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
+    punchGate   = new Tone.Gain(PUNCH_NEUTRAL.gateGain).connect(punchCrush);
+    masterComp = new Tone.Compressor({ threshold: 0, ratio: 1, attack: 0.01, release: 0.2 }).connect(punchGate);
     masterRev  = new Tone.Reverb({ decay: 2.2, wet: 0 }).connect(masterComp);
     // StereoWidener bypassed by default — its mid/side processing weakens per-lane
     // pan and drops level on a mono-ish mix. Spliced in only when WID leaves centre.
@@ -118,7 +132,8 @@ export function createEngine() {
     _masterIn = masterIn;
     // Waveform analyser for master (sink — doesn't alter audio chain).
     scopeMaster = new Tone.Waveform(1024);
-    masterComp.connect(scopeMaster);
+    // Tapped post-punch so the scope shows chops/slumps (analyser sink only).
+    punchTape.connect(scopeMaster);
     // Build per-lane graph
     buildLaneGraph(song.lanes);
     started = true;

--- a/docs/arcade/groovebox/engine/punch.js
+++ b/docs/arcade/groovebox/engine/punch.js
@@ -1,0 +1,34 @@
+// Pure punch-in FX helpers — Tone-free so they're unit-testable.
+// Spec: project-notes/oyster/po20/2026-06-08-punch-in-fx-spec.md
+
+// Neutral (idle) values for the pre-wired punch insert chain. Single source of
+// truth: the engine builds and resets the chain from these; the test pins them
+// to the spec (safeguard 3 — idle graph must be audibly transparent).
+export const PUNCH_NEUTRAL = {
+  gateGain: 1,
+  crushWet: 0,
+  filterFreq: 20000,
+  filterQ: 0.7,
+  throwWet: 0,
+  tapeDelay: 0,
+};
+
+// STOP owns the gate (spec safeguard 1): stutter must not schedule gate
+// events while stop is held.
+export function stutterAllowed(held) {
+  return !held.stop;
+}
+
+// Gate envelope breakpoints for one 16th step: open first half, closed second,
+// with `ramp`-second edges so the chops don't click. Consumed via
+// linearRampToValueAtTime; the final [stepEnd, 0] means the next step's
+// opening edge ramps cleanly from 0.
+export function stutterEvents(t, sixteenth, ramp = 0.003) {
+  const half = sixteenth / 2;
+  return [
+    [t + ramp, 1],
+    [t + half, 1],
+    [t + half + ramp, 0],
+    [t + sixteenth, 0],
+  ];
+}

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -105,6 +105,7 @@
                 <dt>S</dt><dd>Solo a lane (silences all others)</dd>
                 <dt>VIEW</dt><dd>Open that lane in the step editor / piano roll</dd>
                 <dt>FILLS</dt><dd>Queue fill patterns — click a chip to remove it from the queue</dd>
+                <dt>PUNCH</dt><dd>Hold a pad (or keys 1–5) for momentary FX — release to snap back clean</dd>
                 <dt>KEY ± </dt><dd>Transpose the whole song up or down in semitones</dd>
               </dl>
             </div>
@@ -116,6 +117,7 @@
       <div id="viz"></div>
       <div id="strips"></div>
       <div id="fills"></div>
+      <div id="punch"></div>
       <div id="master"></div>
       <div id="arrange"></div>
     </div>

--- a/docs/arcade/groovebox/tests/punch.test.js
+++ b/docs/arcade/groovebox/tests/punch.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { PUNCH_NEUTRAL, stutterAllowed, stutterEvents } from '../engine/punch.js';
+
+describe('PUNCH_NEUTRAL', () => {
+  it('pins the idle chain to audibly-transparent values (spec safeguard 3)', () => {
+    expect(PUNCH_NEUTRAL).toEqual({
+      gateGain: 1, crushWet: 0, filterFreq: 20000, filterQ: 0.7, throwWet: 0, tapeDelay: 0,
+    });
+  });
+});
+
+describe('stutterAllowed', () => {
+  it('blocks stutter while STOP holds the gate (spec safeguard 1)', () => {
+    expect(stutterAllowed({ stutter: true, stop: true })).toBe(false);
+  });
+  it('allows stutter otherwise', () => {
+    expect(stutterAllowed({ stutter: true, stop: false })).toBe(true);
+  });
+});
+
+describe('stutterEvents', () => {
+  const SIX = 0.125; // one 16th at 120bpm
+  it('opens the first half of the step, closes the second, with 3ms edges', () => {
+    expect(stutterEvents(10, SIX)).toEqual([
+      [10.003, 1],
+      [10 + SIX / 2, 1],
+      [10 + SIX / 2 + 0.003, 0],
+      [10 + SIX, 0],
+    ]);
+  });
+  it('lands the final breakpoint exactly on the next step boundary, closed', () => {
+    const ev = stutterEvents(0, SIX);
+    expect(ev[ev.length - 1]).toEqual([SIX, 0]);
+  });
+});

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -399,6 +399,7 @@ input[type=range] {
 #viz,
 #strips,
 #fills,
+#punch,
 #master,
 #arrange {
   /* soft top-light → bottom-shade sheen (derived from --panel) so panels read
@@ -893,6 +894,30 @@ input[type=range] {
   flex-direction: row;
   gap: 3px;
   align-items: center;
+}
+
+/* ─── punch row (momentary performance pads; panel chrome via #punch) ────── */
+.punchrow { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; row-gap: 6px; }
+.punchpad {
+  height: 34px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--dim);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  user-select: none;
+  touch-action: none;          /* hold-gesture pads — no scroll/zoom stealing */
+}
+.punchpad .punchkey { margin-left: 7px; opacity: 0.45; font-size: 9px; }
+.punchpad.held {
+  background: var(--hot);
+  color: var(--ink);
+  border-color: var(--hot);
+  box-shadow: 0 0 12px var(--hot);   /* the existing "driving sound" glow language */
 }
 
 /* ─── fills row (panel chrome via #fills) ───────────────────────────────── */

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -475,6 +475,67 @@ function renderFills() {
   host.appendChild(row);
 }
 
+// ─── Punch-in FX pads (momentary; spec in project-notes/oyster/po20) ─────────
+const PUNCH_PADS = [
+  ['stutter', 'STUT',  '1'],
+  ['crush',   'CRUSH', '2'],
+  ['dive',    'DIVE',  '3'],
+  ['throw',   'THROW', '4'],
+  ['stop',    'STOP',  '5'],
+];
+const PUNCH_BY_KEY = Object.fromEntries(PUNCH_PADS.map(([name, , key]) => [key, name]));
+
+function setPunch(name, on) {
+  eng.punch(name, on);
+  document.querySelector(`#punch .punchpad[data-punch="${name}"]`)?.classList.toggle('held', on);
+}
+
+function renderPunch() {
+  const host = document.getElementById('punch');
+  if (!host) return;
+  host.innerHTML = '';
+  const row = document.createElement('div');
+  row.className = 'punchrow';
+  const lbl = document.createElement('span');
+  lbl.className = 'flbl';
+  lbl.textContent = 'PUNCH';
+  row.appendChild(lbl);
+  for (const [name, label, key] of PUNCH_PADS) {
+    const pad = document.createElement('button');
+    pad.className = 'punchpad';
+    pad.dataset.punch = name;
+    pad.append(label);
+    const hint = document.createElement('span');
+    hint.className = 'punchkey';
+    hint.textContent = key;
+    pad.appendChild(hint);
+    pad.addEventListener('pointerdown', e => { e.preventDefault(); pad.setPointerCapture(e.pointerId); setPunch(name, true); });
+    const off = () => setPunch(name, false);
+    pad.addEventListener('pointerup', off);
+    pad.addEventListener('pointercancel', off);
+    row.appendChild(pad);
+  }
+  host.appendChild(row);
+}
+
+// Keys 1–5 mirror the pads. Guards: key auto-repeat, and typing into inputs /
+// selects / contenteditable (no keyboard hijack while renaming lanes etc.).
+function isTypingTarget(el) {
+  return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable);
+}
+document.addEventListener('keydown', e => {
+  const name = PUNCH_BY_KEY[e.key];
+  if (!name || e.repeat || isTypingTarget(document.activeElement)) return;
+  e.preventDefault();
+  setPunch(name, true);
+});
+document.addEventListener('keyup', e => {
+  const name = PUNCH_BY_KEY[e.key];
+  if (name) setPunch(name, false);
+});
+// Stuck-key guard: losing window focus releases every pad.
+window.addEventListener('blur', () => { for (const [name] of PUNCH_PADS) setPunch(name, false); });
+
 // ─── Master FX ───────────────────────────────────────────────────────────────
 function renderMaster() {
   const masterHost = document.getElementById('master');
@@ -614,6 +675,7 @@ function mount() {
   if (creditEl) creditEl.textContent = song.artist ? `${song.title || ''} — ${song.artist}` : '';
   renderStrips();
   renderFills();
+  renderPunch();
   renderMaster();
   renderArrange();
   viz = makeViz(document.getElementById('viz'), song, eng);


### PR DESCRIPTION
## Summary
Five hold-able performance effects on the master bus — **STUT, CRUSH, DIVE, THROW, STOP** — via a new PUNCH module beside FILLS, with keys **1–5** mirroring the pads. Hold = effect, release = clean. Nothing persists; it's playing the machine, not programming it.

**Architecture:** pre-wired neutral insert chain between `masterComp` and `masterPan` (no live graph surgery — engaging a pad is parameter ramps only). Outside the EQ↔width↔reverb splice zone; after the reverb so punches chop/slur the full mix including tails. Spec + plan: `project-notes/oyster/po20/2026-06-08-punch-in-fx-{spec,plan}.md`.

## Safeguards (from design review)
- **STOP owns the gate** — STUT is a no-op while STOP is active (`stutterAllowed`); STOP release cancels scheduled gate events, then the gate returns **on-grid** via the step callback
- **Strict tape-stop release order** — gate down → `delayTime` reset (silent at gate 0) → gate up on the next step boundary; no reset click
- **Idle neutrality pinned in code** — `PUNCH_NEUTRAL` is the single source of truth for build + reset, unit-tested against the spec values
- **No keyboard hijack** — typing guard (input/textarea/select/contenteditable) + `e.repeat` guard + window-blur releases all pads
- **Scope re-tapped post-punch** (analyser sink only) so the trace shows chops/slumps

## Audio-critical path
Step callback additions are two `if`s; the only allocation is one small array per step *while stuttering*. Lookahead, `?perf` probe, and the no-`Tone.Time()`-parsing rule untouched.

## Testing
- 126/126 Vitest (5 new: neutral constants, STOP/STUT rule, stutter gate math)
- Static serve smoke-checked; **manual by-ear checklist** (idle A/B, STOP release click, `?perf` `late 0/64` while hammering pads) left for review — see plan Task 8

## Coordination
Additive, but `engine/index.js` is also touched by the in-flight `groovebox-patterns-chain` branch — prefer landing this first, or rebase carefully after. No CHANGELOG (arcade scope). Merging ≠ live: manual `wrangler deploy` ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)