### PR TITLE
fix(groovebox): punch row styling + tame CRUSH

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -87,7 +87,7 @@ export function createEngine() {
     punchTape   = new Tone.Delay({ delayTime: PUNCH_NEUTRAL.tapeDelay, maxDelay: 1 }).connect(masterPan);
     punchThrow  = new Tone.FeedbackDelay({ delayTime: '8n.', feedback: 0.55, wet: PUNCH_NEUTRAL.throwWet }).connect(punchTape);
     punchFilter = new Tone.Filter({ type: 'lowpass', frequency: PUNCH_NEUTRAL.filterFreq, Q: PUNCH_NEUTRAL.filterQ }).connect(punchThrow);
-    punchCrush  = new Tone.BitCrusher(4); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
+    punchCrush  = new Tone.BitCrusher(6); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
     punchGate   = new Tone.Gain(PUNCH_NEUTRAL.gateGain).connect(punchCrush);
     masterComp = new Tone.Compressor({ threshold: 0, ratio: 1, attack: 0.01, release: 0.2 }).connect(punchGate);
     masterRev  = new Tone.Reverb({ decay: 2.2, wet: 0 }).connect(masterComp);
@@ -290,7 +290,7 @@ export function createEngine() {
       on = !!on;
       if (_punchHeld[name] === on) return;          // ignore repeat echoes
       _punchHeld[name] = on;
-      if (name === 'crush') punchCrush.wet.rampTo(on ? 1 : PUNCH_NEUTRAL.crushWet, 0.05);
+      if (name === 'crush') punchCrush.wet.rampTo(on ? 0.5 : PUNCH_NEUTRAL.crushWet, 0.05);   // 6-bit @ 50% = lo-fi grit, not broken speaker
       else if (name === 'dive') {
         punchFilter.frequency.rampTo(on ? 150 : PUNCH_NEUTRAL.filterFreq, 0.15);
         punchFilter.Q.rampTo(on ? 8 : PUNCH_NEUTRAL.filterQ, 0.15);

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -451,6 +451,11 @@ input[type=range] {
   padding: 12px 16px;
 }
 
+/* ─── punch panel ────────────────────────────────────────────────────────── */
+#punch {
+  padding: 12px 16px;
+}
+
 /* ─── master panel ───────────────────────────────────────────────────────── */
 #master {
   padding: 12px 16px;
@@ -899,18 +904,26 @@ input[type=range] {
 /* ─── punch row (momentary performance pads; panel chrome via #punch) ────── */
 .punchrow { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; row-gap: 6px; }
 .punchpad {
-  height: 34px;
-  padding: 0 14px;
+  height: 30px;
+  padding: 0 10px;
   border-radius: 6px;
   border: 1px solid var(--line);
   background: var(--panel-2);
   color: var(--dim);
   font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.04),
+    inset 0 -1px 0 rgba(0,0,0,0.25),
+    0 1px 2px rgba(0,0,0,0.3);
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
   cursor: pointer;
   user-select: none;
   touch-action: none;          /* hold-gesture pads — no scroll/zoom stealing */
+}
+.punchpad:hover {
+  background: var(--panel-3);
 }
 .punchpad .punchkey { margin-left: 7px; opacity: 0.45; font-size: 9px; }
 .punchpad.held {
@@ -929,7 +942,8 @@ input[type=range] {
   row-gap: 6px;
 }
 /* § 2 — section header */
-.fillsrow .flbl {
+.fillsrow .flbl,
+.punchrow .flbl {
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.12em;


### PR DESCRIPTION
## Summary
Ear-test + eyeball feedback on #629:

- **Styling** — three concrete misses: `#punch` had no panel padding rule (label sat flush against the edge), the PUNCH label missed the section-header style (`.flbl` was scoped to `.fillsrow` only), and `.punchpad` diverged from the unified control base. Now visually identical to the FILLS row system (30px controls, inset shadows, hover state).
- **CRUSH tamed** — 4-bit @ 100% wet on the full mix sounded like a broken speaker. Now 6-bit @ 50% wet = lo-fi grit. (Slot 2 may still get swapped for a flanger-jet/echo-freeze later; this makes it usable meanwhile.)

126/126 tests green. No CHANGELOG (arcade scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)