### PR TITLE
feat(groovebox): punch joins section drag-reorder; new default section order

### DIFF
--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -115,10 +115,10 @@
       <!-- Tier 3 — views (built by renderViewTabs) -->
       <div class="vtabs"><span class="vtabs-lbl">VIEW</span><button data-view="scope">📈 Scope</button></div>
       <div id="viz"></div>
+      <div id="master"></div>
+      <div id="punch"></div>
       <div id="strips"></div>
       <div id="fills"></div>
-      <div id="punch"></div>
-      <div id="master"></div>
       <div id="arrange"></div>
     </div>
     <div class="crt-vignette"></div>

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -54,7 +54,7 @@ let _editingLaneId = null;
 let _draggedLaneId = null;
 
 // ─── Section drag-reorder state ───────────────────────────────────────────────
-const SECTION_IDS = ['viz', 'strips', 'fills', 'master', 'arrange'];
+const SECTION_IDS = ['viz', 'master', 'punch', 'strips', 'fills', 'arrange'];
 let _draggedSecId = null;
 
 function options(lane) {
@@ -1065,10 +1065,17 @@ function initSectionWrappers() {
     wrap.appendChild(sec);
   }
 
-  // 2. Restore saved order (move wrappers within .cabinet-inner)
+  // 2. Restore saved order (move wrappers within .cabinet-inner).
+  // Tolerant of orders saved before newer sections existed (e.g. punch):
+  // keep the user's sequence, splice missing sections in at their default
+  // position, drop ids that no longer exist.
   const saved = JSON.parse(localStorage.getItem('gb-section-order') || 'null');
-  if (saved && Array.isArray(saved) && saved.length === SECTION_IDS.length) {
-    for (const id of saved) {
+  if (saved && Array.isArray(saved) && saved.length) {
+    const order = saved.filter(id => SECTION_IDS.includes(id));
+    for (const id of SECTION_IDS) {
+      if (!order.includes(id)) order.splice(SECTION_IDS.indexOf(id), 0, id);
+    }
+    for (const id of order) {
       const wrap = inner.querySelector(`.sec[data-sec="${id}"]`);
       if (wrap) inner.appendChild(wrap);
     }


### PR DESCRIPTION
## Summary
- **PUNCH is now draggable** like every other section — it was missing from `SECTION_IDS`, so it never got a `.sec` wrapper/handle.
- **New default order:** LCD (viz) → MASTER → PUNCH → INSTRUMENTS (strips) → FILLS → arrange. (Default = DOM order in `index.html`; VIEW tabs stay glued above the LCD since viz remains first.)
- **Tolerant order migration:** the restore previously required `saved.length === SECTION_IDS.length`, which would have silently discarded every existing user's saved layout the moment a new section shipped. Now: keep the user's saved sequence, splice unknown-to-them sections in at their default position, drop stale ids.

Note for existing layouts (including yours): if you've ever dragged a section, your saved order wins — punch gets spliced in at position 3. To adopt the new default wholesale: `localStorage.removeItem('gb-section-order')` in the console, or just drag things where you want them.

126/126 tests green. No CHANGELOG (arcade scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)