### PR TITLE
arcade(groovebox): punch v2 — per-lane arm chips + AMOUNT knob (DJM channel-assign)

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -155,6 +155,17 @@ export function createEngine() {
         for (const lane of s.lanes) {
           if (!voices[lane.id]) buildLane(lane);
         }
+        // Re-sync punch routing for REUSED lane graphs: the new song's lanes
+        // carry their own punchArm state, but matching-id graphs keep their
+        // old toPunch/toClean gains (review: song-switch desync).
+        for (const lane of s.lanes) {
+          const f = fx[lane.id];
+          if (f && f.toPunch) {
+            const armed = isPunchArmed(lane);
+            f.toPunch.gain.rampTo(armed ? 1 : 0, 0.01);
+            f.toClean.gain.rampTo(armed ? 0 : 1, 0.01);
+          }
+        }
       }
     },
     async play() {
@@ -291,7 +302,9 @@ export function createEngine() {
     setPunchArm(id, on) {
       if (!song) return;
       const lane = song.lanes.find(l => l.id === id);
-      if (lane) lane.punchArm = !!on;
+      // Armed is the default — only an explicit false is stored, so toggling
+      // a lane off and back on leaves no punchArm key to serialize.
+      if (lane) { if (on) delete lane.punchArm; else lane.punchArm = false; }
       const f = fx[id];
       if (f && f.toPunch) {
         f.toPunch.gain.rampTo(on ? 1 : 0, 0.01);
@@ -311,14 +324,16 @@ export function createEngine() {
       on = !!on;
       if (_punchHeld[name] === on) return;          // ignore repeat echoes
       _punchHeld[name] = on;
-      if (name === 'crush') punchCrush.wet.rampTo(on ? 0.5 : PUNCH_NEUTRAL.crushWet, 0.05);   // 6-bit @ 50% = lo-fi grit, not broken speaker
+      // Engaged targets: PUNCH_PARAMS scaled by the AMOUNT knob, read at press time.
+      if (name === 'crush') punchCrush.wet.rampTo(on ? PUNCH_PARAMS.crush.wet * punchAmount : PUNCH_NEUTRAL.crushWet, 0.05);
       else if (name === 'dive') {
-        punchFilter.frequency.rampTo(on ? 150 : PUNCH_NEUTRAL.filterFreq, 0.15);
-        punchFilter.Q.rampTo(on ? 8 : PUNCH_NEUTRAL.filterQ, 0.15);
+        const P = PUNCH_PARAMS.dive;
+        punchFilter.frequency.rampTo(on ? diveFreqForAmount(punchAmount) : PUNCH_NEUTRAL.filterFreq, P.ramp);
+        punchFilter.Q.rampTo(on ? PUNCH_NEUTRAL.filterQ + (P.q - PUNCH_NEUTRAL.filterQ) * punchAmount : PUNCH_NEUTRAL.filterQ, P.ramp);
       }
       else if (name === 'throw') {
-        if (on) punchThrow.wet.rampTo(0.6, 0.05);
-        else    punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, 1.5);   // tail rings out
+        if (on) punchThrow.wet.rampTo(PUNCH_PARAMS.throw.wet * punchAmount, 0.05);
+        else    punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, PUNCH_PARAMS.throw.release);   // tail rings out
       }
       else if (name === 'stop') {
         if (on) {
@@ -327,8 +342,8 @@ export function createEngine() {
           // rampTo pins the current value (setRampPoint → cancelAndHoldAtTime),
           // so it's safe mid-stutter / mid-anything — no explicit cancels.
           _gateReturnPending = false;
-          punchGate.gain.rampTo(0, 0.8);
-          punchTape.delayTime.rampTo(0.6, 0.8);
+          punchGate.gain.rampTo(0, PUNCH_PARAMS.stop.time);
+          punchTape.delayTime.rampTo(PUNCH_PARAMS.stop.depth * punchAmount, PUNCH_PARAMS.stop.time);
         } else {
           // Strict release order (spec safeguard 2), click-free on quick taps:
           // close the gate from wherever the slump got to (3ms), freeze the

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -4,7 +4,7 @@ import { eventsForStep } from './scheduler.js';
 import { createVoiceForType, trigger } from './voices.js';
 import { normalizeLanes, cachePoolsByType, laneByType, setLane as _setLane, toggleMute as _toggleMute, soloExclusive as _soloExclusive, captureScene as _captureScene, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { sectionAt } from './arrangement.js';
-import { PUNCH_NEUTRAL, stutterAllowed, stutterEvents } from './punch.js';
+import { PUNCH_NEUTRAL, PUNCH_PARAMS, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from './punch.js';
 
 export function createEngine() {
   let song = null, step = 0, started = false, repeatId = null, tempo = 120, playing = false, onStepCb = null, pendingFill = null, activeFill = null, fillQueue = [];
@@ -16,6 +16,7 @@ export function createEngine() {
   let punchGate = null, punchCrush = null, punchFilter = null, punchThrow = null, punchTape = null;
   const _punchHeld = { stutter: false, crush: false, dive: false, throw: false, stop: false };
   let _gateReturnPending = false;   // STOP released → gate returns on the next step boundary
+  let punchAmount = 1;              // AMOUNT knob: scales every effect's engaged intensity
   let meterL = null, meterR = null;
   let scopeMaster = null, scopeLane = {};
   // Per-lane keyed maps (by lane.id)
@@ -28,6 +29,7 @@ export function createEngine() {
 
   function buildLane(lane) {
     fx[lane.id]     = _makeFX(_masterIn);
+    if (!isPunchArmed(lane)) { fx[lane.id].toPunch.gain.value = 0; fx[lane.id].toClean.gain.value = 1; }
     voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input);
     // Apply saved tone to melody lanes
     if (lane.type === 'melody' && lane.tone) {
@@ -80,22 +82,21 @@ export function createEngine() {
     const masterTrim = new Tone.Gain(0.5).connect(out);
     masterVol  = new Tone.Gain(1).connect(masterTrim);
     masterPan  = new Tone.Panner(0).connect(masterVol);
-    // Punch-in FX insert (pre-wired, neutral — engaging a pad is param ramps only;
-    // spec: project-notes/oyster/po20/2026-06-08-punch-in-fx-spec.md). Between
-    // comp and pan: outside the EQ↔width↔reverb splice zone, after the reverb so
-    // punches chop/slur the full mix including tails.
-    punchTape   = new Tone.Delay({ delayTime: PUNCH_NEUTRAL.tapeDelay, maxDelay: 1 }).connect(masterPan);
-    punchThrow  = new Tone.FeedbackDelay({ delayTime: '8n.', feedback: 0.55, wet: PUNCH_NEUTRAL.throwWet }).connect(punchTape);
-    punchFilter = new Tone.Filter({ type: 'lowpass', frequency: PUNCH_NEUTRAL.filterFreq, Q: PUNCH_NEUTRAL.filterQ }).connect(punchThrow);
-    punchCrush  = new Tone.BitCrusher(6); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
-    punchGate   = new Tone.Gain(PUNCH_NEUTRAL.gateGain).connect(punchCrush);
-    masterComp = new Tone.Compressor({ threshold: 0, ratio: 1, attack: 0.01, release: 0.2 }).connect(punchGate);
+    masterComp = new Tone.Compressor({ threshold: 0, ratio: 1, attack: 0.01, release: 0.2 }).connect(masterPan);
     masterRev  = new Tone.Reverb({ decay: 2.2, wet: 0 }).connect(masterComp);
     // StereoWidener bypassed by default — its mid/side processing weakens per-lane
     // pan and drops level on a mono-ish mix. Spliced in only when WID leaves centre.
     masterWidth = new Tone.StereoWidener(0.5);
     masterEQ   = new Tone.EQ3({ low: 0, mid: 0, high: 0 }).connect(masterRev);
     const masterIn = masterEQ;
+    // Punch bus (v2 channel-assign): armed lanes route vol → toPunch → this
+    // chain → masterIn; unarmed lanes go vol → toClean → masterIn. Pre-wired
+    // and neutral — engaging a pad is param ramps only (no graph surgery).
+    punchTape   = new Tone.Delay({ delayTime: PUNCH_NEUTRAL.tapeDelay, maxDelay: 1 }).connect(masterIn);
+    punchThrow  = new Tone.FeedbackDelay({ delayTime: '8n.', feedback: PUNCH_PARAMS.throw.feedback, wet: PUNCH_NEUTRAL.throwWet }).connect(punchTape);
+    punchFilter = new Tone.Filter({ type: 'lowpass', frequency: PUNCH_NEUTRAL.filterFreq, Q: PUNCH_NEUTRAL.filterQ }).connect(punchThrow);
+    punchCrush  = new Tone.BitCrusher(PUNCH_PARAMS.crush.bits); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
+    punchGate   = new Tone.Gain(PUNCH_NEUTRAL.gateGain).connect(punchCrush);
     // Shared reverb bus — one convolver for all lanes (per-lane send gain controls amount).
     _laneReverb = new Tone.Reverb({ decay: 2.4, wet: 1 }).connect(masterIn);
     // Stereo output meters — tapped post-volume (silent sinks, don't alter audio chain).
@@ -106,7 +107,11 @@ export function createEngine() {
     split.connect(meterL, 0, 0);
     split.connect(meterR, 1, 0);
     _makeFX = dest => {
-      const vol = new Tone.Gain(1).connect(dest);
+      // Punch-bus split: complementary gains (armed: toPunch 1 / toClean 0).
+      // Arming is a 10ms crossfade on these — never a connect/disconnect.
+      const vol = new Tone.Gain(1);
+      const toClean = new Tone.Gain(0); vol.connect(toClean); toClean.connect(dest);
+      const toPunch = new Tone.Gain(1); vol.connect(toPunch); toPunch.connect(punchGate);
       const pan = new Tone.Panner(0).connect(vol);
       const dl = new Tone.FeedbackDelay({ delayTime: '8n', feedback: 0.28, wet: 0 }).connect(pan);
       const comp = new Tone.Compressor({ threshold: 0, ratio: 1, attack: 0.01, release: 0.2 }).connect(dl);
@@ -126,14 +131,13 @@ export function createEngine() {
         filter: ft, drive: dr,
         crush: null, chorus: null, auto: null,
         slotCrush, slotChorus, slotAuto,
-        comp, reverbSend, delay: dl, panner: pan, vol, input: ft, _cutType: 'lowpass',
+        comp, reverbSend, delay: dl, panner: pan, vol, toPunch, toClean, input: ft, _cutType: 'lowpass',
       };
     };
     _masterIn = masterIn;
     // Waveform analyser for master (sink — doesn't alter audio chain).
     scopeMaster = new Tone.Waveform(1024);
-    // Tapped post-punch so the scope shows chops/slumps (analyser sink only).
-    punchTape.connect(scopeMaster);
+    masterComp.connect(scopeMaster);
     // Build per-lane graph
     buildLaneGraph(song.lanes);
     started = true;
@@ -211,7 +215,7 @@ export function createEngine() {
           _gateReturnPending = false;
         }
         if (_punchHeld.stutter && stutterAllowed(_punchHeld)) {
-          for (const [at, v] of stutterEvents(t, sixteenth)) punchGate.gain.linearRampToValueAtTime(v, at);
+          for (const [at, v] of stutterEvents(t, sixteenth, 0.003, 1 - punchAmount)) punchGate.gain.linearRampToValueAtTime(v, at);
         }
         if (onStepCb) {
           const s = step; const sb = songBar; const qSnap = fillQueue.slice();
@@ -283,6 +287,23 @@ export function createEngine() {
     toggleMute(id)          { return song ? _toggleMute(song.lanes, id) : false; },
     toggleSolo(id)          { return song ? _soloExclusive(song.lanes, id) : false; },
     triggerFill(name)       { pendingFill = name; },
+    // Punch bus channel-assign (v2): 10ms complementary crossfade, no surgery.
+    setPunchArm(id, on) {
+      if (!song) return;
+      const lane = song.lanes.find(l => l.id === id);
+      if (lane) lane.punchArm = !!on;
+      const f = fx[id];
+      if (f && f.toPunch) {
+        f.toPunch.gain.rampTo(on ? 1 : 0, 0.01);
+        f.toClean.gain.rampTo(on ? 0 : 1, 0.01);
+      }
+    },
+    getPunchArm(id) {
+      const lane = song?.lanes.find(l => l.id === id);
+      return lane ? isPunchArmed(lane) : true;
+    },
+    setPunchAmount(v01) { if (typeof v01 === 'number' && isFinite(v01)) punchAmount = Math.max(0, Math.min(1, v01)); },
+    getPunchAmount()    { return punchAmount; },
     // Punch-in FX: momentary performance effects — punch(name, true) on press,
     // punch(name, false) on release. Names: stutter|crush|dive|throw|stop.
     punch(name, on) {

--- a/docs/arcade/groovebox/engine/punch.js
+++ b/docs/arcade/groovebox/engine/punch.js
@@ -1,7 +1,8 @@
 // Pure punch-in FX helpers — Tone-free so they're unit-testable.
 // Spec: project-notes/oyster/po20/2026-06-08-punch-in-fx-spec.md
+//       + 2026-06-08-punch-bus-assign-v2-spec.md (arm chips, AMOUNT)
 
-// Neutral (idle) values for the pre-wired punch insert chain. Single source of
+// Neutral (idle) values for the pre-wired punch chain. Single source of
 // truth: the engine builds and resets the chain from these; the test pins them
 // to the spec (safeguard 3 — idle graph must be audibly transparent).
 export const PUNCH_NEUTRAL = {
@@ -13,22 +14,44 @@ export const PUNCH_NEUTRAL = {
   tapeDelay: 0,
 };
 
+// Engaged (held) targets for each punch effect — internal tuning surface,
+// fixed defaults (crush 0.9: dogfood verdict — drums-only takes near-full).
+export const PUNCH_PARAMS = {
+  crush: { bits: 6, wet: 0.9 },
+  dive:  { freq: 150, q: 8, ramp: 0.15 },
+  throw: { wet: 0.6, feedback: 0.55, release: 1.5 },
+  stop:  { depth: 0.6, time: 0.8 },
+};
+
+// Punch bus channel-assign: lanes are armed by default; only an explicit
+// punchArm === false opts a lane out (serializes with the lane object).
+export function isPunchArmed(lane) {
+  return lane.punchArm !== false;
+}
+
+// AMOUNT-scaled dive target. Log-space interpolation so half-amount sounds
+// like half a sweep, not a barely-audible top-end shelf.
+export function diveFreqForAmount(amount, neutral = PUNCH_NEUTRAL.filterFreq, target = PUNCH_PARAMS.dive.freq) {
+  return neutral * Math.pow(target / neutral, amount);
+}
+
 // STOP owns the gate (spec safeguard 1): stutter must not schedule gate
 // events while stop is held.
 export function stutterAllowed(held) {
   return !held.stop;
 }
 
-// Gate envelope breakpoints for one 16th step: open first half, closed second,
-// with `ramp`-second edges so the chops don't click. Consumed via
-// linearRampToValueAtTime; the final [stepEnd, 0] means the next step's
-// opening edge ramps cleanly from 0.
-export function stutterEvents(t, sixteenth, ramp = 0.003) {
+// Gate envelope breakpoints for one 16th step: open first half, `closed`-level
+// second half (0 = full chop; AMOUNT scales it via closed = 1 - amount), with
+// `ramp`-second edges so the chops don't click. Consumed via
+// linearRampToValueAtTime; the final [stepEnd, closed] means the next step's
+// opening edge ramps cleanly from the closed level.
+export function stutterEvents(t, sixteenth, ramp = 0.003, closed = 0) {
   const half = sixteenth / 2;
   return [
     [t + ramp, 1],
     [t + half, 1],
-    [t + half + ramp, 0],
-    [t + sixteenth, 0],
+    [t + half + ramp, closed],
+    [t + sixteenth, closed],
   ];
 }

--- a/docs/arcade/groovebox/tests/punch.test.js
+++ b/docs/arcade/groovebox/tests/punch.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PUNCH_NEUTRAL, stutterAllowed, stutterEvents } from '../engine/punch.js';
+import { PUNCH_NEUTRAL, PUNCH_PARAMS, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from '../engine/punch.js';
 
 describe('PUNCH_NEUTRAL', () => {
   it('pins the idle chain to audibly-transparent values (spec safeguard 3)', () => {
@@ -31,5 +31,51 @@ describe('stutterEvents', () => {
   it('lands the final breakpoint exactly on the next step boundary, closed', () => {
     const ev = stutterEvents(0, SIX);
     expect(ev[ev.length - 1]).toEqual([SIX, 0]);
+  });
+});
+
+describe('PUNCH_PARAMS', () => {
+  it('pins engaged-target defaults (crush 0.9 per dogfood verdict)', () => {
+    expect(PUNCH_PARAMS.crush).toEqual({ bits: 6, wet: 0.9 });
+    expect(PUNCH_PARAMS.dive.freq).toBe(150);
+    expect(PUNCH_PARAMS.throw.wet).toBeGreaterThan(0);
+    expect(PUNCH_PARAMS.stop.depth).toBeGreaterThan(0);
+  });
+});
+
+describe('isPunchArmed', () => {
+  it('defaults to armed when the lane has no punchArm flag', () => {
+    expect(isPunchArmed({})).toBe(true);
+  });
+  it('respects an explicit false', () => {
+    expect(isPunchArmed({ punchArm: false })).toBe(false);
+  });
+  it('respects an explicit true', () => {
+    expect(isPunchArmed({ punchArm: true })).toBe(true);
+  });
+});
+
+describe('diveFreqForAmount', () => {
+  it('hits the full dive target at amount 1', () => {
+    expect(diveFreqForAmount(1)).toBeCloseTo(150, 5);
+  });
+  it('stays at neutral for amount 0', () => {
+    expect(diveFreqForAmount(0)).toBeCloseTo(20000, 5);
+  });
+  it('interpolates in log space (perceptually even sweep)', () => {
+    expect(diveFreqForAmount(0.5)).toBeCloseTo(Math.sqrt(20000 * 150), 3);
+  });
+});
+
+describe('stutterEvents closed level', () => {
+  it('chops to a partial level when closed > 0 (amount-scaled stutter)', () => {
+    const ev = stutterEvents(0, 0.125, 0.003, 0.4);
+    expect(ev[2][1]).toBe(0.4);
+    expect(ev[3][1]).toBe(0.4);
+  });
+  it('defaults to a full chop (closed 0)', () => {
+    const ev = stutterEvents(0, 0.125);
+    expect(ev[2][1]).toBe(0);
+    expect(ev[3][1]).toBe(0);
   });
 });

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -835,14 +835,19 @@ input[type=range] {
 }
 
 /* ─── mute / solo buttons ────────────────────────────────────────────────── */
-.mute, .solo {
+.mute, .solo, .arm {
   width: 26px; height: 26px; flex: 0 0 26px; padding: 0; border-radius: 6px;
   font: 700 11px ui-monospace,Menlo,monospace; color: var(--dim);
   border: 1px solid var(--line); cursor: pointer; transition: .12s;
   background: var(--panel-2);
   box-shadow: inset 0 1px 0 rgba(255,255,255,.04), inset 0 -1px 2px rgba(0,0,0,.3), 0 1px 2px rgba(0,0,0,.3);
 }
-.mute:hover, .solo:hover { border-color: var(--acc-dim); background: var(--panel-3); }
+.mute:hover, .solo:hover, .arm:hover { border-color: var(--acc-dim); background: var(--panel-3); }
+.arm.armed {
+  color: var(--ink); border-color: var(--hot);
+  background: var(--hot);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.25), 0 0 10px var(--hot), 0 1px 2px rgba(0,0,0,.4);
+}
 .mute.muted {
   color: #fff1e8; border-color: #a8391c;
   background: linear-gradient(180deg, #ff7a3d, #d6481e);
@@ -926,6 +931,7 @@ input[type=range] {
   background: var(--panel-3);
 }
 .punchpad .punchkey { margin-left: 7px; opacity: 0.45; font-size: 9px; }
+.punchrow .knob { margin-left: 10px; }
 .punchpad.held {
   background: var(--hot);
   color: var(--ink);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -232,6 +232,7 @@ function renderStrips() {
       <div class="msgroup">
         <button class="mute" data-lane="${lane.id}" aria-label="mute ${esc(lane.name)}" title="Mute">M</button>
         <button class="solo" data-lane="${lane.id}" aria-label="solo ${esc(lane.name)}" title="Solo">S</button>
+        <button class="arm${eng.getPunchArm(lane.id) ? ' armed' : ''}" data-lane="${lane.id}" aria-label="punch target ${esc(lane.name)}" title="Punch target — pads affect this lane">⚡</button>
       </div>
       <div class="lane-actions">
         ${editBtn}
@@ -290,6 +291,12 @@ function renderStrips() {
   host.querySelectorAll('.mute').forEach(b => b.onclick = () => {
     eng.toggleMute(b.dataset.lane);
     refreshStates();
+  });
+  host.querySelectorAll('.arm').forEach(b => b.onclick = () => {
+    const id = b.dataset.lane;
+    const on = !eng.getPunchArm(id);
+    eng.setPunchArm(id, on);
+    b.classList.toggle('armed', on);
   });
   host.querySelectorAll('.solo').forEach(b => b.onclick = () => {
     eng.toggleSolo(b.dataset.lane);
@@ -515,6 +522,14 @@ function renderPunch() {
     pad.addEventListener('pointercancel', off);
     row.appendChild(pad);
   }
+  // AMOUNT — the one performer-facing setting (DJM level/depth): scales how
+  // hard every pad hits. Effect internals stay fixed.
+  row.appendChild(makeKnob({
+    label: 'AMT',
+    value: eng.getPunchAmount(),
+    onChange: v => eng.setPunchAmount(v),
+    tip: 'Punch amount — how hard the pads hit',
+  }));
   host.appendChild(row);
 }
 


### PR DESCRIPTION
## Summary
The DJM-mixer model for punch FX, as dogfooded (drums-only crush audition: "better just applied to the drums"):

- **⚡ arm chip on every lane strip** (beside M/S, default armed) — the channel-assign switch. Punch pads only affect armed lanes: crush just the drums, dive everything but the kick.
- **AMOUNT knob on the PUNCH row** — the one performer-facing setting (DJM level/depth). Scales every pad's engaged intensity: crush wet, dive depth (log-space sweep), throw send, stop depth, stutter chop level. Effect internals stay fixed (`PUNCH_PARAMS`, internal only — no settings UI, per KISS feedback; crush armed default now 0.9 from the audition).

## Architecture
Punch chain moves from the master insert to a **parallel punch bus**: `lane.vol → toPunch/toClean (complementary gains) → punch chain / direct → masterEQ`. Arming is a **10ms crossfade** — never a connect/disconnect (the splice-click lesson). Known trade-off (specced): punches no longer slice the shared reverb tail — channel-FX behaviour, like the hardware. Scope re-tapped to the full mix.

## ⚠️ Coordination
**Deliberately built before #630 merges** (Matthew's call — "build v2 now, we will refactor once 630 lands, no stress"). Whichever lands second rebases: conflicts expected in `engine/index.js` + `renderStrips`. I'll handle the resolution.

## Testing
135/135 (9 new: PUNCH_PARAMS pins, isPunchArmed default/explicit, diveFreqForAmount log-lerp endpoints+midpoint, amount-scaled stutter closed level). Idle-neutrality invariants unchanged. No CHANGELOG (arcade scope).

Spec + plan + dogfood verdict: `project-notes/oyster/po20/2026-06-08-punch-bus-assign-v2-{spec,plan}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)