### PR TITLE
arcade(groovebox): harmony v1 — chord-relative grooves (read-only)

### DIFF
--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -18,14 +18,31 @@ song = {
       tone?: string }                                // melody lanes: oscillator type
   ],
 
+  // HARMONY — one chord per bar, cycling on the ABSOLUTE bar counter. Lets
+  // grooves be chord-relative (see below). Optional: a song with no harmony has
+  // only literal grooves.
+  harmony?: { progression: [ { name, root, voicing: [note, …] }, … ] },
+
   // GROOVES — named musical content, per lane. Pure data, shareable.
   grooves: {
     [laneId]: {
-      [grooveName]: bars[]                           // 1..8 bars, each:
+      // A groove is EITHER a literal bars[] array OR a chord-relative wrapper.
+      [grooveName]: bars[] | { relative: true, bars: relBars[] }   // 1..8 bars
+      // LITERAL bars[] — each bar:
       // drums lane:   { kick:[steps], snare:[steps], hat:[steps], crash:[steps],
       //                 tom:[[step, semitoneOffset], …] }
       // other lanes:  [ [step, note|notes[], durSteps|'bar'], … ]
       //               note = 'C4' style; notes[] = simultaneous (chords)
+      // RELATIVE relBars[] — each bar: [ [step, REF, durSteps|'bar'], … ]
+      //   REFs resolve against the chord on the absolute bar (harmony.progression):
+      //     'R'        → chord.root
+      //     'R±N'      → root ±N semitones      (e.g. 'R+12')
+      //     'V<i>'     → chord.voicing[i % len] (degree; index clamped)
+      //     'V<i>±N'   → that degree ±N semitones (e.g. 'V2-24')
+      //     'V*'       → the whole voicing (a chords-style pad event)
+      //     'V*±N'     → the whole voicing, each note shifted
+      //   No harmony / empty progression → a relative groove is silent.
+      //   Relative grooves are read-only today (no editor yet); drums never relative.
     }
   },
 
@@ -61,7 +78,7 @@ The 7 preset songs in `songs/*.js` are authored in the OLD rich format (per-lane
 
 Other threads should leave room for these, not invent competing shapes:
 
-- **`harmony`** *(next slice, plan approved — **engine-only and read-only first**)*: `{ progression: [{name, root, voicing}, …] }` — one chord per bar, cycling on the absolute bar counter. With it, grooves may be **chord-relative**: `{ relative: true, bars: [[[step, REF, dur], …]] }`, REF ∈ `'R' | 'R±12' | 'V<i>' | 'V<i>±12|24' | 'V*'` (root / voicing-degree / whole voicing). The slice: copy `harmony.progression` through flatten, support chord-relative bass/chord grooves, prove parity still passes. **No harmony editor yet.** Drums + melody stay literal.
+- **`harmony` + chord-relative grooves** — *LIVE (engine-only, read-only).* The schema and the relative-groove syntax are documented above. The flattener translates known bass figures (`octave`, `eighths`, `16ths`, `arp`, …) and the chord modes (`pad`/`stab`/`arp`) into single chord-relative grooves; array/MIDI bass, melody, and drums stay baked literal. Parity with the legacy note stream is proven for all 7 presets. **Still future:** a harmony editor and editable chord-relative grooves (writes are no-ops today).
 - **`instruments`** *(direction only — design after #630 lands)*: a definitions layer (`instruments: { [id]: synth params | sample ref }`) that lanes reference, replacing the hardcoded `type → voices.js` synthesis. A drum kit becomes an *ensemble* of instrument refs; samples (wav/mp3) enter here. This is the unlock for the social/composable vision. **Until then: `lane.type` stays a broad routing identity — do not extend its semantics or let it become an instrument-definition dumping ground.**
 - **Sharing**: grooves, patterns, and songs are already self-contained named JSON. Sample assets are the one future exception (need hosting/IDs, can't ride in JSON).
 

--- a/docs/arcade/groovebox/engine/flatten.js
+++ b/docs/arcade/groovebox/engine/flatten.js
@@ -4,6 +4,8 @@
 // The rich-resolution copies below live here ON PURPOSE — when the presets are
 // eventually re-authored as explicit JSON, this whole file is deleted.
 import { stepsPerBar } from './meter.js';
+import { chordAt } from './song.js';
+import { resolveRef } from './patterns.js';
 
 const DRUM_SET_KEYS = ['kick', 'snare', 'hat', 'crash'];
 
@@ -11,11 +13,6 @@ function resolveDrumPattern(pattern, bar, cycleLen) {
   if (!Array.isArray(pattern)) return pattern;
   const len = cycleLen ? Math.min(cycleLen, pattern.length) : pattern.length;
   return pattern[((bar % len) + len) % len];
-}
-
-function chordAt(progression, bar) {
-  const n = progression.length || 1;
-  return progression[((bar % n) + n) % n];
 }
 
 function sectionAt(arrangement, songBar) {
@@ -76,6 +73,70 @@ function bakeBar(rich, lane, bar, spb, fillPat, crashFlourish) {
     return phrase.map(([s, n, d]) => [s, n, d]);
   }
   return [];
+}
+
+// ── chord-relative translation ────────────────────────────────────────────────
+// Known bass pool-generator NAMES → a one-bar chord-relative figure, generated
+// from the SAME step math the legacy generator uses (parameterised by spb). The
+// figure is bar-independent (every bar plays the same shape against its own
+// chord), so a one-bar relative groove resolves to the legacy stream. Anything
+// not here (array/MIDI bass, melody pools, drums) bakes literal.
+//
+// Each entry returns [[step, REF, dur], …] | null. The result is always
+// VERIFIED bar-by-bar against the literal bake before use, so a translation
+// that drifts from the source is silently rejected (parity decides, not this
+// table).
+const evens = spb => Array.from({ length: Math.ceil(spb / 2) }, (_, i) => i * 2);
+
+const BASS_TRANSLATIONS = {
+  // octave: alternate root / root+12 on every 8th step (dur 2).
+  octave:    spb => evens(spb).map((s, i) => [s, i % 2 ? 'R+12' : 'R', 2]),
+  // eighths: root on every 8th step (dur 2).
+  eighths:   spb => evens(spb).map(s => [s, 'R', 2]),
+  // 16ths: root on every step (dur 1).
+  '16ths':   spb => Array.from({ length: spb }, (_, s) => [s, 'R', 1]),
+  // on-beat: root on each beat (dur = steps/beat). 4/4 → [0,4,8,12].
+  'on-beat': spb => [0, 4, 8, 12].filter(s => s < spb).map(s => [s, 'R', 4]),
+  // whole: one root spanning the whole bar.
+  whole:     spb => [[0, 'R', spb]],
+  // offbeat: root on the offbeats (dur 2). 4/4 → [2,6,10,14].
+  offbeat:   spb => [2, 6, 10, 14].filter(s => s < spb).map(s => [s, 'R', 2]),
+  // walking: low voicing-degree on each beat (dur 4). low(v[i%len]) = V<i>-24.
+  walking:   spb => [0, 4, 8, 12].filter(s => s < spb).map((s, i) => [s, `V${i}-24`, 4]),
+  // counter: root + low voicing degrees (dur 2). v[2]||v[0] ↔ V2 (clamps to v[0]
+  // on short voicings); v[1]||v[0] ↔ V1; v[0] ↔ V0.
+  counter:   () => [[0, 'R', 2], [3, 'V2-24', 2], [6, 'V1-24', 2], [10, 'R', 2], [12, 'V1-24', 2], [14, 'V0-24', 2]],
+  // busy: root / root+12 + low voicing degrees.
+  busy:      () => [[0, 'R', 2], [2, 'V0-24', 1], [3, 'V1-24', 1], [6, 'V2-24', 2], [8, 'R', 2], [10, 'V1-24', 1], [11, 'V0-24', 1], [14, 'R+12', 2]],
+  // scale run: root, low degrees, root octaves. v[2]||v[1]||v[0] only matches V2
+  // for voicings of length ≥3 — the verify gate rejects shorter ones.
+  'scale run': spb => evens(spb).map((s, i) =>
+    [s, ['R', 'V1-24', 'V2-24', 'R+12', 'V0-24', 'V1-24', 'V2-24', 'R+24'][i], 2]),
+  // rising-sun arp: ascending arpeggio — low voicing degree on every 8th (dur 2).
+  arp:       spb => evens(spb).map((s, i) => [s, `V${i}-24`, 2]),
+  // rising-sun root: root on the two dotted-quarter pulses (6/8 → steps 0,6).
+  root:      spb => [[0, 'R', spb / 2], [spb / 2, 'R', spb / 2]],
+};
+
+// Chord-lane mode → one-bar chord-relative figure.
+function chordTranslation(mode, spb) {
+  if (mode === 'pad')  return [[0, 'V*', 'bar']];
+  if (mode === 'stab') return [[0, 'V*', 2], [spb / 2, 'V*', 2]];
+  if (mode === 'arp')  return Array.from({ length: spb }, (_, s) => [s, `V${s}`, 1]);
+  return null;
+}
+
+// Render one bar of a relative figure against a chord, mirroring eventsForStepV2:
+// V*/array → notes[] entries; single note → [s, note, dur]. Used to verify a
+// translation reproduces the literal bake.
+function renderRelativeBar(figure, chord) {
+  const out = [];
+  for (const [s, ref, dur] of figure) {
+    const resolved = resolveRef(ref, chord);
+    if (resolved == null) return null;            // a ref that won't resolve → reject
+    out.push([s, resolved, dur]);
+  }
+  return out;
 }
 
 // Greedy chunk sizes for a section that has no 1/2/4 period: [4,4,2,1...]
@@ -150,13 +211,8 @@ export function flattenSong(rich) {
     return fill ? `${base} +${fill}` : base;
   }
 
-  // Intern a lane's bars as a groove; return its (deduped) name.
-  function internGroove(laneId, barRange) {
-    const data = barRange.map(b => baked[b][laneId]);
-    const key = JSON.stringify(data);
-    const table = grooveByLane[laneId];
-    if (table.has(key)) return table.get(key);
-    // New content → assign a name, disambiguating collisions with ·2, ·3…
+  // Assign a fresh (collision-free) name for a lane, based on the source selection.
+  function uniqueName(laneId, barRange) {
     let name = baseName(laneId, barRange);
     if (usedNames[laneId].has(name)) {
       let n = 2;
@@ -164,14 +220,59 @@ export function flattenSong(rich) {
       name = `${name} ·${n}`;
     }
     usedNames[laneId].add(name);
+    return name;
+  }
+
+  // Intern a lane's bars as a LITERAL groove; return its (deduped) name.
+  function internGroove(laneId, barRange) {
+    const data = barRange.map(b => baked[b][laneId]);
+    const key = JSON.stringify(data);
+    const table = grooveByLane[laneId];
+    if (table.has(key)) return table.get(key);
+    const name = uniqueName(laneId, barRange);
     table.set(key, name);
     grooves[laneId][name] = data;
     return name;
   }
 
+  // Per-lane relative-groove intern table: JSON(figure) → grooveName.
+  const relByLane = {};
+  for (const lane of working) relByLane[lane.id] = new Map();
+
+  // Try to intern a CHORD-RELATIVE groove for a bass/chords lane over barRange.
+  // Returns the groove name, or null if no faithful translation exists (caller
+  // falls back to literal interning). Faithfulness is VERIFIED: the relative
+  // figure, resolved against each bar's absolute chord, must reproduce the
+  // literal bake exactly.
+  function tryRelativeGroove(lane, barRange) {
+    if (lane.type !== 'bass' && lane.type !== 'chords') return null;
+    const sel = bakedMeta[barRange[0]][lane.id]?.selection;
+    // A fill never lands on bass/chords lanes, but be defensive: a baked variant
+    // (fill present) is never relative.
+    if (barRange.some(b => bakedMeta[b][lane.id]?.fill)) return null;
+    const figure = lane.type === 'chords'
+      ? chordTranslation(sel, spb)
+      : (typeof BASS_TRANSLATIONS[sel] === 'function' ? BASS_TRANSLATIONS[sel](spb) : null);
+    if (!figure) return null;
+    // Verify against every bar in the range (absolute chords).
+    for (const b of barRange) {
+      const chord = chordAt(rich.harmony?.progression ?? [], b);
+      const rendered = renderRelativeBar(figure, chord);
+      if (JSON.stringify(rendered) !== JSON.stringify(baked[b][lane.id])) return null;
+    }
+    // Faithful → intern the one-bar relative figure (deduped by content).
+    const key = JSON.stringify(figure);
+    const table = relByLane[lane.id];
+    if (table.has(key)) return table.get(key);
+    const name = uniqueName(lane.id, barRange);
+    table.set(key, name);
+    grooves[lane.id][name] = { relative: true, bars: [figure] };
+    return name;
+  }
+
   function pushPattern(barRange) {
     const lanes = {};
-    for (const lane of working) lanes[lane.id] = internGroove(lane.id, barRange);
+    for (const lane of working) lanes[lane.id] = tryRelativeGroove(lane, barRange) ?? internGroove(lane.id, barRange);
     const pat = { lanes };
     const key = JSON.stringify(pat);
     if (seen.has(key)) return seen.get(key);
@@ -210,5 +311,10 @@ export function flattenSong(rich) {
     version: 2,                                   // schema version — see DATA-MODEL.md
     title: rich.title, artist: rich.artist, meter: rich.meter, bpm: rich.bpm,
     lanes, grooves, patterns, chain, fills: rich.fills || {},
+    // Harmony carries through so chord-relative grooves resolve at play time.
+    // Deep, JSON-clean copy (no aliasing into the rich source).
+    ...(rich.harmony?.progression?.length
+      ? { harmony: { progression: rich.harmony.progression.map(c => ({ name: c.name, root: c.root, voicing: [...c.voicing] })) } }
+      : {}),
   };
 }

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -234,7 +234,7 @@ export function createEngine() {
         }
         const patternIdx = targetPattern(target, song);
         const fillPat = activeFill ? (song.fills?.[activeFill] ?? null) : null;
-        for (const ev of eventsForStepV2(song, patternIdx, target.barInPattern, step % spb, fillPat, song.transpose || 0)) {
+        for (const ev of eventsForStepV2(song, patternIdx, target.barInPattern, step % spb, fillPat, song.transpose || 0, Math.floor(step / spb))) {
           const v = voices[ev.laneId];
           if (v) trigger(v, ev, t, sixteenth, barSeconds);
         }

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -6,9 +6,44 @@
 // A groove owns its length (its array); at pattern bar b it plays
 // groove[b % groove.length]. A pattern's loop length is DERIVED — the longest
 // picked groove (see patternBars); shorter grooves cycle underneath.
-import { laneAudible, drumVoiceAudible, transposeNote, DRUM_KEYS } from './song.js';
+import { laneAudible, drumVoiceAudible, transposeNote, chordAt, DRUM_KEYS } from './song.js';
 
 export const MAX_PATTERNS = 16;
+
+// ── chord-relative grooves ────────────────────────────────────────────────────
+// A groove is either a plain bars[] array (literal notes) or a chord-relative
+// wrapper { relative: true, bars: [[[step, REF, dur], …], …] }. grooveBars(g)
+// normalizes to the bars array so length/cycling logic stays shape-agnostic.
+export function grooveBars(g) {
+  return Array.isArray(g) ? g : (g ? g.bars : undefined);
+}
+
+// resolveRef(ref, chord) — resolve a chord-relative reference against a chord
+// { root, voicing }. Grammar:
+//   'R'        → chord.root
+//   'V<i>'     → chord.voicing[i % voicing.length]   (degree, clamped)
+//   'V*'       → the whole voicing array
+//   any of the above may carry a '+N'/'-N' semitone suffix (e.g. 'R+12',
+//   'V2-24', 'V*-12') applied via transposeNote.
+// Returns a note string, an array of note strings (for 'V*'), or null
+// (invalid ref / missing chord / empty voicing).
+export function resolveRef(ref, chord) {
+  if (typeof ref !== 'string' || !chord) return null;
+  const m = ref.match(/^(R|V\*|V\d+)([+-]\d+)?$/);
+  if (!m) return null;
+  const base = m[1];
+  const semi = m[2] ? parseInt(m[2], 10) : 0;
+  const shift = n => (semi ? transposeNote(n, semi) : n);
+  if (base === 'R') {
+    if (!chord.root) return null;
+    return shift(chord.root);
+  }
+  const voicing = chord.voicing;
+  if (!Array.isArray(voicing) || !voicing.length) return null;
+  if (base === 'V*') return voicing.map(shift);
+  const i = parseInt(base.slice(1), 10);
+  return shift(voicing[i % voicing.length]);
+}
 
 // patternBars(song, idx) → the pattern's derived duration: the longest groove
 // among its picks (grooves are 1/2/4 bars; shorter ones cycle). Minimum 1.
@@ -17,8 +52,8 @@ export function patternBars(song, patternIdx) {
   if (!pat) return 1;
   let max = 1;
   for (const laneId of Object.keys(pat.lanes)) {
-    const g = song.grooves[laneId]?.[pat.lanes[laneId]];
-    if (Array.isArray(g) && g.length > max) max = g.length;
+    const bars = grooveBars(song.grooves[laneId]?.[pat.lanes[laneId]]);
+    if (Array.isArray(bars) && bars.length > max) max = bars.length;
   }
   return max;
 }
@@ -56,26 +91,29 @@ export function advanceTarget(target, song) {
 }
 
 // ── groove resolution ───────────────────────────────────────────────────────
-// Resolve the groove data array for a lane at a pattern. Returns the array or
-// null (missing groove / empty → silent lane).
+// Resolve the raw groove for a lane at a pattern (literal array OR relative
+// wrapper). Returns the groove value, or null (missing / empty → silent lane).
 function grooveData(song, pat, laneId) {
-  const name = pat.lanes[laneId];
-  const g = song.grooves[laneId]?.[name];
-  return (Array.isArray(g) && g.length) ? g : null;
+  const g = song.grooves[laneId]?.[pat.lanes[laneId]];
+  const bars = grooveBars(g);
+  return (Array.isArray(bars) && bars.length) ? g : null;
 }
 
 // grooveFor(song, patternIdx, laneId) → { name, bars } | null
-// `bars` is the groove's own data array (named `bars` per the rework contract).
+// `bars` is the groove's own per-bar data array — normalized so callers (the
+// editors, viz) never see the relative wrapper.
 export function grooveFor(song, patternIdx, laneId) {
   const pat = song.patterns[patternIdx];
   if (!pat) return null;
   const name = pat.lanes[laneId];
-  const data = song.grooves[laneId]?.[name];
-  return data ? { name, bars: data } : null;
+  const bars = grooveBars(song.grooves[laneId]?.[name]);
+  return bars ? { name, bars } : null;
 }
 
 // ── event resolution ──────────────────────────────────────────────────────────
-export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = null, transpose = 0) {
+// absoluteBar — the song-absolute bar, used to resolve the harmony clock for
+// chord-relative grooves. Literal grooves ignore it.
+export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = null, transpose = 0, absoluteBar = 0) {
   const pat = song.patterns[patternIdx];
   const ev = [];
   const tr = transpose | 0;
@@ -84,7 +122,8 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
     if (!laneAudible(song.lanes, lane)) continue;
     const g = grooveData(song, pat, lane.id);
     if (lane.type === 'drums') {
-      const bar = fillPat || (g ? g[barInPattern % g.length] : null) || {};
+      const bars = grooveBars(g);
+      const bar = fillPat || (bars ? bars[barInPattern % bars.length] : null) || {};
       for (const k of DRUM_KEYS) {
         if (bar[k] && bar[k].includes(step) && drumVoiceAudible(lane, k))
           ev.push({ laneId: lane.id, type: 'drums', voice: k });
@@ -95,16 +134,36 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
             ev.push({ laneId: lane.id, type: 'drums', voice: 'tom', semi: semi ?? 0 });
         }
       }
-    } else {
-      const notes = (g ? g[barInPattern % g.length] : null) || [];
-      for (const [s, n, dur] of notes) {
+      continue;
+    }
+    const bars = grooveBars(g);
+    const notes = (bars ? bars[barInPattern % bars.length] : null) || [];
+    if (g && g.relative) {
+      // Chord-relative: resolve each REF against the chord on the absolute bar.
+      // No harmony / empty progression → the lane is silent (resolveRef → null).
+      const chord = chordAt(song.harmony?.progression ?? [], absoluteBar);
+      for (const [s, ref, dur] of notes) {
         if (s !== step) continue;
-        if (lane.type === 'chords') {
-          if (Array.isArray(n)) ev.push({ laneId: lane.id, type: 'chords', mode: 'pad', notes: n.map(T), dur });
-          else ev.push({ laneId: lane.id, type: 'chords', mode: 'arp', note: T(n), dur });
+        const resolved = resolveRef(ref, chord);
+        if (resolved == null) continue;
+        if (Array.isArray(resolved)) {
+          ev.push({ laneId: lane.id, type: 'chords', mode: 'pad', notes: resolved.map(T), dur });
+        } else if (lane.type === 'chords') {
+          ev.push({ laneId: lane.id, type: 'chords', mode: 'arp', note: T(resolved), dur });
         } else {
-          ev.push({ laneId: lane.id, type: lane.type, note: T(n), dur });
+          ev.push({ laneId: lane.id, type: lane.type, note: T(resolved), dur });
         }
+      }
+      continue;
+    }
+    // Literal groove — untouched behaviour.
+    for (const [s, n, dur] of notes) {
+      if (s !== step) continue;
+      if (lane.type === 'chords') {
+        if (Array.isArray(n)) ev.push({ laneId: lane.id, type: 'chords', mode: 'pad', notes: n.map(T), dur });
+        else ev.push({ laneId: lane.id, type: 'chords', mode: 'arp', note: T(n), dur });
+      } else {
+        ev.push({ laneId: lane.id, type: lane.type, note: T(n), dur });
       }
     }
   }
@@ -156,6 +215,7 @@ const MAX_GROOVE_BARS = 8;
  *  Returns the new length, or null (missing groove / invalid n / no-op same length). */
 export function setGrooveBars(song, laneId, grooveName, n) {
   const bars = song.grooves[laneId]?.[grooveName];
+  // Relative grooves are read-only (no editor yet).
   if (!Array.isArray(bars) || !bars.length) return null;
   if (n !== 1 && n !== 2 && n !== 4 && n !== 8) return null;
   const len = bars.length;
@@ -192,7 +252,7 @@ export function moveChain(song, from, to) {
 // barIdx is within the referenced groove's own length; the caller guarantees range.
 export function setDrumStep(song, laneId, grooveName, barIdx, voice, step, on) {
   const groove = song.grooves[laneId]?.[grooveName];
-  if (!groove) return;
+  if (!Array.isArray(groove)) return;        // missing or relative (read-only)
   const bar = groove[barIdx] || (groove[barIdx] = {});
   if (voice === 'tom') {
     bar.tom = bar.tom || [];
@@ -209,7 +269,7 @@ export function setDrumStep(song, laneId, grooveName, barIdx, voice, step, on) {
 
 export function toggleNote(song, laneId, grooveName, barIdx, step, note, dur = 2) {
   const groove = song.grooves[laneId]?.[grooveName];
-  if (!groove) return;
+  if (!Array.isArray(groove)) return;        // missing or relative (read-only)
   const arr = groove[barIdx] || (groove[barIdx] = []);
   const i = arr.findIndex(x => x[0] === step);
   // Deep compare — chords lanes store array notes (['A3','C4']); reference

--- a/docs/arcade/groovebox/engine/song.js
+++ b/docs/arcade/groovebox/engine/song.js
@@ -29,3 +29,12 @@ export function transposeNote(note, semis) {
   const t = i + (parseInt(m[2]) + 1) * 12 + semis;
   return N[((t % 12) + 12) % 12] + (Math.floor(t / 12) - 1);
 }
+
+// chordAt(progression, bar) — the chord sounding at an absolute bar. The
+// progression cycles (one chord per bar); negative bars wrap. Empty/missing
+// progression → undefined (caller treats the lane as silent).
+export function chordAt(progression, bar) {
+  const n = progression?.length || 0;
+  if (!n) return undefined;
+  return progression[((bar % n) + n) % n];
+}

--- a/docs/arcade/groovebox/tests/flatten-parity.test.js
+++ b/docs/arcade/groovebox/tests/flatten-parity.test.js
@@ -1,6 +1,14 @@
 import { test, expect } from 'vitest';
 import { flattenSong } from '../engine/flatten.js';
-import { patternBars } from '../engine/patterns.js';
+import { patternBars, grooveBars } from '../engine/patterns.js';
+
+// A groove is a literal bars[] array OR a chord-relative wrapper
+// { relative:true, bars:[…] }. grooveBars() normalizes both to the bars array.
+function isValidGroove(g) {
+  if (Array.isArray(g)) return g.length >= 1 && g.length <= 8;
+  if (g && g.relative === true) return Array.isArray(g.bars) && g.bars.length >= 1 && g.bars.length <= 8;
+  return false;
+}
 import { renderLegacyStream } from './legacy/legacy-engine.js';
 import { renderChainStream } from './helpers/stream.js';
 import { kids } from '../songs/kids.js';
@@ -27,16 +35,26 @@ for (const [name, song] of Object.entries(SONGS)) {
       const p = v2.patterns[pi];
       // pattern.bars is gone — duration is derived from the longest picked groove.
       expect(p.bars).toBeUndefined();
-      // Every pick references an existing groove.
+      // Every pick references an existing, well-formed groove (literal or relative).
       for (const lane of v2.lanes) {
         const name = p.lanes[lane.id];
         expect(typeof name).toBe('string');
-        expect(v2.grooves[lane.id]?.[name]).toBeDefined();
+        const g = v2.grooves[lane.id]?.[name];
+        expect(isValidGroove(g)).toBe(true);
       }
-      // Flattener chunks lanes together → all picked grooves share one length,
-      // so the derived bar count is that shared 1/2/4 length.
-      const lengths = v2.lanes.map(l => v2.grooves[l.id][p.lanes[l.id]].length);
-      expect(new Set(lengths).size).toBe(1);
+      // Literal lanes (drums/melody, plus any untranslated bass/chords) share one
+      // length per pattern. Chord-relative grooves are one bar and cycle
+      // underneath — they're excluded from this check.
+      const litLengths = v2.lanes
+        .map(l => v2.grooves[l.id][p.lanes[l.id]])
+        .filter(g => Array.isArray(g))
+        .map(g => g.length);
+      expect(new Set(litLengths).size).toBe(1);
+      // Relative grooves are exactly one bar.
+      for (const lane of v2.lanes) {
+        const g = v2.grooves[lane.id][p.lanes[lane.id]];
+        if (g && g.relative) expect(grooveBars(g).length).toBe(1);
+      }
       expect([1, 2, 4]).toContain(patternBars(v2, pi));
     }
     // Every chain entry indexes an existing pattern.

--- a/docs/arcade/groovebox/tests/harmony.test.js
+++ b/docs/arcade/groovebox/tests/harmony.test.js
@@ -1,0 +1,154 @@
+import { test, expect } from 'vitest';
+import {
+  resolveRef, grooveBars, eventsForStepV2,
+  setDrumStep, toggleNote, setGrooveBars,
+} from '../engine/patterns.js';
+import { chordAt } from '../engine/song.js';
+
+const meter44 = { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 };
+
+// A 3-note chord for ref grammar tests.
+const Am = { name: 'Am', root: 'A2', voicing: ['A3', 'C4', 'E4'] };
+
+// ── resolveRef grammar ─────────────────────────────────────────────────────
+test('resolveRef: R → chord root', () => {
+  expect(resolveRef('R', Am)).toBe('A2');
+});
+
+test('resolveRef: R+12 → root up an octave', () => {
+  expect(resolveRef('R+12', Am)).toBe('A3');
+});
+
+test('resolveRef: V0/V1/V2 → voicing degrees', () => {
+  expect(resolveRef('V0', Am)).toBe('A3');
+  expect(resolveRef('V1', Am)).toBe('C4');
+  expect(resolveRef('V2', Am)).toBe('E4');
+});
+
+test('resolveRef: V index clamps via i % voicing.length', () => {
+  // 3-note voicing: V3 → 3%3=0 → V0.
+  expect(resolveRef('V3', Am)).toBe('A3');
+  expect(resolveRef('V4', Am)).toBe('C4');
+});
+
+test('resolveRef: V2-24 → voicing degree down two octaves', () => {
+  expect(resolveRef('V2-24', Am)).toBe('E2');
+});
+
+test('resolveRef: V* → whole voicing array', () => {
+  expect(resolveRef('V*', Am)).toEqual(['A3', 'C4', 'E4']);
+});
+
+test('resolveRef: V*-12 → whole voicing shifted down an octave', () => {
+  expect(resolveRef('V*-12', Am)).toEqual(['A2', 'C3', 'E3']);
+});
+
+test('resolveRef: invalid ref → null', () => {
+  expect(resolveRef('X', Am)).toBeNull();
+  expect(resolveRef('R*', Am)).toBeNull();
+  expect(resolveRef('', Am)).toBeNull();
+  expect(resolveRef(null, Am)).toBeNull();
+});
+
+test('resolveRef: missing chord → null', () => {
+  expect(resolveRef('R', null)).toBeNull();
+  expect(resolveRef('R', undefined)).toBeNull();
+});
+
+test('resolveRef: voicing ref on a chord with empty voicing → null', () => {
+  expect(resolveRef('V0', { root: 'A2', voicing: [] })).toBeNull();
+});
+
+// ── grooveBars normalizer ──────────────────────────────────────────────────
+test('grooveBars: literal array passes through, relative wrapper unwraps', () => {
+  const lit = [[[0, 'C4', 2]]];
+  expect(grooveBars(lit)).toBe(lit);
+  const figure = [[0, 'R', 2]];
+  expect(grooveBars({ relative: true, bars: [figure] })).toEqual([figure]);
+});
+
+// ── harmony clock through eventsForStepV2 ──────────────────────────────────
+// A 2-chord progression with a one-bar relative bass groove: the resolved note
+// must track the absolute bar.
+function harmonySong() {
+  return {
+    meter: meter44,
+    harmony: { progression: [Am, { name: 'C', root: 'C2', voicing: ['C3', 'E3', 'G3'] }] },
+    lanes: [{ id: 'bass', type: 'bass', name: 'bass', muted: false, soloed: false }],
+    grooves: { bass: { rel: { relative: true, bars: [[[0, 'R', 16]]] } } },
+    patterns: [{ lanes: { bass: 'rel' } }],
+    chain: [0],
+  };
+}
+
+test('relative groove resolves against chordAt(absoluteBar)', () => {
+  const song = harmonySong();
+  const at = b => eventsForStepV2(song, 0, 0, 0, null, 0, b);
+  expect(at(0)).toEqual([{ laneId: 'bass', type: 'bass', note: 'A2', dur: 16 }]); // Am
+  expect(at(1)).toEqual([{ laneId: 'bass', type: 'bass', note: 'C2', dur: 16 }]); // C
+  expect(at(2)).toEqual([{ laneId: 'bass', type: 'bass', note: 'A2', dur: 16 }]); // wraps → Am
+});
+
+test('relative groove: transpose applies AFTER resolution', () => {
+  const song = harmonySong();
+  // +2 semitones on the Am root A2 → B2.
+  expect(eventsForStepV2(song, 0, 0, 0, null, 2, 0))
+    .toEqual([{ laneId: 'bass', type: 'bass', note: 'B2', dur: 16 }]);
+});
+
+test('relative chords lane: V* → pad event, single ref → arp event', () => {
+  const song = {
+    meter: meter44,
+    harmony: { progression: [Am] },
+    lanes: [{ id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false }],
+    grooves: { chords: { pad: { relative: true, bars: [[[0, 'V*', 'bar'], [8, 'V0', 1]]] } } },
+    patterns: [{ lanes: { chords: 'pad' } }],
+    chain: [0],
+  };
+  expect(eventsForStepV2(song, 0, 0, 0, null, 0, 0))
+    .toEqual([{ laneId: 'chords', type: 'chords', mode: 'pad', notes: ['A3', 'C4', 'E4'], dur: 'bar' }]);
+  expect(eventsForStepV2(song, 0, 0, 8, null, 0, 0))
+    .toEqual([{ laneId: 'chords', type: 'chords', mode: 'arp', note: 'A3', dur: 1 }]);
+});
+
+test('no harmony / empty progression → relative groove is silent', () => {
+  const base = harmonySong();
+  const noHarmony = { ...base, harmony: undefined };
+  expect(eventsForStepV2(noHarmony, 0, 0, 0, null, 0, 0)).toEqual([]);
+  const empty = { ...base, harmony: { progression: [] } };
+  expect(eventsForStepV2(empty, 0, 0, 0, null, 0, 0)).toEqual([]);
+});
+
+// ── write-path no-ops on relative grooves ──────────────────────────────────
+test('setGrooveBars no-ops on a relative groove', () => {
+  const song = harmonySong();
+  const before = JSON.stringify(song.grooves.bass.rel);
+  expect(setGrooveBars(song, 'bass', 'rel', 2)).toBeNull();
+  expect(JSON.stringify(song.grooves.bass.rel)).toBe(before);
+});
+
+test('toggleNote no-ops on a relative groove', () => {
+  const song = harmonySong();
+  const before = JSON.stringify(song.grooves.bass.rel);
+  toggleNote(song, 'bass', 'rel', 0, 4, 'C4', 2);
+  expect(JSON.stringify(song.grooves.bass.rel)).toBe(before);
+});
+
+test('setDrumStep no-ops on a relative groove', () => {
+  const song = {
+    grooves: { drums: { rel: { relative: true, bars: [{}] } } },
+  };
+  const before = JSON.stringify(song.grooves.drums.rel);
+  setDrumStep(song, 'drums', 'rel', 0, 'kick', 0, true);
+  expect(JSON.stringify(song.grooves.drums.rel)).toBe(before);
+});
+
+// ── chordAt cycling ────────────────────────────────────────────────────────
+test('chordAt cycles and wraps negative bars; empty → undefined', () => {
+  const prog = [Am, { name: 'C', root: 'C2', voicing: ['C3'] }];
+  expect(chordAt(prog, 0)).toBe(prog[0]);
+  expect(chordAt(prog, 1)).toBe(prog[1]);
+  expect(chordAt(prog, 2)).toBe(prog[0]);
+  expect(chordAt(prog, -1)).toBe(prog[1]);
+  expect(chordAt([], 0)).toBeUndefined();
+});

--- a/docs/arcade/groovebox/tests/helpers/stream.js
+++ b/docs/arcade/groovebox/tests/helpers/stream.js
@@ -11,7 +11,8 @@ export function renderChainStream(song, { cycles = 3, skipCycles = 1 } = {}) {
     const { patternIdx, barInPattern } = chainBarAt(song, bar);
     const outBar = bar - total * skipCycles;
     for (let step = 0; step < spb; step++) {
-      for (const e of eventsForStepV2(song, patternIdx, barInPattern, step, null, 0)) {
+      // `bar` is the song-absolute bar → it is the harmony clock for relative grooves.
+      for (const e of eventsForStepV2(song, patternIdx, barInPattern, step, null, 0, bar)) {
         out.add(eventKey(outBar, step, e));
       }
     }


### PR DESCRIPTION
Read-only harmony slice for the groovebox engine — no UI, no harmony editor. Proves four things:

**1. The song carries its progression.** `flattenSong` deep-copies `rich.harmony` through as `song.harmony = { progression: [{name, root, voicing}, …] }` (JSON-clean). `harmony` is now in the schema proper in `DATA-MODEL.md`; the chord-relative groove syntax is documented alongside it and marked live.

**2. Grooves may be chord-relative.** New `resolveRef(ref, chord)` (`R`, `R±N`, `V<i>` with `i % len` clamp, `V<i>±N`, `V*`, `V*±N`; invalid/missing → null). `chordAt` restored to `song.js` and flatten now imports it. A relative groove is `{ relative: true, bars: [[[step, REF, dur], …]] }`; a `grooveBars(g)` normalizer is used everywhere groove length/bars are read so cycling/`patternBars`/`grooveFor` stay shape-agnostic. `eventsForStepV2` takes a new `absoluteBar` arg, resolves the chord clock for relative grooves (no harmony → silent), applies transpose after resolution. Editor write-paths (`setDrumStep`/`toggleNote`/`setGrooveBars`) no-op on relative grooves.

**3. The scheduler passes the absolute bar.** `engine/index.js` passes `Math.floor(step / spb)`; the stream test helper threads its loop bar.

**4. The flattener translates instead of baking — parity decides.** Known bass figures and chord modes are translated to single chord-relative grooves, each VERIFIED bar-by-bar against the literal bake before use (a drifting translation is silently rejected and stays baked). The 7 legacy note-stream parity assertions pass UNCHANGED.

### Relative vs baked, per song

| Song | Relative | Baked literal |
|------|----------|---------------|
| kids | bass: octave, eighths, 16ths · chords: pad, stab, arp | drums, melody |
| rising-sun (6/8) | bass: arp, octave · chords: pad | drums, melody |
| electric-feel | bass: octave · chords: pad, arp | bass: midi · drums, melody |
| heartbeats | bass: octave · chords: pad, arp | drums, melody |
| digital-love | bass: octave · chords: pad, arp | bass: midi · drums, melody |
| memory-reboot | bass: octave · chords: pad, arp | bass: midi · drums, melody |
| take-on-me | bass: octave · chords: pad, arp | bass: midi · drums, melody |

`octave` dedups to a single relative groove per song. All array/MIDI bass, all melody pools, and all drums stay baked literal.

### Parity

All 7 `flattened <song> reproduces the legacy note stream (steady state)` assertions pass unchanged. Schema-invariant tests updated for relative grooves (object-form validates: `relative === true`, bars 1–8, JSON-serializable; literal lanes still share one length; relative grooves are 1 bar). Suite: **144 passing** (was 125; +19 new harmony unit tests). `vite build` clean.

### Judgment calls

- Relative grooves are emitted as **one bar** and cycle under the pattern's literal-driven length — this is what lets `octave` dedup to a single groove and keeps note-stream parity (the absolute bar is the harmony clock). The schema-invariant "all picked grooves share one length" no longer holds across literal/relative lanes; the test was updated to check literal lanes share a length and relative grooves are 1 bar.
- The bass piano-roll viz will render a relative groove's REF strings (`R`, `V0`) at a default pitch (cosmetic, no crash — `noteToMidi` falls back to 60). Writes no-op, so nothing corrupts. A proper read-only relative-bass view belongs to the harmony-editor slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)