### PR TITLE
arcade(groovebox): pattern-owned chords + melody snap-to-scale

### DIFF
--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -18,13 +18,10 @@ song = {
       tone?: string }                                // melody lanes: oscillator type
   ],
 
-  // HARMONY — one chord per bar, cycling on the ABSOLUTE bar counter. Lets
-  // grooves be chord-relative (see below). Optional: a song with no harmony has
-  // only literal grooves.
-  harmony?: {
-    key?: { root: 'A'|'C#'|…, mode: 'major'|'minor' },  // tonic for snap-to-scale + editor tinting (inert at playback)
-    progression: [ { name, root, voicing: [note, …] }, … ],
-  },
+  // KEY — the song's tonic, for melody snap-to-scale + editor tinting (inert at
+  // playback). Optional. The chord PROGRESSION is not global — it lives on each
+  // pattern (pattern.chords, below).
+  key?: { root: 'A'|'C#'|…, mode: 'major'|'minor' },
 
   // GROOVES — named musical content, per lane. Pure data, shareable.
   grooves: {
@@ -37,22 +34,30 @@ song = {
       // other lanes:  [ [step, note|notes[], durSteps|'bar'], … ]
       //               note = 'C4' style; notes[] = simultaneous (chords)
       // RELATIVE relBars[] — each bar: [ [step, REF, durSteps|'bar'], … ]
-      //   REFs resolve against the chord on the absolute bar (harmony.progression):
+      //   REFs resolve against the PATTERN's chord for that bar
+      //   (pattern.chords[barInPattern % chords.length]):
       //     'R'        → chord.root
       //     'R±N'      → root ±N semitones      (e.g. 'R+12')
       //     'V<i>'     → chord.voicing[i % len] (degree; index clamped)
       //     'V<i>±N'   → that degree ±N semitones (e.g. 'V2-24')
       //     'V*'       → the whole voicing (a chords-style pad event)
       //     'V*±N'     → the whole voicing, each note shifted
-      //   No harmony / empty progression → a relative groove is silent.
+      //   Pattern has no chords → a relative groove is silent.
       //   Relative grooves are read-only today (no editor yet); drums never relative.
     }
   },
 
-  // PATTERNS — a combo: one groove pick per lane. NO length of its own:
-  // a pattern lasts as long as its longest picked groove; shorter grooves
-  // cycle underneath (bar % groove.length).
-  patterns: [ { lanes: { [laneId]: grooveName } } ],  // max 16
+  // PATTERNS — a combo: one groove pick per lane, plus an optional chord loop
+  // that BELONGS to the pattern (one chord per bar, cycling on barInPattern).
+  // Chord-relative grooves resolve against these chords — deterministic and
+  // loop-stable (no global "fourth clock"). NO length of its own: a pattern lasts
+  // as long as its longest picked groove AND its chord count; shorter grooves
+  // (and the chord loop) cycle underneath (bar % length). A 1-bar bass figure
+  // over 4 chords is a 4-bar pattern.
+  patterns: [ {
+    lanes: { [laneId]: grooveName },
+    chords?: [ { name, root, voicing: [note, …] }, … ],   // optional, one per bar
+  } ],  // max 16
 
   // CHAIN — the song order. INVARIANT: length >= 1, every entry a valid pattern index.
   chain: [patternIndex, …],
@@ -68,7 +73,7 @@ song = {
 
 1. `chain.length >= 1`; every chain entry indexes an existing pattern.
 2. **Valid-song invariant:** every pattern pick resolves to an existing groove for that lane. **Engine robustness (separate guarantee):** if a pick ever dangles anyway, the engine plays silence for that lane — never a crash.
-3. Pattern duration is **derived**: `max(groove.length over picks)`, floor 1. Patterns store no length.
+3. Pattern duration is **derived**: `max(groove.length over picks, chords?.length ?? 0)`, floor 1. Patterns store no length.
 4. Groove lengths are 1–8 bars. **The schema permits any length 1–8** (`bar % groove.length` cycling is length-agnostic; non-dividing lengths truncate their cycle at each pattern repeat) — but **the UI stays opinionated at 1/2/4/8**: powers of two always nest evenly, so nothing drifts. Arbitrary 3/5/7-bar grooves are musically surprising and stay a deliberate future decision, not a default.
 5. The whole song is **pure JSON** — no functions, no hidden state. This is the property that makes grooves/patterns/songs shareable and LLM-authorable. Never add a non-serializable field.
 6. Playback state (the chain-position/pattern-loop target, edit selection, fill queue) is **engine runtime, never part of the song**.
@@ -81,12 +86,12 @@ The 7 preset songs in `songs/*.js` are authored in the OLD rich format (per-lane
 
 Other threads should leave room for these, not invent competing shapes:
 
-- **`harmony` + chord-relative grooves** — *LIVE (engine-only, read-only).* The schema and the relative-groove syntax are documented above. The flattener translates known bass figures (`octave`, `eighths`, `16ths`, `arp`, …) and the chord modes (`pad`/`stab`/`arp`) into single chord-relative grooves; array/MIDI bass, melody, and drums stay baked literal. Parity with the legacy note stream is proven for all 7 presets. **Still future:** a harmony editor and editable chord-relative grooves (writes are no-ops today).
+- **`pattern.chords` + chord-relative grooves** — *LIVE.* Chords live on each pattern (one per bar, cycling), and the relative-groove syntax resolves against them (documented above). The chord line in the PATTERNS module edits the selected pattern's chords (parser-backed); melody snap/tint read `song.key`. The flattener translates known bass figures (`octave`, `eighths`, `16ths`, `arp`, …) and the chord modes (`pad`/`stab`/`arp`) into single chord-relative grooves and attaches each pattern's chords from the source progression's bar offsets; array/MIDI bass, melody, and drums stay baked literal. Parity with the legacy note stream is proven for all 7 presets. **Still future:** editable chord-relative grooves (groove writes are no-ops today).
 - **`instruments`** *(direction only — design after #630 lands)*: a definitions layer (`instruments: { [id]: synth params | sample ref }`) that lanes reference, replacing the hardcoded `type → voices.js` synthesis. A drum kit becomes an *ensemble* of instrument refs; samples (wav/mp3) enter here. This is the unlock for the social/composable vision. **Until then: `lane.type` stays a broad routing identity — do not extend its semantics or let it become an instrument-definition dumping ground.**
 - **Sharing**: grooves, patterns, and songs are already self-contained named JSON. Sample assets are the one future exception (need hosting/IDs, can't ride in JSON).
 
 ## API surface (engine — `engine/index.js`)
 
-Read: `getSong getLanes getGrooves getPatterns getChain getEditPatternIndex getEditGroove(laneId) getPlaybackTarget`.
-Mutate: `selectPattern playChain addPattern duplicatePattern removePattern appendToChain removeChainAt moveChain setLaneGroove(laneId, name) setGrooveBars(laneId, n) setDrumStep toggleNote` + lanes (`addLane duplicateLane removeLane renameLane moveLane`), mixer/FX, fills queue, transport.
-Gone (do not reintroduce): `setMode getMode captureScene clearArrangement setLane` per-lane selection, `cycleLen`, pattern `bars`/`setPatternBars`.
+Read: `getSong getLanes getGrooves getPatterns getChain getEditPatternIndex getEditGroove(laneId) getPlaybackTarget getKey getPatternChords(i)`.
+Mutate: `selectPattern playChain addPattern duplicatePattern removePattern appendToChain removeChainAt moveChain setLaneGroove(laneId, name) setGrooveBars(laneId, n) setDrumStep toggleNote setPatternChords(chords)` + lanes (`addLane duplicateLane removeLane renameLane moveLane`), mixer/FX, fills queue, transport.
+Gone (do not reintroduce): `setMode getMode captureScene clearArrangement setLane` per-lane selection, `cycleLen`, pattern `bars`/`setPatternBars`, `getHarmony`/`setProgression` (chords are pattern-owned now).

--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -21,7 +21,10 @@ song = {
   // HARMONY — one chord per bar, cycling on the ABSOLUTE bar counter. Lets
   // grooves be chord-relative (see below). Optional: a song with no harmony has
   // only literal grooves.
-  harmony?: { progression: [ { name, root, voicing: [note, …] }, … ] },
+  harmony?: {
+    key?: { root: 'A'|'C#'|…, mode: 'major'|'minor' },  // tonic for snap-to-scale + editor tinting (inert at playback)
+    progression: [ { name, root, voicing: [note, …] }, … ],
+  },
 
   // GROOVES — named musical content, per lane. Pure data, shareable.
   grooves: {

--- a/docs/arcade/groovebox/engine/chords.js
+++ b/docs/arcade/groovebox/engine/chords.js
@@ -1,0 +1,88 @@
+// engine/chords.js — pure chord-symbol parser/formatter (Tone-free, unit-tested).
+//
+// Turns a text progression like "F#m D A E/G#" into the rich chord shape the
+// harmony schema uses: { name, root, voicing }. The inverse formatProgression()
+// renders chords back to the editable text line.
+//
+// Grammar per whitespace-separated token:
+//   <root><quality>[/<bass>]
+//   root    : A–G with an optional # or b accidental
+//   quality : '' (major triad) or 'm' (minor triad)
+//   bass    : optional slash note (letter + optional accidental) — sets the
+//             chord's ROOT note (the played bass) while the voicing stays the
+//             chord's own triad (a slash/inversion).
+//
+// Register conventions mirror the presets (read kids.js / rising-sun.js):
+//   bass root  → octave 2 (e.g. 'F#2')
+//   triad      → built upward from octave 3 (e.g. ['F#3','A3','C#4'])
+
+const PC_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const LETTER_PC = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+
+// pitch-class (0–11) of a note letter + optional accidental, or null.
+function pc(letter, accidental) {
+  let n = LETTER_PC[letter];
+  if (n == null) return null;
+  if (accidental === '#') n += 1; else if (accidental === 'b') n -= 1;
+  return ((n % 12) + 12) % 12;
+}
+
+// Build a note name at or above a given midi-octave-floor: returns the lowest
+// occurrence of `pitchClass` at octave >= floorOct, then names it.
+function noteAt(pitchClass, octave) {
+  return PC_NAMES[pitchClass] + octave;
+}
+
+// Build an ascending triad from a root pitch-class, starting at octave 3, where
+// each successive tone is the next-higher occurrence of its pitch-class (so the
+// voicing always rises, crossing octave boundaries like the presets do).
+function triad(rootPc, third) {
+  const intervals = [0, third, 7];           // root, 3rd (3=min/4=maj), 5th
+  const out = [];
+  let prevMidi = -Infinity;
+  for (const iv of intervals) {
+    const target = (rootPc + iv) % 12;
+    // lowest midi at octave>=3 with this pitch class that is strictly ascending
+    let oct = 3;
+    let midi = (oct + 1) * 12 + target;
+    while (midi <= prevMidi) { oct++; midi = (oct + 1) * 12 + target; }
+    out.push(noteAt(target, oct));
+    prevMidi = midi;
+  }
+  return out;
+}
+
+const TOKEN_RE = /^([A-G])(#|b)?(m)?(?:\/([A-G])(#|b)?)?$/;
+
+// parseProgression(text) → { chords: [{name, root, voicing}], errors: [{index, token}] }
+// Parses what it can; unparseable tokens are recorded in `errors` (with their
+// position index) and skipped from `chords`.
+export function parseProgression(text) {
+  const chords = [];
+  const errors = [];
+  const tokens = String(text).trim().split(/\s+/).filter(Boolean);
+  tokens.forEach((token, index) => {
+    const m = token.match(TOKEN_RE);
+    if (!m) { errors.push({ index, token }); return; }
+    const [, letter, acc, minor, bassLetter, bassAcc] = m;
+    const rootPc = pc(letter, acc);
+    if (rootPc == null) { errors.push({ index, token }); return; }
+    const third = minor ? 3 : 4;
+    const voicing = triad(rootPc, third);
+    // Bass note: slash bass if present, else the triad root, both at octave 2.
+    const bassPc = bassLetter ? pc(bassLetter, bassAcc) : rootPc;
+    if (bassPc == null) { errors.push({ index, token }); return; }
+    const root = noteAt(bassPc, 2);
+    // Display name: canonicalise the root pitch-class spelling + quality + slash.
+    const name = PC_NAMES[rootPc] + (minor ? 'm' : '')
+      + (bassLetter ? '/' + PC_NAMES[bassPc] : '');
+    chords.push({ name, root, voicing });
+  });
+  return { chords, errors };
+}
+
+// formatProgression(chords) → the editable text line (space-joined chord names).
+export function formatProgression(chords) {
+  if (!Array.isArray(chords)) return '';
+  return chords.map(c => c.name).join(' ');
+}

--- a/docs/arcade/groovebox/engine/flatten.js
+++ b/docs/arcade/groovebox/engine/flatten.js
@@ -270,10 +270,26 @@ export function flattenSong(rich) {
     return name;
   }
 
+  // The pattern's chords: the rich progression's chord on each absolute bar of
+  // the range (deep, JSON-clean copies). Resolving chord-relative grooves against
+  // pattern.chords[barInPattern] reproduces what the absolute-bar clock produced
+  // (the kids 4-bar patterns each carry the full F#m/D/A/E). Patterns whose chords
+  // differ are kept DISTINCT (folded into the dedup key below) so a reused
+  // lane-combo never silently inherits the wrong chords — parity decides.
+  const prog = rich.harmony?.progression ?? [];
+  function patternChords(barRange) {
+    if (!prog.length) return null;
+    return barRange.map(b => {
+      const c = chordAt(prog, b);
+      return c ? { name: c.name, root: c.root, voicing: [...c.voicing] } : null;
+    });
+  }
+
   function pushPattern(barRange) {
     const lanes = {};
     for (const lane of working) lanes[lane.id] = tryRelativeGroove(lane, barRange) ?? internGroove(lane.id, barRange);
-    const pat = { lanes };
+    const chords = patternChords(barRange);
+    const pat = chords ? { lanes, chords } : { lanes };
     const key = JSON.stringify(pat);
     if (seen.has(key)) return seen.get(key);
     patterns.push(pat);
@@ -307,21 +323,20 @@ export function flattenSong(rich) {
     ...(l.type === 'melody' ? { tone: l.tone || 'pulse' } : {}),
   }));
 
+  // Song key (for melody snap-to-scale + editor tinting). The chord progression
+  // now lives ON the patterns (pattern.chords), not in a global harmony layer.
+  // The authored key rides through when present; otherwise it's derived from the
+  // progression so the editor always has a key to read.
+  const key = prog.length
+    ? (rich.harmony?.key
+        ? { root: rich.harmony.key.root, mode: rich.harmony.key.mode }
+        : deriveKey(prog))
+    : null;
+
   return {
     version: 2,                                   // schema version — see DATA-MODEL.md
     title: rich.title, artist: rich.artist, meter: rich.meter, bpm: rich.bpm,
     lanes, grooves, patterns, chain, fills: rich.fills || {},
-    // Harmony carries through so chord-relative grooves resolve at play time.
-    // Deep, JSON-clean copy (no aliasing into the rich source). The `key` rides
-    // through when authored; otherwise it's derived from the progression so the
-    // melody editor's snap-to-scale + tinting always have a key to read.
-    ...(rich.harmony?.progression?.length
-      ? { harmony: {
-          key: rich.harmony.key
-            ? { root: rich.harmony.key.root, mode: rich.harmony.key.mode }
-            : deriveKey(rich.harmony.progression),
-          progression: rich.harmony.progression.map(c => ({ name: c.name, root: c.root, voicing: [...c.voicing] })),
-        } }
-      : {}),
+    ...(key ? { key } : {}),
   };
 }

--- a/docs/arcade/groovebox/engine/flatten.js
+++ b/docs/arcade/groovebox/engine/flatten.js
@@ -4,7 +4,7 @@
 // The rich-resolution copies below live here ON PURPOSE — when the presets are
 // eventually re-authored as explicit JSON, this whole file is deleted.
 import { stepsPerBar } from './meter.js';
-import { chordAt } from './song.js';
+import { chordAt, deriveKey } from './song.js';
 import { resolveRef } from './patterns.js';
 
 const DRUM_SET_KEYS = ['kick', 'snare', 'hat', 'crash'];
@@ -312,9 +312,16 @@ export function flattenSong(rich) {
     title: rich.title, artist: rich.artist, meter: rich.meter, bpm: rich.bpm,
     lanes, grooves, patterns, chain, fills: rich.fills || {},
     // Harmony carries through so chord-relative grooves resolve at play time.
-    // Deep, JSON-clean copy (no aliasing into the rich source).
+    // Deep, JSON-clean copy (no aliasing into the rich source). The `key` rides
+    // through when authored; otherwise it's derived from the progression so the
+    // melody editor's snap-to-scale + tinting always have a key to read.
     ...(rich.harmony?.progression?.length
-      ? { harmony: { progression: rich.harmony.progression.map(c => ({ name: c.name, root: c.root, voicing: [...c.voicing] })) } }
+      ? { harmony: {
+          key: rich.harmony.key
+            ? { root: rich.harmony.key.root, mode: rich.harmony.key.mode }
+            : deriveKey(rich.harmony.progression),
+          progression: rich.harmony.progression.map(c => ({ name: c.name, root: c.root, voicing: [...c.voicing] })),
+        } }
       : {}),
   };
 }

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -251,9 +251,13 @@ export function createEngine() {
           const s = step; const qSnap = fillQueue.slice();
           const tSnap = { kind: target.kind, chainPos: target.kind === 'chain' ? target.pos : -1,
                           patternIdx: targetPattern(target, song), barInPattern: target.barInPattern };
+          // Which chord is sounding (index into harmony.progression), or -1 when
+          // the song has no harmony. The progression cycles on the absolute bar.
+          const progLen = song.harmony?.progression?.length || 0;
+          const chordIdx = progLen ? Math.floor(s / spb) % progLen : -1;
           Tone.Draw.schedule(() => {
             onStepCb({ absStep: s, bar: Math.floor(s / spb), stepInBar: s % spb,
-                       fill: activeFill, queue: qSnap, target: tSnap });
+                       fill: activeFill, queue: qSnap, target: tSnap, chordIdx });
           }, t);
         }
         if (PERF) {
@@ -604,6 +608,17 @@ export function createEngine() {
     },
     moveLane(id, toIndex) {
       if (song) _moveLane(song, id, toIndex);
+    },
+    // ─── harmony ──────────────────────────────────────────────────────────────
+    getHarmony() { return song?.harmony ?? null; },
+    getKey()     { return song?.harmony?.key ?? null; },
+    // Replace the chord progression. Creates a harmony object if absent. Relative
+    // grooves read song.harmony.progression live (via chordAt), so the change is
+    // audible immediately — no other side effects.
+    setProgression(chords) {
+      if (!song || !Array.isArray(chords)) return;
+      if (song.harmony) song.harmony.progression = chords;
+      else song.harmony = { progression: chords };
     },
     setTranspose(semis) {
       if (!song) return;

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -2,6 +2,7 @@ import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
 import { laneByType, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
+import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
 import {
   eventsForStepV2, advanceTarget, targetPattern,
@@ -234,7 +235,7 @@ export function createEngine() {
         }
         const patternIdx = targetPattern(target, song);
         const fillPat = activeFill ? (song.fills?.[activeFill] ?? null) : null;
-        for (const ev of eventsForStepV2(song, patternIdx, target.barInPattern, step % spb, fillPat, song.transpose || 0, Math.floor(step / spb))) {
+        for (const ev of eventsForStepV2(song, patternIdx, target.barInPattern, step % spb, fillPat, song.transpose || 0)) {
           const v = voices[ev.laneId];
           if (v) trigger(v, ev, t, sixteenth, barSeconds);
         }
@@ -251,13 +252,11 @@ export function createEngine() {
           const s = step; const qSnap = fillQueue.slice();
           const tSnap = { kind: target.kind, chainPos: target.kind === 'chain' ? target.pos : -1,
                           patternIdx: targetPattern(target, song), barInPattern: target.barInPattern };
-          // Which chord is sounding (index into harmony.progression), or -1 when
-          // the song has no harmony. The progression cycles on the absolute bar.
-          const progLen = song.harmony?.progression?.length || 0;
-          const chordIdx = progLen ? Math.floor(s / spb) % progLen : -1;
+          // The sounding chord is derived in the UI from tSnap (patternIdx +
+          // barInPattern) against that pattern's own chords — no global clock.
           Tone.Draw.schedule(() => {
             onStepCb({ absStep: s, bar: Math.floor(s / spb), stepInBar: s % spb,
-                       fill: activeFill, queue: qSnap, target: tSnap, chordIdx });
+                       fill: activeFill, queue: qSnap, target: tSnap });
           }, t);
         }
         if (PERF) {
@@ -609,16 +608,22 @@ export function createEngine() {
     moveLane(id, toIndex) {
       if (song) _moveLane(song, id, toIndex);
     },
-    // ─── harmony ──────────────────────────────────────────────────────────────
-    getHarmony() { return song?.harmony ?? null; },
-    getKey()     { return song?.harmony?.key ?? null; },
-    // Replace the chord progression. Creates a harmony object if absent. Relative
-    // grooves read song.harmony.progression live (via chordAt), so the change is
-    // audible immediately — no other side effects.
-    setProgression(chords) {
-      if (!song || !Array.isArray(chords)) return;
-      if (song.harmony) song.harmony.progression = chords;
-      else song.harmony = { progression: chords };
+    // ─── harmony (chords belong to PATTERNS) ────────────────────────────────────
+    getKey()           { return song?.key ?? null; },
+    getPatternChords(i){ return song?.patterns[i]?.chords ?? null; },
+    // Set the EDIT pattern's chords (the parsed array, one chord per bar, cycling).
+    // Relative-groove lanes read these live, so the change is audible immediately.
+    // song.key is re-derived from EVERY pattern's chords (an authored key is
+    // replaced on the first edit — acceptable).
+    setPatternChords(chords) {
+      if (!song) return;
+      const pat = song.patterns[editIdx];
+      if (!pat) return;
+      if (Array.isArray(chords) && chords.length) pat.chords = chords;
+      else delete pat.chords;
+      const all = song.patterns.flatMap(p => p.chords ?? []);
+      const key = deriveKey(all);
+      if (key) song.key = key; else delete song.key;
     },
     setTranspose(semis) {
       if (!song) return;

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -6,7 +6,7 @@
 // A groove owns its length (its array); at pattern bar b it plays
 // groove[b % groove.length]. A pattern's loop length is DERIVED — the longest
 // picked groove (see patternBars); shorter grooves cycle underneath.
-import { laneAudible, drumVoiceAudible, transposeNote, chordAt, DRUM_KEYS } from './song.js';
+import { laneAudible, drumVoiceAudible, transposeNote, DRUM_KEYS } from './song.js';
 
 export const MAX_PATTERNS = 16;
 
@@ -46,11 +46,13 @@ export function resolveRef(ref, chord) {
 }
 
 // patternBars(song, idx) → the pattern's derived duration: the longest groove
-// among its picks (grooves are 1/2/4 bars; shorter ones cycle). Minimum 1.
+// among its picks AND the pattern's own chord count (chords are content — one per
+// bar, cycling — so a 1-bar bass figure over 4 chords is a 4-bar pattern).
+// Minimum 1.
 export function patternBars(song, patternIdx) {
   const pat = song.patterns[patternIdx];
   if (!pat) return 1;
-  let max = 1;
+  let max = Math.max(1, pat.chords?.length ?? 0);
   for (const laneId of Object.keys(pat.lanes)) {
     const bars = grooveBars(song.grooves[laneId]?.[pat.lanes[laneId]]);
     if (Array.isArray(bars) && bars.length > max) max = bars.length;
@@ -111,13 +113,19 @@ export function grooveFor(song, patternIdx, laneId) {
 }
 
 // ── event resolution ──────────────────────────────────────────────────────────
-// absoluteBar — the song-absolute bar, used to resolve the harmony clock for
-// chord-relative grooves. Literal grooves ignore it.
-export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = null, transpose = 0, absoluteBar = 0) {
+// Chord-relative grooves resolve against the pattern's OWN chords: chord =
+// pattern.chords[barInPattern % chords.length]. Chords belong to the pattern
+// (not a global song clock), so playback is deterministic and loop-stable. A
+// pattern with no chords leaves relative-groove lanes silent.
+export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = null, transpose = 0) {
   const pat = song.patterns[patternIdx];
   const ev = [];
   const tr = transpose | 0;
   const T = n => (tr ? transposeNote(n, tr) : n);
+  const chords = pat.chords;
+  const chord = (Array.isArray(chords) && chords.length)
+    ? chords[((barInPattern % chords.length) + chords.length) % chords.length]
+    : null;
   for (const lane of song.lanes) {
     if (!laneAudible(song.lanes, lane)) continue;
     const g = grooveData(song, pat, lane.id);
@@ -139,9 +147,8 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
     const bars = grooveBars(g);
     const notes = (bars ? bars[barInPattern % bars.length] : null) || [];
     if (g && g.relative) {
-      // Chord-relative: resolve each REF against the chord on the absolute bar.
-      // No harmony / empty progression → the lane is silent (resolveRef → null).
-      const chord = chordAt(song.harmony?.progression ?? [], absoluteBar);
+      // Chord-relative: resolve each REF against the pattern's chord for this bar.
+      // No chords on the pattern → the lane is silent (resolveRef → null).
       for (const [s, ref, dur] of notes) {
         if (s !== step) continue;
         const resolved = resolveRef(ref, chord);

--- a/docs/arcade/groovebox/engine/song.js
+++ b/docs/arcade/groovebox/engine/song.js
@@ -38,3 +38,82 @@ export function chordAt(progression, bar) {
   if (!n) return undefined;
   return progression[((bar % n) + n) % n];
 }
+
+// ── key / scale machinery ──────────────────────────────────────────────────
+const PC_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+// Pitch-class (0–11) of a note name ('F#3', 'A', 'Bb2', …) or null.
+function noteToPc(note) {
+  const m = String(note).match(/^([A-G])(#|b)?/);
+  if (!m) return null;
+  let pc = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 }[m[1]];
+  if (m[2] === '#') pc += 1; else if (m[2] === 'b') pc -= 1;
+  return ((pc % 12) + 12) % 12;
+}
+
+// Major scale: W-W-H-W-W-W-H. Natural minor: W-H-W-W-H-W-W.
+const MAJOR_STEPS = [0, 2, 4, 5, 7, 9, 11];
+const MINOR_STEPS = [0, 2, 3, 5, 7, 8, 10];
+
+// scalePitchClasses(key) → Set of the 7 pitch classes for { root, mode }.
+// major/natural-minor only; unknown/missing key → empty Set.
+export function scalePitchClasses(key) {
+  const rootPc = key && key.root != null ? noteToPc(key.root) : null;
+  if (rootPc == null) return new Set();
+  const steps = key.mode === 'minor' ? MINOR_STEPS : MAJOR_STEPS;
+  return new Set(steps.map(s => (rootPc + s) % 12));
+}
+
+// inScale(midi, key) — is this midi pitch in the key's scale?
+export function inScale(midi, key) {
+  return scalePitchClasses(key).has(((midi % 12) + 12) % 12);
+}
+
+// snapMidi(midi, key) — nearest in-scale midi. Ties resolve DOWNWARD.
+// No usable key → midi unchanged.
+export function snapMidi(midi, key) {
+  const pcs = scalePitchClasses(key);
+  if (!pcs.size) return midi;
+  for (let d = 0; d <= 6; d++) {
+    if (pcs.has((((midi - d) % 12) + 12) % 12)) return midi - d;   // down wins ties
+    if (pcs.has((((midi + d) % 12) + 12) % 12)) return midi + d;
+  }
+  return midi;
+}
+
+// deriveKey(progression) → { root, mode } | null.
+// Collects every chord root + voicing pitch-class, scores against all 24
+// major/natural-minor scales (overlap count). Highest wins; ties broken toward
+// the first chord's root, preferring minor when the first chord name is minor.
+export function deriveKey(progression) {
+  if (!Array.isArray(progression) || !progression.length) return null;
+  const pcs = [];
+  for (const c of progression) {
+    if (!c) continue;
+    const rp = noteToPc(c.root);
+    if (rp != null) pcs.push(rp);
+    for (const v of (c.voicing || [])) {
+      const vp = noteToPc(v);
+      if (vp != null) pcs.push(vp);
+    }
+  }
+  if (!pcs.length) return null;
+  const firstRootPc = noteToPc(progression[0].root);
+  const firstIsMinor = /m(?![a-z])/.test(String(progression[0].name || ''));
+  // Score each candidate by [scale overlap, root == first chord, quality match],
+  // compared lexicographically — overlap dominates, ties favour the tonic then
+  // its quality.
+  let best = null, bestKey = [-1, 0, 0];
+  for (let root = 0; root < 12; root++) {
+    for (const mode of ['major', 'minor']) {
+      const set = scalePitchClasses({ root: PC_NAMES[root], mode });
+      const overlap = pcs.reduce((n, pc) => n + (set.has(pc) ? 1 : 0), 0);
+      const key = [overlap, root === firstRootPc ? 1 : 0, (mode === 'minor') === firstIsMinor ? 1 : 0];
+      if (key[0] > bestKey[0] || (key[0] === bestKey[0] && key[1] > bestKey[1])
+          || (key[0] === bestKey[0] && key[1] === bestKey[1] && key[2] > bestKey[2])) {
+        best = { root: PC_NAMES[root], mode }; bestKey = key;
+      }
+    }
+  }
+  return best;
+}

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -117,7 +117,6 @@
       <div class="vtabs"><span class="vtabs-lbl">VIEW</span><button data-view="scope">📈 Scope</button></div>
       <div id="viz"></div>
       <div id="master"></div>
-      <div id="harmony"></div>
       <div id="punch"></div>
       <div id="strips"></div>
       <div id="fills"></div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -117,6 +117,7 @@
       <div class="vtabs"><span class="vtabs-lbl">VIEW</span><button data-view="scope">📈 Scope</button></div>
       <div id="viz"></div>
       <div id="master"></div>
+      <div id="harmony"></div>
       <div id="punch"></div>
       <div id="strips"></div>
       <div id="fills"></div>

--- a/docs/arcade/groovebox/songs/digital-love.js
+++ b/docs/arcade/groovebox/songs/digital-love.js
@@ -27,7 +27,8 @@ export const digitalLove = {
     'crash build':{ kick:[0,8], snare:[14,15], crash:[12] },
     'tom roll':   { kick:[0,4], tom:[[8,7],[10,3],[12,2],[14,-2]] },
   },
-  harmony: { progression: [
+  // Key: C# minor — opens on C#m (i); C#m–E are diatonic to C# natural minor.
+  harmony: { key: { root:'C#', mode:'minor' }, progression: [
     { name:'C#m', root:'C#2', voicing:['C#3','E3','G#3'] },
     { name:'E', root:'E2', voicing:['E3','G#3','B3'] },
   ]},

--- a/docs/arcade/groovebox/songs/electric-feel.js
+++ b/docs/arcade/groovebox/songs/electric-feel.js
@@ -28,7 +28,8 @@ export const electricFeel = {
     'crash build':{ kick:[0,8], snare:[14,15], crash:[12] },
     'tom roll':   { kick:[0,4], tom:[[8,7],[10,3],[12,2],[14,-2]] },
   },
-  harmony: { progression: [
+  // Key: G# major — the riff anchors on G# (G#, G#, Gm); tonic = first chord.
+  harmony: { key: { root:'G#', mode:'major' }, progression: [
     { name:'G#', root:'G#2', voicing:['G#3','C3','D#3'] },
     { name:'G#', root:'G#2', voicing:['G#3','C3','D#3'] },
     { name:'Gm', root:'G2', voicing:['G3','A#3','D3'] },

--- a/docs/arcade/groovebox/songs/heartbeats.js
+++ b/docs/arcade/groovebox/songs/heartbeats.js
@@ -33,7 +33,8 @@ export const heartbeats = {
     'crash build':{ kick:[0,8], snare:[14,15], crash:[12] },
     'tom roll':   { kick:[0,4], tom:[[8,7],[10,3],[12,2],[14,-2]] },
   },
-  harmony: { progression: [
+  // Key: D# major — vamps D#↔C; tonic = the opening (and most-held) D# chord.
+  harmony: { key: { root:'D#', mode:'major' }, progression: [
     { name:'D#', root:'D#2', voicing:['D#3','G3','A#3'] },
     { name:'D#', root:'D#2', voicing:['D#3','G3','A#3'] },
     { name:'C', root:'C2', voicing:['C3','E3','G3'] },

--- a/docs/arcade/groovebox/songs/kids.js
+++ b/docs/arcade/groovebox/songs/kids.js
@@ -51,7 +51,9 @@ export const kids = {
     'crash + tom':{ kick:[0,8], tom:[[10,5],[12,2]], crash:[0,14] },
     'gated glitch':{ snare:[0,1,4,5,8,9,12,13], kick:[6,14], crash:[2,10] },
   },
-  harmony: { progression: [
+  // Key: A major — progression F#m–D–A–E/G# are all diatonic to A major
+  // (the song's tonal centre, though it opens on the relative minor F#m).
+  harmony: { key: { root:'A', mode:'major' }, progression: [
     { name:'F#m',  root:'F#2', voicing:['F#3','A3','C#4','E4'] },
     { name:'D',    root:'D2',  voicing:['D3','E3','A3'] },
     { name:'A',    root:'A2',  voicing:['A3','C#4','E4'] },

--- a/docs/arcade/groovebox/songs/memory-reboot.js
+++ b/docs/arcade/groovebox/songs/memory-reboot.js
@@ -41,7 +41,8 @@ export const memoryReboot = {
     'crash build':{ kick:[0,8], snare:[14,15], crash:[12] },
     'tom roll':   { kick:[0,4], tom:[[8,7],[10,3],[12,2],[14,-2]] },
   },
-  harmony: { progression: [
+  // Key: B major — progression B–A–F#–C# centres on B; tonic = first chord.
+  harmony: { key: { root:'B', mode:'major' }, progression: [
     { name:'B', root:'B2', voicing:['B3','D#3','F#3'] },
     { name:'B', root:'B2', voicing:['B3','D#3','F#3'] },
     { name:'A', root:'A2', voicing:['A3','C#3','E3'] },

--- a/docs/arcade/groovebox/songs/rising-sun.js
+++ b/docs/arcade/groovebox/songs/rising-sun.js
@@ -66,7 +66,10 @@ export const risingSun = {
     'crash open': { kick:[0,6], crash:[0], hat:[0,2,4,6,8,10] },
   },
 
+  // Key: A minor — opens and resolves on Am; Am–C–D–F–Am–E are diatonic to
+  // A natural minor (the E major V is the usual raised-leading-tone exception).
   harmony: {
+    key: { root:'A', mode:'minor' },
     progression: [
       { name:'Am', root:'A2', voicing:['A3','C4','E4'] },
       { name:'C',  root:'C2', voicing:['C3','E3','G3'] },

--- a/docs/arcade/groovebox/songs/take-on-me.js
+++ b/docs/arcade/groovebox/songs/take-on-me.js
@@ -41,7 +41,8 @@ export const takeOnMe = {
     'crash build':{ kick:[0,8], snare:[14,15], crash:[12] },
     'tom roll':   { kick:[0,4], tom:[[8,7],[10,3],[12,2],[14,-2]] },
   },
-  harmony: { progression: [
+  // Key: C major — the vamp opens and dwells on C; tonic = first chord.
+  harmony: { key: { root:'C', mode:'major' }, progression: [
     { name:'C', root:'C2', voicing:['C3','E3','G3'] },
     { name:'C', root:'C2', voicing:['C3','E3','G3'] },
     { name:'C', root:'C2', voicing:['C3','E3','G3'] },

--- a/docs/arcade/groovebox/tests/chords.test.js
+++ b/docs/arcade/groovebox/tests/chords.test.js
@@ -1,0 +1,60 @@
+import { test, expect } from 'vitest';
+import { parseProgression, formatProgression } from '../engine/chords.js';
+
+test('parses a major triad: root @oct2, voicing rising from oct3', () => {
+  const { chords, errors } = parseProgression('A');
+  expect(errors).toEqual([]);
+  expect(chords).toEqual([{ name: 'A', root: 'A2', voicing: ['A3', 'C#4', 'E4'] }]);
+});
+
+test('parses a minor triad (lowercase m quality)', () => {
+  expect(parseProgression('Am').chords[0])
+    .toEqual({ name: 'Am', root: 'A2', voicing: ['A3', 'C4', 'E4'] });
+});
+
+test('voicings match the preset conventions (Am / C from rising-sun)', () => {
+  const { chords } = parseProgression('Am C');
+  expect(chords[0].voicing).toEqual(['A3', 'C4', 'E4']);
+  expect(chords[1].voicing).toEqual(['C3', 'E3', 'G3']);
+});
+
+test('parses sharp and flat roots', () => {
+  expect(parseProgression('F#').chords[0].root).toBe('F#2');
+  // Bb normalises to its pitch-class spelling A#.
+  expect(parseProgression('Bb').chords[0]).toMatchObject({ name: 'A#', root: 'A#2' });
+});
+
+test('slash bass sets the root note; voicing stays the chord triad', () => {
+  const c = parseProgression('E/G#').chords[0];
+  expect(c).toEqual({ name: 'E/G#', root: 'G#2', voicing: ['E3', 'G#3', 'B3'] });
+});
+
+test('parses a full progression', () => {
+  const { chords, errors } = parseProgression('F#m D A E/G#');
+  expect(errors).toEqual([]);
+  expect(chords.map(c => c.name)).toEqual(['F#m', 'D', 'A', 'E/G#']);
+});
+
+test('records per-token errors with index; parses the rest', () => {
+  const { chords, errors } = parseProgression('A x7 Cm');
+  expect(chords.map(c => c.name)).toEqual(['A', 'Cm']);
+  expect(errors).toEqual([{ index: 1, token: 'x7' }]);
+});
+
+test('collapses repeated whitespace and trims', () => {
+  expect(parseProgression('  A    Cm  ').chords.map(c => c.name)).toEqual(['A', 'Cm']);
+});
+
+test('empty input → no chords, no errors', () => {
+  expect(parseProgression('')).toEqual({ chords: [], errors: [] });
+  expect(parseProgression('   ')).toEqual({ chords: [], errors: [] });
+});
+
+test('formatProgression is the inverse of parse (by name)', () => {
+  const text = 'F#m D A E/G#';
+  expect(formatProgression(parseProgression(text).chords)).toBe(text);
+});
+
+test('formatProgression tolerates non-array', () => {
+  expect(formatProgression(null)).toBe('');
+});

--- a/docs/arcade/groovebox/tests/engine-api.test.js
+++ b/docs/arcade/groovebox/tests/engine-api.test.js
@@ -105,6 +105,31 @@ test('addPattern clones the edit pattern picks', () => {
   expect(eng.getSong().patterns[idx].lanes).toEqual(picks);
 });
 
+// ── harmony API ──────────────────────────────────────────────────────────
+test('getHarmony/getKey: kids flattens with its authored A-major key', () => {
+  const eng = loaded();
+  const h = eng.getHarmony();
+  expect(h.progression.length).toBeGreaterThan(0);
+  expect(eng.getKey()).toEqual({ root: 'A', mode: 'major' });
+});
+
+test('setProgression replaces the progression; relative grooves track it live', () => {
+  const eng = loaded();
+  const newProg = [{ name: 'Cm', root: 'C2', voicing: ['C3', 'D#3', 'G3'] }];
+  eng.setProgression(newProg);
+  expect(eng.getHarmony().progression).toBe(newProg);
+  expect(eng.getHarmony().progression[0].name).toBe('Cm');
+});
+
+test('setProgression creates a harmony object when absent', () => {
+  const eng = createEngine();
+  eng.load({ patterns: [{ lanes: {} }], chain: [0], lanes: [], grooves: {}, meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, bpm: 120 });
+  expect(eng.getHarmony()).toBeNull();
+  const prog = [{ name: 'A', root: 'A2', voicing: ['A3', 'C#4', 'E4'] }];
+  eng.setProgression(prog);
+  expect(eng.getHarmony().progression).toBe(prog);
+});
+
 test('getEditGroove returns the edit pattern groove for a lane (name + data) and tracks selectPattern', () => {
   const eng = loaded();
   const g0 = eng.getEditGroove('drums');

--- a/docs/arcade/groovebox/tests/engine-api.test.js
+++ b/docs/arcade/groovebox/tests/engine-api.test.js
@@ -105,29 +105,40 @@ test('addPattern clones the edit pattern picks', () => {
   expect(eng.getSong().patterns[idx].lanes).toEqual(picks);
 });
 
-// ── harmony API ──────────────────────────────────────────────────────────
-test('getHarmony/getKey: kids flattens with its authored A-major key', () => {
+// ── harmony API (chords belong to patterns) ─────────────────────────────────
+test('getKey: kids flattens with its authored A-major key; getPatternChords reads pattern chords', () => {
   const eng = loaded();
-  const h = eng.getHarmony();
-  expect(h.progression.length).toBeGreaterThan(0);
   expect(eng.getKey()).toEqual({ root: 'A', mode: 'major' });
+  expect(eng.getPatternChords(0).length).toBeGreaterThan(0);
 });
 
-test('setProgression replaces the progression; relative grooves track it live', () => {
+test('getHarmony/setProgression are gone (replaced by pattern-owned chords)', () => {
   const eng = loaded();
-  const newProg = [{ name: 'Cm', root: 'C2', voicing: ['C3', 'D#3', 'G3'] }];
-  eng.setProgression(newProg);
-  expect(eng.getHarmony().progression).toBe(newProg);
-  expect(eng.getHarmony().progression[0].name).toBe('Cm');
+  expect(eng.getHarmony).toBeUndefined();
+  expect(eng.setProgression).toBeUndefined();
 });
 
-test('setProgression creates a harmony object when absent', () => {
+test('setPatternChords sets the EDIT pattern chords and re-derives song.key', () => {
+  const eng = loaded();
+  eng.selectPattern(0);
+  const newChords = [{ name: 'Cm', root: 'C2', voicing: ['C3', 'D#3', 'G3'] }];
+  eng.setPatternChords(newChords);
+  expect(eng.getPatternChords(0)).toBe(newChords);
+  // key re-derived across ALL patterns' chords (no throw; a key is found).
+  expect(eng.getKey()).toBeTruthy();
+});
+
+test('setPatternChords([]) clears the edit pattern chords', () => {
   const eng = createEngine();
   eng.load({ patterns: [{ lanes: {} }], chain: [0], lanes: [], grooves: {}, meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, bpm: 120 });
-  expect(eng.getHarmony()).toBeNull();
+  expect(eng.getPatternChords(0)).toBeNull();
   const prog = [{ name: 'A', root: 'A2', voicing: ['A3', 'C#4', 'E4'] }];
-  eng.setProgression(prog);
-  expect(eng.getHarmony().progression).toBe(prog);
+  eng.setPatternChords(prog);
+  expect(eng.getPatternChords(0)).toBe(prog);
+  expect(eng.getKey()).toBeTruthy();
+  eng.setPatternChords([]);
+  expect(eng.getPatternChords(0)).toBeNull();
+  expect(eng.getKey()).toBeNull();
 });
 
 test('getEditGroove returns the edit pattern groove for a lane (name + data) and tracks selectPattern', () => {

--- a/docs/arcade/groovebox/tests/harmony.test.js
+++ b/docs/arcade/groovebox/tests/harmony.test.js
@@ -67,23 +67,23 @@ test('grooveBars: literal array passes through, relative wrapper unwraps', () =>
   expect(grooveBars({ relative: true, bars: [figure] })).toEqual([figure]);
 });
 
-// ── harmony clock through eventsForStepV2 ──────────────────────────────────
-// A 2-chord progression with a one-bar relative bass groove: the resolved note
-// must track the absolute bar.
+// ── pattern-local chords through eventsForStepV2 ────────────────────────────
+// A pattern with 2 chords + a one-bar relative bass groove: the resolved note
+// cycles on barInPattern (pattern.chords), not on a global/absolute clock.
+const C = { name: 'C', root: 'C2', voicing: ['C3', 'E3', 'G3'] };
 function harmonySong() {
   return {
     meter: meter44,
-    harmony: { progression: [Am, { name: 'C', root: 'C2', voicing: ['C3', 'E3', 'G3'] }] },
     lanes: [{ id: 'bass', type: 'bass', name: 'bass', muted: false, soloed: false }],
     grooves: { bass: { rel: { relative: true, bars: [[[0, 'R', 16]]] } } },
-    patterns: [{ lanes: { bass: 'rel' } }],
+    patterns: [{ lanes: { bass: 'rel' }, chords: [Am, C] }],
     chain: [0],
   };
 }
 
-test('relative groove resolves against chordAt(absoluteBar)', () => {
+test('relative groove resolves against pattern.chords[barInPattern], cycling', () => {
   const song = harmonySong();
-  const at = b => eventsForStepV2(song, 0, 0, 0, null, 0, b);
+  const at = b => eventsForStepV2(song, 0, b, 0, null, 0);
   expect(at(0)).toEqual([{ laneId: 'bass', type: 'bass', note: 'A2', dur: 16 }]); // Am
   expect(at(1)).toEqual([{ laneId: 'bass', type: 'bass', note: 'C2', dur: 16 }]); // C
   expect(at(2)).toEqual([{ laneId: 'bass', type: 'bass', note: 'A2', dur: 16 }]); // wraps → Am
@@ -92,31 +92,30 @@ test('relative groove resolves against chordAt(absoluteBar)', () => {
 test('relative groove: transpose applies AFTER resolution', () => {
   const song = harmonySong();
   // +2 semitones on the Am root A2 → B2.
-  expect(eventsForStepV2(song, 0, 0, 0, null, 2, 0))
+  expect(eventsForStepV2(song, 0, 0, 0, null, 2))
     .toEqual([{ laneId: 'bass', type: 'bass', note: 'B2', dur: 16 }]);
 });
 
 test('relative chords lane: V* → pad event, single ref → arp event', () => {
   const song = {
     meter: meter44,
-    harmony: { progression: [Am] },
     lanes: [{ id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false }],
     grooves: { chords: { pad: { relative: true, bars: [[[0, 'V*', 'bar'], [8, 'V0', 1]]] } } },
-    patterns: [{ lanes: { chords: 'pad' } }],
+    patterns: [{ lanes: { chords: 'pad' }, chords: [Am] }],
     chain: [0],
   };
-  expect(eventsForStepV2(song, 0, 0, 0, null, 0, 0))
+  expect(eventsForStepV2(song, 0, 0, 0, null, 0))
     .toEqual([{ laneId: 'chords', type: 'chords', mode: 'pad', notes: ['A3', 'C4', 'E4'], dur: 'bar' }]);
-  expect(eventsForStepV2(song, 0, 0, 8, null, 0, 0))
+  expect(eventsForStepV2(song, 0, 0, 8, null, 0))
     .toEqual([{ laneId: 'chords', type: 'chords', mode: 'arp', note: 'A3', dur: 1 }]);
 });
 
-test('no harmony / empty progression → relative groove is silent', () => {
+test('no chords on the pattern → relative groove is silent', () => {
   const base = harmonySong();
-  const noHarmony = { ...base, harmony: undefined };
-  expect(eventsForStepV2(noHarmony, 0, 0, 0, null, 0, 0)).toEqual([]);
-  const empty = { ...base, harmony: { progression: [] } };
-  expect(eventsForStepV2(empty, 0, 0, 0, null, 0, 0)).toEqual([]);
+  const noChords = { ...base, patterns: [{ lanes: { bass: 'rel' } }] };
+  expect(eventsForStepV2(noChords, 0, 0, 0, null, 0)).toEqual([]);
+  const empty = { ...base, patterns: [{ lanes: { bass: 'rel' }, chords: [] }] };
+  expect(eventsForStepV2(empty, 0, 0, 0, null, 0)).toEqual([]);
 });
 
 // ── write-path no-ops on relative grooves ──────────────────────────────────

--- a/docs/arcade/groovebox/tests/helpers/stream.js
+++ b/docs/arcade/groovebox/tests/helpers/stream.js
@@ -11,8 +11,9 @@ export function renderChainStream(song, { cycles = 3, skipCycles = 1 } = {}) {
     const { patternIdx, barInPattern } = chainBarAt(song, bar);
     const outBar = bar - total * skipCycles;
     for (let step = 0; step < spb; step++) {
-      // `bar` is the song-absolute bar → it is the harmony clock for relative grooves.
-      for (const e of eventsForStepV2(song, patternIdx, barInPattern, step, null, 0, bar)) {
+      // Chord-relative grooves resolve against the pattern's own chords (folded in
+      // by the flattener), so the absolute bar is no longer passed.
+      for (const e of eventsForStepV2(song, patternIdx, barInPattern, step, null, 0)) {
         out.add(eventKey(outBar, step, e));
       }
     }

--- a/docs/arcade/groovebox/tests/patterns.test.js
+++ b/docs/arcade/groovebox/tests/patterns.test.js
@@ -176,6 +176,22 @@ test('patternBars: mixed-length picks → max; missing/empty grooves floor at 1'
   expect(patternBars(s, 99)).toBe(1);              // bad index
 });
 
+test('patternBars includes pattern.chords (chords extend duration; cycle underneath)', () => {
+  const s = makeSong();
+  // Pattern 1 picks 1-bar grooves; 4 chords make it a 4-bar pattern.
+  s.patterns[1].chords = [
+    { name: 'Am', root: 'A2', voicing: ['A3'] },
+    { name: 'C',  root: 'C2', voicing: ['C3'] },
+    { name: 'G',  root: 'G2', voicing: ['G3'] },
+    { name: 'F',  root: 'F2', voicing: ['F3'] },
+  ];
+  expect(patternBars(s, 1)).toBe(4);                    // chords floor the duration
+  // A longer groove still wins over fewer chords.
+  s.grooves.melody.long = [[], [], [], [], [], [], [], []];   // 8-bar
+  s.patterns[1].lanes.melody = 'long';
+  expect(patternBars(s, 1)).toBe(8);
+});
+
 // ── groove pick / lookup ──
 test('setLaneGroove sets the edit pattern pick; rejects unknown grooves', () => {
   const s = makeSong();

--- a/docs/arcade/groovebox/tests/scale.test.js
+++ b/docs/arcade/groovebox/tests/scale.test.js
@@ -1,0 +1,81 @@
+import { test, expect } from 'vitest';
+import { scalePitchClasses, snapMidi, inScale, deriveKey } from '../engine/song.js';
+
+// midi 60 = C4. Pitch classes: C=0 … B=11.
+
+test('scalePitchClasses: C major', () => {
+  const s = scalePitchClasses({ root: 'C', mode: 'major' });
+  expect([...s].sort((a, b) => a - b)).toEqual([0, 2, 4, 5, 7, 9, 11]);
+});
+
+test('scalePitchClasses: A natural minor', () => {
+  const s = scalePitchClasses({ root: 'A', mode: 'minor' });
+  expect([...s].sort((a, b) => a - b)).toEqual([0, 2, 4, 5, 7, 9, 11]); // same set as C major
+});
+
+test('scalePitchClasses: F# major includes the right sharps', () => {
+  const s = scalePitchClasses({ root: 'F#', mode: 'major' });
+  // F# major: F# G# A# B C# D# E# (=F)
+  expect([...s].sort((a, b) => a - b)).toEqual([1, 3, 5, 6, 8, 10, 11]);
+});
+
+test('scalePitchClasses: missing/unknown key → empty set', () => {
+  expect(scalePitchClasses(null).size).toBe(0);
+  expect(scalePitchClasses({}).size).toBe(0);
+});
+
+test('inScale: C major', () => {
+  const C = { root: 'C', mode: 'major' };
+  expect(inScale(60, C)).toBe(true);   // C
+  expect(inScale(61, C)).toBe(false);  // C#
+  expect(inScale(62, C)).toBe(true);   // D
+});
+
+test('snapMidi: in-scale notes pass through', () => {
+  const C = { root: 'C', mode: 'major' };
+  expect(snapMidi(60, C)).toBe(60);
+  expect(snapMidi(64, C)).toBe(64);
+});
+
+test('snapMidi: out-of-scale snaps to nearest in-scale', () => {
+  const C = { root: 'C', mode: 'major' };
+  expect(snapMidi(61, C)).toBe(60);   // C# → C (down) and D both dist 1 → tie → down
+  expect(snapMidi(66, C)).toBe(65);   // F# → F (down) ties with G → down wins
+});
+
+test('snapMidi: no usable key → unchanged', () => {
+  expect(snapMidi(61, null)).toBe(61);
+  expect(snapMidi(61, {})).toBe(61);
+});
+
+// ── deriveKey ──────────────────────────────────────────────────────────────
+const chord = (name, root, voicing) => ({ name, root, voicing });
+
+test('deriveKey: A minor progression (rising-sun shape)', () => {
+  const prog = [
+    chord('Am', 'A2', ['A3', 'C4', 'E4']),
+    chord('C', 'C2', ['C3', 'E3', 'G3']),
+    chord('D', 'D2', ['D3', 'F#3', 'A3']),
+    chord('F', 'F2', ['F3', 'A3', 'C4']),
+    chord('Am', 'A2', ['A3', 'C4', 'E4']),
+    chord('E', 'E2', ['E3', 'G#3', 'B3']),
+  ];
+  expect(deriveKey(prog)).toEqual({ root: 'A', mode: 'minor' });
+});
+
+test('deriveKey: ties break toward first chord root', () => {
+  // F#m–D–A–E all fit A major and F# minor equally (relative keys).
+  const prog = [
+    chord('F#m', 'F#2', ['F#3', 'A3', 'C#4']),
+    chord('D', 'D2', ['D3', 'F#3', 'A3']),
+    chord('A', 'A2', ['A3', 'C#4', 'E4']),
+    chord('E', 'E2', ['E3', 'G#3', 'B3']),
+  ];
+  // First chord is F#m → tie resolves to F# minor.
+  expect(deriveKey(prog)).toEqual({ root: 'F#', mode: 'minor' });
+});
+
+test('deriveKey: empty / missing → null', () => {
+  expect(deriveKey([])).toBeNull();
+  expect(deriveKey(null)).toBeNull();
+});

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -405,7 +405,6 @@ input[type=range] {
 #fills,
 #punch,
 #master,
-#harmony,
 #arrange {
   /* soft top-light → bottom-shade sheen (derived from --panel) so panels read
      as smooth surfaces in every theme, not flat matte cards on dark */
@@ -463,11 +462,6 @@ input[type=range] {
 
 /* ─── master panel ───────────────────────────────────────────────────────── */
 #master {
-  padding: 12px 16px;
-}
-
-/* ─── harmony panel ──────────────────────────────────────────────────────── */
-#harmony {
   padding: 12px 16px;
 }
 
@@ -884,8 +878,7 @@ input[type=range] {
 }
 /* § 2 — section header */
 .fillsrow .flbl,
-.punchrow .flbl,
-.harmonyrow .flbl {
+.punchrow .flbl {
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.12em;
@@ -982,13 +975,14 @@ input[type=range] {
   background: transparent;
 }
 
-/* ─── harmony row (panel chrome via #harmony) ───────────────────────────── */
-.harmonyrow {
+/* ─── chord line (inside the PATTERNS module, between patterns + chain) ───── */
+.chord-row {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
   flex-wrap: wrap;
   row-gap: 6px;
+  margin: 6px 0;
 }
 .h-chips {
   display: flex;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -28,6 +28,10 @@
   --hit2:         #1c2f54;   /* groove hit gradient bottom */
   --roll-bg:      #0f121a;   /* piano-roll / bass lane (white key) */
   --roll-bg-blk:  #0c0e14;   /* piano-roll / bass lane (black key) */
+  /* out-of-scale rows: a dimmer wash of the roll bg. Derived from --roll-bg so
+     it tracks every theme override (themes set --roll-bg on the same element). */
+  --roll-bg-out:  color-mix(in srgb, var(--roll-bg) 78%, var(--bg));
+  --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--acc)); /* chord-tone wash */
   --roll-note:    var(--acc); /* note blocks + bass notes */
   --grid-line:    #2a2e3a;   /* roll / scope gridlines */
   --scope:        #7dffe0;   /* scope trace */
@@ -401,6 +405,7 @@ input[type=range] {
 #fills,
 #punch,
 #master,
+#harmony,
 #arrange {
   /* soft top-light → bottom-shade sheen (derived from --panel) so panels read
      as smooth surfaces in every theme, not flat matte cards on dark */
@@ -458,6 +463,11 @@ input[type=range] {
 
 /* ─── master panel ───────────────────────────────────────────────────────── */
 #master {
+  padding: 12px 16px;
+}
+
+/* ─── harmony panel ──────────────────────────────────────────────────────── */
+#harmony {
   padding: 12px 16px;
 }
 
@@ -874,7 +884,8 @@ input[type=range] {
 }
 /* § 2 — section header */
 .fillsrow .flbl,
-.punchrow .flbl {
+.punchrow .flbl,
+.harmonyrow .flbl {
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.12em;
@@ -970,6 +981,96 @@ input[type=range] {
   border-color: rgba(255,91,158,0.4);
   background: transparent;
 }
+
+/* ─── harmony row (panel chrome via #harmony) ───────────────────────────── */
+.harmonyrow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  row-gap: 6px;
+}
+.h-chips {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  cursor: text;
+  min-height: 27px;
+}
+/* Chord chips — mirror .chain-chip styling. */
+.h-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 30px;
+  height: 27px;
+  border-radius: 5px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.h-chip.h-empty { color: var(--faint); font-weight: 400; }
+/* Sounding chord — reuse the --hot "driving sound" glow language. */
+.h-chip.sounding {
+  border-color: var(--hot);
+  color: var(--hot);
+  box-shadow: 0 0 8px var(--hot);
+}
+/* Key badge — reuse .pat-lbl look. */
+.h-key { margin-left: auto; }
+/* Inline edit input. */
+.h-edit {
+  flex: 1 1 auto;
+  height: 27px;
+  border-radius: 5px;
+  padding: 0 10px;
+  border: 1px solid var(--acc-dim);
+  background: var(--panel-2);
+  color: var(--ink);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  font-family: inherit;
+}
+.h-edit:focus { outline: 2px solid var(--acc); outline-offset: -1px; }
+.h-edit.invalid { border-color: var(--hot); outline-color: var(--hot); }
+
+/* Snap-to-scale toggle — mirror .roll-mode-btn / .glen-btn look. */
+.snap-btn {
+  height: 22px;
+  padding: 0 10px;
+  border-radius: 5px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--dim);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.04),
+    inset 0 -1px 0 rgba(0,0,0,0.2);
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.snap-btn:hover { background: var(--panel-3); border-color: var(--acc-dim); color: var(--ink); }
+.snap-btn.on {
+  background: rgba(84,240,200,0.10);
+  border-color: var(--acc);
+  color: var(--acc);
+  box-shadow: inset 0 -2px 0 var(--acc);
+}
+
+/* Blocks-grid key tint: out-of-scale rows dim; chord-tone cells brighten. The
+   :not(.hit) guard keeps placed-note styling (and the .now playhead) on top. */
+.bg-row.oos .vc:not(.hit) { background: var(--roll-bg-out); }
+.bg-row.oos .bg-lbl { opacity: 0.5; }
+.vc.ctone:not(.hit) { background: var(--roll-ctone); }
+.vc.ctone.bar-alt:not(.hit) { background: color-mix(in srgb, var(--roll-ctone) 88%, #000); }
+.bg-row.oos .vc.ctone:not(.hit) { background: color-mix(in srgb, var(--roll-bg-out) 70%, var(--acc)); }
 
 /* ─── master FX strip (panel chrome via #master) ────────────────────────── */
 .masterfx {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1,5 +1,6 @@
 import { createEngine } from '../engine/index.js';
 import { laneAudible } from '../engine/song.js';
+import { parseProgression, formatProgression } from '../engine/chords.js';
 import { kids } from '../songs/kids.js';
 import { risingSun } from '../songs/rising-sun.js';
 import { electricFeel } from '../songs/electric-feel.js';
@@ -52,7 +53,7 @@ let _editingLaneId = null;
 let _draggedLaneId = null;
 
 // ─── Section drag-reorder state ───────────────────────────────────────────────
-const SECTION_IDS = ['viz', 'master', 'punch', 'strips', 'fills', 'arrange'];
+const SECTION_IDS = ['viz', 'master', 'harmony', 'punch', 'strips', 'fills', 'arrange'];
 let _draggedSecId = null;
 
 function refreshStates() {
@@ -609,6 +610,98 @@ function renderMaster() {
   updateEmptyGroups(); // hide master kgroups where all knobs are hidden
 }
 
+// ─── HARMONY row (chord chips + click-to-edit text) ──────────────────────────
+function fmtKeyName(key) {
+  return key ? `${key.root} ${key.mode}` : '';
+}
+
+function renderHarmony() {
+  const host = document.getElementById('harmony');
+  if (!host) return;
+  const harmony = eng.getHarmony();
+  host.innerHTML = '';
+  const row = document.createElement('div');
+  row.className = 'harmonyrow';
+  const lbl = document.createElement('span');
+  lbl.className = 'flbl';
+  lbl.textContent = 'HARMONY';
+  row.appendChild(lbl);
+
+  const chips = document.createElement('div');
+  chips.className = 'h-chips';
+  const prog = harmony?.progression || [];
+  if (prog.length) {
+    prog.forEach((c, i) => {
+      const chip = document.createElement('span');
+      chip.className = 'h-chip';
+      chip.dataset.idx = i;
+      chip.textContent = c.name;
+      chips.appendChild(chip);
+    });
+  } else {
+    const dash = document.createElement('span');
+    dash.className = 'h-chip h-empty';
+    dash.textContent = '—';
+    chips.appendChild(dash);
+  }
+  row.appendChild(chips);
+
+  const key = eng.getKey();
+  if (key) {
+    const badge = document.createElement('span');
+    badge.className = 'pat-lbl h-key';
+    badge.textContent = fmtKeyName(key);
+    row.appendChild(badge);
+  }
+  host.appendChild(row);
+
+  // Click anywhere on the chip area → swap to a text input (mirrors lane rename).
+  chips.onclick = () => beginHarmonyEdit();
+}
+
+// Swap the chip area for a text input prefilled from the current progression.
+// Enter / blur commit (parse → setProgression → re-render); Escape cancels.
+function beginHarmonyEdit() {
+  const host = document.getElementById('harmony');
+  if (!host) return;
+  const chips = host.querySelector('.h-chips');
+  if (!chips) return;
+  const prog = eng.getHarmony()?.progression || [];
+  const input = document.createElement('input');
+  input.className = 'h-edit';
+  input.value = formatProgression(prog);
+  input.placeholder = 'e.g. F#m D A E/G#';
+  chips.replaceWith(input);
+  input.focus();
+  input.select();
+  let done = false;
+  const cancel = () => { if (done) return; done = true; renderHarmony(); };
+  const commit = () => {
+    if (done) return;
+    const { chords, errors } = parseProgression(input.value);
+    if (errors.length || !chords.length) { input.classList.add('invalid'); return; }
+    done = true;
+    eng.setProgression(chords);
+    renderHarmony();
+    refreshVizPattern();   // melody/bass tinting reads the new chords/key
+  };
+  input.oninput = () => input.classList.remove('invalid');
+  input.onkeydown = e => {
+    if (e.key === 'Enter') { e.preventDefault(); commit(); }
+    else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+  };
+  input.onblur = commit;
+}
+
+// Highlight the sounding chord chip. chordIdx -1 → no harmony, clear all.
+function updateHarmonyPlayback(chordIdx) {
+  const host = document.getElementById('harmony');
+  if (!host) return;
+  host.querySelectorAll('.h-chip').forEach(chip => {
+    chip.classList.toggle('sounding', +chip.dataset.idx === chordIdx);
+  });
+}
+
 // ─── PATTERNS module (patterns row + chain row + playback label) ─────────────
 let _chainDragFrom = null;
 
@@ -769,6 +862,7 @@ function mount() {
   renderFills();
   renderPunch();
   renderMaster();
+  renderHarmony();
   renderPatterns();
   viz?.dispose?.();   // stop the outgoing viz's rAF loops before replacing it
   viz = makeViz(document.getElementById('viz'), song, eng);
@@ -855,7 +949,7 @@ document.getElementById('themesel').onchange = e => {
 // (Scope + quick-edit lane tabs are built and wired in renderViewTabs().)
 
 // ─── Step callback (registered once; closes over module-level song/viz) ──────
-eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
+eng.onStep(({ absStep, bar, stepInBar, fill, queue, target, chordIdx }) => {
   viz.setStep({ absStep, bar, stepInBar, target });
   const fillsHost = document.getElementById('fills');
   if (fillsHost) {
@@ -865,6 +959,7 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
     renderChain(queue);
   }
   updatePatternsPlayback(target);
+  updateHarmonyPlayback(chordIdx);
 });
 
 // ─── Restore saved theme ──────────────────────────────────────────────────────

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -53,7 +53,7 @@ let _editingLaneId = null;
 let _draggedLaneId = null;
 
 // ─── Section drag-reorder state ───────────────────────────────────────────────
-const SECTION_IDS = ['viz', 'master', 'harmony', 'punch', 'strips', 'fills', 'arrange'];
+const SECTION_IDS = ['viz', 'master', 'punch', 'strips', 'fills', 'arrange'];
 let _draggedSecId = null;
 
 function refreshStates() {
@@ -610,99 +610,11 @@ function renderMaster() {
   updateEmptyGroups(); // hide master kgroups where all knobs are hidden
 }
 
-// ─── HARMONY row (chord chips + click-to-edit text) ──────────────────────────
+// ─── PATTERNS module (patterns row + chain row + chord line + playback label) ─
 function fmtKeyName(key) {
   return key ? `${key.root} ${key.mode}` : '';
 }
 
-function renderHarmony() {
-  const host = document.getElementById('harmony');
-  if (!host) return;
-  const harmony = eng.getHarmony();
-  host.innerHTML = '';
-  const row = document.createElement('div');
-  row.className = 'harmonyrow';
-  const lbl = document.createElement('span');
-  lbl.className = 'flbl';
-  lbl.textContent = 'HARMONY';
-  row.appendChild(lbl);
-
-  const chips = document.createElement('div');
-  chips.className = 'h-chips';
-  const prog = harmony?.progression || [];
-  if (prog.length) {
-    prog.forEach((c, i) => {
-      const chip = document.createElement('span');
-      chip.className = 'h-chip';
-      chip.dataset.idx = i;
-      chip.textContent = c.name;
-      chips.appendChild(chip);
-    });
-  } else {
-    const dash = document.createElement('span');
-    dash.className = 'h-chip h-empty';
-    dash.textContent = '—';
-    chips.appendChild(dash);
-  }
-  row.appendChild(chips);
-
-  const key = eng.getKey();
-  if (key) {
-    const badge = document.createElement('span');
-    badge.className = 'pat-lbl h-key';
-    badge.textContent = fmtKeyName(key);
-    row.appendChild(badge);
-  }
-  host.appendChild(row);
-
-  // Click anywhere on the chip area → swap to a text input (mirrors lane rename).
-  chips.onclick = () => beginHarmonyEdit();
-}
-
-// Swap the chip area for a text input prefilled from the current progression.
-// Enter / blur commit (parse → setProgression → re-render); Escape cancels.
-function beginHarmonyEdit() {
-  const host = document.getElementById('harmony');
-  if (!host) return;
-  const chips = host.querySelector('.h-chips');
-  if (!chips) return;
-  const prog = eng.getHarmony()?.progression || [];
-  const input = document.createElement('input');
-  input.className = 'h-edit';
-  input.value = formatProgression(prog);
-  input.placeholder = 'e.g. F#m D A E/G#';
-  chips.replaceWith(input);
-  input.focus();
-  input.select();
-  let done = false;
-  const cancel = () => { if (done) return; done = true; renderHarmony(); };
-  const commit = () => {
-    if (done) return;
-    const { chords, errors } = parseProgression(input.value);
-    if (errors.length || !chords.length) { input.classList.add('invalid'); return; }
-    done = true;
-    eng.setProgression(chords);
-    renderHarmony();
-    refreshVizPattern();   // melody/bass tinting reads the new chords/key
-  };
-  input.oninput = () => input.classList.remove('invalid');
-  input.onkeydown = e => {
-    if (e.key === 'Enter') { e.preventDefault(); commit(); }
-    else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
-  };
-  input.onblur = commit;
-}
-
-// Highlight the sounding chord chip. chordIdx -1 → no harmony, clear all.
-function updateHarmonyPlayback(chordIdx) {
-  const host = document.getElementById('harmony');
-  if (!host) return;
-  host.querySelectorAll('.h-chip').forEach(chip => {
-    chip.classList.toggle('sounding', +chip.dataset.idx === chordIdx);
-  });
-}
-
-// ─── PATTERNS module (patterns row + chain row + playback label) ─────────────
 let _chainDragFrom = null;
 
 function renderPatterns() {
@@ -757,6 +669,11 @@ function renderPatterns() {
   prow.appendChild(del);
   host.appendChild(prow);
 
+  // Chord line for the SELECTED pattern: "chords" label + chord-name chips +
+  // key badge. Chords belong to the pattern (one per bar, cycling). Click
+  // anywhere → text input to edit (parser-backed); empty → a "＋ chords" affordance.
+  host.appendChild(buildChordLine(editIdx));
+
   // Chain row: chips (click = play chain from there; hover-✕ removes; drag reorders) + append.
   const crow = document.createElement('div');
   crow.className = 'chain-row';
@@ -799,6 +716,91 @@ function renderPatterns() {
   syncStripGrooves();   // edit pattern may have changed → resync strip dropdowns
 }
 
+// Build the chord line for pattern `idx`: "chords" label + chord chips (or a
+// "＋ chords" affordance when empty) + the key badge. The chip area is clickable
+// (cursor:text) → beginChordEdit swaps in the text input.
+function buildChordLine(idx) {
+  const row = document.createElement('div');
+  row.className = 'chord-row';
+  const lbl = document.createElement('span');
+  lbl.className = 'pat-lbl';
+  lbl.textContent = 'chords';
+  row.appendChild(lbl);
+
+  const chips = document.createElement('div');
+  chips.className = 'h-chips';
+  const chords = eng.getPatternChords(idx) || [];
+  if (chords.length) {
+    chords.forEach((c, i) => {
+      const chip = document.createElement('span');
+      chip.className = 'h-chip';
+      chip.dataset.idx = i;
+      chip.textContent = c.name;
+      chips.appendChild(chip);
+    });
+  } else {
+    const add = document.createElement('span');
+    add.className = 'h-chip h-empty';
+    add.textContent = '＋ chords';
+    chips.appendChild(add);
+  }
+  chips.onclick = () => beginChordEdit(idx);
+  row.appendChild(chips);
+
+  const key = eng.getKey();
+  if (key) {
+    const badge = document.createElement('span');
+    badge.className = 'pat-lbl h-key';
+    badge.textContent = fmtKeyName(key);
+    row.appendChild(badge);
+  }
+  return row;
+}
+
+// Swap the chip area for a text input prefilled from the pattern's chords.
+// Enter / blur commit (parse → setPatternChords); Escape cancels; invalid input
+// keeps a red border and stays editing.
+function beginChordEdit(idx) {
+  const host = document.getElementById('arrange');
+  const chips = host?.querySelector('.chord-row .h-chips');
+  if (!chips) return;
+  const chords = eng.getPatternChords(idx) || [];
+  const input = document.createElement('input');
+  input.className = 'h-edit';
+  input.value = formatProgression(chords);
+  input.placeholder = 'e.g. F#m D A E/G#';
+  chips.replaceWith(input);
+  input.focus();
+  input.select();
+  let done = false;
+  const cancel = () => { if (done) return; done = true; renderPatterns(); refreshVizPattern(); };
+  const commit = () => {
+    if (done) return;
+    const text = input.value.trim();
+    if (text === '') {                         // empty → clear the pattern's chords
+      done = true;
+      eng.selectPattern(idx);
+      eng.setPatternChords([]);
+      renderPatterns();
+      refreshVizPattern();
+      return;
+    }
+    const { chords: parsed, errors } = parseProgression(text);
+    if (errors.length || !parsed.length) { input.classList.add('invalid'); return; }
+    done = true;
+    eng.selectPattern(idx);                    // setPatternChords targets the edit pattern
+    eng.setPatternChords(parsed);
+    renderPatterns();
+    refreshVizPattern();   // melody/bass tinting reads the new chords/key
+  };
+  input.oninput = () => input.classList.remove('invalid');
+  input.onkeydown = e => {
+    if (e.key === 'Enter') { e.preventDefault(); commit(); }
+    else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+  };
+  input.onblur = commit;
+}
+
 // Glow + label + row dimming — called from renderPatterns and every step.
 function updatePatternsPlayback(target) {
   const host = document.getElementById('arrange');
@@ -814,6 +816,16 @@ function updatePatternsPlayback(target) {
   host.querySelectorAll('.chain-chip').forEach(c => {
     c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos);
   });
+  // Sounding-chord glow on the chord line — only when the SOUNDING pattern is the
+  // one displayed (the chord chips show the edit pattern's chords).
+  const chordChips = host.querySelectorAll('.chord-row .h-chip');
+  if (chordChips.length) {
+    const editIdx = eng.getEditPatternIndex();
+    const sounding = target.patternIdx === editIdx
+      ? target.barInPattern % chordChips.length
+      : -1;
+    chordChips.forEach(chip => chip.classList.toggle('sounding', +chip.dataset.idx === sounding));
+  }
   const lbl = host.querySelector('#pat-playing');
   if (lbl) {
     const chain = eng.getChain();
@@ -862,7 +874,6 @@ function mount() {
   renderFills();
   renderPunch();
   renderMaster();
-  renderHarmony();
   renderPatterns();
   viz?.dispose?.();   // stop the outgoing viz's rAF loops before replacing it
   viz = makeViz(document.getElementById('viz'), song, eng);
@@ -949,7 +960,7 @@ document.getElementById('themesel').onchange = e => {
 // (Scope + quick-edit lane tabs are built and wired in renderViewTabs().)
 
 // ─── Step callback (registered once; closes over module-level song/viz) ──────
-eng.onStep(({ absStep, bar, stepInBar, fill, queue, target, chordIdx }) => {
+eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
   viz.setStep({ absStep, bar, stepInBar, target });
   const fillsHost = document.getElementById('fills');
   if (fillsHost) {
@@ -959,7 +970,6 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target, chordIdx }) => {
     renderChain(queue);
   }
   updatePatternsPlayback(target);
-  updateHarmonyPlayback(chordIdx);
 });
 
 // ─── Restore saved theme ──────────────────────────────────────────────────────

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -1,5 +1,5 @@
 import { stepsPerBar, beatStarts } from '../engine/meter.js';
-import { drumVoiceAudible, laneAudible } from '../engine/song.js';
+import { drumVoiceAudible, laneAudible, snapMidi, inScale, scalePitchClasses, chordAt } from '../engine/song.js';
 import { laneByType } from '../engine/lanes.js';
 
 // ─── Canvas theme colour cache ────────────────────────────────────────────────
@@ -19,6 +19,8 @@ function themeColors() {
     playhead:g('--playhead'),
     rollBg:  g('--roll-bg'),
     rollBlk: g('--roll-bg-blk'),
+    rollOut: g('--roll-bg-out'),
+    ctone:   g('--roll-ctone'),
     ink:     g('--ink'),
     dim:     g('--dim'),
     faint:   g('--faint'),
@@ -104,6 +106,11 @@ export function makeViz(host, song, eng) {
     try { return localStorage.getItem('gb-rollmode') || 'piano'; } catch (_) { return 'piano'; }
   })();
 
+  // Snap-to-scale state (melody only; persisted; default ON).
+  let snapOn = (() => {
+    try { return localStorage.getItem('gb-snap') !== '0'; } catch (_) { return true; }
+  })();
+
   // Current edit target lane (set by editLane(id)).
   // Falls back to laneByType for the initial state.
   let _targetLane = null;
@@ -142,22 +149,53 @@ export function makeViz(host, song, eng) {
 
     const tc = themeColors();
 
+    // Key-aware tinting: dim out-of-scale rows; glow each bar's chord tones.
+    // No key → no tint (the keyboard reads neutral, like before).
+    const key = eng.getKey();
+    const scalePcs = key ? scalePitchClasses(key) : null;
+    const progression = eng.getHarmony()?.progression ?? [];
+
     // Draw pitch rows (keyboard column + grid background).
     for (let mm = ROLL_LO; mm <= ROLL_HI; mm++) {
       const y = (ROLL_HI - mm) * rh;
       const deg = ((mm % 12) + 12) % 12;
       const blk = BLACK_DEGREES.has(deg);
-      // Keyboard column — slightly darker than the roll bg.
-      ctx.fillStyle = blk ? tc.rollBlk : tc.rollBg;
+      // Out-of-scale rows wash dimmer; in-scale rows keep the normal bg.
+      const oos = scalePcs && !scalePcs.has(deg);
+      const bg = oos ? tc.rollOut : (blk ? tc.rollBlk : tc.rollBg);
+      // Keyboard column.
+      ctx.fillStyle = bg;
       ctx.fillRect(0, y, kbW, rh - 0.5);
       // Grid cell background.
-      ctx.fillStyle = blk ? tc.rollBlk : tc.rollBg;
+      ctx.fillStyle = bg;
       ctx.fillRect(kbW, y, gW, rh - 0.5);
       // C label.
       if (deg === 0) {
         ctx.fillStyle = tc.faint;
         ctx.font = '8px monospace';
         ctx.fillText('C' + (Math.floor(mm / 12) - 1), 3, y + rh - 2);
+      }
+    }
+
+    // Chord-tone glow: for each editor bar, brighten rows whose pitch-class is in
+    // that bar's chord, within the bar's x-range. The chord for editor bar b is
+    // approximated by chordAt(progression, b) — well-defined only when the groove
+    // length matches the progression; for other lengths it's a best-effort hint.
+    if (progression.length) {
+      for (let b = 0; b < BARS; b++) {
+        const chord = chordAt(progression, b);
+        if (!chord) continue;
+        const toneNotes = (chord.voicing || []).concat(chord.root ? [chord.root] : []);
+        const tonePcs = new Set(toneNotes.map(n => ((noteToMidi(n) % 12) + 12) % 12));
+        if (!tonePcs.size) continue;
+        const x0 = kbW + (b * spb) / totalSteps * gW;
+        const x1 = kbW + ((b + 1) * spb) / totalSteps * gW;
+        ctx.fillStyle = tc.ctone;
+        for (let mm = ROLL_LO; mm <= ROLL_HI; mm++) {
+          if (!tonePcs.has(((mm % 12) + 12) % 12)) continue;
+          const y = (ROLL_HI - mm) * rh;
+          ctx.fillRect(x0, y, x1 - x0, rh - 0.5);
+        }
       }
     }
 
@@ -217,8 +255,12 @@ export function makeViz(host, song, eng) {
     const absStep = Math.floor((cx - ROLL_KB) / gW * totalSteps);
     if (absStep < 0 || absStep >= totalSteps) return;
 
-    const midi = ROLL_HI - Math.floor(cy / cv.height * ROLL_ROWS);
+    let midi = ROLL_HI - Math.floor(cy / cv.height * ROLL_ROWS);
     if (midi < ROLL_LO || midi > ROLL_HI) return;
+
+    // Snap to the song's key (melody only; on by default, persisted).
+    const key = eng.getKey();
+    if (snapOn && key) midi = snapMidi(midi, key);
 
     const noteName = NMG[((midi % 12) + 12) % 12] + (Math.floor(midi / 12) - 1);
 
@@ -306,14 +348,20 @@ export function makeViz(host, song, eng) {
 
     const tc = themeColors();
 
+    // Key-aware tinting (read-only bass): dim out-of-scale rows. No key → neutral.
+    const key = eng.getKey();
+    const scalePcs = key ? scalePitchClasses(key) : null;
+
     // Draw pitch rows.
     for (let mm = BASS_LO; mm <= BASS_HI; mm++) {
       const y = (BASS_HI - mm) * rh;
       const deg = ((mm % 12) + 12) % 12;
       const blk = BLACK_DEGREES.has(deg);
-      ctx.fillStyle = blk ? tc.rollBlk : tc.rollBg;
+      const oos = scalePcs && !scalePcs.has(deg);
+      const bg = oos ? tc.rollOut : (blk ? tc.rollBlk : tc.rollBg);
+      ctx.fillStyle = bg;
       ctx.fillRect(0, y, kbW, rh - 0.5);
-      ctx.fillStyle = blk ? tc.rollBlk : tc.rollBg;
+      ctx.fillStyle = bg;
       ctx.fillRect(kbW, y, gW, rh - 0.5);
       // Label E and B and octave roots (E = deg 4, B = deg 11, C = deg 0).
       if (deg === 0) {
@@ -342,6 +390,20 @@ export function makeViz(host, song, eng) {
     const editing = soundingBar >= 0;
     const showBar = editing ? soundingBar : 0;
     const notes = bars[showBar] || [];
+
+    // Chord-tone glow for the shown bar (best-effort: chordAt(progression, showBar)).
+    const progression = eng.getHarmony()?.progression ?? [];
+    const chord = progression.length ? chordAt(progression, showBar) : null;
+    if (chord) {
+      const toneNotes = (chord.voicing || []).concat(chord.root ? [chord.root] : []);
+      const tonePcs = new Set(toneNotes.map(n => ((noteToMidi(n) % 12) + 12) % 12));
+      ctx.fillStyle = tc.ctone;
+      for (let mm = BASS_LO; mm <= BASS_HI; mm++) {
+        if (!tonePcs.has(((mm % 12) + 12) % 12)) continue;
+        const y = (BASS_HI - mm) * rh;
+        ctx.fillRect(kbW, y, gW, rh - 0.5);
+      }
+    }
 
     // Draw note blocks.
     ctx.fillStyle = tc.note;
@@ -376,14 +438,19 @@ export function makeViz(host, song, eng) {
   // Returns an HTML string for the segmented Piano/Blocks toggle.
   // `barCtrlLane` (optional): when given an editable lane, append the groove-
   // length selector into the toggle bar (melody only; bass is read-only).
-  function rollModeToggleHTML(barCtrlLane = null) {
+  function rollModeToggleHTML(barCtrlLane = null, showSnap = false) {
     const pa = rollMode === 'piano'  ? ' rm-on' : '';
     const ba = rollMode === 'blocks' ? ' rm-on' : '';
+    // Snap toggle shown for melody only, and only when the song has a key.
+    const snapBtn = (showSnap && eng.getKey())
+      ? `<button class="snap-btn${snapOn ? ' on' : ''}" data-snap title="Snap edits to the song's key">⊞ snap</button>`
+      : '';
     return `<div class="roll-mode-bar">`
       + `<span class="roll-mode-lbl">VIEW</span>`
       + `<button class="roll-mode-btn${pa}" data-rm="piano">Piano</button>`
       + `<button class="roll-mode-btn${ba}" data-rm="blocks">Blocks</button>`
       + (barCtrlLane ? barCountControlsHTML(barCtrlLane) : '')
+      + snapBtn
       + `</div>`;
   }
 
@@ -420,6 +487,12 @@ export function makeViz(host, song, eng) {
         paint(lastStepInBar);
       };
     });
+    const snapBtn = host.querySelector('.snap-btn');
+    if (snapBtn) snapBtn.onclick = () => {
+      snapOn = !snapOn;
+      try { localStorage.setItem('gb-snap', snapOn ? '1' : '0'); } catch (_) {}
+      snapBtn.classList.toggle('on', snapOn);
+    };
   }
 
   // ─── Blocks grid (pitch × step DOM grid) ─────────────────────────────────
@@ -470,17 +543,32 @@ export function makeViz(host, song, eng) {
     }
     headerRow += '</div>';
 
-    let html = rollModeToggleHTML(laneView === 'melody' ? L : null);
+    let html = rollModeToggleHTML(laneView === 'melody' ? L : null, laneView === 'melody');
     html += edLabelHTML(L);
     html += `<div class="bg-scroll"><div class="bg-grid" data-lv="${laneView}">`;
     html += headerRow;
+
+    // Key-aware tinting data: out-of-scale rows (.oos) + per-bar chord tones
+    // (.ctone). No key → no tint. Chord per editor bar = chordAt(progression, b),
+    // a best-effort hint when groove length ≠ progression length.
+    const key = eng.getKey();
+    const scalePcs = key ? scalePitchClasses(key) : null;
+    const progression = eng.getHarmony()?.progression ?? [];
+    const barTonePcs = [];   // [barIdx] → Set(pitchClass) | null
+    for (let b = 0; b < BARS; b++) {
+      const chord = progression.length ? chordAt(progression, b) : null;
+      if (!chord) { barTonePcs[b] = null; continue; }
+      const toneNotes = (chord.voicing || []).concat(chord.root ? [chord.root] : []);
+      barTonePcs[b] = new Set(toneNotes.map(n => ((noteToMidi(n) % 12) + 12) % 12));
+    }
 
     // One row per pitch, top = highest.
     for (let midi = hi; midi >= lo; midi--) {
       const deg = ((midi % 12) + 12) % 12;
       const blk = BLACK_DEGREES.has(deg);
       const lbl = pitchLabel(midi);
-      const rowClass = blk ? ' bg-blk' : '';
+      const oos = scalePcs && !scalePcs.has(deg);
+      const rowClass = (blk ? ' bg-blk' : '') + (oos ? ' oos' : '');
       let cells = `<div class="bg-lbl${rowClass}">${lbl}</div>`;
       for (let absStep = 0; absStep < totalSteps; absStep++) {
         const stepInBar = absStep % spb;
@@ -488,7 +576,9 @@ export function makeViz(host, song, eng) {
         const beatClass = beatSet.has(stepInBar) ? ' beat' : '';
         const altClass  = beatIdx % 2 === 1 ? ' bar-alt' : '';
         const downClass = stepInBar === 0 ? ' downbeat' : '';
-        cells += `<div class="vc${beatClass}${downClass}${altClass}" data-midi="${midi}" data-step="${absStep}"></div>`;
+        const barIdx = Math.floor(absStep / spb);
+        const ctoneClass = barTonePcs[barIdx]?.has(deg) ? ' ctone' : '';
+        cells += `<div class="vc${beatClass}${downClass}${altClass}${ctoneClass}" data-midi="${midi}" data-step="${absStep}"></div>`;
       }
       html += `<div class="bg-row${rowClass}">${cells}</div>`;
     }
@@ -557,6 +647,10 @@ export function makeViz(host, song, eng) {
     const st = absStep % spb;
 
     if (midi < ROLL_LO || midi > ROLL_HI) return;
+
+    // Snap to the song's key (melody only; on by default, persisted).
+    const key = eng.getKey();
+    if (snapOn && key) midi = snapMidi(midi, key);
 
     const noteName = NMG[((midi % 12) + 12) % 12] + (Math.floor(midi / 12) - 1);
 
@@ -673,7 +767,7 @@ export function makeViz(host, song, eng) {
       } else {
         // Melody view: canvas piano-roll.
         const mL = getTargetLane();
-        host.innerHTML = rollModeToggleHTML(mL) + edLabelHTML(mL) + '<canvas id="mroll"></canvas>';
+        host.innerHTML = rollModeToggleHTML(mL, true) + edLabelHTML(mL) + '<canvas id="mroll"></canvas>';
         wireRollModeToggle();
         wireBarCountControls(mL);
         const cv = host.querySelector('#mroll');

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -1,5 +1,5 @@
 import { stepsPerBar, beatStarts } from '../engine/meter.js';
-import { drumVoiceAudible, laneAudible, snapMidi, inScale, scalePitchClasses, chordAt } from '../engine/song.js';
+import { drumVoiceAudible, laneAudible, snapMidi, inScale, scalePitchClasses } from '../engine/song.js';
 import { laneByType } from '../engine/lanes.js';
 
 // ─── Canvas theme colour cache ────────────────────────────────────────────────
@@ -153,7 +153,8 @@ export function makeViz(host, song, eng) {
     // No key → no tint (the keyboard reads neutral, like before).
     const key = eng.getKey();
     const scalePcs = key ? scalePitchClasses(key) : null;
-    const progression = eng.getHarmony()?.progression ?? [];
+    // Chord tones come from the EDIT pattern's own chords (cycling per bar).
+    const chords = eng.getPatternChords(eng.getEditPatternIndex()) ?? [];
 
     // Draw pitch rows (keyboard column + grid background).
     for (let mm = ROLL_LO; mm <= ROLL_HI; mm++) {
@@ -179,11 +180,11 @@ export function makeViz(host, song, eng) {
 
     // Chord-tone glow: for each editor bar, brighten rows whose pitch-class is in
     // that bar's chord, within the bar's x-range. The chord for editor bar b is
-    // approximated by chordAt(progression, b) — well-defined only when the groove
-    // length matches the progression; for other lengths it's a best-effort hint.
-    if (progression.length) {
+    // the pattern's chords[b % len] — well-defined now that chords live on the
+    // pattern alongside the groove.
+    if (chords.length) {
       for (let b = 0; b < BARS; b++) {
-        const chord = chordAt(progression, b);
+        const chord = chords[b % chords.length];
         if (!chord) continue;
         const toneNotes = (chord.voicing || []).concat(chord.root ? [chord.root] : []);
         const tonePcs = new Set(toneNotes.map(n => ((noteToMidi(n) % 12) + 12) % 12));
@@ -391,9 +392,9 @@ export function makeViz(host, song, eng) {
     const showBar = editing ? soundingBar : 0;
     const notes = bars[showBar] || [];
 
-    // Chord-tone glow for the shown bar (best-effort: chordAt(progression, showBar)).
-    const progression = eng.getHarmony()?.progression ?? [];
-    const chord = progression.length ? chordAt(progression, showBar) : null;
+    // Chord-tone glow for the shown bar — the edit pattern's chords[bar % len].
+    const chords = eng.getPatternChords(eng.getEditPatternIndex()) ?? [];
+    const chord = chords.length ? chords[showBar % chords.length] : null;
     if (chord) {
       const toneNotes = (chord.voicing || []).concat(chord.root ? [chord.root] : []);
       const tonePcs = new Set(toneNotes.map(n => ((noteToMidi(n) % 12) + 12) % 12));
@@ -549,14 +550,14 @@ export function makeViz(host, song, eng) {
     html += headerRow;
 
     // Key-aware tinting data: out-of-scale rows (.oos) + per-bar chord tones
-    // (.ctone). No key → no tint. Chord per editor bar = chordAt(progression, b),
-    // a best-effort hint when groove length ≠ progression length.
+    // (.ctone). No key → no tint. Chord per editor bar = the edit pattern's
+    // chords[b % len].
     const key = eng.getKey();
     const scalePcs = key ? scalePitchClasses(key) : null;
-    const progression = eng.getHarmony()?.progression ?? [];
+    const chords = eng.getPatternChords(eng.getEditPatternIndex()) ?? [];
     const barTonePcs = [];   // [barIdx] → Set(pitchClass) | null
     for (let b = 0; b < BARS; b++) {
-      const chord = progression.length ? chordAt(progression, b) : null;
+      const chord = chords.length ? chords[b % chords.length] : null;
       if (!chord) { barTonePcs[b] = null; continue; }
       const toneNotes = (chord.voicing || []).concat(chord.root ? [chord.root] : []);
       barTonePcs[b] = new Set(toneNotes.map(n => ((noteToMidi(n) % 12) + 12) % 12));


### PR DESCRIPTION
## The model

Chords belong to **patterns**, not a global song layer.

- Each pattern carries an optional `chords` array — one chord per bar, cycling on `barInPattern`. A 1-bar bass figure over 4 chords is a 4-bar pattern (chords are content and extend duration).
- Chord-relative grooves resolve against the **pattern's own chords** (`pattern.chords[barInPattern % len]`). `eventsForStepV2` no longer takes an absolute-bar argument.
- `song.harmony` is gone. `song.key` (optional, top-level) stays for melody snap-to-scale + editor tinting.

**Why:** the global progression behaved like a "fourth clock" — the chord under a pattern depended on how you navigated there (loops drift, chain jumps change the song). On the pattern, it's deterministic and loop-stable, and it matches how songs are written: a section owns its chord loop.

## What you see

- **Chord line in the PATTERNS module** — under the pattern slots, above the chain: a `chords` label + chord-name chips for the selected pattern + the key badge (e.g. `A major`). Click anywhere on it → text input prefilled (`F#m D A E/G#`), Enter/blur commits, Esc cancels, invalid input keeps a red border. No chords → a single `＋ chords` affordance. The sounding chord glows while playing (only when the sounding pattern is the one displayed). The standalone HARMONY section is removed.
- **Melody editor** — snap-to-scale unchanged (reads `song.key`); chord-tone tint now reads the edit pattern's chords, which is well-defined per bar (the old "best-effort approximation" caveat is gone).

## Determinism + parity

The chord under any pattern bar is fixed on the pattern, so it can't drift with loop count or chain position. The flattener bakes each preset pattern's chords from the source progression's absolute bar offsets (deduped to the pattern's bar count, folded into the pattern dedup key). The **7 legacy parity tests pass unchanged** — chord-per-pattern-bar equals what the global clock produced, by construction. Across all 7 presets every pattern received its chords with **zero forced-literal fallbacks**.

Suite: 171 green (was 169; harmony/engine-API tests reworked, +1 patternBars-includes-chords, setPatternChords split into two). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)