### PR TITLE
arcade(groovebox): punch v3 — data-driven punch presets (module registry, musical timing, GATE module)

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -12,7 +12,8 @@ import {
   setLaneGroove as _setLaneGroove, grooveFor,
   setGrooveBars as _setGrooveBars,
 } from './patterns.js';
-import { PUNCH_NEUTRAL, PUNCH_PARAMS, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from './punch.js';
+import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, isPunchArmed } from './punch.js';
+import { DEFAULT_PRESETS, validatePreset } from './punch-presets.js';
 
 export function createEngine() {
   let song = null, step = 0, started = false, repeatId = null, tempo = 120, playing = false, onStepCb = null, pendingFill = null, activeFill = null, fillQueue = [];
@@ -26,11 +27,17 @@ export function createEngine() {
   let keyQuantize = false, pendingTranspose = null;
   let masterComp = null, masterRev = null, masterVol = null, masterPan = null, masterWidth = null, masterEQ = null;
   let _widthOn = false;   // is the StereoWidener spliced into the master chain?
-  // Punch-in FX: pre-wired neutral insert chain (comp → punch → pan); momentary.
+  // Punch v3: pre-wired neutral punch bus; presets are data (punch-presets.js)
+  // executed by the automation runner (_runAutomation) over MODULE_PARAMS.
   let punchGate = null, punchCrush = null, punchFilter = null, punchThrow = null, punchTape = null;
-  const _punchHeld = { stutter: false, crush: false, dive: false, throw: false, stop: false };
-  let _gateReturnPending = false;   // STOP released → gate returns on the next step boundary
-  let punchAmount = 1;              // AMOUNT knob: scales every effect's engaged intensity
+  let _punchBindings = null;                     // registry param id → live Tone param
+  let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
+  const _slotHeld = [false, false, false, false, false];
+  let _gate = null;                              // active gate automation: { depth, division } | null
+  let _tapeActive = false;                       // transport.tapeStop engaged (owns the gate)
+  let _gateReturnPending = false;                // tapeStop released → gate returns on-grid
+  const _pendingQuantized = [];                  // [{ when: 'bar'|'pattern', fn }]
+  let punchAmount = 1;                           // AMOUNT knob: scales engaged intensity
   let meterL = null, meterR = null;
   let scopeMaster = null, scopeLane = {};
   // Per-lane keyed maps (by lane.id)
@@ -40,6 +47,53 @@ export function createEngine() {
   let _fxInserted = {};
   // Stored after ensure() so buildLane can be called post-graph-init
   let _makeFX = null, _masterIn = null, _laneReverb = null;
+
+  // Punch v3 automation runner: executes one preset automation (engage or
+  // release) against the live graph. gate.* and transport.tapeStop are
+  // semantic modules (spec decision 6) — the runner owns their behaviour;
+  // everything else maps through _punchBindings + the MODULE_PARAMS registry.
+  function _runAutomation(a, on, timing) {
+    const id = `${a.module}.${a.param}`;
+    const reg = MODULE_PARAMS[id];
+    if (!reg) return;
+    const ramp = Math.max(durationToSeconds(on ? a.engage?.ramp : a.release?.ramp, timing), 0.003);
+    if (id === 'gate.depth') {
+      if (on) {
+        _gate = { depth: (typeof a.to === 'number' ? a.to : 1) * punchAmount, division: a.division || '1/16' };
+      } else {
+        _gate = null;
+        // tapeStop owns the gate (v2 safeguard 1) — only restore when idle.
+        if (!_tapeActive) punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, Math.max(ramp, 0.01));
+      }
+      return;
+    }
+    if (id === 'transport.tapeStop') {
+      if (on) {
+        // Slump: delayTime + gate fade over the same window — the gate sits
+        // before the tape delay, so the line keeps emitting the slowing audio.
+        // rampTo pins current values (no cancel-then-revert clicks).
+        _tapeActive = true; _gateReturnPending = false;
+        punchGate.gain.rampTo(0, ramp);
+        punchTape.delayTime.rampTo(0.6 * punchAmount, ramp);
+      } else {
+        // Strict release order (v2 safeguard 2), click-free on quick taps:
+        // close fast, freeze the slump, snap delayTime back once silent,
+        // gate returns on-grid via the step callback flag.
+        _tapeActive = false;
+        const now = Tone.now();
+        punchGate.gain.rampTo(0, 0.003);
+        punchTape.delayTime.cancelAndHoldAtTime(now);
+        punchTape.delayTime.setValueAtTime(PUNCH_NEUTRAL.tapeDelay, now + 0.005);
+        _gateReturnPending = true;
+      }
+      return;
+    }
+    const bound = _punchBindings[id];
+    if (!bound) return;
+    const from = (a.from === 'neutral' || a.from == null) ? reg.neutral : a.from;
+    const scale = a.scale || reg.scale;
+    bound.rampTo(on ? scaleValue(from, a.to, punchAmount, scale) : from, ramp);
+  }
 
   function buildLane(lane) {
     fx[lane.id]     = _makeFX(_masterIn);
@@ -107,10 +161,19 @@ export function createEngine() {
     // chain → masterIn; unarmed lanes go vol → toClean → masterIn. Pre-wired
     // and neutral — engaging a pad is param ramps only (no graph surgery).
     punchTape   = new Tone.Delay({ delayTime: PUNCH_NEUTRAL.tapeDelay, maxDelay: 1 }).connect(masterIn);
-    punchThrow  = new Tone.FeedbackDelay({ delayTime: '8n.', feedback: PUNCH_PARAMS.throw.feedback, wet: PUNCH_NEUTRAL.throwWet }).connect(punchTape);
+    punchThrow  = new Tone.FeedbackDelay({ delayTime: '8n.', feedback: MODULE_PARAMS['delay.feedback'].neutral, wet: PUNCH_NEUTRAL.throwWet }).connect(punchTape);
     punchFilter = new Tone.Filter({ type: 'lowpass', frequency: PUNCH_NEUTRAL.filterFreq, Q: PUNCH_NEUTRAL.filterQ }).connect(punchThrow);
-    punchCrush  = new Tone.BitCrusher(PUNCH_PARAMS.crush.bits); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
+    punchCrush  = new Tone.BitCrusher(6); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
     punchGate   = new Tone.Gain(PUNCH_NEUTRAL.gateGain).connect(punchCrush);
+    // Registry param → live Tone param. gate.* and transport.* are semantic —
+    // handled by the runner itself, not direct bindings.
+    _punchBindings = {
+      'crusher.wet':    punchCrush.wet,
+      'filter.freq':    punchFilter.frequency,
+      'filter.Q':       punchFilter.Q,
+      'delay.wet':      punchThrow.wet,
+      'delay.feedback': punchThrow.feedback,
+    };
     // Shared reverb bus — one convolver for all lanes (per-lane send gain controls amount).
     _laneReverb = new Tone.Reverb({ decay: 2.4, wet: 1 }).connect(masterIn);
     // Stereo output meters — tapped post-volume (silent sinks, don't alter audio chain).
@@ -238,14 +301,25 @@ export function createEngine() {
           const v = voices[ev.laneId];
           if (v) trigger(v, ev, t, sixteenth, barSeconds);
         }
-        // Punch-in: on-grid gate return after STOP release, then stutter chops.
+        // Punch v3: quantized actions at boundaries, on-grid gate return after
+        // tapeStop, then GATE chops (tapeStop owns the gate while active).
+        if (_pendingQuantized.length && step % spb === 0) {
+          const patternStart = target.barInPattern === 0;
+          for (let i = _pendingQuantized.length - 1; i >= 0; i--) {
+            const p = _pendingQuantized[i];
+            if (p.when === 'bar' || (p.when === 'pattern' && patternStart)) {
+              p.fn(); _pendingQuantized.splice(i, 1);
+            }
+          }
+        }
         if (_gateReturnPending) {
           punchGate.gain.setValueAtTime(0, t);
           punchGate.gain.linearRampToValueAtTime(PUNCH_NEUTRAL.gateGain, t + 0.003);
           _gateReturnPending = false;
         }
-        if (_punchHeld.stutter && stutterAllowed(_punchHeld)) {
-          for (const [at, v] of stutterEvents(t, sixteenth, 0.003, 1 - punchAmount)) punchGate.gain.linearRampToValueAtTime(v, at);
+        if (_gate && !_tapeActive) {
+          for (const [at, v] of gateEventsForStep(t, sixteenth, step, _gate.division, _gate.depth))
+            punchGate.gain.linearRampToValueAtTime(v, at);
         }
         if (onStepCb) {
           const s = step; const qSnap = fillQueue.slice();
@@ -287,8 +361,8 @@ export function createEngine() {
       // Punch pads release with the transport. rampTo pins current values
       // (no cancel-then-revert clicks); delayTime snaps back after the brief
       // gate settle so any reverb tail doesn't doppler.
-      for (const k in _punchHeld) _punchHeld[k] = false;
-      _gateReturnPending = false;
+      _slotHeld.fill(false);
+      _gate = null; _tapeActive = false; _gateReturnPending = false; _pendingQuantized.length = 0;
       if (started) {
         const now = Tone.now();
         punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, 0.01);
@@ -298,6 +372,7 @@ export function createEngine() {
         punchFilter.frequency.rampTo(PUNCH_NEUTRAL.filterFreq, 0.05);
         punchFilter.Q.rampTo(PUNCH_NEUTRAL.filterQ, 0.05);
         punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, 0.05);
+        punchThrow.feedback.rampTo(MODULE_PARAMS['delay.feedback'].neutral, 0.05);
       }
     },
     setTempo(bpm) { if (typeof bpm === 'number' && isFinite(bpm)) { tempo = bpm; Tone.Transport.bpm.value = bpm; } },
@@ -327,54 +402,31 @@ export function createEngine() {
     },
     setPunchAmount(v01) { if (typeof v01 === 'number' && isFinite(v01)) punchAmount = Math.max(0, Math.min(1, v01)); },
     getPunchAmount()    { return punchAmount; },
-    // Punch-in FX: momentary performance effects — punch(name, true) on press,
-    // punch(name, false) on release. Names: stutter|crush|dive|throw|stop.
-    punch(name, on) {
-      if (!started || _punchHeld[name] === undefined) return;
+    // Punch v3: slot-based momentary trigger — punch(slot, true) on press,
+    // punch(slot, false) on release. Executes the slot's preset automations
+    // (data, not code) with engage/release quantize.
+    punch(slot, on) {
+      if (!started || !punchPresets[slot]) return;
       on = !!on;
-      if (_punchHeld[name] === on) return;          // ignore repeat echoes
-      _punchHeld[name] = on;
-      // Engaged targets: PUNCH_PARAMS scaled by the AMOUNT knob, read at press time.
-      if (name === 'crush') punchCrush.wet.rampTo(on ? PUNCH_PARAMS.crush.wet * punchAmount : PUNCH_NEUTRAL.crushWet, 0.05);
-      else if (name === 'dive') {
-        const P = PUNCH_PARAMS.dive;
-        punchFilter.frequency.rampTo(on ? diveFreqForAmount(punchAmount) : PUNCH_NEUTRAL.filterFreq, P.ramp);
-        punchFilter.Q.rampTo(on ? PUNCH_NEUTRAL.filterQ + (P.q - PUNCH_NEUTRAL.filterQ) * punchAmount : PUNCH_NEUTRAL.filterQ, P.ramp);
-      }
-      else if (name === 'throw') {
-        if (on) punchThrow.wet.rampTo(PUNCH_PARAMS.throw.wet * punchAmount, 0.05);
-        else    punchThrow.wet.rampTo(PUNCH_NEUTRAL.throwWet, PUNCH_PARAMS.throw.release);   // tail rings out
-      }
-      else if (name === 'stop') {
-        if (on) {
-          // Slump: delayTime + gate fade over the same window — the gate sits
-          // before the tape delay, so the line keeps emitting the slowing audio.
-          // rampTo pins the current value (setRampPoint → cancelAndHoldAtTime),
-          // so it's safe mid-stutter / mid-anything — no explicit cancels.
-          _gateReturnPending = false;
-          punchGate.gain.rampTo(0, PUNCH_PARAMS.stop.time);
-          punchTape.delayTime.rampTo(PUNCH_PARAMS.stop.depth * punchAmount, PUNCH_PARAMS.stop.time);
-        } else {
-          // Strict release order (spec safeguard 2), click-free on quick taps:
-          // close the gate from wherever the slump got to (3ms), freeze the
-          // slump where it is, snap delayTime back only AFTER the gate is
-          // closed (silent), then gate back up on-grid (step callback flag).
-          const now = Tone.now();
-          punchGate.gain.rampTo(0, 0.003);
-          punchTape.delayTime.cancelAndHoldAtTime(now);
-          punchTape.delayTime.setValueAtTime(PUNCH_NEUTRAL.tapeDelay, now + 0.005);
-          _gateReturnPending = true;
-        }
-      }
-      else if (name === 'stutter') {
-        // Engagement is scheduled by the step callback (stutterAllowed gates it).
-        if (!on && !_punchHeld.stop) {
-          // STOP owns the gate (safeguard 1) — only restore when STOP isn't
-          // active. rampTo cancels the pending chop events itself.
-          punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, 0.01);
-        }
-      }
+      if (_slotHeld[slot] === on) return;            // ignore repeat echoes
+      _slotHeld[slot] = on;
+      const preset = punchPresets[slot];
+      const beatSeconds = 60 / Tone.Transport.bpm.value;
+      const timing = {
+        sixteenth: beatSeconds / 4,
+        beatSeconds,
+        barSeconds: stepsPerBar(song.meter) * (beatSeconds / 4),
+      };
+      const q = on ? preset.engageQuantize : preset.releaseQuantize;
+      const run = () => { for (const a of preset.automations) _runAutomation(a, on, timing); };
+      if (q === 'immediate' || !playing) run();
+      else _pendingQuantized.push({ when: q, fn: run });
     },
+    setPunchPresets(presets) {
+      if (Array.isArray(presets) && presets.length === 5 && presets.every(validatePreset)) punchPresets = presets;
+      return punchPresets;
+    },
+    getPunchPresets() { return punchPresets; },
     queueFill(name)         { fillQueue.push(name); return fillQueue.length; },
     unqueueAt(i)            { if (i >= 0 && i < fillQueue.length) fillQueue.splice(i, 1); return fillQueue.slice(); },
     clearQueue()            { fillQueue = []; },

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -73,8 +73,10 @@ export function createEngine() {
         // before the tape delay, so the line keeps emitting the slowing audio.
         // rampTo pins current values (no cancel-then-revert clicks).
         _tapeActive = true; _gateReturnPending = false;
+        // `to` is the tapeStop depth fraction (1 = full 0.6s slump — v2 parity).
+        const tapeDepth = 0.6 * Math.min(Math.max(a.to, 0), 1) * punchAmount;
         punchGate.gain.rampTo(0, ramp);
-        punchTape.delayTime.rampTo(0.6 * punchAmount, ramp);
+        punchTape.delayTime.rampTo(tapeDepth, ramp);
       } else {
         // Strict release order (v2 safeguard 2), click-free on quick taps:
         // close fast, freeze the slump, snap delayTime back once silent,
@@ -305,12 +307,16 @@ export function createEngine() {
         // tapeStop, then GATE chops (tapeStop owns the gate while active).
         if (_pendingQuantized.length && step % spb === 0) {
           const patternStart = target.barInPattern === 0;
-          for (let i = _pendingQuantized.length - 1; i >= 0; i--) {
+          // FIFO: engage-then-release queued before the same boundary must run
+          // in press order, or the preset ends up stuck engaged (PR review).
+          const due = [];
+          for (let i = 0; i < _pendingQuantized.length; ) {
             const p = _pendingQuantized[i];
             if (p.when === 'bar' || (p.when === 'pattern' && patternStart)) {
-              p.fn(); _pendingQuantized.splice(i, 1);
-            }
+              due.push(p.fn); _pendingQuantized.splice(i, 1);
+            } else i++;
           }
+          for (const fn of due) fn();
         }
         if (_gateReturnPending) {
           punchGate.gain.setValueAtTime(0, t);

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -11,15 +11,30 @@ function validDuration(d) {
   return d == null || (UNITS.includes(d.unit) && typeof d.value === 'number' && isFinite(d.value) && d.value >= 0);
 }
 
+const GATE_DIVISIONS = ['1/8', '1/16', '1/32'];
+
 export function validatePreset(p) {
   if (!p || typeof p.name !== 'string' || typeof p.key !== 'string') return false;
   if (!QUANTIZE.includes(p.engageQuantize) || !QUANTIZE.includes(p.releaseQuantize)) return false;
   if (!Array.isArray(p.automations)) return false;
   for (const a of p.automations) {
-    if (!MODULE_PARAMS[`${a.module}.${a.param}`]) return false;
-    if (a.from !== 'neutral' && a.from != null && typeof a.from !== 'number') return false;
-    if (typeof a.to !== 'number') return false;
+    const id = `${a.module}.${a.param}`;
+    const reg = MODULE_PARAMS[id];
+    if (!reg) return false;
+    // Numeric sanity — overrides are user-supplied (localStorage), so this is
+    // the safety boundary between "valid JSON" and a NaN'd audio graph.
+    if (a.from !== 'neutral' && a.from != null && !Number.isFinite(a.from)) return false;
+    if (!Number.isFinite(a.to)) return false;
     if (a.scale && a.scale !== 'linear' && a.scale !== 'log') return false;
+    // Log-space interpolation needs strictly positive endpoints.
+    const scale = a.scale || reg.scale;
+    const from = (a.from === 'neutral' || a.from == null) ? reg.neutral : a.from;
+    if (scale === 'log' && (from <= 0 || a.to <= 0)) return false;
+    // Gate-specific: depth is 0..1; division must be a supported chop cycle.
+    if (id === 'gate.depth') {
+      if (a.to < 0 || a.to > 1) return false;
+      if (a.division != null && !GATE_DIVISIONS.includes(a.division)) return false;
+    }
     if (!validDuration(a.engage?.ramp) || !validDuration(a.release?.ramp)) return false;
   }
   return true;

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -1,0 +1,62 @@
+// Punch v3 preset data + schema validation. Pure (Tone-free).
+// Spec: project-notes/oyster/po20/2026-06-08-punch-modular-v3-spec.md
+// Repo defaults are immutable seed data; localStorage 'gb-punch-presets'
+// overrides are merged (and validated) in ui/app.js. Editor UI = v3.5.
+import { MODULE_PARAMS } from './punch.js';
+
+const UNITS = ['steps', 'beats', 'bars'];
+const QUANTIZE = ['immediate', 'bar', 'pattern'];
+
+function validDuration(d) {
+  return d == null || (UNITS.includes(d.unit) && typeof d.value === 'number' && isFinite(d.value) && d.value >= 0);
+}
+
+export function validatePreset(p) {
+  if (!p || typeof p.name !== 'string' || typeof p.key !== 'string') return false;
+  if (!QUANTIZE.includes(p.engageQuantize) || !QUANTIZE.includes(p.releaseQuantize)) return false;
+  if (!Array.isArray(p.automations)) return false;
+  for (const a of p.automations) {
+    if (!MODULE_PARAMS[`${a.module}.${a.param}`]) return false;
+    if (a.from !== 'neutral' && a.from != null && typeof a.from !== 'number') return false;
+    if (typeof a.to !== 'number') return false;
+    if (a.scale && a.scale !== 'linear' && a.scale !== 'log') return false;
+    if (!validDuration(a.engage?.ramp) || !validDuration(a.release?.ramp)) return false;
+  }
+  return true;
+}
+
+// v2 parity mapping (120bpm reference): 0.05s≈steps:0.5, 0.15s≈steps:1,
+// throw release 1.5s≈beats:3, stop slump 0.8s≈beats:1.5. CRUSH 0.9 = the
+// dogfood-approved level. These are seed data — never mutated in place.
+export const DEFAULT_PRESETS = [
+  { name: 'STUT', key: '1', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    automations: [
+      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/16',
+        engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
+    ] },
+  { name: 'CRUSH', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    automations: [
+      { module: 'crusher', param: 'wet', from: 'neutral', to: 0.9,
+        engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'steps', value: 0.5 } } },
+    ] },
+  { name: 'DIVE', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    automations: [
+      { module: 'filter', param: 'freq', from: 'neutral', to: 150,
+        engage: { ramp: { unit: 'steps', value: 1 } }, release: { ramp: { unit: 'steps', value: 1 } } },
+      { module: 'filter', param: 'Q', from: 'neutral', to: 8,
+        engage: { ramp: { unit: 'steps', value: 1 } }, release: { ramp: { unit: 'steps', value: 1 } } },
+    ] },
+  { name: 'THROW', key: '4', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    automations: [
+      { module: 'delay', param: 'wet', from: 'neutral', to: 0.6,
+        engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'beats', value: 3 } } },
+    ] },
+  { name: 'STOP', key: '5', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    automations: [
+      // Semantic module (spec decision 6): the engine implements tapeStop
+      // internally (gate fade + tape slump + on-grid return). Engage ramp =
+      // slump duration; release handling is internal to the module.
+      { module: 'transport', param: 'tapeStop', from: 'neutral', to: 1,
+        engage: { ramp: { unit: 'beats', value: 1.5 } }, release: { ramp: { unit: 'steps', value: 0 } } },
+    ] },
+];

--- a/docs/arcade/groovebox/engine/punch.js
+++ b/docs/arcade/groovebox/engine/punch.js
@@ -14,31 +14,10 @@ export const PUNCH_NEUTRAL = {
   tapeDelay: 0,
 };
 
-// Engaged (held) targets for each punch effect — internal tuning surface,
-// fixed defaults (crush 0.9: dogfood verdict — drums-only takes near-full).
-export const PUNCH_PARAMS = {
-  crush: { bits: 6, wet: 0.9 },
-  dive:  { freq: 150, q: 8, ramp: 0.15 },
-  throw: { wet: 0.6, feedback: 0.55, release: 1.5 },
-  stop:  { depth: 0.6, time: 0.8 },
-};
-
 // Punch bus channel-assign: lanes are armed by default; only an explicit
 // punchArm === false opts a lane out (serializes with the lane object).
 export function isPunchArmed(lane) {
   return lane.punchArm !== false;
-}
-
-// AMOUNT-scaled dive target. Log-space interpolation so half-amount sounds
-// like half a sweep, not a barely-audible top-end shelf.
-export function diveFreqForAmount(amount, neutral = PUNCH_NEUTRAL.filterFreq, target = PUNCH_PARAMS.dive.freq) {
-  return neutral * Math.pow(target / neutral, amount);
-}
-
-// STOP owns the gate (spec safeguard 1): stutter must not schedule gate
-// events while stop is held.
-export function stutterAllowed(held) {
-  return !held.stop;
 }
 
 // GATE module math: tempo-synced chopper. division picks the chop cycle;

--- a/docs/arcade/groovebox/engine/punch.js
+++ b/docs/arcade/groovebox/engine/punch.js
@@ -55,3 +55,33 @@ export function stutterEvents(t, sixteenth, ramp = 0.003, closed = 0) {
     [t + sixteenth, closed],
   ];
 }
+
+// ── v3: module-param registry + interpolation/timing math ────────────────────
+
+// Registry: neutral value + AMT interpolation space for every automatable
+// param. Presets may override scale per-automation; absent = this default.
+export const MODULE_PARAMS = {
+  'crusher.wet':        { neutral: 0,     scale: 'linear' },
+  'filter.freq':        { neutral: 20000, scale: 'log'    },
+  'filter.Q':           { neutral: 0.7,   scale: 'linear' },
+  'delay.wet':          { neutral: 0,     scale: 'linear' },
+  'delay.feedback':     { neutral: 0.55,  scale: 'linear' },
+  'gate.depth':         { neutral: 0,     scale: 'linear' },
+  'transport.tapeStop': { neutral: 0,     scale: 'linear' },
+};
+
+// AMT interpolation from→to in the param's space (amount 0 = from, 1 = to).
+export function scaleValue(from, to, amount, scale) {
+  if (scale === 'log') return from * Math.pow(to / from, amount);
+  return from + (to - from) * amount;
+}
+
+// Musical duration → seconds against the live tempo. Extensible by design:
+// 'seconds' is reserved for a future schema rev and rejected in v3.
+export function durationToSeconds(dur, t) {
+  if (!dur) return 0;
+  if (dur.unit === 'steps') return dur.value * t.sixteenth;
+  if (dur.unit === 'beats') return dur.value * t.beatSeconds;
+  if (dur.unit === 'bars')  return dur.value * t.barSeconds;
+  throw new Error(`punch: unsupported duration unit "${dur.unit}"`);
+}

--- a/docs/arcade/groovebox/engine/punch.js
+++ b/docs/arcade/groovebox/engine/punch.js
@@ -41,19 +41,32 @@ export function stutterAllowed(held) {
   return !held.stop;
 }
 
-// Gate envelope breakpoints for one 16th step: open first half, `closed`-level
-// second half (0 = full chop; AMOUNT scales it via closed = 1 - amount), with
-// `ramp`-second edges so the chops don't click. Consumed via
-// linearRampToValueAtTime; the final [stepEnd, closed] means the next step's
-// opening edge ramps cleanly from the closed level.
-export function stutterEvents(t, sixteenth, ramp = 0.003, closed = 0) {
+// GATE module math: tempo-synced chopper. division picks the chop cycle;
+// depth 1 = chop to silence, depth d = chop to (1 - d). `ramp`-second edges
+// so the chops don't click. stepIdx matters for divisions longer than one
+// step ('1/8' alternates whole steps). Consumed via linearRampToValueAtTime;
+// each step's final breakpoint is the level the next step ramps from.
+export function gateEventsForStep(t, sixteenth, stepIdx, division, depth, ramp = 0.003) {
+  const closed = 1 - depth;
+  if (division === '1/8') {
+    const lvl = stepIdx % 2 === 0 ? 1 : closed;
+    return [[t + ramp, lvl], [t + sixteenth, lvl]];
+  }
+  if (division === '1/32') {
+    const q = sixteenth / 4;
+    return [
+      [t + ramp, 1], [t + q, 1], [t + q + ramp, closed], [t + 2 * q, closed],
+      [t + 2 * q + ramp, 1], [t + 3 * q, 1], [t + 3 * q + ramp, closed], [t + 4 * q, closed],
+    ];
+  }
+  // default '1/16': open first half, closed second half of each step
   const half = sixteenth / 2;
-  return [
-    [t + ramp, 1],
-    [t + half, 1],
-    [t + half + ramp, closed],
-    [t + sixteenth, closed],
-  ];
+  return [[t + ramp, 1], [t + half, 1], [t + half + ramp, closed], [t + sixteenth, closed]];
+}
+
+// Back-compat wrapper (v2 signature took the closed level, not depth).
+export function stutterEvents(t, sixteenth, ramp = 0.003, closed = 0) {
+  return gateEventsForStep(t, sixteenth, 0, '1/16', 1 - closed, ramp);
 }
 
 // ── v3: module-param registry + interpolation/timing math ────────────────────

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_PRESETS, validatePreset } from '../engine/punch-presets.js';
+import { MODULE_PARAMS } from '../engine/punch.js';
+
+describe('DEFAULT_PRESETS', () => {
+  it('ships exactly five slots with keys 1-5', () => {
+    expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5']);
+    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUT', 'CRUSH', 'DIVE', 'THROW', 'STOP']);
+  });
+  it('every preset validates', () => {
+    for (const p of DEFAULT_PRESETS) expect(validatePreset(p)).toBe(true);
+  });
+  it('every automation targets a registered param', () => {
+    for (const p of DEFAULT_PRESETS)
+      for (const a of p.automations)
+        expect(MODULE_PARAMS[`${a.module}.${a.param}`]).toBeDefined();
+  });
+  it('CRUSH carries the dogfood-approved 0.9 target', () => {
+    const crush = DEFAULT_PRESETS.find(p => p.name === 'CRUSH');
+    expect(crush.automations[0].to).toBe(0.9);
+  });
+});
+
+describe('validatePreset', () => {
+  const base = { name: 'X', key: '1', engageQuantize: 'immediate', releaseQuantize: 'immediate' };
+  it('rejects unknown duration units (seconds reserved for future)', () => {
+    expect(validatePreset({ ...base,
+      automations: [{ module: 'filter', param: 'freq', from: 'neutral', to: 150,
+        engage: { ramp: { unit: 'seconds', value: 1 } } }] })).toBe(false);
+  });
+  it('rejects unknown quantize values', () => {
+    expect(validatePreset({ ...base, engageQuantize: 'sometime', automations: [] })).toBe(false);
+  });
+  it('rejects automations on unregistered params', () => {
+    expect(validatePreset({ ...base,
+      automations: [{ module: 'nope', param: 'nah', from: 'neutral', to: 1 }] })).toBe(false);
+  });
+  it('accepts a numeric from override and a scale override', () => {
+    expect(validatePreset({ ...base,
+      automations: [{ module: 'filter', param: 'freq', from: 8000, to: 150, scale: 'linear',
+        engage: { ramp: { unit: 'beats', value: 1 } } }] })).toBe(true);
+  });
+});

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -41,3 +41,23 @@ describe('validatePreset', () => {
         engage: { ramp: { unit: 'beats', value: 1 } } }] })).toBe(true);
   });
 });
+
+describe('validatePreset hardening (user-supplied localStorage overrides)', () => {
+  const base = { name: 'X', key: '1', engageQuantize: 'immediate', releaseQuantize: 'immediate' };
+  it('rejects non-finite to/from', () => {
+    expect(validatePreset({ ...base, automations: [{ module: 'crusher', param: 'wet', from: 'neutral', to: Infinity }] })).toBe(false);
+    expect(validatePreset({ ...base, automations: [{ module: 'crusher', param: 'wet', from: NaN, to: 0.5 }] })).toBe(false);
+  });
+  it('rejects non-positive values on log-scaled params (scaleValue would NaN)', () => {
+    expect(validatePreset({ ...base, automations: [{ module: 'filter', param: 'freq', from: 'neutral', to: 0 }] })).toBe(false);
+    expect(validatePreset({ ...base, automations: [{ module: 'filter', param: 'freq', from: -5, to: 150 }] })).toBe(false);
+    expect(validatePreset({ ...base, automations: [{ module: 'crusher', param: 'wet', from: 'neutral', to: 0.5, scale: 'log' }] })).toBe(false); // neutral 0 + log
+  });
+  it('rejects bad gate divisions and out-of-range gate depth', () => {
+    expect(validatePreset({ ...base, automations: [{ module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/7' }] })).toBe(false);
+    expect(validatePreset({ ...base, automations: [{ module: 'gate', param: 'depth', from: 'neutral', to: 1.5 }] })).toBe(false);
+  });
+  it('accepts a valid gate automation with explicit division', () => {
+    expect(validatePreset({ ...base, automations: [{ module: 'gate', param: 'depth', from: 'neutral', to: 0.8, division: '1/32' }] })).toBe(true);
+  });
+});

--- a/docs/arcade/groovebox/tests/punch.test.js
+++ b/docs/arcade/groovebox/tests/punch.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PUNCH_NEUTRAL, PUNCH_PARAMS, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from '../engine/punch.js';
+import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, stutterEvents, isPunchArmed } from '../engine/punch.js';
 
 describe('PUNCH_NEUTRAL', () => {
   it('pins the idle chain to audibly-transparent values (spec safeguard 3)', () => {
@@ -9,14 +9,6 @@ describe('PUNCH_NEUTRAL', () => {
   });
 });
 
-describe('stutterAllowed', () => {
-  it('blocks stutter while STOP holds the gate (spec safeguard 1)', () => {
-    expect(stutterAllowed({ stutter: true, stop: true })).toBe(false);
-  });
-  it('allows stutter otherwise', () => {
-    expect(stutterAllowed({ stutter: true, stop: false })).toBe(true);
-  });
-});
 
 describe('stutterEvents', () => {
   const SIX = 0.125; // one 16th at 120bpm
@@ -34,14 +26,6 @@ describe('stutterEvents', () => {
   });
 });
 
-describe('PUNCH_PARAMS', () => {
-  it('pins engaged-target defaults (crush 0.9 per dogfood verdict)', () => {
-    expect(PUNCH_PARAMS.crush).toEqual({ bits: 6, wet: 0.9 });
-    expect(PUNCH_PARAMS.dive.freq).toBe(150);
-    expect(PUNCH_PARAMS.throw.wet).toBeGreaterThan(0);
-    expect(PUNCH_PARAMS.stop.depth).toBeGreaterThan(0);
-  });
-});
 
 describe('isPunchArmed', () => {
   it('defaults to armed when the lane has no punchArm flag', () => {
@@ -55,17 +39,6 @@ describe('isPunchArmed', () => {
   });
 });
 
-describe('diveFreqForAmount', () => {
-  it('hits the full dive target at amount 1', () => {
-    expect(diveFreqForAmount(1)).toBeCloseTo(150, 5);
-  });
-  it('stays at neutral for amount 0', () => {
-    expect(diveFreqForAmount(0)).toBeCloseTo(20000, 5);
-  });
-  it('interpolates in log space (perceptually even sweep)', () => {
-    expect(diveFreqForAmount(0.5)).toBeCloseTo(Math.sqrt(20000 * 150), 3);
-  });
-});
 
 describe('stutterEvents closed level', () => {
   it('chops to a partial level when closed > 0 (amount-scaled stutter)', () => {

--- a/docs/arcade/groovebox/tests/punch.test.js
+++ b/docs/arcade/groovebox/tests/punch.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PUNCH_NEUTRAL, PUNCH_PARAMS, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from '../engine/punch.js';
+import { PUNCH_NEUTRAL, PUNCH_PARAMS, MODULE_PARAMS, scaleValue, durationToSeconds, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from '../engine/punch.js';
 
 describe('PUNCH_NEUTRAL', () => {
   it('pins the idle chain to audibly-transparent values (spec safeguard 3)', () => {
@@ -77,5 +77,45 @@ describe('stutterEvents closed level', () => {
     const ev = stutterEvents(0, 0.125);
     expect(ev[2][1]).toBe(0);
     expect(ev[3][1]).toBe(0);
+  });
+});
+
+describe('MODULE_PARAMS registry', () => {
+  it('declares neutral + scale for every automatable param', () => {
+    expect(MODULE_PARAMS['filter.freq']).toEqual({ neutral: 20000, scale: 'log' });
+    expect(MODULE_PARAMS['filter.Q']).toEqual({ neutral: 0.7, scale: 'linear' });
+    expect(MODULE_PARAMS['crusher.wet']).toEqual({ neutral: 0, scale: 'linear' });
+    expect(MODULE_PARAMS['delay.wet']).toEqual({ neutral: 0, scale: 'linear' });
+    expect(MODULE_PARAMS['delay.feedback']).toEqual({ neutral: 0.55, scale: 'linear' });
+    expect(MODULE_PARAMS['gate.depth']).toEqual({ neutral: 0, scale: 'linear' });
+    expect(MODULE_PARAMS['transport.tapeStop']).toEqual({ neutral: 0, scale: 'linear' });
+  });
+});
+
+describe('scaleValue', () => {
+  it('linear endpoints + midpoint', () => {
+    expect(scaleValue(0, 0.9, 1, 'linear')).toBeCloseTo(0.9);
+    expect(scaleValue(0, 0.9, 0, 'linear')).toBeCloseTo(0);
+    expect(scaleValue(0, 0.9, 0.5, 'linear')).toBeCloseTo(0.45);
+  });
+  it('log endpoints + midpoint (perceptual sweep)', () => {
+    expect(scaleValue(20000, 150, 1, 'log')).toBeCloseTo(150, 4);
+    expect(scaleValue(20000, 150, 0, 'log')).toBeCloseTo(20000, 4);
+    expect(scaleValue(20000, 150, 0.5, 'log')).toBeCloseTo(Math.sqrt(20000 * 150), 2);
+  });
+});
+
+describe('durationToSeconds', () => {
+  const T = { sixteenth: 0.125, beatSeconds: 0.5, barSeconds: 2 }; // 120bpm 4/4
+  it('resolves steps/beats/bars', () => {
+    expect(durationToSeconds({ unit: 'steps', value: 0.5 }, T)).toBeCloseTo(0.0625);
+    expect(durationToSeconds({ unit: 'beats', value: 3 }, T)).toBeCloseTo(1.5);
+    expect(durationToSeconds({ unit: 'bars', value: 1 }, T)).toBeCloseTo(2);
+  });
+  it('returns 0 for missing duration', () => {
+    expect(durationToSeconds(null, T)).toBe(0);
+  });
+  it('throws on unknown unit (seconds is future, not v3)', () => {
+    expect(() => durationToSeconds({ unit: 'seconds', value: 1 }, T)).toThrow();
   });
 });

--- a/docs/arcade/groovebox/tests/punch.test.js
+++ b/docs/arcade/groovebox/tests/punch.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PUNCH_NEUTRAL, PUNCH_PARAMS, MODULE_PARAMS, scaleValue, durationToSeconds, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from '../engine/punch.js';
+import { PUNCH_NEUTRAL, PUNCH_PARAMS, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, stutterAllowed, stutterEvents, isPunchArmed, diveFreqForAmount } from '../engine/punch.js';
 
 describe('PUNCH_NEUTRAL', () => {
   it('pins the idle chain to audibly-transparent values (spec safeguard 3)', () => {
@@ -117,5 +117,33 @@ describe('durationToSeconds', () => {
   });
   it('throws on unknown unit (seconds is future, not v3)', () => {
     expect(() => durationToSeconds({ unit: 'seconds', value: 1 }, T)).toThrow();
+  });
+});
+
+describe('gateEventsForStep', () => {
+  const SIX = 0.125;
+  it("division '1/16' = open first half, closed second (v2 stutter parity)", () => {
+    expect(gateEventsForStep(10, SIX, 0, '1/16', 1)).toEqual([
+      [10.003, 1], [10 + SIX / 2, 1], [10 + SIX / 2 + 0.003, 0], [10 + SIX, 0],
+    ]);
+  });
+  it("division '1/8' alternates whole steps: even open, odd closed", () => {
+    expect(gateEventsForStep(0, SIX, 0, '1/8', 1)).toEqual([[0.003, 1], [SIX, 1]]);
+    expect(gateEventsForStep(0, SIX, 1, '1/8', 1)).toEqual([[0.003, 0], [SIX, 0]]);
+  });
+  it("division '1/32' chops twice per step", () => {
+    const q = SIX / 4;
+    expect(gateEventsForStep(0, SIX, 0, '1/32', 1)).toEqual([
+      [0.003, 1], [q, 1], [q + 0.003, 0], [2 * q, 0],
+      [2 * q + 0.003, 1], [3 * q, 1], [3 * q + 0.003, 0], [4 * q, 0],
+    ]);
+  });
+  it('depth scales the closed level (depth 0.6 → closed 0.4)', () => {
+    const ev = gateEventsForStep(0, SIX, 0, '1/16', 0.6);
+    expect(ev[2][1]).toBeCloseTo(0.4);
+    expect(ev[3][1]).toBeCloseTo(0.4);
+  });
+  it('stutterEvents stays as the 1/16 wrapper (v2 back-compat)', () => {
+    expect(stutterEvents(5, SIX, 0.003, 0.25)).toEqual(gateEventsForStep(5, SIX, 0, '1/16', 0.75));
   });
 });

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -495,48 +495,53 @@ function renderFills() {
   host.appendChild(row);
 }
 
-// ─── Punch-in FX pads (momentary; spec in project-notes/oyster/po20) ─────────
-const PUNCH_PADS = [
-  ['stutter', 'STUT',  '1'],
-  ['crush',   'CRUSH', '2'],
-  ['dive',    'DIVE',  '3'],
-  ['throw',   'THROW', '4'],
-  ['stop',    'STOP',  '5'],
-];
-const PUNCH_BY_KEY = Object.fromEntries(PUNCH_PADS.map(([name, , key]) => [key, name]));
+// ─── Punch-in FX pads (data-driven; spec in project-notes/oyster/po20) ───────
+// Pads render from preset data — names/keys live in the presets, not here.
+// localStorage 'gb-punch-presets' overrides the repo defaults when valid
+// (no editor UI yet — v3.5; hand-edited or future-UI overrides both load here).
+function loadPunchPresets() {
+  try {
+    const saved = JSON.parse(localStorage.getItem('gb-punch-presets') || 'null');
+    if (saved) return eng.setPunchPresets(saved);   // engine validates; invalid → defaults kept
+  } catch (_) { /* corrupt JSON → defaults */ }
+  return eng.getPunchPresets();
+}
+let PUNCH_BY_KEY = {};   // key → slot index, rebuilt by renderPunch()
 
-function setPunch(name, on) {
-  eng.punch(name, on);
-  document.querySelector(`#punch .punchpad[data-punch="${name}"]`)?.classList.toggle('held', on);
+function setPunch(slot, on) {
+  eng.punch(slot, on);
+  document.querySelector(`#punch .punchpad[data-slot="${slot}"]`)?.classList.toggle('held', on);
 }
 
 function renderPunch() {
   const host = document.getElementById('punch');
   if (!host) return;
   host.innerHTML = '';
+  const presets = loadPunchPresets();
+  PUNCH_BY_KEY = Object.fromEntries(presets.map((p, i) => [p.key, i]));
   const row = document.createElement('div');
   row.className = 'punchrow';
   const lbl = document.createElement('span');
   lbl.className = 'flbl';
   lbl.textContent = 'PUNCH';
   row.appendChild(lbl);
-  for (const [name, label, key] of PUNCH_PADS) {
+  presets.forEach((p, slot) => {
     const pad = document.createElement('button');
     pad.className = 'punchpad';
-    pad.dataset.punch = name;
-    pad.append(label);
+    pad.dataset.slot = slot;
+    pad.append(p.name);
     const hint = document.createElement('span');
     hint.className = 'punchkey';
-    hint.textContent = key;
+    hint.textContent = p.key;
     pad.appendChild(hint);
-    pad.addEventListener('pointerdown', e => { e.preventDefault(); pad.setPointerCapture(e.pointerId); setPunch(name, true); });
-    const off = () => setPunch(name, false);
+    pad.addEventListener('pointerdown', e => { e.preventDefault(); pad.setPointerCapture(e.pointerId); setPunch(slot, true); });
+    const off = () => setPunch(slot, false);
     pad.addEventListener('pointerup', off);
     pad.addEventListener('pointercancel', off);
     row.appendChild(pad);
-  }
+  });
   // AMOUNT — the one performer-facing setting (DJM level/depth): scales how
-  // hard every pad hits. Effect internals stay fixed.
+  // hard every pad hits. Effect internals stay fixed preset data.
   row.appendChild(makeKnob({
     label: 'AMT',
     value: eng.getPunchAmount(),
@@ -546,23 +551,23 @@ function renderPunch() {
   host.appendChild(row);
 }
 
-// Keys 1–5 mirror the pads. Guards: key auto-repeat, and typing into inputs /
+// Preset keys mirror the pads. Guards: key auto-repeat, and typing into inputs /
 // selects / contenteditable (no keyboard hijack while renaming lanes etc.).
 function isTypingTarget(el) {
   return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.isContentEditable);
 }
 document.addEventListener('keydown', e => {
-  const name = PUNCH_BY_KEY[e.key];
-  if (!name || e.repeat || isTypingTarget(document.activeElement)) return;
+  const slot = PUNCH_BY_KEY[e.key];
+  if (slot === undefined || e.repeat || isTypingTarget(document.activeElement)) return;
   e.preventDefault();
-  setPunch(name, true);
+  setPunch(slot, true);
 });
 document.addEventListener('keyup', e => {
-  const name = PUNCH_BY_KEY[e.key];
-  if (name) setPunch(name, false);
+  const slot = PUNCH_BY_KEY[e.key];
+  if (slot !== undefined) setPunch(slot, false);
 });
 // Stuck-key guard: losing window focus releases every pad.
-window.addEventListener('blur', () => { for (const [name] of PUNCH_PADS) setPunch(name, false); });
+window.addEventListener('blur', () => { for (let s = 0; s < 5; s++) setPunch(s, false); });
 
 // ─── Master FX ───────────────────────────────────────────────────────────────
 function renderMaster() {


### PR DESCRIPTION
## Summary
Punch buttons become **data**: each pad is a preset of module automations executed by a runner — no hardcoded effect code. Approved spec: `project-notes/oyster/po20/2026-06-08-punch-modular-v3-spec.md`.

```json
{ "name": "DIVE", "key": "3", "engageQuantize": "immediate", "releaseQuantize": "immediate",
  "automations": [{ "module": "filter", "param": "freq", "from": "neutral", "to": 150,
    "engage": { "ramp": { "unit": "steps", "value": 1 } }, "release": { "ramp": { "unit": "steps", "value": 1 } } }] }
```

- **Module-param registry** (`MODULE_PARAMS`): neutral + AMT interpolation space (log/linear) per param; presets may override scale per-automation
- **Musical-only timing**: `{unit: steps|beats|bars}` resolved against live tempo; `seconds` rejected (reserved for a future schema rev)
- **Dual quantize**: `engageQuantize`/`releaseQuantize` ∈ immediate|bar|pattern — non-immediate actions queue and fire at bar/pattern boundaries in the step callback
- **GATE module** (new primitive): division-aware chopper (`1/8`,`1/16`,`1/32`) + depth — de-special-cases stutter; STUT is now just `gate.depth → 1`
- **STOP stays semantic** (`transport.tapeStop`): the engine owns slump + strict click-free release + on-grid return (all v2 safeguards preserved verbatim)
- **Storage tiers**: repo defaults are immutable seed data; `localStorage['gb-punch-presets']` overrides load (validated; editor UI = v3.5)
- Pads/keys render **from preset data**; AMT knob unchanged (scales via registry-space interpolation)

## v2 parity mapping
0.05s→`steps:0.5` · 0.15s→`steps:1` · throw tail 1.5s→`beats:3` · stop slump 0.8s→`beats:1.5` (within ms of v2 at 120bpm, and now tempo-aware — better). CRUSH keeps the dogfood-approved 0.9.

## Testing
157/157 (31 punch-related: registry, scaleValue log/linear, durations incl. seconds-rejection, gate divisions/depth/back-compat, preset schema + five defaults). Engine+UI bundle-verified. **By-ear parity gate** (spec): A/B each pad vs live site, AMT at 1/0.5, `?perf` hammered → `late 0/64` — left for review on :5186.

## Notes
PUNCH_PARAMS/stutterAllowed/diveFreqForAmount deleted (superseded by registry/presets/runner). No CHANGELOG (arcade scope). Next after this: song-JSON (fresh session) — these presets are designed to ride into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)