### PR TITLE
fix(cloud): transcript gate — render synced transcripts in the remote view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 ### Fixed
 
 - **Untitled sessions get a name** — sessions without a title now show their folder name instead of a raw ID.
+- **Cloud remote view shows transcripts** — opening a session at app.oyster.to now displays the conversation (with live tail for active sessions) instead of a "transcript isn't on this device" notice.
 
 ## [0.11.0] - 2026-06-05
 

--- a/web/src/components/SessionInspector/index.tsx
+++ b/web/src/components/SessionInspector/index.tsx
@@ -316,10 +316,11 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
   // transcript body. The two builds read from different places, so the
   // gate differs:
   //  - cloud: the worker renders events from synced chunks, so the only
-  //    blocker is "no chunks uploaded yet" (hasBytes). originDeviceId is
-  //    set on EVERY cloud session and jsonlAvailableLocally is always
-  //    false there — reusing the local predicate blacked out the whole
-  //    transcript view (the #454 gate predates cloud mode).
+  //    blocker is "no chunks uploaded yet" (hasBytes). The cloud adapter
+  //    hardcodes jsonlAvailableLocally to false and sessions carry their
+  //    origin device_id (nullable only on legacy pre-stamping rows) — so
+  //    the local predicate blacked out essentially every transcript
+  //    (the #454 gate predates cloud mode).
   //  - local: a remote session's jsonl hasn't been reassembled here yet;
   //    the Header above exposes the Resume affordance, and once the user
   //    resumes, the watcher ingests the jsonl.

--- a/web/src/components/SessionInspector/index.tsx
+++ b/web/src/components/SessionInspector/index.tsx
@@ -311,13 +311,21 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
     );
   }
 
-  // A remote session whose jsonl hasn't been reassembled yet has no local
-  // transcript to show. Render a "reassemble to view" notice instead of
-  // an empty transcript body; the Header above already exposes the Resume
-  // affordance. Once the user resumes, the watcher ingests the jsonl and
-  // the events tab becomes the right surface.
-  const isRemoteUnsynced =
-    !!session.originDeviceId && session.jsonlAvailableLocally === false;
+  // A session whose transcript bytes haven't landed where this build reads
+  // them from has nothing to render — show a notice instead of an empty
+  // transcript body. The two builds read from different places, so the
+  // gate differs:
+  //  - cloud: the worker renders events from synced chunks, so the only
+  //    blocker is "no chunks uploaded yet" (hasBytes). originDeviceId is
+  //    set on EVERY cloud session and jsonlAvailableLocally is always
+  //    false there — reusing the local predicate blacked out the whole
+  //    transcript view (the #454 gate predates cloud mode).
+  //  - local: a remote session's jsonl hasn't been reassembled here yet;
+  //    the Header above exposes the Resume affordance, and once the user
+  //    resumes, the watcher ingests the jsonl.
+  const isRemoteUnsynced = caps.cloud
+    ? session.hasBytes !== true
+    : !!session.originDeviceId && session.jsonlAvailableLocally === false;
 
   return (
     <>
@@ -331,12 +339,25 @@ export function SessionInspector({ sessionId, focusEventId, initialSearchQuery, 
       <Banner session={session} />
       {isRemoteUnsynced ? (
         <div className="inspector-empty" style={{ padding: "32px 28px", lineHeight: 1.6 }}>
-          <p style={{ margin: "0 0 8px" }}>
-            <strong>Transcript isn't on this device yet.</strong>
-          </p>
-          <p style={{ margin: 0, color: "var(--text-dim)" }}>
-            This session was started on another device. Use <em>Resume on this device</em> above to reassemble the transcript locally — once it lands, the conversation will show up here.
-          </p>
+          {caps.cloud ? (
+            <>
+              <p style={{ margin: "0 0 8px" }}>
+                <strong>Transcript hasn't reached the cloud yet.</strong>
+              </p>
+              <p style={{ margin: 0, color: "var(--text-dim)" }}>
+                It'll sync next time {session.originDeviceLabel ?? "its origin device"} is online — once the first bytes land, the conversation will show up here.
+              </p>
+            </>
+          ) : (
+            <>
+              <p style={{ margin: "0 0 8px" }}>
+                <strong>Transcript isn't on this device yet.</strong>
+              </p>
+              <p style={{ margin: 0, color: "var(--text-dim)" }}>
+                This session was started on another device. Use <em>Resume on this device</em> above to reassemble the transcript locally — once it lands, the conversation will show up here.
+              </p>
+            </>
+          )}
         </div>
       ) : (
         <>


### PR DESCRIPTION
## Problem

Opening any session at app.oyster.to showed *"Transcript isn't on this device yet"* — even though the entire cloud transcript pipeline already exists (worker rendered-events endpoint over decrypted chunks from #619, manifest-poll live tail + cloud pagination from #622).

The `isRemoteUnsynced` gate in `SessionInspector` predates cloud mode (#454, the *local* cross-device feature). In the cloud build every session has `originDeviceId` set and `jsonlAvailableLocally` hardcoded `false`, so the gate fired unconditionally and the render path went dark. The dead-end copy even referenced a *Resume on this device* button that doesn't render in cloud.

## Fix

- In cloud, gate on the thing that actually blocks rendering there: `hasBytes !== true` (no chunks uploaded yet). Local predicate unchanged.
- Cloud-specific empty-state copy for the no-bytes case, naming the origin device, no Resume reference.

Checked the raw-expand path (`fetchSessionEventRaw` returns `null` in cloud): expanding a tool turn is a graceful no-op — no error, no crash — so left untouched.

## Verification

- `web`: `npm run build` and `npm run build:cloud` both green (tsc + vite).
- Lint: no new findings (the pre-existing error in this file is at line 98, untouched).
- Hand-test after the next `wrangler deploy` of oyster-cloud: session with synced bytes renders transcript + live-tails; session without bytes shows the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)