### PR TITLE
feat(cloud): artefact registry sync — truthful Artefacts tab in the remote view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
+### Added
+
+- **Your artefact library appears in the cloud remote view** — the Artefacts tab at app.oyster.to now lists everything in your registry (read-only), with a chip showing which device each artefact lives on. Published artefacts stay the openable ones.
+
 ### Changed
 
 - **Sessions list shows everything** — the Sessions tab lists all sessions; no more "Show more" clicks.

--- a/infra/auth-worker/migrations/0014_synced_artifacts.sql
+++ b/infra/auth-worker/migrations/0014_synced_artifacts.sql
@@ -1,0 +1,36 @@
+-- 0014_synced_artifacts.sql — artefact registry mirror for the cloud remote
+-- view (app.oyster.to Artefacts tab).
+--
+-- Metadata only: rows prove an artefact EXISTS and where (label, kind,
+-- space, device). No file content, no publication state — oyster-publish
+-- remains the sole source of truth for openable artefacts; the web client
+-- joins the two by artifact_id.
+--
+-- LWW key is sync_version_at (the pushing device's sync_dirty_at, unix ms)
+-- — deliberately NOT named updated_at, because artefacts already carry a
+-- domain-level updated_at (artifact_updated_at below, datetime text).
+--
+-- Tombstones: rows with removed_at set are accepted on POST (deletions must
+-- propagate) and filtered from GET. Pro-only; gate enforced on the Worker.
+
+CREATE TABLE IF NOT EXISTS synced_artifacts (
+  owner_id            TEXT    NOT NULL,
+  artifact_id         TEXT    NOT NULL,
+  device_id           TEXT,
+  device_label        TEXT,
+  label               TEXT    NOT NULL,
+  artifact_kind       TEXT    NOT NULL,
+  space_id            TEXT,
+  project_id          TEXT,
+  group_name          TEXT,
+  source_origin       TEXT    NOT NULL DEFAULT 'manual',
+  created_at          TEXT    NOT NULL,
+  artifact_updated_at TEXT,
+  removed_at          TEXT,
+  pinned_at           INTEGER,
+  sync_version_at     INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, artifact_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_synced_artifacts_owner_version
+  ON synced_artifacts (owner_id, sync_version_at DESC);

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -616,7 +616,10 @@ function isValidArtifact(a: unknown): a is IncomingArtifact {
     const v = o[key];
     if (v !== null && v !== undefined && typeof v !== "string") return false;
   }
-  if (o.pinned_at !== null && o.pinned_at !== undefined && typeof o.pinned_at !== "number") return false;
+  // Same finiteness posture as sync_version_at — NaN/Infinity would bind
+  // into D1 as junk or throw mid-batch.
+  if (o.pinned_at !== null && o.pinned_at !== undefined
+      && (typeof o.pinned_at !== "number" || !Number.isFinite(o.pinned_at) || o.pinned_at < 0)) return false;
   // Same cap as sessions' device_label: truncate to null rather than reject.
   if (typeof o.device_label === "string" && o.device_label.length > DEVICE_LABEL_MAX) {
     o.device_label = null;

--- a/infra/oyster-cloud/src/worker.ts
+++ b/infra/oyster-cloud/src/worker.ts
@@ -94,6 +94,14 @@ export default {
       return handleSessionsMetadataGet(req, env);
     }
 
+    if (url.pathname === "/api/artifacts/metadata" && req.method === "POST") {
+      return handleArtifactsMetadataPost(req, env);
+    }
+
+    if (url.pathname === "/api/artifacts/metadata" && req.method === "GET") {
+      return handleArtifactsMetadataGet(req, env);
+    }
+
     // Session bytes — chunked-delta routes (#322). Four shapes:
     //   PUT  /api/sessions/bytes/:id/chunk/:n        upload one chunk
     //   GET  /api/sessions/bytes/:id/manifest        list chunks for current gen
@@ -562,6 +570,155 @@ async function handleSessionsMetadataGet(req: Request, env: Env): Promise<Respon
   // Normalise has_bytes to boolean for the client.
   const sessions = (results ?? []).map((r) => ({ ...r, has_bytes: r.has_bytes === 1 }));
   return jsonOk({ sessions }, 200, { "cache-control": "private, no-store" });
+}
+
+// ── Artefact registry sync ───────────────────────────────────────────
+// Metadata-only mirror of the local artefact registry so the remote view's
+// Artefacts tab can list what exists. No file content, no publication state
+// (oyster-publish owns that; the web client joins by artifact_id).
+
+interface IncomingArtifact {
+  id: string;
+  device_id?: string | null;
+  device_label?: string | null;
+  label: string;
+  artifact_kind: string;
+  space_id?: string | null;
+  project_id?: string | null;
+  group_name?: string | null;
+  source_origin?: string | null;
+  created_at: string;
+  /** Domain-level timestamp (datetime text) — stored as artifact_updated_at,
+   *  distinct from the LWW key below. */
+  updated_at?: string | null;
+  /** Tombstone marker. Accepted on POST so deletions propagate; rows with
+   *  this set are filtered from GET. */
+  removed_at?: string | null;
+  pinned_at?: number | null;
+  /** LWW key — the pushing device's sync_dirty_at (unix ms). Named
+   *  sync_version_at so the schema doesn't overload updated_at. */
+  sync_version_at: number;
+}
+
+function isValidArtifact(a: unknown): a is IncomingArtifact {
+  if (!a || typeof a !== "object") return false;
+  const o = a as Record<string, unknown>;
+  if (typeof o.id !== "string" || o.id.length === 0) return false;
+  if (typeof o.label !== "string" || o.label.length === 0) return false;
+  if (typeof o.artifact_kind !== "string" || o.artifact_kind.length === 0) return false;
+  if (typeof o.created_at !== "string") return false;
+  if (typeof o.sync_version_at !== "number" || !Number.isFinite(o.sync_version_at)) return false;
+  if (o.sync_version_at < 0) return false;
+  // Nullable strings: anything else would crash D1 .bind() or coerce to
+  // junk. Each malformed artefact is rejected individually so the rest of
+  // the batch still lands (same posture as session metadata ingest).
+  for (const key of ["device_id", "device_label", "space_id", "project_id", "group_name", "source_origin", "updated_at", "removed_at"] as const) {
+    const v = o[key];
+    if (v !== null && v !== undefined && typeof v !== "string") return false;
+  }
+  if (o.pinned_at !== null && o.pinned_at !== undefined && typeof o.pinned_at !== "number") return false;
+  // Same cap as sessions' device_label: truncate to null rather than reject.
+  if (typeof o.device_label === "string" && o.device_label.length > DEVICE_LABEL_MAX) {
+    o.device_label = null;
+  }
+  return true;
+}
+
+async function handleArtifactsMetadataPost(req: Request, env: Env): Promise<Response> {
+  const badOrigin = rejectBadOrigin(req);
+  if (badOrigin) return badOrigin;
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  let body: { artifacts?: unknown };
+  try { body = await req.json() as { artifacts?: unknown }; }
+  catch { return jsonError(400, "invalid_metadata"); }
+
+  const incoming = body.artifacts;
+  if (!Array.isArray(incoming)) return jsonError(400, "invalid_metadata");
+
+  const MAX_ARTIFACTS_PER_REQUEST = 1000;
+  if (incoming.length > MAX_ARTIFACTS_PER_REQUEST) {
+    return jsonError(413, "too_many_artifacts");
+  }
+
+  const accepted: string[] = [];
+  const rejected: string[] = [];
+
+  try {
+    for (const raw of incoming) {
+      if (!isValidArtifact(raw)) {
+        const id = (raw as { id?: unknown })?.id;
+        rejected.push(typeof id === "string" && id.length > 0 ? id : "<malformed>");
+        continue;
+      }
+      const a = raw;
+      // LWW: only overwrite when the incoming sync_version_at is strictly
+      // greater. New rows always insert. Mirrors session metadata ingest.
+      await env.DB.prepare(
+        `INSERT INTO synced_artifacts
+           (owner_id, artifact_id, device_id, device_label, label, artifact_kind,
+            space_id, project_id, group_name, source_origin, created_at,
+            artifact_updated_at, removed_at, pinned_at, sync_version_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(owner_id, artifact_id) DO UPDATE SET
+           device_id           = excluded.device_id,
+           device_label        = COALESCE(excluded.device_label, synced_artifacts.device_label),
+           label               = excluded.label,
+           artifact_kind       = excluded.artifact_kind,
+           space_id            = excluded.space_id,
+           project_id          = excluded.project_id,
+           group_name          = excluded.group_name,
+           source_origin       = excluded.source_origin,
+           created_at          = excluded.created_at,
+           artifact_updated_at = excluded.artifact_updated_at,
+           removed_at          = excluded.removed_at,
+           pinned_at           = excluded.pinned_at,
+           sync_version_at     = excluded.sync_version_at
+          WHERE excluded.sync_version_at > synced_artifacts.sync_version_at`,
+      ).bind(
+        user.id, a.id, a.device_id ?? null, a.device_label ?? null, a.label, a.artifact_kind,
+        a.space_id ?? null, a.project_id ?? null, a.group_name ?? null,
+        a.source_origin ?? "manual", a.created_at,
+        a.updated_at ?? null, a.removed_at ?? null, a.pinned_at ?? null, a.sync_version_at,
+      ).run();
+      // Acknowledge even when LWW dropped the write (changes 0) — cloud has
+      // a newer version, the client should clear its dirty flag.
+      accepted.push(a.id);
+    }
+  } catch (err) {
+    console.warn("[artifacts] metadata ingest db error:", err);
+    return jsonError(500, "db_error");
+  }
+
+  return jsonOk({ accepted, rejected });
+}
+
+async function handleArtifactsMetadataGet(req: Request, env: Env): Promise<Response> {
+  const user = await resolveSession(req, env);
+  if (!user) return jsonError(401, "sign_in_required");
+  if (user.tier !== "pro") return jsonError(403, "pro_required");
+
+  type Row = {
+    artifact_id: string; device_id: string | null; device_label: string | null;
+    label: string; artifact_kind: string; space_id: string | null;
+    project_id: string | null; group_name: string | null; source_origin: string;
+    created_at: string; artifact_updated_at: string | null;
+    pinned_at: number | null; sync_version_at: number;
+  };
+  // Tombstones stay in the table (they keep winning LWW against stale
+  // re-pushes) but never reach the client.
+  const { results } = await env.DB.prepare(
+    `SELECT artifact_id, device_id, device_label, label, artifact_kind,
+            space_id, project_id, group_name, source_origin, created_at,
+            artifact_updated_at, pinned_at, sync_version_at
+       FROM synced_artifacts
+      WHERE owner_id = ? AND removed_at IS NULL
+      ORDER BY created_at DESC`,
+  ).bind(user.id).all<Row>();
+
+  return jsonOk({ artifacts: results ?? [] }, 200, { "cache-control": "private, no-store" });
 }
 
 // Per-chunk upload cap. Workers' default body limit is 100 MB; we stay well

--- a/infra/oyster-cloud/test/artifacts-routes.test.ts
+++ b/infra/oyster-cloud/test/artifacts-routes.test.ts
@@ -135,6 +135,22 @@ describe("POST /api/artifacts/metadata", () => {
     expect(count?.n).toBe(1);
   });
 
+  it("rejects non-finite pinned_at (1e999 parses to Infinity; NaN can't arrive via JSON)", async () => {
+    const { token } = await makeProSession();
+    const aid = `a-${crypto.randomUUID()}`;
+    // Hand-crafted body: JSON.stringify would turn Infinity into null, which
+    // is legal. 1e999 is the wire-reachable way to smuggle a non-finite in.
+    const res = await signedFetch("/api/artifacts/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: `{"artifacts":[{"id":"${aid}","label":"x","artifact_kind":"notes","created_at":"2026-06-01 10:00:00","sync_version_at":1000,"pinned_at":1e999}]}`,
+    }, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([]);
+    expect(body.rejected).toEqual([aid]);
+  });
+
   it("accepts tombstones (removed_at set) — deletions propagate", async () => {
     const { token, userId } = await makeProSession();
     const aid = `a-${crypto.randomUUID()}`;

--- a/infra/oyster-cloud/test/artifacts-routes.test.ts
+++ b/infra/oyster-cloud/test/artifacts-routes.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { env, SELF } from "cloudflare:test";
+import { applySchema } from "./fixtures/seed.js";
+
+async function makeProSession(suffix = crypto.randomUUID()): Promise<{ token: string; userId: string }> {
+  const userId = `u-pro-${suffix}`;
+  const token  = `tok-pro-${suffix}`;
+  await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'pro', ?)`)
+    .bind(userId, `pro-${suffix}@example.com`, Date.now()).run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, created_at, expires_at, revoked_at)
+     VALUES (?, ?, ?, ?, NULL)`,
+  ).bind(token, userId, Date.now(), Date.now() + 86400_000).run();
+  return { token, userId };
+}
+
+async function makeFreeSession(suffix = crypto.randomUUID()): Promise<{ token: string; userId: string }> {
+  const userId = `u-free-${suffix}`;
+  const token  = `tok-free-${suffix}`;
+  await env.DB.prepare(`INSERT INTO users (id, email, tier, created_at) VALUES (?, ?, 'free', ?)`)
+    .bind(userId, `free-${suffix}@example.com`, Date.now()).run();
+  await env.DB.prepare(
+    `INSERT INTO sessions (id, user_id, created_at, expires_at, revoked_at)
+     VALUES (?, ?, ?, ?, NULL)`,
+  ).bind(token, userId, Date.now(), Date.now() + 86400_000).run();
+  return { token, userId };
+}
+
+function signedFetch(path: string, init: RequestInit, token: string): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("Cookie", `oyster_session=${token}`);
+  return SELF.fetch(`https://example.com${path}`, { ...init, headers });
+}
+
+function sampleArtifact(id: string, syncVersionAt: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    device_id: "dev-mac-01",
+    device_label: "MacBook-Pro",
+    label: "Quarterly notes",
+    artifact_kind: "notes",
+    space_id: "spc-1",
+    project_id: "prj-1",
+    group_name: null,
+    source_origin: "ai_generated",
+    created_at: "2026-06-01 10:00:00",
+    updated_at: "2026-06-01 10:00:00",
+    removed_at: null,
+    pinned_at: null,
+    sync_version_at: syncVersionAt,
+    ...overrides,
+  };
+}
+
+function postArtifacts(token: string, artifacts: unknown[]): Promise<Response> {
+  return signedFetch("/api/artifacts/metadata", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ artifacts }),
+  }, token);
+}
+
+describe("POST /api/artifacts/metadata", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("rejects unsigned requests with 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/artifacts/metadata", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ artifacts: [] }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects free-tier users with 403", async () => {
+    const { token } = await makeFreeSession();
+    const res = await postArtifacts(token, []);
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts a valid artefact and stores it scoped to owner", async () => {
+    const { token, userId } = await makeProSession();
+    const aid = `a-${crypto.randomUUID()}`;
+    const res = await postArtifacts(token, [sampleArtifact(aid, 1000)]);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([aid]);
+    expect(body.rejected).toEqual([]);
+
+    const row = await env.DB.prepare(
+      `SELECT owner_id, label, artifact_kind, source_origin, sync_version_at, artifact_updated_at
+         FROM synced_artifacts WHERE owner_id = ? AND artifact_id = ?`,
+    ).bind(userId, aid).first();
+    expect(row).toMatchObject({
+      owner_id: userId, label: "Quarterly notes", artifact_kind: "notes",
+      source_origin: "ai_generated", sync_version_at: 1000,
+      artifact_updated_at: "2026-06-01 10:00:00",
+    });
+  });
+
+  it("LWW: a stale sync_version_at does not overwrite a newer cloud row", async () => {
+    const { token, userId } = await makeProSession();
+    const aid = `a-${crypto.randomUUID()}`;
+    await postArtifacts(token, [sampleArtifact(aid, 2000, { label: "v1" })]);
+    await postArtifacts(token, [sampleArtifact(aid, 3000, { label: "v2" })]);
+    // Stale write still gets acked (client clears its dirty flag) but loses.
+    const res = await postArtifacts(token, [sampleArtifact(aid, 1000, { label: "ancient" })]);
+    const body = await res.json() as { accepted: string[] };
+    expect(body.accepted).toEqual([aid]);
+
+    const row = await env.DB.prepare(
+      `SELECT label, sync_version_at FROM synced_artifacts WHERE owner_id = ? AND artifact_id = ?`,
+    ).bind(userId, aid).first<{ label: string; sync_version_at: number }>();
+    expect(row).toMatchObject({ label: "v2", sync_version_at: 3000 });
+  });
+
+  it("rejects malformed rows individually without poisoning the batch", async () => {
+    const { token, userId } = await makeProSession();
+    const good = `a-${crypto.randomUUID()}`;
+    const res = await postArtifacts(token, [
+      sampleArtifact(good, 1000),
+      { id: "", label: "no id", artifact_kind: "notes", created_at: "x", sync_version_at: 1 },
+      sampleArtifact(`a-${crypto.randomUUID()}`, 1000, { label: 42 }),          // non-string label
+      sampleArtifact(`a-${crypto.randomUUID()}`, Number.NaN),                   // bad LWW key
+      sampleArtifact(`a-${crypto.randomUUID()}`, 1000, { space_id: ["x"] }),    // non-string nullable
+    ]);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accepted: string[]; rejected: string[] };
+    expect(body.accepted).toEqual([good]);
+    expect(body.rejected).toHaveLength(4);
+
+    const count = await env.DB.prepare(
+      `SELECT COUNT(*) AS n FROM synced_artifacts WHERE owner_id = ?`,
+    ).bind(userId).first<{ n: number }>();
+    expect(count?.n).toBe(1);
+  });
+
+  it("accepts tombstones (removed_at set) — deletions propagate", async () => {
+    const { token, userId } = await makeProSession();
+    const aid = `a-${crypto.randomUUID()}`;
+    await postArtifacts(token, [sampleArtifact(aid, 1000)]);
+    const res = await postArtifacts(token, [
+      sampleArtifact(aid, 2000, { removed_at: "2026-06-06 12:00:00" }),
+    ]);
+    const body = await res.json() as { accepted: string[] };
+    expect(body.accepted).toEqual([aid]);
+
+    const row = await env.DB.prepare(
+      `SELECT removed_at FROM synced_artifacts WHERE owner_id = ? AND artifact_id = ?`,
+    ).bind(userId, aid).first<{ removed_at: string | null }>();
+    expect(row?.removed_at).toBe("2026-06-06 12:00:00");
+  });
+
+  it("caps the batch at 1000 artefacts with 413", async () => {
+    const { token } = await makeProSession();
+    const res = await postArtifacts(
+      token,
+      Array.from({ length: 1001 }, (_, i) => sampleArtifact(`a-${i}`, 1000)),
+    );
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("GET /api/artifacts/metadata", () => {
+  beforeAll(async () => { await applySchema(); });
+
+  it("rejects unsigned requests with 401", async () => {
+    const res = await SELF.fetch("https://example.com/api/artifacts/metadata");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects free-tier users with 403", async () => {
+    const { token } = await makeFreeSession();
+    const res = await signedFetch("/api/artifacts/metadata", {}, token);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns only the owner's live rows; tombstones are filtered", async () => {
+    const { token, userId } = await makeProSession();
+    const live = `a-${crypto.randomUUID()}`;
+    const dead = `a-${crypto.randomUUID()}`;
+    await postArtifacts(token, [
+      sampleArtifact(live, 1000, { label: "alive", pinned_at: 777 }),
+      sampleArtifact(dead, 1000, { removed_at: "2026-06-06 12:00:00" }),
+    ]);
+    // Another owner's artefact must not leak in.
+    const other = await makeProSession();
+    await postArtifacts(other.token, [sampleArtifact(`a-${crypto.randomUUID()}`, 1000)]);
+
+    const res = await signedFetch("/api/artifacts/metadata", {}, token);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { artifacts: Array<Record<string, unknown>> };
+    expect(body.artifacts).toHaveLength(1);
+    expect(body.artifacts[0]).toMatchObject({
+      artifact_id: live, label: "alive", device_label: "MacBook-Pro",
+      space_id: "spc-1", pinned_at: 777,
+    });
+    void userId;
+  });
+
+  it("a tombstoned artefact disappears from GET after the delete propagates", async () => {
+    const { token } = await makeProSession();
+    const aid = `a-${crypto.randomUUID()}`;
+    await postArtifacts(token, [sampleArtifact(aid, 1000)]);
+
+    let body = await (await signedFetch("/api/artifacts/metadata", {}, token)).json() as
+      { artifacts: Array<{ artifact_id: string }> };
+    expect(body.artifacts.map((a) => a.artifact_id)).toContain(aid);
+
+    await postArtifacts(token, [sampleArtifact(aid, 2000, { removed_at: "2026-06-06 12:00:00" })]);
+    body = await (await signedFetch("/api/artifacts/metadata", {}, token)).json() as
+      { artifacts: Array<{ artifact_id: string }> };
+    expect(body.artifacts.map((a) => a.artifact_id)).not.toContain(aid);
+  });
+});

--- a/infra/oyster-cloud/test/fixtures/seed.ts
+++ b/infra/oyster-cloud/test/fixtures/seed.ts
@@ -89,6 +89,27 @@ CREATE TABLE IF NOT EXISTS synced_session_chunks (
 );
 CREATE INDEX IF NOT EXISTS idx_synced_session_chunks_active
   ON synced_session_chunks (owner_id, session_id, bytes_generation, chunk_number);
+-- Mirror of infra/auth-worker/migrations/0014_synced_artifacts.sql
+CREATE TABLE IF NOT EXISTS synced_artifacts (
+  owner_id            TEXT    NOT NULL,
+  artifact_id         TEXT    NOT NULL,
+  device_id           TEXT,
+  device_label        TEXT,
+  label               TEXT    NOT NULL,
+  artifact_kind       TEXT    NOT NULL,
+  space_id            TEXT,
+  project_id          TEXT,
+  group_name          TEXT,
+  source_origin       TEXT    NOT NULL DEFAULT 'manual',
+  created_at          TEXT    NOT NULL,
+  artifact_updated_at TEXT,
+  removed_at          TEXT,
+  pinned_at           INTEGER,
+  sync_version_at     INTEGER NOT NULL,
+  PRIMARY KEY (owner_id, artifact_id)
+);
+CREATE INDEX IF NOT EXISTS idx_synced_artifacts_owner_version
+  ON synced_artifacts (owner_id, sync_version_at DESC);
 -- Mirror of infra/auth-worker/migrations/0013_app_handoff_codes.sql
 CREATE TABLE IF NOT EXISTS app_handoff_codes (
   code_hash   TEXT PRIMARY KEY,

--- a/server/src/artifact-space-migration.ts
+++ b/server/src/artifact-space-migration.ts
@@ -34,7 +34,11 @@ export function backfillArtifactProjects(db: Database.Database, userlandDir: str
          OR substr(?, 1, length(pp.path) + 1) = pp.path || '\\'
       ORDER BY LENGTH(pp.path) DESC LIMIT 1`,
   );
-  const setProject = db.prepare("UPDATE artifacts SET project_id = ? WHERE id = ?");
+  // sync_dirty_at: project binding drives the derived space_id the cloud
+  // mirror scopes by, so a rebound row must re-push.
+  const setProject = db.prepare(
+    "UPDATE artifacts SET project_id = ?, sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000 WHERE id = ?",
+  );
   const projectSpace = db.prepare("SELECT space_id FROM projects WHERE id = ?");
   const nativeRoot = join(userlandDir, "spaces");
 

--- a/server/src/artifact-store.ts
+++ b/server/src/artifact-store.ts
@@ -87,12 +87,14 @@ export class SqliteArtifactStore implements ArtifactStore {
       getAllArchived: db.prepare(
         `${SELECT} WHERE a.removed_at IS NOT NULL ORDER BY a.removed_at DESC`
       ),
+      // sync_dirty_at: every write stamps unix-ms so the artefact registry
+      // sync (artifact-sync-service.ts) picks the row up on its next drain.
       insert: db.prepare(
         hasSpaceCol
-          ? `INSERT INTO artifacts (id, owner_id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
-             VALUES (@id, @owner_id, '', @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`
-          : `INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id)
-             VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id)`,
+          ? `INSERT INTO artifacts (id, owner_id, space_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id, sync_dirty_at)
+             VALUES (@id, @owner_id, '', @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id, @sync_dirty_at)`
+          : `INSERT INTO artifacts (id, owner_id, label, artifact_kind, storage_kind, storage_config, runtime_kind, runtime_config, group_name, source_origin, source_ref, project_id, sync_dirty_at)
+             VALUES (@id, @owner_id, @label, @artifact_kind, @storage_kind, @storage_config, @runtime_kind, @runtime_config, @group_name, COALESCE(@source_origin,'manual'), @source_ref, @project_id, @sync_dirty_at)`,
       ),
       delete: db.prepare("DELETE FROM artifacts WHERE id = ?"),
     };
@@ -119,13 +121,13 @@ export class SqliteArtifactStore implements ArtifactStore {
   }
 
   insert(row: InsertRow): void {
-    this.stmts.insert.run({ project_id: null, source_origin: null, source_ref: null, ...row });
+    this.stmts.insert.run({ project_id: null, source_origin: null, source_ref: null, sync_dirty_at: Date.now(), ...row });
   }
 
   resurface(id: string): void {
     this.db.prepare(
-      "UPDATE artifacts SET removed_at = NULL, updated_at = datetime('now') WHERE id = ?"
-    ).run(id);
+      "UPDATE artifacts SET removed_at = NULL, updated_at = datetime('now'), sync_dirty_at = ? WHERE id = ?"
+    ).run(Date.now(), id);
   }
 
   private static readonly UPDATABLE_COLUMNS = new Set([
@@ -147,19 +149,22 @@ export class SqliteArtifactStore implements ArtifactStore {
     if (sets.length === 0) return;
 
     sets.push("updated_at = datetime('now')");
+    sets.push("sync_dirty_at = @sync_dirty_at");
+    values.sync_dirty_at = Date.now();
     this.db.prepare(`UPDATE artifacts SET ${sets.join(", ")} WHERE id = @id`).run(values);
   }
 
   remove(id: string): void {
-    this.db.prepare("UPDATE artifacts SET removed_at = datetime('now') WHERE id = ?").run(id);
+    // Tombstone: removed_at set + dirty so the deletion propagates to cloud.
+    this.db.prepare("UPDATE artifacts SET removed_at = datetime('now'), sync_dirty_at = ? WHERE id = ?").run(Date.now(), id);
   }
 
   pin(id: string, pinnedAt: number): void {
-    this.db.prepare("UPDATE artifacts SET pinned_at = ?, updated_at = datetime('now') WHERE id = ?").run(pinnedAt, id);
+    this.db.prepare("UPDATE artifacts SET pinned_at = ?, updated_at = datetime('now'), sync_dirty_at = ? WHERE id = ?").run(pinnedAt, Date.now(), id);
   }
 
   unpin(id: string): void {
-    this.db.prepare("UPDATE artifacts SET pinned_at = NULL, updated_at = datetime('now') WHERE id = ?").run(id);
+    this.db.prepare("UPDATE artifacts SET pinned_at = NULL, updated_at = datetime('now'), sync_dirty_at = ? WHERE id = ?").run(Date.now(), id);
   }
 
   // All rows that have been soft-deleted — newest first, for the Archived view.

--- a/server/src/artifact-sync-service.ts
+++ b/server/src/artifact-sync-service.ts
@@ -1,0 +1,197 @@
+// artifact-sync-service.ts — one-way push of artefact registry METADATA to
+// the cloud worker, so the remote view's Artefacts tab can list what exists.
+// No file content, no publication state (the publish worker stays the sole
+// source of truth for openable artefacts) — registry rows only prove that
+// artefacts exist and where.
+//
+// Mirrors session-sync-service.ts's metadata flow: the store stamps
+// sync_dirty_at on every mutation (insert/update/remove/pin), this service
+// drains pending rows in batches and records cloud_synced_at on ack. The
+// db.ts promotion backfill marks pre-existing rows dirty once, so the whole
+// registry reaches the cloud on first Pro sign-in. Tombstones (removed_at
+// set) are pushed like any other row — the worker accepts them and filters
+// them from GET, which is how deletions propagate.
+
+import type Database from "better-sqlite3";
+import type { ProfileBindingService } from "./profile-binding-service.js";
+import { createOfflineLogger } from "./sync-log.js";
+
+interface SyncUser { id: string; email: string; tier: string }
+
+export interface ArtifactSyncDeps {
+  db: Database.Database;
+  /** Same account-switch guard as session/memory sync: a second Pro account
+   *  signing into this profile must not push (or claim) this registry. */
+  profileBinding: ProfileBindingService;
+  currentUser: () => SyncUser | null;
+  sessionToken: () => string | null;
+  workerBase: string;
+  fetch: typeof fetch;
+}
+
+export interface ArtifactSyncService {
+  /** Drain dirty registry rows to the cloud. Returns rows acknowledged. */
+  pushPending(): Promise<number>;
+}
+
+const BATCH_SIZE = 100;
+
+function isProSession(deps: ArtifactSyncDeps): { user: SyncUser; token: string } | null {
+  const user = deps.currentUser();
+  const token = deps.sessionToken();
+  if (!user || !token || user.tier !== "pro") return null;
+  if (!deps.profileBinding.isOwnedBy(user.id)) {
+    console.warn(
+      `[artifacts] sync blocked — profile is bound to a different account; current=${user.id}, bound=${deps.profileBinding.getBoundOwner()}`,
+    );
+    return null;
+  }
+  return { user, token };
+}
+
+interface OutgoingArtifact {
+  id: string;
+  label: string;
+  artifact_kind: string;
+  /** Derived space (artifact → project → space), '' when unfiled — same
+   *  derivation as ArtifactStore's SELECTs. Normalised to null on the wire. */
+  space_id: string | null;
+  project_id: string | null;
+  group_name: string | null;
+  source_origin: string;
+  created_at: string;
+  /** Domain-level timestamp (datetime('now') text), distinct from the LWW
+   *  key below. Named artifact_updated_at cloud-side. */
+  updated_at: string;
+  removed_at: string | null;
+  pinned_at: number | null;
+  /** LWW key on the wire — the local sync_dirty_at (unix ms). Named
+   *  sync_version_at so the worker schema doesn't overload `updated_at`,
+   *  which artefacts already use at the domain level. */
+  sync_version_at: number;
+  device_id: string | null;
+  device_label: string | null;
+}
+
+export function createArtifactSyncService(deps: ArtifactSyncDeps): ArtifactSyncService {
+  let inFlightPush: Promise<number> | null = null;
+  const pushLog = createOfflineLogger("[artifacts] pushPending");
+
+  // Pending predicate mirrors session-sync's scanDirty, with one addition:
+  // rows with cloud_owner_id IS NULL are claimable by the current Pro user.
+  // The store stamps sync_dirty_at without knowing the owner (writes happen
+  // signed-out too); profileBinding guarantees only one account can ever
+  // sync from this profile, so claiming unowned rows is safe.
+  const scanDirty = deps.db.prepare(
+    `SELECT a.id, a.label, a.artifact_kind,
+            COALESCE(p.space_id, '') AS space_id,
+            a.project_id, a.group_name, a.source_origin,
+            a.created_at, a.updated_at, a.removed_at, a.pinned_at,
+            a.sync_dirty_at
+       FROM artifacts a LEFT JOIN projects p ON p.id = a.project_id
+      WHERE a.sync_dirty_at IS NOT NULL
+        AND (a.cloud_owner_id IS NULL OR a.cloud_owner_id = ?)
+        AND (a.cloud_synced_at IS NULL OR a.cloud_synced_at < a.sync_dirty_at)
+      ORDER BY a.sync_dirty_at ASC
+      LIMIT ?`,
+  );
+
+  // Ack also claims the row for the pushing owner. The owner guard refuses
+  // to flip a row that somehow belongs to a different account.
+  const markSyncedStmt = deps.db.prepare(
+    `UPDATE artifacts
+        SET cloud_synced_at = ?,
+            cloud_owner_id  = ?
+      WHERE id = ? AND (cloud_owner_id IS NULL OR cloud_owner_id = ?)`,
+  );
+
+  /** Same lazy device-identity read as session-sync: cache only on success
+   *  so a not-yet-seeded row retries instead of locking in null. */
+  let cachedDeviceIdentity: { device_id: string; label: string } | null = null;
+  function loadDeviceIdentity(): { device_id: string | null; label: string | null } {
+    if (cachedDeviceIdentity !== null) return cachedDeviceIdentity;
+    const row = deps.db.prepare(
+      `SELECT device_id, label FROM device_identity WHERE id = 1 LIMIT 1`,
+    ).get() as { device_id: string; label: string } | undefined;
+    if (row) {
+      cachedDeviceIdentity = row;
+      return row;
+    }
+    return { device_id: null, label: null };
+  }
+
+  async function doPushPending(): Promise<number> {
+    const session = isProSession(deps);
+    if (!session) return 0;
+
+    let totalAccepted = 0;
+    const MAX_BATCHES = 1000;  // defensive safety cap
+
+    const identity = loadDeviceIdentity();
+
+    for (let i = 0; i < MAX_BATCHES; i++) {
+      type PendingRow = Omit<OutgoingArtifact, "space_id" | "sync_version_at" | "device_id" | "device_label"> & {
+        space_id: string;
+        sync_dirty_at: number;
+      };
+      const pending = scanDirty.all(session.user.id, BATCH_SIZE) as PendingRow[];
+      if (pending.length === 0) break;
+
+      const stamped: OutgoingArtifact[] = pending.map(({ sync_dirty_at, ...row }) => ({
+        ...row,
+        space_id: row.space_id === "" ? null : row.space_id,
+        sync_version_at: sync_dirty_at,
+        device_id: identity.device_id,
+        device_label: identity.label,
+      }));
+
+      let res: Response;
+      try {
+        res = await deps.fetch(`${deps.workerBase}/api/artifacts/metadata`, {
+          method: "POST",
+          headers: { Cookie: `oyster_session=${session.token}`, "content-type": "application/json" },
+          body: JSON.stringify({ artifacts: stamped }),
+        });
+      } catch (err) {
+        pushLog.failure(err);
+        return totalAccepted;
+      }
+      if (!res.ok) {
+        console.warn(`[artifacts] pushPending non-ok ${res.status}`);
+        return totalAccepted;
+      }
+      pushLog.success();
+      const body = await res.json().catch(() => null) as { accepted?: string[] } | null;
+      const accepted = body?.accepted ?? [];
+
+      // Mark accepted rows synced (and claimed). A row dirtied again between
+      // scan and ack keeps sync_dirty_at > cloud_synced_at and re-pushes on
+      // the next drain — same race posture as session-sync.
+      const now = Date.now();
+      const tx = deps.db.transaction(() => {
+        for (const id of accepted) markSyncedStmt.run(now, session.user.id, id, session.user.id);
+      });
+      tx();
+      totalAccepted += accepted.length;
+
+      if (accepted.length > 1) {
+        console.log(`[artifacts] pushed: accepted=${accepted.length}`);
+      }
+      if (accepted.length === 0) break;
+    }
+
+    return totalAccepted;
+  }
+
+  return {
+    async pushPending() {
+      if (inFlightPush) return inFlightPush;
+      inFlightPush = doPushPending();
+      try {
+        return await inFlightPush;
+      } finally {
+        inFlightPush = null;
+      }
+    },
+  };
+}

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -660,8 +660,11 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
     .prepare("SELECT id, storage_config FROM artifacts WHERE removed_at IS NOT NULL AND storage_kind = 'filesystem'")
     .all() as Array<{ id: string; storage_config: string }>;
   if (tombstones.length > 0) {
+    // sync_dirty_at: an un-deleted row must reach the cloud mirror — without
+    // the stamp it stays invisible to artifact-sync (the promotion backfill
+    // above already ran this boot and skipped it as a tombstone).
     const update = db.prepare(
-      "UPDATE artifacts SET removed_at = NULL, storage_config = ?, project_id = ?, updated_at = datetime('now') WHERE id = ?",
+      "UPDATE artifacts SET removed_at = NULL, storage_config = ?, project_id = ?, updated_at = datetime('now'), sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000 WHERE id = ?",
     );
     for (const row of tombstones) {
       let oldPath: string | undefined;
@@ -729,7 +732,8 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
     UPDATE session_artifacts
        SET artifact_id = (SELECT winner_id FROM artefact_dedup_winners WHERE loser_id = session_artifacts.artifact_id)
      WHERE artifact_id IN (SELECT loser_id FROM artefact_dedup_winners);
-    UPDATE artifacts SET removed_at = datetime('now')
+    UPDATE artifacts SET removed_at = datetime('now'),
+           sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000
      WHERE id IN (SELECT loser_id FROM artefact_dedup_winners);
     DROP TABLE artefact_dedup_winners;
   `);

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -133,6 +133,30 @@ export function initDb(dbDir: string, oysterHome: string = dbDir): Database.Data
   // the user pinned the artefact, used to sort most-recently-pinned first.
   try { db.exec("ALTER TABLE artifacts ADD COLUMN pinned_at INTEGER"); } catch { /* already exists */ }
 
+  // Cloud mirror of the artefact registry — metadata only, no file content.
+  // Same dirty-tracking trio as sessions: the store stamps sync_dirty_at on
+  // every mutation; artifact-sync-service drains pending rows to D1 and
+  // records cloud_synced_at + cloud_owner_id on ack.
+  for (const sql of [
+    "ALTER TABLE artifacts ADD COLUMN sync_dirty_at INTEGER",
+    "ALTER TABLE artifacts ADD COLUMN cloud_synced_at INTEGER",
+    "ALTER TABLE artifacts ADD COLUMN cloud_owner_id TEXT",
+  ]) {
+    try { db.exec(sql); } catch { /* already exists */ }
+  }
+  // Promotion backfill, mirroring the spaces one above: rows that pre-date
+  // these columns (or were created on the free tier) get marked dirty exactly
+  // once so the whole registry reaches the cloud on first Pro sign-in.
+  // Tombstones (removed_at) are excluded — the cloud never knew them, so
+  // there's nothing to propagate.
+  db.exec(`
+    UPDATE artifacts
+       SET sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000
+     WHERE sync_dirty_at IS NULL
+       AND cloud_synced_at IS NULL
+       AND removed_at IS NULL
+  `);
+
   // Profile binding (#318). Locks this local Oyster profile to one cloud
   // account on first Pro sign-in, preventing a second Pro user from pulling
   // their cloud data into the wrong local SQLite via cross-device sync.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,6 +42,7 @@ import { createPublishService, PublishError } from "./publish-service.js";
 import { createSpaceSyncService } from "./space-sync-service.js";
 import { createMemorySyncService, type MemorySyncService } from "./memory-sync-service.js";
 import { createSessionSyncService, encodeCwd, projectsRoot, type SessionSyncService } from "./session-sync-service.js";
+import { createArtifactSyncService, type ArtifactSyncService } from "./artifact-sync-service.js";
 import { createProfileBindingService } from "./profile-binding-service.js";
 import { hashPassword } from "./password-hash.js";
 import { tryHandleOAuthMcpRoute } from "./routes/oauth-mcp.js";
@@ -478,6 +479,22 @@ const sessionSync: SessionSyncService = createSessionSyncService({
   fetch: globalThis.fetch,
 });
 
+// Artefact registry mirror — metadata-only push so the cloud remote view's
+// Artefacts tab can list what exists (no file content, no publication
+// state). The store stamps sync_dirty_at on every mutation; the 30s poll
+// tick below + syncOnAuth drain pending rows.
+const artifactSync: ArtifactSyncService = createArtifactSyncService({
+  db,
+  profileBinding,
+  currentUser: () => {
+    const u = authService.getState().user;
+    return u ? { id: u.id, email: u.email, tier: u.tier } : null;
+  },
+  sessionToken: () => authService.getState().sessionToken,
+  workerBase: CLOUD_WORKER_BASE,
+  fetch: globalThis.fetch,
+});
+
 // Periodic pull. Pull-only triggers (auth-changed and app-startup) leave a
 // running server stale until the next reconcile event. A modest 30s tick
 // keeps cross-device memory updates fresh without burning excessive
@@ -506,6 +523,17 @@ const memoryPollHandle = setInterval(() => {
     }
   }).catch((err) => {
     console.warn("[sessions] periodic pull failed:", err);
+  });
+  // Artefact registry push on the same tick. Store mutations only stamp
+  // sync_dirty_at (no push trigger of their own), so this drain is what
+  // bounds cloud staleness — ≤30s from mutation to remote view. No-op (one
+  // SQL query, zero HTTP) when nothing is dirty.
+  artifactSync.pushPending().then((pushed) => {
+    if (pushed > 0) {
+      console.log(`[artifacts] periodic push: accepted=${pushed}`);
+    }
+  }).catch((err) => {
+    console.warn("[artifacts] periodic push failed:", err);
   });
 }, MEMORY_POLL_INTERVAL_MS);
 memoryPollHandle.unref();
@@ -651,6 +679,14 @@ async function syncOnAuth(label: string): Promise<void> {
       }
     } catch (err) {
       console.warn(`[sessions] ${label} reconcile failed:`, err);
+    }
+    try {
+      const artPushed = await artifactSync.pushPending();
+      if (artPushed > 0) {
+        console.log(`[artifacts] push (${label}): accepted=${artPushed}`);
+      }
+    } catch (err) {
+      console.warn(`[artifacts] ${label} push failed:`, err);
     }
   }
   // Then publications (preserves existing behaviour: clears ghost cache on

--- a/server/src/project-service.ts
+++ b/server/src/project-service.ts
@@ -343,8 +343,10 @@ export class ProjectService {
       const sessions = this.db
         .prepare("UPDATE sessions SET project_id = ?, space_id = ? WHERE project_id = ?")
         .run(into.id, into.space_id, args.fromId);
+      // sync_dirty_at: rebinding changes the derived space_id the cloud
+      // mirror scopes by — re-push the moved rows.
       const artefacts = this.db
-        .prepare("UPDATE artifacts SET project_id = ? WHERE project_id = ?")
+        .prepare("UPDATE artifacts SET project_id = ?, sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000 WHERE project_id = ?")
         .run(into.id, args.fromId);
       // De-dup PK conflicts (same path cached against both projects) by
       // dropping the loser's row before the bulk update.
@@ -390,7 +392,8 @@ export class ProjectService {
         .run(projectId);
       if (info.changes === 0) throw new Error(`Project "${projectId}" not found`);
       this.db.prepare("UPDATE sessions SET project_id = NULL WHERE project_id = ?").run(projectId);
-      this.db.prepare("UPDATE artifacts SET project_id = NULL WHERE project_id = ?").run(projectId);
+      // sync_dirty_at: demoted orphans lose their derived space_id — re-push.
+      this.db.prepare("UPDATE artifacts SET project_id = NULL, sync_dirty_at = CAST(strftime('%s','now') AS INTEGER) * 1000 WHERE project_id = ?").run(projectId);
     });
     tx();
   }

--- a/server/test/artifact-service.test.ts
+++ b/server/test/artifact-service.test.ts
@@ -29,7 +29,10 @@ function makeDb(): Database.Database {
       published_at         INTEGER,
       share_updated_at     INTEGER,
       unpublished_at       INTEGER,
-      pinned_at            INTEGER
+      pinned_at            INTEGER,
+      sync_dirty_at        INTEGER,
+      cloud_synced_at      INTEGER,
+      cloud_owner_id       TEXT
     );
     CREATE TABLE projects (
       id       TEXT PRIMARY KEY,

--- a/server/test/artifact-space-migration.test.ts
+++ b/server/test/artifact-space-migration.test.ts
@@ -118,7 +118,7 @@ describe("backfillArtifactProjects", () => {
         id TEXT PRIMARY KEY, project_id TEXT,
         label TEXT, artifact_kind TEXT, storage_kind TEXT,
         storage_config TEXT, runtime_kind TEXT, runtime_config TEXT,
-        source_ref TEXT, removed_at TEXT
+        source_ref TEXT, removed_at TEXT, sync_dirty_at INTEGER
       );
     `);
     mem.exec(`INSERT INTO spaces (id,display_name,color,scan_status) VALUES ('w','W','#000','none')`);
@@ -165,7 +165,7 @@ describe("backfillArtifactProjects", () => {
         id TEXT PRIMARY KEY, space_id TEXT NOT NULL, project_id TEXT,
         label TEXT, artifact_kind TEXT, storage_kind TEXT,
         storage_config TEXT, runtime_kind TEXT, runtime_config TEXT,
-        source_ref TEXT, removed_at TEXT
+        source_ref TEXT, removed_at TEXT, sync_dirty_at INTEGER
       );
     `);
     mem.exec(`INSERT INTO spaces (id,display_name,color,scan_status) VALUES ('work','Work','#000','none'),('home','Home','#111','none')`);

--- a/server/test/artifact-sync-service.test.ts
+++ b/server/test/artifact-sync-service.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi } from "vitest";
+import Database from "better-sqlite3";
+import { createArtifactSyncService } from "../src/artifact-sync-service.js";
+import { createProfileBindingService } from "../src/profile-binding-service.js";
+
+// Minimal DB harness: just the columns ArtifactSyncService reads from
+// artifacts (+ projects for the derived space_id, profile_binding for the
+// gate, device_identity for stamping). Mirrors session-sync-service.test.ts.
+function harness() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE artifacts (
+      id              TEXT PRIMARY KEY,
+      label           TEXT NOT NULL,
+      artifact_kind   TEXT NOT NULL,
+      group_name      TEXT,
+      removed_at      TEXT,
+      source_origin   TEXT NOT NULL DEFAULT 'manual',
+      project_id      TEXT,
+      created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      pinned_at       INTEGER,
+      sync_dirty_at   INTEGER,
+      cloud_synced_at INTEGER,
+      cloud_owner_id  TEXT
+    );
+    CREATE TABLE projects (
+      id       TEXT PRIMARY KEY,
+      space_id TEXT
+    );
+    CREATE TABLE profile_binding (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      cloud_owner_id TEXT NOT NULL,
+      bound_at INTEGER NOT NULL
+    );
+    CREATE TABLE device_identity (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      device_id TEXT NOT NULL,
+      label TEXT NOT NULL
+    );
+  `);
+  const profileBinding = createProfileBindingService({ db });
+  return { db, profileBinding };
+}
+
+function makeService(
+  h: ReturnType<typeof harness>,
+  fetchImpl: typeof fetch,
+  user: { id: string; email: string; tier: string } | null = { id: "user-A", email: "a@a", tier: "pro" },
+) {
+  return createArtifactSyncService({
+    db: h.db,
+    profileBinding: h.profileBinding,
+    currentUser: () => user,
+    sessionToken: () => (user ? "tok" : null),
+    workerBase: "https://example.com",
+    fetch: fetchImpl,
+  });
+}
+
+function insertDirtyArtifact(
+  db: Database.Database,
+  id: string,
+  dirtyAt = Date.now(),
+  overrides: Record<string, unknown> = {},
+) {
+  db.prepare(
+    `INSERT INTO artifacts (id, label, artifact_kind, sync_dirty_at, project_id, removed_at, cloud_owner_id, cloud_synced_at)
+     VALUES (@id, @label, @kind, @dirty, @project_id, @removed_at, @cloud_owner_id, @cloud_synced_at)`,
+  ).run({
+    id,
+    label: `Artefact ${id}`,
+    kind: "notes",
+    dirty: dirtyAt,
+    project_id: null,
+    removed_at: null,
+    cloud_owner_id: null,
+    cloud_synced_at: null,
+    ...overrides,
+  });
+}
+
+function okAccepting(ids: () => string[]) {
+  return vi.fn(async (_url: string | URL, init?: RequestInit) => {
+    void init;
+    return new Response(JSON.stringify({ accepted: ids() }), { status: 200 });
+  });
+}
+
+describe("ArtifactSyncService", () => {
+  it("pushPending is a no-op for free users", async () => {
+    const h = harness();
+    insertDirtyArtifact(h.db, "a1");
+    const fetchSpy = vi.fn();
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch, { id: "u1", email: "x@x", tier: "free" });
+    expect(await svc.pushPending()).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("pushPending is a no-op when profile is bound to a different account", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "a1");
+    const fetchSpy = vi.fn();
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch, { id: "user-B", email: "b@b", tier: "pro" });
+    expect(await svc.pushPending()).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("pushes dirty rows with the wire shape: sync_version_at, derived space_id, device stamp", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    h.db.prepare(`INSERT INTO device_identity (id, device_id, label) VALUES (1, ?, ?)`)
+      .run("dev-uuid", "MacBook-Pro");
+    h.db.prepare(`INSERT INTO projects (id, space_id) VALUES ('prj-1', 'spc-1')`).run();
+    insertDirtyArtifact(h.db, "a1", 1234, { project_id: "prj-1" });
+    insertDirtyArtifact(h.db, "a2", 1235);  // unfiled → space_id null on the wire
+
+    let capturedBody: string | null = null;
+    const fetchSpy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({ accepted: ["a1", "a2"] }), { status: 200 });
+    });
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+    expect(await svc.pushPending()).toBe(2);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://example.com/api/artifacts/metadata",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(capturedBody ?? "{}") as {
+      artifacts: Array<Record<string, unknown>>;
+    };
+    expect(body.artifacts).toHaveLength(2);
+    const a1 = body.artifacts.find((a) => a.id === "a1")!;
+    expect(a1.sync_version_at).toBe(1234);
+    expect(a1.space_id).toBe("spc-1");
+    expect(a1.device_id).toBe("dev-uuid");
+    expect(a1.device_label).toBe("MacBook-Pro");
+    expect(a1).not.toHaveProperty("sync_dirty_at");
+    const a2 = body.artifacts.find((a) => a.id === "a2")!;
+    expect(a2.space_id).toBeNull();
+  });
+
+  it("marks accepted rows synced + claimed; they don't re-push", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "a1", 1000);
+    const fetchSpy = okAccepting(() => ["a1"]);
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+
+    expect(await svc.pushPending()).toBe(1);
+    const row = h.db.prepare(
+      "SELECT cloud_synced_at, cloud_owner_id FROM artifacts WHERE id='a1'",
+    ).get() as { cloud_synced_at: number; cloud_owner_id: string };
+    expect(row.cloud_synced_at).toBeGreaterThan(0);
+    expect(row.cloud_owner_id).toBe("user-A");
+
+    // Second drain: nothing pending, no HTTP.
+    fetchSpy.mockClear();
+    expect(await svc.pushPending()).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("a row dirtied again after ack re-pushes on the next drain", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "a1", 1000);
+    const fetchSpy = okAccepting(() => ["a1"]);
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+    await svc.pushPending();
+
+    // Mutation after the ack: sync_dirty_at moves one ms past cloud_synced_at.
+    const synced = h.db.prepare("SELECT cloud_synced_at FROM artifacts WHERE id = 'a1'")
+      .get() as { cloud_synced_at: number };
+    h.db.prepare("UPDATE artifacts SET sync_dirty_at = ? WHERE id = 'a1'").run(synced.cloud_synced_at + 1);
+    // Let the wall clock pass the new dirty mark so the next ack clears it
+    // in one batch (same-ms acks self-heal a tick later in production).
+    await new Promise((r) => setTimeout(r, 5));
+    fetchSpy.mockClear();
+    expect(await svc.pushPending()).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const after = h.db.prepare("SELECT cloud_synced_at FROM artifacts WHERE id = 'a1'")
+      .get() as { cloud_synced_at: number };
+    expect(after.cloud_synced_at).toBeGreaterThan(synced.cloud_synced_at);
+  });
+
+  it("pushes tombstones (removed_at set) so deletions propagate", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "a1", 1000, { removed_at: "2026-06-06 10:00:00" });
+
+    let capturedBody: string | null = null;
+    const fetchSpy = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({ accepted: ["a1"] }), { status: 200 });
+    });
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+    expect(await svc.pushPending()).toBe(1);
+    const body = JSON.parse(capturedBody ?? "{}") as { artifacts: Array<Record<string, unknown>> };
+    expect(body.artifacts[0]!.removed_at).toBe("2026-06-06 10:00:00");
+  });
+
+  it("does not push rows owned by a different account", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "theirs", 1000, { cloud_owner_id: "user-B" });
+    const fetchSpy = vi.fn();
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+    expect(await svc.pushPending()).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("stops draining when the server accepts nothing (no hot loop)", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "a1");
+    const fetchSpy = okAccepting(() => []);
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+    expect(await svc.pushPending()).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("network failure returns what was accepted so far without throwing", async () => {
+    const h = harness();
+    h.profileBinding.bindToOwner("user-A");
+    insertDirtyArtifact(h.db, "a1");
+    const fetchSpy = vi.fn(async () => { throw new Error("offline"); });
+    const svc = makeService(h, fetchSpy as unknown as typeof fetch);
+    await expect(svc.pushPending()).resolves.toBe(0);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -60,6 +60,11 @@ export interface Artifact {
   pinnedAt?: number | null;
   /** Filesystem path of the backing file (filesystem artefacts only). */
   path?: string;
+  /** Cloud remote view only: human label of the device whose registry this
+   *  row was synced from (e.g. "MacBook-Pro"). Drives the "on <device>"
+   *  chip — the artefact's content lives on that machine, not in the cloud.
+   *  Never set in local builds. */
+  originDeviceLabel?: string | null;
 }
 
 export interface ArtefactPublication {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -495,10 +495,12 @@ export default function App() {
   async function handleArtifactClick(artifact: Artifact) {
     if (artifact.status === "generating") return;
 
-    // Cloud mode: every artefact row is a publication; clicking opens the
-    // public share page in a new tab (no local viewer / dev server).
+    // Cloud mode: the only openable artefacts are published ones (url =
+    // public share page). Synced registry rows carry no url — their content
+    // lives on the origin device, so the click is a no-op (the row's
+    // "on <device>" chip explains why).
     if (caps.cloud) {
-      window.open(artifact.url, "_blank", "noopener");
+      if (artifact.url) window.open(artifact.url, "_blank", "noopener");
       return;
     }
 

--- a/web/src/components/Home/ArtefactTable.tsx
+++ b/web/src/components/Home/ArtefactTable.tsx
@@ -63,6 +63,11 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
 
   const isPublished = ctx?.artifact.publication?.unpublishedAt === null;
   const isCloudOnly = !!ctx?.artifact.cloudOnly;
+  // In the cloud build, published registry rows need the same token-routed
+  // actions as cloud-only ghosts — the by-id routes in the other branch only
+  // exist on the local server. (Unpublished cloud rows never open this menu;
+  // see hasCloudMenu at the row.)
+  const cloudShareActions = isCloudOnly || (caps.cloud && isPublished);
 
   return (
     <div className="home-table-wrap">
@@ -75,18 +80,25 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
         </div>
         {sorted.map((art) => {
           const space = spaces.find((s) => s.id === art.spaceId);
+          // Cloud registry rows without a publication aren't openable — the
+          // content lives on the origin device. Render them inert (no button
+          // semantics, no pointer) and skip the context menu, whose actions
+          // (pin, publish) all need the local server.
+          const inert = caps.cloud && !art.url;
+          const hasCloudMenu = !caps.cloud || art.publication?.unpublishedAt === null;
           return (
             <div
               key={art.id}
-              className="home-artefact-row"
-              role="button"
-              tabIndex={0}
-              onClick={() => onArtifactClick(art)}
+              className={`home-artefact-row${inert ? " home-artefact-row--inert" : ""}`}
+              role={inert ? undefined : "button"}
+              tabIndex={inert ? undefined : 0}
+              onClick={inert ? undefined : () => onArtifactClick(art)}
               onContextMenu={(e) => {
                 e.preventDefault();
+                if (!hasCloudMenu) return;
                 setCtx({ artifact: art, x: e.clientX, y: e.clientY });
               }}
-              onKeyDown={(e) => {
+              onKeyDown={inert ? undefined : (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   onArtifactClick(art);
@@ -97,6 +109,14 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
                 {art.label}
                 {art.publication?.unpublishedAt === null && (
                   <PublishedChip publication={art.publication} cloudOnly={art.cloudOnly} />
+                )}
+                {caps.cloud && art.originDeviceLabel && (
+                  <span
+                    className="home-remote-chip"
+                    title={`Lives on ${art.originDeviceLabel} — open Oyster there to work with it`}
+                  >
+                    <span aria-hidden="true">⌂</span> {art.originDeviceLabel}
+                  </span>
                 )}
               </span>
               <span className="home-artefact-row-space">
@@ -115,10 +135,11 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
           className="space-ctx-menu"
           style={{ left: ctx.x, top: ctx.y, transform: "translateY(-100%)", marginTop: -8 }}
         >
-          {/* Cloud-only ghosts: Rename, Publish settings, Unpublish. All go
-              through metadata-only routes — no bytes required. Pin needs a
-              local row, so it's skipped. */}
-          {isCloudOnly && isPublished && (
+          {/* Cloud-only ghosts + published rows in the cloud build: Rename,
+              Publish settings, Unpublish. All go through token-routed
+              metadata-only routes — no bytes required. Pin needs a local
+              row, so it's skipped. */}
+          {cloudShareActions && isPublished && (
             <>
               <button
                 className="space-ctx-item"
@@ -156,7 +177,7 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
             </>
           )}
 
-          {!isCloudOnly && (
+          {!cloudShareActions && (
             <>
               {caps.canWrite && (
                 ctx.artifact.pinnedAt != null ? (

--- a/web/src/components/Home/ArtefactTable.tsx
+++ b/web/src/components/Home/ArtefactTable.tsx
@@ -94,8 +94,10 @@ export function ArtefactTable({ artifacts, spaces, onArtifactClick, onArtifactPu
               tabIndex={inert ? undefined : 0}
               onClick={inert ? undefined : () => onArtifactClick(art)}
               onContextMenu={(e) => {
-                e.preventDefault();
+                // No app menu for inert cloud rows — leave the browser's
+                // default context menu alone rather than eating the event.
                 if (!hasCloudMenu) return;
+                e.preventDefault();
                 setCtx({ artifact: art, x: e.clientX, y: e.clientY });
               }}
               onKeyDown={inert ? undefined : (e) => {

--- a/web/src/components/Home/Home.css
+++ b/web/src/components/Home/Home.css
@@ -691,6 +691,10 @@
   background: rgba(124, 107, 255, 0.05);
 }
 .home-artefact-row:last-child { border-bottom: none; }
+/* Cloud registry rows without a publication aren't openable — content lives
+   on the origin device. No pointer, no hover invite. */
+.home-artefact-row--inert { cursor: default; }
+.home-artefact-row--inert:hover { background: transparent; }
 
 /* Column-header row for the artefacts table (mirrors .home-row--header on the
    sessions table). Reuses .home-artefact-row's grid; just restyles + disables

--- a/web/src/components/PublishModal.tsx
+++ b/web/src/components/PublishModal.tsx
@@ -6,6 +6,7 @@ import { Link2 } from "lucide-react";
 import type { Artifact, ArtefactPublication } from "../../../shared/types";
 import { publishArtifact, unpublishArtifact, unpublishCloudShare, updateCloudShare, PublishApiError } from "../data/publish-api";
 import { apiPath } from "../data/http";
+import { caps } from "../caps";
 import { useCopyLink } from "../hooks/useCopyLink";
 import { ConfirmModal } from "./ConfirmModal";
 import { subscribeUiEvents } from "../data/ui-events";
@@ -182,10 +183,12 @@ export function PublishModal({ artifact, onClose }: Props) {
     setPhase("publishing");
     setError(null);
     try {
-      // Cloud-only artefact: update mode/password without re-uploading bytes
-      // (the bytes live in R2 and we don't have them locally). Otherwise
-      // the normal full re-publish path runs (legacy behaviour).
-      const result = artifact.cloudOnly && publication
+      // Token-routed update (mode/password change without re-uploading
+      // bytes) for cloud-only ghosts AND the cloud build generally — the
+      // by-id publish routes only exist on the local server, and synced
+      // registry rows there aren't cloudOnly. Otherwise the normal full
+      // re-publish path runs (legacy behaviour).
+      const result = (artifact.cloudOnly || caps.cloud) && publication
         ? await updateCloudShare(publication.shareToken, mode, mode === "password" ? password : undefined)
         : await publishArtifact(artifact.id, mode, mode === "password" ? password : undefined);
       setOptimisticPublication({
@@ -211,7 +214,8 @@ export function PublishModal({ artifact, onClose }: Props) {
     setPhase("unpublishing");
     setError(null);
     try {
-      if (artifact.cloudOnly && publication) {
+      // Same routing rule as handleSave: token routes in the cloud build.
+      if ((artifact.cloudOnly || caps.cloud) && publication) {
         await unpublishCloudShare(publication.shareToken);
       } else {
         await unpublishArtifact(artifact.id);

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -3,11 +3,31 @@ import type { Artifact, SessionJoinedForArtifact } from "../../../shared/types";
 import { getJson, patchJson, postJson, postEmpty, del, apiPath } from "./http";
 import { caps } from "../caps";
 import { fetchCloudPublications } from "./cloud-publications";
+import { fetchCloudArtifacts } from "./cloud-artifacts";
 
 export async function fetchArtifacts(signal?: AbortSignal): Promise<Artifact[]> {
-  // Cloud Artefacts tab = your publications (apex publish worker), not the
-  // local artefact registry.
-  if (caps.cloud) return fetchCloudPublications(signal);
+  // Cloud Artefacts tab = the synced registry, plus orphan live publications
+  // as fallback. Publications are joined onto registry rows by artifact_id
+  // ONLY to mark which are openable (url = shareUrl) and keep the published
+  // pill working — publication state itself is never synced or duplicated;
+  // the publish worker stays authoritative. A publication whose registry row
+  // never synced (or was deleted locally) still appears as its own row,
+  // preserving the pre-registry behaviour.
+  if (caps.cloud) {
+    const [registry, publications] = await Promise.all([
+      fetchCloudArtifacts(signal),
+      fetchCloudPublications(signal),
+    ]);
+    const pubById = new Map(publications.map((p) => [p.id, p]));
+    const merged = registry.map((a) => {
+      const pub = pubById.get(a.id);
+      if (!pub) return a;
+      pubById.delete(a.id);
+      return { ...a, url: pub.url, status: pub.status, publication: pub.publication };
+    });
+    // Orphans: live publications with no surviving registry row.
+    return [...merged, ...pubById.values()];
+  }
   return getJson<Artifact[]>(apiPath("/api/artifacts"), signal);
 }
 

--- a/web/src/data/cloud-artifacts.ts
+++ b/web/src/data/cloud-artifacts.ts
@@ -1,0 +1,55 @@
+// cloud-artifacts.ts — the synced artefact REGISTRY for the cloud Artefacts
+// tab (worker GET /api/artifacts/metadata). Rows prove an artefact exists
+// and on which device; content stays on that machine, so url is empty and
+// the row renders inert unless a live publication is joined onto it
+// (artifacts-api.ts does the join — publish worker stays authoritative for
+// what's openable).
+import type { Artifact, ArtifactKind } from "../../../shared/types";
+import { getJson, apiPath } from "./http";
+
+interface CloudArtifactRow {
+  artifact_id: string;
+  device_id: string | null;
+  device_label: string | null;
+  label: string;
+  artifact_kind: string;
+  space_id: string | null;
+  project_id: string | null;
+  group_name: string | null;
+  source_origin: string;
+  created_at: string;
+  artifact_updated_at: string | null;
+  pinned_at: number | null;
+  sync_version_at: number;
+}
+
+function toArtifact(r: CloudArtifactRow): Artifact {
+  return {
+    id: r.artifact_id,
+    label: r.label,
+    // Coerce like cloud-publications.ts: unknown kinds render the default
+    // glyph, which is fine for a read-only listing.
+    artifactKind: r.artifact_kind as ArtifactKind,
+    spaceId: r.space_id ?? "",
+    // Content lives on the origin device — there's nothing to open here
+    // until artifacts-api.ts joins a live publication on.
+    status: "offline",
+    runtimeKind: "",
+    runtimeConfig: {},
+    url: "",
+    createdAt: r.created_at,
+    groupName: r.group_name ?? undefined,
+    sourceOrigin: (["manual", "discovered", "ai_generated"] as const)
+      .find((v) => v === r.source_origin) ?? "manual",
+    projectId: r.project_id,
+    pinnedAt: r.pinned_at,
+    originDeviceLabel: r.device_label,
+  };
+}
+
+export async function fetchCloudArtifacts(signal?: AbortSignal): Promise<Artifact[]> {
+  const data = await getJson<{ artifacts: CloudArtifactRow[] }>(
+    apiPath("/api/artifacts/metadata"), signal,
+  );
+  return (data.artifacts ?? []).map(toArtifact);
+}


### PR DESCRIPTION
## Problem

The cloud Artefacts tab at app.oyster.to showed only publications — your screenshot's "Artefacts 0 / This space is empty" despite a full local registry. The remote view pretended the registry didn't exist.

## What this does

**Cloud artefacts list = registry rows, plus orphan live publications as fallback.** Registry-only scope, per review:

- **No file sync.** Rows prove an artefact *exists* and on which device — content stays local. Unpublished rows render inert (no pointer, no click) with a `⌂ on <device>` chip.
- **No publication-state duplication.** The publish worker stays authoritative; the client joins `/api/publish/mine` by `artifact_id` purely to mark which rows are openable (`url = shareUrl`) and keep the published pill working.
- **No session↔artefact joins, no memory attribution** — deferred per the agreed cut.

## How

- **Local server** — sessions-style dirty trio on `artifacts` (`sync_dirty_at` stamped at the store's write chokepoints; `cloud_synced_at`/`cloud_owner_id` on ack), spaces-style promotion backfill in `db.ts` so pre-existing registries reach the cloud on first Pro sign-in, new `artifact-sync-service.ts` cloned from `session-sync-service.ts`'s metadata path, drained on the 30s poll tick + `syncOnAuth`.
- **Worker** — migration `0014_synced_artifacts.sql` with LWW key **`sync_version_at`** (deliberately not `updated_at` — artefacts already carry a domain-level `updated_at`, stored as `artifact_updated_at`). `POST /api/artifacts/metadata` **accepts tombstones** (`removed_at` set) so deletions propagate; `GET` filters them. Pro-gated both directions.
- **Web** — `cloud-artifacts.ts` adapter + merge in `artifacts-api.ts`; ArtefactTable device chip, inert unpublished rows, and token-routed share actions for published rows in cloud (the by-id publish routes only exist on the local server).

## Tests (the agreed risk points)

- free/non-Pro can neither POST nor GET artefact metadata ✅
- tombstones accepted on POST, absent from GET ✅
- stale `sync_version_at` does not overwrite a newer cloud row ✅
- malformed rows rejected individually without poisoning the batch ✅
- server side: pro/profile-binding gates, wire shape (`sync_version_at`, derived `space_id`, device stamp), ack/claim, re-dirty re-push, owner mismatch, no hot loop, offline tolerance ✅

`server`: 636/636 · `oyster-cloud`: 114/114 + typecheck · web `build` + `build:cloud` green · eslint clean on changed files.

## Deploy

Needs `wrangler d1 migrations apply oyster-auth --remote` (additive CREATE TABLE only) **before** `wrangler deploy` of oyster-cloud. Old servers ignore the new endpoints; new GETs return empty until rows arrive — safe both ways. Commands to be confirmed at the deploy pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)