### PR TITLE
arcade(groovebox): mobile-friendly UI — accordion lanes, touch knobs, edge-to-edge

### DIFF
--- a/docs/arcade/groovebox/phone.html
+++ b/docs/arcade/groovebox/phone.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Groovebox — phone preview</title>
+<style>
+  body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; gap: 24px; background: #14161c; font: 12px system-ui; color: #8a90a0; }
+  .frame { display: flex; flex-direction: column; gap: 6px; align-items: center; }
+  iframe { width: 390px; height: 780px; border: 6px solid #2a2e3a; border-radius: 28px; background: #000; }
+</style></head>
+<body>
+  <div class="frame"><iframe src="./index.html" title="Groovebox phone preview"></iframe><span>390 × 780 — prototype preview (use the PROTO chips bottom-right of the frame)</span></div>
+</body></html>

--- a/docs/arcade/groovebox/phone.html
+++ b/docs/arcade/groovebox/phone.html
@@ -6,5 +6,5 @@
   iframe { width: min(390px, 100vw - 12px); height: min(780px, 100vh - 40px); border: 6px solid #2a2e3a; border-radius: 28px; background: #000; }
 </style></head>
 <body>
-  <div class="frame"><iframe src="./index.html" title="Groovebox phone preview"></iframe><span>390 × 780 — prototype preview (use the PROTO chips bottom-right of the frame)</span></div>
+  <div class="frame"><iframe src="./index.html" title="Groovebox phone preview"></iframe><span>390 × 780 — mobile layout preview</span></div>
 </body></html>

--- a/docs/arcade/groovebox/phone.html
+++ b/docs/arcade/groovebox/phone.html
@@ -3,7 +3,7 @@
 <style>
   body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; gap: 24px; background: #14161c; font: 12px system-ui; color: #8a90a0; }
   .frame { display: flex; flex-direction: column; gap: 6px; align-items: center; }
-  iframe { width: 390px; height: 780px; border: 6px solid #2a2e3a; border-radius: 28px; background: #000; }
+  iframe { width: min(390px, 100vw - 12px); height: min(780px, 100vh - 40px); border: 6px solid #2a2e3a; border-radius: 28px; background: #000; }
 </style></head>
 <body>
   <div class="frame"><iframe src="./index.html" title="Groovebox phone preview"></iframe><span>390 × 780 — prototype preview (use the PROTO chips bottom-right of the frame)</span></div>

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -768,14 +768,14 @@ input[type=range] {
   text-transform: uppercase;
 }
 
-/* persistent numeric readout under the label — opt-in via body.gbm-knobval */
+/* persistent numeric readout under the label — opt-in via body.gb-knobval */
 .knob-val {
   display: none;
   font: 500 9px ui-monospace, Menlo, monospace;
   color: var(--dim);
   line-height: 1;
 }
-body.gbm-knobval .knob-val { display: block; }
+body.gb-knobval .knob-val { display: block; }
 
 /* floating value bubble while dragging a knob (fixed → escapes overflow clips) */
 .knob-bubble {
@@ -2139,7 +2139,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
    body.gbm-strip     — knobs in one horizontally swipeable row (default)
    body.gbm-wrap      — knobs wrap onto extra rows
    body.gbm-accordion — knobs hidden; tap a lane header to expand one at a time
-   body.gbm-knobval   — persistent numeric readout under every knob (any width)
+   body.gb-knobval    — persistent numeric readout (global Display setting, default off)
 */
 @media (max-width: 760px) {
   /* ── reclaim chrome: edge-to-edge — cabinet flattens into the page ── */
@@ -2219,13 +2219,52 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   /* ── variant: WRAP — knobs wrap onto extra rows ────────────────────────── */
   body.gbm-wrap .knobrow { flex-wrap: wrap; row-gap: 10px; }
 
-  /* ── variant: ACCORDION — tap lane header to expand ────────────────────── */
+  /* ── variant: ACCORDION — tap lane header (or chevron) to expand ───────── */
+  body.gbm-accordion .lane {
+    grid-template-columns: 16px 1fr auto auto auto;
+    grid-template-areas:
+      "drag  name  ms    actions chev"
+      "mctl  mctl  mctl  mctl    lvl"
+      "knobs knobs knobs knobs   knobs";
+    cursor: pointer;
+  }
   body.gbm-accordion .lane .knobrow { display: none; }
-  body.gbm-accordion .lane.open .knobrow { display: flex; }
-  body.gbm-accordion .lane .name { cursor: pointer; }
-  body.gbm-accordion .lane .name::after { content: " ▾"; color: var(--faint); }
-  body.gbm-accordion .lane.open .name::after { content: " ▴"; }
+  body.gbm-accordion .lane.open .knobrow {
+    display: flex;
+    animation: gbm-expand 0.16s ease;
+  }
+  /* disclosure chevron — the accordion affordance */
+  body.gbm-accordion .lane-expand {
+    display: inline-flex;
+    grid-area: chev;
+  }
+  body.gbm-accordion .lane.open {
+    border-color: var(--acc-dim);
+  }
+  body.gbm-accordion .lane.open .lane-expand {
+    transform: rotate(180deg);
+    color: var(--acc);
+    border-color: var(--acc-dim);
+  }
   /* master knobs always visible — accordion only applies to lanes */
+}
+
+@keyframes gbm-expand {
+  from { opacity: 0; transform: translateY(-4px); }
+}
+
+/* chevron button: hidden everywhere except mobile accordion mode */
+.lane-expand {
+  display: none;
+  width: 26px; height: 26px; padding: 0;
+  align-items: center; justify-content: center;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--dim);
+  font-size: 12px;
+  line-height: 1;
+  transition: transform 0.18s ease, color 0.12s, border-color 0.12s;
 }
 
 /* ─── PROTO variant switcher (prototype-only chrome) ───────────────────────── */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2155,11 +2155,23 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .titlebar { margin-bottom: 8px; }
   h1 { font-size: 13px; letter-spacing: 0.1em; white-space: nowrap; }
 
-  /* ── transport wraps; tempo + song get full rows ── */
-  .transport { flex-wrap: wrap; row-gap: 8px; }
-  .transport-tempo { flex: 1 1 auto; min-width: 0; }
+  /* ── transport: explicit grid — play+key / tempo / song, no orphan rows ── */
+  .transport {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "play  key"
+      "tempo tempo"
+      "song  song";
+    row-gap: 10px;
+    column-gap: 10px;
+  }
+  .transport-divider { display: none; }
+  #play { grid-area: play; height: 38px; font-size: 14px; }
+  .transport-key { grid-area: key; display: flex; align-items: center; gap: 8px; }
+  .transport-tempo { grid-area: tempo; min-width: 0; }
   #bpm { flex: 1; min-width: 50px; }
-  .transport-song { margin-left: 0; flex: 1 1 100%; }
+  .transport-song { grid-area: song; margin-left: 0; min-width: 0; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }
 

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -657,8 +657,8 @@ input[type=range] {
 /* ─── § 5 — lane strips: aligned shared grid ────────────────────────────── */
 .lane {
   display: grid;
-  /* drag | name | pattern-select | meter | MIX | TONE | FX | M/S | actions */
-  grid-template-columns: 16px 64px minmax(150px,220px) 10px auto auto auto 56px auto;
+  /* drag | name | pattern-select | meter | knobs (MIX·TONE·FX) | M/S | actions */
+  grid-template-columns: 16px 64px minmax(150px,220px) 10px auto 56px auto;
   column-gap: 12px;
   align-items: center;
   background: var(--panel-2);
@@ -721,6 +721,14 @@ input[type=range] {
   margin-left: 2px;
 }
 
+/* all kgroups of a strip live in one .knobrow so mobile variants can scroll/wrap it */
+.knobrow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+}
+
 /* legacy .knobs kept for master strip compatibility */
 .knobs {
   display: flex;
@@ -737,6 +745,7 @@ input[type=range] {
 }
 .knob-dial {
   width: 32px; height: 32px; border-radius: 50%; position: relative; cursor: ns-resize;
+  touch-action: none;          /* vertical drag — no scroll/zoom stealing */
   background: radial-gradient(circle at 38% 32%, #3a3e4e, #15171f 70%);
   box-shadow:
     inset 0 1px 1px rgba(255,255,255,0.15),
@@ -757,6 +766,39 @@ input[type=range] {
   color: var(--faint);
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+/* persistent numeric readout under the label — opt-in via body.gbm-knobval */
+.knob-val {
+  display: none;
+  font: 500 9px ui-monospace, Menlo, monospace;
+  color: var(--dim);
+  line-height: 1;
+}
+body.gbm-knobval .knob-val { display: block; }
+
+/* floating value bubble while dragging a knob (fixed → escapes overflow clips) */
+.knob-bubble {
+  position: fixed;
+  z-index: 200;
+  pointer-events: none;
+  transform: translate(-50%, -100%);
+  background: var(--panel-3, #2a2e3a);
+  color: var(--ink);
+  border: 1px solid var(--acc);
+  border-radius: 6px;
+  font: 600 13px ui-monospace, Menlo, monospace;
+  padding: 3px 9px;
+  opacity: 0;
+  transition: opacity 0.12s;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.55), 0 0 8px color-mix(in srgb, var(--acc) 30%, transparent);
+}
+.knob-bubble.show { opacity: 1; }
+
+/* bigger touch targets on touch devices */
+@media (pointer: coarse) {
+  .knob-dial { width: 42px; height: 42px; }
+  .knob-ind  { top: 4px; height: 15px; transform-origin: 50% 17px; }
 }
 
 /* ─── mute / solo buttons ────────────────────────────────────────────────── */
@@ -2089,4 +2131,132 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   color: #04201a;
   font-weight: 700;
   box-shadow: 0 0 8px rgba(84,240,200,0.35);
+}
+
+/* ═══ MOBILE LAYOUT (≤760px) — prototype ═════════════════════════════════════
+   Three lane-layout variants, switched by body class via the PROTO chip row:
+   body.gbm-strip     — knobs in one horizontally swipeable row (default)
+   body.gbm-wrap      — knobs wrap onto extra rows
+   body.gbm-accordion — knobs hidden; tap a lane header to expand one at a time
+   body.gbm-knobval   — persistent numeric readout under every knob (any width)
+*/
+@media (max-width: 760px) {
+  /* ── reclaim chrome: page → cabinet → inner → panels ── */
+  body { padding: 6px 4px 28px; }
+  .cabinet { padding: 8px 6px 10px; border-radius: 12px; }
+  .screw { display: none; }
+  .cabinet-inner { padding: 8px 8px 10px; border-radius: 8px; }
+  #strips { padding: 8px 6px; }
+  #fills, #punch, #master { padding: 8px 10px; }
+  #viz, #strips, #fills, #punch, #master, #arrange { margin-bottom: 8px; }
+  .sec-drag { display: none; }   /* mouse-only affordance */
+
+  /* ── transport wraps; tempo + song get full rows ── */
+  .transport { flex-wrap: wrap; row-gap: 8px; }
+  .transport-tempo { flex: 1 1 auto; min-width: 0; }
+  #bpm { flex: 1; min-width: 50px; }
+  .transport-song { margin-left: 0; flex: 1 1 100%; }
+  .transport-song .song-wrap { flex: 1; min-width: 0; }
+  .transport-song select { width: 100%; }
+
+  /* ── lane: header row / select row / knob row ── */
+  .lane {
+    grid-template-columns: 16px 1fr auto auto;
+    grid-template-areas:
+      "drag  name  ms    actions"
+      "mctl  mctl  mctl  lvl"
+      "knobs knobs knobs knobs";
+    column-gap: 8px;
+    row-gap: 8px;
+    padding: 8px 8px 10px;
+  }
+  .lane .lane-drag     { grid-area: drag; }
+  .lane .name          { grid-area: name; }
+  .lane .mctl          { grid-area: mctl; }
+  .lane .lvl           { grid-area: lvl; height: 26px; }
+  .lane .knobrow       { grid-area: knobs; justify-content: flex-start; }
+  .lane .msgroup       { grid-area: ms; }
+  .lane .lane-actions  { grid-area: actions; }
+
+  /* ── master strip: label+meters row, knobs row ── */
+  .masterfx { flex-wrap: wrap; row-gap: 8px; }
+  .masterfx .knobrow { flex: 1 1 100%; }
+
+  /* ── variant: STRIP — one swipeable knob row ───────────────────────────── */
+  body.gbm-strip .knobrow,
+  body.gbm-accordion .knobrow {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 2px;
+  }
+  body.gbm-strip .knobrow::-webkit-scrollbar,
+  body.gbm-accordion .knobrow::-webkit-scrollbar { display: none; }
+  /* dials pass horizontal pans to the strip; vertical drags turn the knob */
+  body.gbm-strip .knobrow .knob-dial,
+  body.gbm-accordion .knobrow .knob-dial { touch-action: pan-x; }
+  /* edge fades (classes maintained by JS) hint at off-screen knobs */
+  body.gbm-strip .knobrow.fade-r,
+  body.gbm-accordion .knobrow.fade-r {
+    mask-image: linear-gradient(90deg, #000 calc(100% - 28px), transparent);
+    -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 28px), transparent);
+  }
+  body.gbm-strip .knobrow.fade-l,
+  body.gbm-accordion .knobrow.fade-l {
+    mask-image: linear-gradient(90deg, transparent, #000 28px);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 28px);
+  }
+  body.gbm-strip .knobrow.fade-l.fade-r,
+  body.gbm-accordion .knobrow.fade-l.fade-r {
+    mask-image: linear-gradient(90deg, transparent, #000 28px, #000 calc(100% - 28px), transparent);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 28px, #000 calc(100% - 28px), transparent);
+  }
+
+  /* ── variant: WRAP — knobs wrap onto extra rows ────────────────────────── */
+  body.gbm-wrap .knobrow { flex-wrap: wrap; row-gap: 10px; }
+
+  /* ── variant: ACCORDION — tap lane header to expand ────────────────────── */
+  body.gbm-accordion .lane .knobrow { display: none; }
+  body.gbm-accordion .lane.open .knobrow { display: flex; }
+  body.gbm-accordion .lane .name { cursor: pointer; }
+  body.gbm-accordion .lane .name::after { content: " ▾"; color: var(--faint); }
+  body.gbm-accordion .lane.open .name::after { content: " ▴"; }
+  /* master knobs always visible — accordion only applies to lanes */
+}
+
+/* ─── PROTO variant switcher (prototype-only chrome) ───────────────────────── */
+#gbm-proto {
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+  z-index: 300;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  background: rgba(10, 12, 18, 0.88);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 5px 6px;
+  backdrop-filter: blur(4px);
+}
+#gbm-proto .gbm-lbl {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--faint);
+  margin-right: 2px;
+}
+#gbm-proto button {
+  height: 24px;
+  font-size: 10px;
+  padding: 0 8px;
+  border-radius: 5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--dim);
+}
+#gbm-proto button.on {
+  border-color: var(--acc);
+  color: var(--acc);
+  background: rgba(84, 240, 200, 0.08);
 }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2162,17 +2162,24 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }
 
-  /* ── lane accordion: header row / select row / knob row (when open) ── */
+  /* ── lane accordion: header / select / knobs (when open) / pull strip ── */
   .lane {
-    grid-template-columns: 16px 1fr auto auto auto;
+    grid-template-columns: 16px 1fr auto auto;
     grid-template-areas:
-      "drag  name  ms    actions chev"
-      "mctl  mctl  mctl  mctl    lvl"
-      "knobs knobs knobs knobs   knobs";
+      "drag  name  ms    actions"
+      "mctl  mctl  mctl  lvl"
+      "pull  pull  pull  pull";
     column-gap: 8px;
     row-gap: 8px;
-    padding: 8px 8px 10px;
+    padding: 8px 8px 0;
     cursor: pointer;
+  }
+  .lane.open {
+    grid-template-areas:
+      "drag  name  ms    actions"
+      "mctl  mctl  mctl  lvl"
+      "knobs knobs knobs knobs"
+      "pull  pull  pull  pull";
   }
   .lane .lane-drag     { grid-area: drag; }
   .lane .name          { grid-area: name; }
@@ -2187,20 +2194,47 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
     display: flex;
     animation: gbm-expand 0.16s ease;
   }
-  /* disclosure chevron — the accordion affordance
-     (.lane prefix outranks the base display:none, which follows in source) */
-  .lane .lane-expand {
-    display: inline-flex;
-    grid-area: chev;
-  }
   .lane.open {
     border-color: var(--acc-dim);
   }
-  .lane.open .lane-expand {
-    transform: rotate(180deg);
-    color: var(--acc);
-    border-color: var(--acc-dim);
+
+  /* drawer-pull strip — the accordion affordance: full-width bottom bar
+     (.lane prefix outranks the base display:none, which follows in source) */
+  .lane .lane-expand {
+    display: flex;
+    grid-area: pull;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 20px;
+    margin: 0 -8px;             /* bleed to the card edges */
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-top: 1px solid var(--line);
+    border-radius: 0 0 7px 7px;
+    box-shadow: none;
+    color: var(--faint);
   }
+  .lane .lane-expand:hover,
+  .lane .lane-expand:active {
+    background: var(--panel-3);
+    color: var(--dim);
+  }
+  .le-arrow {
+    font-size: 11px;
+    line-height: 1;
+    transition: transform 0.18s ease;
+  }
+  .le-lbl {
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .lane.open .lane-expand { color: var(--acc); }
+  .lane.open .le-arrow { transform: rotate(180deg); }
+  .lane.open .le-lbl { display: none; }
 
   /* ── master strip: label+meters row, knobs row (always visible) ── */
   .masterfx { flex-wrap: wrap; row-gap: 8px; }
@@ -2216,19 +2250,41 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .knobrow::-webkit-scrollbar { display: none; }
   /* dials pass horizontal pans to the strip; vertical drags turn the knob */
   .knobrow .knob-dial { touch-action: pan-x; }
-  /* edge fades (classes maintained by JS) hint at off-screen knobs */
-  .knobrow.fade-r {
-    mask-image: linear-gradient(90deg, #000 calc(100% - 28px), transparent);
-    -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 28px), transparent);
+
+  /* edge arrows + gradient scrims (shown via JS .fade-l/.fade-r classes):
+     sticky to the strip edges, fade the clipped knobs, tap to page */
+  .knobrow .knob-scroll-hint {
+    position: sticky;
+    z-index: 2;
+    align-self: stretch;
+    flex: 0 0 30px;
+    width: 30px;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    height: auto;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    color: var(--acc);
+    text-shadow: 0 0 6px color-mix(in srgb, var(--acc) 45%, transparent);
   }
-  .knobrow.fade-l {
-    mask-image: linear-gradient(90deg, transparent, #000 28px);
-    -webkit-mask-image: linear-gradient(90deg, transparent, #000 28px);
+  .knobrow .knob-scroll-hint.l {
+    left: 0;
+    margin-right: -30px;
+    background: linear-gradient(270deg, transparent, var(--panel-2) 70%);
+    justify-content: flex-start;
   }
-  .knobrow.fade-l.fade-r {
-    mask-image: linear-gradient(90deg, transparent, #000 28px, #000 calc(100% - 28px), transparent);
-    -webkit-mask-image: linear-gradient(90deg, transparent, #000 28px, #000 calc(100% - 28px), transparent);
+  .knobrow .knob-scroll-hint.r {
+    right: 0;
+    margin-left: -30px;
+    background: linear-gradient(90deg, transparent, var(--panel-2) 70%);
+    justify-content: flex-end;
   }
+  .knobrow.fade-l .knob-scroll-hint.l { display: flex; }
+  .knobrow.fade-r .knob-scroll-hint.r { display: flex; }
 
   /* ── Display setting: wrap knobs onto extra rows instead of swiping ── */
   body.gb-knobwrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
@@ -2238,16 +2294,6 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   from { opacity: 0; transform: translateY(-4px); }
 }
 
-/* chevron button: hidden on desktop, shown by the mobile accordion */
-.lane-expand {
-  display: none;
-  width: 26px; height: 26px; padding: 0;
-  align-items: center; justify-content: center;
-  border-radius: 6px;
-  border: 1px solid var(--line);
-  background: var(--panel-2);
-  color: var(--dim);
-  font-size: 12px;
-  line-height: 1;
-  transition: transform 0.18s ease, color 0.12s, border-color 0.12s;
-}
+/* accordion pull strip + swipe hints: hidden on desktop, shown by the mobile layout */
+.lane-expand { display: none; }
+.knob-scroll-hint { display: none; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2203,6 +2203,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .lane .lane-expand {
     display: inline-flex;
     grid-area: pull;
+    justify-self: end;          /* flush with the card's right edge, under ✕ */
     align-items: center;
     justify-content: center;
     width: 30px;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2134,12 +2134,11 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   box-shadow: 0 0 8px rgba(84,240,200,0.35);
 }
 
-/* ═══ MOBILE LAYOUT (≤760px) — prototype ═════════════════════════════════════
-   Three lane-layout variants, switched by body class via the PROTO chip row:
-   body.gbm-strip     — knobs in one horizontally swipeable row (default)
-   body.gbm-wrap      — knobs wrap onto extra rows
-   body.gbm-accordion — knobs hidden; tap a lane header to expand one at a time
-   body.gb-knobval    — persistent numeric readout (global Display setting, default off)
+/* ═══ MOBILE LAYOUT (≤760px) ═════════════════════════════════════════════════
+   Lanes collapse to an accordion: header rows only; tap a lane (or its chevron)
+   to expand its knob strip — one open at a time. The strip swipes horizontally
+   with edge fades; body.gb-knobwrap (Display setting) wraps it instead.
+   body.gb-knobval — persistent numeric readout (global Display setting).
 */
 @media (max-width: 760px) {
   /* ── reclaim chrome: edge-to-edge — cabinet flattens into the page ── */
@@ -2163,16 +2162,17 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }
 
-  /* ── lane: header row / select row / knob row ── */
+  /* ── lane accordion: header row / select row / knob row (when open) ── */
   .lane {
-    grid-template-columns: 16px 1fr auto auto;
+    grid-template-columns: 16px 1fr auto auto auto;
     grid-template-areas:
-      "drag  name  ms    actions"
-      "mctl  mctl  mctl  lvl"
-      "knobs knobs knobs knobs";
+      "drag  name  ms    actions chev"
+      "mctl  mctl  mctl  mctl    lvl"
+      "knobs knobs knobs knobs   knobs";
     column-gap: 8px;
     row-gap: 8px;
     padding: 8px 8px 10px;
+    cursor: pointer;
   }
   .lane .lane-drag     { grid-area: drag; }
   .lane .name          { grid-area: name; }
@@ -2182,78 +2182,63 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .lane .msgroup       { grid-area: ms; }
   .lane .lane-actions  { grid-area: actions; }
 
-  /* ── master strip: label+meters row, knobs row ── */
+  .lane .knobrow { display: none; }
+  .lane.open .knobrow {
+    display: flex;
+    animation: gbm-expand 0.16s ease;
+  }
+  /* disclosure chevron — the accordion affordance
+     (.lane prefix outranks the base display:none, which follows in source) */
+  .lane .lane-expand {
+    display: inline-flex;
+    grid-area: chev;
+  }
+  .lane.open {
+    border-color: var(--acc-dim);
+  }
+  .lane.open .lane-expand {
+    transform: rotate(180deg);
+    color: var(--acc);
+    border-color: var(--acc-dim);
+  }
+
+  /* ── master strip: label+meters row, knobs row (always visible) ── */
   .masterfx { flex-wrap: wrap; row-gap: 8px; }
   .masterfx .knobrow { flex: 1 1 100%; }
 
-  /* ── variant: STRIP — one swipeable knob row ───────────────────────────── */
-  body.gbm-strip .knobrow,
-  body.gbm-accordion .knobrow {
+  /* ── knob strips swipe horizontally (default) ── */
+  .knobrow {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
     padding-bottom: 2px;
   }
-  body.gbm-strip .knobrow::-webkit-scrollbar,
-  body.gbm-accordion .knobrow::-webkit-scrollbar { display: none; }
+  .knobrow::-webkit-scrollbar { display: none; }
   /* dials pass horizontal pans to the strip; vertical drags turn the knob */
-  body.gbm-strip .knobrow .knob-dial,
-  body.gbm-accordion .knobrow .knob-dial { touch-action: pan-x; }
+  .knobrow .knob-dial { touch-action: pan-x; }
   /* edge fades (classes maintained by JS) hint at off-screen knobs */
-  body.gbm-strip .knobrow.fade-r,
-  body.gbm-accordion .knobrow.fade-r {
+  .knobrow.fade-r {
     mask-image: linear-gradient(90deg, #000 calc(100% - 28px), transparent);
     -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 28px), transparent);
   }
-  body.gbm-strip .knobrow.fade-l,
-  body.gbm-accordion .knobrow.fade-l {
+  .knobrow.fade-l {
     mask-image: linear-gradient(90deg, transparent, #000 28px);
     -webkit-mask-image: linear-gradient(90deg, transparent, #000 28px);
   }
-  body.gbm-strip .knobrow.fade-l.fade-r,
-  body.gbm-accordion .knobrow.fade-l.fade-r {
+  .knobrow.fade-l.fade-r {
     mask-image: linear-gradient(90deg, transparent, #000 28px, #000 calc(100% - 28px), transparent);
     -webkit-mask-image: linear-gradient(90deg, transparent, #000 28px, #000 calc(100% - 28px), transparent);
   }
 
-  /* ── variant: WRAP — knobs wrap onto extra rows ────────────────────────── */
-  body.gbm-wrap .knobrow { flex-wrap: wrap; row-gap: 10px; }
-
-  /* ── variant: ACCORDION — tap lane header (or chevron) to expand ───────── */
-  body.gbm-accordion .lane {
-    grid-template-columns: 16px 1fr auto auto auto;
-    grid-template-areas:
-      "drag  name  ms    actions chev"
-      "mctl  mctl  mctl  mctl    lvl"
-      "knobs knobs knobs knobs   knobs";
-    cursor: pointer;
-  }
-  body.gbm-accordion .lane .knobrow { display: none; }
-  body.gbm-accordion .lane.open .knobrow {
-    display: flex;
-    animation: gbm-expand 0.16s ease;
-  }
-  /* disclosure chevron — the accordion affordance */
-  body.gbm-accordion .lane-expand {
-    display: inline-flex;
-    grid-area: chev;
-  }
-  body.gbm-accordion .lane.open {
-    border-color: var(--acc-dim);
-  }
-  body.gbm-accordion .lane.open .lane-expand {
-    transform: rotate(180deg);
-    color: var(--acc);
-    border-color: var(--acc-dim);
-  }
-  /* master knobs always visible — accordion only applies to lanes */
+  /* ── Display setting: wrap knobs onto extra rows instead of swiping ── */
+  body.gb-knobwrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
 }
 
 @keyframes gbm-expand {
   from { opacity: 0; transform: translateY(-4px); }
 }
 
-/* chevron button: hidden everywhere except mobile accordion mode */
+/* chevron button: hidden on desktop, shown by the mobile accordion */
 .lane-expand {
   display: none;
   width: 26px; height: 26px; padding: 0;
@@ -2265,41 +2250,4 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   font-size: 12px;
   line-height: 1;
   transition: transform 0.18s ease, color 0.12s, border-color 0.12s;
-}
-
-/* ─── PROTO variant switcher (prototype-only chrome) ───────────────────────── */
-#gbm-proto {
-  position: fixed;
-  right: 10px;
-  bottom: 10px;
-  z-index: 300;
-  display: flex;
-  gap: 4px;
-  align-items: center;
-  background: rgba(10, 12, 18, 0.88);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 5px 6px;
-  backdrop-filter: blur(4px);
-}
-#gbm-proto .gbm-lbl {
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  color: var(--faint);
-  margin-right: 2px;
-}
-#gbm-proto button {
-  height: 24px;
-  font-size: 10px;
-  padding: 0 8px;
-  border-radius: 5px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--dim);
-}
-#gbm-proto button.on {
-  border-color: var(--acc);
-  color: var(--acc);
-  background: rgba(84, 240, 200, 0.08);
 }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -794,6 +794,7 @@ body.gbm-knobval .knob-val { display: block; }
   box-shadow: 0 2px 10px rgba(0,0,0,0.55), 0 0 8px color-mix(in srgb, var(--acc) 30%, transparent);
 }
 .knob-bubble.show { opacity: 1; }
+.knob-bubble.below { transform: translate(-50%, 0); }   /* flipped under the dial */
 
 /* bigger touch targets on touch devices */
 @media (pointer: coarse) {
@@ -2141,15 +2142,18 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
    body.gbm-knobval   — persistent numeric readout under every knob (any width)
 */
 @media (max-width: 760px) {
-  /* ── reclaim chrome: page → cabinet → inner → panels ── */
-  body { padding: 6px 4px 28px; }
-  .cabinet { padding: 8px 6px 10px; border-radius: 12px; }
+  /* ── reclaim chrome: edge-to-edge — cabinet flattens into the page ── */
+  body { padding: 0 0 28px; }
+  .cabinet { padding: 0 0 6px; border-radius: 0; box-shadow: none; }
   .screw { display: none; }
-  .cabinet-inner { padding: 8px 8px 10px; border-radius: 8px; }
-  #strips { padding: 8px 6px; }
-  #fills, #punch, #master { padding: 8px 10px; }
+  .crt-vignette { display: none; }
+  .cabinet-inner { padding: 6px 4px 8px; border-radius: 0; box-shadow: none; }
+  #strips { padding: 6px 4px; }
+  #fills, #punch, #master { padding: 6px 8px; }
   #viz, #strips, #fills, #punch, #master, #arrange { margin-bottom: 8px; }
   .sec-drag { display: none; }   /* mouse-only affordance */
+  .titlebar { margin-bottom: 8px; }
+  h1 { font-size: 13px; letter-spacing: 0.1em; white-space: nowrap; }
 
   /* ── transport wraps; tempo + song get full rows ── */
   .transport { flex-wrap: wrap; row-gap: 8px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2142,11 +2142,12 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 */
 @media (max-width: 760px) {
   /* ── reclaim chrome: edge-to-edge — cabinet flattens into the page ── */
-  body { padding: 0 0 28px; }
-  .cabinet { padding: 0 0 6px; border-radius: 0; box-shadow: none; }
+  html, body { background: var(--bg); }   /* one flat surface, no bands at the page bottom */
+  body { padding: 0; }
+  .cabinet { padding: 0; border-radius: 0; box-shadow: none; background: var(--bg); }
   .screw { display: none; }
   .crt-vignette { display: none; }
-  .cabinet-inner { padding: 6px 4px 8px; border-radius: 0; box-shadow: none; }
+  .cabinet-inner { padding: 6px 4px 16px; border-radius: 0; box-shadow: none; }
   #strips { padding: 6px 4px; }
   #fills, #punch, #master { padding: 6px 8px; }
   #viz, #strips, #fills, #punch, #master, #arrange { margin-bottom: 8px; }
@@ -2162,13 +2163,12 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }
 
-  /* ── lane accordion: header / select / knobs (when open) / pull strip ── */
+  /* ── lane accordion: header / select+expand / knobs (when open) ── */
   .lane {
     grid-template-columns: 16px 1fr auto auto;
     grid-template-areas:
-      "drag  name  ms    actions"
-      "mctl  mctl  mctl  lvl"
-      "pull  pull  pull  pull";
+      "drag name ms  actions"
+      "mctl mctl lvl pull";
     column-gap: 8px;
     row-gap: 8px;
     padding: 8px;
@@ -2177,9 +2177,8 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .lane.open {
     grid-template-areas:
       "drag  name  ms    actions"
-      "mctl  mctl  mctl  lvl"
-      "knobs knobs knobs knobs"
-      "pull  pull  pull  pull";
+      "mctl  mctl  lvl   pull"
+      "knobs knobs knobs knobs";
   }
   .lane .lane-drag     { grid-area: drag; }
   .lane .name          { grid-area: name; }
@@ -2198,34 +2197,27 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
     border-color: var(--acc-dim);
   }
 
-  /* expand button — the accordion affordance: a real full-width button with
-     the unified control chrome, so it can't be mistaken for decoration
+  /* expand button — the accordion affordance: a square control beside the
+     groove select, with the unified button chrome + lucide chevron
      (.lane prefix outranks the base display:none, which follows in source) */
   .lane .lane-expand {
-    display: flex;
+    display: inline-flex;
     grid-area: pull;
     align-items: center;
     justify-content: center;
-    gap: 7px;
-    height: 26px;
+    width: 30px;
+    height: 30px;
+    flex: 0 0 30px;
     padding: 0;
-    color: var(--dim);
+    color: var(--acc);
   }
   .le-arrow {
-    font-size: 11px;
-    line-height: 1;
-    color: var(--acc);
+    display: block;
     transition: transform 0.18s ease;
   }
-  .le-lbl {
-    font-size: 9px;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-  }
   .lane.open .lane-expand {
-    color: var(--acc);
     border-color: var(--acc-dim);
+    background: color-mix(in srgb, var(--acc) 10%, var(--panel-2));
   }
   .lane.open .le-arrow { transform: rotate(180deg); }
 

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2171,7 +2171,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
       "pull  pull  pull  pull";
     column-gap: 8px;
     row-gap: 8px;
-    padding: 8px 8px 0;
+    padding: 8px;
     cursor: pointer;
   }
   .lane.open {
@@ -2198,43 +2198,36 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
     border-color: var(--acc-dim);
   }
 
-  /* drawer-pull strip — the accordion affordance: full-width bottom bar
+  /* expand button — the accordion affordance: a real full-width button with
+     the unified control chrome, so it can't be mistaken for decoration
      (.lane prefix outranks the base display:none, which follows in source) */
   .lane .lane-expand {
     display: flex;
     grid-area: pull;
     align-items: center;
     justify-content: center;
-    gap: 6px;
-    height: 20px;
-    margin: 0 -8px;             /* bleed to the card edges */
+    gap: 7px;
+    height: 26px;
     padding: 0;
-    background: transparent;
-    border: none;
-    border-top: 1px solid var(--line);
-    border-radius: 0 0 7px 7px;
-    box-shadow: none;
-    color: var(--faint);
-  }
-  .lane .lane-expand:hover,
-  .lane .lane-expand:active {
-    background: var(--panel-3);
     color: var(--dim);
   }
   .le-arrow {
     font-size: 11px;
     line-height: 1;
+    color: var(--acc);
     transition: transform 0.18s ease;
   }
   .le-lbl {
-    font-size: 8px;
+    font-size: 9px;
     font-weight: 600;
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
-  .lane.open .lane-expand { color: var(--acc); }
+  .lane.open .lane-expand {
+    color: var(--acc);
+    border-color: var(--acc-dim);
+  }
   .lane.open .le-arrow { transform: rotate(180deg); }
-  .lane.open .le-lbl { display: none; }
 
   /* ── master strip: label+meters row, knobs row (always visible) ── */
   .masterfx { flex-wrap: wrap; row-gap: 8px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -721,13 +721,57 @@ input[type=range] {
   margin-left: 2px;
 }
 
-/* all kgroups of a strip live in one .knobrow so mobile variants can scroll/wrap it */
+/* all kgroups of a strip live in one .knobrow — a horizontal scroll container.
+   On wide desktop it never overflows (inert); on tablet/mobile widths the
+   knobs swipe within the lane instead of blowing out the grid. */
 .knobrow {
   display: flex;
   gap: 12px;
   align-items: center;
   min-width: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding-bottom: 2px;
 }
+.knobrow::-webkit-scrollbar { display: none; }
+/* dials pass horizontal pans to the strip; vertical drags turn the knob */
+.knobrow .knob-dial { touch-action: pan-x; }
+
+/* edge arrows + gradient scrims (shown via JS .fade-l/.fade-r classes):
+   sticky to the strip edges, fade the clipped knobs, tap to page */
+.knob-scroll-hint {
+  position: sticky;
+  z-index: 2;
+  align-self: stretch;
+  flex: 0 0 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  height: auto;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: var(--acc);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--acc) 45%, transparent);
+}
+.knob-scroll-hint.l {
+  left: 0;
+  margin-right: -30px;
+  background: linear-gradient(270deg, transparent, var(--panel-2) 70%);
+  justify-content: flex-start;
+}
+.knob-scroll-hint.r {
+  right: 0;
+  margin-left: -30px;
+  background: linear-gradient(90deg, transparent, var(--panel-2) 70%);
+  justify-content: flex-end;
+}
+.knobrow.fade-l .knob-scroll-hint.l { display: flex; }
+.knobrow.fade-r .knob-scroll-hint.r { display: flex; }
 
 /* legacy .knobs kept for master strip compatibility */
 .knobs {
@@ -2134,13 +2178,13 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   box-shadow: 0 0 8px rgba(84,240,200,0.35);
 }
 
-/* ═══ MOBILE LAYOUT (≤760px) ═════════════════════════════════════════════════
+/* ═══ MOBILE LAYOUT (≤900px) ═════════════════════════════════════════════════
    Lanes collapse to an accordion: header rows only; tap a lane (or its chevron)
    to expand its knob strip — one open at a time. The strip swipes horizontally
    with edge fades; body.gb-knobwrap (Display setting) wraps it instead.
    body.gb-knobval — persistent numeric readout (global Display setting).
 */
-@media (max-width: 760px) {
+@media (max-width: 900px) {
   /* ── reclaim chrome: edge-to-edge — cabinet flattens into the page ── */
   html, body { background: var(--bg); }   /* one flat surface, no bands at the page bottom */
   body { padding: 0; }
@@ -2245,52 +2289,6 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .masterfx { flex-wrap: wrap; row-gap: 8px; }
   .masterfx .knobrow { flex: 1 1 100%; }
 
-  /* ── knob strips swipe horizontally (default) ── */
-  .knobrow {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    padding-bottom: 2px;
-  }
-  .knobrow::-webkit-scrollbar { display: none; }
-  /* dials pass horizontal pans to the strip; vertical drags turn the knob */
-  .knobrow .knob-dial { touch-action: pan-x; }
-
-  /* edge arrows + gradient scrims (shown via JS .fade-l/.fade-r classes):
-     sticky to the strip edges, fade the clipped knobs, tap to page */
-  .knobrow .knob-scroll-hint {
-    position: sticky;
-    z-index: 2;
-    align-self: stretch;
-    flex: 0 0 30px;
-    width: 30px;
-    padding: 0;
-    border: none;
-    border-radius: 0;
-    box-shadow: none;
-    height: auto;
-    display: none;
-    align-items: center;
-    justify-content: center;
-    font-size: 16px;
-    color: var(--acc);
-    text-shadow: 0 0 6px color-mix(in srgb, var(--acc) 45%, transparent);
-  }
-  .knobrow .knob-scroll-hint.l {
-    left: 0;
-    margin-right: -30px;
-    background: linear-gradient(270deg, transparent, var(--panel-2) 70%);
-    justify-content: flex-start;
-  }
-  .knobrow .knob-scroll-hint.r {
-    right: 0;
-    margin-left: -30px;
-    background: linear-gradient(90deg, transparent, var(--panel-2) 70%);
-    justify-content: flex-end;
-  }
-  .knobrow.fade-l .knob-scroll-hint.l { display: flex; }
-  .knobrow.fade-r .knob-scroll-hint.r { display: flex; }
-
   /* ── Display setting: wrap knobs onto extra rows instead of swiping ── */
   body.gb-knobwrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
 }
@@ -2299,6 +2297,5 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   from { opacity: 0; transform: translateY(-4px); }
 }
 
-/* accordion pull strip + swipe hints: hidden on desktop, shown by the mobile layout */
+/* accordion expand button: hidden on desktop, shown by the mobile layout */
 .lane-expand { display: none; }
-.knob-scroll-hint { display: none; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2174,6 +2174,13 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .transport-song { grid-area: song; margin-left: 0; min-width: 0; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }
+  /* drop labels that repeat what the control already says ("120 BPM" labels
+     the slider, "♪ Kids" labels the dropdown, tabs label themselves); KEY
+     stays — a bare stepper is ambiguous */
+  .transport-tempo .transport-lbl,
+  .transport-song .transport-lbl,
+  .vtabs-lbl { display: none; }
+  .vtabs { margin-bottom: 8px; }
 
   /* ── lane accordion: header / select+expand / knobs (when open) ── */
   .lane {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -686,7 +686,8 @@ input[type=range] {
   border-color: #5a2030;
   color: #ff7da6;
 }
-.lane.silenced > :not(.msgroup) { opacity: .4; transition: opacity .15s; }
+/* keep the expand chevron full-strength — it's a control, not lane content */
+.lane.silenced > :not(.msgroup):not(.lane-expand) { opacity: .4; transition: opacity .15s; }
 
 .mctl { display:flex; gap:8px; align-items:center; }
 .mctl select { width:auto; }
@@ -812,14 +813,14 @@ input[type=range] {
   text-transform: uppercase;
 }
 
-/* persistent numeric readout under the label — opt-in via body.gb-knobval */
+/* persistent numeric readout under the label — opt-in via body.gb-knob-values */
 .knob-val {
   display: none;
   font: 500 9px ui-monospace, Menlo, monospace;
   color: var(--dim);
   line-height: 1;
 }
-body.gb-knobval .knob-val { display: block; }
+body.gb-knob-values .knob-val { display: block; }
 
 /* floating value bubble while dragging a knob (fixed → escapes overflow clips) */
 .knob-bubble {
@@ -2178,11 +2179,14 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   box-shadow: 0 0 8px rgba(84,240,200,0.35);
 }
 
+/* accordion expand button: hidden by default; the mobile layout shows it */
+.lane-expand { display: none; }
+
 /* ═══ MOBILE LAYOUT (≤900px) ═════════════════════════════════════════════════
    Lanes collapse to an accordion: header rows only; tap a lane (or its chevron)
    to expand its knob strip — one open at a time. The strip swipes horizontally
-   with edge fades; body.gb-knobwrap (Display setting) wraps it instead.
-   body.gb-knobval — persistent numeric readout (global Display setting).
+   with edge fades; body.gb-knob-wrap (Display setting) wraps it instead.
+   body.gb-knob-values — persistent numeric readout (global Display setting).
 */
 @media (max-width: 900px) {
   /* ── reclaim chrome: edge-to-edge — cabinet flattens into the page ── */
@@ -2261,9 +2265,8 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   }
 
   /* expand button — the accordion affordance: a square control beside the
-     groove select, with the unified button chrome + lucide chevron
-     (.lane prefix outranks the base display:none, which follows in source) */
-  .lane .lane-expand {
+     groove select, with the unified button chrome + lucide chevron */
+  .lane-expand {
     display: inline-flex;
     grid-area: pull;
     justify-self: end;          /* flush with the card's right edge, under ✕ */
@@ -2290,12 +2293,10 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .masterfx .knobrow { flex: 1 1 100%; }
 
   /* ── Display setting: wrap knobs onto extra rows instead of swiping ── */
-  body.gb-knobwrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
+  body.gb-knob-wrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
 }
 
 @keyframes gbm-expand {
   from { opacity: 0; transform: translateY(-4px); }
 }
 
-/* accordion expand button: hidden on desktop, shown by the mobile layout */
-.lane-expand { display: none; }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -47,6 +47,9 @@ let song;
 let viz;
 // Track which lane is currently open in the viz (for edit-button highlight).
 let _editingLaneId = null;
+// Mobile accordion — which lane's knob strip is expanded. Survives re-renders
+// (renderStrips re-applies it), mirroring the _editingLaneId pattern.
+let _openLaneId = null;
 
 // ─── Drag-reorder state ───────────────────────────────────────────────────────
 let _draggedLaneId = null;
@@ -148,17 +151,38 @@ function makeKnobrow(groups) {
   return row;
 }
 
-// Edge-fade hint classes for horizontally scrollable knob strips (strip variant).
+// Edge-fade hint classes for horizontally scrollable knob strips. rAF-coalesced:
+// momentum scrolling and resize bursts fire many times per frame, but the
+// layout reads + class toggles only need to run once per paint.
 function updateKnobrowFade(row) {
-  const overR = row.scrollLeft + row.clientWidth < row.scrollWidth - 1;
-  const overL = row.scrollLeft > 1;
-  row.classList.toggle('fade-r', overR);
-  row.classList.toggle('fade-l', overL);
+  if (row._fadeRaf) return;
+  row._fadeRaf = requestAnimationFrame(() => {
+    row._fadeRaf = null;
+    const overR = row.scrollLeft + row.clientWidth < row.scrollWidth - 1;
+    const overL = row.scrollLeft > 1;
+    row.classList.toggle('fade-r', overR);
+    row.classList.toggle('fade-l', overL);
+  });
 }
 function updateAllKnobrowFades() {
   document.querySelectorAll('.knobrow').forEach(updateKnobrowFade);
 }
 window.addEventListener('resize', updateAllKnobrowFades);
+
+// Open/close the mobile accordion. null closes all. Single owner of the .open
+// class and aria-expanded so they can't drift.
+function setOpenLane(id) {
+  _openLaneId = id;
+  const host = document.getElementById('strips');
+  if (!host) return;
+  host.querySelectorAll('.lane').forEach(l => {
+    const open = !!id && l.dataset.lane === id;
+    l.classList.toggle('open', open);
+    const chev = l.querySelector('.lane-expand');
+    if (chev) chev.setAttribute('aria-expanded', String(open));
+  });
+  updateAllKnobrowFades();
+}
 
 function makeKgroup(label, knobDefs) {
   const grp = document.createElement('div');
@@ -414,22 +438,15 @@ function renderStrips() {
     // Mobile accordion: chevron or lane header (not its controls) toggles the
     // lane's knob strip — one lane open at a time. No-op on desktop (chevron
     // hidden, knobrows always visible).
-    const toggleOpen = () => {
-      const wasOpen = row.classList.contains('open');
-      host.querySelectorAll('.lane.open').forEach(l => {
-        l.classList.remove('open');
-        l.querySelector('.lane-expand').setAttribute('aria-expanded', 'false');
-      });
-      if (!wasOpen) {
-        row.classList.add('open');
-        row.querySelector('.lane-expand').setAttribute('aria-expanded', 'true');
-        updateAllKnobrowFades();
-      }
-    };
-    row.querySelector('.lane-expand').onclick = toggleOpen;
+    const chev = row.querySelector('.lane-expand');
+    const toggleOpen = () => setOpenLane(row.classList.contains('open') ? null : id);
+    chev.onclick = toggleOpen;
     row.addEventListener('click', e => {
-      if (!window.matchMedia('(max-width: 900px)').matches) return;
-      if (e.target.closest('button, select, input, .knobrow, .lane-drag')) return;
+      // Gate on the CSS breakpoint itself (chevron is display:none on desktop)
+      // so the JS behaviour can't desync from the @media value.
+      if (getComputedStyle(chev).display === 'none') return;
+      // .name owns dblclick-rename; .lvl is a readout, not a control.
+      if (e.target.closest('button, select, input, .knobrow, .lane-drag, .name, .lvl')) return;
       toggleOpen();
     });
   });
@@ -487,6 +504,9 @@ function renderStrips() {
   cacheMeterFills();  // re-cache .lvl-fill refs after DOM rebuild
   renderViewTabs();   // rebuild quick-edit tabs to track the current lane list
   updateEmptyGroups(); // hide kgroups where all knobs are hidden
+  // Re-apply the accordion's open lane across the innerHTML rebuild (drop it
+  // if that lane was removed).
+  setOpenLane(host.querySelector(`.lane[data-lane="${_openLaneId}"]`) ? _openLaneId : null);
 }
 
 // Sync every strip groove dropdown to the EDIT pattern's picks. Called whenever
@@ -1158,16 +1178,18 @@ for (const [groupName, groupKeys] of _vsGroups) {
   head.className = 'vs-group-lbl';
   head.textContent = 'DISPLAY';
   _vsForm.appendChild(head);
-  const addToggle = (label, storeKey, bodyClass, onChange) => {
+  // `key` doubles as the localStorage key and the body class, so one grep
+  // finds every representation of a toggle.
+  const addToggle = (label, key, onChange) => {
     const row = document.createElement('label');
     row.className = 'vs-row';
     const cb = document.createElement('input');
     cb.type = 'checkbox';
-    cb.checked = localStorage.getItem(storeKey) === '1';
-    document.body.classList.toggle(bodyClass, cb.checked);
+    cb.checked = localStorage.getItem(key) === '1';
+    document.body.classList.toggle(key, cb.checked);
     cb.addEventListener('change', () => {
-      document.body.classList.toggle(bodyClass, cb.checked);
-      localStorage.setItem(storeKey, cb.checked ? '1' : '0');
+      document.body.classList.toggle(key, cb.checked);
+      localStorage.setItem(key, cb.checked ? '1' : '0');
       if (onChange) onChange();
     });
     const lbl = document.createElement('span');
@@ -1176,8 +1198,8 @@ for (const [groupName, groupKeys] of _vsGroups) {
     row.appendChild(lbl);
     _vsForm.appendChild(row);
   };
-  addToggle('Knob values', 'gb-knob-values', 'gb-knobval');
-  addToggle('Wrap knobs (mobile)', 'gb-knob-wrap', 'gb-knobwrap', updateAllKnobrowFades);
+  addToggle('Knob values', 'gb-knob-values');
+  addToggle('Wrap knobs (mobile)', 'gb-knob-wrap', updateAllKnobrowFades);
 }
 
 // Highlight the matching preset on load (based on already-restored hidden set).

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -396,13 +396,14 @@ function renderStrips() {
     const knobrow = makeKnobrow([mixGrp, toneGrp, fxGrp]);
     msgroup.before(knobrow);
 
-    // PROTO accordion variant: chevron or lane header (not its controls) toggles
+    // Mobile accordion: chevron or lane header (not its controls) toggles the
+    // lane's knob strip — one lane open at a time. No-op on desktop (chevron
+    // hidden, knobrows always visible).
     const toggleOpen = () => {
       const wasOpen = row.classList.contains('open');
       host.querySelectorAll('.lane.open').forEach(l => {
         l.classList.remove('open');
-        const c = l.querySelector('.lane-expand');
-        if (c) c.setAttribute('aria-expanded', 'false');
+        l.querySelector('.lane-expand').setAttribute('aria-expanded', 'false');
       });
       if (!wasOpen) {
         row.classList.add('open');
@@ -412,7 +413,7 @@ function renderStrips() {
     };
     row.querySelector('.lane-expand').onclick = toggleOpen;
     row.addEventListener('click', e => {
-      if (!document.body.classList.contains('gbm-accordion')) return;
+      if (!window.matchMedia('(max-width: 760px)').matches) return;
       if (e.target.closest('button, select, input, .knobrow, .lane-drag')) return;
       toggleOpen();
     });
@@ -1136,27 +1137,32 @@ for (const [groupName, groupKeys] of _vsGroups) {
   }
 }
 
-// ── Display section: persistent knob value readout (global, default off) ──
+// ── Display section: global UI toggles (all default off) ──
 {
   const head = document.createElement('div');
   head.className = 'vs-group-lbl';
   head.textContent = 'DISPLAY';
   _vsForm.appendChild(head);
-  const row = document.createElement('label');
-  row.className = 'vs-row';
-  const cb = document.createElement('input');
-  cb.type = 'checkbox';
-  cb.checked = localStorage.getItem('gb-knob-values') === '1';
-  document.body.classList.toggle('gb-knobval', cb.checked);
-  cb.addEventListener('change', () => {
-    document.body.classList.toggle('gb-knobval', cb.checked);
-    localStorage.setItem('gb-knob-values', cb.checked ? '1' : '0');
-  });
-  const lbl = document.createElement('span');
-  lbl.textContent = 'Knob values';
-  row.appendChild(cb);
-  row.appendChild(lbl);
-  _vsForm.appendChild(row);
+  const addToggle = (label, storeKey, bodyClass, onChange) => {
+    const row = document.createElement('label');
+    row.className = 'vs-row';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = localStorage.getItem(storeKey) === '1';
+    document.body.classList.toggle(bodyClass, cb.checked);
+    cb.addEventListener('change', () => {
+      document.body.classList.toggle(bodyClass, cb.checked);
+      localStorage.setItem(storeKey, cb.checked ? '1' : '0');
+      if (onChange) onChange();
+    });
+    const lbl = document.createElement('span');
+    lbl.textContent = label;
+    row.appendChild(cb);
+    row.appendChild(lbl);
+    _vsForm.appendChild(row);
+  };
+  addToggle('Knob values', 'gb-knob-values', 'gb-knobval');
+  addToggle('Wrap knobs (mobile)', 'gb-knob-wrap', 'gb-knobwrap', updateAllKnobrowFades);
 }
 
 // Highlight the matching preset on load (based on already-restored hidden set).
@@ -1294,31 +1300,6 @@ function initSectionWrappers() {
   });
 }
 
-// ─── PROTO: mobile layout variant switcher ────────────────────────────────────
-// Temporary, prototype-only. Floating chip row to flip between mobile lane
-// layouts live: STRIP (h-scroll knobs) / WRAP / ACCORDION.
-const GBM_VARIANTS = ['strip', 'wrap', 'accordion'];
-
-function applyGbmVariant(v) {
-  for (const x of GBM_VARIANTS) document.body.classList.toggle('gbm-' + x, x === v);
-  localStorage.setItem('gbm-variant', v);
-  document.querySelectorAll('#gbm-proto [data-variant]').forEach(b =>
-    b.classList.toggle('on', b.dataset.variant === v));
-  requestAnimationFrame(updateAllKnobrowFades);
-}
-
-function initProtoSwitcher() {
-  const el = document.createElement('div');
-  el.id = 'gbm-proto';
-  el.innerHTML = `<span class="gbm-lbl">PROTO</span>` +
-    GBM_VARIANTS.map(v => `<button data-variant="${v}">${v}</button>`).join('');
-  document.body.appendChild(el);
-
-  el.querySelectorAll('[data-variant]').forEach(b => b.onclick = () => applyGbmVariant(b.dataset.variant));
-
-  applyGbmVariant(localStorage.getItem('gbm-variant') || 'accordion');
-}
-
 // ─── Initial load ─────────────────────────────────────────────────────────────
 eng.load(kids);
 const initialSong = eng.getSong();
@@ -1328,4 +1309,3 @@ eng.setTempo(initialSong.bpm);
 mount();
 // Wrap sections and wire section drag-reorder once, after first mount.
 initSectionWrappers();
-initProtoSwitcher();

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -276,7 +276,7 @@ function renderStrips() {
         <button class="lane-dup" data-lane="${lane.id}" title="Duplicate lane">⧉</button>
         <button class="lane-rm" data-lane="${lane.id}" title="Remove lane"${isLast ? ' disabled' : ''}>✕</button>
       </div>
-      <button class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-expanded="false"><span class="le-arrow">▾</span><span class="le-lbl">mix · fx</span></button>
+      <button class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-expanded="false"><svg class="le-arrow" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg></button>
     </div>`;
   }).join('');
 

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -428,7 +428,7 @@ function renderStrips() {
     };
     row.querySelector('.lane-expand').onclick = toggleOpen;
     row.addEventListener('click', e => {
-      if (!window.matchMedia('(max-width: 760px)').matches) return;
+      if (!window.matchMedia('(max-width: 900px)').matches) return;
       if (e.target.closest('button, select, input, .knobrow, .lane-drag')) return;
       toggleOpen();
     });

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -123,6 +123,28 @@ function stopMeterLoop() {
   if (_masterFillCache[1]) _masterFillCache[1].style.height = '0%';
 }
 
+// Wrap kgroups in a single flex container so mobile variants can scroll/wrap it.
+function makeKnobrow(groups) {
+  const row = document.createElement('div');
+  row.className = 'knobrow';
+  for (const g of groups) row.appendChild(g);
+  row.addEventListener('scroll', () => updateKnobrowFade(row), { passive: true });
+  requestAnimationFrame(() => updateKnobrowFade(row));
+  return row;
+}
+
+// Edge-fade hint classes for horizontally scrollable knob strips (strip variant).
+function updateKnobrowFade(row) {
+  const overR = row.scrollLeft + row.clientWidth < row.scrollWidth - 1;
+  const overL = row.scrollLeft > 1;
+  row.classList.toggle('fade-r', overR);
+  row.classList.toggle('fade-l', overL);
+}
+function updateAllKnobrowFades() {
+  document.querySelectorAll('.knobrow').forEach(updateKnobrowFade);
+}
+window.addEventListener('resize', updateAllKnobrowFades);
+
 function makeKgroup(label, knobDefs) {
   const grp = document.createElement('div');
   grp.className = 'kgroup';
@@ -370,7 +392,17 @@ function renderStrips() {
       { label: 'cmp',  value: 0,   onChange: v => eng.setLaneFX(id, 'comp',   v), tip: knobTip('cmp'),  k: 'cmp'  },
     ]);
 
-    msgroup.before(mixGrp, toneGrp, fxGrp);
+    const knobrow = makeKnobrow([mixGrp, toneGrp, fxGrp]);
+    msgroup.before(knobrow);
+
+    // PROTO accordion variant: tap the lane header (not its controls) to expand
+    row.addEventListener('click', e => {
+      if (!document.body.classList.contains('gbm-accordion')) return;
+      if (e.target.closest('button, select, input, .knobrow, .lane-drag')) return;
+      const wasOpen = row.classList.contains('open');
+      host.querySelectorAll('.lane.open').forEach(l => l.classList.remove('open'));
+      if (!wasOpen) { row.classList.add('open'); updateAllKnobrowFades(); }
+    });
   });
   // ─── Drag-to-reorder ────────────────────────────────────────────────────────
   host.querySelectorAll('.lane-drag').forEach(handle => {
@@ -600,9 +632,7 @@ function renderMaster() {
     { label: 'vrb', value: 0, onChange: v => eng.setMasterFX('reverb', v), tip: knobTip('vrb'), k: 'vrb' },
     { label: 'cmp', value: 0, onChange: v => eng.setMasterFX('comp',   v), tip: knobTip('cmp'), k: 'cmp' },
   ]);
-  mwrap.appendChild(mixGrp);
-  mwrap.appendChild(toneGrp);
-  mwrap.appendChild(fxGrp);
+  mwrap.appendChild(makeKnobrow([mixGrp, toneGrp, fxGrp]));
 
   masterHost.appendChild(mwrap);
   cacheMeterFills();  // re-cache master meter fill refs after DOM rebuild
@@ -1228,6 +1258,40 @@ function initSectionWrappers() {
   });
 }
 
+// ─── PROTO: mobile layout variant switcher ────────────────────────────────────
+// Temporary, prototype-only. Floating chip row to flip between mobile lane
+// layouts live: STRIP (h-scroll knobs) / WRAP / ACCORDION, + VALS readout toggle.
+const GBM_VARIANTS = ['strip', 'wrap', 'accordion'];
+
+function applyGbmVariant(v) {
+  for (const x of GBM_VARIANTS) document.body.classList.toggle('gbm-' + x, x === v);
+  localStorage.setItem('gbm-variant', v);
+  document.querySelectorAll('#gbm-proto [data-variant]').forEach(b =>
+    b.classList.toggle('on', b.dataset.variant === v));
+  requestAnimationFrame(updateAllKnobrowFades);
+}
+
+function initProtoSwitcher() {
+  const el = document.createElement('div');
+  el.id = 'gbm-proto';
+  el.innerHTML = `<span class="gbm-lbl">PROTO</span>` +
+    GBM_VARIANTS.map(v => `<button data-variant="${v}">${v}</button>`).join('') +
+    `<button data-knobval>vals</button>`;
+  document.body.appendChild(el);
+
+  el.querySelectorAll('[data-variant]').forEach(b => b.onclick = () => applyGbmVariant(b.dataset.variant));
+  const valBtn = el.querySelector('[data-knobval]');
+  const applyVal = on => {
+    document.body.classList.toggle('gbm-knobval', on);
+    valBtn.classList.toggle('on', on);
+    localStorage.setItem('gbm-knobval', on ? '1' : '0');
+  };
+  valBtn.onclick = () => applyVal(!document.body.classList.contains('gbm-knobval'));
+
+  applyGbmVariant(localStorage.getItem('gbm-variant') || 'strip');
+  applyVal(localStorage.getItem('gbm-knobval') === '1');
+}
+
 // ─── Initial load ─────────────────────────────────────────────────────────────
 eng.load(kids);
 const initialSong = eng.getSong();
@@ -1237,3 +1301,4 @@ eng.setTempo(initialSong.bpm);
 mount();
 // Wrap sections and wire section drag-reorder once, after first mount.
 initSectionWrappers();
+initProtoSwitcher();

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -261,6 +261,7 @@ function renderStrips() {
         <button class="lane-dup" data-lane="${lane.id}" title="Duplicate lane">⧉</button>
         <button class="lane-rm" data-lane="${lane.id}" title="Remove lane"${isLast ? ' disabled' : ''}>✕</button>
       </div>
+      <button class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-expanded="false">▾</button>
     </div>`;
   }).join('');
 
@@ -395,13 +396,25 @@ function renderStrips() {
     const knobrow = makeKnobrow([mixGrp, toneGrp, fxGrp]);
     msgroup.before(knobrow);
 
-    // PROTO accordion variant: tap the lane header (not its controls) to expand
+    // PROTO accordion variant: chevron or lane header (not its controls) toggles
+    const toggleOpen = () => {
+      const wasOpen = row.classList.contains('open');
+      host.querySelectorAll('.lane.open').forEach(l => {
+        l.classList.remove('open');
+        const c = l.querySelector('.lane-expand');
+        if (c) c.setAttribute('aria-expanded', 'false');
+      });
+      if (!wasOpen) {
+        row.classList.add('open');
+        row.querySelector('.lane-expand').setAttribute('aria-expanded', 'true');
+        updateAllKnobrowFades();
+      }
+    };
+    row.querySelector('.lane-expand').onclick = toggleOpen;
     row.addEventListener('click', e => {
       if (!document.body.classList.contains('gbm-accordion')) return;
       if (e.target.closest('button, select, input, .knobrow, .lane-drag')) return;
-      const wasOpen = row.classList.contains('open');
-      host.querySelectorAll('.lane.open').forEach(l => l.classList.remove('open'));
-      if (!wasOpen) { row.classList.add('open'); updateAllKnobrowFades(); }
+      toggleOpen();
     });
   });
   // ─── Drag-to-reorder ────────────────────────────────────────────────────────
@@ -1123,6 +1136,29 @@ for (const [groupName, groupKeys] of _vsGroups) {
   }
 }
 
+// ── Display section: persistent knob value readout (global, default off) ──
+{
+  const head = document.createElement('div');
+  head.className = 'vs-group-lbl';
+  head.textContent = 'DISPLAY';
+  _vsForm.appendChild(head);
+  const row = document.createElement('label');
+  row.className = 'vs-row';
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.checked = localStorage.getItem('gb-knob-values') === '1';
+  document.body.classList.toggle('gb-knobval', cb.checked);
+  cb.addEventListener('change', () => {
+    document.body.classList.toggle('gb-knobval', cb.checked);
+    localStorage.setItem('gb-knob-values', cb.checked ? '1' : '0');
+  });
+  const lbl = document.createElement('span');
+  lbl.textContent = 'Knob values';
+  row.appendChild(cb);
+  row.appendChild(lbl);
+  _vsForm.appendChild(row);
+}
+
 // Highlight the matching preset on load (based on already-restored hidden set).
 {
   const initialHidden = JSON.parse(localStorage.getItem('gb-hidden-knobs') || '[]');
@@ -1260,7 +1296,7 @@ function initSectionWrappers() {
 
 // ─── PROTO: mobile layout variant switcher ────────────────────────────────────
 // Temporary, prototype-only. Floating chip row to flip between mobile lane
-// layouts live: STRIP (h-scroll knobs) / WRAP / ACCORDION, + VALS readout toggle.
+// layouts live: STRIP (h-scroll knobs) / WRAP / ACCORDION.
 const GBM_VARIANTS = ['strip', 'wrap', 'accordion'];
 
 function applyGbmVariant(v) {
@@ -1275,21 +1311,12 @@ function initProtoSwitcher() {
   const el = document.createElement('div');
   el.id = 'gbm-proto';
   el.innerHTML = `<span class="gbm-lbl">PROTO</span>` +
-    GBM_VARIANTS.map(v => `<button data-variant="${v}">${v}</button>`).join('') +
-    `<button data-knobval>vals</button>`;
+    GBM_VARIANTS.map(v => `<button data-variant="${v}">${v}</button>`).join('');
   document.body.appendChild(el);
 
   el.querySelectorAll('[data-variant]').forEach(b => b.onclick = () => applyGbmVariant(b.dataset.variant));
-  const valBtn = el.querySelector('[data-knobval]');
-  const applyVal = on => {
-    document.body.classList.toggle('gbm-knobval', on);
-    valBtn.classList.toggle('on', on);
-    localStorage.setItem('gbm-knobval', on ? '1' : '0');
-  };
-  valBtn.onclick = () => applyVal(!document.body.classList.contains('gbm-knobval'));
 
-  applyGbmVariant(localStorage.getItem('gbm-variant') || 'strip');
-  applyVal(localStorage.getItem('gbm-knobval') === '1');
+  applyGbmVariant(localStorage.getItem('gbm-variant') || 'accordion');
 }
 
 // ─── Initial load ─────────────────────────────────────────────────────────────

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -134,9 +134,10 @@ function makeKnobrow(groups) {
   row.className = 'knobrow';
   const mkHint = dir => {
     const h = document.createElement('button');
+    h.type = 'button';
     h.className = 'knob-scroll-hint ' + dir;
     h.textContent = dir === 'l' ? '‹' : '›';
-    h.tabIndex = -1;
+    h.setAttribute('aria-label', dir === 'l' ? 'Scroll knobs left' : 'Scroll knobs right');
     h.addEventListener('click', e => {
       e.stopPropagation();
       row.scrollBy({ left: dir === 'l' ? -140 : 140, behavior: 'smooth' });
@@ -300,7 +301,7 @@ function renderStrips() {
         <button class="lane-dup" data-lane="${lane.id}" title="Duplicate lane">⧉</button>
         <button class="lane-rm" data-lane="${lane.id}" title="Remove lane"${isLast ? ' disabled' : ''}>✕</button>
       </div>
-      <button class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-expanded="false"><svg class="le-arrow" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg></button>
+      <button type="button" class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-label="${esc(lane.name)} mixer knobs" aria-expanded="false"><svg class="le-arrow" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg></button>
     </div>`;
   }).join('');
 

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -123,11 +123,26 @@ function stopMeterLoop() {
   if (_masterFillCache[1]) _masterFillCache[1].style.height = '0%';
 }
 
-// Wrap kgroups in a single flex container so mobile variants can scroll/wrap it.
+// Wrap kgroups in a single flex container so the mobile layout can scroll/wrap it.
+// Sticky edge arrows (shown via .fade-l/.fade-r) hint at off-screen knobs and
+// page the strip on tap.
 function makeKnobrow(groups) {
   const row = document.createElement('div');
   row.className = 'knobrow';
+  const mkHint = dir => {
+    const h = document.createElement('button');
+    h.className = 'knob-scroll-hint ' + dir;
+    h.textContent = dir === 'l' ? '‹' : '›';
+    h.tabIndex = -1;
+    h.addEventListener('click', e => {
+      e.stopPropagation();
+      row.scrollBy({ left: dir === 'l' ? -140 : 140, behavior: 'smooth' });
+    });
+    return h;
+  };
+  row.appendChild(mkHint('l'));
   for (const g of groups) row.appendChild(g);
+  row.appendChild(mkHint('r'));
   row.addEventListener('scroll', () => updateKnobrowFade(row), { passive: true });
   requestAnimationFrame(() => updateKnobrowFade(row));
   return row;
@@ -261,7 +276,7 @@ function renderStrips() {
         <button class="lane-dup" data-lane="${lane.id}" title="Duplicate lane">⧉</button>
         <button class="lane-rm" data-lane="${lane.id}" title="Remove lane"${isLast ? ' disabled' : ''}>✕</button>
       </div>
-      <button class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-expanded="false">▾</button>
+      <button class="lane-expand" data-lane="${lane.id}" title="Show/hide mixer knobs" aria-expanded="false"><span class="le-arrow">▾</span><span class="le-lbl">mix · fx</span></button>
     </div>`;
   }).join('');
 

--- a/docs/arcade/groovebox/ui/knob.js
+++ b/docs/arcade/groovebox/ui/knob.js
@@ -41,7 +41,7 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   lbl.className = 'knob-lbl';
   lbl.textContent = label;
 
-  // Persistent numeric readout (hidden unless body.gbm-knobval)
+  // Persistent numeric readout (hidden unless body.gb-knobval)
   const val = document.createElement('span');
   val.className = 'knob-val';
 

--- a/docs/arcade/groovebox/ui/knob.js
+++ b/docs/arcade/groovebox/ui/knob.js
@@ -7,8 +7,8 @@
  */
 
 // One shared bubble on <body> — inside a knob strip it would be clipped by the
-// strip's overflow scroll + edge-fade mask (mask-image masks fixed descendants
-// too). Only one pointer drags a knob at a time, so a singleton is enough.
+// strip's overflow scroll container. Only one pointer drags a knob at a time,
+// so a singleton is enough.
 let _bubble = null;
 function getBubble() {
   if (!_bubble) {
@@ -41,7 +41,7 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   lbl.className = 'knob-lbl';
   lbl.textContent = label;
 
-  // Persistent numeric readout (hidden unless body.gb-knobval)
+  // Persistent numeric readout (hidden unless body.gb-knob-values)
   const val = document.createElement('span');
   val.className = 'knob-val';
 
@@ -59,6 +59,9 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     current = Math.max(0, Math.min(1, v));
     setRotation(current);
     val.textContent = fmt(current);
+    // Keep the visible bubble in sync for non-move value changes too
+    // (double-tap / double-click reset while it is still showing).
+    if (_bubble && _bubble.classList.contains('show')) _bubble.textContent = fmt(current);
     onChange(current);
   }
 
@@ -68,7 +71,9 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   function showBubble() {
     const bubble = getBubble();
     const r = dial.getBoundingClientRect();
-    bubble.style.left = (r.left + r.width / 2) + 'px';
+    // Clamp so the (~40px wide) bubble stays on-screen for edge-of-strip knobs
+    const x = Math.max(26, Math.min(window.innerWidth - 26, r.left + r.width / 2));
+    bubble.style.left = x + 'px';
     // Flip below the dial when there's no headroom (knob near viewport top)
     const below = r.top < 40;
     bubble.classList.toggle('below', below);
@@ -102,7 +107,6 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     const dy = e.clientY - dragStartY;
     movedPx = Math.max(movedPx, Math.abs(dy));
     setValue(dragStartValue - dy / 150);
-    getBubble().textContent = fmt(current);
   });
 
   // End the drag on up OR on cancel/lost-capture (OS gesture, blur, modal),
@@ -114,8 +118,9 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     hideBubble();
   };
   dial.addEventListener('pointerup', e => {
-    // Double-tap reset for touch, where dblclick is unreliable with pointer capture
-    if (e.pointerType === 'touch' && movedPx < 5) {
+    // Double-tap reset for touch, where dblclick is unreliable with pointer
+    // capture. 10px slop: finger taps jitter well past a mouse's.
+    if (e.pointerType === 'touch' && movedPx < 10) {
       const now = performance.now();
       if (now - lastTapAt < 350) { setValue(initial); lastTapAt = 0; }
       else lastTapAt = now;

--- a/docs/arcade/groovebox/ui/knob.js
+++ b/docs/arcade/groovebox/ui/knob.js
@@ -60,7 +60,10 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   function showBubble() {
     const r = dial.getBoundingClientRect();
     bubble.style.left = (r.left + r.width / 2) + 'px';
-    bubble.style.top = (r.top - 6) + 'px';
+    // Flip below the dial when there's no headroom (knob near viewport top)
+    const below = r.top < 40;
+    bubble.classList.toggle('below', below);
+    bubble.style.top = below ? (r.bottom + 6) + 'px' : (r.top - 6) + 'px';
     bubble.textContent = fmt(current);
     clearTimeout(bubbleHideTimer);
     bubble.classList.add('show');

--- a/docs/arcade/groovebox/ui/knob.js
+++ b/docs/arcade/groovebox/ui/knob.js
@@ -5,6 +5,23 @@
  * Double-click (or double-tap) resets to initial value.
  * While dragging, a floating bubble shows the value (0–100).
  */
+
+// One shared bubble on <body> — inside a knob strip it would be clipped by the
+// strip's overflow scroll + edge-fade mask (mask-image masks fixed descendants
+// too). Only one pointer drags a knob at a time, so a singleton is enough.
+let _bubble = null;
+function getBubble() {
+  if (!_bubble) {
+    _bubble = document.createElement('div');
+    _bubble.className = 'knob-bubble';
+    document.body.appendChild(_bubble);
+  }
+  return _bubble;
+}
+let _bubbleHideTimer = null;
+
+const fmt = v => Math.round(v * 100);
+
 export function makeKnob({ label, value = 0, onChange, tip, k }) {
   const initial = value;
   let current = value;
@@ -28,17 +45,10 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   const val = document.createElement('span');
   val.className = 'knob-val';
 
-  // Floating value bubble while dragging (position:fixed → escapes overflow clips)
-  const bubble = document.createElement('div');
-  bubble.className = 'knob-bubble';
-
   dial.appendChild(ind);
   wrapper.appendChild(dial);
   wrapper.appendChild(lbl);
   wrapper.appendChild(val);
-  wrapper.appendChild(bubble);
-
-  const fmt = v => Math.round(v * 100);
 
   function setRotation(v) {
     const deg = -135 + v * 270;
@@ -49,15 +59,14 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     current = Math.max(0, Math.min(1, v));
     setRotation(current);
     val.textContent = fmt(current);
-    bubble.textContent = fmt(current);
     onChange(current);
   }
 
   setRotation(current);
   val.textContent = fmt(current);
 
-  let bubbleHideTimer = null;
   function showBubble() {
+    const bubble = getBubble();
     const r = dial.getBoundingClientRect();
     bubble.style.left = (r.left + r.width / 2) + 'px';
     // Flip below the dial when there's no headroom (knob near viewport top)
@@ -65,12 +74,12 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     bubble.classList.toggle('below', below);
     bubble.style.top = below ? (r.bottom + 6) + 'px' : (r.top - 6) + 'px';
     bubble.textContent = fmt(current);
-    clearTimeout(bubbleHideTimer);
+    clearTimeout(_bubbleHideTimer);
     bubble.classList.add('show');
   }
   function hideBubble() {
-    clearTimeout(bubbleHideTimer);
-    bubbleHideTimer = setTimeout(() => bubble.classList.remove('show'), 350);
+    clearTimeout(_bubbleHideTimer);
+    _bubbleHideTimer = setTimeout(() => getBubble().classList.remove('show'), 350);
   }
 
   // Vertical drag
@@ -93,6 +102,7 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     const dy = e.clientY - dragStartY;
     movedPx = Math.max(movedPx, Math.abs(dy));
     setValue(dragStartValue - dy / 150);
+    getBubble().textContent = fmt(current);
   });
 
   // End the drag on up OR on cancel/lost-capture (OS gesture, blur, modal),

--- a/docs/arcade/groovebox/ui/knob.js
+++ b/docs/arcade/groovebox/ui/knob.js
@@ -2,7 +2,8 @@
  * makeKnob({ label, value, onChange })
  * Returns a DOM element: a 34px rotary knob with vertical-drag interaction.
  * value: 0..1; indicator rotates from -135deg (0) to +135deg (1).
- * Double-click resets to initial value.
+ * Double-click (or double-tap) resets to initial value.
+ * While dragging, a floating bubble shows the value (0–100).
  */
 export function makeKnob({ label, value = 0, onChange, tip, k }) {
   const initial = value;
@@ -23,9 +24,21 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   lbl.className = 'knob-lbl';
   lbl.textContent = label;
 
+  // Persistent numeric readout (hidden unless body.gbm-knobval)
+  const val = document.createElement('span');
+  val.className = 'knob-val';
+
+  // Floating value bubble while dragging (position:fixed → escapes overflow clips)
+  const bubble = document.createElement('div');
+  bubble.className = 'knob-bubble';
+
   dial.appendChild(ind);
   wrapper.appendChild(dial);
   wrapper.appendChild(lbl);
+  wrapper.appendChild(val);
+  wrapper.appendChild(bubble);
+
+  const fmt = v => Math.round(v * 100);
 
   function setRotation(v) {
     const deg = -135 + v * 270;
@@ -35,25 +48,47 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
   function setValue(v) {
     current = Math.max(0, Math.min(1, v));
     setRotation(current);
+    val.textContent = fmt(current);
+    bubble.textContent = fmt(current);
     onChange(current);
   }
 
   setRotation(current);
+  val.textContent = fmt(current);
+
+  let bubbleHideTimer = null;
+  function showBubble() {
+    const r = dial.getBoundingClientRect();
+    bubble.style.left = (r.left + r.width / 2) + 'px';
+    bubble.style.top = (r.top - 6) + 'px';
+    bubble.textContent = fmt(current);
+    clearTimeout(bubbleHideTimer);
+    bubble.classList.add('show');
+  }
+  function hideBubble() {
+    clearTimeout(bubbleHideTimer);
+    bubbleHideTimer = setTimeout(() => bubble.classList.remove('show'), 350);
+  }
 
   // Vertical drag
   let dragStartY = null;
   let dragStartValue = null;
+  let lastTapAt = 0;
+  let movedPx = 0;
 
   dial.addEventListener('pointerdown', e => {
     e.preventDefault();
     dragStartY = e.clientY;
     dragStartValue = current;
+    movedPx = 0;
     dial.setPointerCapture(e.pointerId);
+    showBubble();
   });
 
   dial.addEventListener('pointermove', e => {
     if (dragStartY === null) return;
     const dy = e.clientY - dragStartY;
+    movedPx = Math.max(movedPx, Math.abs(dy));
     setValue(dragStartValue - dy / 150);
   });
 
@@ -63,8 +98,17 @@ export function makeKnob({ label, value = 0, onChange, tip, k }) {
     dragStartY = null;
     dragStartValue = null;
     if (e && e.pointerId != null) { try { dial.releasePointerCapture(e.pointerId); } catch {} }
+    hideBubble();
   };
-  dial.addEventListener('pointerup', endDrag);
+  dial.addEventListener('pointerup', e => {
+    // Double-tap reset for touch, where dblclick is unreliable with pointer capture
+    if (e.pointerType === 'touch' && movedPx < 5) {
+      const now = performance.now();
+      if (now - lastTapAt < 350) { setValue(initial); lastTapAt = 0; }
+      else lastTapAt = now;
+    }
+    endDrag(e);
+  });
   dial.addEventListener('pointercancel', endDrag);
   dial.addEventListener('lostpointercapture', endDrag);
 


### PR DESCRIPTION
## Summary

Makes the groovebox usable on phones and tablets. Desktop is unchanged (wide screens never hit the new code paths).

### Lanes → accordion (≤900px)
- Lanes collapse to header + groove-select rows; a lucide-chevron button (bottom-right, flush under ✕) expands one lane's knob strip at a time
- Tapping anywhere on the lane header also toggles; `aria-expanded` maintained

### Knob strips scroll at any width
- All of a strip's kgroups now live in one `.knobrow` scroll container (lanes + master)
- Sticky `‹ ›` edge arrows over gradient scrims appear only when knobs are off-screen; tapping an arrow pages the strip
- This is global, not just mobile: at in-between widths (iPad portrait was the repro) knobs scroll inside the lane instead of overflowing the cabinet

### Touch-correct knobs
- `touch-action` fixed so vertical drag turns the knob while horizontal pans scroll the strip; 42px dials on coarse pointers
- Floating value bubble while dragging — one shared element on `<body>` so no ancestor scroll/mask can clip it; flips below the dial near the viewport top
- Double-tap resets (touch equivalent of the existing double-click)

### Edge-to-edge mobile chrome
- Cabinet/vignette/screws flatten away under 900px; html/body/cabinet share one flat `var(--bg)` surface
- Transport becomes an explicit grid: play+key / tempo / song; redundant TEMPO/SONG/VIEW labels dropped (the controls label themselves); KEY label kept
- Breakpoint is 900px (CSS) with the JS accordion gate on the same `matchMedia`, so tablet portrait gets the accordion — at 768px an expanded lane fits all 12 knobs in one row

### ⚙ View settings → new DISPLAY section (both default off)
- **Knob values** — persistent numeric readout under every knob, any width
- **Wrap knobs (mobile)** — wrap the strip onto extra rows instead of swiping

### Dev harness
- `phone.html` — 390px iframe preview for quick desktop checks (not linked anywhere)

## Test plan
- [x] 125/125 engine tests green
- [x] 390px phone: accordion, swipe, bubble, transport grid verified in-browser
- [x] 768px tablet portrait: accordion, full knob row, no overflow
- [x] Wide desktop: layout identical, knob scroll inert
- [ ] Hand-test on real iPhone + iPad (portrait/landscape rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)