### PR TITLE
arcade(groovebox): suppress long-press selection/context menus on touch

### DIFF
--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -849,6 +849,19 @@ body.gb-knob-values .knob-val { display: block; }
 @media (pointer: coarse) {
   .knob-dial { width: 42px; height: 42px; }
   .knob-ind  { top: 4px; height: 15px; transform-origin: 50% 17px; }
+
+  /* It's an instrument, not a document: press-and-hold must not start text
+     selection (Android Chrome's "more actions / translate" toolbar) or the
+     iOS callout. Editing fields and help text keep normal selection. */
+  body {
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+  input, textarea, #help-modal-box {
+    -webkit-user-select: text;
+    user-select: text;
+  }
 }
 
 /* ─── mute / solo buttons ────────────────────────────────────────────────── */

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1457,3 +1457,11 @@ eng.setTempo(initialSong.bpm);
 mount();
 // Wrap sections and wire section drag-reorder once, after first mount.
 initSectionWrappers();
+// Press-and-hold on a control must not open the browser context menu (Android
+// Chrome long-press → "more actions / translate"). Scoped to controls so
+// right-click elsewhere stays normal on desktop.
+document.addEventListener('contextmenu', e => {
+  if (e.target.closest('.knob, .punchpad, .lane-expand, .knob-scroll-hint, .lane-drag, .sec-drag, #viz')) {
+    e.preventDefault();
+  }
+});


### PR DESCRIPTION
## Summary
Press-and-hold on knobs/pads on Android Chrome was opening the text-selection toolbar ("more actions / translate") mid-performance. `touch-action` doesn't cover this gesture — it's selection + contextmenu.

- `pointer: coarse` → `user-select: none` + `-webkit-touch-callout: none` on body; inputs/textareas/help-modal text keep normal selection
- `contextmenu` preventDefault scoped to controls (knobs, punch pads, expand chevrons, scroll hints, drag handles, the LCD) — desktop right-click elsewhere unaffected

## Test plan
- [x] 188/188 tests green
- [ ] Press-and-hold a knob / punch pad on Android Chrome — no toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)