### PR TITLE
arcade(groovebox): share registry v1 — publish songs + grooves at groovebox.oyster.to/s/<id>

### DIFF
--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -8,7 +8,7 @@
 song = {
   version: 2,                                        // schema version — bump only with this doc
   title: string, artist: string,
-  meter: { beatsPerBar, beatUnit, stepsPerBeat },   // 4/4 → 16 steps/bar; 6/8 → 12
+  meter: { beatsPerBar, beatUnit, stepsPerBeat, group? },  // 4/4 → 16 steps/bar; 6/8 → 12, group:3 accents
   bpm: number,
 
   // INSTRUMENT CHANNELS — mixer + voice identity. NO musical content here.
@@ -88,10 +88,11 @@ Other threads should leave room for these, not invent competing shapes:
 
 - **`pattern.chords` + chord-relative grooves** — *LIVE.* Chords live on each pattern (one per bar, cycling), and the relative-groove syntax resolves against them (documented above). The chord line in the PATTERNS module edits the selected pattern's chords (parser-backed); melody snap/tint read `song.key`. The flattener translates known bass figures (`octave`, `eighths`, `16ths`, `arp`, …) and the chord modes (`pad`/`stab`/`arp`) into single chord-relative grooves and attaches each pattern's chords from the source progression's bar offsets; array/MIDI bass, melody, and drums stay baked literal. Parity with the legacy note stream is proven for all 7 presets. **Still future:** editable chord-relative grooves (groove writes are no-ops today).
 - **`instruments`** *(direction only — design after #630 lands)*: a definitions layer (`instruments: { [id]: synth params | sample ref }`) that lanes reference, replacing the hardcoded `type → voices.js` synthesis. A drum kit becomes an *ensemble* of instrument refs; samples (wav/mp3) enter here. This is the unlock for the social/composable vision. **Until then: `lane.type` stays a broad routing identity — do not extend its semantics or let it become an instrument-definition dumping ground.**
-- **Sharing**: grooves, patterns, and songs are already self-contained named JSON. Sample assets are the one future exception (need hosting/IDs, can't ride in JSON).
+- **Sharing** — *LIVE (share registry v1).* Songs and grooves are **registry items**: a kind-generic Worker+D1 store behind `groovebox.oyster.to/api/registry`, pretty links `/s/<id>` (`@rev` reserved, ignored in v1). Per-kind schema versions: `song=2` (this doc), `groove=1` (bundle: `{ laneType, meter, bars, relative?, bpm?, extensions? }`). The enforcement point is `registry/validate.js` — shared verbatim by the Worker and the app, strict keys with `extensions: {}` as the only hatch; change it only with this doc and the spec (`project-notes po20/2026-06-06-share-registry-spec.md`). Future kinds (`instrument`, `sample`, `module`) are new enum values, not new systems.
+- **`sampleRef`** *(reserved, NOT in any schema yet)*: when samples arrive they are **metadata-only** first — `sampleRef: { type: 'built-in', id: 'kick-808' }`, later `{ type: 'r2', assetId }`. Audio bytes never ride in registry JSON (the validator's 1KB string cap enforces this); R2 hosting is the instruments-layer slice.
 
 ## API surface (engine — `engine/index.js`)
 
 Read: `getSong getLanes getGrooves getPatterns getChain getEditPatternIndex getEditGroove(laneId) getPlaybackTarget getKey getPatternChords(i)`.
-Mutate: `selectPattern playChain addPattern duplicatePattern removePattern appendToChain removeChainAt moveChain setLaneGroove(laneId, name) setGrooveBars(laneId, n) setDrumStep toggleNote setPatternChords(chords)` + lanes (`addLane duplicateLane removeLane renameLane moveLane`), mixer/FX, fills queue, transport.
+Mutate: `selectPattern playChain addPattern duplicatePattern removePattern appendToChain removeChainAt moveChain setLaneGroove(laneId, name) addGroove(laneId, name, value) setGrooveBars(laneId, n) setDrumStep toggleNote setPatternChords(chords)` + lanes (`addLane duplicateLane removeLane renameLane moveLane`), mixer/FX, fills queue, transport.
 Gone (do not reintroduce): `setMode getMode captureScene clearArrangement setLane` per-lane selection, `cycleLen`, pattern `bars`/`setPatternBars`, `getHarmony`/`setProgression` (chords are pattern-owned now).

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -10,7 +10,7 @@ import {
   appendToChain as _appendToChain,
   removeChainAt as _removeChainAt, moveChain as _moveChain,
   setDrumStep as _setDrumStep, toggleNote as _toggleNote,
-  setLaneGroove as _setLaneGroove, grooveFor,
+  setLaneGroove as _setLaneGroove, addGroove as _addGroove, grooveFor,
   setGrooveBars as _setGrooveBars,
 } from './patterns.js';
 import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, isPunchArmed } from './punch.js';
@@ -476,6 +476,7 @@ export function createEngine() {
     addPattern()            { return song ? _addPattern(song, editIdx) : null; },
     duplicatePattern(i)     { return song ? _duplicatePattern(song, i) : null; },
     setLaneGroove(laneId, grooveName) { return song ? _setLaneGroove(song, editIdx, laneId, grooveName) : false; },
+    addGroove(laneId, name, value) { return song ? _addGroove(song, laneId, name, value) : false; },
     setGrooveBars(laneId, n) {
       if (!song) return null;
       const g = grooveFor(song, editIdx, laneId);

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -212,6 +212,19 @@ export function setLaneGroove(song, patternIdx, laneId, grooveName) {
   return true;
 }
 
+// addGroove(song, laneId, name, value) — register new named groove content for
+// a lane (share-import path). value is a groove VALUE: bars[] or, for note
+// lanes, { relative: true, bars }. Caller dedupes names; collision → false.
+export function addGroove(song, laneId, name, value) {
+  if (!song.lanes.some(l => l.id === laneId)) return false;
+  const bars = grooveBars(value);
+  if (!Array.isArray(bars) || bars.length < 1 || bars.length > 8) return false;
+  if (!song.grooves[laneId]) song.grooves[laneId] = {};
+  if (song.grooves[laneId][name]) return false;
+  song.grooves[laneId][name] = value;
+  return true;
+}
+
 // ── groove bar count ──────────────────────────────────────────────────────────
 // Groove lengths are powers of two (1/2/4/8). This keeps every groove dividing
 // the pattern's longest groove cleanly — no audible drift/wrapping.

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -86,6 +86,10 @@
             <button id="share-copy">Copy</button>
           </div>
           <div id="share-error" hidden></div>
+          <div id="share-mine" hidden>
+            <h3>Your published</h3>
+            <ul id="share-mine-list"></ul>
+          </div>
         </div>
       </div>
 

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -78,8 +78,8 @@
           <label class="share-field">Name <input id="share-name" maxlength="80"></label>
           <label class="share-field">By <input id="share-author" maxlength="40" placeholder="optional"></label>
           <div id="share-actions">
-            <button id="share-submit">Publish</button>
             <button id="share-update" hidden>Update</button>
+            <button id="share-submit">Publish</button>
           </div>
           <div id="share-result" hidden>
             <input id="share-link" readonly>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -57,16 +57,16 @@
             <select id="songsel"><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
             <div id="credit"></div>
           </div>
-          <button id="share-btn" title="Share this song or a groove">SHARE</button>
+          <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
       </div>
 
       <!-- Share modal -->
       <div id="share-modal" hidden>
         <div id="share-modal-backdrop"></div>
-        <div id="share-modal-box" role="dialog" aria-modal="true" aria-label="Share">
-          <button id="share-modal-close" aria-label="Close share">✕</button>
-          <h2>Share</h2>
+        <div id="share-modal-box" role="dialog" aria-modal="true" aria-label="Publish">
+          <button id="share-modal-close" aria-label="Close publish">✕</button>
+          <h2>Publish</h2>
           <div id="share-tabs">
             <button id="share-tab-song" class="share-tab active">Song</button>
             <button id="share-tab-groove" class="share-tab">Groove</button>
@@ -78,8 +78,8 @@
           <label class="share-field">Name <input id="share-name" maxlength="80"></label>
           <label class="share-field">By <input id="share-author" maxlength="40" placeholder="optional"></label>
           <div id="share-actions">
-            <button id="share-submit">Share</button>
-            <button id="share-update" hidden>Update share</button>
+            <button id="share-submit">Publish</button>
+            <button id="share-update" hidden>Update</button>
           </div>
           <div id="share-result" hidden>
             <input id="share-link" readonly>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -57,6 +57,35 @@
             <select id="songsel"><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
             <div id="credit"></div>
           </div>
+          <button id="share-btn" title="Share this song or a groove">SHARE</button>
+        </div>
+      </div>
+
+      <!-- Share modal -->
+      <div id="share-modal" hidden>
+        <div id="share-modal-backdrop"></div>
+        <div id="share-modal-box" role="dialog" aria-modal="true" aria-label="Share">
+          <button id="share-modal-close" aria-label="Close share">✕</button>
+          <h2>Share</h2>
+          <div id="share-tabs">
+            <button id="share-tab-song" class="share-tab active">Song</button>
+            <button id="share-tab-groove" class="share-tab">Groove</button>
+          </div>
+          <div id="share-groove-pickers" hidden>
+            <select id="share-lane"></select>
+            <select id="share-groove"></select>
+          </div>
+          <label class="share-field">Name <input id="share-name" maxlength="80"></label>
+          <label class="share-field">By <input id="share-author" maxlength="40" placeholder="optional"></label>
+          <div id="share-actions">
+            <button id="share-submit">Share</button>
+            <button id="share-update" hidden>Update share</button>
+          </div>
+          <div id="share-result" hidden>
+            <input id="share-link" readonly>
+            <button id="share-copy">Copy</button>
+          </div>
+          <div id="share-error" hidden></div>
         </div>
       </div>
 

--- a/docs/arcade/groovebox/registry/client.js
+++ b/docs/arcade/groovebox/registry/client.js
@@ -5,7 +5,12 @@
 export const API_BASE = '/api/registry';
 export const CANONICAL_ORIGIN = 'https://groovebox.oyster.to';
 
-export function shareUrl(id) { return `${CANONICAL_ORIGIN}/s/${id}`; }
+// Canonical host for links — except in local dev (wrangler dev / vite), where a
+// canonical link would 404 until deployed; there the local origin is the truth.
+export function shareUrl(id) {
+  const local = typeof location !== 'undefined' && /^(localhost|127\.)/.test(location.hostname);
+  return `${local ? location.origin : CANONICAL_ORIGIN}/s/${id}`;
+}
 
 // /s/<id> redirects here as /?s=<id>; @revision is reserved syntax, ignored in v1.
 export function parseShareParam(search) {

--- a/docs/arcade/groovebox/registry/client.js
+++ b/docs/arcade/groovebox/registry/client.js
@@ -24,13 +24,27 @@ export function parseShareParam(search) {
 function readJSON(key, fallback) {
   try { return JSON.parse(localStorage.getItem(key) || 'null') ?? fallback; } catch { return fallback; }
 }
-export function getEditKey(id) { return readJSON('gb-registry-edit-keys', {})[id] ?? null; }
-export function storeEditKey(id, key) {
+// Map values are { key, name, kind, at } — or a bare key string from the
+// earliest builds (tolerated on read).
+export function getEditKey(id) {
+  const v = readJSON('gb-registry-edit-keys', {})[id];
+  return v ? (typeof v === 'string' ? v : v.key) : null;
+}
+export function storeEditKey(id, key, meta = {}) {
   try {
     const map = readJSON('gb-registry-edit-keys', {});
-    map[id] = key;
+    const prev = typeof map[id] === 'object' ? map[id] : {};
+    map[id] = { ...prev, key, ...meta, at: Date.now() };
     localStorage.setItem('gb-registry-edit-keys', JSON.stringify(map));
   } catch {}
+}
+// Your private publish history (newest first) — local to this browser, NOT a
+// discovery surface. Bare-string legacy entries surface as unnamed items.
+export function listMine() {
+  const map = readJSON('gb-registry-edit-keys', {});
+  return Object.entries(map)
+    .map(([id, v]) => typeof v === 'string' ? { id, name: id, kind: '', at: 0 } : { id, name: v.name || id, kind: v.kind || '', at: v.at || 0 })
+    .sort((a, b) => b.at - a.at);
 }
 export function getAuthor() { try { return localStorage.getItem('gb-registry-author') || ''; } catch { return ''; } }
 export function setAuthor(name) { try { localStorage.setItem('gb-registry-author', name); } catch {} }

--- a/docs/arcade/groovebox/registry/client.js
+++ b/docs/arcade/groovebox/registry/client.js
@@ -1,0 +1,45 @@
+// ─── Browser client for the share registry ───────────────────────────────────
+// Pure helpers (parse, storage) are unit-tested; fetch wrappers are exercised
+// against wrangler dev + the live deploy.
+
+export const API_BASE = '/api/registry';
+export const CANONICAL_ORIGIN = 'https://groovebox.oyster.to';
+
+export function shareUrl(id) { return `${CANONICAL_ORIGIN}/s/${id}`; }
+
+// /s/<id> redirects here as /?s=<id>; @revision is reserved syntax, ignored in v1.
+export function parseShareParam(search) {
+  const raw = new URLSearchParams(search).get('s');
+  if (!raw) return null;
+  const m = raw.match(/^([a-z0-9]{8})(?:@\d+)?$/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+// localStorage access mirrors app.js convention: try/catch, degrade silently.
+function readJSON(key, fallback) {
+  try { return JSON.parse(localStorage.getItem(key) || 'null') ?? fallback; } catch { return fallback; }
+}
+export function getEditKey(id) { return readJSON('gb-registry-edit-keys', {})[id] ?? null; }
+export function storeEditKey(id, key) {
+  try {
+    const map = readJSON('gb-registry-edit-keys', {});
+    map[id] = key;
+    localStorage.setItem('gb-registry-edit-keys', JSON.stringify(map));
+  } catch {}
+}
+export function getAuthor() { try { return localStorage.getItem('gb-registry-author') || ''; } catch { return ''; } }
+export function setAuthor(name) { try { localStorage.setItem('gb-registry-author', name); } catch {} }
+
+async function call(method, path, body) {
+  const res = await fetch(API_BASE + path, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || `request failed (${res.status})`);
+  return data;
+}
+export const createItem = (body) => call('POST', '', body);            // → { id, editKey }
+export const getItem = (id) => call('GET', `/${id}`);                  // → record
+export const updateItem = (id, body) => call('PUT', `/${id}`, body);   // → { revision }

--- a/docs/arcade/groovebox/registry/handler.js
+++ b/docs/arcade/groovebox/registry/handler.js
@@ -1,0 +1,108 @@
+// ─── Share-registry HTTP handler (pure; db + secret injected) ────────────────
+// Worker glue (infra/oyster-arcade-site/src/worker.ts) supplies the D1 adapter,
+// the HMAC secret, and rate limiting. This file is testable in plain node.
+// db interface: get(id)→row|null, insert(row) [throws {code:'conflict'} on dup id],
+//               update(id, fields).
+
+import { validateCreate, validateUpdate } from './validate.js';
+
+const ID_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+export function makeId() {
+  const b = crypto.getRandomValues(new Uint8Array(8));
+  return [...b].map((x) => ID_ALPHABET[x % 36]).join('');   // tiny modulo bias is fine: ids are not secrets
+}
+
+export function makeEditKey() {
+  const b = crypto.getRandomValues(new Uint8Array(32));
+  return btoa(String.fromCharCode(...b)).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+async function hmacHex(secret, value) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(value));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Constant-time string compare (XOR-fold). Both inputs are HMAC hex digests of
+// fixed length, which is what makes this equivalent to timingSafeEqual.
+function constantTimeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+const json = (status, body) => new Response(JSON.stringify(body), {
+  status, headers: { 'content-type': 'application/json' },
+});
+
+async function readJson(req) {
+  try { return await req.json(); } catch { return undefined; }
+}
+
+async function create(req, db, secret) {
+  const body = await readJson(req);
+  if (body === undefined) return json(400, { error: 'invalid JSON' });
+  const v = validateCreate(body);
+  if (!v.ok) return json(400, { error: v.error });
+  if (body.remix_of !== undefined && !(await db.get(body.remix_of))) return json(400, { error: 'remix_of not found' });
+
+  const editKey = makeEditKey();
+  const now = new Date().toISOString();
+  const row = {
+    kind: body.kind, schema_version: body.schema_version,
+    name: body.name, author: body.author ?? '',
+    payload: JSON.stringify(body.payload),
+    remix_of: body.remix_of ?? null, revision: 1,
+    edit_key_hash: await hmacHex(secret, editKey),
+    created_at: now, updated_at: now,
+  };
+  for (let attempt = 0; attempt < 5; attempt++) {       // server-side ids; regenerate on collision
+    const id = makeId();
+    try { await db.insert({ id, ...row }); return json(201, { id, editKey }); }
+    catch (e) { if (e.code !== 'conflict') throw e; }
+  }
+  return json(503, { error: 'could not allocate id' });
+}
+
+async function get(id, db) {
+  const row = await db.get(id);
+  if (!row) return json(404, { error: 'not found' });
+  const { edit_key_hash, ...pub } = row;                // NEVER returned
+  return json(200, { ...pub, payload: JSON.parse(row.payload) });
+}
+
+async function update(id, req, db, secret) {
+  const row = await db.get(id);
+  if (!row) return json(404, { error: 'not found' });
+  const body = await readJson(req);
+  if (body === undefined) return json(400, { error: 'invalid JSON' });
+  const v = validateUpdate(body, row.kind, row.schema_version);   // same gate as POST
+  if (!v.ok) return json(400, { error: v.error });
+  const hash = await hmacHex(secret, body.editKey);
+  if (!constantTimeEqual(hash, row.edit_key_hash)) return json(403, { error: 'forbidden' });
+  const revision = row.revision + 1;
+  await db.update(id, {
+    name: body.name, author: body.author ?? '',
+    payload: JSON.stringify(body.payload),
+    revision, updated_at: new Date().toISOString(),     // server timestamps only
+  });
+  return json(200, { revision });
+}
+
+export async function handleRegistry(req, db, secret) {
+  const url = new URL(req.url);
+  const m = url.pathname.match(/^\/api\/registry(?:\/([a-z0-9]{1,32}))?$/);
+  if (!m) return json(404, { error: 'not found' });
+  const id = m[1];
+  try {
+    if (req.method === 'POST' && !id) return await create(req, db, secret);
+    if (req.method === 'GET' && id) return await get(id, db);
+    if (req.method === 'PUT' && id) return await update(id, req, db, secret);
+  } catch {
+    return json(500, { error: 'internal error' });
+  }
+  return json(405, { error: 'method not allowed' });
+}

--- a/docs/arcade/groovebox/registry/handler.js
+++ b/docs/arcade/groovebox/registry/handler.js
@@ -94,7 +94,7 @@ async function update(id, req, db, secret) {
 
 export async function handleRegistry(req, db, secret) {
   const url = new URL(req.url);
-  const m = url.pathname.match(/^\/api\/registry(?:\/([a-z0-9]{1,32}))?$/);
+  const m = url.pathname.match(/^\/api\/registry(?:\/([a-z0-9]{8}))?$/);
   if (!m) return json(404, { error: 'not found' });
   const id = m[1];
   try {

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -1,0 +1,149 @@
+// ─── Share-registry validation (pure, shared by Worker AND browser app) ──────
+// Single source of truth alongside DATA-MODEL.md and the spec
+// (po20/2026-06-06-share-registry-spec.md). Strict everywhere: unknown keys
+// rejected; the ONLY extension point is `extensions: {}` inside payloads.
+
+export const KIND_VERSIONS = { song: 2, groove: 1 };
+export const LANE_TYPES = ['drums', 'bass', 'chords', 'melody'];
+const NAME_MAX = 80, AUTHOR_MAX = 40;
+const PAYLOAD_MAX = 64 * 1024;   // JSON.stringify length
+const STRING_MAX = 1024;         // any single string value/key — blocks base64 audio
+const ID_RE = /^[a-z0-9]{8}$/;
+
+const ok = { ok: true };
+const err = (error) => ({ ok: false, error });
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+function strictKeys(obj, allowed, label) {
+  for (const k of Object.keys(obj)) if (!allowed.includes(k)) return `${label}: unknown key "${k}"`;
+  return null;
+}
+
+// Walk payload: no string (value or key) may exceed STRING_MAX.
+function oversizedString(v) {
+  if (typeof v === 'string') return v.length > STRING_MAX;
+  if (Array.isArray(v)) return v.some(oversizedString);
+  if (isObj(v)) return Object.keys(v).some((k) => k.length > STRING_MAX || oversizedString(v[k]));
+  return false;
+}
+
+function meterValid(m) {
+  return isObj(m) && strictKeys(m, ['beatsPerBar', 'beatUnit', 'stepsPerBeat', 'group'], 'meter') === null &&
+    [m.beatsPerBar, m.beatUnit, m.stepsPerBeat].every((n) => Number.isInteger(n) && n >= 1 && n <= 64) &&
+    (m.group === undefined || (Number.isInteger(m.group) && m.group >= 1 && m.group <= 64));
+}
+
+// Bar-shape depth only: drums bar = plain object of arrays; note bar
+// (bass/chords/melody) = array of note events. Per-step tuples are not
+// re-validated here — the engine is robust to bad picks by contract.
+function barsValid(laneType, bars) {
+  if (!Array.isArray(bars) || bars.length < 1 || bars.length > 8) return false;
+  if (laneType === 'drums') return bars.every((b) => isObj(b) && Object.values(b).every(Array.isArray));
+  return bars.every((b) => Array.isArray(b) && b.every(Array.isArray));
+}
+
+// A groove VALUE in song.grooves: bars[] (literal) or — note lanes only —
+// { relative: true, bars } with chord-relative REFs resolved against
+// pattern.chords at schedule time.
+function grooveValueValid(laneType, g) {
+  if (Array.isArray(g)) return barsValid(laneType, g);
+  if (laneType === 'drums') return false;
+  return isObj(g) && strictKeys(g, ['relative', 'bars'], 'groove') === null &&
+    g.relative === true && barsValid(laneType, g.bars);
+}
+
+// pattern.chords — one entry per bar of the pattern: {name, root, voicing} | null.
+function chordsValid(chords) {
+  if (!Array.isArray(chords) || chords.length < 1) return false;
+  return chords.every((c) => c === null ||
+    (isObj(c) && strictKeys(c, ['name', 'root', 'voicing'], 'chord') === null &&
+     typeof c.name === 'string' && typeof c.root === 'string' && Array.isArray(c.voicing)));
+}
+
+export function validateGroovePayload(p) {
+  if (!isObj(p)) return err('payload must be an object');
+  const bad = strictKeys(p, ['laneType', 'meter', 'bars', 'relative', 'bpm', 'extensions'], 'groove payload');
+  if (bad) return err(bad);
+  if (!LANE_TYPES.includes(p.laneType)) return err('invalid laneType');
+  if (!meterValid(p.meter)) return err('invalid meter');
+  if (p.relative !== undefined && (p.relative !== true || p.laneType === 'drums')) return err('invalid relative');
+  if (!barsValid(p.laneType, p.bars)) return err('invalid bars');
+  if (p.bpm !== undefined && !(typeof p.bpm === 'number' && p.bpm >= 20 && p.bpm <= 999)) return err('invalid bpm');
+  if (p.extensions !== undefined && !isObj(p.extensions)) return err('extensions must be an object');
+  return ok;
+}
+
+export function validateSongPayload(p) {
+  if (!isObj(p)) return err('payload must be an object');
+  const bad = strictKeys(p, ['version', 'title', 'artist', 'meter', 'bpm', 'lanes', 'grooves',
+    'patterns', 'chain', 'fills', 'transpose', 'key', 'extensions'], 'song payload');
+  if (bad) return err(bad);
+  if (p.key !== undefined && !(isObj(p.key) && typeof p.key.root === 'string' && typeof p.key.mode === 'string')) return err('invalid key');
+  if (p.version !== 2) return err('song payload version must be 2');
+  if (!meterValid(p.meter)) return err('invalid meter');
+  if (!(typeof p.bpm === 'number' && p.bpm >= 20 && p.bpm <= 999)) return err('invalid bpm');
+  if (!Array.isArray(p.lanes) || p.lanes.length < 1) return err('lanes required');
+  const laneIds = new Set();
+  for (const l of p.lanes) {
+    if (!isObj(l) || typeof l.id !== 'string' || !LANE_TYPES.includes(l.type)) return err('invalid lane');
+    if (laneIds.has(l.id)) return err('duplicate lane id');
+    laneIds.add(l.id);
+  }
+  if (!isObj(p.grooves)) return err('grooves must be an object');
+  for (const [laneId, byName] of Object.entries(p.grooves)) {
+    if (!laneIds.has(laneId)) return err(`grooves for unknown lane "${laneId}"`);
+    if (!isObj(byName)) return err('groove map must be an object');
+    const laneType = p.lanes.find((l) => l.id === laneId).type;
+    for (const g of Object.values(byName)) if (!grooveValueValid(laneType, g)) return err('invalid groove bars');
+  }
+  if (!Array.isArray(p.patterns) || p.patterns.length < 1 || p.patterns.length > 16) return err('patterns must be 1..16');
+  for (const pat of p.patterns) {
+    if (!isObj(pat) || strictKeys(pat, ['lanes', 'chords'], 'pattern') !== null || !isObj(pat.lanes)) return err('invalid pattern');
+    if (pat.chords !== undefined && pat.chords !== null && !chordsValid(pat.chords)) return err('invalid pattern chords');
+    for (const [laneId, name] of Object.entries(pat.lanes)) {
+      if (name === null || name === undefined) continue;     // explicit no-pick is allowed
+      if (!p.grooves[laneId]?.[name]) return err('pattern pick does not resolve');
+    }
+  }
+  if (!Array.isArray(p.chain) || p.chain.length < 1 ||
+      !p.chain.every((i) => Number.isInteger(i) && i >= 0 && i < p.patterns.length)) return err('invalid chain');
+  if (p.fills !== undefined && !isObj(p.fills)) return err('fills must be an object');
+  if (p.transpose !== undefined && !Number.isInteger(p.transpose)) return err('transpose must be an integer');
+  if (p.extensions !== undefined && !isObj(p.extensions)) return err('extensions must be an object');
+  return ok;
+}
+
+function validatePayload(kind, payload) {
+  if (JSON.stringify(payload).length > PAYLOAD_MAX) return err('payload too large');
+  if (oversizedString(payload)) return err('string field too large');
+  return kind === 'song' ? validateSongPayload(payload) : validateGroovePayload(payload);
+}
+
+function validateNameAuthor(body) {
+  if (typeof body.name !== 'string' || body.name.length < 1 || body.name.length > NAME_MAX) return err('invalid name');
+  if (body.author !== undefined && (typeof body.author !== 'string' || body.author.length > AUTHOR_MAX)) return err('invalid author');
+  return ok;
+}
+
+export function validateCreate(body) {
+  if (!isObj(body)) return err('body must be an object');
+  const bad = strictKeys(body, ['kind', 'schema_version', 'name', 'author', 'payload', 'remix_of'], 'body');
+  if (bad) return err(bad);
+  if (!(body.kind in KIND_VERSIONS)) return err('unknown kind');
+  if (body.schema_version !== KIND_VERSIONS[body.kind]) return err('unsupported schema_version for kind');
+  const na = validateNameAuthor(body); if (!na.ok) return na;
+  if (body.remix_of !== undefined && !(typeof body.remix_of === 'string' && ID_RE.test(body.remix_of))) return err('invalid remix_of');
+  return validatePayload(body.kind, body.payload);
+}
+
+// Update validates against the EXISTING row's kind/schema_version (identity
+// fields are not in the allowed key list, so changing them is impossible).
+export function validateUpdate(body, kind, schemaVersion) {
+  if (!isObj(body)) return err('body must be an object');
+  const bad = strictKeys(body, ['editKey', 'name', 'author', 'payload'], 'body');
+  if (bad) return err(bad);
+  if (typeof body.editKey !== 'string' || body.editKey.length < 16) return err('invalid editKey');
+  const na = validateNameAuthor(body); if (!na.ok) return na;
+  if (schemaVersion !== KIND_VERSIONS[kind]) return err('row schema_version unsupported');
+  return validatePayload(kind, body.payload);
+}

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -57,7 +57,8 @@ function chordsValid(chords) {
   if (!Array.isArray(chords) || chords.length < 1) return false;
   return chords.every((c) => c === null ||
     (isObj(c) && strictKeys(c, ['name', 'root', 'voicing'], 'chord') === null &&
-     typeof c.name === 'string' && typeof c.root === 'string' && Array.isArray(c.voicing)));
+     typeof c.name === 'string' && typeof c.root === 'string' &&
+     Array.isArray(c.voicing) && c.voicing.every((v) => typeof v === 'string')));
 }
 
 export function validateGroovePayload(p) {

--- a/docs/arcade/groovebox/tests/groove-import.test.js
+++ b/docs/arcade/groovebox/tests/groove-import.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine } from '../engine/index.js';
+import { kids } from '../songs/kids.js';
+import { dedupeName, pickHostLanes, metersEqual, buildGrooveBundle, decideShareMode, importGroove }
+  from '../ui/share.js';
+import { validateGroovePayload } from '../registry/validate.js';
+
+function engineWithSong() { const eng = createEngine(); eng.load(kids); return eng; }
+const drumLaneId = (eng) => eng.getLanes().find((l) => l.type === 'drums').id;
+
+describe('eng.addGroove(laneId, name, value)', () => {
+  const BARS = [{ kick: [0, 8], snare: [4, 12], hat: [], crash: [], tom: [] }];
+
+  it('adds a named groove to an existing lane', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    expect(eng.addGroove(laneId, 'imported', BARS)).toBe(true);
+    expect(eng.getGrooves()[laneId].imported).toEqual(BARS);
+  });
+
+  it('refuses name collisions and unknown lanes', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    eng.addGroove(laneId, 'imported', BARS);
+    expect(eng.addGroove(laneId, 'imported', BARS)).toBe(false);
+    expect(eng.addGroove('ghost-lane', 'x', BARS)).toBe(false);
+  });
+
+  it('refuses bars outside 1..8', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    expect(eng.addGroove(laneId, 'x', [])).toBe(false);
+    expect(eng.addGroove(laneId, 'x', Array.from({ length: 9 }, () => ({})))).toBe(false);
+  });
+
+  it('accepts a chord-relative groove value on a note lane', () => {
+    const eng = engineWithSong();
+    const laneId = eng.getLanes().find((l) => l.type === 'bass').id;
+    expect(eng.addGroove(laneId, 'imported-rel', { relative: true, bars: [[[0, 'R', 2]]] })).toBe(true);
+    expect(eng.setLaneGroove(laneId, 'imported-rel')).toBe(true);
+  });
+
+  it('added groove is selectable via setLaneGroove', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    eng.addGroove(laneId, 'imported', BARS);
+    expect(eng.setLaneGroove(laneId, 'imported')).toBe(true);
+  });
+
+  it('works on a freshly added lane (grooves slot exists)', () => {
+    const eng = engineWithSong();
+    const lane = eng.addLane('bass');
+    expect(eng.addGroove(lane.id, 'imported', [[[0, 'C2', 2]]])).toBe(true);
+  });
+});
+
+describe('share.js pure helpers', () => {
+  it('dedupeName: name, name-2, name-3…', () => {
+    expect(dedupeName([], 'amen')).toBe('amen');
+    expect(dedupeName(['amen'], 'amen')).toBe('amen-2');
+    expect(dedupeName(['amen', 'amen-2'], 'amen')).toBe('amen-3');
+  });
+
+  it('pickHostLanes filters by type', () => {
+    const lanes = [{ id: 'drums', type: 'drums' }, { id: 'bass', type: 'bass' }, { id: 'drums-2', type: 'drums' }];
+    expect(pickHostLanes(lanes, 'drums').map((l) => l.id)).toEqual(['drums', 'drums-2']);
+    expect(pickHostLanes(lanes, 'melody')).toEqual([]);
+  });
+
+  it('metersEqual compares the three rhythm fields (group is cosmetic)', () => {
+    expect(metersEqual({ beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 })).toBe(true);
+    expect(metersEqual({ beatsPerBar: 6, beatUnit: 8, stepsPerBeat: 2 }, { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 })).toBe(false);
+    expect(metersEqual({ beatsPerBar: 6, beatUnit: 8, stepsPerBeat: 2, group: 3 }, { beatsPerBar: 6, beatUnit: 8, stepsPerBeat: 2 })).toBe(true);
+  });
+
+  it('buildGrooveBundle: literal drums groove → valid payload', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    const grooveName = Object.keys(eng.getGrooves()[laneId])[0];
+    const bundle = buildGrooveBundle(eng, laneId, grooveName);
+    expect(bundle.laneType).toBe('drums');
+    expect(bundle.meter).toEqual(JSON.parse(JSON.stringify(eng.getSong().meter)));
+    expect(bundle.relative).toBeUndefined();
+    expect(typeof bundle.bpm).toBe('number');
+    expect(validateGroovePayload(bundle).ok).toBe(true);   // bundle ↔ validator contract
+  });
+
+  it('buildGrooveBundle: chord-relative groove → relative flag + valid payload', () => {
+    const eng = engineWithSong();
+    const laneId = eng.getLanes().find((l) => l.type === 'bass').id;
+    const grooves = eng.getGrooves()[laneId];
+    const relName = Object.keys(grooves).find((n) => !Array.isArray(grooves[n]));
+    expect(relName).toBeTruthy();                          // kids has relative bass grooves
+    const bundle = buildGrooveBundle(eng, laneId, relName);
+    expect(bundle.relative).toBe(true);
+    expect(Array.isArray(bundle.bars)).toBe(true);
+    expect(validateGroovePayload(bundle).ok).toBe(true);
+  });
+
+  it('decideShareMode: owner-choice / remix / new', () => {
+    expect(decideShareMode({ loadedFrom: { id: 'a', kind: 'song' }, hasEditKey: true, kind: 'song' })).toBe('owner-choice');
+    expect(decideShareMode({ loadedFrom: { id: 'a', kind: 'song' }, hasEditKey: false, kind: 'song' })).toBe('remix');
+    expect(decideShareMode({ loadedFrom: { id: 'a', kind: 'song' }, hasEditKey: false, kind: 'groove' })).toBe('new'); // cross-kind = new in v1
+    expect(decideShareMode({ loadedFrom: null, hasEditKey: false, kind: 'song' })).toBe('new');
+  });
+});
+
+describe('importGroove (engine-level, no DOM)', () => {
+  const RECORD = (over = {}) => ({
+    id: 'abcd1234', kind: 'groove', name: 'imported-beat',
+    payload: {
+      laneType: 'drums',
+      meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
+      bars: [{ kick: [0, 8], snare: [4, 12], hat: [], crash: [], tom: [] }],
+    }, ...over,
+  });
+
+  it('meter match: adds groove AND selects it on the lane', () => {
+    const eng = engineWithSong();                       // kids is 4/4
+    const laneId = drumLaneId(eng);
+    const result = importGroove(eng, RECORD(), laneId);
+    expect(result.placed).toBe(true);
+    expect(eng.getGrooves()[laneId]['imported-beat']).toBeTruthy();
+    const editIdx = eng.getEditPatternIndex();
+    expect(eng.getPatterns()[editIdx].lanes[laneId]).toBe('imported-beat');
+  });
+
+  it('meter mismatch: adds as data only, NOT selected', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    const before = eng.getPatterns()[eng.getEditPatternIndex()].lanes[laneId];
+    const rec = RECORD();
+    rec.payload = { ...rec.payload, meter: { beatsPerBar: 6, beatUnit: 8, stepsPerBeat: 2 } };
+    const result = importGroove(eng, rec, laneId);
+    expect(result.placed).toBe(false);
+    expect(eng.getGrooves()[laneId]['imported-beat']).toBeTruthy();           // data preserved
+    expect(eng.getPatterns()[eng.getEditPatternIndex()].lanes[laneId]).toBe(before);
+  });
+
+  it('name collision dedupes with -2 suffix', () => {
+    const eng = engineWithSong();
+    const laneId = drumLaneId(eng);
+    importGroove(eng, RECORD(), laneId);
+    const result = importGroove(eng, RECORD(), laneId);
+    expect(result.name).toBe('imported-beat-2');
+    expect(eng.getGrooves()[laneId]['imported-beat-2']).toBeTruthy();
+  });
+
+  it('relative groove bundle imports as a relative groove value', () => {
+    const eng = engineWithSong();
+    const laneId = eng.getLanes().find((l) => l.type === 'bass').id;
+    const rec = RECORD({
+      name: 'rel-bass',
+      payload: { laneType: 'bass', meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, relative: true, bars: [[[0, 'R', 2]]] },
+    });
+    const result = importGroove(eng, rec, laneId);
+    expect(result.placed).toBe(true);
+    const v = eng.getGrooves()[laneId]['rel-bass'];
+    expect(v.relative).toBe(true);
+    expect(v.bars).toEqual([[[0, 'R', 2]]]);
+  });
+});

--- a/docs/arcade/groovebox/tests/helpers/registry-fixtures.js
+++ b/docs/arcade/groovebox/tests/helpers/registry-fixtures.js
@@ -1,0 +1,15 @@
+// Shared minimal-valid registry payloads for registry-*.test.js.
+export const GROOVE_PAYLOAD = {
+  laneType: 'drums',
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
+  bars: [{ kick: [0, 8], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [], tom: [] }],
+};
+export const SONG_PAYLOAD = {
+  version: 2, title: 'T', artist: 'A',
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, bpm: 120,
+  lanes: [{ id: 'drums', type: 'drums', name: 'Drums', muted: false, soloed: false }],
+  grooves: { drums: { main: [{ kick: [0], snare: [], hat: [], crash: [], tom: [] }] } },
+  patterns: [{ lanes: { drums: 'main' } }],
+  chain: [0],
+  fills: {},
+};

--- a/docs/arcade/groovebox/tests/registry-client.test.js
+++ b/docs/arcade/groovebox/tests/registry-client.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { parseShareParam, shareUrl, getEditKey, storeEditKey, getAuthor, setAuthor } from '../registry/client.js';
+import { parseShareParam, shareUrl, getEditKey, storeEditKey, listMine, getAuthor, setAuthor } from '../registry/client.js';
 
 describe('parseShareParam', () => {
   it('reads ?s=<id>', () => expect(parseShareParam('?s=abcd1234')).toBe('abcd1234'));
@@ -39,6 +39,24 @@ describe('editKey + author storage (gb-registry-*)', () => {
     setAuthor('Henry');
     expect(getAuthor()).toBe('Henry');
     expect(localStorage.getItem('gb-registry-author')).toBe('Henry');
+  });
+  it('stores name/kind meta; listMine returns newest first', () => {
+    let t = 1000;
+    vi.spyOn(Date, 'now').mockImplementation(() => ++t);   // same-ms publishes must still order
+    storeEditKey('abcd1234', 'KEY1', { name: 'Kids', kind: 'song' });
+    storeEditKey('efgh5678', 'KEY2', { name: 'amen', kind: 'groove' });
+    expect(getEditKey('abcd1234')).toBe('KEY1');
+    const mine = listMine();
+    expect(mine.map((m) => m.id)).toEqual(['efgh5678', 'abcd1234']);
+    expect(mine[1]).toMatchObject({ name: 'Kids', kind: 'song' });
+  });
+  it('tolerates legacy bare-string values', () => {
+    localStorage.setItem('gb-registry-edit-keys', JSON.stringify({ old00000: 'RAWKEY' }));
+    expect(getEditKey('old00000')).toBe('RAWKEY');
+    expect(listMine()).toEqual([{ id: 'old00000', name: 'old00000', kind: '', at: 0 }]);
+    storeEditKey('old00000', 'RAWKEY', { name: 'Named now', kind: 'song' });
+    expect(getEditKey('old00000')).toBe('RAWKEY');
+    expect(listMine()[0].name).toBe('Named now');
   });
   it('degrades silently without localStorage', () => {
     vi.stubGlobal('localStorage', undefined);

--- a/docs/arcade/groovebox/tests/registry-client.test.js
+++ b/docs/arcade/groovebox/tests/registry-client.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { parseShareParam, shareUrl, getEditKey, storeEditKey, getAuthor, setAuthor } from '../registry/client.js';
+
+describe('parseShareParam', () => {
+  it('reads ?s=<id>', () => expect(parseShareParam('?s=abcd1234')).toBe('abcd1234'));
+  it('tolerates @revision (ignored in v1) and uppercase', () => {
+    expect(parseShareParam('?s=abcd1234@3')).toBe('abcd1234');
+    expect(parseShareParam('?s=ABCD1234')).toBe('abcd1234');
+  });
+  it('null on absent/malformed', () => {
+    expect(parseShareParam('')).toBe(null);
+    expect(parseShareParam('?s=short')).toBe(null);
+    expect(parseShareParam('?s=../../etc')).toBe(null);
+  });
+});
+
+describe('shareUrl', () => {
+  it('canonical pretty link', () => expect(shareUrl('abcd1234')).toBe('https://groovebox.oyster.to/s/abcd1234'));
+});
+
+describe('editKey + author storage (gb-registry-*)', () => {
+  beforeEach(() => {
+    const store = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => store[k] ?? null,
+      setItem: (k, v) => { store[k] = String(v); },
+    });
+  });
+  it('stores and retrieves per-id edit keys', () => {
+    storeEditKey('abcd1234', 'KEY1');
+    storeEditKey('efgh5678', 'KEY2');
+    expect(getEditKey('abcd1234')).toBe('KEY1');
+    expect(getEditKey('efgh5678')).toBe('KEY2');
+    expect(getEditKey('nope0000')).toBe(null);
+    expect(localStorage.getItem('gb-registry-edit-keys')).toContain('KEY1');
+  });
+  it('remembers author name', () => {
+    expect(getAuthor()).toBe('');
+    setAuthor('Henry');
+    expect(getAuthor()).toBe('Henry');
+    expect(localStorage.getItem('gb-registry-author')).toBe('Henry');
+  });
+  it('degrades silently without localStorage', () => {
+    vi.stubGlobal('localStorage', undefined);
+    expect(getEditKey('abcd1234')).toBe(null);
+    expect(getAuthor()).toBe('');
+    storeEditKey('abcd1234', 'k');   // must not throw
+    setAuthor('x');                  // must not throw
+  });
+});

--- a/docs/arcade/groovebox/tests/registry-handler.test.js
+++ b/docs/arcade/groovebox/tests/registry-handler.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleRegistry, makeId, makeEditKey } from '../registry/handler.js';
+import { GROOVE_PAYLOAD, SONG_PAYLOAD } from './registry-validate.test.js';
+
+const SECRET = 'test-secret';
+
+// In-memory db implementing the injected interface. insert throws
+// { code: 'conflict' } on duplicate id — mirrors the D1 adapter contract.
+function memDb(rows = {}) {
+  return {
+    rows,
+    async get(id) { return rows[id] ?? null; },
+    async insert(row) {
+      if (rows[row.id]) { const e = new Error('UNIQUE'); e.code = 'conflict'; throw e; }
+      rows[row.id] = { ...row };
+    },
+    async update(id, fields) { Object.assign(rows[id], fields); },
+  };
+}
+
+const post = (body) => new Request('https://groovebox.oyster.to/api/registry', {
+  method: 'POST', body: JSON.stringify(body), headers: { 'content-type': 'application/json' },
+});
+const CREATE = (over = {}) => ({ kind: 'groove', schema_version: 1, name: 'amen-ish', author: 'Henry', payload: GROOVE_PAYLOAD, ...over });
+
+describe('id + key generation', () => {
+  it('makeId: 8 chars lowercase alnum', () => expect(makeId()).toMatch(/^[a-z0-9]{8}$/));
+  it('makeEditKey: long base64url, high entropy', () => {
+    const k = makeEditKey();
+    expect(k).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(makeEditKey()).not.toBe(k);
+  });
+});
+
+describe('POST /api/registry', () => {
+  let db; beforeEach(() => { db = memDb(); });
+
+  it('creates: 201 { id, editKey }; row stored with hash, never raw key', async () => {
+    const res = await handleRegistry(post(CREATE()), db, SECRET);
+    expect(res.status).toBe(201);
+    const { id, editKey } = await res.json();
+    expect(id).toMatch(/^[a-z0-9]{8}$/);
+    const row = db.rows[id];
+    expect(row.kind).toBe('groove');
+    expect(row.revision).toBe(1);
+    expect(row.edit_key_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(row.edit_key_hash).not.toBe(editKey);
+    expect(JSON.stringify(row)).not.toContain(editKey);
+    expect(typeof row.payload).toBe('string');          // stored serialized
+    expect(row.created_at).toBe(row.updated_at);
+  });
+
+  it('400 on invalid body, with the validator message', async () => {
+    const res = await handleRegistry(post(CREATE({ kind: 'sample' })), db, SECRET);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBeTruthy();
+  });
+
+  it('400 on malformed JSON', async () => {
+    const res = await handleRegistry(new Request('https://x/api/registry', { method: 'POST', body: '{nope' }), db, SECRET);
+    expect(res.status).toBe(400);
+  });
+
+  it('remix_of must reference an existing item', async () => {
+    expect((await handleRegistry(post(CREATE({ remix_of: 'aaaaaaaa' })), db, SECRET)).status).toBe(400);
+    const first = await (await handleRegistry(post(CREATE()), db, SECRET)).json();
+    const res = await handleRegistry(post(CREATE({ remix_of: first.id })), db, SECRET);
+    expect(res.status).toBe(201);
+    const { id } = await res.json();
+    expect(db.rows[id].remix_of).toBe(first.id);
+  });
+
+  it('retries on id collision up to 5 times, then 503', async () => {
+    let calls = 0;
+    db.insert = async () => { calls++; const e = new Error('UNIQUE'); e.code = 'conflict'; throw e; };
+    const res = await handleRegistry(post(CREATE()), db, SECRET);
+    expect(calls).toBe(5);
+    expect(res.status).toBe(503);
+  });
+
+  it('non-conflict insert errors surface as 500, no retry', async () => {
+    let calls = 0;
+    db.insert = async () => { calls++; throw new Error('D1 exploded'); };
+    const res = await handleRegistry(post(CREATE()), db, SECRET);
+    expect(calls).toBe(1);
+    expect(res.status).toBe(500);
+  });
+
+  it('405 on unknown method/path combos; 404 on bad path', async () => {
+    expect((await handleRegistry(new Request('https://x/api/registry', { method: 'DELETE' }), db, SECRET)).status).toBe(405);
+    expect((await handleRegistry(new Request('https://x/api/other', { method: 'GET' }), db, SECRET)).status).toBe(404);
+  });
+});
+
+describe('GET /api/registry/:id', () => {
+  it('returns full record, payload parsed, edit_key_hash absent', async () => {
+    const db = memDb();
+    const { id } = await (await handleRegistry(post(CREATE()), db, SECRET)).json();
+    const res = await handleRegistry(new Request(`https://x/api/registry/${id}`), db, SECRET);
+    expect(res.status).toBe(200);
+    const rec = await res.json();
+    expect(rec.id).toBe(id);
+    expect(rec.payload).toEqual(GROOVE_PAYLOAD);              // parsed JSON, not a string
+    expect(rec.edit_key_hash).toBeUndefined();
+    expect(rec).toMatchObject({ kind: 'groove', schema_version: 1, name: 'amen-ish', author: 'Henry', remix_of: null, revision: 1 });
+    expect(rec.created_at).toBeTruthy(); expect(rec.updated_at).toBeTruthy();
+  });
+  it('404 on unknown id', async () => {
+    expect((await handleRegistry(new Request('https://x/api/registry/zzzzzzzz'), memDb(), SECRET)).status).toBe(404);
+  });
+});
+
+describe('PUT /api/registry/:id', () => {
+  const put = (id, body) => new Request(`https://x/api/registry/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+  let db, id, editKey;
+  beforeEach(async () => {
+    db = memDb();
+    ({ id, editKey } = await (await handleRegistry(post(CREATE()), db, SECRET)).json());
+  });
+
+  it('owner update: 200 { revision: 2 }, fields updated, identity untouched', async () => {
+    const newPayload = { ...GROOVE_PAYLOAD, bpm: 140 };
+    const res = await handleRegistry(put(id, { editKey, name: 'amen-2', author: 'H', payload: newPayload }), db, SECRET);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ revision: 2 });
+    const row = db.rows[id];
+    expect(row.name).toBe('amen-2');
+    expect(JSON.parse(row.payload).bpm).toBe(140);
+    expect(row.kind).toBe('groove');                       // identity fields unchanged
+    expect(row.created_at).toBeTruthy();
+  });
+
+  it('second update → revision 3', async () => {
+    const body = { editKey, name: 'n', author: '', payload: GROOVE_PAYLOAD };
+    await handleRegistry(put(id, body), db, SECRET);
+    const res = await handleRegistry(put(id, body), db, SECRET);
+    expect(await res.json()).toEqual({ revision: 3 });
+  });
+
+  it('403 on wrong editKey; row untouched', async () => {
+    const res = await handleRegistry(put(id, { editKey: 'x'.repeat(43), name: 'evil', author: '', payload: GROOVE_PAYLOAD }), db, SECRET);
+    expect(res.status).toBe(403);
+    expect(db.rows[id].name).toBe('amen-ish');
+    expect(db.rows[id].revision).toBe(1);
+  });
+
+  it('400 when body smuggles identity fields', async () => {
+    const res = await handleRegistry(put(id, { editKey, name: 'n', author: '', payload: GROOVE_PAYLOAD, kind: 'song' }), db, SECRET);
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT payload passes the same validation gate as POST', async () => {
+    const res = await handleRegistry(put(id, { editKey, name: 'n', author: '', payload: { laneType: 'vocals' } }), db, SECRET);
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT payload is validated against the ROW kind (groove row rejects song payload)', async () => {
+    const res = await handleRegistry(put(id, { editKey, name: 'n', author: '', payload: SONG_PAYLOAD }), db, SECRET);
+    expect(res.status).toBe(400);
+  });
+
+  it('404 on unknown id (before any key check)', async () => {
+    expect((await handleRegistry(put('zzzzzzzz', { editKey, name: 'n', author: '', payload: GROOVE_PAYLOAD }), db, SECRET)).status).toBe(404);
+  });
+});

--- a/docs/arcade/groovebox/tests/registry-handler.test.js
+++ b/docs/arcade/groovebox/tests/registry-handler.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { handleRegistry, makeId, makeEditKey } from '../registry/handler.js';
-import { GROOVE_PAYLOAD, SONG_PAYLOAD } from './registry-validate.test.js';
+import { GROOVE_PAYLOAD, SONG_PAYLOAD } from './helpers/registry-fixtures.js';
 
 const SECRET = 'test-secret';
 

--- a/docs/arcade/groovebox/tests/registry-validate.test.js
+++ b/docs/arcade/groovebox/tests/registry-validate.test.js
@@ -10,21 +10,7 @@ import { digitalLove } from '../songs/digital-love.js';
 import { memoryReboot } from '../songs/memory-reboot.js';
 import { takeOnMe } from '../songs/take-on-me.js';
 
-// Minimal valid payloads — also imported by registry-handler.test.js
-export const GROOVE_PAYLOAD = {
-  laneType: 'drums',
-  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
-  bars: [{ kick: [0, 8], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [], tom: [] }],
-};
-export const SONG_PAYLOAD = {
-  version: 2, title: 'T', artist: 'A',
-  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, bpm: 120,
-  lanes: [{ id: 'drums', type: 'drums', name: 'Drums', muted: false, soloed: false }],
-  grooves: { drums: { main: [{ kick: [0], snare: [], hat: [], crash: [], tom: [] }] } },
-  patterns: [{ lanes: { drums: 'main' } }],
-  chain: [0],
-  fills: {},
-};
+import { GROOVE_PAYLOAD, SONG_PAYLOAD } from './helpers/registry-fixtures.js';
 const CREATE = (over = {}) => ({
   kind: 'groove', schema_version: 1, name: 'amen-ish', author: 'Henry',
   payload: GROOVE_PAYLOAD, ...over,

--- a/docs/arcade/groovebox/tests/registry-validate.test.js
+++ b/docs/arcade/groovebox/tests/registry-validate.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { validateCreate, validateUpdate, validateSongPayload, validateGroovePayload, KIND_VERSIONS }
+  from '../registry/validate.js';
+import { createEngine } from '../engine/index.js';
+import { kids } from '../songs/kids.js';
+import { risingSun } from '../songs/rising-sun.js';
+import { electricFeel } from '../songs/electric-feel.js';
+import { heartbeats } from '../songs/heartbeats.js';
+import { digitalLove } from '../songs/digital-love.js';
+import { memoryReboot } from '../songs/memory-reboot.js';
+import { takeOnMe } from '../songs/take-on-me.js';
+
+// Minimal valid payloads — also imported by registry-handler.test.js
+export const GROOVE_PAYLOAD = {
+  laneType: 'drums',
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
+  bars: [{ kick: [0, 8], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [], tom: [] }],
+};
+export const SONG_PAYLOAD = {
+  version: 2, title: 'T', artist: 'A',
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 }, bpm: 120,
+  lanes: [{ id: 'drums', type: 'drums', name: 'Drums', muted: false, soloed: false }],
+  grooves: { drums: { main: [{ kick: [0], snare: [], hat: [], crash: [], tom: [] }] } },
+  patterns: [{ lanes: { drums: 'main' } }],
+  chain: [0],
+  fills: {},
+};
+const CREATE = (over = {}) => ({
+  kind: 'groove', schema_version: 1, name: 'amen-ish', author: 'Henry',
+  payload: GROOVE_PAYLOAD, ...over,
+});
+
+describe('validateCreate — record fields', () => {
+  it('accepts a valid groove create', () => expect(validateCreate(CREATE()).ok).toBe(true));
+  it('accepts a valid song create', () =>
+    expect(validateCreate(CREATE({ kind: 'song', schema_version: 2, payload: SONG_PAYLOAD })).ok).toBe(true));
+  it('rejects unknown kind', () => expect(validateCreate(CREATE({ kind: 'sample' })).ok).toBe(false));
+  it('rejects wrong per-kind schema_version', () => {
+    expect(validateCreate(CREATE({ schema_version: 2 })).ok).toBe(false);          // groove must be 1
+    expect(validateCreate(CREATE({ kind: 'song', schema_version: 1, payload: SONG_PAYLOAD })).ok).toBe(false); // song must be 2
+    expect(KIND_VERSIONS).toEqual({ song: 2, groove: 1 });
+  });
+  it('rejects missing schema_version', () => {
+    const b = CREATE(); delete b.schema_version;
+    expect(validateCreate(b).ok).toBe(false);
+  });
+  it('caps name at 80 and author at 40', () => {
+    expect(validateCreate(CREATE({ name: 'x'.repeat(80) })).ok).toBe(true);
+    expect(validateCreate(CREATE({ name: 'x'.repeat(81) })).ok).toBe(false);
+    expect(validateCreate(CREATE({ author: 'x'.repeat(40) })).ok).toBe(true);
+    expect(validateCreate(CREATE({ author: 'x'.repeat(41) })).ok).toBe(false);
+  });
+  it('requires non-empty name; author optional', () => {
+    expect(validateCreate(CREATE({ name: '' })).ok).toBe(false);
+    const b = CREATE(); delete b.author;
+    expect(validateCreate(b).ok).toBe(true);
+  });
+  it('rejects unknown top-level body keys', () =>
+    expect(validateCreate(CREATE({ likes: 9000 })).ok).toBe(false));
+  it('validates remix_of shape when present', () => {
+    expect(validateCreate(CREATE({ remix_of: 'abcd1234' })).ok).toBe(true);
+    expect(validateCreate(CREATE({ remix_of: 'NOPE' })).ok).toBe(false);
+  });
+  it('rejects oversized payload (>64KB)', () => {
+    const big = { ...GROOVE_PAYLOAD, extensions: { pad: Array.from({ length: 70 }, () => 'y'.repeat(1000)) } };
+    expect(validateCreate(CREATE({ payload: big })).ok).toBe(false);
+  });
+  it('rejects any single string >1KB anywhere in payload (audio smuggling)', () => {
+    const sneaky = { ...GROOVE_PAYLOAD, extensions: { blob: 'A'.repeat(2000) } };
+    expect(validateCreate(CREATE({ payload: sneaky })).ok).toBe(false);
+  });
+});
+
+describe('validateUpdate', () => {
+  const UPDATE = (over = {}) => ({ editKey: 'k'.repeat(43), name: 'n', author: '', payload: GROOVE_PAYLOAD, ...over });
+  it('accepts a valid update', () => expect(validateUpdate(UPDATE(), 'groove', 1).ok).toBe(true));
+  it('requires editKey', () => {
+    const b = UPDATE(); delete b.editKey;
+    expect(validateUpdate(b, 'groove', 1).ok).toBe(false);
+  });
+  it('rejects identity fields in body (id, kind, remix_of, schema_version, timestamps)', () => {
+    for (const k of ['id', 'kind', 'remix_of', 'schema_version', 'created_at', 'updated_at', 'edit_key_hash'])
+      expect(validateUpdate(UPDATE({ [k]: 'x' }), 'groove', 1).ok).toBe(false);
+  });
+  it('payload re-validated against the ROW kind, not anything client-sent', () =>
+    expect(validateUpdate(UPDATE({ payload: SONG_PAYLOAD }), 'groove', 1).ok).toBe(false));
+});
+
+describe('validateSongPayload — invariants', () => {
+  const song = () => JSON.parse(JSON.stringify(SONG_PAYLOAD));
+  it('accepts the minimal song', () => expect(validateSongPayload(song()).ok).toBe(true));
+  it('rejects unknown top-level song keys (extensions is the only hatch)', () => {
+    expect(validateSongPayload({ ...song(), extensions: {} }).ok).toBe(true);
+    expect(validateSongPayload({ ...song(), swing: 0.2 }).ok).toBe(false);
+  });
+  it('accepts optional key {root, mode}, rejects malformed key', () => {
+    expect(validateSongPayload({ ...song(), key: { root: 'A', mode: 'major' } }).ok).toBe(true);
+    expect(validateSongPayload({ ...song(), key: 'A major' }).ok).toBe(false);
+  });
+  it('rejects empty chain and out-of-range chain entries', () => {
+    expect(validateSongPayload({ ...song(), chain: [] }).ok).toBe(false);
+    expect(validateSongPayload({ ...song(), chain: [1] }).ok).toBe(false);   // only pattern 0 exists
+  });
+  it('rejects pattern picks that do not resolve', () => {
+    const s = song(); s.patterns[0].lanes.drums = 'ghost';
+    expect(validateSongPayload(s).ok).toBe(false);
+  });
+  it('rejects >16 patterns and groove bars >8', () => {
+    const s = song(); s.patterns = Array.from({ length: 17 }, () => ({ lanes: { drums: 'main' } }));
+    expect(validateSongPayload(s).ok).toBe(false);
+    const s2 = song(); s2.grooves.drums.main = Array.from({ length: 9 }, () => ({ kick: [0] }));
+    expect(validateSongPayload(s2).ok).toBe(false);
+  });
+  it('rejects duplicate lane ids and grooves for unknown lanes', () => {
+    const s = song(); s.lanes.push({ ...s.lanes[0] });
+    expect(validateSongPayload(s).ok).toBe(false);
+    const s2 = song(); s2.grooves.ghost = { main: [{ kick: [0] }] };
+    expect(validateSongPayload(s2).ok).toBe(false);
+  });
+});
+
+describe('validateGroovePayload — edge cases', () => {
+  it('rejects bad laneType / meter / bars', () => {
+    expect(validateGroovePayload({ ...GROOVE_PAYLOAD, laneType: 'vocals' }).ok).toBe(false);
+    expect(validateGroovePayload({ ...GROOVE_PAYLOAD, meter: { beatsPerBar: 4 } }).ok).toBe(false);
+    expect(validateGroovePayload({ ...GROOVE_PAYLOAD, bars: [] }).ok).toBe(false);
+  });
+  it('note-lane bars must be arrays of arrays', () => {
+    const noteBundle = { laneType: 'bass', meter: GROOVE_PAYLOAD.meter, bars: [[[0, 'C2', 2], [8, 'G2', 2]]] };
+    expect(validateGroovePayload(noteBundle).ok).toBe(true);
+    expect(validateGroovePayload({ ...noteBundle, bars: [{ kick: [0] }] }).ok).toBe(false);
+  });
+  it('accepts the extensions hatch, rejects other unknown keys', () => {
+    expect(validateGroovePayload({ ...GROOVE_PAYLOAD, extensions: { future: true } }).ok).toBe(true);
+    expect(validateGroovePayload({ ...GROOVE_PAYLOAD, color: 'red' }).ok).toBe(false);
+  });
+});
+
+describe('chord-relative grooves + pattern chords (harmony slice shapes)', () => {
+  const song = () => JSON.parse(JSON.stringify(SONG_PAYLOAD));
+  it('accepts { relative: true, bars } on note lanes, rejects on drums', () => {
+    const s = song();
+    s.lanes.push({ id: 'bass', type: 'bass', name: 'Bass', muted: false, soloed: false });
+    s.grooves.bass = { octave: { relative: true, bars: [[[0, 'R', 2], [2, 'R+12', 2]]] } };
+    expect(validateSongPayload(s).ok).toBe(true);
+    const s2 = song();
+    s2.grooves.drums.rel = { relative: true, bars: [{ kick: [0] }] };
+    expect(validateSongPayload(s2).ok).toBe(false);
+  });
+  it('accepts pattern.chords (per-bar {name,root,voicing}|null), rejects malformed', () => {
+    const s = song();
+    s.patterns[0].chords = [{ name: 'F#m', root: 'F#2', voicing: ['F#3', 'A3', 'C#4'] }, null];
+    expect(validateSongPayload(s).ok).toBe(true);
+    const s2 = song();
+    s2.patterns[0].chords = ['F#m'];
+    expect(validateSongPayload(s2).ok).toBe(false);
+  });
+  it('groove bundle: relative flag allowed on note lanes only', () => {
+    const rel = { laneType: 'bass', meter: GROOVE_PAYLOAD.meter, relative: true, bars: [[[0, 'R', 2]]] };
+    expect(validateGroovePayload(rel).ok).toBe(true);
+    expect(validateGroovePayload({ ...rel, laneType: 'drums', bars: [{ kick: [0] }] }).ok).toBe(false);
+  });
+});
+
+// The contract between validator and engine: getSong() is the exact object the
+// share dialog POSTs. If one of these fails, the VALIDATOR is wrong, not the song.
+describe('all 7 real flattened presets validate as song payloads', () => {
+  const PRESETS = { kids, risingSun, electricFeel, heartbeats, digitalLove, memoryReboot, takeOnMe };
+  for (const [name, rich] of Object.entries(PRESETS)) {
+    it(`${name} (flattened) passes validateSongPayload`, () => {
+      const eng = createEngine();
+      eng.load(rich);                     // flattens old rich format → v2
+      const payload = JSON.parse(JSON.stringify(eng.getSong()));
+      const res = validateSongPayload(payload);
+      expect(res.error).toBeUndefined();  // surfaces WHICH rule failed
+      expect(res.ok).toBe(true);
+    });
+  }
+});

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2469,6 +2469,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 #share-tabs { display: flex; gap: 8px; }
 .share-tab.active { background: var(--panel-3); color: var(--ink); border-color: var(--dim); }
 #share-groove-pickers { display: flex; gap: 8px; }
+#share-groove-pickers[hidden] { display: none; }
 #share-groove-pickers select { flex: 1; min-width: 0; }
 .share-field {
   display: flex;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2408,3 +2408,98 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   from { opacity: 0; transform: translateY(-4px); }
 }
 
+
+/* ─── Share modal ────────────────────────────────────────────────────────────── */
+#share-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#share-modal[hidden] { display: none; }
+#share-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.65);
+}
+#share-modal-box {
+  position: relative;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 24px 28px 28px;
+  box-shadow: 0 8px 40px rgba(0,0,0,0.6);
+  width: min(420px, calc(100vw - 48px));
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+#share-modal-box h2 {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--dim);
+  margin: 0;
+}
+#share-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--faint);
+  font-size: 13px;
+  box-shadow: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+#share-modal-close:hover { background: var(--panel-3); color: var(--ink); }
+#share-tabs { display: flex; gap: 8px; }
+.share-tab.active { background: var(--panel-3); color: var(--ink); border-color: var(--dim); }
+#share-groove-pickers { display: flex; gap: 8px; }
+#share-groove-pickers select { flex: 1; min-width: 0; }
+.share-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--dim);
+}
+.share-field input { flex: 1; min-width: 0; }
+#share-actions { display: flex; gap: 8px; }
+#share-result { display: flex; gap: 8px; }
+#share-result[hidden] { display: none; }
+#share-result input { flex: 1; min-width: 0; font-size: 11px; }
+#share-error { color: #e06c75; font-size: 11px; }
+
+/* ─── Transient notice (share feedback) ──────────────────────────────────────── */
+#gb-notice {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--ink);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.5);
+  z-index: 300;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+#gb-notice.show { opacity: 1; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2504,3 +2504,27 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   transition: opacity 0.2s;
 }
 #gb-notice.show { opacity: 1; }
+
+/* "Your published" list in the publish modal */
+#share-mine[hidden] { display: none; }
+#share-mine h3 {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 4px 0 6px;
+}
+#share-mine-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 140px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+}
+#share-mine-list a { color: var(--ink); text-decoration: none; }
+#share-mine-list a:hover { text-decoration: underline; }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -10,6 +10,7 @@ import { memoryReboot } from '../songs/memory-reboot.js';
 import { takeOnMe } from '../songs/take-on-me.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
+import { initShare, maybeLoadShared } from './share.js';
 
 const eng = createEngine();
 const TONES = ['pulse','square','sawtooth','fatsawtooth','triangle','sine'];
@@ -978,6 +979,12 @@ function loadSong(key) {
   play.classList.remove('on');
   play.textContent = '▶ play';
   eng.load(SONGS[key]);
+  afterSongLoad();
+}
+
+// Shared post-load path (preset switch + shared-song load): bpm/key sync, FX
+// reset, full UI remount. Caller has already eng.load()ed the new song.
+function afterSongLoad() {
   const s = eng.getSong();
   const bpm = document.getElementById('bpm');
   bpm.value = s.bpm;
@@ -1457,6 +1464,43 @@ eng.setTempo(initialSong.bpm);
 mount();
 // Wrap sections and wire section drag-reorder once, after first mount.
 initSectionWrappers();
+
+// ─── Share registry ───────────────────────────────────────────────────────────
+function gbNotice(msg) {
+  let el = document.getElementById('gb-notice');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'gb-notice';
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  el.classList.add('show');
+  clearTimeout(gbNotice._t);
+  gbNotice._t = setTimeout(() => el.classList.remove('show'), 2600);
+}
+const shareHooks = {
+  notice: gbNotice,
+  onSongLoaded: () => {
+    afterSongLoad();
+    // songsel no longer matches a preset — park it on a hidden "(shared)" option.
+    const sel = document.getElementById('songsel');
+    let opt = document.getElementById('songsel-shared');
+    if (!opt) {
+      opt = document.createElement('option');
+      opt.id = 'songsel-shared';
+      opt.hidden = true;
+      opt.textContent = '(shared)';
+      sel.appendChild(opt);
+    }
+    opt.selected = true;
+  },
+  onGroovesChanged: () => { renderStrips(); refreshVizPattern(); },
+  // v1: import into the first matching lane (multi-lane-same-type songs are
+  // rare; the groove still lands correctly, just without a picker).
+  pickLane: lanes => Promise.resolve(lanes[0].id),
+};
+initShare(eng, shareHooks);
+maybeLoadShared(eng, shareHooks);
 // Press-and-hold on a control must not open the browser context menu (Android
 // Chrome long-press → "more actions / translate"). Scoped to controls so
 // right-click elsewhere stays normal on desktop.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -10,7 +10,7 @@ import { memoryReboot } from '../songs/memory-reboot.js';
 import { takeOnMe } from '../songs/take-on-me.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
-import { initShare, maybeLoadShared } from './share.js';
+import { initShare, maybeLoadShared, clearLoadedFrom } from './share.js';
 
 const eng = createEngine();
 const TONES = ['pulse','square','sawtooth','fatsawtooth','triangle','sine'];
@@ -979,6 +979,7 @@ function loadSong(key) {
   play.classList.remove('on');
   play.textContent = '▶ play';
   eng.load(SONGS[key]);
+  clearLoadedFrom();   // the registry item this session had loaded is gone
   afterSongLoad();
 }
 

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -61,6 +61,10 @@ export function importGroove(eng, record, laneId) {
 let loadedFrom = null;          // { id, kind } of the record this session loaded, if any
 const $ = (id) => document.getElementById(id);
 
+// Called by app.js when a preset load replaces the session — whatever was
+// loaded from the registry is gone, so Update/remix must not target it.
+export function clearLoadedFrom() { loadedFrom = null; }
+
 // initShare(eng, hooks) — hooks: { notice, onSongLoaded, onGroovesChanged, pickLane }.
 // app.js supplies render callbacks and its notice helper; share.js owns the modal.
 export function initShare(eng, hooks) {
@@ -77,16 +81,18 @@ export function initShare(eng, hooks) {
   };
   const close = () => { $('share-modal').hidden = true; };
 
+  // Lane/groove names can originate in shared payloads (untrusted) — always
+  // esc() before innerHTML.
   function fillPickers() {
     const lanes = eng.getLanes();
     const cur = $('share-lane').value;
-    $('share-lane').innerHTML = lanes.map((l) => `<option value="${l.id}"${l.id === cur ? ' selected' : ''}>${l.name}</option>`).join('');
+    $('share-lane').innerHTML = lanes.map((l) => `<option value="${esc(l.id)}"${l.id === cur ? ' selected' : ''}>${esc(l.name)}</option>`).join('');
     fillGrooves();
   }
   function fillGrooves() {
     const laneId = $('share-lane').value;
     const names = Object.keys(eng.getGrooves()[laneId] || {});
-    $('share-groove').innerHTML = names.map((n) => `<option value="${n}">${n}</option>`).join('');
+    $('share-groove').innerHTML = names.map((n) => `<option value="${esc(n)}">${esc(n)}</option>`).join('');
   }
   function syncMode() {
     const mode = decideShareMode({ loadedFrom, hasEditKey: !!(loadedFrom && getEditKey(loadedFrom.id)), kind: tab });
@@ -113,6 +119,7 @@ export function initShare(eng, hooks) {
   async function submit(asUpdate) {
     const name = $('share-name').value.trim(), author = $('share-author').value.trim();
     if (!name) return showError('name required');
+    if (tab === 'groove' && !$('share-groove').value) return showError('this lane has no grooves to publish');
     setAuthor(author);
     try {
       const base = bodyForTab();

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -1,0 +1,177 @@
+// ─── Share UI: pure helpers + modal + boot loader ─────────────────────────────
+// Pure helpers up top (unit-tested, no DOM). initShare()/maybeLoadShared() at
+// the bottom own all DOM and are only called from app.js in the browser.
+
+import { createItem, getItem, updateItem, getEditKey, storeEditKey, getAuthor, setAuthor,
+         shareUrl, parseShareParam } from '../registry/client.js';
+import { KIND_VERSIONS } from '../registry/validate.js';
+
+export function dedupeName(existing, name) {
+  const names = new Set(existing);
+  if (!names.has(name)) return name;
+  let n = 2;
+  while (names.has(`${name}-${n}`)) n++;
+  return `${name}-${n}`;
+}
+
+export function pickHostLanes(lanes, laneType) { return lanes.filter((l) => l.type === laneType); }
+
+export function metersEqual(a, b) {
+  return a.beatsPerBar === b.beatsPerBar && a.beatUnit === b.beatUnit && a.stepsPerBeat === b.stepsPerBeat;
+}
+
+// Assemble a kind=groove payload from the current song. Groove values may be
+// chord-relative ({ relative: true, bars }) — the bundle carries the flag.
+export function buildGrooveBundle(eng, laneId, grooveName) {
+  const song = eng.getSong();
+  const lane = eng.getLanes().find((l) => l.id === laneId);
+  const value = eng.getGrooves()[laneId][grooveName];
+  const relative = !Array.isArray(value);
+  return JSON.parse(JSON.stringify({
+    laneType: lane.type,
+    meter: song.meter,
+    bars: relative ? value.bars : value,
+    ...(relative ? { relative: true } : {}),
+    bpm: song.bpm,                                   // hint only, never applied on import
+  }));
+}
+
+// 'owner-choice' → dialog offers Update / Share-as-new; 'remix' → POST with
+// remix_of; 'new' → plain POST. Cross-kind extraction is 'new' in v1.
+export function decideShareMode({ loadedFrom, hasEditKey, kind }) {
+  if (!loadedFrom || loadedFrom.kind !== kind) return 'new';
+  return hasEditKey ? 'owner-choice' : 'remix';
+}
+
+// Import a fetched groove record into laneId of the current song (spec's
+// conservative semantics — no transformation). Returns { name, placed }.
+export function importGroove(eng, record, laneId) {
+  const existing = Object.keys(eng.getGrooves()[laneId] || {});
+  const name = dedupeName(existing, record.name);
+  const p = record.payload;
+  const value = p.relative ? { relative: true, bars: p.bars } : p.bars;
+  eng.addGroove(laneId, name, value);
+  const placed = metersEqual(eng.getSong().meter, p.meter);
+  if (placed) eng.setLaneGroove(laneId, name);
+  return { name, placed };
+}
+
+// ─── DOM half ─────────────────────────────────────────────────────────────────
+
+let loadedFrom = null;          // { id, kind } of the record this session loaded, if any
+const $ = (id) => document.getElementById(id);
+
+// initShare(eng, hooks) — hooks: { notice, onSongLoaded, onGroovesChanged, pickLane }.
+// app.js supplies render callbacks and its notice helper; share.js owns the modal.
+export function initShare(eng, hooks) {
+  let tab = 'song';
+
+  const open = () => {
+    $('share-author').value = getAuthor();
+    if (tab === 'groove') fillPickers();
+    $('share-name').value = tab === 'song' ? (eng.getSong()?.title || 'untitled') : ($('share-groove').value || '');
+    syncMode();
+    $('share-result').hidden = true; $('share-error').hidden = true;
+    $('share-modal').hidden = false;
+  };
+  const close = () => { $('share-modal').hidden = true; };
+
+  function fillPickers() {
+    const lanes = eng.getLanes();
+    const cur = $('share-lane').value;
+    $('share-lane').innerHTML = lanes.map((l) => `<option value="${l.id}"${l.id === cur ? ' selected' : ''}>${l.name}</option>`).join('');
+    fillGrooves();
+  }
+  function fillGrooves() {
+    const laneId = $('share-lane').value;
+    const names = Object.keys(eng.getGrooves()[laneId] || {});
+    $('share-groove').innerHTML = names.map((n) => `<option value="${n}">${n}</option>`).join('');
+  }
+  function syncMode() {
+    const mode = decideShareMode({ loadedFrom, hasEditKey: !!(loadedFrom && getEditKey(loadedFrom.id)), kind: tab });
+    $('share-update').hidden = mode !== 'owner-choice';
+    $('share-submit').textContent = mode === 'owner-choice' ? 'Share as new' : 'Share';
+  }
+  function setTab(t) {
+    tab = t;
+    $('share-tab-song').classList.toggle('active', t === 'song');
+    $('share-tab-groove').classList.toggle('active', t === 'groove');
+    $('share-groove-pickers').hidden = t !== 'groove';
+    open();
+  }
+
+  function bodyForTab() {
+    if (tab === 'song') {
+      return { kind: 'song', schema_version: KIND_VERSIONS.song,
+               payload: JSON.parse(JSON.stringify(eng.getSong())) };
+    }
+    return { kind: 'groove', schema_version: KIND_VERSIONS.groove,
+             payload: buildGrooveBundle(eng, $('share-lane').value, $('share-groove').value) };
+  }
+
+  async function submit(asUpdate) {
+    const name = $('share-name').value.trim(), author = $('share-author').value.trim();
+    if (!name) return showError('name required');
+    setAuthor(author);
+    try {
+      const base = bodyForTab();
+      if (asUpdate) {
+        const { revision } = await updateItem(loadedFrom.id, {
+          editKey: getEditKey(loadedFrom.id), name, author, payload: base.payload });
+        showResult(loadedFrom.id, `updated (rev ${revision})`);
+      } else {
+        const body = { ...base, name, author };
+        const mode = decideShareMode({ loadedFrom, hasEditKey: !!(loadedFrom && getEditKey(loadedFrom.id)), kind: tab });
+        if (mode === 'remix') body.remix_of = loadedFrom.id;
+        const { id, editKey } = await createItem(body);
+        storeEditKey(id, editKey);
+        if (tab === 'song') loadedFrom = { id, kind: 'song' };   // you now own what's on screen
+        showResult(id);
+      }
+    } catch (e) { showError(e.message); }                        // dialog stays open, state intact
+  }
+
+  function showResult(id, note) {
+    $('share-link').value = shareUrl(id);
+    $('share-result').hidden = false; $('share-error').hidden = true;
+    if (note) hooks.notice(note);
+    syncMode();
+  }
+  function showError(msg) { $('share-error').textContent = msg; $('share-error').hidden = false; }
+
+  $('share-btn').onclick = open;
+  $('share-modal-close').onclick = close;
+  $('share-modal-backdrop').onclick = close;
+  $('share-tab-song').onclick = () => setTab('song');
+  $('share-tab-groove').onclick = () => setTab('groove');
+  $('share-lane').onchange = fillGrooves;
+  $('share-submit').onclick = () => submit(false);
+  $('share-update').onclick = () => submit(true);
+  $('share-copy').onclick = () => { navigator.clipboard?.writeText($('share-link').value); hooks.notice('link copied'); };
+}
+
+// Boot-time: /s/<id> was redirected to /?s=<id> by the worker. Returns true if
+// a share id was present (whether or not it loaded).
+export async function maybeLoadShared(eng, hooks) {
+  const id = parseShareParam(location.search);
+  if (!id) return false;
+  try {
+    const rec = await getItem(id);
+    loadedFrom = { id: rec.id, kind: rec.kind };
+    if (rec.kind === 'song') {
+      eng.load(rec.payload);
+      hooks.onSongLoaded(rec);
+      hooks.notice(`loaded "${rec.name}"${rec.author ? ` by ${rec.author}` : ''}`);
+    } else {
+      const lanes = pickHostLanes(eng.getLanes(), rec.payload.laneType);
+      const laneId = lanes.length === 0 ? eng.addLane(rec.payload.laneType).id
+                   : lanes.length === 1 ? lanes[0].id
+                   : await hooks.pickLane(lanes);
+      const { name, placed } = importGroove(eng, rec, laneId);
+      hooks.onGroovesChanged();
+      hooks.notice(placed ? `imported "${name}"${rec.author ? ` by ${rec.author}` : ''}`
+        : `imported "${name}" (${rec.payload.meter.beatsPerBar}/${rec.payload.meter.beatUnit}) — in the groove menu, but this song is a different meter`);
+    }
+  } catch (e) { hooks.notice(`share not found (${e.message})`); }  // app boots normally regardless
+  return true;
+}

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -90,7 +90,7 @@ export function initShare(eng, hooks) {
   function syncMode() {
     const mode = decideShareMode({ loadedFrom, hasEditKey: !!(loadedFrom && getEditKey(loadedFrom.id)), kind: tab });
     $('share-update').hidden = mode !== 'owner-choice';
-    $('share-submit').textContent = mode === 'owner-choice' ? 'Share as new' : 'Share';
+    $('share-submit').textContent = mode === 'owner-choice' ? 'Publish as new' : 'Publish';
   }
   function setTab(t) {
     tab = t;
@@ -172,6 +172,6 @@ export async function maybeLoadShared(eng, hooks) {
       hooks.notice(placed ? `imported "${name}"${rec.author ? ` by ${rec.author}` : ''}`
         : `imported "${name}" (${rec.payload.meter.beatsPerBar}/${rec.payload.meter.beatUnit}) — in the groove menu, but this song is a different meter`);
     }
-  } catch (e) { hooks.notice(`share not found (${e.message})`); }  // app boots normally regardless
+  } catch (e) { hooks.notice(`not found (${e.message})`); }  // app boots normally regardless
   return true;
 }

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -2,7 +2,7 @@
 // Pure helpers up top (unit-tested, no DOM). initShare()/maybeLoadShared() at
 // the bottom own all DOM and are only called from app.js in the browser.
 
-import { createItem, getItem, updateItem, getEditKey, storeEditKey, getAuthor, setAuthor,
+import { createItem, getItem, updateItem, getEditKey, storeEditKey, listMine, getAuthor, setAuthor,
          shareUrl, parseShareParam } from '../registry/client.js';
 import { KIND_VERSIONS } from '../registry/validate.js';
 
@@ -72,6 +72,7 @@ export function initShare(eng, hooks) {
     $('share-name').value = tab === 'song' ? (eng.getSong()?.title || 'untitled') : ($('share-groove').value || '');
     syncMode();
     $('share-result').hidden = true; $('share-error').hidden = true;
+    renderMine();
     $('share-modal').hidden = false;
   };
   const close = () => { $('share-modal').hidden = true; };
@@ -118,13 +119,14 @@ export function initShare(eng, hooks) {
       if (asUpdate) {
         const { revision } = await updateItem(loadedFrom.id, {
           editKey: getEditKey(loadedFrom.id), name, author, payload: base.payload });
+        storeEditKey(loadedFrom.id, getEditKey(loadedFrom.id), { name, kind: tab });
         showResult(loadedFrom.id, `updated (rev ${revision})`);
       } else {
         const body = { ...base, name, author };
         const mode = decideShareMode({ loadedFrom, hasEditKey: !!(loadedFrom && getEditKey(loadedFrom.id)), kind: tab });
         if (mode === 'remix') body.remix_of = loadedFrom.id;
         const { id, editKey } = await createItem(body);
-        storeEditKey(id, editKey);
+        storeEditKey(id, editKey, { name, kind: tab });
         if (tab === 'song') loadedFrom = { id, kind: 'song' };   // you now own what's on screen
         showResult(id);
       }
@@ -136,7 +138,17 @@ export function initShare(eng, hooks) {
     $('share-result').hidden = false; $('share-error').hidden = true;
     if (note) hooks.notice(note);
     syncMode();
+    renderMine();
   }
+
+  // "Your published" — private list from this browser's editKey store.
+  function renderMine() {
+    const mine = listMine();
+    $('share-mine').hidden = mine.length === 0;
+    $('share-mine-list').innerHTML = mine.map((m) =>
+      `<li><a href="${shareUrl(m.id)}">${m.kind ? `[${m.kind}] ` : ''}${esc(m.name)}</a></li>`).join('');
+  }
+  function esc(s) { const d = document.createElement('span'); d.textContent = s; return d.innerHTML; }
   function showError(msg) { $('share-error').textContent = msg; $('share-error').hidden = false; }
 
   $('share-btn').onclick = open;

--- a/infra/oyster-arcade-site/migrations/0001_registry.sql
+++ b/infra/oyster-arcade-site/migrations/0001_registry.sql
@@ -1,0 +1,14 @@
+-- Share registry v1 (spec: project-notes po20/2026-06-06-share-registry-spec.md)
+CREATE TABLE IF NOT EXISTS gb_registry_items (
+  id             TEXT PRIMARY KEY,
+  kind           TEXT NOT NULL,
+  schema_version INTEGER NOT NULL,
+  name           TEXT NOT NULL,
+  author         TEXT NOT NULL DEFAULT '',
+  payload        TEXT NOT NULL,
+  remix_of       TEXT,
+  revision       INTEGER NOT NULL DEFAULT 1,
+  edit_key_hash  TEXT NOT NULL,
+  created_at     TEXT NOT NULL,
+  updated_at     TEXT NOT NULL
+);

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -5,13 +5,74 @@
 // truth. Cloudflare's edge caches the responses by the origin's
 // Cache-Control headers (GitHub Pages sets long max-age on static files).
 
+// The share-registry handler is plain JS shared with the groovebox app and its
+// vitest suite (single source of truth) — wrangler bundles it here, hence the
+// allowJs tsconfig flag.
+import { handleRegistry } from '../../../docs/arcade/groovebox/registry/handler.js';
+
 export interface Env {
   ASSETS: Fetcher;
+  DB: D1Database;
+  EDIT_KEY_SECRET: string;
+  WRITE_LIMIT?: { limit(opts: { key: string }): Promise<{ success: boolean }> };
+}
+
+// D1 adapter for the handler's injected db interface. UNIQUE violations are
+// surfaced as { code: 'conflict' } so the handler can retry id generation.
+function d1Db(d1: D1Database) {
+  const T = 'gb_registry_items';
+  return {
+    async get(id: string) {
+      return await d1.prepare(`SELECT * FROM ${T} WHERE id = ?`).bind(id).first();
+    },
+    async insert(r: Record<string, unknown>) {
+      try {
+        await d1.prepare(
+          `INSERT INTO ${T} (id,kind,schema_version,name,author,payload,remix_of,revision,edit_key_hash,created_at,updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
+          .bind(r.id, r.kind, r.schema_version, r.name, r.author, r.payload, r.remix_of,
+                r.revision, r.edit_key_hash, r.created_at, r.updated_at).run();
+      } catch (e) {
+        if (String(e).includes('UNIQUE')) {
+          const err = new Error('conflict') as Error & { code: string };
+          err.code = 'conflict';
+          throw err;
+        }
+        throw e;
+      }
+    },
+    async update(id: string, f: { name: string; author: string; payload: string; revision: number; updated_at: string }) {
+      await d1.prepare(`UPDATE ${T} SET name=?, author=?, payload=?, revision=?, updated_at=? WHERE id=?`)
+        .bind(f.name, f.author, f.payload, f.revision, f.updated_at, id).run();
+    },
+  };
 }
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
+
+    // ─── Share registry API (all hosts; same-origin from both prod domains) ──
+    if (url.pathname === '/api/registry' || url.pathname.startsWith('/api/registry/')) {
+      if (req.method === 'POST' || req.method === 'PUT') {
+        const ip = req.headers.get('cf-connecting-ip') ?? 'unknown';
+        const rl = await env.WRITE_LIMIT?.limit({ key: ip });   // binding absent in local dev → skip
+        if (rl && !rl.success) {
+          return new Response(JSON.stringify({ error: 'rate limited — try again in a minute' }),
+            { status: 429, headers: { 'content-type': 'application/json' } });
+        }
+      }
+      return handleRegistry(req, d1Db(env.DB), env.EDIT_KEY_SECRET);
+    }
+
+    // ─── Pretty share links: /s/<id>[@rev] → /?s=<id> ─────────────────────────
+    // Redirect (not rewrite): index.html uses all-relative asset refs, so
+    // serving the app AT /s/<id> would break them. @rev is reserved syntax,
+    // ignored in v1 (never 404s).
+    {
+      const m = url.pathname.match(/^\/s\/([a-z0-9]{4,16})(?:@\d+)?\/?$/i);
+      if (m) return Response.redirect(new URL(`/?s=${m[1].toLowerCase()}`, req.url).toString(), 302);
+    }
 
     // groovebox.oyster.to serves the groovebox at its root — rewrite every
     // path onto the /groovebox/ subtree of the same ASSETS directory. The

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -65,13 +65,17 @@ export default {
       return handleRegistry(req, d1Db(env.DB), env.EDIT_KEY_SECRET);
     }
 
-    // ─── Pretty share links: /s/<id>[@rev] → /?s=<id> ─────────────────────────
+    // ─── Pretty share links: /s/<id>[@rev] → groovebox app with ?s=<id> ───────
     // Redirect (not rewrite): index.html uses all-relative asset refs, so
-    // serving the app AT /s/<id> would break them. @rev is reserved syntax,
-    // ignored in v1 (never 404s).
+    // serving the app AT /s/<id> would break them. On groovebox.oyster.to the
+    // app lives at /; on arcade.oyster.to and wrangler dev (localhost) it lives
+    // at /groovebox/. @rev is reserved syntax, ignored in v1 (never 404s).
     {
       const m = url.pathname.match(/^\/s\/([a-z0-9]{4,16})(?:@\d+)?\/?$/i);
-      if (m) return Response.redirect(new URL(`/?s=${m[1].toLowerCase()}`, req.url).toString(), 302);
+      if (m) {
+        const base = url.hostname === 'groovebox.oyster.to' ? '/' : '/groovebox/';
+        return Response.redirect(new URL(`${base}?s=${m[1].toLowerCase()}`, req.url).toString(), 302);
+      }
     }
 
     // groovebox.oyster.to serves the groovebox at its root — rewrite every

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -33,7 +33,8 @@ function d1Db(d1: D1Database) {
           .bind(r.id, r.kind, r.schema_version, r.name, r.author, r.payload, r.remix_of,
                 r.revision, r.edit_key_hash, r.created_at, r.updated_at).run();
       } catch (e) {
-        if (String(e).includes('UNIQUE')) {
+        const msg = `${(e as Error).message ?? e} ${((e as Error & { cause?: Error }).cause?.message) ?? ''}`;
+        if (msg.includes('UNIQUE')) {
           const err = new Error('conflict') as Error & { code: string };
           err.code = 'conflict';
           throw err;
@@ -71,7 +72,7 @@ export default {
     // app lives at /; on arcade.oyster.to and wrangler dev (localhost) it lives
     // at /groovebox/. @rev is reserved syntax, ignored in v1 (never 404s).
     {
-      const m = url.pathname.match(/^\/s\/([a-z0-9]{4,16})(?:@\d+)?\/?$/i);
+      const m = url.pathname.match(/^\/s\/([a-z0-9]{8})(?:@\d+)?\/?$/i);
       if (m) {
         const base = url.hostname === 'groovebox.oyster.to' ? '/' : '/groovebox/';
         return Response.redirect(new URL(`${base}?s=${m[1].toLowerCase()}`, req.url).toString(), 302);

--- a/infra/oyster-arcade-site/tsconfig.json
+++ b/infra/oyster-arcade-site/tsconfig.json
@@ -3,11 +3,18 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022"],
-    "types": ["@cloudflare/workers-types"],
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "@cloudflare/workers-types"
+    ],
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowJs": true
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/infra/oyster-arcade-site/wrangler.toml
+++ b/infra/oyster-arcade-site/wrangler.toml
@@ -35,3 +35,22 @@ custom_domain = true
 # Observability: lets `wrangler tail` work for debugging.
 [observability]
 enabled = true
+
+# ─── Share registry ───────────────────────────────────────────────────────────
+# One-time provisioning (see migrations/0001_registry.sql):
+#   npx wrangler d1 create gb-registry          → paste database_id below
+#   npx wrangler d1 migrations apply gb-registry --remote
+#   npx wrangler secret put EDIT_KEY_SECRET     → long random value (HMAC key)
+[[d1_databases]]
+binding = "DB"
+database_name = "gb-registry"
+database_id = "FILLED-AFTER-wrangler-d1-create"
+migrations_dir = "migrations"
+
+# Write rate limit: 5 writes / 60s / IP. (Binding periods only support 10|60s,
+# so the spec's ~20/hr intent is enforced as a per-minute burst cap.)
+[[unsafe.bindings]]
+name = "WRITE_LIMIT"
+type = "ratelimit"
+namespace_id = "4401"
+simple = { limit = 5, period = 60 }

--- a/infra/oyster-arcade-site/wrangler.toml
+++ b/infra/oyster-arcade-site/wrangler.toml
@@ -44,7 +44,7 @@ enabled = true
 [[d1_databases]]
 binding = "DB"
 database_name = "gb-registry"
-database_id = "FILLED-AFTER-wrangler-d1-create"
+database_id = "e7426a6d-91b2-497c-965a-4df469bb0727"
 migrations_dir = "migrations"
 
 # Write rate limit: 5 writes / 60s / IP. (Binding periods only support 10|60s,


### PR DESCRIPTION
## What

The groovebox share registry v1: **publish** songs and grooves to a kind-generic Worker+D1 registry; share them as `groovebox.oyster.to/s/<id>` links; owners update in place via editKey; everyone else's edits fork with `remix_of` lineage.

Spec + plan (approved): `project-notes/oyster/po20/2026-06-06-share-registry-spec.md` / `-plan.md`. Scope lock honored: no discovery, no accounts, no R2, no groove conversion.

## How

- `docs/arcade/groovebox/registry/` — pure-JS modules shared by Worker, app, and tests: `validate.js` (strict per-kind payload validation, single source of truth with DATA-MODEL.md), `handler.js` (POST/GET/PUT, server-side 8-char ids w/ collision retry, HMAC-SHA256 editKey hashing, constant-time compare), `client.js` (fetch wrappers, `gb-registry-*` storage, `?s=` parse)
- `infra/oyster-arcade-site` — thin glue: D1 adapter (UNIQUE→conflict for id retry), write rate limit via ratelimit binding, host-aware `/s/<id>[@rev]` → app redirect
- Engine: new `addGroove(laneId, name, value)` (accepts literal + chord-relative groove values)
- UI: PUBLISH modal (Song/Groove tabs), owner mode leads with **Update**, "Your published" private list from the browser's editKey store, boot loader for `?s=`, conservative groove import (meter mismatch → data only, no transformation)

## Recorded deviations from spec (all discussed with Matthew during build/hand-test)

- UI verb renamed **Share → Publish** (registry mental model); `/s/` links unchanged
- Owner dialog defaults to **Update**; "Publish as new" demoted to secondary
- **"Your published"** list added (private, per-browser keyring — not discovery)
- Links + `/s/` redirects are **host-aware** (localhost dev / arcade host / canonical)
- Constant-time compare is a portable XOR-fold over HMAC hex digests (node + Workers)
- Rate limit binding only supports 10|60s periods → **5 writes/min/IP** instead of ~20/hr
- Groove import targets the **first** matching lane (no picker) — multi-lane-same-type is rare
- `remix_of` is recorded for same-kind re-publishes only; cross-kind extraction is plain new

## Validation contract finding

The all-7-presets contract test (flattened preset must pass `validateSongPayload`) caught schema drift on first run: `song.key`, `meter.group`, chord-relative `{relative, bars}` grooves, and `pattern.chords` had landed post-#630 without DATA-MODEL coverage. Validator accepts all; DATA-MODEL.md updated in this PR (registry section, `sampleRef` reservation, `addGroove` API).

## Tests

266 passing (76 new): validator accept/reject tables incl. size/string caps and audio-blob smuggling, handler POST/GET/PUT incl. 403/identity-protection/collision-retry/non-conflict-500, client storage incl. legacy tolerance, import semantics incl. meter mismatch and relative grooves, all-presets contract. 7-preset flatten parity untouched and green. Hand-tested by Matthew against `wrangler dev` + local D1 (publish, load, owner update, remix fork, groove import).

## Deploy (after merge)

```
cd infra/oyster-arcade-site
# database_id already pasted in wrangler.toml by this PR (created during review)
npx wrangler d1 migrations apply gb-registry --remote
npx wrangler secret put EDIT_KEY_SECRET
npx wrangler deploy
```

No CHANGELOG entry (consumer-only policy; arcade surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)