### PR TITLE
arcade(groovebox): SONG box layout, 4 AI-authored songs, honest status line

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -386,6 +386,7 @@ export function createEngine() {
     },
     setTempo(bpm) { if (typeof bpm === 'number' && isFinite(bpm)) { tempo = bpm; Tone.Transport.bpm.value = bpm; } },
     onStep(cb) { onStepCb = cb; },
+    isPlaying()  { return playing; },
     getSong() { return song; },
     getLanes() { return song ? song.lanes : []; },
     // Lane ops by id

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -54,7 +54,7 @@
         <div class="transport-song">
           <span class="transport-lbl">Song</span>
           <div class="song-wrap">
-            <select id="songsel"><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
+            <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
             <div id="credit"></div>
           </div>
         </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -24,13 +24,13 @@
             <option value="r1">Rabbit</option>
           </select>
           <div class="vs-wrap">
-            <button id="viewsettings-btn" title="View settings">⚙</button>
+            <button id="viewsettings-btn" title="View settings">Settings</button>
             <div id="viewsettings" hidden>
               <span class="vs-title">Active knobs</span>
               <div id="viewsettings-checks"></div>
             </div>
           </div>
-          <button id="help-btn" title="Open help">?</button>
+          <button id="help-btn" title="Open help">Help</button>
         </div>
       </div>
 

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -54,7 +54,7 @@
         <div class="transport-song">
           <span class="transport-lbl">Song</span>
           <div class="song-wrap">
-            <select id="songsel"><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
+            <select id="songsel"><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
             <div id="credit"></div>
           </div>
         </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -34,30 +34,35 @@
         </div>
       </div>
 
-      <!-- Tier 2 — transport (performance controls only) -->
-      <div class="transport">
-        <button id="play">▶ play</button>
-        <div class="transport-divider"></div>
-        <div class="transport-tempo">
-          <span class="transport-lbl">Tempo</span>
-          <input type="range" id="bpm" min="80" max="180" value="120">
-          <span id="bpmv" class="transport-bpm-val">120</span>
-          <span class="transport-bpm-unit">BPM</span>
-        </div>
-        <div class="transport-key">
-          <span class="transport-lbl">Key</span>
-          <div class="key-stepper">
-            <button id="key-dn">−</button><span id="keyv" class="mono">0</span><button id="key-up">＋</button>
+      <!-- Tier 2 — SONG box: transport (performance controls) + arrangement,
+           pinned as one module above the draggable view sections. -->
+      <div id="songbox">
+        <div class="transport">
+          <button id="play">▶ play</button>
+          <div class="transport-divider"></div>
+          <div class="transport-tempo">
+            <span class="transport-lbl">Tempo</span>
+            <input type="range" id="bpm" min="80" max="180" value="120">
+            <span id="bpmv" class="transport-bpm-val">120</span>
+            <span class="transport-bpm-unit">BPM</span>
           </div>
-          <button id="key-q" class="key-q" title="Quantize key change to the bar" aria-pressed="false">⟳ bar</button>
-        </div>
-        <div class="transport-song">
-          <span class="transport-lbl">Song</span>
-          <div class="song-wrap">
-            <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="scallywag">★ Scallywag (AI)</option><option value="boo-waltz">★ Boo Waltz (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
-            <div id="credit"></div>
+          <div class="transport-key">
+            <span class="transport-lbl">Key</span>
+            <div class="key-stepper">
+              <button id="key-dn">−</button><span id="keyv" class="mono">0</span><button id="key-up">＋</button>
+            </div>
+            <button id="key-q" class="key-q" title="Quantize key change to the bar" aria-pressed="false">⟳ bar</button>
+          </div>
+          <span id="song-status"><span class="pat-playing" id="pat-playing"></span><span class="pat-editing"></span></span>
+          <div class="transport-song">
+            <span class="transport-lbl">Song</span>
+            <div class="song-wrap">
+              <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="scallywag">★ Scallywag (AI)</option><option value="boo-waltz">★ Boo Waltz (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
+              <div id="credit"></div>
+            </div>
           </div>
         </div>
+        <div id="arrange"></div>
       </div>
 
       <!-- Help modal -->
@@ -120,7 +125,6 @@
       <div id="punch"></div>
       <div id="strips"></div>
       <div id="fills"></div>
-      <div id="arrange"></div>
     </div>
     <div class="crt-vignette"></div>
   </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -54,7 +54,7 @@
         <div class="transport-song">
           <span class="transport-lbl">Song</span>
           <div class="song-wrap">
-            <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
+            <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="scallywag">★ Scallywag (AI)</option><option value="boo-waltz">★ Boo Waltz (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
             <div id="credit"></div>
           </div>
         </div>

--- a/docs/arcade/groovebox/songs/boo-waltz.js
+++ b/docs/arcade/groovebox/songs/boo-waltz.js
@@ -1,0 +1,80 @@
+// "Boo Waltz" — spooky haunted-mansion theme (Luigi's Mansion idiom), authored
+// in v2 by an AI. D minor waltz (3/4, 12 steps/bar, beats at 0/4/8): oom-cha-cha
+// bass, sine-wave theremin lead drifting through C# (harmonic minor) and a
+// chromatic creep. A MAJOR as V = the menace. Composed by Claude, 2026-06-06.
+
+const Dm = { name: 'Dm', root: 'D2', voicing: ['D3', 'F3', 'A3'] };
+const Gm = { name: 'Gm', root: 'G2', voicing: ['G3', 'A#3', 'D4'] };
+const A  = { name: 'A',  root: 'A2', voicing: ['A3', 'C#4', 'E4'] };
+const Bb = { name: 'Bb', root: 'A#2', voicing: ['A#3', 'D4', 'F4'] };
+
+export const booWaltz = {
+  version: 2,
+  title: 'Boo Waltz',
+  artist: 'Claude × Oyster',
+  meter: { beatsPerBar: 3, beatUnit: 4, stepsPerBeat: 4 },
+  bpm: 120,
+  key: { root: 'D', mode: 'minor' },
+
+  lanes: [
+    { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
+    { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
+    { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'sine' },
+  ],
+
+  grooves: {
+    drums: {
+      // the ballroom: soft pulse on 1, brushes on 2 and 3
+      ballroom: [{ kick: [0], hat: [4, 8] }],
+      // footsteps: something walks on the off-16ths
+      footsteps: [{ kick: [0], hat: [4, 8], snare: [6] }],
+      // the chase: toms lurch through the bar
+      lurch: [{ kick: [0, 8], hat: [2, 6, 10], tom: [[4, 0], [10, -4]] }],
+    },
+    bass: {
+      // oom-cha-cha: root on 1, fifth above on 2 and 3
+      'oom-cha-cha': { relative: true, bars: [[[0, 'R', 4], [4, 'V2-12', 4], [8, 'V2-12', 4]]] },
+      // dread: one long root per bar, octave dip
+      dread:         { relative: true, bars: [[[0, 'R', 8], [8, 'R+12', 4]]] },
+    },
+    chords: {
+      // organ pad, whole bar
+      organ: { relative: true, bars: [[[0, 'V*', 'bar']]] },
+      // waltz comps on 2 and 3
+      comp:  { relative: true, bars: [[[4, 'V*', 2], [8, 'V*', 2]]] },
+    },
+    melody: {
+      // theremin line — long sighs, C# leading tones, a ghost exhaling
+      theremin: [
+        [[0, 'D5', 8], [8, 'C#5', 4]],
+        [[0, 'D5', 4], [4, 'F5', 4], [8, 'E5', 4]],
+        [[0, 'C#5', 8], [8, 'A4', 4]],
+        [[0, 'D5', 12]],
+      ],
+      // the creep — chromatic descent, footstep-paced
+      creep: [
+        [[0, 'F5', 4], [4, 'E5', 4], [8, 'D#5', 4]],
+        [[0, 'D5', 4], [4, 'C#5', 4], [8, 'D5', 4]],
+        [[0, 'A#4', 4], [4, 'A4', 4], [8, 'G#4', 4]],
+        [[0, 'A4', 12]],
+      ],
+      empty: [[]],
+    },
+  },
+
+  patterns: [
+    // 0: the door creaks open — organ + dread, theremin alone
+    { lanes: { drums: 'ballroom', bass: 'dread', chords: 'organ', melody: 'theremin' }, chords: [Dm, Gm, A, Dm] },
+    // 1: the waltz proper — oom-cha-cha
+    { lanes: { drums: 'footsteps', bass: 'oom-cha-cha', chords: 'comp', melody: 'theremin' }, chords: [Dm, Gm, A, Dm] },
+    // 2: something's behind you — chromatic creep over the darkened turn
+    { lanes: { drums: 'lurch', bass: 'oom-cha-cha', chords: 'comp', melody: 'creep' }, chords: [Bb, Gm, A, A] },
+  ],
+
+  chain: [0, 1, 1, 2, 1],
+
+  fills: {
+    'thunder': { kick: [0, 4, 8], tom: [[2, 7], [6, 3], [10, -2]], crash: [0] },
+  },
+};

--- a/docs/arcade/groovebox/songs/first-roll.js
+++ b/docs/arcade/groovebox/songs/first-roll.js
@@ -1,0 +1,73 @@
+// "First Roll" — the first song authored directly in the v2 schema (no rich
+// format, no flattener): an AI-written smoke test of DATA-MODEL.md as an
+// authoring format. E minor, i–VI–III–VII (Em C G D) — the classic minor loop.
+// Composed by Claude, 2026-06-06. Melody included as a starter — overwrite it.
+
+const Em = { name: 'Em', root: 'E2', voicing: ['E3', 'G3', 'B3'] };
+const C  = { name: 'C',  root: 'C2', voicing: ['C3', 'E3', 'G3'] };
+const G  = { name: 'G',  root: 'G2', voicing: ['G3', 'B3', 'D4'] };
+const D  = { name: 'D',  root: 'D2', voicing: ['D3', 'F#3', 'A3'] };
+
+export const firstRoll = {
+  version: 2,
+  title: 'First Roll',
+  artist: 'Claude × Oyster',
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
+  bpm: 112,
+  key: { root: 'E', mode: 'minor' },
+
+  lanes: [
+    { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
+    { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
+    { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'pulse' },
+  ],
+
+  grooves: {
+    drums: {
+      // steady verse kit
+      four:        [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      // sparse intro/bridge kit
+      'half-time': [{ kick: [0], snare: [8], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      // busy chorus kit
+      breaks:      [{ kick: [0, 6, 10], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] }],
+    },
+    bass: {
+      // root/octave bounce — rides whatever chords the pattern carries
+      octave:  { relative: true, bars: [[[0, 'R', 2], [2, 'R+12', 2], [4, 'R', 2], [6, 'R+12', 2], [8, 'R', 2], [10, 'R+12', 2], [12, 'R', 2], [14, 'R+12', 2]]] },
+      // driving straight 8ths on the root
+      drive:   { relative: true, bars: [[[0, 'R', 2], [2, 'R', 2], [4, 'R', 2], [6, 'R', 2], [8, 'R', 2], [10, 'R', 2], [12, 'R', 2], [14, 'R', 2]]] },
+    },
+    chords: {
+      pad:  { relative: true, bars: [[[0, 'V*', 'bar']]] },
+      stab: { relative: true, bars: [[[0, 'V*', 2], [8, 'V*', 2]]] },
+    },
+    melody: {
+      // 4-bar hook in E minor — every note in key, chord tones on the downbeats.
+      hook: [
+        [[0, 'E4', 4], [4, 'G4', 2], [6, 'F#4', 2], [8, 'E4', 4], [12, 'B3', 4]],
+        [[0, 'C4', 4], [4, 'E4', 2], [6, 'D4', 2], [8, 'B3', 8]],
+        [[0, 'G4', 4], [4, 'A4', 2], [6, 'B4', 2], [8, 'A4', 2], [10, 'G4', 2], [12, 'F#4', 4]],
+        [[0, 'F#4', 8], [8, 'D4', 4], [12, 'E4', 4]],
+      ],
+      // blank slate for a human (Henry) — snap-to-scale has your back
+      empty: [[]],
+    },
+  },
+
+  patterns: [
+    // 1: verse — steady, padded
+    { lanes: { drums: 'four', bass: 'octave', chords: 'pad', melody: 'hook' },  chords: [Em, C, G, D] },
+    // 2: chorus — busier kit, driving bass, stabbed chords, melody yours
+    { lanes: { drums: 'breaks', bass: 'drive', chords: 'stab', melody: 'empty' }, chords: [Em, C, G, D] },
+    // 3: breakdown — half-time, pads, space to breathe
+    { lanes: { drums: 'half-time', bass: 'octave', chords: 'pad', melody: 'empty' }, chords: [Em, C, G, D] },
+  ],
+
+  chain: [0, 0, 1, 0, 0, 1, 2, 0],
+
+  fills: {
+    'snare roll': { kick: [0], snare: [8, 9, 10, 11, 12, 13, 14, 15] },
+    'tom run':    { kick: [0], tom: [[6, 7], [8, 5], [10, 3], [12, 0], [14, -3]], crash: [0] },
+  },
+};

--- a/docs/arcade/groovebox/songs/press-start.js
+++ b/docs/arcade/groovebox/songs/press-start.js
@@ -1,0 +1,88 @@
+// "Press Start" — an upbeat game opening theme in the Mario/Sonic idiom,
+// authored directly in the v2 schema by an AI. C major, 144 BPM.
+// Ingredients: oom-pah root-fifth bass (the classic game bass), offbeat chord
+// stabs (the Sonic skank), staccato repeated-note hooks with arpeggio leaps,
+// fanfare intro. Composed by Claude, 2026-06-06.
+
+const C  = { name: 'C',  root: 'C2', voicing: ['C3', 'E3', 'G3'] };
+const F  = { name: 'F',  root: 'F2', voicing: ['F3', 'A3', 'C4'] };
+const G  = { name: 'G',  root: 'G2', voicing: ['G3', 'B3', 'D4'] };
+const Am = { name: 'Am', root: 'A2', voicing: ['A3', 'C4', 'E4'] };
+
+export const pressStart = {
+  version: 2,
+  title: 'Press Start',
+  artist: 'Claude × Oyster',
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
+  bpm: 144,
+  key: { root: 'C', mode: 'major' },
+
+  lanes: [
+    { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
+    { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
+    { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'square' },
+  ],
+
+  grooves: {
+    drums: {
+      // fanfare bed — sparse, big crash
+      fanfare: [{ kick: [0, 8], snare: [12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [0] }],
+      // main run — driving 16th hats, four on the floor
+      sprint:  [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] }],
+      // B section — syncopated kick, lighter hats
+      skip:    [{ kick: [0, 6, 8, 14], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+    },
+    bass: {
+      // THE game bass: root/fifth oom-pah in 8ths
+      'oom-pah': { relative: true, bars: [[[0, 'R', 2], [2, 'V2-12', 2], [4, 'R', 2], [6, 'V2-12', 2], [8, 'R', 2], [10, 'V2-12', 2], [12, 'R', 2], [14, 'V2-12', 2]]] },
+      // octave bounce for the B section lift
+      octave:    { relative: true, bars: [[[0, 'R', 2], [2, 'R+12', 2], [4, 'R', 2], [6, 'R+12', 2], [8, 'R', 2], [10, 'R+12', 2], [12, 'R', 2], [14, 'R+12', 2]]] },
+    },
+    chords: {
+      // the Sonic skank: stabs on the offbeats only
+      'offbeat-stab': { relative: true, bars: [[[2, 'V*', 2], [6, 'V*', 2], [10, 'V*', 2], [14, 'V*', 2]]] },
+      pad:            { relative: true, bars: [[[0, 'V*', 'bar']]] },
+    },
+    melody: {
+      // fanfare: rising arpeggio flourish, then a held high note
+      fanfare: [
+        [[0, 'C4', 2], [2, 'E4', 2], [4, 'G4', 2], [6, 'C5', 2], [8, 'E5', 4], [12, 'D5', 2], [14, 'B4', 2]],
+        [[0, 'D5', 2], [2, 'B4', 2], [4, 'G4', 2], [6, 'B4', 2], [8, 'D5', 8]],
+      ],
+      // A hook: staccato repeated notes + leaps (the Mario rhythm DNA, original tune)
+      'hook-a': [
+        [[0, 'G4', 1], [2, 'G4', 1], [4, 'E4', 2], [8, 'G4', 1], [10, 'A4', 1], [12, 'C5', 2]],
+        [[0, 'A4', 2], [4, 'G4', 1], [6, 'F4', 1], [8, 'A4', 2], [12, 'C5', 2], [14, 'A4', 2]],
+        [[0, 'B4', 1], [2, 'B4', 1], [4, 'G4', 2], [8, 'D5', 2], [12, 'B4', 2], [14, 'A4', 2]],
+        [[0, 'A4', 2], [4, 'C5', 2], [8, 'D5', 1], [10, 'C5', 1], [12, 'A4', 1], [14, 'G4', 1]],
+      ],
+      // B hook: longer notes, the emotional lift before returning to the run
+      'hook-b': [
+        [[0, 'E5', 4], [4, 'C5', 2], [6, 'B4', 2], [8, 'A4', 4], [12, 'B4', 2], [14, 'C5', 2]],
+        [[0, 'D5', 4], [4, 'C5', 2], [6, 'A4', 2], [8, 'F4', 6]],
+        [[0, 'E5', 4], [4, 'G5', 2], [6, 'E5', 2], [8, 'C5', 4], [12, 'D5', 2], [14, 'E5', 2]],
+        [[0, 'D5', 4], [4, 'B4', 2], [6, 'A4', 2], [8, 'G4', 4], [12, 'B4', 2], [14, 'D5', 2]],
+      ],
+      // blank slate — yours
+      empty: [[]],
+    },
+  },
+
+  patterns: [
+    // 0: fanfare intro — "press start"
+    { lanes: { drums: 'fanfare', bass: 'oom-pah', chords: 'pad', melody: 'fanfare' }, chords: [C, G] },
+    // 1: the run — main theme
+    { lanes: { drums: 'sprint', bass: 'oom-pah', chords: 'offbeat-stab', melody: 'hook-a' }, chords: [C, F, G, F] },
+    // 2: the lift — B section
+    { lanes: { drums: 'skip', bass: 'octave', chords: 'offbeat-stab', melody: 'hook-b' }, chords: [Am, F, C, G] },
+  ],
+
+  // intro → run ×2 → lift → run (loops forever, like a level should)
+  chain: [0, 1, 1, 2, 1],
+
+  fills: {
+    'snare roll': { kick: [0], snare: [8, 9, 10, 11, 12, 13, 14, 15] },
+    'tom run':    { kick: [0], tom: [[6, 7], [8, 5], [10, 3], [12, 0], [14, -3]], crash: [0] },
+  },
+};

--- a/docs/arcade/groovebox/songs/scallywag.js
+++ b/docs/arcade/groovebox/songs/scallywag.js
@@ -1,0 +1,80 @@
+// "Scallywag" — Monkey Island-esque pirate theme, authored in v2 by an AI.
+// A minor, 6/8 lilt (12 steps/bar, pulses at 0 and 6) — the actual meter of the
+// great pirate themes. E MAJOR as the V chord = harmonic-minor flavour (that
+// G# is the whole pirate sound). Triangle lead ≈ marimba. Composed by Claude.
+
+const Am = { name: 'Am', root: 'A2', voicing: ['A3', 'C4', 'E4'] };
+const G  = { name: 'G',  root: 'G2', voicing: ['G3', 'B3', 'D4'] };
+const F  = { name: 'F',  root: 'F2', voicing: ['F3', 'A3', 'C4'] };
+const C  = { name: 'C',  root: 'C2', voicing: ['C3', 'E3', 'G3'] };
+const E  = { name: 'E',  root: 'E2', voicing: ['E3', 'G#3', 'B3'] };
+
+export const scallywag = {
+  version: 2,
+  title: 'Scallywag',
+  artist: 'Claude × Oyster',
+  meter: { beatsPerBar: 6, beatUnit: 8, stepsPerBeat: 2, group: 3 },
+  bpm: 100,
+  key: { root: 'A', mode: 'minor' },
+
+  lanes: [
+    { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
+    { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
+    { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'triangle' },
+  ],
+
+  grooves: {
+    drums: {
+      // gentle ship-sway: pulses on the two dotted quarters
+      sway:  [{ kick: [0, 6], hat: [0, 2, 4, 6, 8, 10] }],
+      // tavern stomp: snare answers on the second pulse
+      stomp: [{ kick: [0, 6], snare: [6], hat: [0, 2, 4, 6, 8, 10] }],
+      // full sail: busier kick, crash to open
+      'full sail': [{ kick: [0, 3, 6, 9], snare: [6], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], crash: [0] }],
+    },
+    bass: {
+      // lilting root → octave → fifth, the 6/8 sea-legs walk
+      'sea legs': { relative: true, bars: [[[0, 'R', 4], [4, 'R+12', 2], [6, 'V2-12', 4], [10, 'R+12', 2]]] },
+      // long pulls on the two big beats
+      anchor:     { relative: true, bars: [[[0, 'R', 6], [6, 'V2-12', 6]]] },
+    },
+    chords: {
+      // light skank between the pulses
+      lilt: { relative: true, bars: [[[2, 'V*', 2], [8, 'V*', 2]]] },
+      pad:  { relative: true, bars: [[[0, 'V*', 'bar']]] },
+    },
+    melody: {
+      // A theme — the rolling shanty tune; G# over E = pure pirate
+      shanty: [
+        [[0, 'A4', 2], [2, 'B4', 2], [4, 'C5', 2], [6, 'E5', 4], [10, 'C5', 2]],
+        [[0, 'B4', 2], [2, 'A4', 2], [4, 'G4', 2], [6, 'B4', 4], [10, 'D5', 2]],
+        [[0, 'C5', 2], [2, 'B4', 2], [4, 'A4', 2], [6, 'E4', 4], [10, 'A4', 2]],
+        [[0, 'G#4', 4], [4, 'B4', 2], [6, 'E5', 6]],
+      ],
+      // B theme — the chorus lift, sails full
+      'horizon': [
+        [[0, 'A4', 4], [4, 'C5', 2], [6, 'F5', 4], [10, 'E5', 2]],
+        [[0, 'E5', 2], [2, 'D5', 2], [4, 'C5', 2], [6, 'G4', 6]],
+        [[0, 'B4', 2], [2, 'C5', 2], [4, 'D5', 2], [6, 'B4', 4], [10, 'G4', 2]],
+        [[0, 'G#4', 2], [2, 'A4', 2], [4, 'B4', 2], [6, 'E5', 6]],
+      ],
+      empty: [[]],
+    },
+  },
+
+  patterns: [
+    // 0: dockside — sway, pads, the tune alone
+    { lanes: { drums: 'sway', bass: 'anchor', chords: 'pad', melody: 'shanty' }, chords: [Am, G, Am, E] },
+    // 1: underway — stomp + skank
+    { lanes: { drums: 'stomp', bass: 'sea legs', chords: 'lilt', melody: 'shanty' }, chords: [Am, G, Am, E] },
+    // 2: full sail — the lift
+    { lanes: { drums: 'full sail', bass: 'sea legs', chords: 'lilt', melody: 'horizon' }, chords: [F, C, G, E] },
+  ],
+
+  chain: [0, 1, 1, 2, 1],
+
+  fills: {
+    'broadside': { kick: [0, 6], tom: [[8, 5], [9, 3], [10, 0], [11, -3]], crash: [0] },
+  },
+};

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -184,9 +184,9 @@ body {
   padding-right: 26px;
 }
 .titlebar-tools button {
-  width: 26px;
-  padding: 0;
-  font-size: 13px;
+  padding: 0 10px;
+  font-size: 11px;
+  letter-spacing: .04em;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -405,7 +405,7 @@ input[type=range] {
 #fills,
 #punch,
 #master,
-#arrange {
+#songbox {
   /* soft top-light → bottom-shade sheen (derived from --panel) so panels read
      as smooth surfaces in every theme, not flat matte cards on dark */
   background: linear-gradient(180deg,
@@ -417,6 +417,15 @@ input[type=range] {
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.06),
     0 1px 4px rgba(0,0,0,0.45);
+  margin-bottom: 12px;
+}
+
+/* SONG box — one pinned module wrapping the transport + arrangement. The
+   transport and #arrange inside it are not separate cards; they share the box. */
+#songbox {
+  padding: 12px 16px;
+}
+#songbox .transport {
   margin-bottom: 12px;
 }
 
@@ -465,10 +474,7 @@ input[type=range] {
   padding: 12px 16px;
 }
 
-/* ─── arrangement panel ──────────────────────────────────────────────────── */
-#arrange {
-  padding: 12px 16px;
-}
+/* ─── arrangement (lives inside #songbox; no card chrome of its own) ──────── */
 
 /* ─── beat-number header row ────────────────────────────────────────────── */
 .vhead {
@@ -1170,27 +1176,25 @@ body.gb-knob-values .knob-val { display: block; }
   text-transform: uppercase;
 }
 
-/* ─── arrangement UI (panel chrome via #arrange) ────────────────────────── */
-.arrange-head {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-bottom: 8px;
-}
-/* § 2 — section header */
-.albl {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  color: var(--faint);
-  text-transform: uppercase;
-  margin-right: 4px;
-}
-
 /* ─── PATTERNS module ─── */
-.pat-editing { margin-left: auto; font-size: 11px; color: var(--acc); opacity: .9; }
-.pat-playing { font-size: 11px; color: var(--hot); opacity: .9; margin-left: 12px; }
+/* Consolidated song status: lives in the transport row (#song-status), playing
+   state (pink) then a hairline separator then editing state (green). */
+#song-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.pat-playing { font-size: 11px; color: var(--hot); opacity: .9; }
+.pat-editing { font-size: 11px; color: var(--acc); opacity: .9; }
+.pat-playing:not(:empty) + .pat-editing:not(:empty)::before {
+  content: '│';
+  color: var(--line);
+  margin-right: 8px;
+}
 .ed-lbl { font-size: 10px; color: var(--dim); letter-spacing: .1em; text-transform: uppercase; margin: 2px 0 4px; }
 .pat-row, .chain-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 6px 0; transition: opacity .2s; }
 .pat-row.dimmed, .chain-row.dimmed { opacity: .45; }
@@ -1552,7 +1556,6 @@ body.gb-knob-values .knob-val { display: block; }
 [data-theme="gameboy"] .kgroup-lbl,
 [data-theme="gameboy"] .fillsrow .flbl,
 [data-theme="gameboy"] .masterfx .mlbl,
-[data-theme="gameboy"] .albl,
 [data-theme="gameboy"] .transport-lbl {
   color: #2a2a78;
   font-weight: 800;
@@ -2294,7 +2297,8 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .cabinet-inner { padding: 6px 4px 16px; border-radius: 0; box-shadow: none; }
   #strips { padding: 6px 4px; }
   #fills, #punch, #master { padding: 6px 8px; }
-  #viz, #strips, #fills, #punch, #master, #arrange { margin-bottom: 8px; }
+  #viz, #strips, #fills, #punch, #master, #songbox { margin-bottom: 8px; }
+  #songbox { padding: 6px 8px; }
   .sec-drag { display: none; }   /* mouse-only affordance */
   .titlebar { margin-bottom: 8px; }
   h1 { font-size: 13px; letter-spacing: 0.1em; white-space: nowrap; }
@@ -2304,9 +2308,10 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
     display: grid;
     grid-template-columns: 1fr auto;
     grid-template-areas:
-      "play  key"
-      "tempo tempo"
-      "song  song";
+      "play   key"
+      "tempo  tempo"
+      "status status"
+      "song   song";
     row-gap: 10px;
     column-gap: 10px;
   }
@@ -2315,6 +2320,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .transport-key { grid-area: key; display: flex; align-items: center; gap: 8px; }
   .transport-tempo { grid-area: tempo; min-width: 0; }
   #bpm { flex: 1; min-width: 50px; }
+  #song-status { grid-area: status; min-width: 0; }
   .transport-song { grid-area: song; margin-left: 0; min-width: 0; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1105,6 +1105,7 @@ body.gb-knob-values .knob-val { display: block; }
 }
 /* Key badge — reuse .pat-lbl look. */
 .h-key { margin-left: auto; }
+.h-pat { font-size: 10px; color: var(--hot); opacity: .8; min-width: 22px; }
 /* Inline edit input. */
 .h-edit {
   flex: 1 1 auto;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -9,6 +9,7 @@ import { digitalLove } from '../songs/digital-love.js';
 import { memoryReboot } from '../songs/memory-reboot.js';
 import { takeOnMe } from '../songs/take-on-me.js';
 import { firstRoll } from '../songs/first-roll.js';
+import { pressStart } from '../songs/press-start.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 
@@ -40,7 +41,7 @@ function knobTip(k) {
   return info ? info[0] + ' — ' + info[1] : k;
 }
 
-const SONGS = { kids, 'rising-sun': risingSun, 'electric-feel': electricFeel, heartbeats, 'digital-love': digitalLove, 'memory-reboot': memoryReboot, 'take-on-me': takeOnMe, 'first-roll': firstRoll };
+const SONGS = { kids, 'rising-sun': risingSun, 'electric-feel': electricFeel, heartbeats, 'digital-love': digitalLove, 'memory-reboot': memoryReboot, 'take-on-me': takeOnMe, 'first-roll': firstRoll, 'press-start': pressStart };
 
 const esc = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
@@ -1450,7 +1451,7 @@ function initSectionWrappers() {
 }
 
 // ─── Initial load ─────────────────────────────────────────────────────────────
-eng.load(firstRoll);
+eng.load(pressStart);
 const initialSong = eng.getSong();
 document.getElementById('bpm').value = initialSong.bpm;
 document.getElementById('bpmv').textContent = initialSong.bpm;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -60,7 +60,7 @@ let _openLaneId = null;
 let _draggedLaneId = null;
 
 // ─── Section drag-reorder state ───────────────────────────────────────────────
-const SECTION_IDS = ['viz', 'master', 'punch', 'strips', 'fills', 'arrange'];
+const SECTION_IDS = ['viz', 'master', 'punch', 'strips', 'fills'];
 let _draggedSecId = null;
 
 function refreshStates() {
@@ -714,14 +714,14 @@ function renderPatterns() {
   const chain = eng.getChain();
   const editIdx = eng.getEditPatternIndex();
 
-  const head = document.createElement('div');
-  head.className = 'arrange-head';
-  head.innerHTML = `<span class="albl">PATTERNS</span><span class="pat-editing">Editing: Pattern ${editIdx + 1}</span><span class="pat-playing" id="pat-playing"></span>`;
-  host.appendChild(head);
-
-  // Patterns row: slots + length + duplicate/delete for the selected pattern.
+  // Patterns row: small "patterns" label (matching chords/chain rows) + slots +
+  // duplicate/delete for the selected pattern.
   const prow = document.createElement('div');
   prow.className = 'pat-row';
+  const plbl = document.createElement('span');
+  plbl.className = 'pat-lbl';
+  plbl.textContent = 'patterns';
+  prow.appendChild(plbl);
   patterns.forEach((p, i) => {
     const b = document.createElement('button');
     b.className = 'pat-slot' + (i === editIdx ? ' sel' : '');
@@ -924,14 +924,17 @@ function updatePatternsPlayback(target) {
     const sounding = target.barInPattern % chordChips.length;
     chordChips.forEach(chip => chip.classList.toggle('sounding', +chip.dataset.idx === sounding));
   }
-  const lbl = host.querySelector('#pat-playing');
+  // Status spans now live in the transport row (#song-status), not in #arrange.
+  const lbl = document.getElementById('pat-playing');
   if (lbl) {
     const chain = eng.getChain();
     const verb = eng.isPlaying() ? 'Playing' : 'Will play';
     lbl.textContent = isPattern
-      ? `${verb}: Pattern ${target.patternIdx + 1} (loop)`
-      : `${verb}: Chain · ${chain.map((pi, i) => (i === target.chainPos ? '▸' : '') + (pi + 1)).join(' ')}`;
+      ? `▶ ${verb}: Pattern ${target.patternIdx + 1} (loop)`
+      : `▶ ${verb}: Chain · ${chain.map((pi, i) => (i === target.chainPos ? '▸' : '') + (pi + 1)).join(' ')}`;
   }
+  const ed = document.querySelector('#song-status .pat-editing');
+  if (ed) ed.textContent = `✎ Pattern ${eng.getEditPatternIndex() + 1}`;
 }
 
 // Tell the viz the edit pattern changed (rebuilds the open editor).
@@ -1465,7 +1468,12 @@ function initSectionWrappers() {
 }
 
 // ─── Initial load ─────────────────────────────────────────────────────────────
-eng.load(pressStart);
+const BOOT_SONG = 'press-start';
+eng.load(SONGS[BOOT_SONG]);
+// Pin the dropdown to the boot song so the selector, the loaded song, and the
+// credit line (set in mount from the loaded song) always agree — don't rely on
+// the option's `selected` attribute matching the boot song by coincidence.
+document.getElementById('songsel').value = BOOT_SONG;
 const initialSong = eng.getSong();
 document.getElementById('bpm').value = initialSong.bpm;
 document.getElementById('bpmv').textContent = initialSong.bpm;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -10,6 +10,8 @@ import { memoryReboot } from '../songs/memory-reboot.js';
 import { takeOnMe } from '../songs/take-on-me.js';
 import { firstRoll } from '../songs/first-roll.js';
 import { pressStart } from '../songs/press-start.js';
+import { scallywag } from '../songs/scallywag.js';
+import { booWaltz } from '../songs/boo-waltz.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 
@@ -41,7 +43,7 @@ function knobTip(k) {
   return info ? info[0] + ' — ' + info[1] : k;
 }
 
-const SONGS = { kids, 'rising-sun': risingSun, 'electric-feel': electricFeel, heartbeats, 'digital-love': digitalLove, 'memory-reboot': memoryReboot, 'take-on-me': takeOnMe, 'first-roll': firstRoll, 'press-start': pressStart };
+const SONGS = { kids, 'rising-sun': risingSun, 'electric-feel': electricFeel, heartbeats, 'digital-love': digitalLove, 'memory-reboot': memoryReboot, 'take-on-me': takeOnMe, 'first-roll': firstRoll, 'press-start': pressStart, scallywag, 'boo-waltz': booWaltz };
 
 const esc = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
@@ -803,16 +805,23 @@ function renderPatterns() {
   syncStripGrooves();   // edit pattern may have changed → resync strip dropdowns
 }
 
-// Build the chord line for pattern `idx`: "chords" label + chord chips (or a
-// "＋ chords" affordance when empty) + the key badge. The chip area is clickable
-// (cursor:text) → beginChordEdit swaps in the text input.
+// Build the chord line for pattern `idx`: "chords" label + a P<n> marker + chord
+// chips (or a "＋ chords" affordance when empty) + the key badge. The chip area is
+// clickable → beginChordEdit swaps in the text input. During playback the row
+// FOLLOWS THE SOUNDING PATTERN (updatePatternsPlayback rebuilds it on pattern
+// change) — watching is the default, editing is the explicit click.
 function buildChordLine(idx) {
   const row = document.createElement('div');
   row.className = 'chord-row';
+  row.dataset.idx = idx;
   const lbl = document.createElement('span');
   lbl.className = 'pat-lbl';
   lbl.textContent = 'chords';
   row.appendChild(lbl);
+  const pmark = document.createElement('span');
+  pmark.className = 'h-pat';
+  pmark.textContent = 'P' + (idx + 1);
+  row.appendChild(pmark);
 
   const chips = document.createElement('div');
   chips.className = 'h-chips';
@@ -903,14 +912,16 @@ function updatePatternsPlayback(target) {
   host.querySelectorAll('.chain-chip').forEach(c => {
     c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos);
   });
-  // Sounding-chord glow on the chord line — only when the SOUNDING pattern is the
-  // one displayed (the chord chips show the edit pattern's chords).
-  const chordChips = host.querySelectorAll('.chord-row .h-chip');
-  if (chordChips.length) {
-    const editIdx = eng.getEditPatternIndex();
-    const sounding = target.patternIdx === editIdx
-      ? target.barInPattern % chordChips.length
-      : -1;
+  // Chord line follows the SOUNDING pattern (unless the user is mid-edit):
+  // rebuild it when the sounding pattern changes, then light the live chord.
+  const row = host.querySelector('.chord-row');
+  if (row && !host.querySelector('.h-edit') && +row.dataset.idx !== target.patternIdx) {
+    row.replaceWith(buildChordLine(target.patternIdx));
+  }
+  const liveRow = host.querySelector('.chord-row');
+  const chordChips = liveRow ? liveRow.querySelectorAll('.h-chip:not(.h-empty)') : [];
+  if (chordChips.length && +liveRow.dataset.idx === target.patternIdx) {
+    const sounding = target.barInPattern % chordChips.length;
     chordChips.forEach(chip => chip.classList.toggle('sounding', +chip.dataset.idx === sounding));
   }
   const lbl = host.querySelector('#pat-playing');

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -727,7 +727,7 @@ function renderPatterns() {
     b.className = 'pat-slot' + (i === editIdx ? ' sel' : '');
     b.dataset.idx = i;
     b.textContent = i + 1;
-    b.title = 'edit (loops while playing)';
+    b.title = 'click: edit this pattern — play will loop it';
     b.onclick = () => { eng.selectPattern(i); renderPatterns(); refreshVizPattern(); };
     prow.appendChild(b);
   });
@@ -927,9 +927,10 @@ function updatePatternsPlayback(target) {
   const lbl = host.querySelector('#pat-playing');
   if (lbl) {
     const chain = eng.getChain();
+    const verb = eng.isPlaying() ? 'Playing' : 'Will play';
     lbl.textContent = isPattern
-      ? `Playing: Pattern ${target.patternIdx + 1} (loop)`
-      : `Playing: Chain · ${chain.map((pi, i) => (i === target.chainPos ? '▸' : '') + (pi + 1)).join(' ')}`;
+      ? `${verb}: Pattern ${target.patternIdx + 1} (loop)`
+      : `${verb}: Chain · ${chain.map((pi, i) => (i === target.chainPos ? '▸' : '') + (pi + 1)).join(' ')}`;
   }
 }
 
@@ -1008,9 +1009,11 @@ document.getElementById('play').onclick = async function() {
   if (this.classList.contains('on')) {
     eng.stop(); this.classList.remove('on'); this.textContent='▶ play';
     stopMeterLoop();
+    updatePatternsPlayback(eng.getPlaybackTarget());
   } else {
     await eng.play(); this.classList.add('on'); this.textContent='⏹ stop';
     startMeterLoop();
+    updatePatternsPlayback(eng.getPlaybackTarget());
   }
 };
 document.getElementById('bpm').oninput = e => { eng.setTempo(+e.target.value); document.getElementById('bpmv').textContent = e.target.value; };

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -8,6 +8,7 @@ import { heartbeats } from '../songs/heartbeats.js';
 import { digitalLove } from '../songs/digital-love.js';
 import { memoryReboot } from '../songs/memory-reboot.js';
 import { takeOnMe } from '../songs/take-on-me.js';
+import { firstRoll } from '../songs/first-roll.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 
@@ -39,7 +40,7 @@ function knobTip(k) {
   return info ? info[0] + ' — ' + info[1] : k;
 }
 
-const SONGS = { kids, 'rising-sun': risingSun, 'electric-feel': electricFeel, heartbeats, 'digital-love': digitalLove, 'memory-reboot': memoryReboot, 'take-on-me': takeOnMe };
+const SONGS = { kids, 'rising-sun': risingSun, 'electric-feel': electricFeel, heartbeats, 'digital-love': digitalLove, 'memory-reboot': memoryReboot, 'take-on-me': takeOnMe, 'first-roll': firstRoll };
 
 const esc = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
@@ -1449,7 +1450,7 @@ function initSectionWrappers() {
 }
 
 // ─── Initial load ─────────────────────────────────────────────────────────────
-eng.load(kids);
+eng.load(firstRoll);
 const initialSong = eng.getSong();
 document.getElementById('bpm').value = initialSong.bpm;
 document.getElementById('bpmv').textContent = initialSong.bpm;


### PR DESCRIPTION
## Summary

- **SONG box** (Matthew's design): transport + status + song picker + patterns/chords/chain as one pinned module at the top — everything song-related together, play stays at the top edge. Old PATTERNS header and its three competing labels replaced by one status line: `▶ Playing|Will play: … │ ✎ Pattern N`.
- **Four AI-authored v2 songs** — the smoke test of the schema as an authoring format: ★ Press Start (4/4 chiptune, boots by default), ★ Scallywag (6/8 pirate), ★ Boo Waltz (3/4 haunted waltz), ★ First Roll (4/4 minor pop). Each exercises a different meter; melody slots deliberately left empty in places for human (Henry) overdubs.
- **Chord row follows the sounding pattern** (with a P-marker), so harmony lights up through the whole chain.
- Fixes: boot song/dropdown/credit desync; honest "Will play" tense when stopped; Settings/Help as words (theme-proof, matches the app's label language).

## Test Plan
- [x] 188 tests green incl. 7-preset parity
- [x] vite build clean
- [x] Hand-tested through the day's session (layout, songs, chord lighting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)