### PR TITLE
arcade(groovebox): punch v4 — per-lane application (masks become real)

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -33,7 +33,7 @@ export function createEngine() {
   let punchGate = null, punchCrush = null, punchFilter = null, punchThrow = null, punchTape = null;
   const _punchCaptures = new Map();              // 'laneId|paramId' → { value: knob value at first engage, count }
   let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
-  const _slotHeld = [false, false, false, false, false];
+  const _slotHeld = new Array(DEFAULT_PRESETS.length).fill(false);
   let _gate = null;                              // active gate: { depth, division, laneIds } | null
   let _tapeActive = false;                       // transport.tapeStop engaged (owns the gate)
   let _gateReturnPending = false;                // tapeStop released → gate returns on-grid
@@ -510,7 +510,7 @@ export function createEngine() {
       else _pendingQuantized.push({ when: q, fn: run, slot, on });
     },
     setPunchPresets(presets) {
-      if (Array.isArray(presets) && presets.length === 5 && presets.every(validatePreset)) {
+      if (Array.isArray(presets) && presets.length === DEFAULT_PRESETS.length && presets.every(validatePreset)) {
         punchPresets = presets;
         _prebuildPunchNodes(punchPresets);
       }

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -35,9 +35,9 @@ export function createEngine() {
   let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
   const _slotHeld = new Array(DEFAULT_PRESETS.length).fill(false);
   let _gate = null;                              // active gate: { depth, division, laneIds } | null
-  let _tapeActive = false;                       // transport.tapeStop engaged (owns the gate)
+  let _tapeActive = false;                       // transport.tapeStop engaged (owns the BUS punchGate; lane-fader gate is independent)
   let _gateReturnPending = false;                // tapeStop released → gate returns on-grid
-  const _pendingQuantized = [];                  // [{ when: 'bar'|'pattern', fn }]
+  const _pendingQuantized = [];                  // [{ when: 'bar'|'pattern', fn, slot, on }] — slot/on drive quick-tap annihilation
   let _previewMask;                              // editor TEST: draft's lane mask while held (undefined = no preview)
   let meterL = null, meterR = null;
   let scopeMaster = null, scopeLane = {};
@@ -65,9 +65,9 @@ export function createEngine() {
     if (_fxInserted[id]) _fxInserted[id].crush = true;
   }
 
-  // v4 per-lane punch: automations drive the masked lanes' OWN fx params
-  // (capture knob value at engage, restore at last release). Only tapeStop
-  // still uses the shared bus.
+  // v4 per-lane punch: automations drive the masked lanes' OWN fx params via
+  // _laneParam (capture knob value at engage, restore at last release —
+  // refcounted in _punchCaptures). Only tapeStop still uses the shared bus.
   function _laneParam(f, id) {
     if (id === 'filter.freq')    return f.filter.frequency;
     if (id === 'filter.Q')       return f.filter.Q;
@@ -295,8 +295,8 @@ export function createEngine() {
     masterComp.connect(scopeMaster);
     // Build per-lane graph
     buildLaneGraph(song.lanes);
-    _prebuildPunchNodes(punchPresets);
     started = true;
+    _prebuildPunchNodes(punchPresets);   // after started flips — the guard would no-op it otherwise
   }
 
   return {

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -34,7 +34,7 @@ export function createEngine() {
   const _punchCaptures = new Map();              // 'laneId|paramId' → { value: knob value at first engage, count }
   let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
   const _slotHeld = new Array(DEFAULT_PRESETS.length).fill(false);
-  let _gate = null;                              // active gate: { depth, division, laneIds } | null
+  const _gates = new Map();                      // slot → { depth, division, laneIds } (preview uses 'preview')
   let _tapeActive = false;                       // transport.tapeStop engaged (owns the BUS punchGate; lane-fader gate is independent)
   let _gateReturnPending = false;                // tapeStop released → gate returns on-grid
   const _pendingQuantized = [];                  // [{ when: 'bar'|'pattern', fn, slot, on }] — slot/on drive quick-tap annihilation
@@ -108,11 +108,12 @@ export function createEngine() {
     }
   }
 
-  // Punch v3 automation runner: executes one preset automation (engage or
-  // release) against the live graph. gate.* and transport.tapeStop are
-  // semantic modules (spec decision 6) — the runner owns their behaviour;
-  // everything else maps through _punchBindings + the MODULE_PARAMS registry.
-  function _runAutomation(a, on, timing, atTime, amount = 1, mask = null) {
+  // Punch automation runner: executes one preset automation (engage or
+  // release) against the live graph. gate.* chops per-lane faders (state in
+  // _gates, keyed by slot); transport.tapeStop drives the shared bus; every
+  // other param resolves per masked lane via _laneParam, with knob values
+  // captured/restored through _punchCaptures.
+  function _runAutomation(a, on, timing, atTime, amount = 1, mask = null, slotKey = 'preview') {
     const id = `${a.module}.${a.param}`;
     const reg = MODULE_PARAMS[id];
     if (!reg) return;
@@ -120,7 +121,9 @@ export function createEngine() {
     if (id === 'gate.depth') {
       if (on) {
         // Chop each masked lane's fader (scaled by its captured knob value)
-        // in the step callback — no shared gate node involved.
+        // in the step callback. Gate state is PER SLOT — two gate pads held
+        // together (e.g. default STUTTER + STUTTER BASS) must not overwrite
+        // each other's lane lists (review: stranded captures).
         const laneIds = [];
         for (const lane of _maskedLanes(mask)) {
           const f = fx[lane.id];
@@ -128,11 +131,11 @@ export function createEngine() {
           engageCapture(_punchCaptures, lane.id + '|vol', f.vol.gain.value);
           laneIds.push(lane.id);
         }
-        _gate = { depth: (typeof a.to === 'number' ? a.to : 1) * amount, division: a.division || '1/16', laneIds };
+        _gates.set(slotKey, { depth: (typeof a.to === 'number' ? a.to : 1) * amount, division: a.division || '1/16', laneIds });
       } else {
-        const laneIds = _gate ? _gate.laneIds : [];
-        _gate = null;
-        for (const laneId of laneIds) {
+        const g = _gates.get(slotKey);
+        _gates.delete(slotKey);
+        for (const laneId of (g ? g.laneIds : [])) {
           const v = releaseCapture(_punchCaptures, laneId + '|vol');
           if (v != null && fx[laneId]) fx[laneId].vol.gain.rampTo(v, Math.max(ramp, 0.01), atTime);
         }
@@ -392,12 +395,12 @@ export function createEngine() {
           punchGate.gain.linearRampToValueAtTime(PUNCH_NEUTRAL.gateGain, t + 0.003);
           _gateReturnPending = false;
         }
-        if (_gate) {
-          for (const laneId of _gate.laneIds) {
+        for (const g of _gates.values()) {
+          for (const laneId of g.laneIds) {
             const f = fx[laneId];
             const cap = _punchCaptures.get(laneId + '|vol');
             if (!f || !cap) continue;
-            for (const [at, v] of gateEventsForStep(t, sixteenth, step, _gate.division, _gate.depth))
+            for (const [at, v] of gateEventsForStep(t, sixteenth, step, g.division, g.depth))
               f.vol.gain.linearRampToValueAtTime(v * cap.value, at);
           }
         }
@@ -444,7 +447,7 @@ export function createEngine() {
       // (no cancel-then-revert clicks); delayTime snaps back after the brief
       // gate settle so any reverb tail doesn't doppler.
       _slotHeld.fill(false);
-      _gate = null; _tapeActive = false; _gateReturnPending = false; _pendingQuantized.length = 0;
+      _gates.clear(); _tapeActive = false; _gateReturnPending = false; _pendingQuantized.length = 0;
       _previewMask = undefined;
       // Restore every captured lane param to its knob value.
       for (const [key, cap] of _punchCaptures) {
@@ -505,7 +508,7 @@ export function createEngine() {
           return;
         }
       }
-      const run = (atTime) => { for (const a of preset.automations) _runAutomation(a, on, timing, atTime, amount, mask); };
+      const run = (atTime) => { for (const a of preset.automations) _runAutomation(a, on, timing, atTime, amount, mask, slot); };
       if (q === 'immediate' || !playing) run();
       else _pendingQuantized.push({ when: q, fn: run, slot, on });
     },
@@ -533,7 +536,7 @@ export function createEngine() {
         barSeconds: stepsPerBar(song.meter) * (beatSeconds / 4),
       };
       if (on) _prebuildPunchNodes([preset]);   // draft may use crush on lanes without the node yet
-      for (const a of preset.automations) _runAutomation(a, !!on, timing, undefined, amount, preset.lanes ?? null);
+      for (const a of preset.automations) _runAutomation(a, !!on, timing, undefined, amount, preset.lanes ?? null, 'preview');
     },
     isPlaying() { return playing; },
     queueFill(name)         { fillQueue.push(name); return fillQueue.length; },

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -13,7 +13,7 @@ import {
   setLaneGroove as _setLaneGroove, addGroove as _addGroove, grooveFor,
   setGrooveBars as _setGrooveBars,
 } from './patterns.js';
-import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, laneInPunchBus } from './punch.js';
+import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, laneInPunchBus, engageCapture, releaseCapture } from './punch.js';
 import { DEFAULT_PRESETS, validatePreset } from './punch-presets.js';
 
 export function createEngine() {
@@ -31,10 +31,10 @@ export function createEngine() {
   // Punch v3: pre-wired neutral punch bus; presets are data (punch-presets.js)
   // executed by the automation runner (_runAutomation) over MODULE_PARAMS.
   let punchGate = null, punchCrush = null, punchFilter = null, punchThrow = null, punchTape = null;
-  let _punchBindings = null;                     // registry param id → live Tone param
+  const _punchCaptures = new Map();              // 'laneId|paramId' → { value: knob value at first engage, count }
   let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
   const _slotHeld = [false, false, false, false, false];
-  let _gate = null;                              // active gate automation: { depth, division } | null
+  let _gate = null;                              // active gate: { depth, division, laneIds } | null
   let _tapeActive = false;                       // transport.tapeStop engaged (owns the gate)
   let _gateReturnPending = false;                // tapeStop released → gate returns on-grid
   const _pendingQuantized = [];                  // [{ when: 'bar'|'pattern', fn }]
@@ -48,6 +48,45 @@ export function createEngine() {
   let _fxInserted = {};
   // Stored after ensure() so buildLane can be called post-graph-init
   let _makeFX = null, _masterIn = null, _laneReverb = null;
+
+  // Lazy BitCrusher splice (shared by the CRU knob and punch pre-build):
+  // creating it at config time avoids the splice click at perform time.
+  function _ensureLaneCrush(id) {
+    const c = fx[id];
+    if (!c || c.crush) return;
+    c.crush = new Tone.BitCrusher(4);
+    c.crush.wet.value = 0;
+    c.drive.disconnect(c.slotCrush);
+    c.drive.connect(c.crush);
+    c.crush.connect(c.slotChorus);   // slotCrush is no longer needed; slotChorus is now the bridge
+    c.slotCrush.disconnect();
+    c.slotCrush.dispose();
+    c.slotCrush = null;
+    if (_fxInserted[id]) _fxInserted[id].crush = true;
+  }
+
+  // v4 per-lane punch: automations drive the masked lanes' OWN fx params
+  // (capture knob value at engage, restore at last release). Only tapeStop
+  // still uses the shared bus.
+  function _laneParam(f, id) {
+    if (id === 'filter.freq')    return f.filter.frequency;
+    if (id === 'filter.Q')       return f.filter.Q;
+    if (id === 'delay.wet')      return f.delay.wet;
+    if (id === 'delay.feedback') return f.delay.feedback;
+    if (id === 'crusher.wet')    return f.crush ? f.crush.wet : null;
+    return null;
+  }
+  function _maskedLanes(mask) {
+    return song ? song.lanes.filter(l => mask == null || mask.includes(l.type)) : [];
+  }
+  // Pre-build lazy nodes any preset needs, at config time (no perform-time click).
+  function _prebuildPunchNodes(presets) {
+    if (!started) return;
+    for (const p of presets) {
+      if (!p?.automations?.some(a => a.module === 'crusher')) continue;
+      for (const lane of _maskedLanes(p.lanes ?? null)) _ensureLaneCrush(lane.id);
+    }
+  }
 
   // Per-preset lane targeting: rebuild every lane's punch/clean crossfade from
   // chips ∩ the union of held presets' masks. Called on every press/release,
@@ -73,18 +112,30 @@ export function createEngine() {
   // release) against the live graph. gate.* and transport.tapeStop are
   // semantic modules (spec decision 6) — the runner owns their behaviour;
   // everything else maps through _punchBindings + the MODULE_PARAMS registry.
-  function _runAutomation(a, on, timing, atTime, amount = 1) {
+  function _runAutomation(a, on, timing, atTime, amount = 1, mask = null) {
     const id = `${a.module}.${a.param}`;
     const reg = MODULE_PARAMS[id];
     if (!reg) return;
     const ramp = Math.max(durationToSeconds(on ? a.engage?.ramp : a.release?.ramp, timing), 0.003);
     if (id === 'gate.depth') {
       if (on) {
-        _gate = { depth: (typeof a.to === 'number' ? a.to : 1) * amount, division: a.division || '1/16' };
+        // Chop each masked lane's fader (scaled by its captured knob value)
+        // in the step callback — no shared gate node involved.
+        const laneIds = [];
+        for (const lane of _maskedLanes(mask)) {
+          const f = fx[lane.id];
+          if (!f) continue;
+          engageCapture(_punchCaptures, lane.id + '|vol', f.vol.gain.value);
+          laneIds.push(lane.id);
+        }
+        _gate = { depth: (typeof a.to === 'number' ? a.to : 1) * amount, division: a.division || '1/16', laneIds };
       } else {
+        const laneIds = _gate ? _gate.laneIds : [];
         _gate = null;
-        // tapeStop owns the gate (v2 safeguard 1) — only restore when idle.
-        if (!_tapeActive) punchGate.gain.rampTo(PUNCH_NEUTRAL.gateGain, Math.max(ramp, 0.01));
+        for (const laneId of laneIds) {
+          const v = releaseCapture(_punchCaptures, laneId + '|vol');
+          if (v != null && fx[laneId]) fx[laneId].vol.gain.rampTo(v, Math.max(ramp, 0.01), atTime);
+        }
       }
       return;
     }
@@ -111,14 +162,25 @@ export function createEngine() {
       }
       return;
     }
-    const bound = _punchBindings[id];
-    if (!bound) return;
-    const from = (a.from === 'neutral' || a.from == null) ? reg.neutral : a.from;
     const scale = a.scale || reg.scale;
-    // atTime (quantized actions): schedule the ramp AT the boundary's audio
-    // time — the callback fires ~lookahead early, so ramping "now" would land
-    // a third of a second before the downbeat.
-    bound.rampTo(on ? scaleValue(from, a.to, amount, scale) : from, ramp, atTime);
+    for (const lane of _maskedLanes(mask)) {
+      const f = fx[lane.id];
+      const param = f && _laneParam(f, id);
+      if (!param) continue;
+      const key = lane.id + '|' + id;
+      if (on) {
+        // 'neutral' from = the lane's CURRENT (knob) value — captured once,
+        // refcounted across overlapping pads, restored at last release.
+        const captured = engageCapture(_punchCaptures, key, param.value);
+        const from = (a.from === 'neutral' || a.from == null) ? captured : a.from;
+        // atTime (quantized actions): schedule AT the boundary's audio time —
+        // the callback fires ~lookahead early.
+        param.rampTo(scaleValue(from, a.to, amount, scale), ramp, atTime);
+      } else {
+        const v = releaseCapture(_punchCaptures, key);
+        if (v != null) param.rampTo(v, ramp, atTime);
+      }
+    }
   }
 
   function buildLane(lane) {
@@ -190,15 +252,6 @@ export function createEngine() {
     punchFilter = new Tone.Filter({ type: 'lowpass', frequency: PUNCH_NEUTRAL.filterFreq, Q: PUNCH_NEUTRAL.filterQ }).connect(punchThrow);
     punchCrush  = new Tone.BitCrusher(6); punchCrush.wet.value = PUNCH_NEUTRAL.crushWet; punchCrush.connect(punchFilter);
     punchGate   = new Tone.Gain(PUNCH_NEUTRAL.gateGain).connect(punchCrush);
-    // Registry param → live Tone param. gate.* and transport.* are semantic —
-    // handled by the runner itself, not direct bindings.
-    _punchBindings = {
-      'crusher.wet':    punchCrush.wet,
-      'filter.freq':    punchFilter.frequency,
-      'filter.Q':       punchFilter.Q,
-      'delay.wet':      punchThrow.wet,
-      'delay.feedback': punchThrow.feedback,
-    };
     // Shared reverb bus — one convolver for all lanes (per-lane send gain controls amount).
     _laneReverb = new Tone.Reverb({ decay: 2.4, wet: 1 }).connect(masterIn);
     // Stereo output meters — tapped post-volume (silent sinks, don't alter audio chain).
@@ -242,6 +295,7 @@ export function createEngine() {
     masterComp.connect(scopeMaster);
     // Build per-lane graph
     buildLaneGraph(song.lanes);
+    _prebuildPunchNodes(punchPresets);
     started = true;
   }
 
@@ -267,9 +321,9 @@ export function createEngine() {
             voices[lane.id].lead.set({ oscillator: { type: lane.tone, width: 0.3 } });
           }
         }
-        // Re-sync punch routing for REUSED lane graphs (song-switch desync) —
-        // mask-aware recompute covers chips and any held presets.
+        // Re-sync punch routing for REUSED lane graphs (song-switch desync).
         _recomputePunchRouting();
+        _prebuildPunchNodes(punchPresets);
       }
     },
     async play() {
@@ -338,9 +392,14 @@ export function createEngine() {
           punchGate.gain.linearRampToValueAtTime(PUNCH_NEUTRAL.gateGain, t + 0.003);
           _gateReturnPending = false;
         }
-        if (_gate && !_tapeActive) {
-          for (const [at, v] of gateEventsForStep(t, sixteenth, step, _gate.division, _gate.depth))
-            punchGate.gain.linearRampToValueAtTime(v, at);
+        if (_gate) {
+          for (const laneId of _gate.laneIds) {
+            const f = fx[laneId];
+            const cap = _punchCaptures.get(laneId + '|vol');
+            if (!f || !cap) continue;
+            for (const [at, v] of gateEventsForStep(t, sixteenth, step, _gate.division, _gate.depth))
+              f.vol.gain.linearRampToValueAtTime(v * cap.value, at);
+          }
         }
         if (onStepCb) {
           const s = step; const qSnap = fillQueue.slice();
@@ -387,6 +446,15 @@ export function createEngine() {
       _slotHeld.fill(false);
       _gate = null; _tapeActive = false; _gateReturnPending = false; _pendingQuantized.length = 0;
       _previewMask = undefined;
+      // Restore every captured lane param to its knob value.
+      for (const [key, cap] of _punchCaptures) {
+        const [laneId, paramId] = [key.slice(0, key.indexOf('|')), key.slice(key.indexOf('|') + 1)];
+        const f = fx[laneId];
+        if (!f) continue;
+        const param = paramId === 'vol' ? f.vol.gain : _laneParam(f, paramId);
+        if (param) param.rampTo(cap.value, 0.02);
+      }
+      _punchCaptures.clear();
       _recomputePunchRouting();
       if (started) {
         const now = Tone.now();
@@ -427,12 +495,16 @@ export function createEngine() {
       };
       const q = on ? preset.engageQuantize : preset.releaseQuantize;
       const amount = preset.amount ?? 1;
-      const run = (atTime) => { for (const a of preset.automations) _runAutomation(a, on, timing, atTime, amount); };
+      const mask = preset.lanes ?? null;
+      const run = (atTime) => { for (const a of preset.automations) _runAutomation(a, on, timing, atTime, amount, mask); };
       if (q === 'immediate' || !playing) run();
       else _pendingQuantized.push({ when: q, fn: run });
     },
     setPunchPresets(presets) {
-      if (Array.isArray(presets) && presets.length === 5 && presets.every(validatePreset)) punchPresets = presets;
+      if (Array.isArray(presets) && presets.length === 5 && presets.every(validatePreset)) {
+        punchPresets = presets;
+        _prebuildPunchNodes(punchPresets);
+      }
       return punchPresets;
     },
     getPunchPresets() { return punchPresets; },
@@ -451,7 +523,8 @@ export function createEngine() {
         beatSeconds,
         barSeconds: stepsPerBar(song.meter) * (beatSeconds / 4),
       };
-      for (const a of preset.automations) _runAutomation(a, !!on, timing, undefined, amount);
+      if (on) _prebuildPunchNodes([preset]);   // draft may use crush on lanes without the node yet
+      for (const a of preset.automations) _runAutomation(a, !!on, timing, undefined, amount, preset.lanes ?? null);
     },
     isPlaying() { return playing; },
     queueFill(name)         { fillQueue.push(name); return fillQueue.length; },
@@ -575,18 +648,7 @@ export function createEngine() {
       }
       else if (param === 'drive')  { c.drive.wet.rampTo(v01 * 0.85, 0.08); c.drive.oversample = v01 > 0 ? '2x' : 'none'; }
       else if (param === 'crush') {
-        // Lazy-create BitCrusher on first use: splice it in place of slotCrush.
-        if (!c.crush) {
-          c.crush = new Tone.BitCrusher(4);
-          c.crush.wet.value = 0;
-          c.drive.disconnect(c.slotCrush);
-          c.drive.connect(c.crush);
-          c.crush.connect(c.slotChorus);   // slotCrush is no longer needed; slotChorus is now the bridge
-          c.slotCrush.disconnect();
-          c.slotCrush.dispose();
-          c.slotCrush = null;
-          if (_fxInserted[id]) _fxInserted[id].crush = true;
-        }
+        _ensureLaneCrush(id);
         c.crush.wet.rampTo(v01, 0.08);
       }
       else if (param === 'delay')  c.delay.wet.rampTo(v01 * 0.5, 0.08);

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -496,9 +496,18 @@ export function createEngine() {
       const q = on ? preset.engageQuantize : preset.releaseQuantize;
       const amount = preset.amount ?? 1;
       const mask = preset.lanes ?? null;
+      // Quick-tap correctness: an UNFIRED opposite action for this slot
+      // annihilates instead of stacking (quantized engage + instant release
+      // would otherwise fire the engage at the bar with the pad already up).
+      for (let i = 0; i < _pendingQuantized.length; i++) {
+        if (_pendingQuantized[i].slot === slot && _pendingQuantized[i].on === !on) {
+          _pendingQuantized.splice(i, 1);
+          return;
+        }
+      }
       const run = (atTime) => { for (const a of preset.automations) _runAutomation(a, on, timing, atTime, amount, mask); };
       if (q === 'immediate' || !playing) run();
-      else _pendingQuantized.push({ when: q, fn: run });
+      else _pendingQuantized.push({ when: q, fn: run, slot, on });
     },
     setPunchPresets(presets) {
       if (Array.isArray(presets) && presets.length === 5 && presets.every(validatePreset)) {

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -75,8 +75,9 @@ export const DEFAULT_PRESETS = [
         engage: { ramp: { unit: 'steps', value: 1 } }, release: { ramp: { unit: 'steps', value: 1 } } },
     ] },
   { name: 'THROW', key: '5', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    lanes: ['drums', 'bass', 'chords'],   // ear-tuned: melody throws smear the topline
     automations: [
-      { module: 'delay', param: 'wet', from: 'neutral', to: 0.6,
+      { module: 'delay', param: 'wet', from: 'neutral', to: 0.5,
         engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'beats', value: 3 } } },
     ] },
   { name: 'STOP', key: '6', engageQuantize: 'immediate', releaseQuantize: 'immediate',

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -54,11 +54,10 @@ export const DEFAULT_PRESETS = [
       { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
         engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
-  { name: 'STUTTER BASS', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
-    lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
+  { name: 'CRUSH', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [
-      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
-        engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
+      { module: 'crusher', param: 'wet', from: 'neutral', to: 0.9,
+        engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'steps', value: 0.5 } } },
     ] },
   { name: 'DIVE', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [
@@ -79,5 +78,11 @@ export const DEFAULT_PRESETS = [
       // slump duration; release handling is internal to the module.
       { module: 'transport', param: 'tapeStop', from: 'neutral', to: 1,
         engage: { ramp: { unit: 'beats', value: 1.5 } }, release: { ramp: { unit: 'steps', value: 0 } } },
+    ] },
+  { name: 'STUTTER BASS', key: '6', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
+    automations: [
+      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
+        engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
 ];

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -54,35 +54,35 @@ export const DEFAULT_PRESETS = [
       { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
         engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
-  { name: 'CRUSH', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+  { name: 'STUTTER BASS', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
+    automations: [
+      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
+        engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
+    ] },
+  { name: 'CRUSH', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [
       { module: 'crusher', param: 'wet', from: 'neutral', to: 0.9,
         engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'steps', value: 0.5 } } },
     ] },
-  { name: 'DIVE', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+  { name: 'DIVE', key: '4', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [
       { module: 'filter', param: 'freq', from: 'neutral', to: 150,
         engage: { ramp: { unit: 'steps', value: 1 } }, release: { ramp: { unit: 'steps', value: 1 } } },
       { module: 'filter', param: 'Q', from: 'neutral', to: 8,
         engage: { ramp: { unit: 'steps', value: 1 } }, release: { ramp: { unit: 'steps', value: 1 } } },
     ] },
-  { name: 'THROW', key: '4', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+  { name: 'THROW', key: '5', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [
       { module: 'delay', param: 'wet', from: 'neutral', to: 0.6,
         engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'beats', value: 3 } } },
     ] },
-  { name: 'STOP', key: '5', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+  { name: 'STOP', key: '6', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [
       // Semantic module (spec decision 6): the engine implements tapeStop
       // internally (gate fade + tape slump + on-grid return). Engage ramp =
       // slump duration; release handling is internal to the module.
       { module: 'transport', param: 'tapeStop', from: 'neutral', to: 1,
         engage: { ramp: { unit: 'beats', value: 1.5 } }, release: { ramp: { unit: 'steps', value: 0 } } },
-    ] },
-  { name: 'STUTTER BASS', key: '6', engageQuantize: 'immediate', releaseQuantize: 'immediate',
-    lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
-    automations: [
-      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
-        engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
 ];

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -49,15 +49,16 @@ export function validatePreset(p) {
 // dogfood-approved level. These are seed data — never mutated in place.
 export const DEFAULT_PRESETS = [
   { name: 'STUTTER', key: '1', engageQuantize: 'immediate', releaseQuantize: 'immediate',
-    lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
+    lanes: ['melody'],          // chop the topline; rhythm section rides underneath
     automations: [
       { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
         engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
-  { name: 'CRUSH', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+  { name: 'STUTTER BASS', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
     automations: [
-      { module: 'crusher', param: 'wet', from: 'neutral', to: 0.9,
-        engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'steps', value: 0.5 } } },
+      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
+        engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
   { name: 'DIVE', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     automations: [

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -62,6 +62,7 @@ export const DEFAULT_PRESETS = [
     ] },
   { name: 'CRUSH', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     lanes: ['drums', 'bass'],   // crushed pads/melody read as noise — keep the grit on the rhythm section
+    amount: 0.6,                // ear-tuned: full-strength crush is too much even on the rhythm section
     automations: [
       { module: 'crusher', param: 'wet', from: 'neutral', to: 0.9,
         engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'steps', value: 0.5 } } },

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -61,6 +61,7 @@ export const DEFAULT_PRESETS = [
         engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
   { name: 'CRUSH', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',
+    lanes: ['drums', 'bass'],   // crushed pads/melody read as noise — keep the grit on the rhythm section
     automations: [
       { module: 'crusher', param: 'wet', from: 'neutral', to: 0.9,
         engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'steps', value: 0.5 } } },

--- a/docs/arcade/groovebox/engine/punch.js
+++ b/docs/arcade/groovebox/engine/punch.js
@@ -87,3 +87,21 @@ export function durationToSeconds(dur, t) {
   if (dur.unit === 'bars')  return dur.value * t.barSeconds;
   throw new Error(`punch: unsupported duration unit "${dur.unit}"`);
 }
+
+// ── v4: per-lane capture/refcount ────────────────────────────────────────────
+// Punch automations drive masked lanes' OWN fx params, which hold the user's
+// knob values. The first automation on a (lane, param) captures that value;
+// nested holds refcount; the LAST release restores. Pure Map logic.
+export function engageCapture(map, key, current) {
+  const e = map.get(key);
+  if (e) { e.count++; return e.value; }
+  map.set(key, { value: current, count: 1 });
+  return current;
+}
+export function releaseCapture(map, key) {
+  const e = map.get(key);
+  if (!e) return null;
+  if (--e.count > 0) return null;
+  map.delete(key);
+  return e.value;
+}

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -11,10 +11,10 @@
       </div>
       <!-- Tier 1 — title bar -->
       <div class="titlebar">
-        <h1>oyster groovebox</h1>
+        <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>oyster groovebox</h1>
         <div class="titlebar-tools">
-          <!-- Lucide "boombox" (MIT, lucide.dev) — inlined per the no-CDN/static rule -->
-          <span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>
+          <!-- Lucide "palette" (MIT, lucide.dev) — theme picker affordance -->
+          <span class="theme-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/></svg></span>
           <select id="themesel">
             <option value="dark" selected>Dark</option>
             <option value="light">Light</option>
@@ -65,6 +65,7 @@
           </div>
           <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
+        <div id="arrange"></div>
       </div>
 
       <!-- Share modal -->
@@ -97,7 +98,6 @@
             <ul id="share-mine-list"></ul>
           </div>
         </div>
-        <div id="arrange"></div>
       </div>
 
       <!-- Help modal -->

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -13,6 +13,8 @@
       <div class="titlebar">
         <h1>oyster groovebox</h1>
         <div class="titlebar-tools">
+          <!-- Lucide "boombox" (MIT, lucide.dev) — inlined per the no-CDN/static rule -->
+          <span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>
           <select id="themesel">
             <option value="dark" selected>Dark</option>
             <option value="light">Light</option>

--- a/docs/arcade/groovebox/tests/punch-editor.test.js
+++ b/docs/arcade/groovebox/tests/punch-editor.test.js
@@ -11,7 +11,7 @@ describe('PARAM_UI', () => {
 
 describe('draftFromPreset', () => {
   it('deep clones — editing the draft never touches the source', () => {
-    const src = DEFAULT_PRESETS[1];
+    const src = DEFAULT_PRESETS.find(p => p.name === 'CRUSH');
     const draft = draftFromPreset(src);
     draft.name = 'WRECK';
     draft.automations[0].to = 0.1;
@@ -35,7 +35,7 @@ describe('paramPos / paramValue (slider mapping in registry scale space)', () =>
 
 describe('availableParams', () => {
   it('excludes params already used by the draft', () => {
-    const draft = draftFromPreset(DEFAULT_PRESETS[1]); // CRUSH uses crusher.wet
+    const draft = draftFromPreset(DEFAULT_PRESETS.find(p => p.name === 'CRUSH')); // CRUSH uses crusher.wet
     const avail = availableParams(draft);
     expect(avail).not.toContain('crusher.wet');
     expect(avail).toContain('gate.depth');

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -94,7 +94,10 @@ describe('lane masks (v3.5 — per-preset targeting)', () => {
     expect(validatePreset({ ...base, lanes: ['drums', 'vocals'] })).toBe(false);
     expect(validatePreset({ ...base, lanes: 'drums' })).toBe(false);
   });
-  it('omitted lanes means all (other defaults carry no mask)', () => {
+  it('CRUSH targets the rhythm section by default', () => {
+    expect(DEFAULT_PRESETS.find(p => p.name === 'CRUSH').lanes).toEqual(['drums', 'bass']);
+  });
+  it('omitted lanes means all (DIVE/THROW/STOP carry no mask)', () => {
     expect(DEFAULT_PRESETS.find(p => p.name === 'DIVE').lanes).toBeUndefined();
   });
 });

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -109,7 +109,10 @@ describe('per-preset amount (v3.5 — replaces the global AMT knob)', () => {
     expect(validatePreset({ ...base, amount: 1.5 })).toBe(false);
     expect(validatePreset({ ...base, amount: -0.1 })).toBe(false);
   });
-  it('defaults carry no amount (= full strength)', () => {
-    for (const p of DEFAULT_PRESETS) expect(p.amount).toBeUndefined();
+  it('amount defaults: CRUSH ear-tuned to 0.6, everything else full', () => {
+    for (const p of DEFAULT_PRESETS) {
+      if (p.name === 'CRUSH') expect(p.amount).toBe(0.6);
+      else expect(p.amount).toBeUndefined();
+    }
   });
 });

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -3,9 +3,9 @@ import { DEFAULT_PRESETS, validatePreset } from '../engine/punch-presets.js';
 import { MODULE_PARAMS } from '../engine/punch.js';
 
 describe('DEFAULT_PRESETS', () => {
-  it('ships exactly five slots with keys 1-5', () => {
-    expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5']);
-    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'STUTTER BASS', 'DIVE', 'THROW', 'STOP']);
+  it('ships six slots with keys 1-6', () => {
+    expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5', '6']);
+    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'CRUSH', 'DIVE', 'THROW', 'STOP', 'STUTTER BASS']);
   });
   it('every preset validates', () => {
     for (const p of DEFAULT_PRESETS) expect(validatePreset(p)).toBe(true);

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -5,7 +5,7 @@ import { MODULE_PARAMS } from '../engine/punch.js';
 describe('DEFAULT_PRESETS', () => {
   it('ships exactly five slots with keys 1-5', () => {
     expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5']);
-    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'CRUSH', 'DIVE', 'THROW', 'STOP']);
+    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'STUTTER BASS', 'DIVE', 'THROW', 'STOP']);
   });
   it('every preset validates', () => {
     for (const p of DEFAULT_PRESETS) expect(validatePreset(p)).toBe(true);
@@ -15,9 +15,13 @@ describe('DEFAULT_PRESETS', () => {
       for (const a of p.automations)
         expect(MODULE_PARAMS[`${a.module}.${a.param}`]).toBeDefined();
   });
-  it('CRUSH carries the dogfood-approved 0.9 target', () => {
-    const crush = DEFAULT_PRESETS.find(p => p.name === 'CRUSH');
-    expect(crush.automations[0].to).toBe(0.9);
+  it('both stutters chop at 1/8 with their own sections', () => {
+    const mel = DEFAULT_PRESETS.find(p => p.name === 'STUTTER');
+    const bas = DEFAULT_PRESETS.find(p => p.name === 'STUTTER BASS');
+    expect(mel.automations[0].division).toBe('1/8');
+    expect(mel.lanes).toEqual(['melody']);
+    expect(bas.automations[0].division).toBe('1/8');
+    expect(bas.lanes).toEqual(['drums', 'bass']);
   });
 });
 
@@ -80,10 +84,10 @@ describe('registry ranges (v3.5 — single source of truth)', () => {
 
 describe('lane masks (v3.5 — per-preset targeting)', () => {
   const base = { name: 'X', key: '1', engageQuantize: 'immediate', releaseQuantize: 'immediate', automations: [] };
-  it('STUT defaults to 1/8 chop on drums+bass only', () => {
+  it('STUTTER defaults to 1/8 on melody', () => {
     const stut = DEFAULT_PRESETS.find(p => p.name === 'STUTTER');
     expect(stut.automations[0].division).toBe('1/8');
-    expect(stut.lanes).toEqual(['drums', 'bass']);
+    expect(stut.lanes).toEqual(['melody']);
   });
   it('validates lanes as a subset of known lane types', () => {
     expect(validatePreset({ ...base, lanes: ['drums', 'bass'] })).toBe(true);

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -97,8 +97,14 @@ describe('lane masks (v3.5 — per-preset targeting)', () => {
   it('CRUSH targets the rhythm section by default', () => {
     expect(DEFAULT_PRESETS.find(p => p.name === 'CRUSH').lanes).toEqual(['drums', 'bass']);
   });
-  it('omitted lanes means all (DIVE/THROW/STOP carry no mask)', () => {
+  it('THROW ear-tuned: 0.5 echo on drums+bass+chords', () => {
+    const th = DEFAULT_PRESETS.find(p => p.name === 'THROW');
+    expect(th.automations[0].to).toBe(0.5);
+    expect(th.lanes).toEqual(['drums', 'bass', 'chords']);
+  });
+  it('omitted lanes means all (DIVE/STOP carry no mask)', () => {
     expect(DEFAULT_PRESETS.find(p => p.name === 'DIVE').lanes).toBeUndefined();
+    expect(DEFAULT_PRESETS.find(p => p.name === 'STOP').lanes).toBeUndefined();
   });
 });
 

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -5,7 +5,7 @@ import { MODULE_PARAMS } from '../engine/punch.js';
 describe('DEFAULT_PRESETS', () => {
   it('ships six slots with keys 1-6', () => {
     expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5', '6']);
-    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'CRUSH', 'DIVE', 'THROW', 'STOP', 'STUTTER BASS']);
+    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'STUTTER BASS', 'CRUSH', 'DIVE', 'THROW', 'STOP']);
   });
   it('every preset validates', () => {
     for (const p of DEFAULT_PRESETS) expect(validatePreset(p)).toBe(true);

--- a/docs/arcade/groovebox/tests/punch.test.js
+++ b/docs/arcade/groovebox/tests/punch.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, stutterEvents, laneInPunchBus } from '../engine/punch.js';
+import { PUNCH_NEUTRAL, MODULE_PARAMS, scaleValue, durationToSeconds, gateEventsForStep, stutterEvents, laneInPunchBus, engageCapture, releaseCapture } from '../engine/punch.js';
 
 describe('PUNCH_NEUTRAL', () => {
   it('pins the idle chain to audibly-transparent values (spec safeguard 3)', () => {
@@ -127,5 +127,35 @@ describe('laneInPunchBus (active masks, union across held pads)', () => {
   });
   it('null mask in the set means all lanes', () => {
     expect(laneInPunchBus(lane, [null, ['drums']])).toBe(true);
+  });
+});
+
+describe('engageCapture / releaseCapture (per-lane knob capture, refcounted)', () => {
+  it('first engage captures the current value', () => {
+    const m = new Map();
+    expect(engageCapture(m, 'drums|filter.freq', 7000)).toBe(7000);
+    expect(m.get('drums|filter.freq')).toEqual({ value: 7000, count: 1 });
+  });
+  it('nested engage returns the ORIGINAL capture, not the punched value', () => {
+    const m = new Map();
+    engageCapture(m, 'k', 7000);
+    expect(engageCapture(m, 'k', 150)).toBe(7000);   // param already punched to 150
+    expect(m.get('k').count).toBe(2);
+  });
+  it('non-last release returns null (no restore yet)', () => {
+    const m = new Map();
+    engageCapture(m, 'k', 7000); engageCapture(m, 'k', 150);
+    expect(releaseCapture(m, 'k')).toBe(null);
+    expect(m.get('k').count).toBe(1);
+  });
+  it('last release returns the captured value and clears', () => {
+    const m = new Map();
+    engageCapture(m, 'k', 7000); engageCapture(m, 'k', 150);
+    releaseCapture(m, 'k');
+    expect(releaseCapture(m, 'k')).toBe(7000);
+    expect(m.has('k')).toBe(false);
+  });
+  it('release without engage is a safe null', () => {
+    expect(releaseCapture(new Map(), 'nope')).toBe(null);
   });
 });

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -969,6 +969,15 @@ body.gb-knob-values .knob-val { display: block; }
   box-shadow: 0 0 12px var(--hot);   /* the existing "driving sound" glow language */
 }
 
+/* ─── brand icon (topbar, beside the theme selector) ─────────────────────── */
+.brand-icon {
+  display: inline-flex; align-items: center;
+  color: var(--acc);
+  margin-right: 6px;
+  vertical-align: middle;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--acc) 40%, transparent));
+}
+
 /* ─── punch preset editor (v3.5 modal) ──────────────────────────────────── */
 .punchpad .punchedit { margin-left: 8px; opacity: 0.5; font-size: 11px; cursor: pointer; }
 .punchpad .punchedit:hover { opacity: 1; color: var(--acc); }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -973,9 +973,15 @@ body.gb-knob-values .knob-val { display: block; }
 .brand-icon {
   display: inline-flex; align-items: center;
   color: var(--acc);
-  margin-right: 6px;
-  vertical-align: middle;
+  margin-right: 8px;
+  vertical-align: -3px;
   filter: drop-shadow(0 0 6px color-mix(in srgb, var(--acc) 40%, transparent));
+}
+.theme-icon {
+  display: inline-flex; align-items: center;
+  color: var(--faint);
+  margin-right: 5px;
+  vertical-align: middle;
 }
 
 /* ─── punch preset editor (v3.5 modal) ──────────────────────────────────── */

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -585,9 +585,13 @@ function renderFills() {
 function loadPunchPresets() {
   try {
     const saved = JSON.parse(localStorage.getItem('gb-punch-presets') || 'null');
-    // Migration: sets saved before the slot count grew gain the new defaults.
+    // Migration: saved sets gain any defaults they lack — matched BY NAME
+    // (index-based appending duplicated STOP when the default order changed).
+    // Keys then reassign to slot order, since keys are slot-bound.
     if (Array.isArray(saved)) {
-      while (saved.length < DEFAULT_PRESETS.length) saved.push(DEFAULT_PRESETS[saved.length]);
+      const have = new Set(saved.map(p => p && p.name));
+      for (const d of DEFAULT_PRESETS) if (!have.has(d.name)) saved.push(d);
+      saved.forEach((p, i) => { if (p) p.key = String(i + 1); });
     }
     if (saved) return eng.setPunchPresets(saved);   // engine validates; invalid → defaults kept
   } catch (_) { /* corrupt JSON → defaults */ }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -584,14 +584,21 @@ function renderFills() {
 // (no editor UI yet — v3.5; hand-edited or future-UI overrides both load here).
 function loadPunchPresets() {
   try {
-    const saved = JSON.parse(localStorage.getItem('gb-punch-presets') || 'null');
-    // Migration: saved sets gain any defaults they lack — matched BY NAME
-    // (index-based appending duplicated STOP when the default order changed).
-    // Keys then reassign to slot order, since keys are slot-bound.
+    let saved = JSON.parse(localStorage.getItem('gb-punch-presets') || 'null');
+    // Migration (matched BY NAME — index math broke when defaults reordered):
+    // fill any defaults the saved set lacks, then — if no pads were renamed —
+    // adopt the canonical default ORDER while keeping each pad's saved edits.
+    // Renamed pads = user owns the layout; keep their order. Keys are
+    // slot-bound, so they renumber either way.
     if (Array.isArray(saved)) {
-      const have = new Set(saved.map(p => p && p.name));
-      for (const d of DEFAULT_PRESETS) if (!have.has(d.name)) saved.push(d);
-      saved.forEach((p, i) => { if (p) p.key = String(i + 1); });
+      const byName = new Map(saved.filter(Boolean).map(p => [p.name, p]));
+      for (const d of DEFAULT_PRESETS) if (!byName.has(d.name)) byName.set(d.name, d);
+      const defaultNames = DEFAULT_PRESETS.map(d => d.name);
+      const allStock = byName.size === defaultNames.length && defaultNames.every(n => byName.has(n));
+      saved = allStock
+        ? defaultNames.map(n => byName.get(n))
+        : [...byName.values()].slice(0, DEFAULT_PRESETS.length);
+      saved.forEach((p, i) => { p.key = String(i + 1); });
     }
     if (saved) return eng.setPunchPresets(saved);   // engine validates; invalid → defaults kept
   } catch (_) { /* corrupt JSON → defaults */ }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -16,6 +16,7 @@ import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 import { initShare, maybeLoadShared, clearLoadedFrom } from './share.js';
 import { openPunchEditor, isPunchEditorOpen } from './punch-editor.js';
+import { DEFAULT_PRESETS } from '../engine/punch-presets.js';
 
 const eng = createEngine();
 const TONES = ['pulse','square','sawtooth','fatsawtooth','triangle','sine'];
@@ -584,6 +585,10 @@ function renderFills() {
 function loadPunchPresets() {
   try {
     const saved = JSON.parse(localStorage.getItem('gb-punch-presets') || 'null');
+    // Migration: sets saved before the slot count grew gain the new defaults.
+    if (Array.isArray(saved)) {
+      while (saved.length < DEFAULT_PRESETS.length) saved.push(DEFAULT_PRESETS[saved.length]);
+    }
     if (saved) return eng.setPunchPresets(saved);   // engine validates; invalid → defaults kept
   } catch (_) { /* corrupt JSON → defaults */ }
   return eng.getPunchPresets();
@@ -654,7 +659,7 @@ document.addEventListener('keyup', e => {
   if (slot !== undefined) setPunch(slot, false);
 });
 // Stuck-key guard: losing window focus releases every pad.
-window.addEventListener('blur', () => { for (let s = 0; s < 5; s++) setPunch(s, false); });
+window.addEventListener('blur', () => { for (let s = 0; s < eng.getPunchPresets().length; s++) setPunch(s, false); });
 
 // ─── Master FX ───────────────────────────────────────────────────────────────
 function renderMaster() {

--- a/docs/arcade/groovebox/ui/punch-editor.js
+++ b/docs/arcade/groovebox/ui/punch-editor.js
@@ -128,7 +128,7 @@ export function openPunchEditor({ slot, eng, onSaved }) {
     name.oninput = () => { draft.name = name.value; };
     const badge = document.createElement('span');
     badge.className = 'pe-badge';
-    badge.textContent = `key ${draft.key} · slot ${slot + 1} of 5`;
+    badge.textContent = `key ${draft.key} · slot ${slot + 1} of ${eng.getPunchPresets().length}`;
     const test = document.createElement('button');
     test.className = 'pe-test' + (playing ? '' : ' idle');
     test.innerHTML = `TEST<small>hold · or key ${draft.key}</small>`;


### PR DESCRIPTION
## Summary
Fixes the multi-pad mask cross-bleed (#647's documented limit): punch automations now drive **each masked lane's own FX nodes** instead of the shared bus — STUTTER-on-melody + DIVE-on-all no longer chops everything.

- **Per-lane retarget**: filter/delay/crush ramps land on the lane's own chain; the **gate chops each masked lane's fader** (scaled by its captured volume) — no shared gate node
- **Capture/restore, refcounted** (pure + tested): the first automation on a (lane, param) captures the **knob's current value**; overlapping pads refcount; the last release restores. `from:"neutral"` now means *the knob value* — what a performer expects
- **Crush pre-builds at config time** (preset load/save/song-switch) — no perform-time splice click; the lazy-splice logic is factored and shared with the CRU knob
- **tapeStop keeps the bus** (inherently a master trick); the bus + routing stay as its plumbing
- **Quick-tap correctness**: unfired quantized engage/release pairs annihilate (a snapped engage can no longer strand on after an instant release)

## Known/accepted
- Turning a knob *while* a pad holds that same param: punch wins, release restores the pre-punch value (documented)
- Per-lane DIVE sounds subtly different from bus DIVE (filters sit before each lane's delay/reverb sends — tails behave more musically) — ear-gate item

## Testing
210/210 (5 new: capture/refcount semantics). Engine bundles; no new per-step allocations beyond the per-lane chop loop (only while gating).

No CHANGELOG (arcade). Coordination: touches `engine/index.js` — song-JSON session in flight elsewhere; second-lander rebases as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)