### PR TITLE
arcade(groovebox): play counter — 'N plays' on shared songs and grooves

### DIFF
--- a/docs/arcade/groovebox/registry/client.js
+++ b/docs/arcade/groovebox/registry/client.js
@@ -62,3 +62,5 @@ async function call(method, path, body) {
 export const createItem = (body) => call('POST', '', body);            // → { id, editKey }
 export const getItem = (id) => call('GET', `/${id}`);                  // → record
 export const updateItem = (id, body) => call('PUT', `/${id}`, body);   // → { revision }
+// Fire-and-forget play beacon — never blocks or breaks the load path.
+export const pingPlay = (id) => { fetch(`${API_BASE}/${id}/play`, { method: 'POST' }).catch(() => {}); };

--- a/docs/arcade/groovebox/registry/handler.js
+++ b/docs/arcade/groovebox/registry/handler.js
@@ -92,15 +92,25 @@ async function update(id, req, db, secret) {
   return json(200, { revision });
 }
 
+// POST /:id/play — anonymous play beacon. Fire-and-forget from the app; counts
+// are approximate by design (self-plays and reloads count; stakes are low).
+async function play(id, db) {
+  const row = await db.get(id);
+  if (!row) return json(404, { error: 'not found' });
+  await db.bumpPlays(id);
+  return new Response(null, { status: 204 });
+}
+
 export async function handleRegistry(req, db, secret) {
   const url = new URL(req.url);
-  const m = url.pathname.match(/^\/api\/registry(?:\/([a-z0-9]{8}))?$/);
+  const m = url.pathname.match(/^\/api\/registry(?:\/([a-z0-9]{8})(\/play)?)?$/);
   if (!m) return json(404, { error: 'not found' });
-  const id = m[1];
+  const id = m[1], isPlay = !!m[2];
   try {
+    if (req.method === 'POST' && id && isPlay) return await play(id, db);
     if (req.method === 'POST' && !id) return await create(req, db, secret);
-    if (req.method === 'GET' && id) return await get(id, db);
-    if (req.method === 'PUT' && id) return await update(id, req, db, secret);
+    if (req.method === 'GET' && id && !isPlay) return await get(id, db);
+    if (req.method === 'PUT' && id && !isPlay) return await update(id, req, db, secret);
   } catch {
     return json(500, { error: 'internal error' });
   }

--- a/docs/arcade/groovebox/tests/registry-handler.test.js
+++ b/docs/arcade/groovebox/tests/registry-handler.test.js
@@ -15,6 +15,7 @@ function memDb(rows = {}) {
       rows[row.id] = { ...row };
     },
     async update(id, fields) { Object.assign(rows[id], fields); },
+    async bumpPlays(id) { rows[id].plays = (rows[id].plays ?? 0) + 1; },
   };
 }
 
@@ -161,5 +162,36 @@ describe('PUT /api/registry/:id', () => {
 
   it('404 on unknown id (before any key check)', async () => {
     expect((await handleRegistry(put('zzzzzzzz', { editKey, name: 'n', author: '', payload: GROOVE_PAYLOAD }), db, SECRET)).status).toBe(404);
+  });
+});
+
+describe('POST /api/registry/:id/play', () => {
+  const playReq = (id) => new Request(`https://x/api/registry/${id}/play`, { method: 'POST' });
+  let db, id;
+  beforeEach(async () => {
+    db = memDb();
+    ({ id } = await (await handleRegistry(post(CREATE()), db, SECRET)).json());
+  });
+
+  it('204, increments plays', async () => {
+    expect((await handleRegistry(playReq(id), db, SECRET)).status).toBe(204);
+    expect((await handleRegistry(playReq(id), db, SECRET)).status).toBe(204);
+    expect(db.rows[id].plays).toBe(2);
+  });
+
+  it('404 on unknown id; non-POST methods rejected', async () => {
+    expect((await handleRegistry(playReq('zzzzzzzz'), db, SECRET)).status).toBe(404);
+    expect((await handleRegistry(new Request(`https://x/api/registry/${id}/play`), db, SECRET)).status).toBe(405);
+    expect((await handleRegistry(new Request(`https://x/api/registry/${id}/play`, { method: 'PUT', body: '{}' }), db, SECRET)).status).toBe(405);
+  });
+
+  it('plays survives owner updates and cannot be set via PUT body', async () => {
+    await handleRegistry(playReq(id), db, SECRET);
+    // PUT with plays in body → 400 (strict keys protect the counter)
+    const res = await handleRegistry(new Request(`https://x/api/registry/${id}`, {
+      method: 'PUT', body: JSON.stringify({ editKey: 'k'.repeat(43), name: 'n', author: '', payload: GROOVE_PAYLOAD, plays: 9000 }),
+    }), db, SECRET);
+    expect(res.status).toBe(400);
+    expect(db.rows[id].plays).toBe(1);
   });
 });

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -178,7 +178,8 @@ export async function maybeLoadShared(eng, hooks) {
     const rec = await getItem(id);
     loadedFrom = { id: rec.id, kind: rec.kind };
     pingPlay(rec.id);
-    const plays = typeof rec.plays === 'number' ? ` · ${rec.plays + 1} plays` : '';
+    const n = typeof rec.plays === 'number' ? rec.plays + 1 : null;
+    const plays = n ? ` · ${n} play${n === 1 ? '' : 's'}` : '';
     if (rec.kind === 'song') {
       eng.load(rec.payload);
       hooks.onSongLoaded(rec);

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -2,7 +2,7 @@
 // Pure helpers up top (unit-tested, no DOM). initShare()/maybeLoadShared() at
 // the bottom own all DOM and are only called from app.js in the browser.
 
-import { createItem, getItem, updateItem, getEditKey, storeEditKey, listMine, getAuthor, setAuthor,
+import { createItem, getItem, updateItem, pingPlay, getEditKey, storeEditKey, listMine, getAuthor, setAuthor,
          shareUrl, parseShareParam } from '../registry/client.js';
 import { KIND_VERSIONS } from '../registry/validate.js';
 
@@ -177,10 +177,12 @@ export async function maybeLoadShared(eng, hooks) {
   try {
     const rec = await getItem(id);
     loadedFrom = { id: rec.id, kind: rec.kind };
+    pingPlay(rec.id);
+    const plays = typeof rec.plays === 'number' ? ` · ${rec.plays + 1} plays` : '';
     if (rec.kind === 'song') {
       eng.load(rec.payload);
       hooks.onSongLoaded(rec);
-      hooks.notice(`loaded "${rec.name}"${rec.author ? ` by ${rec.author}` : ''}`);
+      hooks.notice(`loaded "${rec.name}"${rec.author ? ` by ${rec.author}` : ''}${plays}`);
     } else {
       const lanes = pickHostLanes(eng.getLanes(), rec.payload.laneType);
       const laneId = lanes.length === 0 ? eng.addLane(rec.payload.laneType).id

--- a/infra/oyster-arcade-site/migrations/0002_plays.sql
+++ b/infra/oyster-arcade-site/migrations/0002_plays.sql
@@ -1,0 +1,2 @@
+-- Play counter: bumped by the app when a shared item loads. Anonymous, no PII.
+ALTER TABLE gb_registry_items ADD COLUMN plays INTEGER NOT NULL DEFAULT 0;

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -58,9 +58,10 @@ export default {
 
     // ─── Share registry API (all hosts; same-origin from both prod domains) ──
     if (url.pathname === '/api/registry' || url.pathname.startsWith('/api/registry/')) {
-      // /play beacons are exempt from the write limit — they'd starve a
-      // publisher's 5/min budget; inflated counts are low-stakes.
-      if ((req.method === 'POST' || req.method === 'PUT') && !url.pathname.endsWith('/play')) {
+      // /play beacons (exact shape only) are exempt from the write limit —
+      // they'd starve a publisher's 5/min budget; inflated counts are low-stakes.
+      const isPlayBeacon = req.method === 'POST' && /^\/api\/registry\/[a-z0-9]{8}\/play$/.test(url.pathname);
+      if ((req.method === 'POST' || req.method === 'PUT') && !isPlayBeacon) {
         const ip = req.headers.get('cf-connecting-ip') ?? 'unknown';
         const rl = await env.WRITE_LIMIT?.limit({ key: ip });   // binding absent in local dev → skip
         if (rl && !rl.success) {

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -46,6 +46,9 @@ function d1Db(d1: D1Database) {
       await d1.prepare(`UPDATE ${T} SET name=?, author=?, payload=?, revision=?, updated_at=? WHERE id=?`)
         .bind(f.name, f.author, f.payload, f.revision, f.updated_at, id).run();
     },
+    async bumpPlays(id: string) {
+      await d1.prepare(`UPDATE ${T} SET plays = plays + 1 WHERE id = ?`).bind(id).run();
+    },
   };
 }
 
@@ -55,7 +58,9 @@ export default {
 
     // ─── Share registry API (all hosts; same-origin from both prod domains) ──
     if (url.pathname === '/api/registry' || url.pathname.startsWith('/api/registry/')) {
-      if (req.method === 'POST' || req.method === 'PUT') {
+      // /play beacons are exempt from the write limit — they'd starve a
+      // publisher's 5/min budget; inflated counts are low-stakes.
+      if ((req.method === 'POST' || req.method === 'PUT') && !url.pathname.endsWith('/play')) {
         const ip = req.headers.get('cf-connecting-ip') ?? 'unknown';
         const rl = await env.WRITE_LIMIT?.limit({ key: ip });   // binding absent in local dev → skip
         if (rl && !rl.success) {


### PR DESCRIPTION
Follow-up to #649, slice 1 of the analytics conversation: an anonymous play counter.

- `plays` column (migration `0002_plays.sql`, default 0)
- `POST /api/registry/:id/play` → 204, increments; 404 unknown id; non-POST 405
- Exempt from the 5/min write rate limit (beacons would starve a publisher's budget); inflated counts are accepted as low-stakes — self-plays and reloads count by design
- Counter is unforgeable via API: PUT body strict-keys reject `plays`, update SQL never touches it
- App fires the beacon fire-and-forget on shared load and shows `· N plays` in the load notice
- No PII, no cookies, no discovery surface — deliberately the smallest possible analytics slice

293 tests green (10 new), typecheck clean, probed against wrangler dev + local D1 (204×2 → plays=2).

Deploy after merge: `npx wrangler d1 migrations apply gb-registry --remote && npx wrangler deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)