### PR TITLE
arcade(groovebox): punch editor mobile pass — bottom sheet + iOS zoom fix

### DIFF
--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -1,4 +1,4 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,viewport-fit=cover">
 <title>Oyster Groovebox</title><link rel="stylesheet" href="ui/app.css"></head>
 <body>
   <div class="cabinet">

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1020,6 +1020,7 @@ body.gb-knob-values .knob-val { display: block; }
 .pe-row { display: flex; align-items: center; gap: 10px; margin: 6px 0; }
 .pe-rl { width: 84px; flex: 0 0 84px; color: var(--faint); font-size: 11px; }
 .pe-q .pe-rl { width: auto; flex: 0 0 auto; }
+.pe-qpair { display: inline-flex; align-items: center; gap: 10px; }
 .pe-slider { flex: 1; accent-color: var(--acc); }
 .pe-val { width: 56px; flex: 0 0 56px; text-align: right; color: var(--ink); }
 .pe-sel { background: var(--panel-3); border: 1px solid var(--line); border-radius: 5px; padding: 2px 8px; color: var(--dim); font: inherit; }
@@ -3235,6 +3236,31 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 
   /* ── Display setting: wrap knobs onto extra rows instead of swiping ── */
   body.gb-knob-wrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
+
+  /* ── punch preset editor: bottom sheet, thumb-sized, nothing clips ── */
+  #punch-editor-backdrop { align-items: flex-end; }
+  #punch-editor {
+    width: 100vw;
+    max-height: calc(100dvh - 32px);
+    border-radius: 14px 14px 0 0;
+    border-left: 0; border-right: 0; border-bottom: 0;
+    padding: 14px 12px calc(16px + env(safe-area-inset-bottom));
+  }
+  .pe-hd { flex-wrap: wrap; row-gap: 8px; }
+  .pe-name { flex: 1 1 120px; min-width: 0; }
+  .pe-badge { display: none; }   /* the editable name is right there; keys don't exist on phones */
+  .pe-test { padding: 10px 20px; }
+  .pe-row { gap: 6px; }
+  .pe-rl { width: 64px; flex: 0 0 64px; }
+  .pe-val { width: 42px; flex: 0 0 42px; }
+  .pe-slider { min-width: 0; }
+  .pe-sel { padding: 6px 8px; }            /* thumb-sized */
+  .pe-lane { height: 30px; }
+  .pe-lanes { flex-wrap: wrap; row-gap: 6px; }
+  .pe-lanes .pe-rl { width: auto; flex: 0 0 100%; }   /* label gets its own line, chips wrap below */
+  .pe-q { flex-wrap: wrap; row-gap: 8px; column-gap: 14px; }
+  .pe-qpair { gap: 6px; }
+  .pe-save { padding: 8px 22px; }
 }
 
 @keyframes gbm-expand {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -3241,13 +3241,14 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   #punch-editor-backdrop { align-items: flex-end; }
   #punch-editor {
     width: 100vw;
+    max-height: calc(100vh - 32px);    /* fallback where dvh is unsupported */
     max-height: calc(100dvh - 32px);
     border-radius: 14px 14px 0 0;
     border-left: 0; border-right: 0; border-bottom: 0;
     padding: 14px 12px calc(16px + env(safe-area-inset-bottom));
   }
   .pe-hd { flex-wrap: wrap; row-gap: 8px; }
-  .pe-name { flex: 1 1 120px; min-width: 0; }
+  .pe-name { flex: 1 1 120px; min-width: 0; font-size: 16px; }  /* ≥16px = no iOS focus-zoom */
   .pe-badge { display: none; }   /* the editable name is right there; keys don't exist on phones */
   .pe-test { padding: 10px 20px; }
   .pe-row { gap: 6px; }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -641,7 +641,7 @@ function renderPunch() {
     edit.textContent = '✎';
     edit.addEventListener('pointerdown', e => {
       e.preventDefault(); e.stopPropagation();
-      for (let s = 0; s < 5; s++) setPunch(s, false);
+      for (let s = 0; s < presets.length; s++) setPunch(s, false);
       openPunchEditor({ slot, eng, onSaved: renderPunch });
     });
     pad.appendChild(edit);

--- a/docs/arcade/groovebox/ui/punch-editor.js
+++ b/docs/arcade/groovebox/ui/punch-editor.js
@@ -16,6 +16,9 @@ export const PARAM_UI = {
   'transport.tapeStop': { label: 'Tape stop',     fmt: v => v.toFixed(2) },
 };
 
+// Touch devices have no number keys — keyboard hints are noise there.
+const COARSE = typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches;
+
 const UNITS = ['steps', 'beats', 'bars'];
 const UNIT_MAX = { steps: 8, beats: 8, bars: 4 };
 const QUANTIZE = [['immediate', 'instant'], ['bar', 'next bar'], ['pattern', 'pattern start']];
@@ -128,10 +131,10 @@ export function openPunchEditor({ slot, eng, onSaved }) {
     name.oninput = () => { draft.name = name.value; };
     const badge = document.createElement('span');
     badge.className = 'pe-badge';
-    badge.textContent = `key ${draft.key} · slot ${slot + 1} of ${eng.getPunchPresets().length}`;
+    badge.textContent = (COARSE ? '' : `key ${draft.key} · `) + `slot ${slot + 1} of ${eng.getPunchPresets().length}`;
     const test = document.createElement('button');
     test.className = 'pe-test' + (playing ? '' : ' idle');
-    test.innerHTML = `TEST<small>hold · or key ${draft.key}</small>`;
+    test.innerHTML = COARSE ? 'TEST<small>hold to hear</small>' : `TEST<small>hold · or key ${draft.key}</small>`;
     test.addEventListener('pointerdown', e => {
       e.preventDefault(); test.setPointerCapture(e.pointerId);
       if (!eng.isPlaying()) {            // live check — not the render-time snapshot
@@ -237,7 +240,7 @@ export function openPunchEditor({ slot, eng, onSaved }) {
     // active-on lane mask (omitted = all lanes)
     const LANE_TYPES = ['drums', 'bass', 'chords', 'melody'];
     const laneRow = document.createElement('div');
-    laneRow.className = 'pe-row';
+    laneRow.className = 'pe-row pe-lanes';
     const ll = label('active on');
     ll.title = 'Which lanes this pad affects; holding multiple pads unions their lanes';
     laneRow.appendChild(ll);
@@ -260,14 +263,20 @@ export function openPunchEditor({ slot, eng, onSaved }) {
     // quantize
     const q = document.createElement('div');
     q.className = 'pe-row pe-q';
-    const sl = label('snap · press');
-    sl.title = 'WHEN the effect fires after pressing: instantly, on the next bar, or at pattern start (bar 1)';
-    q.appendChild(sl);
-    q.appendChild(select(QUANTIZE, draft.engageQuantize, v => { draft.engageQuantize = v; }));
-    const rl2 = label('snap · release');
-    rl2.title = 'WHEN the release takes effect after letting go';
-    q.appendChild(rl2);
-    q.appendChild(select(QUANTIZE, draft.releaseQuantize, v => { draft.releaseQuantize = v; }));
+    const pair = (lbl, title, sel_) => {
+      const p = document.createElement('span');
+      p.className = 'pe-qpair';
+      const l = label(lbl);
+      l.title = title;
+      p.append(l, sel_);
+      return p;
+    };
+    q.appendChild(pair('snap · press',
+      'WHEN the effect fires after pressing: instantly, on the next bar, or at pattern start (bar 1)',
+      select(QUANTIZE, draft.engageQuantize, v => { draft.engageQuantize = v; })));
+    q.appendChild(pair('snap · release',
+      'WHEN the release takes effect after letting go',
+      select(QUANTIZE, draft.releaseQuantize, v => { draft.releaseQuantize = v; })));
     modal.appendChild(q);
 
     // footer


### PR DESCRIPTION
## What

The punch preset editor (v3.5, #647) was built desktop-first and was rough on phones (clipped unit dropdowns, overflowing lane chips, orphaned snap selects, and iOS focus-zoom pushing the whole layout off-screen).

- **≤900px: editor becomes a full-width bottom sheet** — pinned to the bottom, `dvh`-capped height, safe-area bottom padding
- **Rows no longer clip**: label column 84→64px, value 56→42px, tighter gaps, slider allowed to shrink — the fade in/out unit selects now fit
- **Lane chips wrap** under their own "active on" line; **snap label+select pairs** wrap as units (`.pe-qpair`) instead of orphaning a select
- **Coarse pointers drop keyboard hints** — TEST reads "hold to hear", the "key 1 · slot…" badge is hidden (no number keys on phones)
- **iOS focus auto-zoom suppressed** — `maximum-scale=1` (manual pinch still allowed by iOS) + `viewport-fit=cover` so the safe-area padding takes effect
- **Bug fix**: editor-open force-release loop was hardcoded to 5 slots from the five-slot era — a held STOP (slot 6) stayed latched when opening an editor

## Testing

- 290 Vitest green
- Verified at 308px via the phone.html harness (browser-driven): nothing clips, chips/snap rows wrap correctly, sheet pins to bottom
- Desktop unchanged — all layout changes live in the existing ≤900px block + `(pointer: coarse)` JS guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)