### PR TITLE
arcade(groovebox): console skins — NES, SNES, SNES US, Sega, PlayStation, N64, GameCube, Switch

### DIFF
--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -26,6 +26,14 @@
               <option value="gameboy">Game Boy</option>
               <option value="r1">Rabbit</option>
             </optgroup>
+            <optgroup label="Consoles">
+              <option value="nes">NES</option>
+              <option value="snes">SNES</option>
+              <option value="megadrive">Mega Drive</option>
+              <option value="ps1">PlayStation</option>
+              <option value="n64">N64</option>
+              <option value="gamecube">GameCube</option>
+            </optgroup>
             <optgroup label="Calculators">
               <option value="casiofx">Casio fx</option>
               <option value="ti83">TI-83</option>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -30,7 +30,7 @@
               <option value="nes">NES</option>
               <option value="snes">SNES</option>
               <option value="snesus">SNES US</option>
-              <option value="megadrive">Mega Drive</option>
+              <option value="megadrive">Sega</option>
               <option value="ps1">PlayStation</option>
               <option value="n64">N64</option>
               <option value="gamecube">GameCube</option>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -29,6 +29,7 @@
             <optgroup label="Consoles">
               <option value="nes">NES</option>
               <option value="snes">SNES</option>
+              <option value="snesus">SNES US</option>
               <option value="megadrive">Mega Drive</option>
               <option value="ps1">PlayStation</option>
               <option value="n64">N64</option>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -33,6 +33,7 @@
               <option value="ps1">PlayStation</option>
               <option value="n64">N64</option>
               <option value="gamecube">GameCube</option>
+              <option value="switch">Switch</option>
             </optgroup>
             <optgroup label="Calculators">
               <option value="casiofx">Casio fx</option>

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2111,6 +2111,274 @@ body.gb-knob-values .knob-val { display: block; }
 [data-theme="casiofx"] h1,
 [data-theme="ti83"] h1 { text-shadow: none; }
 
+/* ─── hardware homage skins — consoles ────────────────────────────────────── */
+
+[data-theme="ps1"] {
+  /* BODY — PS1 warm console grey; the four shape colours:
+     △ green accent, ○ red, ✕ blue playhead, □ pink (meters) */
+  --bg:          #9b9b95;
+  --panel:       #c7c6c0;
+  --panel-2:     #bbbab4;
+  --panel-3:     #aeada7;
+  --line:        rgba(40,40,36,.18);
+  --line-dk:     rgba(40,40,36,.32);
+  --ink:         #2b2b28;
+  --dim:         #5d5d58;
+  --faint:       #8a8a84;
+  --acc:         #2ea35c;   /* △ */
+  --acc-dim:     #7cc89a;
+  --hot:         #d8344c;   /* ○ */
+  --warn:        #b8862a;
+  --ink-on-acc:  #ffffff;
+  --meter-lo:    #2ea35c;
+  --meter-mid:   #d863a8;   /* □ */
+  --meter-hi:    #d8344c;
+  --chrome-hi:   #b4b3ad;
+  --chrome-mid:  #a4a39d;
+  --chrome-lo:   #94938d;
+  --bevel-hi:    rgba(255,255,255,0.5);
+  --bevel-lo:    rgba(0,0,0,0.12);
+  /* SCREEN — dark CRT, green hits, ✕-blue playhead */
+  --screen-bg:   #0c0c10;
+  --screen-glow: rgba(125,164,221,0.08);
+  --roll-bg:     #121218;
+  --roll-bg-blk: #0d0d12;
+  --roll-note:   #4ab474;   /* △-green melody notes */
+  --grid-line:   #2a2a34;
+  --scope:       #9ab8e8;
+  --playhead:    #ffffff;   /* boot-screen white */
+  --cell:        #14141a;
+  --cell-alt:    #1a1a20;
+  --hit1:        #5a82c8;   /* ✕-blue drum hits */
+  --hit2:        #2e4e94;
+}
+[data-theme="ps1"] h1 { text-shadow: none; }
+[data-theme="ps1"] .vc.hit { box-shadow: 0 0 6px rgba(125,164,221,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="ps1"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(125,164,221,0.35); background: rgba(125,164,221,0.08); }
+[data-theme="ps1"] .vc.hit.now { box-shadow: 0 0 10px rgba(125,164,221,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
+
+[data-theme="gamecube"] {
+  /* BODY — the indigo cube itself; A-button green, B-red, C-stick yellow */
+  --bg:          #3d3478;
+  --panel:       #5b4d9e;
+  --panel-2:     #544692;
+  --panel-3:     #6a5cb0;
+  --line:        rgba(0,0,0,.25);
+  --line-dk:     rgba(0,0,0,.4);
+  --ink:         #f0eefa;
+  --dim:         #c2bce0;
+  --faint:       #968fc0;
+  --acc:         #3cb878;   /* A */
+  --acc-dim:     #2a8456;
+  --hot:         #e04848;   /* B */
+  --warn:        #e8c83a;   /* C */
+  --ink-on-acc:  #06281a;
+  --meter-lo:    #3cb878;
+  --meter-mid:   #e8c83a;
+  --meter-hi:    #e04848;
+  --chrome-hi:   #6a5cb0;
+  --chrome-mid:  #544692;
+  --chrome-lo:   #43377c;
+  --bevel-hi:    rgba(255,255,255,0.22);
+  --bevel-lo:    rgba(0,0,0,0.35);
+  /* SCREEN — near-black purple CRT, A-green content */
+  --screen-bg:   #0d0a18;
+  --screen-glow: rgba(60,184,120,0.08);
+  --roll-bg:     #131024;
+  --roll-bg-blk: #0e0b1c;
+  --roll-note:   #3cb878;
+  --grid-line:   #2c2648;
+  --scope:       #7ee8b0;
+  --playhead:    #ffffff;
+  --cell:        #161230;
+  --cell-alt:    #1b1738;
+  --hit1:        #44c884;
+  --hit2:        #268652;
+}
+[data-theme="gamecube"] .vc.hit { box-shadow: 0 0 6px rgba(60,184,120,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+
+[data-theme="n64"] {
+  /* BODY — matte charcoal; controller colours: A-blue, B-green via meters,
+     C-yellow playhead, logo red */
+  --bg:          #1b1b1d;
+  --panel:       #2a2a2d;
+  --panel-2:     #333337;
+  --panel-3:     #404045;
+  --line:        rgba(255,255,255,.08);
+  --line-dk:     rgba(0,0,0,.5);
+  --ink:         #ececee;
+  --dim:         #9c9ca2;
+  --faint:       #646468;
+  --acc:         #4a7ae8;   /* A button */
+  --acc-dim:     #2e51a8;
+  --hot:         #e03c30;
+  --warn:        #e8c020;
+  --ink-on-acc:  #ffffff;
+  --meter-lo:    #3aa53a;
+  --meter-mid:   #e8c020;
+  --meter-hi:    #e03c30;
+  --chrome-hi:   #404045;
+  --chrome-mid:  #2e2e32;
+  --chrome-lo:   #1e1e20;
+  --bevel-hi:    rgba(255,255,255,0.07);
+  --bevel-lo:    rgba(0,0,0,0.5);
+  /* SCREEN — dark CRT, A-blue notes, C-yellow playhead */
+  --screen-bg:   #0b0b0d;
+  --screen-glow: rgba(74,122,232,0.07);
+  --roll-bg:     #111114;
+  --roll-bg-blk: #0c0c0f;
+  --roll-note:   #6a96f0;   /* A-blue melody notes */
+  --grid-line:   #2a2a30;
+  --scope:       #8ab0f8;
+  --playhead:    #e8c020;   /* C-yellow */
+  --cell:        #131316;
+  --cell-alt:    #18181c;
+  --hit1:        #4aab4a;   /* B-green drum hits */
+  --hit2:        #2a7a2a;
+}
+[data-theme="n64"] .vc.hit { box-shadow: 0 0 6px rgba(74,171,74,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="n64"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(232,192,32,0.3); background: rgba(232,192,32,0.07); }
+[data-theme="n64"] .vc.hit.now { box-shadow: 0 0 10px rgba(232,192,32,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
+
+[data-theme="nes"] {
+  /* BODY — cool two-tone console grey + NES red */
+  --bg:          #94928c;
+  --panel:       #c4c2ba;
+  --panel-2:     #b6b4ac;
+  --panel-3:     #a8a69e;
+  --line:        rgba(40,40,36,.18);
+  --line-dk:     rgba(40,40,36,.32);
+  --ink:         #2c2b28;
+  --dim:         #5c5b56;
+  --faint:       #888780;
+  --acc:         #c8201c;   /* logo red */
+  --acc-dim:     #da6a64;
+  --hot:         #c8201c;
+  --warn:        #8a7212;
+  --ink-on-acc:  #ffffff;
+  --meter-lo:    #6f8f5a;
+  --meter-mid:   #8a7212;
+  --meter-hi:    #c8201c;
+  --chrome-hi:   #b0aea6;
+  --chrome-mid:  #a09e96;
+  --chrome-lo:   #908e86;
+  --bevel-hi:    rgba(255,255,255,0.45);
+  --bevel-lo:    rgba(0,0,0,0.15);
+  /* SCREEN — near-black CRT, white pixels, red-lit hits */
+  --screen-bg:   #0a0a0c;
+  --screen-glow: rgba(200,32,28,0.06);
+  --roll-bg:     #101013;
+  --roll-bg-blk: #0b0b0e;
+  --roll-note:   #e8e6e0;
+  --grid-line:   #28282c;
+  --scope:       #e8e6e0;
+  --playhead:    #e8312a;
+  --cell:        #121215;
+  --cell-alt:    #17171a;
+  --hit1:        #d8423c;
+  --hit2:        #962420;
+}
+/* Red plastic-stamped wordmark, like the logo on the front loader */
+[data-theme="nes"] h1 {
+  color: #c8201c;
+  text-shadow: 0 1px 0 rgba(255,255,255,0.4);
+}
+[data-theme="nes"] .vc.hit { box-shadow: 0 0 6px rgba(200,32,28,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="nes"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(232,49,42,0.3); background: rgba(232,49,42,0.07); }
+[data-theme="nes"] .vc.hit.now { box-shadow: 0 0 10px rgba(232,49,42,0.55), inset 0 1px 0 rgba(255,255,255,0.25); }
+
+[data-theme="snes"] {
+  /* BODY — PAL light grey; ABXY red/yellow/green/blue, mode-7 purple screen */
+  --bg:          #9a9a96;
+  --panel:       #cac9c4;
+  --panel-2:     #bdbcb7;
+  --panel-3:     #b0afaa;
+  --line:        rgba(40,40,36,.18);
+  --line-dk:     rgba(40,40,36,.32);
+  --ink:         #2e2e2c;
+  --dim:         #5e5e5a;
+  --faint:       #8a8a86;
+  --acc:         #3a6ee0;   /* X/A blue */
+  --acc-dim:     #8aa6e8;
+  --hot:         #d8403a;   /* B red */
+  --warn:        #b8962a;
+  --ink-on-acc:  #ffffff;
+  --meter-lo:    #3aa54a;   /* Y green / X yellow / B red */
+  --meter-mid:   #d8b43a;
+  --meter-hi:    #d8403a;
+  --chrome-hi:   #b8b7b2;
+  --chrome-mid:  #a8a7a2;
+  --chrome-lo:   #989792;
+  --bevel-hi:    rgba(255,255,255,0.5);
+  --bevel-lo:    rgba(0,0,0,0.12);
+  /* SCREEN — dark CRT with a mode-7 lavender cast */
+  --screen-bg:   #0c0b10;
+  --screen-glow: rgba(122,98,200,0.08);
+  --roll-bg:     #14121c;
+  --roll-bg-blk: #0e0c16;
+  --roll-note:   #e8e6f0;
+  --grid-line:   #2c2a38;
+  --scope:       #b8a8e8;
+  --playhead:    #d8b43a;
+  --cell:        #16141e;
+  --cell-alt:    #1b1924;
+  --hit1:        #7a6ad0;
+  --hit2:        #4a3e92;
+}
+[data-theme="snes"] h1 { text-shadow: none; }
+[data-theme="snes"] .vc.hit { box-shadow: 0 0 6px rgba(122,108,210,0.4), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="snes"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(216,180,58,0.3); background: rgba(216,180,58,0.07); }
+[data-theme="snes"] .vc.hit.now { box-shadow: 0 0 10px rgba(216,180,58,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
+
+[data-theme="megadrive"] {
+  /* BODY — black console, Sega blue, 16-BIT gold, red power LED */
+  --bg:          #0e0e10;
+  --panel:       #1a1a1d;
+  --panel-2:     #222226;
+  --panel-3:     #2d2d32;
+  --line:        rgba(255,255,255,.08);
+  --line-dk:     rgba(0,0,0,.6);
+  --ink:         #ececee;
+  --dim:         #95959c;
+  --faint:       #5e5e64;
+  --acc:         #3d6fe8;   /* Sega blue */
+  --acc-dim:     #2a4ba0;
+  --hot:         #e0312e;   /* power LED */
+  --warn:        #c8a23a;   /* 16-BIT gold */
+  --ink-on-acc:  #ffffff;
+  --meter-lo:    #3d6fe8;
+  --meter-mid:   #c8a23a;
+  --meter-hi:    #e0312e;
+  --chrome-hi:   #303034;
+  --chrome-mid:  #222226;
+  --chrome-lo:   #151518;
+  --bevel-hi:    rgba(255,255,255,0.07);
+  --bevel-lo:    rgba(0,0,0,0.6);
+  /* SCREEN — dark CRT, blue content, gold playhead */
+  --screen-bg:   #0a0a0c;
+  --screen-glow: rgba(61,111,232,0.08);
+  --roll-bg:     #0f0f12;
+  --roll-bg-blk: #0a0a0d;
+  --roll-note:   #4a86f0;
+  --grid-line:   #26262a;
+  --scope:       #6a9ef8;
+  --playhead:    #d8b44a;
+  --cell:        #111114;
+  --cell-alt:    #16161a;
+  --hit1:        #4a7ae8;
+  --hit2:        #2a4ba0;
+}
+/* Gold italic wordmark, like the 16-BIT badge on the fascia */
+[data-theme="megadrive"] h1 {
+  color: #c8a23a;
+  font-style: italic;
+  font-weight: 800;
+  text-shadow: none;
+}
+[data-theme="megadrive"] .vc.hit { box-shadow: 0 0 6px rgba(61,111,232,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="megadrive"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(216,180,74,0.3); background: rgba(216,180,74,0.07); }
+[data-theme="megadrive"] .vc.hit.now { box-shadow: 0 0 10px rgba(216,180,74,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
+
 /* ─── § 5 — lane actions: dup + remove buttons ────────────────────────────── */
 .lane-actions {
   display: flex;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2322,13 +2322,56 @@ body.gb-knob-values .knob-val { display: block; }
   --playhead:    #d8b43a;
   --cell:        #16141e;
   --cell-alt:    #1b1924;
+  --hit1:        #4ab44a;   /* Y-green drum hits */
+  --hit2:        #2a7a30;
+}
+[data-theme="snes"] h1 { text-shadow: none; }
+[data-theme="snes"] .vc.hit { box-shadow: 0 0 6px rgba(74,180,74,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="snes"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(216,180,58,0.3); background: rgba(216,180,58,0.07); }
+[data-theme="snes"] .vc.hit.now { box-shadow: 0 0 10px rgba(216,180,58,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
+
+[data-theme="snesus"] {
+  /* BODY — US SNES: light grey with the two purples (lavender + grape) */
+  --bg:          #9a9a96;
+  --panel:       #cac9c4;
+  --panel-2:     #bdbcb7;
+  --panel-3:     #b0afaa;
+  --line:        rgba(40,40,36,.18);
+  --line-dk:     rgba(40,40,36,.32);
+  --ink:         #2e2e2c;
+  --dim:         #5e5e5a;
+  --faint:       #8a8a86;
+  --acc:         #5a4fc8;   /* grape */
+  --acc-dim:     #a193c8;   /* lavender */
+  --hot:         #c8403a;   /* power LED */
+  --warn:        #b8962a;
+  --ink-on-acc:  #ffffff;
+  --meter-lo:    #a193c8;
+  --meter-mid:   #b8962a;
+  --meter-hi:    #c8403a;
+  --chrome-hi:   #b8b7b2;
+  --chrome-mid:  #a8a7a2;
+  --chrome-lo:   #989792;
+  --bevel-hi:    rgba(255,255,255,0.5);
+  --bevel-lo:    rgba(0,0,0,0.12);
+  /* SCREEN — dark CRT, grape hits, lavender trace */
+  --screen-bg:   #0c0b10;
+  --screen-glow: rgba(90,79,200,0.08);
+  --roll-bg:     #14121c;
+  --roll-bg-blk: #0e0c16;
+  --roll-note:   #e8e6f0;
+  --grid-line:   #2c2a38;
+  --scope:       #b8a8e8;
+  --playhead:    #a193c8;
+  --cell:        #16141e;
+  --cell-alt:    #1b1924;
   --hit1:        #7a6ad0;
   --hit2:        #4a3e92;
 }
-[data-theme="snes"] h1 { text-shadow: none; }
-[data-theme="snes"] .vc.hit { box-shadow: 0 0 6px rgba(122,108,210,0.4), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
-[data-theme="snes"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(216,180,58,0.3); background: rgba(216,180,58,0.07); }
-[data-theme="snes"] .vc.hit.now { box-shadow: 0 0 10px rgba(216,180,58,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
+[data-theme="snesus"] h1 { text-shadow: none; }
+[data-theme="snesus"] .vc.hit { box-shadow: 0 0 6px rgba(122,108,210,0.4), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="snesus"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(161,147,200,0.35); background: rgba(161,147,200,0.08); }
+[data-theme="snesus"] .vc.hit.now { box-shadow: 0 0 10px rgba(161,147,200,0.55), inset 0 1px 0 rgba(255,255,255,0.25); }
 
 [data-theme="megadrive"] {
   /* BODY — black console, Sega blue, 16-BIT gold, red power LED */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2379,6 +2379,58 @@ body.gb-knob-values .knob-val { display: block; }
 [data-theme="megadrive"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(216,180,74,0.3); background: rgba(216,180,74,0.07); }
 [data-theme="megadrive"] .vc.hit.now { box-shadow: 0 0 10px rgba(216,180,74,0.5), inset 0 1px 0 rgba(255,255,255,0.25); }
 
+[data-theme="switch"] {
+  /* BODY — the black tablet; neon-blue/neon-red Joy-Cons live on the page
+     surround (body gradient below) and in the accents */
+  --bg:          #0b0b0d;
+  --panel:       #161619;
+  --panel-2:     #1f1f23;
+  --panel-3:     #2a2a2f;
+  --line:        rgba(255,255,255,.09);
+  --line-dk:     rgba(0,0,0,.6);
+  --ink:         #f2f2f4;
+  --dim:         #9a9aa2;
+  --faint:       #606068;
+  --acc:         #0ab9e6;   /* neon blue (L) */
+  --acc-dim:     #0782a2;
+  --hot:         #ff3c28;   /* neon red (R) */
+  --warn:        #e8c020;
+  --ink-on-acc:  #03222c;
+  --meter-lo:    #0ab9e6;
+  --meter-mid:   #e8c020;
+  --meter-hi:    #ff3c28;
+  --chrome-hi:   #2a2a2e;
+  --chrome-mid:  #1c1c20;
+  --chrome-lo:   #101014;
+  --bevel-hi:    rgba(255,255,255,0.07);
+  --bevel-lo:    rgba(0,0,0,0.6);
+  /* SCREEN — black tablet screen: blue melody notes (L), red drum hits (R) */
+  --screen-bg:   #0d0d10;
+  --screen-glow: rgba(10,185,230,0.08);
+  --roll-bg:     #131316;
+  --roll-bg-blk: #0e0e11;
+  --roll-note:   #3ec8ec;
+  --grid-line:   #28282c;
+  --scope:       #6adcf8;
+  --playhead:    #ffffff;
+  --cell:        #141417;
+  --cell-alt:    #19191d;
+  --hit1:        #ff5a48;
+  --hit2:        #c22414;
+}
+/* The Joy-Con sandwich: neon blue on top, the black tablet in the middle,
+   neon red at the bottom. Fixed to the viewport so the bands hold on scroll. */
+[data-theme="switch"] body {
+  background: linear-gradient(180deg,
+    #0ab9e6 0%, #0ab9e6 10%,
+    #0b0b0d 24%, #0b0b0d 76%,
+    #ff3c28 90%, #ff3c28 100%);
+  background-attachment: fixed;
+}
+[data-theme="switch"] .vc.hit { box-shadow: 0 0 6px rgba(255,60,40,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
+[data-theme="switch"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(10,185,230,0.35); background: rgba(10,185,230,0.08); }
+[data-theme="switch"] .vc.hit.now { box-shadow: 0 0 10px rgba(10,185,230,0.55), inset 0 1px 0 rgba(255,255,255,0.25); }
+
 /* ─── § 5 — lane actions: dup + remove buttons ────────────────────────────── */
 .lane-actions {
   display: flex;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2461,14 +2461,13 @@ body.gb-knob-values .knob-val { display: block; }
   --hit1:        #ff5a48;
   --hit2:        #c22414;
 }
-/* The Joy-Con sandwich: neon blue on top, the black tablet in the middle,
-   neon red at the bottom. Fixed to the viewport so the bands hold on scroll. */
-[data-theme="switch"] body {
+/* The Joy-Con sandwich, on the device chrome itself: solid neon-blue top,
+   black tablet middle, solid neon-red bottom — crisp plastic seams, no fade. */
+[data-theme="switch"] .cabinet {
   background: linear-gradient(180deg,
-    #0ab9e6 0%, #0ab9e6 10%,
-    #0b0b0d 24%, #0b0b0d 76%,
-    #ff3c28 90%, #ff3c28 100%);
-  background-attachment: fixed;
+    #0ab9e6 0%, #0ab9e6 16%,
+    #131316 16%, #131316 84%,
+    #ff3c28 84%, #ff3c28 100%);
 }
 [data-theme="switch"] .vc.hit { box-shadow: 0 0 6px rgba(255,60,40,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
 [data-theme="switch"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(10,185,230,0.35); background: rgba(10,185,230,0.08); }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2115,7 +2115,7 @@ body.gb-knob-values .knob-val { display: block; }
 
 [data-theme="ps1"] {
   /* BODY — PS1 warm console grey; the four shape colours:
-     △ green accent, ○ red, ✕ blue playhead, □ pink (meters) */
+     △ green accent/notes, ○ red hot, ✕ blue hits, □ pink (meters) */
   --bg:          #9b9b95;
   --panel:       #c7c6c0;
   --panel-2:     #bbbab4;
@@ -2138,7 +2138,8 @@ body.gb-knob-values .knob-val { display: block; }
   --chrome-lo:   #94938d;
   --bevel-hi:    rgba(255,255,255,0.5);
   --bevel-lo:    rgba(0,0,0,0.12);
-  /* SCREEN — dark CRT, green hits, ✕-blue playhead */
+  /* SCREEN — dark CRT: △-green melody notes, ✕-blue drum hits,
+     boot-screen-white playhead */
   --screen-bg:   #0c0c10;
   --screen-glow: rgba(125,164,221,0.08);
   --roll-bg:     #121218;


### PR DESCRIPTION
Eight console themes in a new **Consoles** optgroup (chronological order), following the token-block pattern from #656.

| Theme | Body | Screen | Signature |
|---|---|---|---|
| **NES** | cool two-tone grey | near-black CRT | red mono accent, red-stamped wordmark, red-lit hits |
| **SNES** | PAL light grey | mode-7 lavender CRT | all four pad colours: X-blue accent, Y-green hits, A-red hot, B-yellow playhead |
| **SNES US** | console grey | dark CRT | the US purples: grape accent, lavender playhead, purple-lit hits |
| **Sega** (Mega Drive) | black | dark CRT | Sega-blue accent/hits, gold italic 16-BIT wordmark, red power-LED |
| **PlayStation** | PS1 warm grey | dark CRT | the four shapes: △-green accent/notes, ✕-blue hits, ○-red hot, □-pink meter, white playhead |
| **N64** | matte charcoal | dark CRT | controller colours: A-blue accent/notes, B-green hits, C-yellow playhead |
| **GameCube** | the indigo cube | purple-black CRT | A-button green accent/hits, B-red, C-stick yellow |
| **Switch** | black tablet | black tablet screen | Joy-Con sandwich on the cabinet chrome: solid neon-blue top band, neon-red bottom, crisp plastic seams; blue accent/notes (L), red hits (R) |

Design constraint handled during the visual pass: PS1, N64 and Mega Drive all started as "dark screen + blue hits" — re-split so each reads at a glance (N64 → green hits, PS1 → blue hits on grey body, Sega → blue hits on black + gold wordmark). Every dark console has its own themed playhead/hit glow; no default-teal leaks.

Labelling: the Mega Drive theme is labelled **Sega** in the picker (owner's call); the internal theme key stays `megadrive`.

No CHANGELOG entry (arcade scope).

## Verification
- All 8 screenshotted in-browser (drums view; PS1/N64 re-shot after the hit-colour split; Switch checked scrolled + unscrolled for the chrome bands; SNES re-shot with all four pad colours)
- `npx vitest run`: 22 files, 295 tests pass
- Copilot review: stale PS1 comments fixed in c145c86; theme-count mismatch fixed by this description; "Sega" label kept intentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)