### PR TITLE
arcade(groovebox): screen/cabinet redesign — Song tab, LCD strip, Oyster theme, screen picker

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -25,7 +25,6 @@ export function createEngine() {
   let target = { kind: 'chain', pos: 0, barInPattern: 0 };
   let pendingTarget = null;      // applied at the next bar boundary
   let editIdx = 0;               // pattern open in the editors
-  let keyQuantize = false, pendingTranspose = null;
   let masterComp = null, masterRev = null, masterVol = null, masterPan = null, masterWidth = null, masterEQ = null;
   let _widthOn = false;   // is the StereoWidener spliced into the master chain?
   // Punch v3: pre-wired neutral punch bus; presets are data (punch-presets.js)
@@ -353,7 +352,6 @@ export function createEngine() {
         const barSeconds = stepsPerBar(song.meter) * sixteenth;
         const spb = stepsPerBar(song.meter);
         if (step % spb === 0) {
-          if (pendingTranspose !== null) { song.transpose = pendingTranspose; pendingTranspose = null; }
           if (step === 0) {
             target = { ...target, barInPattern: 0 };       // play restarts the current target from its top bar
           } else if (pendingTarget) {
@@ -442,7 +440,7 @@ export function createEngine() {
     stop() {
       Tone.Transport.stop();
       if (repeatId !== null) { Tone.Transport.clear(repeatId); repeatId = null; }
-      step = 0; playing = false; pendingFill = null; activeFill = null; fillQueue = []; pendingTranspose = null; pendingTarget = null;
+      step = 0; playing = false; pendingFill = null; activeFill = null; fillQueue = []; pendingTarget = null;
       // Punch pads release with the transport. rampTo pins current values
       // (no cancel-then-revert clicks); delayTime snaps back after the brief
       // gate settle so any reverb tail doesn't doppler.
@@ -778,12 +776,8 @@ export function createEngine() {
     },
     setTranspose(semis) {
       if (!song) return;
-      const n = semis | 0;
-      if (keyQuantize && playing) { pendingTranspose = n; }
-      else { song.transpose = n; pendingTranspose = null; }
+      song.transpose = semis | 0;
     },
     getTranspose() { return song ? (song.transpose || 0) : 0; },
-    setKeyQuantize(on) { keyQuantize = !!on; },
-    getKeyQuantize() { return keyQuantize; },
   };
 }

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -134,30 +134,30 @@
             </div>
             <div class="help-section" data-help="mix">
               <dl>
-                <dt>VOL</dt><dd>Lane output level</dd>
-                <dt>PAN</dt><dd>Left / right placement</dd>
-                <dt>BAL</dt><dd>Master left / right</dd>
-                <dt>WID</dt><dd>Stereo width (mono ↔ wide)</dd>
+                <dt>VOL</dt><dd>How loud this instrument is</dd>
+                <dt>PAN</dt><dd>Push the sound towards the left or right speaker</dd>
+                <dt>BAL</dt><dd>Lean the whole mix left or right</dd>
+                <dt>WID</dt><dd>How wide the sound feels — narrow mono to extra-wide stereo</dd>
               </dl>
             </div>
             <div class="help-section" data-help="tone">
               <dl>
-                <dt>CUT</dt><dd>Filter sweep — left = low-pass (darker), right = high-pass (thinner), centre = open</dd>
-                <dt>RES</dt><dd>Emphasis at the filter cutoff (squelch)</dd>
-                <dt>DRV</dt><dd>Overdrive / distortion</dd>
-                <dt>LO</dt><dd>Master bass shelf</dd>
-                <dt>HI</dt><dd>Master treble shelf</dd>
+                <dt>CUT</dt><dd>Brightness — left for dark and muffled, right for thin and crispy, middle is natural</dd>
+                <dt>RES</dt><dd>Adds a whistly squelch right where the brightness sits — great for acid bass</dd>
+                <dt>DRV</dt><dd>Crunch — pushes the sound like a guitar amp turned up too far</dd>
+                <dt>LO</dt><dd>More or less bass, for everything at once</dd>
+                <dt>HI</dt><dd>More or less sparkle, for everything at once</dd>
               </dl>
             </div>
             <div class="help-section" data-help="fx">
               <dl>
-                <dt>DLY</dt><dd>Echo send amount</dd>
-                <dt>FDBK</dt><dd>How many times the delay repeats (slap → wash)</dd>
-                <dt>CHO</dt><dd>Shimmer / width</dd>
-                <dt>WOB</dt><dd>LFO auto-filter movement</dd>
-                <dt>CRU</dt><dd>Bit-crusher (lo-fi)</dd>
-                <dt>VRB</dt><dd>Space / room send</dd>
-                <dt>CMP</dt><dd>Compression — evens out dynamics</dd>
+                <dt>DLY</dt><dd>Echo — how much of the sound bounces back</dd>
+                <dt>FDBK</dt><dd>How long the echoes keep going — one quick slap to a long trailing wash</dd>
+                <dt>CHO</dt><dd>Shimmer — makes the sound thicker and dreamier</dd>
+                <dt>WOB</dt><dd>Makes the sound wobble in slow waves</dd>
+                <dt>CRU</dt><dd>Crunchy retro lo-fi, like an old game console</dd>
+                <dt>VRB</dt><dd>Room sound — from a small box to a huge hall</dd>
+                <dt>CMP</dt><dd>Squashes loud and quiet closer together so everything punches</dd>
               </dl>
             </div>
           </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -79,7 +79,6 @@
           <div class="transport-song">
             <div class="song-wrap">
               <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="scallywag">★ Scallywag (AI)</option><option value="boo-waltz">★ Boo Waltz (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
-              <div id="credit"></div>
             </div>
           </div>
           <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -72,6 +72,7 @@
               <div id="credit"></div>
             </div>
           </div>
+          <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
       </div>
 
@@ -172,7 +173,6 @@
         <div id="lcd-body"></div>
         <div id="lcd-song" hidden>
           <div id="lcd-song-rows"></div>
-          <div class="lcd-song-foot"><span id="lcd-song-key"></span><button id="share-btn" title="Publish this song or a groove">PUBLISH</button></div>
         </div>
       </div>
       <div id="master"></div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -13,21 +13,22 @@
       <div class="titlebar">
         <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>oyster groovebox</h1>
         <div class="titlebar-tools">
-          <!-- Lucide "palette" (MIT, lucide.dev) — theme picker affordance -->
-          <span class="theme-icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/></svg></span>
-          <select id="themesel">
-            <option value="dark" selected>Dark</option>
-            <option value="light">Light</option>
-            <option value="beige">Beige</option>
-            <option value="playdate">Playdate</option>
-            <option value="purple">Purple</option>
-            <option value="gameboy">Game Boy</option>
-            <option value="amber">Amber</option>
-            <option value="r1">Rabbit</option>
-          </select>
           <div class="vs-wrap">
-            <button id="viewsettings-btn" title="View settings">Settings</button>
+            <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>
+              <div class="vs-theme">
+                <span class="vs-title">Theme</span>
+                <select id="themesel">
+                  <option value="dark" selected>Dark</option>
+                  <option value="light">Light</option>
+                  <option value="beige">Beige</option>
+                  <option value="playdate">Playdate</option>
+                  <option value="purple">Purple</option>
+                  <option value="gameboy">Game Boy</option>
+                  <option value="amber">Amber</option>
+                  <option value="r1">Rabbit</option>
+                </select>
+              </div>
               <span class="vs-title">Active knobs</span>
               <div id="viewsettings-checks"></div>
             </div>
@@ -36,36 +37,19 @@
         </div>
       </div>
 
-      <!-- Tier 2 — SONG box: transport (performance controls) + arrangement,
-           pinned as one module above the draggable view sections. -->
+      <!-- Tier 2 — transport (the cabinet): play + the song slot. Everything
+           song-structural lives on the screen (Song tab); tempo/transpose are
+           hardware on MASTER. -->
       <div id="songbox">
         <div class="transport">
           <button id="play">▶ play</button>
-          <div class="transport-divider"></div>
-          <div class="transport-tempo">
-            <span class="transport-lbl">Tempo</span>
-            <input type="range" id="bpm" min="80" max="180" value="120">
-            <span id="bpmv" class="transport-bpm-val">120</span>
-            <span class="transport-bpm-unit">BPM</span>
-          </div>
-          <div class="transport-key">
-            <span class="transport-lbl">Key</span>
-            <div class="key-stepper">
-              <button id="key-dn">−</button><span id="keyv" class="mono">0</span><button id="key-up">＋</button>
-            </div>
-            <button id="key-q" class="key-q" title="Quantize key change to the bar" aria-pressed="false">⟳ bar</button>
-          </div>
-          <span id="song-status"><span class="pat-playing" id="pat-playing"></span><span class="pat-editing"></span></span>
           <div class="transport-song">
-            <span class="transport-lbl">Song</span>
             <div class="song-wrap">
               <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="scallywag">★ Scallywag (AI)</option><option value="boo-waltz">★ Boo Waltz (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
               <div id="credit"></div>
             </div>
           </div>
-          <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
-        <div id="arrange"></div>
       </div>
 
       <!-- Share modal -->
@@ -145,17 +129,27 @@
                 <dt>S</dt><dd>Solo a lane (silences all others)</dd>
                 <dt>VIEW</dt><dd>Open that lane in the step editor / piano roll</dd>
                 <dt>FILLS</dt><dd>Queue fill patterns — click a chip to remove it from the queue</dd>
-                <dt>PATTERNS</dt><dd>Click a pattern to edit it (it loops while playing). Click a chain chip to play the song from there. ＋ adds, ⧉ duplicates.</dd>
+                <dt>SONG tab</dt><dd>The song's structure on the screen — click a pattern to edit it (it loops while playing), click a chain chip to play the song from there. ＋ adds, ⧉ duplicates.</dd>
                 <dt>PUNCH</dt><dd>Hold a pad (or keys 1–5) for momentary FX — release to snap back clean</dd>
-                <dt>KEY ± </dt><dd>Transpose the whole song up or down in semitones</dd>
+                <dt>TEMPO</dt><dd>Song speed in BPM — on MASTER</dd>
+                <dt>TRANSPOSE ±</dt><dd>Shift the whole song up or down in semitones — on MASTER</dd>
               </dl>
             </div>
           </div>
         </div>
       </div>
-      <!-- Tier 3 — views (built by renderViewTabs) -->
-      <div class="vtabs"><span class="vtabs-lbl">VIEW</span><button data-view="scope">📈 Scope</button></div>
-      <div id="viz"></div>
+      <!-- Tier 3 — the screen: status strip + tabs (built by renderViewTabs)
+           + body. makeViz owns #lcd-body's innerHTML; the Song tab body
+           (#lcd-song) is a sibling so the two can swap via display toggle. -->
+      <div id="viz">
+        <div id="lcd-strip"></div>
+        <div class="vtabs"></div>
+        <div id="lcd-body"></div>
+        <div id="lcd-song" hidden>
+          <div id="lcd-song-rows"></div>
+          <div class="lcd-song-foot"><span id="lcd-song-key"></span><button id="share-btn" title="Publish this song or a groove">PUBLISH</button></div>
+        </div>
+      </div>
       <div id="master"></div>
       <div id="punch"></div>
       <div id="strips"></div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -41,6 +41,17 @@
           <div class="vs-wrap">
             <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>
+              <div class="vs-screen">
+                <span class="vs-title">Screen</span>
+                <select id="screensel">
+                  <option value="default" selected>Theme default</option>
+                  <option value="pearl">Pearl</option>
+                  <option value="phosphor">Phosphor</option>
+                  <option value="lime">Lime</option>
+                  <option value="amber">Amber</option>
+                  <option value="paper">Paper</option>
+                </select>
+              </div>
               <span class="vs-title">Active knobs</span>
               <div id="viewsettings-checks"></div>
             </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -11,7 +11,7 @@
       </div>
       <!-- Tier 1 — title bar -->
       <div class="titlebar">
-        <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>oyster groovebox</h1>
+        <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span><span class="brand-oyster">oyster </span>groovebox</h1>
         <div class="titlebar-tools">
           <select id="themesel">
             <option value="oyster" selected>Oyster</option>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -13,22 +13,19 @@
       <div class="titlebar">
         <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>oyster groovebox</h1>
         <div class="titlebar-tools">
+          <select id="themesel">
+            <option value="dark" selected>Dark</option>
+            <option value="light">Light</option>
+            <option value="beige">Beige</option>
+            <option value="playdate">Playdate</option>
+            <option value="purple">Purple</option>
+            <option value="gameboy">Game Boy</option>
+            <option value="amber">Amber</option>
+            <option value="r1">Rabbit</option>
+          </select>
           <div class="vs-wrap">
             <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>
-              <div class="vs-theme">
-                <span class="vs-title">Theme</span>
-                <select id="themesel">
-                  <option value="dark" selected>Dark</option>
-                  <option value="light">Light</option>
-                  <option value="beige">Beige</option>
-                  <option value="playdate">Playdate</option>
-                  <option value="purple">Purple</option>
-                  <option value="gameboy">Game Boy</option>
-                  <option value="amber">Amber</option>
-                  <option value="r1">Rabbit</option>
-                </select>
-              </div>
               <span class="vs-title">Active knobs</span>
               <div id="viewsettings-checks"></div>
             </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -112,50 +112,52 @@
         <div id="help-modal-backdrop"></div>
         <div id="help-modal-box" role="dialog" aria-modal="true" aria-label="Groovebox help">
           <button id="help-modal-close" aria-label="Close help">✕</button>
-          <h2>Groovebox — Quick Reference</h2>
+          <h2>Quick Reference</h2>
+          <div id="help-tabs">
+            <button class="help-tab active" data-help="controls">Controls</button>
+            <button class="help-tab" data-help="mix">Mix</button>
+            <button class="help-tab" data-help="tone">Tone</button>
+            <button class="help-tab" data-help="fx">FX</button>
+          </div>
           <div class="help-sections">
-            <div class="help-section">
-              <h3>Mix</h3>
+            <div class="help-section active" data-help="controls">
               <dl>
-                <dt>Volume</dt><dd>Lane output level</dd>
-                <dt>Pan</dt><dd>Left / right placement</dd>
-                <dt>Balance</dt><dd>Master left / right</dd>
-                <dt>Width</dt><dd>Stereo width (mono ↔ wide)</dd>
-              </dl>
-            </div>
-            <div class="help-section">
-              <h3>Tone</h3>
-              <dl>
-                <dt>Cutoff</dt><dd>Filter sweep — left = low-pass (darker), right = high-pass (thinner), centre = open</dd>
-                <dt>Resonance</dt><dd>Emphasis at the filter cutoff (squelch)</dd>
-                <dt>Drive</dt><dd>Overdrive / distortion</dd>
-                <dt>Low EQ</dt><dd>Master bass shelf</dd>
-                <dt>High EQ</dt><dd>Master treble shelf</dd>
-              </dl>
-            </div>
-            <div class="help-section">
-              <h3>FX</h3>
-              <dl>
-                <dt>Delay</dt><dd>Echo send amount</dd>
-                <dt>Feedback</dt><dd>How many times the delay repeats (slap → wash)</dd>
-                <dt>Chorus</dt><dd>Shimmer / width</dd>
-                <dt>Wobble</dt><dd>LFO auto-filter movement</dd>
-                <dt>Crush</dt><dd>Bit-crusher (lo-fi)</dd>
-                <dt>Reverb</dt><dd>Space / room send</dd>
-                <dt>Comp</dt><dd>Compression — evens out dynamics</dd>
-              </dl>
-            </div>
-            <div class="help-section">
-              <h3>Controls</h3>
-              <dl>
+                <dt>SONG</dt><dd>The song's structure on the screen — click a pattern to edit it (it loops while playing), click a chain chip to play the song from there. ＋ adds, ⧉ duplicates.</dd>
                 <dt>M</dt><dd>Mute a lane (silences it; FX state preserved)</dd>
                 <dt>S</dt><dd>Solo a lane (silences all others)</dd>
                 <dt>VIEW</dt><dd>Open that lane in the step editor / piano roll</dd>
                 <dt>FILLS</dt><dd>Queue fill patterns — click a chip to remove it from the queue</dd>
-                <dt>SONG tab</dt><dd>The song's structure on the screen — click a pattern to edit it (it loops while playing), click a chain chip to play the song from there. ＋ adds, ⧉ duplicates.</dd>
                 <dt>PUNCH</dt><dd>Hold a pad (or keys 1–5) for momentary FX — release to snap back clean</dd>
                 <dt>TEMPO</dt><dd>Song speed in BPM — on MASTER</dd>
                 <dt>TRANSPOSE ±</dt><dd>Shift the whole song up or down in semitones — on MASTER</dd>
+              </dl>
+            </div>
+            <div class="help-section" data-help="mix">
+              <dl>
+                <dt>VOL</dt><dd>Lane output level</dd>
+                <dt>PAN</dt><dd>Left / right placement</dd>
+                <dt>BAL</dt><dd>Master left / right</dd>
+                <dt>WID</dt><dd>Stereo width (mono ↔ wide)</dd>
+              </dl>
+            </div>
+            <div class="help-section" data-help="tone">
+              <dl>
+                <dt>CUT</dt><dd>Filter sweep — left = low-pass (darker), right = high-pass (thinner), centre = open</dd>
+                <dt>RES</dt><dd>Emphasis at the filter cutoff (squelch)</dd>
+                <dt>DRV</dt><dd>Overdrive / distortion</dd>
+                <dt>LO</dt><dd>Master bass shelf</dd>
+                <dt>HI</dt><dd>Master treble shelf</dd>
+              </dl>
+            </div>
+            <div class="help-section" data-help="fx">
+              <dl>
+                <dt>DLY</dt><dd>Echo send amount</dd>
+                <dt>FDBK</dt><dd>How many times the delay repeats (slap → wash)</dd>
+                <dt>CHO</dt><dd>Shimmer / width</dd>
+                <dt>WOB</dt><dd>LFO auto-filter movement</dd>
+                <dt>CRU</dt><dd>Bit-crusher (lo-fi)</dd>
+                <dt>VRB</dt><dd>Space / room send</dd>
+                <dt>CMP</dt><dd>Compression — evens out dynamics</dd>
               </dl>
             </div>
           </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -14,7 +14,8 @@
         <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span>oyster groovebox</h1>
         <div class="titlebar-tools">
           <select id="themesel">
-            <option value="dark" selected>Dark</option>
+            <option value="oyster" selected>Oyster</option>
+            <option value="midnight">Midnight</option>
             <option value="light">Light</option>
             <option value="beige">Beige</option>
             <option value="playdate">Playdate</option>

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2874,6 +2874,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .sec-drag { display: none; }   /* mouse-only affordance */
   .titlebar { margin-bottom: 8px; }
   h1 { font-size: 13px; letter-spacing: 0.1em; white-space: nowrap; }
+  .brand-oyster { display: none; }   /* "GROOVEBOX" alone — buys room for theme + Settings + Help */
 
   /* ── transport: one row — play + the song slot ── */
   .transport { gap: 8px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1,12 +1,67 @@
 /* ─── design tokens ─────────────────────────────────────────────────────── */
+/* Default theme: OYSTER — the oyster.to "Pearl in Orbit" palette
+   (docs/assets/oyster.css): space-navy cabinet, violet accent, plasma-pink
+   playing glow; the screen is signal-cyan backlit glass. */
 :root {
   /* § 1 — color system */
+  --bg:        #04060d;
+  --panel:     #0a0e1f;
+  --panel-2:   #10152e;
+  --panel-3:   #181f42;
+  --line:      rgba(243,244,255,0.08);
+  --line-dk:   rgba(0,0,0,0.45);
+  --ink:       #f3f4ff;
+  --dim:       #9197bd;
+  --faint:     #5c628a;
+  --acc:       #8b76ff;
+  --acc-dim:   #574a9e;
+  --hot:       #ff8de0;
+  --warn:      #ffd97a;
+  --ink-on-acc: #0c071f;  /* text colour on --acc background; override per theme */
+  --tab-on-ink: var(--acc); /* active-tab text colour; override when --panel-3 is dark */
+  --tab-bg:     var(--panel-3); /* active-tab pill fill; decoupled from hover surface */
+  --meter-lo:  #4ade80;
+  --meter-mid: #ffd97a;
+  --meter-hi:  #f87171;
+
+  /* component tokens — themed per [data-theme].
+     The cabinet wears the brand (violet); the screen wears the SIGNAL (cyan) —
+     a different material, visibly backlit against the near-black cabinet. */
+  --cell:         #0a2538;   /* empty drum cell */
+  --cell-alt:     #0d2e45;   /* bar-alt cell */
+  --hit1:         #67d9ff;   /* groove hit gradient top — lit signal pixel */
+  --hit2:         #1d7fae;   /* groove hit gradient bottom */
+  --roll-bg:      #07202f;   /* piano-roll / bass lane (white key) */
+  --roll-bg-blk:  #051824;   /* piano-roll / bass lane (black key) */
+  /* out-of-scale rows: a dimmer wash of the roll bg. Derived from --roll-bg so
+     it tracks every theme override (themes set --roll-bg on the same element). */
+  --roll-bg-out:  color-mix(in srgb, var(--roll-bg) 78%, var(--bg));
+  --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--acc)); /* chord-tone wash */
+  --roll-note:    #7be7ff;   /* note blocks + bass notes — signal cyan on the screen */
+  --grid-line:    #16455e;   /* roll / scope gridlines */
+  --scope:        #7be7ff;   /* scope trace */
+  --playhead:     #ffffff;   /* roll / scope playhead */
+
+  /* screen / glow — deep signal-cyan glass */
+  --screen-bg:   #041420;
+  --screen-glow: rgba(123,231,255,0.13);
+
+  /* cabinet chrome — kept for screws */
+  --chrome-hi:  #3a3e57;
+  --chrome-mid: #222538;
+  --chrome-lo:  #12141f;
+  --bevel-hi:   rgba(255,255,255,0.06);
+  --bevel-lo:   rgba(0,0,0,0.45);
+}
+
+/* ─── MIDNIGHT — the former Dark theme: graphite cabinet, teal accent,
+   teal-phosphor screen ───────────────────────────────────────────────────── */
+[data-theme="midnight"] {
   --bg:        #0a0b0f;
   --panel:     #13151c;
   --panel-2:   #1a1d26;
   --panel-3:   #232732;
   --line:      rgba(255,255,255,0.07);
-  --line-dk:   rgba(0,0,0,0.45);
   --ink:       #e6e8ee;
   --dim:       #8a90a0;
   --faint:     #5a6072;
@@ -14,41 +69,25 @@
   --acc-dim:   #2e8a74;
   --hot:       #ff5b9e;
   --warn:      #ffd24a;
-  --ink-on-acc: #04201a;  /* text colour on --acc background; override per theme */
-  --tab-on-ink: var(--acc); /* active-tab text colour; override when --panel-3 is dark */
-  --tab-bg:     var(--panel-3); /* active-tab pill fill; decoupled from hover surface */
+  --ink-on-acc: #04201a;
   --meter-lo:  #54f0c8;
   --meter-mid: #ffd24a;
   --meter-hi:  #ff5b6b;
-
-  /* component tokens — themed per [data-theme].
-     Dark's screen is a backlit teal-phosphor display (the cabinet is near-black,
-     so the screen must be a different MATERIAL, not just a darker shade). */
-  --cell:         #0a231d;   /* empty drum cell */
-  --cell-alt:     #0d2b23;   /* bar-alt cell */
-  --hit1:         #2fd6ab;   /* groove hit gradient top — lit phosphor */
-  --hit2:         #117a5f;   /* groove hit gradient bottom */
-  --roll-bg:      #081d17;   /* piano-roll / bass lane (white key) */
-  --roll-bg-blk:  #061710;   /* piano-roll / bass lane (black key) */
-  /* out-of-scale rows: a dimmer wash of the roll bg. Derived from --roll-bg so
-     it tracks every theme override (themes set --roll-bg on the same element). */
-  --roll-bg-out:  color-mix(in srgb, var(--roll-bg) 78%, var(--bg));
-  --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--acc)); /* chord-tone wash */
-  --roll-note:    var(--acc); /* note blocks + bass notes */
-  --grid-line:    #1b4438;   /* roll / scope gridlines */
-  --scope:        #7dffe0;   /* scope trace */
-  --playhead:     #ffffff;   /* roll / scope playhead */
-
-  /* screen / glow — deep teal glass, visibly backlit against the black cabinet */
+  --cell:         #0a231d;
+  --cell-alt:     #0d2b23;
+  --hit1:         #2fd6ab;   /* lit teal phosphor */
+  --hit2:         #117a5f;
+  --roll-bg:      #081d17;
+  --roll-bg-blk:  #061710;
+  --roll-note:    var(--acc);
+  --grid-line:    #1b4438;
+  --scope:        #7dffe0;
+  --playhead:     #ffffff;
   --screen-bg:   #051813;
   --screen-glow: rgba(84,240,200,0.14);
-
-  /* cabinet chrome — kept for screws */
   --chrome-hi:  #3a3e4e;
   --chrome-mid: #22252f;
   --chrome-lo:  #12141a;
-  --bevel-hi:   rgba(255,255,255,0.06);
-  --bevel-lo:   rgba(0,0,0,0.45);
 }
 
 /* ─── reset ─────────────────────────────────────────────────────────────── */
@@ -207,7 +246,7 @@ h1 {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--dim);
-  text-shadow: 0 0 12px rgba(84,240,200,0.3);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--acc) 30%, transparent);
 }
 
 /* ─── § 3 — unified control base ───────────────────────────────────────── */
@@ -576,7 +615,7 @@ input[type=range] {
   color: var(--dim);
   font-weight: 600;
   letter-spacing: 0.04em;
-  text-shadow: 0 0 6px rgba(84,240,200,0.4);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--acc) 40%, transparent);
 }
 
 /* ─── grid rows ──────────────────────────────────────────────────────────── */
@@ -622,7 +661,7 @@ input[type=range] {
 .dvs.soloed {
   color: #04201a; border-color: #2eaa8a;
   background: linear-gradient(180deg, #63f8d4, #3dd6b0);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 0 6px rgba(84,240,200,.5);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 0 6px color-mix(in srgb, var(--acc) 50%, transparent);
 }
 .vrow .vr .dvm, .vrow .vr .dvs { margin: 0; }
 
@@ -655,7 +694,7 @@ input[type=range] {
 
 /* § 6 — downbeat (step 0): even stronger marker */
 .vc.downbeat {
-  box-shadow: inset 2px 0 0 rgba(84,240,200,0.35);
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--acc) 35%, transparent);
 }
 
 /* § 6 — hit cells: subtle vertical gradient + soft teal glow */
@@ -663,7 +702,7 @@ input[type=range] {
   background: linear-gradient(180deg, var(--hit1) 0%, color-mix(in srgb, var(--hit1) 60%, var(--hit2)) 60%, var(--hit2) 100%);
   color: #cfe0ff;
   box-shadow:
-    0 0 6px rgba(84,240,200,0.35),
+    0 0 6px color-mix(in srgb, var(--acc) 35%, transparent),
     inset 0 1px 0 rgba(100,180,255,0.25),
     inset 0 -1px 0 rgba(0,0,0,0.3);
 }
@@ -676,14 +715,14 @@ input[type=range] {
 .vc.now {
   outline: 2px solid var(--acc);
   outline-offset: -2px;
-  box-shadow: 0 0 8px rgba(84,240,200,0.30);
-  background: rgba(84,240,200,0.06);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 30%, transparent);
+  background: color-mix(in srgb, var(--acc) 6%, transparent);
 }
 .vc.hit.now {
   outline: 2px solid var(--acc);
   outline-offset: -2px;
   box-shadow:
-    0 0 10px rgba(84,240,200,0.55),
+    0 0 10px color-mix(in srgb, var(--acc) 55%, transparent),
     0 0 4px rgba(255,255,255,0.25),
     inset 0 1px 0 rgba(100,220,200,0.3);
 }
@@ -962,7 +1001,7 @@ body.gb-knob-values .knob-val { display: block; }
 .solo.soloed {
   color: #04201a; border-color: #2eaa8a;
   background: linear-gradient(180deg, #63f8d4, #3dd6b0);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.3), 0 0 12px rgba(84,240,200,.6), 0 1px 2px rgba(0,0,0,.4);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.3), 0 0 12px color-mix(in srgb, var(--acc) 60%, transparent), 0 1px 2px rgba(0,0,0,.4);
   text-shadow: 0 1px 0 rgba(255,255,255,.2);
 }
 
@@ -1191,7 +1230,7 @@ body.gb-knob-values .knob-val { display: block; }
 .fillchip.next {
   border-color: var(--acc);
   color: var(--acc);
-  box-shadow: 0 0 0 1px rgba(84,240,200,0.25), 0 0 6px rgba(84,240,200,0.2);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--acc) 25%, transparent), 0 0 6px color-mix(in srgb, var(--acc) 20%, transparent);
 }
 
 /* § 8 — clear button: subtle icon button */
@@ -1289,7 +1328,7 @@ body.gb-knob-values .knob-val { display: block; }
 }
 .snap-btn:hover { background: var(--panel-3); border-color: var(--acc-dim); color: var(--ink); }
 .snap-btn.on {
-  background: rgba(84,240,200,0.10);
+  background: color-mix(in srgb, var(--acc) 10%, transparent);
   border-color: var(--acc);
   color: var(--acc);
   box-shadow: inset 0 -2px 0 var(--acc);
@@ -1797,7 +1836,7 @@ body.gb-knob-values .knob-val { display: block; }
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.03),
     0 1px 2px rgba(0,0,0,0.3),
-    0 0 0 1px rgba(84,240,200,0.08);
+    0 0 0 1px color-mix(in srgb, var(--acc) 8%, transparent);
 }
 
 /* ─── § 5 — inline lane rename input ───────────────────────────────────────── */
@@ -1815,7 +1854,7 @@ body.gb-knob-values .knob-val { display: block; }
   height: 22px;
   width: 60px;
   outline: none;
-  box-shadow: 0 0 0 2px rgba(84,240,200,0.15);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--acc) 15%, transparent);
 }
 
 /* ─── § 5 — add-lane button + menu ─────────────────────────────────────────── */
@@ -1914,14 +1953,14 @@ body.gb-knob-values .knob-val { display: block; }
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.03),
     0 1px 2px rgba(0,0,0,0.3),
-    0 -2px 8px rgba(84,240,200,0.25);
+    0 -2px 8px color-mix(in srgb, var(--acc) 25%, transparent);
 }
 .lane.drop-below {
   border-bottom: 2px solid var(--acc);
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.03),
     0 1px 2px rgba(0,0,0,0.3),
-    0 2px 8px rgba(84,240,200,0.25);
+    0 2px 8px color-mix(in srgb, var(--acc) 25%, transparent);
 }
 
 /* ─── Piano ⇄ Blocks roll-mode toggle ──────────────────────────────────────── */
@@ -1961,12 +2000,12 @@ body.gb-knob-values .knob-val { display: block; }
   color: var(--ink);
 }
 .roll-mode-btn.rm-on {
-  background: rgba(84,240,200,0.10);
+  background: color-mix(in srgb, var(--acc) 10%, transparent);
   border-color: var(--acc);
   color: var(--acc);
   box-shadow:
     inset 0 -2px 0 var(--acc),
-    inset 0 1px 0 rgba(84,240,200,0.08);
+    inset 0 1px 0 color-mix(in srgb, var(--acc) 8%, transparent);
 }
 
 /* ─── Blocks grid (pitch × step DOM grid) ───────────────────────────────────── */
@@ -2071,12 +2110,12 @@ body.gb-knob-values .knob-val { display: block; }
 .sec.sec-drop-above {
   outline: 2px solid var(--acc);
   outline-offset: 2px;
-  box-shadow: 0 -3px 10px rgba(84,240,200,0.25);
+  box-shadow: 0 -3px 10px color-mix(in srgb, var(--acc) 25%, transparent);
 }
 .sec.sec-drop-below {
   outline: 2px solid var(--acc);
   outline-offset: 2px;
-  box-shadow: 0 3px 10px rgba(84,240,200,0.25);
+  box-shadow: 0 3px 10px color-mix(in srgb, var(--acc) 25%, transparent);
 }
 
 /* ─── Transport actions group (View + Help) ──────────────────────────────────── */
@@ -2162,12 +2201,12 @@ body.gb-knob-values .knob-val { display: block; }
   color: var(--ink);
 }
 .vs-preset-btn.on {
-  background: rgba(84,240,200,0.10);
+  background: color-mix(in srgb, var(--acc) 10%, transparent);
   border-color: var(--acc);
   color: var(--acc);
   box-shadow:
     inset 0 -2px 0 var(--acc),
-    inset 0 1px 0 rgba(84,240,200,0.08);
+    inset 0 1px 0 color-mix(in srgb, var(--acc) 8%, transparent);
 }
 .vs-group-lbl {
   font-size: 10px;
@@ -2332,7 +2371,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   border-color: var(--acc);
   color: #04201a;
   font-weight: 700;
-  box-shadow: 0 0 8px rgba(84,240,200,0.35);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 35%, transparent);
 }
 .bsel.playing {
   outline: 2px solid var(--hot);
@@ -2356,7 +2395,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   border-color: var(--acc);
   color: #04201a;
   font-weight: 700;
-  box-shadow: 0 0 8px rgba(84,240,200,0.35);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 35%, transparent);
 }
 
 /* accordion expand button: hidden by default; the mobile layout shows it */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -65,6 +65,22 @@
 [data-theme] {
   --screen-ink: var(--ink);
   --screen-dim: var(--dim);
+  /* Legacy dark screen defaults: themes that don't override a screen token
+     used to inherit these from the old dark :root — they must not inherit
+     Oyster's pearl values instead. Explicit theme blocks win (later, equal
+     specificity). */
+  --cell:         #0d1020;
+  --cell-alt:     #111828;
+  --hit1:         #3a5890;
+  --hit2:         #1c2f54;
+  --roll-bg:      #0f121a;
+  --roll-bg-blk:  #0c0e14;
+  --roll-note:    var(--acc);
+  --grid-line:    #2a2e3a;
+  --scope:        #7dffe0;
+  --playhead:     #ffffff;
+  --screen-bg:    #07080d;
+  --screen-glow:  color-mix(in srgb, var(--acc) 6%, transparent);
 }
 
 /* ─── MIDNIGHT — the former Dark theme: graphite cabinet, teal accent,
@@ -2126,6 +2142,7 @@ body.gb-knob-values .knob-val { display: block; }
 
 /* Pale-LCD screens: swap the deep CRT inset for a soft reflective-LCD inset
    (same treatment as playdate) so the screen reads as glass, not a cave. */
+html:not([data-theme]) #viz,
 [data-theme="casiofx"] #viz,
 [data-theme="ti83"] #viz,
 [data-theme="vl1"] #viz,
@@ -2138,11 +2155,13 @@ body.gb-knob-values .knob-val { display: block; }
 }
 /* …and the teal cell glows / title shadow don't belong on pale LCDs
    or light plastic bodies. */
+html:not([data-theme]) .vc.hit,
 [data-theme="casiofx"] .vc.hit,
 [data-theme="ti83"] .vc.hit,
 [data-theme="vl1"] .vc.hit,
 [data-theme="hp12c"] .vc.hit,
 [data-theme="mpc"] .vc.hit { box-shadow: none; }
+html:not([data-theme]) .vc.now,
 [data-theme="casiofx"] .vc.now,
 [data-theme="ti83"] .vc.now,
 [data-theme="vl1"] .vc.now,
@@ -2153,6 +2172,7 @@ body.gb-knob-values .knob-val { display: block; }
 [data-theme="vl1"] .vc.hit.now,
 [data-theme="hp12c"] .vc.hit.now,
 [data-theme="mpc"] .vc.hit.now { box-shadow: none; }
+html:not([data-theme]) .vc.now:not(.hit),
 [data-theme="casiofx"] .vc.now:not(.hit),
 [data-theme="ti83"] .vc.now:not(.hit),
 [data-theme="vl1"] .vc.now:not(.hit),
@@ -2168,6 +2188,13 @@ body.gb-knob-values .knob-val { display: block; }
 [data-theme="hp12c"] h1,
 [data-theme="casiofx"] h1,
 [data-theme="ti83"] h1 { text-shadow: none; }
+
+/* Root-level screen inks for the dark-cabinet + pale-LCD skins: the status
+   strip, screen tabs, Song pane and canvas text read --screen-ink from :root,
+   so they need the same dark-on-pale flip the #viz rebinding gives DOM labels. */
+[data-theme="casiofx"] { --screen-ink: #232a20; --screen-dim: #46503e; }
+[data-theme="ti83"]    { --screen-ink: #1e2424; --screen-dim: #424c46; }
+[data-theme="hp12c"]   { --screen-ink: #22241e; --screen-dim: #45483c; }
 
 /* ─── § 5 — lane actions: dup + remove buttons ────────────────────────────── */
 .lane-actions {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -25,26 +25,32 @@
   --meter-hi:  #f87171;
 
   /* component tokens — themed per [data-theme].
-     The cabinet wears the brand (violet); the screen wears the SIGNAL (cyan) —
-     a different material, visibly backlit against the near-black cabinet. */
-  --cell:         #0a2538;   /* empty drum cell */
-  --cell-alt:     #0d2e45;   /* bar-alt cell */
-  --hit1:         #67d9ff;   /* groove hit gradient top — lit signal pixel */
-  --hit2:         #1d7fae;   /* groove hit gradient bottom */
-  --roll-bg:      #07202f;   /* piano-roll / bass lane (white key) */
-  --roll-bg-blk:  #051824;   /* piano-roll / bass lane (black key) */
+     Oyster's screen is a classic PEARL LCD: pale ice glass with deep-navy
+     pixels (Game Boy idiom, pearlescent colourway) — its own material against
+     the space-navy cabinet. */
+  --cell:         #bcd2de;   /* empty drum cell */
+  --cell-alt:     #b3c9d6;   /* bar-alt cell */
+  --hit1:         #2b4a7e;   /* groove hit gradient top — dark LCD pixel */
+  --hit2:         #18305a;   /* groove hit gradient bottom */
+  --roll-bg:      #c6d9e4;   /* piano-roll / bass lane (white key) */
+  --roll-bg-blk:  #b9cedb;   /* piano-roll / bass lane (black key) */
   /* out-of-scale rows: a dimmer wash of the roll bg. Derived from --roll-bg so
      it tracks every theme override (themes set --roll-bg on the same element). */
   --roll-bg-out:  color-mix(in srgb, var(--roll-bg) 78%, var(--bg));
   --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--acc)); /* chord-tone wash */
-  --roll-note:    #7be7ff;   /* note blocks + bass notes — signal cyan on the screen */
-  --grid-line:    #16455e;   /* roll / scope gridlines */
-  --scope:        #7be7ff;   /* scope trace */
-  --playhead:     #ffffff;   /* roll / scope playhead */
+  --roll-note:    #1d3766;   /* note blocks + bass notes — dark pixels */
+  --grid-line:    #9db5c4;   /* roll / scope gridlines */
+  --scope:        #1d4a7e;   /* scope trace */
+  --playhead:     #122441;   /* roll / scope playhead */
 
-  /* screen / glow — deep signal-cyan glass */
-  --screen-bg:   #041420;
-  --screen-glow: rgba(123,231,255,0.13);
+  /* screen / glow — pearl glass */
+  --screen-bg:   #cfe0ea;
+  --screen-glow: rgba(123,231,255,0.10);
+  /* screen-scoped text ink — the screen's polarity can differ from the
+     cabinet's (Oyster: light cabinet ink, DARK screen ink). Themes whose
+     screen matches their cabinet just alias these to --ink/--dim. */
+  --screen-ink:  #16243f;
+  --screen-dim:  #4d6787;
 
   /* cabinet chrome — kept for screws */
   --chrome-hi:  #3a3e57;
@@ -52,6 +58,13 @@
   --chrome-lo:  #12141f;
   --bevel-hi:   rgba(255,255,255,0.06);
   --bevel-lo:   rgba(0,0,0,0.45);
+}
+
+/* Every named theme's screen shares its cabinet polarity — alias the screen
+   inks back to the cabinet inks. (Only the default Oyster theme splits them.) */
+[data-theme] {
+  --screen-ink: var(--ink);
+  --screen-dim: var(--dim);
 }
 
 /* ─── MIDNIGHT — the former Dark theme: graphite cabinet, teal accent,
@@ -359,7 +372,7 @@ select {
   padding: 0;
   background: transparent;
   border: none;
-  border-bottom: 1px solid color-mix(in srgb, var(--dim) 30%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent);
   box-shadow: none;
 }
 .vtabs button {
@@ -369,7 +382,7 @@ select {
   border-radius: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
-  color: var(--dim);
+  color: var(--screen-dim);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -379,7 +392,7 @@ select {
 }
 .vtabs button:hover {
   background: color-mix(in srgb, var(--acc) 8%, transparent);
-  color: var(--ink);
+  color: var(--screen-ink);
   border-color: transparent;
 }
 .vtabs button.on {
@@ -470,8 +483,8 @@ input[type=range] {
   padding: 6px 10px;
   /* mix from --ink so the band reads on BOTH screen polarities: light ink on a
      dark screen lifts it, dark ink on a lime screen shades it */
-  background: color-mix(in srgb, var(--ink) 8%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--ink) 22%, transparent);
+  background: color-mix(in srgb, var(--screen-ink) 8%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--screen-ink) 22%, transparent);
   min-height: 28px;
 }
 #lcd-strip:empty { display: none; }
@@ -479,13 +492,13 @@ input[type=range] {
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: var(--ink);
+  color: var(--screen-ink);
   white-space: nowrap;
 }
 .strip-credit {
   font-size: 9px;
   font-style: italic;
-  color: var(--faint);
+  color: var(--screen-dim);
   white-space: nowrap;
 }
 .strip-chain, .strip-chords {
@@ -498,8 +511,8 @@ input[type=range] {
   min-width: 16px;
   padding: 1px 5px;
   border-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ink) 40%, transparent);
-  color: color-mix(in srgb, var(--ink) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 40%, transparent);
+  color: color-mix(in srgb, var(--screen-ink) 80%, transparent);
   font-size: 9px;
   font-family: ui-monospace, Menlo, monospace;
   text-align: center;
@@ -516,7 +529,7 @@ input[type=range] {
 .strip-key, .strip-bpm {
   font-size: 9px;
   letter-spacing: 0.08em;
-  color: var(--dim);
+  color: var(--screen-dim);
   font-family: ui-monospace, Menlo, monospace;
   white-space: nowrap;
 }
@@ -530,10 +543,12 @@ input[type=range] {
 #lcd-song .chain-chip,
 #lcd-song .h-chip {
   background: transparent;
-  border-color: color-mix(in srgb, var(--dim) 45%, transparent);
-  color: var(--dim);
+  border-color: color-mix(in srgb, var(--screen-ink) 40%, transparent);
+  color: color-mix(in srgb, var(--screen-ink) 80%, transparent);
   box-shadow: none;
 }
+#lcd-song .pat-lbl { color: var(--screen-dim); }
+#lcd-song .h-chip.h-empty { color: var(--screen-dim); }
 #lcd-song .pat-slot.sel {
   background: var(--acc);
   border-color: var(--acc);
@@ -558,7 +573,7 @@ input[type=range] {
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--dim);
+  color: var(--screen-dim);
 }
 .lcd-song-foot #share-btn { margin-left: auto; }
 
@@ -612,7 +627,7 @@ input[type=range] {
   pointer-events: none;
 }
 .vhcell.beat {
-  color: var(--dim);
+  color: var(--screen-dim);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-shadow: 0 0 6px color-mix(in srgb, var(--acc) 40%, transparent);
@@ -628,7 +643,7 @@ input[type=range] {
 .vrow .vl {
   width: 46px;
   font-size: 10px;
-  color: var(--dim);
+  color: var(--screen-dim);
   text-align: right;
   padding-right: 4px;
   flex: 0 0 46px;
@@ -1358,7 +1373,7 @@ body.gb-knob-values .knob-val { display: block; }
 }
 
 /* ─── PATTERNS module (Song tab rows) ─── */
-.ed-lbl { font-size: 10px; color: var(--dim); letter-spacing: .1em; text-transform: uppercase; margin: 2px 0 4px; }
+.ed-lbl { font-size: 10px; color: var(--screen-dim); letter-spacing: .1em; text-transform: uppercase; margin: 2px 0 4px; }
 .pat-row, .chain-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 6px 0; transition: opacity .2s; }
 .pat-row.dimmed, .chain-row.dimmed { opacity: .45; }
 .pat-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--dim); margin-right: 4px; }
@@ -1975,7 +1990,7 @@ body.gb-knob-values .knob-val { display: block; }
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--faint);
+  color: var(--screen-dim);
   padding-right: 4px;
   user-select: none;
 }
@@ -2061,8 +2076,8 @@ body.gb-knob-values .knob-val { display: block; }
   pointer-events: none;
 }
 /* Show label only on C rows (non-empty lbl text) */
-.bg-lbl:not(:empty) { color: var(--faint); }
-.bg-blk .bg-lbl:not(:empty) { color: var(--dim); }
+.bg-lbl:not(:empty) { color: var(--screen-dim); }
+.bg-blk .bg-lbl:not(:empty) { color: var(--screen-ink); }
 
 /* Step cells — compact height for pitch-density */
 .bg-grid .vc {
@@ -2355,7 +2370,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   font-size: 11px;
   color: var(--dim);
 }
-.barsel-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--dim); margin-right: 4px; }
+.barsel-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--screen-dim); margin-right: 4px; }
 .bsel {
   height: 26px;
   padding: 0 11px;
@@ -2379,7 +2394,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   box-shadow: 0 0 8px rgba(255,91,158,0.3);
 }
 .glen { display: inline-flex; align-items: center; gap: 4px; margin-left: auto; }
-.glen-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--dim); margin-right: 2px; }
+.glen-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--screen-dim); margin-right: 2px; }
 .glen-btn {
   height: 26px;
   padding: 0 11px;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -2746,6 +2746,35 @@ html:not([data-theme]) .vc.now:not(.hit),
   background: var(--panel-3);
   color: var(--ink);
 }
+
+/* Mobile: help is a bottom sheet — card slides up from the bottom edge. */
+@media (max-width: 900px) {
+  #help-modal { align-items: flex-end; }
+  #help-modal-box {
+    width: 100vw;
+    max-width: none;
+    max-height: 80vh;
+    border-radius: 16px 16px 0 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    padding: 14px 20px calc(24px + env(safe-area-inset-bottom));
+    animation: gbm-sheet-up 0.22s cubic-bezier(0.2, 0.8, 0.3, 1);
+  }
+  /* grabber bar — the bottom-sheet idiom */
+  #help-modal-box::before {
+    content: '';
+    display: block;
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--line);
+    margin: 0 auto 14px;
+  }
+}
+@keyframes gbm-sheet-up {
+  from { transform: translateY(40px); opacity: 0.4; }
+}
 .help-sections {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1008,8 +1008,8 @@ body.gb-knob-values .knob-val { display: block; }
 
 /* bigger touch targets on touch devices */
 @media (pointer: coarse) {
-  .knob-dial { width: 42px; height: 42px; }
-  .knob-ind  { top: 4px; height: 15px; transform-origin: 50% 17px; }
+  .knob-dial { width: 36px; height: 36px; }
+  .knob-ind  { top: 3px; height: 13px; transform-origin: 50% 15px; }
 
   /* It's an instrument, not a document: press-and-hold must not start text
      selection (Android Chrome's "more actions / translate" toolbar) or the

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -367,16 +367,6 @@ select {
 }
 
 /* ─── § 3 — segmented tab control ──────────────────────────────────────── */
-/* song credit — inline subtitle below the song selector */
-#credit {
-  font-size: 10px;
-  color: var(--faint);
-  min-height: 12px;
-  letter-spacing: 0.02em;
-  font-style: italic;
-  line-height: 1.2;
-}
-#credit:not(:empty)::before { content: '♪ '; font-style: normal; opacity: 0.7; }
 
 /* ─── screen tabs — software modes ON the LCD, styled as screen furniture
    (no cabinet-button chrome: flat, ink-on-screen, active = lit underline) ── */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -308,60 +308,47 @@ select {
 }
 #credit:not(:empty)::before { content: '♪ '; font-style: normal; opacity: 0.7; }
 
+/* ─── screen tabs — software modes ON the LCD, styled as screen furniture
+   (no cabinet-button chrome: flat, ink-on-screen, active = lit underline) ── */
 .vtabs {
   display: flex;
-  gap: 6px;
-  align-items: center;
-  margin-bottom: 12px;
+  gap: 2px;
+  align-items: stretch;
+  margin: 0 0 8px;
   padding: 0;
   background: transparent;
   border: none;
+  border-bottom: 1px solid color-mix(in srgb, var(--dim) 30%, transparent);
   box-shadow: none;
 }
-/* "VIEW" label to the left of the Scope toggle */
-.vtabs-lbl {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--faint);
-  padding-right: 2px;
-  user-select: none;
-}
-/* Scope is now a standalone toggle button, not a full-width pill strip */
 .vtabs button {
   flex: 0 0 auto;
-  height: 28px;
-  border-radius: 6px;
-  border: 1px solid var(--line);
-  background: var(--panel-2);
+  height: 26px;
+  border: none;
+  border-radius: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
   color: var(--dim);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
-  box-shadow:
-    inset 0 1px 0 rgba(255,255,255,0.04),
-    inset 0 -1px 0 rgba(0,0,0,0.25),
-    0 1px 3px rgba(0,0,0,0.35);
-  padding: 0 14px;
-  transition: background 0.12s, color 0.12s, border-color 0.12s, box-shadow 0.12s;
+  box-shadow: none;
+  padding: 0 12px;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .vtabs button:hover {
-  background: var(--panel-3);
-  border-color: var(--acc-dim);
+  background: color-mix(in srgb, var(--acc) 8%, transparent);
   color: var(--ink);
+  border-color: transparent;
 }
 .vtabs button.on {
-  background: rgba(84,240,200,0.10);
-  border-color: var(--acc);
+  background: color-mix(in srgb, var(--acc) 10%, transparent);
+  border-bottom-color: var(--acc);
   color: var(--acc);
-  box-shadow:
-    inset 0 -2px 0 var(--acc),
-    inset 0 1px 0 rgba(84,240,200,0.08);
 }
 .vtabs button:focus-visible {
   outline: 2px solid var(--acc);
-  outline-offset: 1px;
+  outline-offset: -2px;
 }
 .vtab-lane { font-size: 11px; text-transform: capitalize; }
 
@@ -375,21 +362,8 @@ input[type=range] {
 /* ─── § 8 — transport bar ───────────────────────────────────────────────── */
 .transport {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
-  margin-bottom: 16px;
-}
-.transport-tempo {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.transport-bpm-val {
-  font-size: 13px;
-  font-family: ui-monospace, Menlo, monospace;
-  color: var(--ink);
-  min-width: 3ch;
-  text-align: right;
 }
 .transport-song {
   display: flex;
@@ -420,13 +394,9 @@ input[type=range] {
   margin-bottom: 12px;
 }
 
-/* SONG box — one pinned module wrapping the transport + arrangement. The
-   transport and #arrange inside it are not separate cards; they share the box. */
+/* Transport box — the cabinet top: play + the song slot, nothing else. */
 #songbox {
   padding: 12px 16px;
-}
-#songbox .transport {
-  margin-bottom: 12px;
 }
 
 /* ─── CRT screen / viz area ──────────────────────────────────────────────── */
@@ -448,6 +418,106 @@ input[type=range] {
   outline: 1px solid rgba(0,0,0,0.30);
   outline-offset: -2px;
 }
+
+/* ─── LCD status strip — the screen's read-only narrator ─────────────────── */
+#lcd-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: -10px -10px 8px;            /* bleed to the screen edges (#viz pads 10px) */
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--dim) 8%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--dim) 25%, transparent);
+  min-height: 28px;
+}
+#lcd-strip:empty { display: none; }
+.strip-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.strip-credit {
+  font-size: 9px;
+  font-style: italic;
+  color: var(--faint);
+  white-space: nowrap;
+}
+.strip-chain, .strip-chords {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+.strip-chain { margin-left: 4px; }
+.strip-seg {
+  min-width: 16px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--dim) 45%, transparent);
+  color: var(--dim);
+  font-size: 9px;
+  font-family: ui-monospace, Menlo, monospace;
+  text-align: center;
+  line-height: 1.5;
+}
+/* The sounding position/chord — same --hot language as every other "playing" glow. */
+.strip-seg.hot {
+  background: var(--hot);
+  border-color: var(--hot);
+  color: var(--screen-bg);
+  font-weight: 700;
+  box-shadow: 0 0 6px var(--hot);
+}
+.strip-key, .strip-bpm {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--faint);
+  font-family: ui-monospace, Menlo, monospace;
+  white-space: nowrap;
+}
+.strip-bpm { margin-left: auto; }
+
+/* ─── SONG tab pane — song structure in screen-language (flat segs, not
+   cabinet buttons) ───────────────────────────────────────────────────────── */
+#lcd-song { padding: 2px 2px 6px; }
+#lcd-song .pat-slot,
+#lcd-song .pat-act,
+#lcd-song .chain-chip,
+#lcd-song .h-chip {
+  background: transparent;
+  border-color: color-mix(in srgb, var(--dim) 45%, transparent);
+  color: var(--dim);
+  box-shadow: none;
+}
+#lcd-song .pat-slot.sel {
+  background: var(--acc);
+  border-color: var(--acc);
+  color: var(--screen-bg);
+}
+#lcd-song .pat-slot.playing { border-color: var(--hot); box-shadow: 0 0 8px var(--hot); }
+#lcd-song .chain-chip.playing { border-color: var(--hot); color: var(--hot); box-shadow: 0 0 6px var(--hot); }
+#lcd-song .h-chip.sounding { border-color: var(--hot); color: var(--hot); box-shadow: 0 0 8px var(--hot); }
+/* Chords nest under their pattern: indent + accent spine = "this pattern's chords". */
+#lcd-song .chord-row {
+  margin-left: 30px;
+  padding-left: 10px;
+  border-left: 2px solid color-mix(in srgb, var(--acc) 40%, transparent);
+}
+.lcd-song-foot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+#lcd-song-key {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+.lcd-song-foot #share-btn { margin-left: auto; }
 
 /* ─── lane strips panel ──────────────────────────────────────────────────── */
 #strips {
@@ -977,12 +1047,16 @@ body.gb-knob-values .knob-val { display: block; }
   vertical-align: -3px;
   filter: drop-shadow(0 0 6px color-mix(in srgb, var(--acc) 40%, transparent));
 }
-.theme-icon {
-  display: inline-flex; align-items: center;
-  color: var(--faint);
-  margin-right: 5px;
-  vertical-align: middle;
+/* Theme row — first row of the Settings popover */
+.vs-theme {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--line);
 }
+.vs-theme select { flex: 1 1 auto; height: 26px; font-size: 11px; }
 
 /* ─── punch preset editor (v3.5 modal) ──────────────────────────────────── */
 .punchpad .punchedit { margin-left: 8px; opacity: 0.5; font-size: 11px; cursor: pointer; }
@@ -1186,9 +1260,6 @@ body.gb-knob-values .knob-val { display: block; }
   color: var(--hot);
   box-shadow: 0 0 8px var(--hot);
 }
-/* Key badge — reuse .pat-lbl look. */
-.h-key { margin-left: auto; }
-.h-pat { font-size: 10px; color: var(--hot); opacity: .8; min-width: 22px; }
 /* Inline edit input. */
 .h-edit {
   flex: 1 1 auto;
@@ -1253,25 +1324,7 @@ body.gb-knob-values .knob-val { display: block; }
   text-transform: uppercase;
 }
 
-/* ─── PATTERNS module ─── */
-/* Consolidated song status: lives in the transport row (#song-status), playing
-   state (pink) then a hairline separator then editing state (green). */
-#song-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-.pat-playing { font-size: 11px; color: var(--hot); opacity: .9; }
-.pat-editing { font-size: 11px; color: var(--acc); opacity: .9; }
-.pat-playing:not(:empty) + .pat-editing:not(:empty)::before {
-  content: '│';
-  color: var(--line);
-  margin-right: 8px;
-}
+/* ─── PATTERNS module (Song tab rows) ─── */
 .ed-lbl { font-size: 10px; color: var(--dim); letter-spacing: .1em; text-transform: uppercase; margin: 2px 0 4px; }
 .pat-row, .chain-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 6px 0; transition: opacity .2s; }
 .pat-row.dimmed, .chain-row.dimmed { opacity: .45; }
@@ -1289,50 +1342,8 @@ body.gb-knob-values .knob-val { display: block; }
 .chain-add { opacity: .6; }
 .pat-slot:disabled, .pat-act:disabled, .chain-chip:disabled { opacity: .35; cursor: default; }
 
-/* ─── transport key group ────────────────────────────────────────────────── */
-.transport-key {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-/* KEY quantize toggle */
-.key-q {
-  width: auto;
-  padding: 0 7px;
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  color: var(--dim);
-  border-color: var(--line);
-}
-.key-q.on {
-  background: rgba(84,240,200,0.12);
-  border-color: var(--acc);
-  color: var(--acc);
-  box-shadow:
-    inset 0 -1px 0 var(--acc),
-    inset 0 1px 0 rgba(84,240,200,0.06);
-}
-
-/* ─── transport: shared label style (muted) ──────────────────────────────── */
-.transport-lbl {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--faint);
-}
-
-/* ─── transport: vertical dividers between chunks ───────────────────────── */
-.transport-divider {
-  width: 1px;
-  align-self: stretch;
-  background: var(--line);
-  margin: 0 4px;
-  flex-shrink: 0;
-}
-
-/* ─── key stepper: tight unit wrapping − value + ───────────────────────── */
+/* ─── key stepper (TRANSPOSE, on MASTER): tight unit wrapping − value + ── */
+.kgroup-knobs .key-stepper { align-self: center; }
 .key-stepper {
   display: inline-flex;
   align-items: center;
@@ -1360,7 +1371,7 @@ body.gb-knob-values .knob-val { display: block; }
 }
 .key-stepper button:hover { background: var(--panel-2); border-color: transparent; }
 .key-stepper button:active { background: var(--acc-dim); }
-.key-stepper #keyv {
+.key-stepper span {
   font-size: 12px;
   font-family: ui-monospace, Menlo, monospace;
   color: var(--ink);
@@ -1632,8 +1643,7 @@ body.gb-knob-values .knob-val { display: block; }
 [data-theme="gameboy"] .lane .name,
 [data-theme="gameboy"] .kgroup-lbl,
 [data-theme="gameboy"] .fillsrow .flbl,
-[data-theme="gameboy"] .masterfx .mlbl,
-[data-theme="gameboy"] .transport-lbl {
+[data-theme="gameboy"] .masterfx .mlbl {
   color: #2a2a78;
   font-weight: 800;
 }
@@ -2380,34 +2390,17 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .titlebar { margin-bottom: 8px; }
   h1 { font-size: 13px; letter-spacing: 0.1em; white-space: nowrap; }
 
-  /* ── transport: explicit grid — play+key / tempo / song, no orphan rows ── */
-  .transport {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    grid-template-areas:
-      "play   key"
-      "tempo  tempo"
-      "status status"
-      "song   song";
-    row-gap: 10px;
-    column-gap: 10px;
-  }
-  .transport-divider { display: none; }
-  #play { grid-area: play; height: 38px; font-size: 14px; }
-  .transport-key { grid-area: key; display: flex; align-items: center; gap: 8px; }
-  .transport-tempo { grid-area: tempo; min-width: 0; }
-  #bpm { flex: 1; min-width: 50px; }
-  #song-status { grid-area: status; min-width: 0; }
-  .transport-song { grid-area: song; margin-left: 0; min-width: 0; }
+  /* ── transport: one row — play + the song slot ── */
+  .transport { gap: 8px; }
+  #play { flex: 0 0 auto; height: 38px; font-size: 14px; padding: 0 18px; }
+  .transport-song { flex: 1 1 auto; margin-left: 0; min-width: 0; }
   .transport-song .song-wrap { flex: 1; min-width: 0; }
   .transport-song select { width: 100%; }
-  /* drop labels that repeat what the control already says ("120 BPM" labels
-     the slider, "♪ Kids" labels the dropdown, tabs label themselves); KEY
-     stays — a bare stepper is ambiguous */
-  .transport-tempo .transport-lbl,
-  .transport-song .transport-lbl,
-  .vtabs-lbl { display: none; }
-  .vtabs { margin-bottom: 8px; }
+
+  /* ── LCD strip: narrow → title, walking chain, the sounding chord, bpm ── */
+  #lcd-strip { gap: 6px; }
+  .strip-credit, .strip-key { display: none; }
+  #lcd-strip .strip-chords .strip-seg:not(.hot) { display: none; }
 
   /* ── lane accordion: header / select+expand / knobs (when open) ── */
   .lane {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -534,6 +534,14 @@ input[type=range] {
   text-align: center;
   line-height: 1.5;
 }
+/* The pattern the editors are pointed at — editing language (accent), and the
+   strip itself is tappable (→ Song tab). */
+#lcd-strip { cursor: pointer; }
+.strip-seg.strip-edit {
+  border-color: var(--acc);
+  color: var(--acc);
+  white-space: nowrap;
+}
 /* The sounding position/chord — same --hot language as every other "playing" glow. */
 .strip-seg.hot {
   background: var(--hot);
@@ -573,25 +581,30 @@ input[type=range] {
 #lcd-song .pat-slot.playing { border-color: var(--hot); box-shadow: 0 0 8px var(--hot); }
 #lcd-song .chain-chip.playing { border-color: var(--hot); color: var(--hot); box-shadow: 0 0 6px var(--hot); }
 #lcd-song .h-chip.sounding { border-color: var(--hot); color: var(--hot); box-shadow: 0 0 8px var(--hot); }
+/* Shared label spine: PATTERNS / CHAIN labels right-align in one column so the
+   chip rows read as a table. */
+#lcd-song .pat-row > .pat-lbl,
+#lcd-song .chain-row > .pat-lbl {
+  flex: 0 0 64px;
+  width: 64px;
+  text-align: right;
+  margin-right: 4px;
+}
 /* Chords nest under their pattern: indent + accent spine = "this pattern's chords". */
 #lcd-song .chord-row {
-  margin-left: 30px;
+  margin-left: 68px;
   padding-left: 10px;
   border-left: 2px solid color-mix(in srgb, var(--acc) 40%, transparent);
 }
-.lcd-song-foot {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 10px;
-}
-#lcd-song-key {
+/* The song's key, riding the chords row. */
+#lcd-song .h-key {
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--screen-dim);
+  margin-left: 10px;
+  white-space: nowrap;
 }
-.lcd-song-foot #share-btn { margin-left: auto; }
 
 /* Screen row — first row of the Settings popover */
 .vs-screen {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -593,6 +593,17 @@ input[type=range] {
 }
 .lcd-song-foot #share-btn { margin-left: auto; }
 
+/* Screen row — first row of the Settings popover */
+.vs-screen {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
+.vs-screen select { flex: 1 1 auto; height: 26px; font-size: 11px; }
+
 /* ─── lane strips panel ──────────────────────────────────────────────────── */
 #strips {
   display: flex;
@@ -3066,3 +3077,70 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 }
 #share-mine-list a { color: var(--ink); text-decoration: none; }
 #share-mine-list a:hover { text-decoration: underline; }
+
+/* ─── SCREEN PICKER — swap the theme's glass for a chosen LCD ──────────────
+   Settings → Screen. Each bundle is the full screen token set + a #viz ink
+   rebinding, so any glass works on any cabinet. Placed last so it outranks
+   theme blocks and theme #viz rules at equal specificity. */
+[data-screen="pearl"] {
+  --screen-bg: #cfe0ea; --screen-glow: rgba(123,231,255,0.10);
+  --screen-ink: #16243f; --screen-dim: #4d6787;
+  --cell: #bcd2de; --cell-alt: #b3c9d6; --hit1: #2b4a7e; --hit2: #18305a;
+  --roll-bg: #c6d9e4; --roll-bg-blk: #b9cedb; --roll-note: #1d3766;
+  --grid-line: #9db5c4; --scope: #1d4a7e; --playhead: #122441;
+}
+[data-screen="phosphor"] {
+  --screen-bg: #051813; --screen-glow: rgba(84,240,200,0.14);
+  --screen-ink: #d9efe8; --screen-dim: #79a597;
+  --cell: #0a231d; --cell-alt: #0d2b23; --hit1: #2fd6ab; --hit2: #117a5f;
+  --roll-bg: #081d17; --roll-bg-blk: #061710; --roll-note: #54f0c8;
+  --grid-line: #1b4438; --scope: #7dffe0; --playhead: #ffffff;
+}
+[data-screen="lime"] {
+  --screen-bg: #9bbc0f; --screen-glow: rgba(155,188,15,0.12);
+  --screen-ink: #0f380f; --screen-dim: #306230;
+  --cell: #8bac0f; --cell-alt: #93b412; --hit1: #306230; --hit2: #0f380f;
+  --roll-bg: #8bac0f; --roll-bg-blk: #7e9d0d; --roll-note: #0f380f;
+  --grid-line: #6f8f0d; --scope: #0f380f; --playhead: #0f380f;
+}
+[data-screen="amber"] {
+  --screen-bg: #050300; --screen-glow: rgba(255,176,0,0.08);
+  --screen-ink: #ffcf7a; --screen-dim: #b87f20;
+  --cell: #140d02; --cell-alt: #1e1506; --hit1: #b87f20; --hit2: #7a5410;
+  --roll-bg: #140d02; --roll-bg-blk: #0d0800; --roll-note: #ffd24a;
+  --grid-line: #3a2c0e; --scope: #ffd24a; --playhead: #ffcf7a;
+}
+[data-screen="paper"] {
+  --screen-bg: #b6b8ac; --screen-glow: rgba(0,0,0,0.05);
+  --screen-ink: #1a1a12; --screen-dim: #50503f;
+  --cell: #b6b8ac; --cell-alt: #bec0b4; --hit1: #3a3a2e; --hit2: #1a1a12;
+  --roll-bg: #bcbeb2; --roll-bg-blk: #b0b2a6; --roll-note: #1a1a12;
+  --grid-line: #989a8c; --scope: #2a2a1e; --playhead: #6a2ce0;
+}
+/* In-screen DOM ink rebinding per glass (matches the theme #viz treatment). */
+[data-screen="pearl"] #viz    { --ink: #16243f; --dim: #4d6787; --faint: #6d83a0; }
+[data-screen="lime"] #viz     { --ink: #0f380f; --dim: #306230; --faint: #4a7a3a; }
+[data-screen="paper"] #viz    { --ink: #1a1a12; --dim: #50503f; --faint: #6e6e5c; }
+[data-screen="phosphor"] #viz { --ink: #d9efe8; --dim: #79a597; --faint: #587e72; }
+[data-screen="amber"] #viz    { --ink: #ffcf7a; --dim: #b87f20; --faint: #8a5f16; }
+/* Pale glass gets the reflective-LCD inset; dark glass gets the CRT cave. */
+[data-screen="pearl"] #viz,
+[data-screen="lime"] #viz,
+[data-screen="paper"] #viz {
+  box-shadow:
+    inset 0 0 0 1px rgba(0,0,0,0.15),
+    inset 0 2px 8px rgba(0,0,0,0.18),
+    0 0 0 1px rgba(0,0,0,0.3);
+}
+[data-screen="pearl"] .vc.hit,
+[data-screen="lime"] .vc.hit,
+[data-screen="paper"] .vc.hit { box-shadow: none; }
+[data-screen="phosphor"] #viz,
+[data-screen="amber"] #viz {
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.06),
+    inset 0 2px 14px rgba(0,0,0,0.85),
+    inset 0 0 40px rgba(0,0,0,0.5),
+    0 0 0 1px var(--line),
+    0 0 24px var(--screen-glow);
+}

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1390,6 +1390,12 @@ body.gb-knob-values .knob-val { display: block; }
   align-items: center;
   gap: 14px;
 }
+/* tempo + transpose — header-line controls, not part of the FX knobrow */
+.master-song-ctls {
+  display: flex;
+  gap: 14px;
+  align-items: flex-end;
+}
 /* § 2 — section header */
 .masterfx .mlbl {
   font-size: 10px;
@@ -2775,37 +2781,63 @@ html:not([data-theme]) .vc.now:not(.hit),
 @keyframes gbm-sheet-up {
   from { transform: translateY(40px); opacity: 0.4; }
 }
-.help-sections {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 20px 28px;
+/* Section tabs — one topic on screen at a time (Controls / Mix / Tone / FX). */
+#help-tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin: 0 0 16px;
 }
-.help-section h3 {
-  font-size: 9px;
+.help-tab {
+  height: 26px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--dim);
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--faint);
-  margin: 0 0 8px;
+  letter-spacing: 0.04em;
+  box-shadow: none;
 }
+.help-tab:hover { background: var(--panel-3); color: var(--ink); border-color: var(--acc-dim); }
+.help-tab.active {
+  background: color-mix(in srgb, var(--acc) 10%, transparent);
+  border-color: var(--acc);
+  color: var(--acc);
+}
+.help-section { display: none; }
+.help-section.active { display: block; }
 .help-section dl {
   margin: 0;
   display: grid;
   grid-template-columns: auto 1fr;
-  column-gap: 10px;
-  row-gap: 4px;
-  align-items: baseline;
+  column-gap: 14px;
+  row-gap: 10px;
+  align-items: start;
 }
+/* Terms as keycaps — they ARE the buttons/knobs they describe. */
 .help-section dt {
-  font-size: 11px;
-  font-weight: 700;
+  justify-self: start;
+  font: 700 10px ui-monospace, Menlo, monospace;
+  letter-spacing: 0.05em;
   color: var(--ink);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 4px 8px;
   white-space: nowrap;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.05),
+    inset 0 -1px 0 rgba(0,0,0,0.25),
+    0 1px 2px rgba(0,0,0,0.25);
 }
 .help-section dd {
-  font-size: 11px;
+  font-size: 12px;
+  line-height: 1.5;
   color: var(--dim);
   margin: 0;
+  padding-top: 3px;
 }
 
 /* ─── Global hide-knob rules ─────────────────────────────────────────────────── */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -427,8 +427,10 @@ input[type=range] {
   flex-wrap: wrap;
   margin: -10px -10px 8px;            /* bleed to the screen edges (#viz pads 10px) */
   padding: 6px 10px;
-  background: color-mix(in srgb, var(--dim) 8%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--dim) 25%, transparent);
+  /* mix from --ink so the band reads on BOTH screen polarities: light ink on a
+     dark screen lifts it, dark ink on a lime screen shades it */
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 22%, transparent);
   min-height: 28px;
 }
 #lcd-strip:empty { display: none; }
@@ -455,8 +457,8 @@ input[type=range] {
   min-width: 16px;
   padding: 1px 5px;
   border-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--dim) 45%, transparent);
-  color: var(--dim);
+  border: 1px solid color-mix(in srgb, var(--ink) 40%, transparent);
+  color: color-mix(in srgb, var(--ink) 80%, transparent);
   font-size: 9px;
   font-family: ui-monospace, Menlo, monospace;
   text-align: center;
@@ -473,7 +475,7 @@ input[type=range] {
 .strip-key, .strip-bpm {
   font-size: 9px;
   letter-spacing: 0.08em;
-  color: var(--faint);
+  color: var(--dim);
   font-family: ui-monospace, Menlo, monospace;
   white-space: nowrap;
 }
@@ -1047,16 +1049,6 @@ body.gb-knob-values .knob-val { display: block; }
   vertical-align: -3px;
   filter: drop-shadow(0 0 6px color-mix(in srgb, var(--acc) 40%, transparent));
 }
-/* Theme row — first row of the Settings popover */
-.vs-theme {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-bottom: 8px;
-  margin-bottom: 8px;
-  border-bottom: 1px solid var(--line);
-}
-.vs-theme select { flex: 1 1 auto; height: 26px; font-size: 11px; }
 
 /* ─── punch preset editor (v3.5 modal) ──────────────────────────────────── */
 .punchpad .punchedit { margin-left: 8px; opacity: 0.5; font-size: 11px; cursor: pointer; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -21,25 +21,27 @@
   --meter-mid: #ffd24a;
   --meter-hi:  #ff5b6b;
 
-  /* component tokens — themed per [data-theme] */
-  --cell:         #0d1020;   /* empty drum cell */
-  --cell-alt:     #111828;   /* bar-alt cell */
-  --hit1:         #3a5890;   /* groove hit gradient top */
-  --hit2:         #1c2f54;   /* groove hit gradient bottom */
-  --roll-bg:      #0f121a;   /* piano-roll / bass lane (white key) */
-  --roll-bg-blk:  #0c0e14;   /* piano-roll / bass lane (black key) */
+  /* component tokens — themed per [data-theme].
+     Dark's screen is a backlit teal-phosphor display (the cabinet is near-black,
+     so the screen must be a different MATERIAL, not just a darker shade). */
+  --cell:         #0a231d;   /* empty drum cell */
+  --cell-alt:     #0d2b23;   /* bar-alt cell */
+  --hit1:         #2fd6ab;   /* groove hit gradient top — lit phosphor */
+  --hit2:         #117a5f;   /* groove hit gradient bottom */
+  --roll-bg:      #081d17;   /* piano-roll / bass lane (white key) */
+  --roll-bg-blk:  #061710;   /* piano-roll / bass lane (black key) */
   /* out-of-scale rows: a dimmer wash of the roll bg. Derived from --roll-bg so
      it tracks every theme override (themes set --roll-bg on the same element). */
   --roll-bg-out:  color-mix(in srgb, var(--roll-bg) 78%, var(--bg));
   --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--acc)); /* chord-tone wash */
   --roll-note:    var(--acc); /* note blocks + bass notes */
-  --grid-line:    #2a2e3a;   /* roll / scope gridlines */
+  --grid-line:    #1b4438;   /* roll / scope gridlines */
   --scope:        #7dffe0;   /* scope trace */
   --playhead:     #ffffff;   /* roll / scope playhead */
 
-  /* screen / glow */
-  --screen-bg:   #07080d;
-  --screen-glow: rgba(84,240,200,0.06);
+  /* screen / glow — deep teal glass, visibly backlit against the black cabinet */
+  --screen-bg:   #051813;
+  --screen-glow: rgba(84,240,200,0.14);
 
   /* cabinet chrome — kept for screws */
   --chrome-hi:  #3a3e4e;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -339,6 +339,33 @@ select {
     0 0 12px color-mix(in srgb, var(--acc) 50%, transparent),
     0 2px 6px rgba(0,0,0,0.45);
 }
+/* PUBLISH — the other big CTA on the cabinet: play it (accent), share it (hot).
+   Same hardware-button formula as #play, in the sounding colour. */
+#share-btn {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--hot) 82%, #fff) 0%,
+    var(--hot) 55%,
+    color-mix(in srgb, var(--hot) 80%, #000) 100%);
+  color: #fff;
+  border-color: color-mix(in srgb, var(--hot) 70%, #000);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-shadow: 0 1px 0 rgba(0,0,0,0.25);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.35),
+    inset 0 -2px 0 rgba(0,0,0,0.25),
+    0 0 12px color-mix(in srgb, var(--hot) 50%, transparent),
+    0 2px 6px rgba(0,0,0,0.45);
+}
+#share-btn:hover {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--hot) 70%, #fff) 0%,
+    color-mix(in srgb, var(--hot) 90%, #fff) 55%,
+    var(--hot) 100%);
+  border-color: var(--hot);
+  color: #fff;
+}
+
 #play:hover {
   background: linear-gradient(180deg,
     color-mix(in srgb, var(--acc) 90%, #fff) 0%,

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1390,11 +1390,16 @@ body.gb-knob-values .knob-val { display: block; }
   align-items: center;
   gap: 14px;
 }
-/* tempo + transpose — header-line controls, not part of the FX knobrow */
+/* tempo + transpose — header-line controls, not part of the FX knobrow.
+   Same anatomy as the knob groups: label top, control on a shared dial axis. */
 .master-song-ctls {
   display: flex;
   gap: 14px;
-  align-items: flex-end;
+  align-items: flex-start;
+}
+.master-song-ctls .kgroup-knobs {
+  min-height: 36px;
+  align-items: center;
 }
 /* § 2 — section header */
 .masterfx .mlbl {
@@ -2601,6 +2606,38 @@ html:not([data-theme]) .vc.now:not(.hit),
   min-width: 210px;
 }
 #viewsettings[hidden] { display: none; }
+
+/* Mobile: settings is a bottom sheet, like help — slides up, grabber, scroll. */
+@media (max-width: 900px) {
+  #viewsettings {
+    position: fixed;
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
+    min-width: 0;
+    max-height: 75vh;
+    overflow-y: auto;
+    border-radius: 16px 16px 0 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    padding: 14px 20px calc(24px + env(safe-area-inset-bottom));
+    box-shadow: 0 -8px 40px rgba(0,0,0,0.45);
+    animation: gbm-sheet-up 0.22s cubic-bezier(0.2, 0.8, 0.3, 1);
+    z-index: 210;
+  }
+  #viewsettings::before {
+    content: '';
+    display: block;
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--line);
+    margin: 0 auto 14px;
+  }
+}
 .vs-title {
   display: block;
   font-size: 9px;
@@ -2838,6 +2875,35 @@ html:not([data-theme]) .vc.now:not(.hit),
   color: var(--dim);
   margin: 0;
   padding-top: 3px;
+}
+/* Mix / Tone / FX terms are knobs, not buttons — swap the keycap chrome for a
+   mini dial (same gradient + accent tick as the real knob component). */
+.help-section[data-help="mix"] dt,
+.help-section[data-help="tone"] dt,
+.help-section[data-help="fx"] dt {
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 2px 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.help-section[data-help="mix"] dt::before,
+.help-section[data-help="tone"] dt::before,
+.help-section[data-help="fx"] dt::before {
+  content: '';
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  border-radius: 50%;
+  background:
+    linear-gradient(var(--acc), var(--acc)) no-repeat 50% 2px / 2px 5px,
+    radial-gradient(circle at 38% 32%, #3a3e4e, #15171f 70%);
+  box-shadow:
+    inset 0 1px 1px rgba(255,255,255,0.15),
+    inset 0 -2px 3px rgba(0,0,0,0.6),
+    0 1px 2px rgba(0,0,0,0.5);
 }
 
 /* ─── Global hide-knob rules ─────────────────────────────────────────────────── */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -141,7 +141,6 @@ body {
 
 /* § 2 — mono utility: numeric readouts */
 .mono,
-#bpmv,
 .vhcell,
 .vrow .vl,
 .knob-lbl {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -60,8 +60,10 @@
   --bevel-lo:   rgba(0,0,0,0.45);
 }
 
-/* Every named theme's screen shares its cabinet polarity — alias the screen
-   inks back to the cabinet inks. (Only the default Oyster theme splits them.) */
+/* Default for named themes: screen shares the cabinet's polarity — alias the
+   screen inks back to the cabinet inks. Themes whose screen polarity differs
+   (Oyster's pearl LCD via :root; casiofx/ti83/hp12c dark-on-pale and
+   nes/snes/snesus/ps1 light-on-CRT via overrides further down) set their own. */
 [data-theme] {
   --screen-ink: var(--ink);
   --screen-dim: var(--dim);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1168,8 +1168,10 @@ function resetFX() {
 // ─── Mount: (re)build all per-song UI ────────────────────────────────────────
 function mount() {
   song = eng.getSong();
+  // Credit = artist only — the dropdown already says the title (and the strip
+  // says it again); repeating it three times was noise.
   const creditEl = document.getElementById('credit');
-  if (creditEl) creditEl.textContent = song.artist ? `${song.title || ''} — ${song.artist}` : '';
+  if (creditEl) creditEl.textContent = song.artist ? `by ${song.artist}` : '';
   renderStrips();
   renderFills();
   renderPunch();
@@ -1693,7 +1695,7 @@ function gbNotice(msg) {
 }
 const shareHooks = {
   notice: gbNotice,
-  onSongLoaded: () => {
+  onSongLoaded: (rec) => {
     afterSongLoad();
     // songsel no longer matches a preset — park it on a hidden "(shared)" option.
     const sel = document.getElementById('songsel');
@@ -1706,6 +1708,17 @@ const shareHooks = {
       sel.appendChild(opt);
     }
     opt.selected = true;
+    // Shared songs: the credit line carries who made it + how it's doing.
+    if (rec) {
+      const n = typeof rec.plays === 'number' ? rec.plays + 1 : null;
+      const credit = document.getElementById('credit');
+      if (credit) {
+        credit.textContent = [
+          rec.author ? `by ${rec.author}` : '',
+          n ? `${n} play${n === 1 ? '' : 's'}` : '',
+        ].filter(Boolean).join(' · ');
+      }
+    }
   },
   onGroovesChanged: () => { renderStrips(); refreshVizPattern(); },
   // v1: import into the first matching lane (multi-lane-same-type songs are

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -921,10 +921,6 @@ function renderPatterns() {
   crow.appendChild(append);
   host.appendChild(crow);
 
-  // Foot: key badge (the song's key, not the transpose control — that's on MASTER).
-  const keyEl = document.getElementById('lcd-song-key');
-  if (keyEl) keyEl.textContent = fmtKeyName(eng.getKey());
-
   renderStrip();        // chain/chords may have changed → rebuild the readout
   updatePatternsPlayback(eng.getPlaybackTarget());
   syncStripGrooves();   // edit pattern may have changed → resync strip dropdowns
@@ -961,6 +957,15 @@ function renderStrip() {
   loop.hidden = true;
   chainWrap.appendChild(loop);
   host.appendChild(chainWrap);
+  // Which pattern the editors are pointed at — visible from every view, in the
+  // editing colour (teal), not the sounding colour (pink).
+  const edit = document.createElement('span');
+  edit.className = 'strip-seg strip-edit';
+  edit.textContent = `✎ P${eng.getEditPatternIndex() + 1}`;
+  host.appendChild(edit);
+  // The strip is the door to the song's structure: tap it → Song tab.
+  host.title = 'Open the Song editor';
+  host.onclick = () => activateSongTab();
   const chordWrap = document.createElement('span');
   chordWrap.className = 'strip-chords';
   chordWrap.dataset.idx = -1;
@@ -1048,6 +1053,14 @@ function buildChordLine(idx) {
   }
   chips.onclick = () => beginChordEdit(idx);
   row.appendChild(chips);
+  // The song's key rides the chords row — it's harmony information.
+  const key = eng.getKey();
+  if (key) {
+    const badge = document.createElement('span');
+    badge.className = 'h-key';
+    badge.textContent = fmtKeyName(key);
+    row.appendChild(badge);
+  }
   return row;
 }
 

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -798,7 +798,15 @@ function renderMaster() {
     { label: 'vrb', value: 0, onChange: v => eng.setMasterFX('reverb', v), tip: knobTip('vrb'), k: 'vrb' },
     { label: 'cmp', value: 0, onChange: v => eng.setMasterFX('comp',   v), tip: knobTip('cmp'), k: 'cmp' },
   ]);
-  mwrap.appendChild(makeKnobrow([makeTempoGroup(), makeTransposeGroup(), mixGrp, toneGrp, fxGrp]));
+  // Tempo + transpose ride the header line (beside the label/meters) so they
+  // stay on the top row on mobile while the FX knobrow wraps below.
+  const songCtls = document.createElement('div');
+  songCtls.className = 'master-song-ctls';
+  songCtls.appendChild(makeTempoGroup());
+  songCtls.appendChild(makeTransposeGroup());
+  mwrap.appendChild(songCtls);
+
+  mwrap.appendChild(makeKnobrow([mixGrp, toneGrp, fxGrp]));
 
   masterHost.appendChild(mwrap);
   cacheMeterFills();  // re-cache master meter fill refs after DOM rebuild
@@ -1260,6 +1268,12 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
 })();
 
 // ─── Help modal ───────────────────────────────────────────────────────────────
+document.querySelectorAll('#help-tabs .help-tab').forEach(btn => {
+  btn.onclick = () => {
+    document.querySelectorAll('#help-tabs .help-tab').forEach(b => b.classList.toggle('active', b === btn));
+    document.querySelectorAll('.help-section').forEach(s => s.classList.toggle('active', s.dataset.help === btn.dataset.help));
+  };
+});
 document.getElementById('help-btn').onclick = () => {
   document.getElementById('help-modal').hidden = false;
 };

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1204,7 +1204,7 @@ document.getElementById('play').onclick = async function() {
 document.getElementById('songsel').onchange = e => loadSong(e.target.value);
 document.getElementById('themesel').onchange = e => {
   const t = e.target.value;
-  if (t === 'dark') delete document.documentElement.dataset.theme;
+  if (t === 'oyster') delete document.documentElement.dataset.theme;
   else document.documentElement.dataset.theme = t;
   localStorage.setItem('gb-theme', t);
   // Invalidate canvas colour cache + repaint active view with new colours.
@@ -1229,8 +1229,9 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
 
 // ─── Restore saved theme ──────────────────────────────────────────────────────
 (function () {
-  const saved = localStorage.getItem('gb-theme');
-  if (saved && saved !== 'dark') {
+  let saved = localStorage.getItem('gb-theme');
+  if (saved === 'dark') saved = 'midnight';   // Dark was renamed; Oyster is the default now
+  if (saved && saved !== 'oyster') {
     document.documentElement.dataset.theme = saved;
     const sel = document.getElementById('themesel');
     if (sel) sel.value = saved;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -719,23 +719,27 @@ function makeTempoGroup() {
   grp.className = 'kgroup';
   const lbl = document.createElement('span');
   lbl.className = 'kgroup-lbl';
-  lbl.textContent = `TEMPO · ${currentBpm}`;
+  lbl.textContent = 'TEMPO';
   grp.appendChild(lbl);
   const row = document.createElement('div');
   row.className = 'kgroup-knobs';
-  row.appendChild(makeKnob({
-    label: 'bpm',
+  // One label per control: the group label names it, the knob's sublabel slot
+  // (where MIX knobs say vol/bal/wid) carries the live BPM value.
+  const knob = makeKnob({
+    label: String(currentBpm),
     value: (currentBpm - 80) / 100,
     fmt: v => Math.round(80 + v * 100),
     onChange: v => {
       currentBpm = Math.round(80 + v * 100);
       eng.setTempo(currentBpm);
-      lbl.textContent = `TEMPO · ${currentBpm}`;
+      const kl = knob.querySelector('.knob-lbl');
+      if (kl) kl.textContent = String(currentBpm);
       const sb = document.getElementById('strip-bpm');
       if (sb) sb.textContent = `${currentBpm} BPM`;
     },
     tip: 'Tempo (BPM) — drag up / down',
-  }));
+  });
+  row.appendChild(knob);
   grp.appendChild(row);
   return grp;
 }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -248,7 +248,7 @@ function renderViewTabs() {
   }
   const scope = document.createElement('button');
   scope.dataset.view = 'scope';
-  scope.textContent = '📈 Scope';
+  scope.textContent = 'Scope';
   scope.onclick = () => toggleScope(scope);
   bar.appendChild(scope);
   if (_songTabOpen) songTab.classList.add('on');

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1704,9 +1704,10 @@ const shareHooks = {
       opt = document.createElement('option');
       opt.id = 'songsel-shared';
       opt.hidden = true;
-      opt.textContent = '(shared)';
       sel.appendChild(opt);
     }
+    // The dropdown is the title surface — show the shared song's name, not a placeholder.
+    opt.textContent = rec?.name ? `♫ ${rec.name}` : '(shared)';
     opt.selected = true;
     // Shared songs: the credit line carries who made it + how it's doing.
     if (rec) {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1168,10 +1168,7 @@ function resetFX() {
 // ─── Mount: (re)build all per-song UI ────────────────────────────────────────
 function mount() {
   song = eng.getSong();
-  // Credit = artist only — the dropdown already says the title (and the strip
-  // says it again); repeating it three times was noise.
-  const creditEl = document.getElementById('credit');
-  if (creditEl) creditEl.textContent = song.artist ? `by ${song.artist}` : '';
+  // No credit line — the strip carries title + artist; the dropdown carries the title.
   renderStrips();
   renderFills();
   renderPunch();
@@ -1706,20 +1703,14 @@ const shareHooks = {
       opt.hidden = true;
       sel.appendChild(opt);
     }
-    // The dropdown is the title surface — show the shared song's name, not a placeholder.
-    opt.textContent = rec?.name ? `♫ ${rec.name}` : '(shared)';
+    // The dropdown is the title surface — name, author and play count all
+    // live in the option text. No second line.
+    const n = typeof rec?.plays === 'number' ? rec.plays + 1 : null;
+    opt.textContent = rec?.name
+      ? ['♫ ' + rec.name, rec.author ? `by ${rec.author}` : '', n ? `${n} play${n === 1 ? '' : 's'}` : '']
+          .filter(Boolean).join(' · ')
+      : '(shared)';
     opt.selected = true;
-    // Shared songs: the credit line carries who made it + how it's doing.
-    if (rec) {
-      const n = typeof rec.plays === 'number' ? rec.plays + 1 : null;
-      const credit = document.getElementById('credit');
-      if (credit) {
-        credit.textContent = [
-          rec.author ? `by ${rec.author}` : '',
-          n ? `${n} play${n === 1 ? '' : 's'}` : '',
-        ].filter(Boolean).join(' · ');
-      }
-    }
   },
   onGroovesChanged: () => { renderStrips(); refreshVizPattern(); },
   // v1: import into the first matching lane (multi-lane-same-type songs are

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -226,12 +226,17 @@ function updateEditHighlight(id) {
   }
 }
 
-// Quick-edit tabs in the VIEW bar: one per editable lane (emoji + name) + Scope.
+// Screen tabs in the LCD: Song first, then one per editable lane, then Scope.
 // Rebuilt on every renderStrips() so it tracks add/dup/remove/rename.
 function renderViewTabs() {
   const bar = document.querySelector('.vtabs');
   if (!bar) return;
-  bar.innerHTML = '<span class="vtabs-lbl">VIEW</span>';
+  bar.innerHTML = '';
+  const songTab = document.createElement('button');
+  songTab.dataset.view = 'song';
+  songTab.textContent = 'Song';
+  songTab.onclick = () => activateSongTab();
+  bar.appendChild(songTab);
   for (const lane of eng.getLanes()) {
     if (lane.type === 'chords') continue;   // chords has no grid/roll editor
     const b = document.createElement('button');
@@ -246,7 +251,35 @@ function renderViewTabs() {
   scope.textContent = '📈 Scope';
   scope.onclick = () => toggleScope(scope);
   bar.appendChild(scope);
-  if (_editingLaneId) updateEditHighlight(_editingLaneId);
+  if (_songTabOpen) songTab.classList.add('on');
+  else if (_editingLaneId) updateEditHighlight(_editingLaneId);
+}
+
+// The screen has two panes: #lcd-body (viz: lane editors / scope) and
+// #lcd-song (song structure). Display toggle only — the viz is never disposed
+// here, so switching tabs is free.
+let _songTabOpen = false;
+function setLcdPane(songOpen) {
+  _songTabOpen = songOpen;
+  const body = document.getElementById('lcd-body');
+  const songPane = document.getElementById('lcd-song');
+  if (body) body.hidden = songOpen;
+  if (songPane) songPane.hidden = !songOpen;
+}
+
+// Song tab: show the song structure pane, clear lane-editing highlights.
+function activateSongTab() {
+  const bar = document.querySelector('.vtabs');
+  if (bar) {
+    bar.querySelectorAll('button').forEach(x => x.classList.remove('on'));
+    bar.querySelector('[data-view="song"]')?.classList.add('on');
+  }
+  const host = document.getElementById('strips');
+  if (host) {
+    host.querySelectorAll('.lane').forEach(row => row.classList.remove('editing'));
+    host.querySelectorAll('.lane-edit').forEach(b => b.classList.remove('editing'));
+  }
+  setLcdPane(true);
 }
 
 // Scope toggle: on → show oscilloscope; off (click again) → back to last lane editor.
@@ -262,12 +295,14 @@ function toggleScope(btn) {
       host.querySelectorAll('.lane').forEach(row => row.classList.remove('editing'));
       host.querySelectorAll('.lane-edit').forEach(b => b.classList.remove('editing'));
     }
+    setLcdPane(false);
     viz.setView('scope');
   }
 }
 
 // Open a lane editor in the viz + update highlight.
 function activateEditLane(id) {
+  setLcdPane(false);
   viz.editLane(id);
   updateEditHighlight(id);
 }
@@ -673,6 +708,61 @@ document.addEventListener('keyup', e => {
 window.addEventListener('blur', () => { for (let s = 0; s < eng.getPunchPresets().length; s++) setPunch(s, false); });
 
 // ─── Master FX ───────────────────────────────────────────────────────────────
+// Tempo + transpose are hardware on MASTER (the screen strip carries the
+// readouts; the controls live where the knobs are).
+let currentBpm = 120;
+let transpose = 0;
+function fmtKey(n) { return n > 0 ? '+' + n : String(n); }
+
+function makeTempoGroup() {
+  const grp = document.createElement('div');
+  grp.className = 'kgroup';
+  const lbl = document.createElement('span');
+  lbl.className = 'kgroup-lbl';
+  lbl.textContent = `TEMPO · ${currentBpm}`;
+  grp.appendChild(lbl);
+  const row = document.createElement('div');
+  row.className = 'kgroup-knobs';
+  row.appendChild(makeKnob({
+    label: 'bpm',
+    value: (currentBpm - 80) / 100,
+    fmt: v => Math.round(80 + v * 100),
+    onChange: v => {
+      currentBpm = Math.round(80 + v * 100);
+      eng.setTempo(currentBpm);
+      lbl.textContent = `TEMPO · ${currentBpm}`;
+      const sb = document.getElementById('strip-bpm');
+      if (sb) sb.textContent = `${currentBpm} BPM`;
+    },
+    tip: 'Tempo (BPM) — drag up / down',
+  }));
+  grp.appendChild(row);
+  return grp;
+}
+
+function makeTransposeGroup() {
+  const grp = document.createElement('div');
+  grp.className = 'kgroup';
+  const lbl = document.createElement('span');
+  lbl.className = 'kgroup-lbl';
+  lbl.textContent = 'TRANSPOSE';
+  grp.appendChild(lbl);
+  const row = document.createElement('div');
+  row.className = 'kgroup-knobs';
+  const stepper = document.createElement('div');
+  stepper.className = 'key-stepper';
+  const dn = document.createElement('button'); dn.textContent = '−';
+  const val = document.createElement('span'); val.className = 'mono'; val.textContent = fmtKey(transpose);
+  const up = document.createElement('button'); up.textContent = '＋';
+  dn.onclick = () => { transpose = Math.max(-12, transpose - 1); eng.setTranspose(transpose); val.textContent = fmtKey(transpose); };
+  up.onclick = () => { transpose = Math.min(12, transpose + 1); eng.setTranspose(transpose); val.textContent = fmtKey(transpose); };
+  stepper.appendChild(dn); stepper.appendChild(val); stepper.appendChild(up);
+  stepper.title = 'Shift the whole song up / down in semitones';
+  row.appendChild(stepper);
+  grp.appendChild(row);
+  return grp;
+}
+
 function renderMaster() {
   const masterHost = document.getElementById('master');
   masterHost.innerHTML = '';
@@ -708,14 +798,14 @@ function renderMaster() {
     { label: 'vrb', value: 0, onChange: v => eng.setMasterFX('reverb', v), tip: knobTip('vrb'), k: 'vrb' },
     { label: 'cmp', value: 0, onChange: v => eng.setMasterFX('comp',   v), tip: knobTip('cmp'), k: 'cmp' },
   ]);
-  mwrap.appendChild(makeKnobrow([mixGrp, toneGrp, fxGrp]));
+  mwrap.appendChild(makeKnobrow([makeTempoGroup(), makeTransposeGroup(), mixGrp, toneGrp, fxGrp]));
 
   masterHost.appendChild(mwrap);
   cacheMeterFills();  // re-cache master meter fill refs after DOM rebuild
   updateEmptyGroups(); // hide master kgroups where all knobs are hidden
 }
 
-// ─── PATTERNS module (patterns row + chain row + chord line + playback label) ─
+// ─── SONG tab (patterns row + nested chord line + chain row, on the screen) ──
 function fmtKeyName(key) {
   return key ? `${key.root} ${key.mode}` : '';
 }
@@ -723,7 +813,7 @@ function fmtKeyName(key) {
 let _chainDragFrom = null;
 
 function renderPatterns() {
-  const host = document.getElementById('arrange');   // id kept for saved section order
+  const host = document.getElementById('lcd-song-rows');
   if (!host) return;
   host.innerHTML = '';
   const patterns = eng.getPatterns();
@@ -742,7 +832,7 @@ function renderPatterns() {
     const b = document.createElement('button');
     b.className = 'pat-slot' + (i === editIdx ? ' sel' : '');
     b.dataset.idx = i;
-    b.textContent = i + 1;
+    b.textContent = i === editIdx ? `${i + 1} ✎` : `${i + 1}`;
     b.title = 'click: edit this pattern — play will loop it';
     b.onclick = () => { eng.selectPattern(i); renderPatterns(); refreshVizPattern(); };
     prow.appendChild(b);
@@ -774,9 +864,11 @@ function renderPatterns() {
   prow.appendChild(del);
   host.appendChild(prow);
 
-  // Chord line for the SELECTED pattern: "chords" label + chord-name chips +
-  // key badge. Chords belong to the pattern (one per bar, cycling). Click
-  // anywhere → text input to edit (parser-backed); empty → a "＋ chords" affordance.
+  // Chord line for the SELECTED pattern, nested under the patterns row (the
+  // indent + spine say "this pattern's chords"). Chords belong to the pattern
+  // (one per bar, cycling). Click anywhere → text input to edit (parser-backed);
+  // empty → a "＋ chords" affordance. The status strip carries the SOUNDING
+  // pattern's chords — this row is purely the edit pattern's.
   host.appendChild(buildChordLine(editIdx));
 
   // Chain row: chips (click = play chain from there; hover-✕ removes; drag reorders) + append.
@@ -817,15 +909,105 @@ function renderPatterns() {
   crow.appendChild(append);
   host.appendChild(crow);
 
+  // Foot: key badge (the song's key, not the transpose control — that's on MASTER).
+  const keyEl = document.getElementById('lcd-song-key');
+  if (keyEl) keyEl.textContent = fmtKeyName(eng.getKey());
+
+  renderStrip();        // chain/chords may have changed → rebuild the readout
   updatePatternsPlayback(eng.getPlaybackTarget());
   syncStripGrooves();   // edit pattern may have changed → resync strip dropdowns
 }
 
-// Build the chord line for pattern `idx`: "chords" label + a P<n> marker + chord
-// chips (or a "＋ chords" affordance when empty) + the key badge. The chip area is
-// clickable → beginChordEdit swaps in the text input. During playback the row
-// FOLLOWS THE SOUNDING PATTERN (updatePatternsPlayback rebuilds it on pattern
-// change) — watching is the default, editing is the explicit click.
+// ─── LCD status strip (read-only narrator: title · chain · chords · key · bpm) ─
+function renderStrip() {
+  const host = document.getElementById('lcd-strip');
+  if (!host) return;
+  host.innerHTML = '';
+  const s = eng.getSong();
+  if (!s) return;
+  const title = document.createElement('span');
+  title.className = 'strip-title';
+  title.textContent = (s.title || '').toUpperCase();
+  host.appendChild(title);
+  if (s.artist) {
+    const credit = document.createElement('span');
+    credit.className = 'strip-credit';
+    credit.textContent = s.artist;
+    host.appendChild(credit);
+  }
+  const chainWrap = document.createElement('span');
+  chainWrap.className = 'strip-chain';
+  eng.getChain().forEach((pi, pos) => {
+    const seg = document.createElement('span');
+    seg.className = 'strip-seg';
+    seg.dataset.pos = pos;
+    seg.textContent = pi + 1;
+    chainWrap.appendChild(seg);
+  });
+  const loop = document.createElement('span');
+  loop.className = 'strip-seg strip-loop hot';
+  loop.hidden = true;
+  chainWrap.appendChild(loop);
+  host.appendChild(chainWrap);
+  const chordWrap = document.createElement('span');
+  chordWrap.className = 'strip-chords';
+  chordWrap.dataset.idx = -1;
+  host.appendChild(chordWrap);
+  const key = eng.getKey();
+  if (key) {
+    const keyEl = document.createElement('span');
+    keyEl.className = 'strip-key';
+    keyEl.textContent = fmtKeyName(key).toUpperCase();
+    host.appendChild(keyEl);
+  }
+  const bpmEl = document.createElement('span');
+  bpmEl.className = 'strip-bpm';
+  bpmEl.id = 'strip-bpm';
+  bpmEl.textContent = `${currentBpm} BPM`;
+  host.appendChild(bpmEl);
+  updateStrip(eng.getPlaybackTarget());
+}
+
+// Per-step strip update: hot-class moves only — chord segs rebuild only when
+// the sounding pattern changes (a handful of nodes, on a bar boundary).
+function updateStrip(target) {
+  const host = document.getElementById('lcd-strip');
+  if (!host || !target) return;
+  const isPattern = target.kind === 'pattern';
+  host.querySelectorAll('.strip-chain .strip-seg:not(.strip-loop)').forEach(seg => {
+    seg.classList.toggle('hot', !isPattern && +seg.dataset.pos === target.chainPos);
+  });
+  const loop = host.querySelector('.strip-loop');
+  if (loop) {
+    loop.hidden = !isPattern;
+    if (isPattern) loop.textContent = `LOOP P${target.patternIdx + 1}`;
+  }
+  const wrap = host.querySelector('.strip-chords');
+  if (wrap) {
+    if (+wrap.dataset.idx !== target.patternIdx) {
+      wrap.dataset.idx = target.patternIdx;
+      wrap.innerHTML = '';
+      (eng.getPatternChords(target.patternIdx) || []).forEach((c, i) => {
+        const seg = document.createElement('span');
+        seg.className = 'strip-seg';
+        seg.dataset.i = i;
+        seg.textContent = c.name;
+        wrap.appendChild(seg);
+      });
+    }
+    const segs = wrap.querySelectorAll('.strip-seg');
+    if (segs.length) {
+      const hot = target.barInPattern % segs.length;
+      segs.forEach(seg => seg.classList.toggle('hot', +seg.dataset.i === hot));
+    }
+  }
+}
+
+// Build the chord line for pattern `idx`: "chords" label + chord chips (or a
+// "＋ chords" affordance when empty). Nested under the patterns row — the
+// indent says whose chords they are, so no P-marker. The chip area is
+// clickable → beginChordEdit swaps in the text input. Watching the sounding
+// pattern's chords is the strip's job; this row is the edit pattern's.
 function buildChordLine(idx) {
   const row = document.createElement('div');
   row.className = 'chord-row';
@@ -834,10 +1016,6 @@ function buildChordLine(idx) {
   lbl.className = 'pat-lbl';
   lbl.textContent = 'chords';
   row.appendChild(lbl);
-  const pmark = document.createElement('span');
-  pmark.className = 'h-pat';
-  pmark.textContent = 'P' + (idx + 1);
-  row.appendChild(pmark);
 
   const chips = document.createElement('div');
   chips.className = 'h-chips';
@@ -858,14 +1036,6 @@ function buildChordLine(idx) {
   }
   chips.onclick = () => beginChordEdit(idx);
   row.appendChild(chips);
-
-  const key = eng.getKey();
-  if (key) {
-    const badge = document.createElement('span');
-    badge.className = 'pat-lbl h-key';
-    badge.textContent = fmtKeyName(key);
-    row.appendChild(badge);
-  }
   return row;
 }
 
@@ -873,7 +1043,7 @@ function buildChordLine(idx) {
 // Enter / blur commit (parse → setPatternChords); Escape cancels; invalid input
 // keeps a red border and stays editing.
 function beginChordEdit(idx) {
-  const host = document.getElementById('arrange');
+  const host = document.getElementById('lcd-song-rows');
   const chips = host?.querySelector('.chord-row .h-chips');
   if (!chips) return;
   const chords = eng.getPatternChords(idx) || [];
@@ -913,9 +1083,9 @@ function beginChordEdit(idx) {
   input.onblur = commit;
 }
 
-// Glow + label + row dimming — called from renderPatterns and every step.
+// Glow + row dimming — called from renderPatterns and every step.
 function updatePatternsPlayback(target) {
-  const host = document.getElementById('arrange');
+  const host = document.getElementById('lcd-song-rows');
   if (!host || !target) return;
   const isPattern = target.kind === 'pattern';
   const prow = host.querySelector('.pat-row');
@@ -928,29 +1098,16 @@ function updatePatternsPlayback(target) {
   host.querySelectorAll('.chain-chip').forEach(c => {
     c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos);
   });
-  // Chord line follows the SOUNDING pattern (unless the user is mid-edit):
-  // rebuild it when the sounding pattern changes, then light the live chord.
-  const row = host.querySelector('.chord-row');
-  if (row && !host.querySelector('.h-edit') && +row.dataset.idx !== target.patternIdx) {
-    row.replaceWith(buildChordLine(target.patternIdx));
-  }
+  // The chord row shows the EDIT pattern's chords; light the live chord only
+  // when the edit pattern happens to be the one sounding. (The strip narrates
+  // the sounding pattern; no prose status — the chips ARE the status.)
   const liveRow = host.querySelector('.chord-row');
   const chordChips = liveRow ? liveRow.querySelectorAll('.h-chip:not(.h-empty)') : [];
-  if (chordChips.length && +liveRow.dataset.idx === target.patternIdx) {
+  if (chordChips.length) {
+    const isSounding = +liveRow.dataset.idx === target.patternIdx;
     const sounding = target.barInPattern % chordChips.length;
-    chordChips.forEach(chip => chip.classList.toggle('sounding', +chip.dataset.idx === sounding));
+    chordChips.forEach(chip => chip.classList.toggle('sounding', isSounding && +chip.dataset.idx === sounding));
   }
-  // Status spans now live in the transport row (#song-status), not in #arrange.
-  const lbl = document.getElementById('pat-playing');
-  if (lbl) {
-    const chain = eng.getChain();
-    const verb = eng.isPlaying() ? 'Playing' : 'Will play';
-    lbl.textContent = isPattern
-      ? `▶ ${verb}: Pattern ${target.patternIdx + 1} (loop)`
-      : `▶ ${verb}: Chain · ${chain.map((pi, i) => (i === target.chainPos ? '▸' : '') + (pi + 1)).join(' ')}`;
-  }
-  const ed = document.querySelector('#song-status .pat-editing');
-  if (ed) ed.textContent = `✎ Pattern ${eng.getEditPatternIndex() + 1}`;
 }
 
 // Tell the viz the edit pattern changed (rebuilds the open editor).
@@ -992,10 +1149,10 @@ function mount() {
   renderFills();
   renderPunch();
   renderMaster();
-  renderPatterns();
+  renderPatterns();   // also rebuilds the LCD status strip
   viz?.dispose?.();   // stop the outgoing viz's rAF loops before replacing it
-  viz = makeViz(document.getElementById('viz'), song, eng);
-  // Scope tab off — lane editor takes over.
+  viz = makeViz(document.getElementById('lcd-body'), song, eng);
+  // Scope/Song tabs off — lane editor takes over.
   document.querySelectorAll('[data-view]').forEach(x => x.classList.remove('on'));
   // Auto-open the first editable lane (drums or first non-chords lane).
   const lanes = eng.getLanes();
@@ -1016,16 +1173,14 @@ function loadSong(key) {
 }
 
 // Shared post-load path (preset switch + shared-song load): bpm/key sync, FX
-// reset, full UI remount. Caller has already eng.load()ed the new song.
+// reset, full UI remount (mount → renderMaster rebuilds the TEMPO/TRANSPOSE
+// controls from the synced state). Caller has already eng.load()ed the new song.
 function afterSongLoad() {
   const s = eng.getSong();
-  const bpm = document.getElementById('bpm');
-  bpm.value = s.bpm;
-  document.getElementById('bpmv').textContent = s.bpm;
+  currentBpm = s.bpm;
   eng.setTempo(s.bpm);
   transpose = 0;
   eng.setTranspose(0);
-  updateKeyDisplay();
   resetFX();
   mount();
 }
@@ -1036,43 +1191,15 @@ document.getElementById('play').onclick = async function() {
     eng.stop(); this.classList.remove('on'); this.textContent='▶ play';
     stopMeterLoop();
     updatePatternsPlayback(eng.getPlaybackTarget());
+    updateStrip(eng.getPlaybackTarget());
   } else {
     await eng.play(); this.classList.add('on'); this.textContent='⏹ stop';
     startMeterLoop();
     updatePatternsPlayback(eng.getPlaybackTarget());
+    updateStrip(eng.getPlaybackTarget());
   }
 };
-document.getElementById('bpm').oninput = e => { eng.setTempo(+e.target.value); document.getElementById('bpmv').textContent = e.target.value; };
-
-// ─── KEY / transpose ─────────────────────────────────────────────────────────
-let transpose = 0;
-let keyQuantizeOn = localStorage.getItem('gb-key-quantize') === '1';
-function fmtKey(n) { return n > 0 ? '+' + n : String(n); }
-function updateKeyDisplay() { document.getElementById('keyv').textContent = fmtKey(transpose); }
-document.getElementById('key-dn').onclick = () => {
-  transpose = Math.max(-12, transpose - 1);
-  eng.setTranspose(transpose);
-  updateKeyDisplay();
-};
-document.getElementById('key-up').onclick = () => {
-  transpose = Math.min(12, transpose + 1);
-  eng.setTranspose(transpose);
-  updateKeyDisplay();
-};
-const _keyQBtn = document.getElementById('key-q');
-function applyKeyQuantizeState() {
-  _keyQBtn.setAttribute('aria-pressed', String(keyQuantizeOn));
-  _keyQBtn.classList.toggle('on', keyQuantizeOn);
-}
-_keyQBtn.onclick = () => {
-  keyQuantizeOn = !keyQuantizeOn;
-  eng.setKeyQuantize(keyQuantizeOn);
-  localStorage.setItem('gb-key-quantize', keyQuantizeOn ? '1' : '0');
-  applyKeyQuantizeState();
-};
-// Restore persisted state
-eng.setKeyQuantize(keyQuantizeOn);
-applyKeyQuantizeState();
+// (Tempo + transpose controls live on MASTER — built in renderMaster().)
 
 document.getElementById('songsel').onchange = e => loadSong(e.target.value);
 document.getElementById('themesel').onchange = e => {
@@ -1097,6 +1224,7 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
     renderChain(queue);
   }
   updatePatternsPlayback(target);
+  updateStrip(target);
 });
 
 // ─── Restore saved theme ──────────────────────────────────────────────────────
@@ -1498,8 +1626,7 @@ eng.load(SONGS[BOOT_SONG]);
 // the option's `selected` attribute matching the boot song by coincidence.
 document.getElementById('songsel').value = BOOT_SONG;
 const initialSong = eng.getSong();
-document.getElementById('bpm').value = initialSong.bpm;
-document.getElementById('bpmv').textContent = initialSong.bpm;
+currentBpm = initialSong.bpm;
 eng.setTempo(initialSong.bpm);
 mount();
 // Wrap sections and wire section drag-reorder once, after first mount.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1664,6 +1664,16 @@ function initSectionWrappers() {
 }
 
 // ─── Initial load ─────────────────────────────────────────────────────────────
+// Song dropdown = the record shelf: every option shows "title — artist",
+// straight from the song data. ("(AI)" goes — the artist credit says it.)
+{
+  const sel = document.getElementById('songsel');
+  for (const opt of sel.options) {
+    const s = SONGS[opt.value];
+    if (s?.artist) opt.textContent = `${opt.textContent.replace(' (AI)', '')} — ${s.artist}`;
+  }
+}
+
 const BOOT_SONG = 'press-start';
 eng.load(SONGS[BOOT_SONG]);
 // Pin the dropdown to the boot song so the selector, the loaded song, and the

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1210,6 +1210,14 @@ document.getElementById('themesel').onchange = e => {
   // Invalidate canvas colour cache + repaint active view with new colours.
   viz.invalidateThemeColors?.();
 };
+// Screen picker (Settings) — override the theme's glass with a chosen LCD.
+document.getElementById('screensel').onchange = e => {
+  const v = e.target.value;
+  if (v === 'default') delete document.documentElement.dataset.screen;
+  else document.documentElement.dataset.screen = v;
+  localStorage.setItem('gb-screen', v);
+  viz.invalidateThemeColors?.();
+};
 
 // (Scope + quick-edit lane tabs are built and wired in renderViewTabs().)
 
@@ -1235,6 +1243,12 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
     document.documentElement.dataset.theme = saved;
     const sel = document.getElementById('themesel');
     if (sel) sel.value = saved;
+  }
+  const screen = localStorage.getItem('gb-screen');
+  if (screen && screen !== 'default') {
+    document.documentElement.dataset.screen = screen;
+    const ssel = document.getElementById('screensel');
+    if (ssel) ssel.value = screen;
   }
 })();
 

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -727,7 +727,9 @@ function makeTempoGroup() {
   // (where MIX knobs say vol/bal/wid) carries the live BPM value.
   const knob = makeKnob({
     label: String(currentBpm),
-    value: (currentBpm - 80) / 100,
+    // Clamp the dial position — a shared/legacy song can carry a BPM outside
+    // the knob's 80–180 sweep; the engine keeps the true tempo, the dial pins.
+    value: Math.max(0, Math.min(1, (currentBpm - 80) / 100)),
     fmt: v => Math.round(80 + v * 100),
     onChange: v => {
       currentBpm = Math.round(80 + v * 100);
@@ -964,8 +966,15 @@ function renderStrip() {
   edit.textContent = `✎ P${eng.getEditPatternIndex() + 1}`;
   host.appendChild(edit);
   // The strip is the door to the song's structure: tap it → Song tab.
+  // It's a div, so make it a real control for keyboards / assistive tech.
   host.title = 'Open the Song editor';
+  host.setAttribute('role', 'button');
+  host.setAttribute('aria-label', 'Open the Song editor');
+  host.tabIndex = 0;
   host.onclick = () => activateSongTab();
+  host.onkeydown = e => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activateSongTab(); }
+  };
   const chordWrap = document.createElement('span');
   chordWrap.className = 'strip-chords';
   chordWrap.dataset.idx = -1;

--- a/docs/arcade/groovebox/ui/knob.js
+++ b/docs/arcade/groovebox/ui/knob.js
@@ -20,9 +20,9 @@ function getBubble() {
 }
 let _bubbleHideTimer = null;
 
-const fmt = v => Math.round(v * 100);
+const defaultFmt = v => Math.round(v * 100);
 
-export function makeKnob({ label, value = 0, onChange, tip, k }) {
+export function makeKnob({ label, value = 0, onChange, tip, k, fmt = defaultFmt }) {
   const initial = value;
   let current = value;
 

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -429,12 +429,13 @@ export function makeViz(host, song, eng) {
     }
   }
 
-  // "editing: <groove name>" label — names the groove the editor mutates and
-  // warns that shared grooves change everywhere. Empty when the lane has none.
+  // "editing: P<n> · <groove name>" label — names the pattern the editor is
+  // inside (same P<n> as the strip's ✎ marker and the Song tab) plus the groove
+  // it mutates. Empty when the lane has none.
   function edLabelHTML(L) {
     const G = editGroove(L);
     if (!G) return '';
-    return `<div class="ed-lbl">editing: ${esc(G.name)}</div>`;
+    return `<div class="ed-lbl">editing: P${eng.getEditPatternIndex() + 1} · ${esc(G.name)}</div>`;
   }
 
   // ─── Roll-mode toggle bar (melody + bass only) ───────────────────────────

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -21,9 +21,11 @@ function themeColors() {
     rollBlk: g('--roll-bg-blk'),
     rollOut: g('--roll-bg-out'),
     ctone:   g('--roll-ctone'),
-    ink:     g('--ink'),
-    dim:     g('--dim'),
-    faint:   g('--faint'),
+    // Canvas text draws ON the screen — use the screen-scoped inks (the
+    // screen's polarity can differ from the cabinet's, e.g. Oyster's pearl LCD).
+    ink:     g('--screen-ink'),
+    dim:     g('--screen-dim'),
+    faint:   g('--screen-dim'),
   };
   return _tc;
 }


### PR DESCRIPTION
## What

The mobile-first top-section redesign, built around one rule from the brainstorm: **cabinet = hardware, screen = software.**

### The screen (`#viz`)
- **Status strip** on top of the LCD, every view: song title · artist · walking chain segs · sounding chords · key · BPM (read-only; pink = sounding, teal `✎ P1` = editing). Tapping the strip opens the Song tab.
- **View tabs move inside the LCD**: `Song · Drums · Bass · Melody · Scope`, styled as screen furniture. **Song is a tab** — patterns (✎ on the selected slot), chords nested under their pattern (indent + accent spine, the `P1` marker and key badge folded in), chain, all in screen-language.
- Editor header gains pattern context: `EDITING: P1 · FANFARE`.

### The cabinet
- **Transport = play · song picker · PUBLISH** (now a hot-pink hardware CTA). The prose status line is gone — the chips/segments ARE the status.
- **MASTER gains TEMPO** (knob, live value in the sublabel slot) **and TRANSPOSE** (stepper, renamed from KEY) on the header line. The `⟳ bar` key-quantize feature is deleted (engine + UI).
- Song dropdown shows `title — artist` for every entry; shared songs show `♫ name · by author · N plays` (no more `(shared)`); the credit line under the picker is gone.

### Themes
- **OYSTER is the new default theme** — the oyster.to "Pearl in Orbit" palette (space-navy cabinet, violet accent, plasma-pink hot) with a **classic pearl LCD** (pale ice glass, deep-navy pixels). The old Dark lives on as **Midnight** (saved prefs migrate).
- New `--screen-ink/--screen-dim` tokens let a screen's polarity differ from its cabinet's — reconciled with the hardware-skin system from #656/#658 (calculators get dark-on-pale, NES/SNES/PS1 get light-on-CRT; legacy screen defaults preserved for themes relying on inheritance).
- **Screen picker** (Settings → Screen): Pearl / Phosphor / Lime / Amber / Paper glass bundles work on any cabinet.
- 24 hardcoded teal glows now derive from `--acc` — every theme glows in its own accent.

### Mobile
- Titlebar fits (wordmark drops to GROOVEBOX); Help and Settings are slide-up bottom sheets; touch knobs 42→36px; transport is one row.
- Help redesigned: Controls/Mix/Tone/FX section tabs, keycap terms, mini knob dials on knob sections, plain-English copy.

## Test plan
- [x] 295 tests green (incl. unchanged 7-preset parity)
- [x] `vite build` clean
- [ ] Hand test (desktop + phone): boot = Drums tab; strip walks on play; Song tab structure ops; TEMPO/TRANSPOSE audible; theme × screen-picker combos; shared-link load; `?perf` `late 0/64`

Merging ≠ live — deploy stays a manual wrangler step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)