### PR TITLE
arcade(groovebox): the social shelf — registry browsing, cartridge drawer, theme gallery + glass system

### DIFF
--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -13,50 +13,10 @@
       <div class="titlebar">
         <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span><span class="brand-oyster">oyster </span>groovebox</h1>
         <div class="titlebar-tools">
-          <select id="themesel">
-            <option value="oyster" selected>Oyster</option>
-            <option value="midnight">Midnight</option>
-            <option value="light">Light</option>
-            <option value="beige">Beige</option>
-            <option value="purple">Purple</option>
-            <option value="amber">Amber</option>
-            <optgroup label="Handhelds">
-              <option value="playdate">Playdate</option>
-              <option value="gameboy">Game Boy</option>
-              <option value="r1">Rabbit</option>
-              <option value="switch">Switch</option>
-            </optgroup>
-            <optgroup label="Consoles">
-              <option value="atari2600">Atari 2600</option>
-              <option value="famicom">Famicom</option>
-              <option value="nes">NES</option>
-              <option value="snes">SNES</option>
-              <option value="snesus">SNES US</option>
-              <option value="megadrive">Sega</option>
-              <option value="ps1">PlayStation</option>
-              <option value="n64">N64</option>
-              <option value="dreamcast">Dreamcast</option>
-              <option value="gamecube">GameCube</option>
-              <option value="xbox">Xbox</option>
-            </optgroup>
-            <optgroup label="Computers">
-              <option value="spectrum">ZX Spectrum</option>
-              <option value="amiga">Amiga</option>
-            </optgroup>
-            <optgroup label="Calculators">
-              <option value="casiofx">Casio fx</option>
-              <option value="ti83">TI-83</option>
-              <option value="vl1">VL-Tone</option>
-              <option value="hp12c">HP-12C</option>
-              <option value="et66">Braun ET66</option>
-              <option value="littleprof">Little Professor</option>
-            </optgroup>
-            <optgroup label="Studio">
-              <option value="tr808">TR-808</option>
-              <option value="mpc">MPC</option>
-              <option value="dx7">DX7</option>
-            </optgroup>
-          </select>
+          <div class="theme-wrap">
+            <button id="themebtn" title="Select a theme" aria-haspopup="true">Oyster</button>
+            <div id="theme-picker" hidden></div>
+          </div>
           <div class="vs-wrap">
             <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -17,17 +17,6 @@
           <div class="vs-wrap">
             <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>
-              <div class="vs-screen">
-                <span class="vs-title">Screen</span>
-                <select id="screensel">
-                  <option value="default" selected>Theme default</option>
-                  <option value="pearl">Pearl</option>
-                  <option value="phosphor">Phosphor</option>
-                  <option value="lime">Lime</option>
-                  <option value="amber">Amber</option>
-                  <option value="paper">Paper</option>
-                </select>
-              </div>
               <span class="vs-title">Active knobs</span>
               <div id="viewsettings-checks"></div>
             </div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -13,7 +13,7 @@
       <div class="titlebar">
         <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span><span class="brand-oyster">oyster </span>groovebox</h1>
         <div class="titlebar-tools">
-          <button id="themebtn" title="Select a theme" aria-haspopup="true">Oyster</button>
+          <button id="themebtn" title="Select a theme" aria-haspopup="true">Theme</button>
           <div class="vs-wrap">
             <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -86,9 +86,7 @@
         <div class="transport">
           <button id="play">▶ play</button>
           <div class="transport-song">
-            <div class="song-wrap">
-              <select id="songsel"><option value="press-start">★ Press Start (AI)</option><option value="scallywag">★ Scallywag (AI)</option><option value="boo-waltz">★ Boo Waltz (AI)</option><option value="first-roll">★ First Roll (AI)</option><option value="kids">Kids</option><option value="rising-sun">House of the Rising Sun</option><option value="electric-feel">Electric Feel</option><option value="heartbeats">Heartbeats</option><option value="digital-love">Digital Love</option><option value="memory-reboot">Memory Reboot</option><option value="take-on-me">Take On Me</option></select>
-            </div>
+            <button id="songbtn" title="Select a song" aria-haspopup="true"><span class="songbtn-t">★ Press Start</span><span class="songbtn-caret">▾</span></button>
           </div>
           <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
@@ -192,6 +190,7 @@
         <div id="lcd-song" hidden>
           <div id="lcd-song-rows"></div>
         </div>
+        <div id="lcd-picker" hidden></div>
       </div>
       <div id="master"></div>
       <div id="punch"></div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -87,6 +87,7 @@
           <button id="play">▶ play</button>
           <div class="transport-song">
             <button id="songbtn" title="Select a song" aria-haspopup="true"><span class="songbtn-t">★ Press Start</span><span class="songbtn-caret">▾</span></button>
+            <div id="song-picker" hidden></div>
           </div>
           <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
@@ -190,7 +191,6 @@
         <div id="lcd-song" hidden>
           <div id="lcd-song-rows"></div>
         </div>
-        <div id="lcd-picker" hidden></div>
       </div>
       <div id="master"></div>
       <div id="punch"></div>

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -13,10 +13,7 @@
       <div class="titlebar">
         <h1><span class="brand-icon" title="Oyster Groovebox" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4"/><path d="M8 8v1"/><path d="M12 8v1"/><path d="M16 8v1"/><rect width="20" height="12" x="2" y="9" rx="2"/><circle cx="8" cy="15" r="2"/><circle cx="16" cy="15" r="2"/></svg></span><span class="brand-oyster">oyster </span>groovebox</h1>
         <div class="titlebar-tools">
-          <div class="theme-wrap">
-            <button id="themebtn" title="Select a theme" aria-haspopup="true">Oyster</button>
-            <div id="theme-picker" hidden></div>
-          </div>
+          <button id="themebtn" title="Select a theme" aria-haspopup="true">Oyster</button>
           <div class="vs-wrap">
             <button id="viewsettings-btn" title="Settings">Settings</button>
             <div id="viewsettings" hidden>
@@ -52,6 +49,9 @@
           <button id="share-btn" title="Publish this song or a groove">PUBLISH</button>
         </div>
       </div>
+
+      <!-- Theme gallery — body-level so it inherits nothing from the titlebar -->
+      <div id="theme-picker" hidden></div>
 
       <!-- Share modal -->
       <div id="share-modal" hidden>

--- a/docs/arcade/groovebox/registry/client.js
+++ b/docs/arcade/groovebox/registry/client.js
@@ -62,5 +62,7 @@ async function call(method, path, body) {
 export const createItem = (body) => call('POST', '', body);            // → { id, editKey }
 export const getItem = (id) => call('GET', `/${id}`);                  // → record
 export const updateItem = (id, body) => call('PUT', `/${id}`, body);   // → { revision }
+// Discovery shelf — light rows (id/kind/name/author/plays/remix_of/created_at), newest first.
+export const listItems = (kind = 'song', limit = 25) => call('GET', `?kind=${kind}&limit=${limit}`);
 // Fire-and-forget play beacon — never blocks or breaks the load path.
 export const pingPlay = (id) => { fetch(`${API_BASE}/${id}/play`, { method: 'POST' }).catch(() => {}); };

--- a/docs/arcade/groovebox/registry/client.js
+++ b/docs/arcade/groovebox/registry/client.js
@@ -63,6 +63,7 @@ export const createItem = (body) => call('POST', '', body);            // → { 
 export const getItem = (id) => call('GET', `/${id}`);                  // → record
 export const updateItem = (id, body) => call('PUT', `/${id}`, body);   // → { revision }
 // Discovery shelf — light rows (id/kind/name/author/plays/remix_of/created_at), newest first.
-export const listItems = (kind = 'song', limit = 25) => call('GET', `?kind=${kind}&limit=${limit}`);
+export const listItems = (kind = 'song', limit = 25) =>
+  call('GET', `?kind=${encodeURIComponent(kind)}&limit=${encodeURIComponent(limit)}`);
 // Fire-and-forget play beacon — never blocks or breaks the load path.
 export const pingPlay = (id) => { fetch(`${API_BASE}/${id}/play`, { method: 'POST' }).catch(() => {}); };

--- a/docs/arcade/groovebox/registry/handler.js
+++ b/docs/arcade/groovebox/registry/handler.js
@@ -106,7 +106,8 @@ async function play(id, db) {
 async function list(url, db) {
   const kind = url.searchParams.get('kind') ?? 'song';
   if (kind !== 'song' && kind !== 'groove') return json(400, { error: 'bad kind' });
-  const limit = Math.min(50, Math.max(1, parseInt(url.searchParams.get('limit') ?? '25', 10) || 25));
+  const raw = parseInt(url.searchParams.get('limit') ?? '', 10);
+  const limit = Math.min(50, Math.max(1, Number.isNaN(raw) ? 25 : raw));
   const rows = await db.list(kind, limit);
   return json(200, {
     items: rows.map(({ id, kind: k, name, author, plays, remix_of, created_at }) =>

--- a/docs/arcade/groovebox/registry/handler.js
+++ b/docs/arcade/groovebox/registry/handler.js
@@ -101,6 +101,19 @@ async function play(id, db) {
   return new Response(null, { status: 204 });
 }
 
+// GET /api/registry?kind=song&limit=25 — the discovery shelf. Light rows only
+// (no payload, no edit_key_hash), newest first.
+async function list(url, db) {
+  const kind = url.searchParams.get('kind') ?? 'song';
+  if (kind !== 'song' && kind !== 'groove') return json(400, { error: 'bad kind' });
+  const limit = Math.min(50, Math.max(1, parseInt(url.searchParams.get('limit') ?? '25', 10) || 25));
+  const rows = await db.list(kind, limit);
+  return json(200, {
+    items: rows.map(({ id, kind: k, name, author, plays, remix_of, created_at }) =>
+      ({ id, kind: k, name, author, plays, remix_of, created_at })),
+  });
+}
+
 export async function handleRegistry(req, db, secret) {
   const url = new URL(req.url);
   const m = url.pathname.match(/^\/api\/registry(?:\/([a-z0-9]{8})(\/play)?)?$/);
@@ -109,6 +122,7 @@ export async function handleRegistry(req, db, secret) {
   try {
     if (req.method === 'POST' && id && isPlay) return await play(id, db);
     if (req.method === 'POST' && !id) return await create(req, db, secret);
+    if (req.method === 'GET' && !id) return await list(url, db);
     if (req.method === 'GET' && id && !isPlay) return await get(id, db);
     if (req.method === 'PUT' && id && !isPlay) return await update(id, req, db, secret);
   } catch {

--- a/docs/arcade/groovebox/tests/registry-handler.test.js
+++ b/docs/arcade/groovebox/tests/registry-handler.test.js
@@ -16,6 +16,12 @@ function memDb(rows = {}) {
     },
     async update(id, fields) { Object.assign(rows[id], fields); },
     async bumpPlays(id) { rows[id].plays = (rows[id].plays ?? 0) + 1; },
+    async list(kind, limit) {
+      return Object.values(rows)
+        .filter(r => r.kind === kind)
+        .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+        .slice(0, limit);
+    },
   };
 }
 
@@ -193,5 +199,52 @@ describe('POST /api/registry/:id/play', () => {
     }), db, SECRET);
     expect(res.status).toBe(400);
     expect(db.rows[id].plays).toBe(1);
+  });
+});
+
+describe('GET /api/registry (list — the discovery shelf)', () => {
+  let db; beforeEach(() => { db = memDb(); });
+  const listReq = (qs = '') => new Request(`https://groovebox.oyster.to/api/registry${qs}`);
+
+  async function seed(kind, name, plays = 0) {
+    const res = await handleRegistry(post(CREATE({
+      kind, name,
+      schema_version: kind === 'song' ? 2 : 1,
+      payload: kind === 'song' ? SONG_PAYLOAD : GROOVE_PAYLOAD,
+    })), db, SECRET);
+    expect(res.status).toBe(201);
+    const { id } = await res.json();
+    db.rows[id].plays = plays;
+    return id;
+  }
+
+  it('returns light song rows — no payload, no edit_key_hash', async () => {
+    await seed('song', 'Cool Song', 7);
+    await seed('groove', 'Some Groove');
+    const res = await handleRegistry(listReq('?kind=song'), db, SECRET);
+    expect(res.status).toBe(200);
+    const { items } = await res.json();
+    expect(items).toHaveLength(1);
+    expect(items[0].name).toBe('Cool Song');
+    expect(items[0].plays).toBe(7);
+    expect(items[0].author).toBe('Henry');
+    expect(items[0]).not.toHaveProperty('payload');
+    expect(items[0]).not.toHaveProperty('edit_key_hash');
+  });
+
+  it('defaults to kind=song; bad kind → 400; limit clamps to 50', async () => {
+    await seed('song', 'A');
+    const def = await handleRegistry(listReq(''), db, SECRET);
+    expect((await def.json()).items).toHaveLength(1);
+    const bad = await handleRegistry(listReq('?kind=banana'), db, SECRET);
+    expect(bad.status).toBe(400);
+    const big = await handleRegistry(listReq('?limit=999'), db, SECRET);
+    expect(big.status).toBe(200);   // clamp is the db arg; just must not error
+  });
+
+  it('grooves listable too', async () => {
+    await seed('groove', 'G1');
+    const res = await handleRegistry(listReq('?kind=groove'), db, SECRET);
+    expect((await res.json()).items.map(i => i.name)).toEqual(['G1']);
   });
 });

--- a/docs/arcade/groovebox/tests/registry-handler.test.js
+++ b/docs/arcade/groovebox/tests/registry-handler.test.js
@@ -19,7 +19,10 @@ function memDb(rows = {}) {
     async list(kind, limit) {
       return Object.values(rows)
         .filter(r => r.kind === kind)
-        .sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+        // newest first, id tie-break — mirrors the D1 adapter's ORDER BY
+        .sort((a, b) => (a.created_at !== b.created_at
+          ? (a.created_at < b.created_at ? 1 : -1)
+          : (a.id < b.id ? -1 : 1)))
         .slice(0, limit);
     },
   };

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -37,7 +37,7 @@
   /* out-of-scale rows: a dimmer wash of the roll bg. Derived from --roll-bg so
      it tracks every theme override (themes set --roll-bg on the same element). */
   --roll-bg-out:  color-mix(in srgb, var(--roll-bg) 78%, var(--bg));
-  --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--acc)); /* chord-tone wash */
+  --roll-ctone:   color-mix(in srgb, var(--roll-bg) 80%, var(--screen-acc)); /* chord-tone wash */
   --roll-note:    #1d3766;   /* note blocks + bass notes — dark pixels */
   --grid-line:    #9db5c4;   /* roll / scope gridlines */
   --scope:        #1d4a7e;   /* scope trace */
@@ -51,6 +51,10 @@
      screen matches their cabinet just alias these to --ink/--dim. */
   --screen-ink:  #16243f;
   --screen-dim:  #4d6787;
+  /* screen highlight pair — the glass's own accent family (playhead, selected,
+     sounding). Defaults to the cabinet accents; glass bundles override. */
+  --screen-acc:  var(--acc);
+  --screen-hot:  var(--hot);
 
   /* cabinet chrome — kept for screws */
   --chrome-hi:  #3a3e57;
@@ -67,6 +71,8 @@
 [data-theme] {
   --screen-ink: var(--ink);
   --screen-dim: var(--dim);
+  --screen-acc: var(--acc);
+  --screen-hot: var(--hot);
   /* Legacy dark screen defaults: themes that don't override a screen token
      used to inherit these from the old dark :root — they must not inherit
      Oyster's pearl values instead. Explicit theme blocks win (later, equal
@@ -437,14 +443,14 @@ select {
   transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .vtabs button:hover {
-  background: color-mix(in srgb, var(--acc) 8%, transparent);
+  background: color-mix(in srgb, var(--screen-acc) 8%, transparent);
   color: var(--screen-ink);
   border-color: transparent;
 }
 .vtabs button.on {
-  background: color-mix(in srgb, var(--acc) 10%, transparent);
-  border-bottom-color: var(--acc);
-  color: var(--acc);
+  background: color-mix(in srgb, var(--screen-acc) 10%, transparent);
+  border-bottom-color: var(--screen-acc);
+  color: var(--screen-acc);
 }
 .vtabs button:focus-visible {
   outline: 2px solid var(--acc);
@@ -568,17 +574,17 @@ input[type=range] {
    strip itself is tappable (→ Song tab). */
 #lcd-strip { cursor: pointer; }
 .strip-seg.strip-edit {
-  border-color: var(--acc);
-  color: var(--acc);
+  border-color: var(--screen-acc);
+  color: var(--screen-acc);
   white-space: nowrap;
 }
 /* The sounding position/chord — same --hot language as every other "playing" glow. */
 .strip-seg.hot {
-  background: var(--hot);
-  border-color: var(--hot);
+  background: var(--screen-hot);
+  border-color: var(--screen-hot);
   color: var(--screen-bg);
   font-weight: 700;
-  box-shadow: 0 0 6px var(--hot);
+  box-shadow: 0 0 6px var(--screen-hot);
 }
 .strip-key, .strip-bpm {
   font-size: 9px;
@@ -604,13 +610,13 @@ input[type=range] {
 #lcd-song .pat-lbl { color: var(--screen-dim); }
 #lcd-song .h-chip.h-empty { color: var(--screen-dim); }
 #lcd-song .pat-slot.sel {
-  background: var(--acc);
-  border-color: var(--acc);
+  background: var(--screen-acc);
+  border-color: var(--screen-acc);
   color: var(--screen-bg);
 }
-#lcd-song .pat-slot.playing { border-color: var(--hot); box-shadow: 0 0 8px var(--hot); }
-#lcd-song .chain-chip.playing { border-color: var(--hot); color: var(--hot); box-shadow: 0 0 6px var(--hot); }
-#lcd-song .h-chip.sounding { border-color: var(--hot); color: var(--hot); box-shadow: 0 0 8px var(--hot); }
+#lcd-song .pat-slot.playing { border-color: var(--screen-hot); box-shadow: 0 0 8px var(--screen-hot); }
+#lcd-song .chain-chip.playing { border-color: var(--screen-hot); color: var(--screen-hot); box-shadow: 0 0 6px var(--screen-hot); }
+#lcd-song .h-chip.sounding { border-color: var(--screen-hot); color: var(--screen-hot); box-shadow: 0 0 8px var(--screen-hot); }
 /* Shared label spine: PATTERNS / CHAIN labels right-align in one column so the
    chip rows read as a table. */
 #lcd-song .pat-row > .pat-lbl,
@@ -624,7 +630,7 @@ input[type=range] {
 #lcd-song .chord-row {
   margin-left: 68px;
   padding-left: 10px;
-  border-left: 2px solid color-mix(in srgb, var(--acc) 40%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--screen-acc) 40%, transparent);
 }
 /* The song's key, riding the chords row. */
 #lcd-song .h-key {
@@ -984,7 +990,7 @@ input[type=range] {
   color: var(--screen-dim);
   font-weight: 600;
   letter-spacing: 0.04em;
-  text-shadow: 0 0 6px color-mix(in srgb, var(--acc) 40%, transparent);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--screen-acc) 40%, transparent);
 }
 
 /* ─── grid rows ──────────────────────────────────────────────────────────── */
@@ -1082,16 +1088,16 @@ input[type=range] {
 
 /* § 6 — playhead: crisp --acc ring + faint column tint */
 .vc.now {
-  outline: 2px solid var(--acc);
+  outline: 2px solid var(--screen-acc);
   outline-offset: -2px;
-  box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 30%, transparent);
-  background: color-mix(in srgb, var(--acc) 6%, transparent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--screen-acc) 30%, transparent);
+  background: color-mix(in srgb, var(--screen-acc) 6%, transparent);
 }
 .vc.hit.now {
-  outline: 2px solid var(--acc);
+  outline: 2px solid var(--screen-acc);
   outline-offset: -2px;
   box-shadow:
-    0 0 10px color-mix(in srgb, var(--acc) 55%, transparent),
+    0 0 10px color-mix(in srgb, var(--screen-acc) 55%, transparent),
     0 0 4px rgba(255,255,255,0.25),
     inset 0 1px 0 rgba(100,220,200,0.3);
 }
@@ -1676,8 +1682,8 @@ body.gb-knob-values .knob-val { display: block; }
   letter-spacing: 0.02em;
   font-family: inherit;
 }
-.h-edit:focus { outline: 2px solid var(--acc); outline-offset: -1px; }
-.h-edit.invalid { border-color: var(--hot); outline-color: var(--hot); }
+.h-edit:focus { outline: 2px solid var(--screen-acc); outline-offset: -1px; }
+.h-edit.invalid { border-color: var(--screen-hot); outline-color: var(--screen-hot); }
 
 /* Snap-to-scale toggle — mirror .roll-mode-btn / .glen-btn look. */
 .snap-btn {
@@ -1698,10 +1704,10 @@ body.gb-knob-values .knob-val { display: block; }
 }
 .snap-btn:hover { background: var(--panel-3); border-color: var(--acc-dim); color: var(--ink); }
 .snap-btn.on {
-  background: color-mix(in srgb, var(--acc) 10%, transparent);
-  border-color: var(--acc);
-  color: var(--acc);
-  box-shadow: inset 0 -2px 0 var(--acc);
+  background: color-mix(in srgb, var(--screen-acc) 10%, transparent);
+  border-color: var(--screen-acc);
+  color: var(--screen-acc);
+  box-shadow: inset 0 -2px 0 var(--screen-acc);
 }
 
 /* Blocks-grid key tint: out-of-scale rows dim; chord-tone cells brighten. The
@@ -1710,7 +1716,7 @@ body.gb-knob-values .knob-val { display: block; }
 .bg-row.oos .bg-lbl { opacity: 0.5; }
 .vc.ctone:not(.hit) { background: var(--roll-ctone); }
 .vc.ctone.bar-alt:not(.hit) { background: color-mix(in srgb, var(--roll-ctone) 88%, #000); }
-.bg-row.oos .vc.ctone:not(.hit) { background: color-mix(in srgb, var(--roll-bg-out) 70%, var(--acc)); }
+.bg-row.oos .vc.ctone:not(.hit) { background: color-mix(in srgb, var(--roll-bg-out) 70%, var(--screen-acc)); }
 
 /* ─── master FX strip (panel chrome via #master) ────────────────────────── */
 .masterfx {
@@ -3977,16 +3983,16 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   font-size: 12px;
 }
 .bsel.on {
-  background: var(--acc);
-  border-color: var(--acc);
-  color: #04201a;
+  background: var(--screen-acc);
+  border-color: var(--screen-acc);
+  color: var(--screen-bg);
   font-weight: 700;
-  box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 35%, transparent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--screen-acc) 35%, transparent);
 }
 .bsel.playing {
-  outline: 2px solid var(--hot);
+  outline: 2px solid var(--screen-hot);
   outline-offset: 2px;
-  box-shadow: 0 0 8px rgba(255,91,158,0.3);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--screen-hot) 30%, transparent);
 }
 .glen { display: inline-flex; align-items: center; gap: 4px; margin-left: auto; }
 .glen-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--screen-dim); margin-right: 2px; }
@@ -4001,11 +4007,11 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   font-size: 12px;
 }
 .glen-btn.on {
-  background: var(--acc);
-  border-color: var(--acc);
-  color: #04201a;
+  background: var(--screen-acc);
+  border-color: var(--screen-acc);
+  color: var(--screen-bg);
   font-weight: 700;
-  box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 35%, transparent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--screen-acc) 35%, transparent);
 }
 
 /* accordion expand button: hidden by default; the mobile layout shows it */
@@ -4267,6 +4273,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
    rebinding, so any glass works on any cabinet. Placed last so it outranks
    theme blocks and theme #viz rules at equal specificity. */
 [data-screen="pearl"] {
+  --screen-acc: #8b76ff; --screen-hot: #ff8de0;
   --screen-bg: #cfe0ea; --screen-glow: rgba(123,231,255,0.10);
   --screen-ink: #16243f; --screen-dim: #4d6787;
   --cell: #bcd2de; --cell-alt: #b3c9d6; --hit1: #2b4a7e; --hit2: #18305a;
@@ -4274,6 +4281,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   --grid-line: #9db5c4; --scope: #1d4a7e; --playhead: #122441;
 }
 [data-screen="phosphor"] {
+  --screen-acc: #54f0c8; --screen-hot: #ff5b9e;
   --screen-bg: #051813; --screen-glow: rgba(84,240,200,0.14);
   --screen-ink: #d9efe8; --screen-dim: #79a597;
   --cell: #0a231d; --cell-alt: #0d2b23; --hit1: #2fd6ab; --hit2: #117a5f;
@@ -4281,6 +4289,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   --grid-line: #1b4438; --scope: #7dffe0; --playhead: #ffffff;
 }
 [data-screen="lime"] {
+  --screen-acc: #2f6230; --screen-hot: #c2255c;
   --screen-bg: #9bbc0f; --screen-glow: rgba(155,188,15,0.12);
   --screen-ink: #0f380f; --screen-dim: #306230;
   --cell: #8bac0f; --cell-alt: #93b412; --hit1: #306230; --hit2: #0f380f;
@@ -4288,6 +4297,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   --grid-line: #6f8f0d; --scope: #0f380f; --playhead: #0f380f;
 }
 [data-screen="amber"] {
+  --screen-acc: #ffd24a; --screen-hot: #ff7a3d;
   --screen-bg: #050300; --screen-glow: rgba(255,176,0,0.08);
   --screen-ink: #ffcf7a; --screen-dim: #b87f20;
   --cell: #140d02; --cell-alt: #1e1506; --hit1: #b87f20; --hit2: #7a5410;
@@ -4295,6 +4305,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   --grid-line: #3a2c0e; --scope: #ffd24a; --playhead: #ffcf7a;
 }
 [data-screen="paper"] {
+  --screen-acc: #6a2ce0; --screen-hot: #e0317e;
   --screen-bg: #b6b8ac; --screen-glow: rgba(0,0,0,0.05);
   --screen-ink: #1a1a12; --screen-dim: #50503f;
   --cell: #b6b8ac; --cell-alt: #bec0b4; --hit1: #3a3a2e; --hit2: #1a1a12;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -645,10 +645,26 @@ input[type=range] {
 #songbtn.open { border-color: var(--acc); color: var(--acc); box-shadow: 0 0 6px color-mix(in srgb, var(--acc) 40%, transparent); }
 #songbtn.open .songbtn-caret { transform: rotate(180deg); color: var(--acc); }
 
-/* ─── SELECT SONG — cartridge picker pane on the LCD ─────────────────────────
-   Console game-select idiom: every song is a cartridge card drawn in screen
-   pixels. Notch colour = AI original (accent) / cover (dim) / shared (hot). */
-#lcd-picker { padding: 2px 2px 8px; }
+/* ─── SELECT SONG — the cartridge drawer ─────────────────────────────────────
+   Cartridges are hardware: a rack panel anchored under the song slot (bottom
+   sheet on mobile). Notch colour = AI original (accent) / cover (dim) /
+   shared (hot); the loaded cart fills in the accent. */
+.transport-song { position: relative; }
+#song-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 200;
+  width: min(380px, calc(100vw - 32px));
+  max-height: min(420px, 60vh);
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+}
+#song-picker[hidden] { display: none; }
 .picker-head {
   display: flex;
   align-items: center;
@@ -656,8 +672,8 @@ input[type=range] {
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.12em;
-  color: var(--screen-ink);
-  padding: 4px 6px 6px;
+  color: var(--dim);
+  padding: 0 0 4px;
 }
 .picker-close {
   width: 24px;
@@ -665,18 +681,18 @@ input[type=range] {
   padding: 0;
   font-size: 11px;
   border-radius: 5px;
-  border: 1px solid color-mix(in srgb, var(--screen-ink) 35%, transparent);
+  border: 1px solid var(--line);
   background: transparent;
-  color: var(--screen-dim);
+  color: var(--faint);
   box-shadow: none;
 }
-.picker-close:hover { color: var(--screen-ink); border-color: var(--screen-ink); background: transparent; }
+.picker-close:hover { color: var(--ink); border-color: var(--dim); background: var(--panel-3); }
 .picker-sect {
   font-size: 8px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--screen-dim);
-  padding: 8px 6px 2px;
+  color: var(--faint);
+  padding: 8px 0 2px;
 }
 .kart {
   display: flex;
@@ -686,28 +702,28 @@ input[type=range] {
   text-align: left;
   margin: 4px 0;
   padding: 6px 9px;
-  border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent);
+  border: 1px solid var(--line);
   border-radius: 7px;
-  background: color-mix(in srgb, var(--screen-ink) 5%, transparent);
-  color: var(--screen-ink);
-  box-shadow: none;
+  background: var(--panel-2);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.04), 0 1px 2px rgba(0,0,0,0.25);
   cursor: pointer;
   height: auto;
 }
-.kart:hover { border-color: var(--screen-ink); background: color-mix(in srgb, var(--screen-ink) 10%, transparent); }
+.kart:hover { border-color: var(--acc-dim); background: var(--panel-3); }
 .kart-notch {
   width: 14px;
   height: 19px;
   flex: 0 0 14px;
   border-radius: 3px;
-  background: color-mix(in srgb, var(--screen-ink) 55%, transparent);
-  box-shadow: inset 0 -6px 0 rgba(0,0,0,0.25);
+  background: color-mix(in srgb, var(--dim) 60%, transparent);
+  box-shadow: inset 0 -6px 0 rgba(0,0,0,0.3);
 }
 .kart.ai .kart-notch { background: var(--acc); }
 .kart.shared .kart-notch { background: var(--hot); }
 .kart-meta { display: flex; flex-direction: column; min-width: 0; }
 .kart-t { font-weight: 700; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.kart-a { font-size: 10px; color: var(--screen-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kart-a { font-size: 10px; color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .kart-plays {
   margin-left: auto;
   font-size: 10px;
@@ -718,14 +734,42 @@ input[type=range] {
   padding: 1px 7px;
   white-space: nowrap;
 }
-/* The cart in the machine — inverted, like a real LCD menu selection. */
+/* The cart in the machine. */
 .kart.sel {
-  background: var(--screen-ink);
-  border-color: var(--screen-ink);
-  color: var(--screen-bg);
+  background: color-mix(in srgb, var(--acc) 14%, var(--panel-2));
+  border-color: var(--acc);
 }
-.kart.sel .kart-a { color: color-mix(in srgb, var(--screen-bg) 75%, transparent); }
-.kart.sel .kart-notch { background: var(--screen-bg); }
+.kart.sel .kart-t { color: var(--acc); }
+
+/* Mobile: the drawer is a bottom sheet, like Help and Settings. */
+@media (max-width: 900px) {
+  #song-picker {
+    position: fixed;
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
+    max-height: 75vh;
+    border-radius: 16px 16px 0 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    padding: 14px 20px calc(24px + env(safe-area-inset-bottom));
+    box-shadow: 0 -8px 40px rgba(0,0,0,0.45);
+    animation: gbm-sheet-up 0.22s cubic-bezier(0.2, 0.8, 0.3, 1);
+    z-index: 210;
+  }
+  #song-picker::before {
+    content: '';
+    display: block;
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--line);
+    margin: 0 auto 12px;
+  }
+}
 
 /* Screen row — first row of the Settings popover */
 .vs-screen {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -677,24 +677,62 @@ input[type=range] {
   cursor: pointer;
 }
 .ttile-plate {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   position: relative;
   width: 100%;
-  height: 84px;
+  height: 96px;
+  padding: 9px;
   border-radius: 8px;
   background: var(--bg);
   border: 1px solid rgba(0,0,0,0.45);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
 }
-.ttile-plate i { position: absolute; display: block; }
+/* the miniature screen: strip line + three rows of REAL .vc cells */
 .ttile-plate .tp-scr {
-  top: 10px; left: 10px; right: 10px; height: 42px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
   border-radius: 4px;
   background: var(--screen-bg);
   border: 1px solid rgba(0,0,0,0.3);
+  padding: 4px 5px;
+  overflow: hidden;
 }
-.ttile-plate .tp-acc { left: 10px; bottom: 10px; width: 26px; height: 11px; border-radius: 3px; background: var(--acc); }
-.ttile-plate .tp-hot { left: 42px; bottom: 10px; width: 11px; height: 11px; border-radius: 50%; background: var(--hot); }
+.ttile-plate .tp-strip {
+  display: block;
+  height: 3px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--screen-ink) 30%, transparent);
+  margin-bottom: 1px;
+}
+/* dollhouse-scale overrides for the app's own cell classes — theme rules
+   (banded 808 steps, lit phosphor hits) keep applying */
+.ttile-plate .vrow { display: flex; gap: 2px; margin: 0; align-items: stretch; flex: 1; }
+.ttile-plate .vc {
+  flex: 1 1 0;
+  width: auto;
+  height: auto;
+  min-height: 5px;
+  border-radius: 1.5px;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  cursor: pointer;
+}
+.ttile-plate .tp-ctl { display: flex; gap: 5px; align-items: center; flex: 0 0 auto; }
+.ttile-plate .tp-acc { display: block; width: 24px; height: 10px; border-radius: 3px; background: var(--acc); }
+.ttile-plate .tp-hot { display: block; width: 10px; height: 10px; border-radius: 50%; background: var(--hot); }
+.ttile-plate .knob-dial {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 12px;
+  cursor: pointer;
+  margin-left: 1px;
+}
+.ttile-plate .knob-dial:first-of-type { margin-left: auto; }
 .ttile-nm {
   display: block;
   width: 100%;
@@ -741,10 +779,10 @@ input[type=range] {
   }
   .theme-grid { grid-template-columns: 1fr; gap: 9px; }
   .ttile { flex-direction: row; align-items: center; gap: 12px; }
-  .ttile-plate { width: 130px; flex: 0 0 130px; height: 56px; }
-  .ttile-plate .tp-scr { top: 7px; left: 7px; right: 7px; height: 28px; }
-  .ttile-plate .tp-acc { left: 7px; bottom: 7px; width: 20px; height: 9px; }
-  .ttile-plate .tp-hot { left: 33px; bottom: 7px; width: 9px; height: 9px; }
+  .ttile-plate { width: 150px; flex: 0 0 150px; height: 72px; padding: 6px; gap: 4px; }
+  .ttile-plate .tp-acc { width: 18px; height: 8px; }
+  .ttile-plate .tp-hot { width: 8px; height: 8px; }
+  .ttile-plate .knob-dial { width: 10px; height: 10px; flex: 0 0 10px; }
   .ttile-nm { text-align: left; font-size: 13px; }
 }
 

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -652,41 +652,57 @@ input[type=range] {
   box-shadow: 0 8px 32px rgba(0,0,0,0.5);
 }
 #theme-picker[hidden] { display: none; }
-.trow {
+/* Mini-machine tiles, 3-up. Each plate carries data-theme, so the theme's own
+   CSS block paints it: cabinet (--panel over --bg), screen, accent, hot. */
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 7px;
+  margin: 2px 0 6px;
+}
+.ttile {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  width: 100%;
-  text-align: left;
-  margin: 3px 0;
-  padding: 6px 9px;
+  flex-direction: column;
+  gap: 3px;
+  padding: 0;
   height: auto;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  background: var(--panel-2);
-  color: var(--ink);
-  font-size: 12px;
+  border: none;
+  background: transparent;
   box-shadow: none;
   cursor: pointer;
 }
-.trow:hover { border-color: var(--acc-dim); background: var(--panel-3); }
-.trow.sel { border-color: var(--acc); }
-.trow.sel .trow-t { color: var(--acc); font-weight: 700; }
-/* The swatches: each strip carries the theme's data-theme attribute, so its
-   own CSS block resolves the chips — cabinet · screen · accent · hot. */
-.swatches { display: inline-flex; gap: 3px; flex: 0 0 auto; }
-.swatches i {
-  width: 13px;
-  height: 13px;
-  border-radius: 3px;
-  border: 1px solid rgba(0,0,0,0.35);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
+.ttile-plate {
+  display: block;
+  position: relative;
+  height: 44px;
+  border-radius: 6px;
+  background: var(--bg);
+  border: 1px solid rgba(0,0,0,0.45);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
 }
-.swatches i:nth-child(1) { background: var(--bg); }
-.swatches i:nth-child(2) { background: var(--screen-bg); }
-.swatches i:nth-child(3) { background: var(--acc); }
-.swatches i:nth-child(4) { background: var(--hot); }
+.ttile-plate i { position: absolute; display: block; }
+.ttile-plate .tp-scr {
+  top: 6px; left: 6px; right: 6px; height: 20px;
+  border-radius: 3px;
+  background: var(--screen-bg);
+  border: 1px solid rgba(0,0,0,0.3);
+}
+.ttile-plate .tp-acc { left: 6px; bottom: 6px; width: 16px; height: 7px; border-radius: 2px; background: var(--acc); }
+.ttile-plate .tp-hot { left: 26px; bottom: 6px; width: 7px; height: 7px; border-radius: 50%; background: var(--hot); }
+.ttile-nm {
+  font-size: 9px;
+  letter-spacing: 0.02em;
+  color: var(--dim);
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+.ttile:hover .ttile-plate { outline: 1px solid var(--acc-dim); }
+.ttile:hover .ttile-nm { color: var(--ink); }
+.ttile.sel .ttile-plate { outline: 2px solid var(--acc); outline-offset: 1px; box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 45%, transparent); }
+.ttile.sel .ttile-nm { color: var(--acc); font-weight: 700; }
 
 /* Mobile: bottom sheet, like the song drawer. */
 @media (max-width: 900px) {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -91,6 +91,8 @@
 [data-theme="oyster"] {
   --bg:        #04060d;
   --screen-bg: #cfe0ea;
+  --screen-ink: #16243f;
+  --screen-dim: #4d6787;
   --acc:       #8b76ff;
   --hot:       #ff8de0;
 }
@@ -668,6 +670,7 @@ input[type=range] {
   align-items: stretch;
   gap: 5px;
   width: 100%;
+  min-width: 0;
   padding: 0;
   height: auto;
   min-height: 0;
@@ -678,76 +681,50 @@ input[type=range] {
 }
 .ttile-plate {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
   position: relative;
   width: 100%;
-  height: 96px;
-  padding: 9px;
+  height: 64px;
+  padding: 8px 8px 13px;
   border-radius: 8px;
   background: var(--bg);
   border: 1px solid rgba(0,0,0,0.45);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
 }
-/* the miniature screen: strip line + three rows of REAL .vc cells */
+/* the screen IS the label: theme name in its own screen ink on its own glass */
 .ttile-plate .tp-scr {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  justify-content: center;
   flex: 1 1 auto;
+  min-width: 0;
   border-radius: 4px;
   background: var(--screen-bg);
   border: 1px solid rgba(0,0,0,0.3);
-  padding: 4px 5px;
+  padding: 2px 8px;
   overflow: hidden;
 }
-.ttile-plate .tp-strip {
-  display: block;
-  height: 3px;
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--screen-ink) 30%, transparent);
-  margin-bottom: 1px;
-}
-/* dollhouse-scale overrides for the app's own cell classes — theme rules
-   (banded 808 steps, lit phosphor hits) keep applying */
-.ttile-plate .vrow { display: flex; gap: 2px; margin: 0; align-items: stretch; flex: 1; }
-.ttile-plate .vc {
-  flex: 1 1 0;
-  width: auto;
-  height: auto;
-  min-height: 5px;
-  border-radius: 1.5px;
-  padding: 0;
-  border: none;
-  box-shadow: none;
-  cursor: pointer;
-}
-.ttile-plate .tp-ctl { display: flex; gap: 5px; align-items: center; flex: 0 0 auto; }
-.ttile-plate .tp-acc { display: block; width: 24px; height: 10px; border-radius: 3px; background: var(--acc); }
-.ttile-plate .tp-hot { display: block; width: 10px; height: 10px; border-radius: 50%; background: var(--hot); }
-.ttile-plate .knob-dial {
-  width: 12px;
-  height: 12px;
-  flex: 0 0 12px;
-  cursor: pointer;
-  margin-left: 1px;
-}
-.ttile-plate .knob-dial:first-of-type { margin-left: auto; }
-.ttile-nm {
-  display: block;
-  width: 100%;
-  font-size: 11px;
-  letter-spacing: 0.02em;
-  color: var(--dim);
-  text-align: center;
+.ttile-plate .tp-nm {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--screen-ink);
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+}
+/* one accent LED on the bezel */
+.ttile-plate .tp-led {
+  position: absolute;
+  left: 10px;
+  bottom: 5px;
+  width: 12px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--acc);
+  box-shadow: 0 0 4px var(--acc);
 }
 .ttile:hover .ttile-plate { outline: 1px solid var(--acc-dim); }
-.ttile:hover .ttile-nm { color: var(--ink); }
 .ttile.sel .ttile-plate { outline: 2px solid var(--acc); outline-offset: 1px; box-shadow: 0 0 10px color-mix(in srgb, var(--acc) 45%, transparent); }
-.ttile.sel .ttile-nm { color: var(--acc); font-weight: 700; }
 
 /* Mobile: bottom sheet, single column — one big machine per row. */
 @media (max-width: 900px) {
@@ -777,13 +754,9 @@ input[type=range] {
     background: var(--line);
     margin: 0 auto 12px;
   }
-  .theme-grid { grid-template-columns: 1fr; gap: 9px; }
-  .ttile { flex-direction: row; align-items: center; gap: 12px; }
-  .ttile-plate { width: 150px; flex: 0 0 150px; height: 72px; padding: 6px; gap: 4px; }
-  .ttile-plate .tp-acc { width: 18px; height: 8px; }
-  .ttile-plate .tp-hot { width: 8px; height: 8px; }
-  .ttile-plate .knob-dial { width: 10px; height: 10px; flex: 0 0 10px; }
-  .ttile-nm { text-align: left; font-size: 13px; }
+  .theme-grid { grid-template-columns: 1fr 1fr; gap: 9px; }
+  .ttile-plate { height: 58px; }
+  .ttile-plate .tp-nm { font-size: 12px; }
 }
 
 /* ─── Song slot button — opens the cartridge picker on the screen ─────────── */
@@ -2548,6 +2521,10 @@ html:not([data-theme]) .vc.now:not(.hit),
 [data-theme="snes"],
 [data-theme="snesus"],
 [data-theme="ps1"] { --screen-ink: #e8e8ea; --screen-dim: #989fa8; }
+[data-theme="famicom"],
+[data-theme="dreamcast"] { --screen-ink: #e8e8ea; --screen-dim: #989fa8; }
+/* Amiga: Workbench-blue screen wants its own light ink (mirrors the #viz rebind). */
+[data-theme="amiga"] { --screen-ink: #e8f0fa; --screen-dim: #a8c4e0; }
 
 /* ─── hardware homage skins — consoles ────────────────────────────────────── */
 

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -85,6 +85,16 @@
   --screen-glow:  color-mix(in srgb, var(--acc) 6%, transparent);
 }
 
+/* Oyster's swatch identity — the theme-picker chips carry data-theme, and the
+   default theme has no block of its own, so pin just the swatch tokens here.
+   (Must follow the [data-theme] alias rule so these win at equal specificity.) */
+[data-theme="oyster"] {
+  --bg:        #04060d;
+  --screen-bg: #cfe0ea;
+  --acc:       #8b76ff;
+  --hot:       #ff8de0;
+}
+
 /* ─── MIDNIGHT — the former Dark theme: graphite cabinet, teal accent,
    teal-phosphor screen ───────────────────────────────────────────────────── */
 [data-theme="midnight"] {
@@ -622,6 +632,90 @@ input[type=range] {
   color: var(--screen-dim);
   margin-left: 10px;
   white-space: nowrap;
+}
+
+/* ─── Theme picker — drawer with live swatches under the titlebar button ──── */
+.theme-wrap { position: relative; }
+#themebtn.open { border-color: var(--acc); color: var(--acc); }
+#theme-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 200;
+  width: min(300px, calc(100vw - 32px));
+  max-height: min(480px, 70vh);
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+}
+#theme-picker[hidden] { display: none; }
+.trow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  margin: 3px 0;
+  padding: 6px 9px;
+  height: auto;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel-2);
+  color: var(--ink);
+  font-size: 12px;
+  box-shadow: none;
+  cursor: pointer;
+}
+.trow:hover { border-color: var(--acc-dim); background: var(--panel-3); }
+.trow.sel { border-color: var(--acc); }
+.trow.sel .trow-t { color: var(--acc); font-weight: 700; }
+/* The swatches: each strip carries the theme's data-theme attribute, so its
+   own CSS block resolves the chips — cabinet · screen · accent · hot. */
+.swatches { display: inline-flex; gap: 3px; flex: 0 0 auto; }
+.swatches i {
+  width: 13px;
+  height: 13px;
+  border-radius: 3px;
+  border: 1px solid rgba(0,0,0,0.35);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.15);
+}
+.swatches i:nth-child(1) { background: var(--bg); }
+.swatches i:nth-child(2) { background: var(--screen-bg); }
+.swatches i:nth-child(3) { background: var(--acc); }
+.swatches i:nth-child(4) { background: var(--hot); }
+
+/* Mobile: bottom sheet, like the song drawer. */
+@media (max-width: 900px) {
+  #theme-picker {
+    position: fixed;
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
+    max-height: 75vh;
+    border-radius: 16px 16px 0 0;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    padding: 14px 20px calc(24px + env(safe-area-inset-bottom));
+    box-shadow: 0 -8px 40px rgba(0,0,0,0.45);
+    animation: gbm-sheet-up 0.22s cubic-bezier(0.2, 0.8, 0.3, 1);
+    z-index: 210;
+  }
+  #theme-picker::before {
+    content: '';
+    display: block;
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--line);
+    margin: 0 auto 12px;
+  }
 }
 
 /* ─── Song slot button — opens the cartridge picker on the screen ─────────── */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -822,6 +822,20 @@ input[type=range] {
   box-shadow: none;
 }
 .picker-close:hover { color: var(--ink); border-color: var(--dim); background: var(--panel-3); }
+/* the confirm-to-dismiss — a real button, not a mystery ✕ */
+.picker-done {
+  height: 26px;
+  padding: 0 16px;
+  border-radius: 6px;
+  border: 1px solid var(--acc);
+  background: color-mix(in srgb, var(--acc) 12%, transparent);
+  color: var(--acc);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  box-shadow: none;
+}
+.picker-done:hover { background: color-mix(in srgb, var(--acc) 22%, transparent); color: var(--acc); border-color: var(--acc); }
 .picker-sect {
   font-size: 8px;
   letter-spacing: 0.16em;

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -635,7 +635,6 @@ input[type=range] {
 }
 
 /* ─── Theme picker — drawer with live swatches under the titlebar button ──── */
-.theme-wrap { position: relative; }
 #themebtn.open { border-color: var(--acc); color: var(--acc); }
 /* Desktop: a full gallery — 32 machines deserve real estate, not a keyhole. */
 #theme-picker {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -828,6 +828,7 @@ input[type=range] {
   box-shadow: none;
 }
 .picker-close:hover { color: var(--ink); border-color: var(--dim); background: var(--panel-3); }
+#theme-picker-tabs { display: flex; gap: 6px; margin: 2px 0 12px; }
 /* the confirm-to-dismiss — a real button, not a mystery ✕ */
 .picker-done {
   height: 26px;
@@ -4304,6 +4305,38 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   --roll-bg: #140d02; --roll-bg-blk: #0d0800; --roll-note: #ffd24a;
   --grid-line: #3a2c0e; --scope: #ffd24a; --playhead: #ffcf7a;
 }
+[data-screen="signal"] {
+  --screen-acc: #7be7ff; --screen-hot: #ff8de0;
+  --screen-bg: #041420; --screen-glow: rgba(123,231,255,0.13);
+  --screen-ink: #d9ecf5; --screen-dim: #7da3b8;
+  --cell: #0a2538; --cell-alt: #0d2e45; --hit1: #67d9ff; --hit2: #1d7fae;
+  --roll-bg: #07202f; --roll-bg-blk: #051824; --roll-note: #7be7ff;
+  --grid-line: #16455e; --scope: #7be7ff; --playhead: #ffffff;
+}
+[data-screen="workbench"] {
+  --screen-acc: #7ab8f0; --screen-hot: #e8742a;
+  --screen-bg: #0a3c7c; --screen-glow: rgba(26,92,184,0.15);
+  --screen-ink: #e8f0fa; --screen-dim: #a8c4e0;
+  --cell: #0d4a92; --cell-alt: #10529e; --hit1: #f08a3a; --hit2: #c85a10;
+  --roll-bg: #0c4488; --roll-bg-blk: #0a3c78; --roll-note: #ffffff;
+  --grid-line: #2a62a8; --scope: #7ab8f0; --playhead: #e8742a;
+}
+[data-screen="sage"] {
+  --screen-acc: #2c4490; --screen-hot: #cf5548;
+  --screen-bg: #a3ad9c; --screen-glow: transparent;
+  --screen-ink: #1e2424; --screen-dim: #424c46;
+  --cell: #97a190; --cell-alt: #9da796; --hit1: #2c3434; --hit2: #161c1c;
+  --roll-bg: #a9b3a2; --roll-bg-blk: #9da796; --roll-note: #1e2424;
+  --grid-line: #87917e; --scope: #1e2424; --playhead: #2c4490;
+}
+[data-screen="backlit"] {
+  --screen-acc: #2fc4ac; --screen-hot: #e03f8c;
+  --screen-bg: #0a2018; --screen-glow: rgba(47,196,172,0.10);
+  --screen-ink: #c8efe4; --screen-dim: #6fa295;
+  --cell: #0d2820; --cell-alt: #113026; --hit1: #2fc4ac; --hit2: #157a64;
+  --roll-bg: #0d2820; --roll-bg-blk: #0a221b; --roll-note: #5ff0d4;
+  --grid-line: #1c4438; --scope: #7df5dc; --playhead: #ffffff;
+}
 [data-screen="paper"] {
   --screen-acc: #6a2ce0; --screen-hot: #e0317e;
   --screen-bg: #b6b8ac; --screen-glow: rgba(0,0,0,0.05);
@@ -4314,6 +4347,10 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 }
 /* In-screen DOM ink rebinding per glass (matches the theme #viz treatment). */
 [data-screen="pearl"] #viz    { --ink: #16243f; --dim: #4d6787; --faint: #6d83a0; }
+[data-screen="sage"] #viz     { --ink: #1e2424; --dim: #424c46; --faint: #66706a; }
+[data-screen="signal"] #viz   { --ink: #d9ecf5; --dim: #7da3b8; --faint: #5d8094; }
+[data-screen="workbench"] #viz { --ink: #e8f0fa; --dim: #a8c4e0; --faint: #7a9cc4; }
+[data-screen="backlit"] #viz  { --ink: #c8efe4; --dim: #6fa295; --faint: #54806e; }
 [data-screen="lime"] #viz     { --ink: #0f380f; --dim: #306230; --faint: #4a7a3a; }
 [data-screen="paper"] #viz    { --ink: #1a1a12; --dim: #50503f; --faint: #6e6e5c; }
 [data-screen="phosphor"] #viz { --ink: #d9efe8; --dim: #79a597; --faint: #587e72; }
@@ -4321,6 +4358,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 /* Pale glass gets the reflective-LCD inset; dark glass gets the CRT cave. */
 [data-screen="pearl"] #viz,
 [data-screen="lime"] #viz,
+[data-screen="sage"] #viz,
 [data-screen="paper"] #viz {
   box-shadow:
     inset 0 0 0 1px rgba(0,0,0,0.15),
@@ -4329,8 +4367,12 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 }
 [data-screen="pearl"] .vc.hit,
 [data-screen="lime"] .vc.hit,
+[data-screen="sage"] .vc.hit,
 [data-screen="paper"] .vc.hit { box-shadow: none; }
 [data-screen="phosphor"] #viz,
+[data-screen="signal"] #viz,
+[data-screen="workbench"] #viz,
+[data-screen="backlit"] #viz,
 [data-screen="amber"] #viz {
   box-shadow:
     inset 0 1px 0 rgba(255,255,255,0.06),

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -624,6 +624,109 @@ input[type=range] {
   white-space: nowrap;
 }
 
+/* ─── Song slot button — opens the cartridge picker on the screen ─────────── */
+#songbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0 12px;
+  font-size: 12px;
+  color: var(--ink);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+#songbtn .songbtn-t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#songbtn .songbtn-caret { color: var(--dim); font-size: 10px; }
+#songbtn:hover { border-color: var(--acc-dim); background: var(--panel-3); }
+#songbtn.open { border-color: var(--acc); color: var(--acc); box-shadow: 0 0 6px color-mix(in srgb, var(--acc) 40%, transparent); }
+#songbtn.open .songbtn-caret { transform: rotate(180deg); color: var(--acc); }
+
+/* ─── SELECT SONG — cartridge picker pane on the LCD ─────────────────────────
+   Console game-select idiom: every song is a cartridge card drawn in screen
+   pixels. Notch colour = AI original (accent) / cover (dim) / shared (hot). */
+#lcd-picker { padding: 2px 2px 8px; }
+.picker-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--screen-ink);
+  padding: 4px 6px 6px;
+}
+.picker-close {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 11px;
+  border-radius: 5px;
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 35%, transparent);
+  background: transparent;
+  color: var(--screen-dim);
+  box-shadow: none;
+}
+.picker-close:hover { color: var(--screen-ink); border-color: var(--screen-ink); background: transparent; }
+.picker-sect {
+  font-size: 8px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--screen-dim);
+  padding: 8px 6px 2px;
+}
+.kart {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  text-align: left;
+  margin: 4px 0;
+  padding: 6px 9px;
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--screen-ink) 5%, transparent);
+  color: var(--screen-ink);
+  box-shadow: none;
+  cursor: pointer;
+  height: auto;
+}
+.kart:hover { border-color: var(--screen-ink); background: color-mix(in srgb, var(--screen-ink) 10%, transparent); }
+.kart-notch {
+  width: 14px;
+  height: 19px;
+  flex: 0 0 14px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--screen-ink) 55%, transparent);
+  box-shadow: inset 0 -6px 0 rgba(0,0,0,0.25);
+}
+.kart.ai .kart-notch { background: var(--acc); }
+.kart.shared .kart-notch { background: var(--hot); }
+.kart-meta { display: flex; flex-direction: column; min-width: 0; }
+.kart-t { font-weight: 700; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kart-a { font-size: 10px; color: var(--screen-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kart-plays {
+  margin-left: auto;
+  font-size: 10px;
+  font-family: ui-monospace, Menlo, monospace;
+  color: var(--hot);
+  border: 1px solid color-mix(in srgb, var(--hot) 55%, transparent);
+  border-radius: 9px;
+  padding: 1px 7px;
+  white-space: nowrap;
+}
+/* The cart in the machine — inverted, like a real LCD menu selection. */
+.kart.sel {
+  background: var(--screen-ink);
+  border-color: var(--screen-ink);
+  color: var(--screen-bg);
+}
+.kart.sel .kart-a { color: color-mix(in srgb, var(--screen-bg) 75%, transparent); }
+.kart.sel .kart-notch { background: var(--screen-bg); }
+
 /* Screen row — first row of the Settings popover */
 .vs-screen {
   display: flex;
@@ -1503,22 +1606,6 @@ body.gb-knob-values .knob-val { display: block; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-}
-
-/* ─── song-wrap: selector + inline credit stacked ───────────────────────── */
-.song-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-/* ─── transport-bpm-unit: muted ─────────────────────────────────────────── */
-.transport-bpm-unit {
-  font-size: 9px;
-  color: var(--faint);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 
 /* ─── colour themes — each block overrides design tokens only ────────────── */
@@ -3754,8 +3841,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   .transport { gap: 8px; }
   #play { flex: 0 0 auto; height: 38px; font-size: 14px; padding: 0 18px; }
   .transport-song { flex: 1 1 auto; margin-left: 0; min-width: 0; }
-  .transport-song .song-wrap { flex: 1; min-width: 0; }
-  .transport-song select { width: 100%; }
+  #songbtn { width: 100%; justify-content: space-between; }
 
   /* ── LCD strip: narrow → title, walking chain, the sounding chord, bpm ── */
   #lcd-strip { gap: 6px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -637,35 +637,41 @@ input[type=range] {
 /* ─── Theme picker — drawer with live swatches under the titlebar button ──── */
 .theme-wrap { position: relative; }
 #themebtn.open { border-color: var(--acc); color: var(--acc); }
+/* Desktop: a full gallery — 32 machines deserve real estate, not a keyhole. */
 #theme-picker {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  position: fixed;
+  top: 6vh;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 200;
-  width: min(300px, calc(100vw - 32px));
-  max-height: min(480px, 70vh);
+  width: min(960px, calc(100vw - 48px));
+  max-height: 86vh;
   overflow-y: auto;
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 10px 12px;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  border-radius: 14px;
+  padding: 16px 20px 20px;
+  box-shadow: 0 16px 60px rgba(0,0,0,0.65);
 }
 #theme-picker[hidden] { display: none; }
-/* Mini-machine tiles, 3-up. Each plate carries data-theme, so the theme's own
-   CSS block paints it: cabinet (--panel over --bg), screen, accent, hot. */
+/* Mini-machine tiles. Each plate carries data-theme, so the theme's own CSS
+   block paints it: cabinet, screen, accent play-bar, hot dot. Explicit widths/
+   heights everywhere — the global button base otherwise collapses the plates. */
 .theme-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 7px;
-  margin: 2px 0 6px;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+  margin: 4px 0 12px;
 }
 .ttile {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  align-items: stretch;
+  gap: 5px;
+  width: 100%;
   padding: 0;
   height: auto;
+  min-height: 0;
   border: none;
   background: transparent;
   box-shadow: none;
@@ -674,46 +680,48 @@ input[type=range] {
 .ttile-plate {
   display: block;
   position: relative;
-  height: 44px;
-  border-radius: 6px;
+  width: 100%;
+  height: 84px;
+  border-radius: 8px;
   background: var(--bg);
   border: 1px solid rgba(0,0,0,0.45);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.12);
 }
 .ttile-plate i { position: absolute; display: block; }
 .ttile-plate .tp-scr {
-  top: 6px; left: 6px; right: 6px; height: 20px;
-  border-radius: 3px;
+  top: 10px; left: 10px; right: 10px; height: 42px;
+  border-radius: 4px;
   background: var(--screen-bg);
   border: 1px solid rgba(0,0,0,0.3);
 }
-.ttile-plate .tp-acc { left: 6px; bottom: 6px; width: 16px; height: 7px; border-radius: 2px; background: var(--acc); }
-.ttile-plate .tp-hot { left: 26px; bottom: 6px; width: 7px; height: 7px; border-radius: 50%; background: var(--hot); }
+.ttile-plate .tp-acc { left: 10px; bottom: 10px; width: 26px; height: 11px; border-radius: 3px; background: var(--acc); }
+.ttile-plate .tp-hot { left: 42px; bottom: 10px; width: 11px; height: 11px; border-radius: 50%; background: var(--hot); }
 .ttile-nm {
-  font-size: 9px;
+  display: block;
+  width: 100%;
+  font-size: 11px;
   letter-spacing: 0.02em;
   color: var(--dim);
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 100%;
 }
 .ttile:hover .ttile-plate { outline: 1px solid var(--acc-dim); }
 .ttile:hover .ttile-nm { color: var(--ink); }
-.ttile.sel .ttile-plate { outline: 2px solid var(--acc); outline-offset: 1px; box-shadow: 0 0 8px color-mix(in srgb, var(--acc) 45%, transparent); }
+.ttile.sel .ttile-plate { outline: 2px solid var(--acc); outline-offset: 1px; box-shadow: 0 0 10px color-mix(in srgb, var(--acc) 45%, transparent); }
 .ttile.sel .ttile-nm { color: var(--acc); font-weight: 700; }
 
-/* Mobile: bottom sheet, like the song drawer. */
+/* Mobile: bottom sheet, single column — one big machine per row. */
 @media (max-width: 900px) {
   #theme-picker {
-    position: fixed;
     top: auto;
     left: 0;
     right: 0;
     bottom: 0;
+    transform: none;
     width: 100vw;
-    max-height: 75vh;
+    max-height: 80vh;
     border-radius: 16px 16px 0 0;
     border-left: none;
     border-right: none;
@@ -732,6 +740,13 @@ input[type=range] {
     background: var(--line);
     margin: 0 auto 12px;
   }
+  .theme-grid { grid-template-columns: 1fr; gap: 9px; }
+  .ttile { flex-direction: row; align-items: center; gap: 12px; }
+  .ttile-plate { width: 130px; flex: 0 0 130px; height: 56px; }
+  .ttile-plate .tp-scr { top: 7px; left: 7px; right: 7px; height: 28px; }
+  .ttile-plate .tp-acc { left: 7px; bottom: 7px; width: 20px; height: 9px; }
+  .ttile-plate .tp-hot { left: 33px; bottom: 7px; width: 9px; height: 9px; }
+  .ttile-nm { text-align: left; font-size: 13px; }
 }
 
 /* ─── Song slot button — opens the cartridge picker on the screen ─────────── */

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1389,7 +1389,8 @@ let _themePickerOpen = false;
 
 function currentTheme() { return document.documentElement.dataset.theme || 'oyster'; }
 
-const SCREEN_OPTIONS = [['default', 'Theme glass'], ['pearl', 'Pearl'], ['phosphor', 'Phosphor'], ['lime', 'Lime'], ['amber', 'Amber'], ['paper', 'Paper']];
+const SCREEN_OPTIONS = [['default', 'Theme default'], ['pearl', 'Pearl'], ['phosphor', 'Phosphor'], ['signal', 'Signal'], ['lime', 'Lime'], ['backlit', 'Backlit'], ['amber', 'Amber'], ['workbench', 'Workbench'], ['sage', 'Sage'], ['paper', 'Paper']];
+let _themePickerTab = 'chrome';   // 'chrome' (cabinets) | 'lcd' (glass)
 
 function applyScreen(v) {
   if (v === 'default') delete document.documentElement.dataset.screen;
@@ -1420,6 +1421,21 @@ function renderThemePicker() {
   done.onclick = () => closeThemePicker();
   head.appendChild(done);
   host.appendChild(head);
+
+  // Chrome (the cabinet) and LCD (the glass) are separate choices — tabs.
+  const tabs = document.createElement('div');
+  tabs.id = 'theme-picker-tabs';
+  for (const [key, label] of [['chrome', 'Chrome'], ['lcd', 'LCD']]) {
+    const t = document.createElement('button');
+    t.className = 'help-tab' + (_themePickerTab === key ? ' active' : '');
+    t.textContent = label;
+    t.onclick = () => { _themePickerTab = key; renderThemePicker(); };
+    tabs.appendChild(t);
+  }
+  host.appendChild(tabs);
+
+  if (_themePickerTab === 'lcd') { renderGlassGrid(host); return; }
+
   const cur = currentTheme();
   for (const [label, themes] of THEME_GROUPS) {
     if (label) {
@@ -1449,12 +1465,10 @@ function renderThemePicker() {
     }
     host.appendChild(grid);
   }
+}
 
-  // The glass: swap any theme's LCD for another bundle (theme A, screen B).
-  const gs = document.createElement('div');
-  gs.className = 'picker-sect';
-  gs.textContent = 'Glass — swap the LCD';
-  host.appendChild(gs);
+// The LCD tab: theme default first, then the glass overrides (theme A, screen B).
+function renderGlassGrid(host) {
   const curScreen = document.documentElement.dataset.screen || 'default';
   const ggrid = document.createElement('div');
   ggrid.className = 'theme-grid';
@@ -1982,6 +1996,7 @@ document.addEventListener('contextmenu', e => {
 // force a cabinet/glass combo — lets headless-browser screenshots verify
 // visuals without clicks. Inert in normal use.
 if (location.search.includes('devopen=theme')) setTimeout(() => openThemePicker(), 300);
+if (location.search.includes('devopen=lcd')) setTimeout(() => { _themePickerTab = 'lcd'; openThemePicker(); }, 300);
 if (location.search.includes('devopen=song')) setTimeout(() => openPicker(), 300);
 {
   const q = new URLSearchParams(location.search);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1385,7 +1385,6 @@ const THEME_GROUPS = [
   ['Calculators', [['casiofx', 'Casio fx'], ['ti83', 'TI-83'], ['vl1', 'VL-Tone'], ['hp12c', 'HP-12C'], ['et66', 'Braun ET66'], ['littleprof', 'Little Professor']]],
   ['Studio', [['tr808', 'TR-808'], ['mpc', 'MPC'], ['dx7', 'DX7']]],
 ];
-const THEME_LABELS = new Map(THEME_GROUPS.flatMap(([, ts]) => ts));
 let _themePickerOpen = false;
 
 function currentTheme() { return document.documentElement.dataset.theme || 'oyster'; }
@@ -1394,8 +1393,6 @@ function applyTheme(t) {
   if (t === 'oyster') delete document.documentElement.dataset.theme;
   else document.documentElement.dataset.theme = t;
   localStorage.setItem('gb-theme', t);
-  const btn = document.getElementById('themebtn');
-  if (btn) btn.textContent = THEME_LABELS.get(t) || t;
   // Invalidate canvas colour cache + repaint active view with new colours.
   viz?.invalidateThemeColors?.();
 }
@@ -1407,12 +1404,12 @@ function renderThemePicker() {
   const head = document.createElement('div');
   head.className = 'picker-head';
   head.innerHTML = '<span>SELECT THEME</span>';
-  const close = document.createElement('button');
-  close.className = 'picker-close';
-  close.textContent = '✕';
-  close.setAttribute('aria-label', 'Close theme picker');
-  close.onclick = () => closeThemePicker();
-  head.appendChild(close);
+  const done = document.createElement('button');
+  done.className = 'picker-done';
+  done.textContent = 'Done';
+  done.setAttribute('aria-label', 'Close theme picker');
+  done.onclick = () => closeThemePicker();
+  head.appendChild(done);
   host.appendChild(head);
   const cur = currentTheme();
   for (const [label, themes] of THEME_GROUPS) {
@@ -1431,8 +1428,9 @@ function renderThemePicker() {
       // Calm tile: cabinet plate + screen, with the theme's NAME shown on its
       // own screen in its own ink — a boot screen. One accent LED. Detail at
       // thumbnail scale is noise; the hover live-preview is the real preview.
+      const isCur = value === cur;
       b.innerHTML = `<span class="ttile-plate" data-theme="${esc(value)}">`
-        + `<span class="tp-scr"><span class="tp-nm">${esc(name)}</span></span>`
+        + `<span class="tp-scr"><span class="tp-nm">${isCur ? '✓ ' : ''}${esc(name)}</span></span>`
         + `<i class="tp-led"></i>`
         + `</span>`;
       // One gesture, one meaning: click tries the theme (and trying is
@@ -1497,8 +1495,6 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
   if (saved === 'dark') saved = 'midnight';   // Dark was renamed; Oyster is the default now
   if (saved && saved !== 'oyster') {
     document.documentElement.dataset.theme = saved;
-    const btn = document.getElementById('themebtn');
-    if (btn) btn.textContent = THEME_LABELS.get(saved) || saved;
   }
   const screen = localStorage.getItem('gb-screen');
   if (screen && screen !== 'default') {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -434,8 +434,10 @@ function closePicker() {
   document.getElementById('songbtn')?.classList.remove('open');
 }
 
-// Outside click closes the drawer (same manners as the Settings popover).
-document.addEventListener('click', e => {
+// Outside press closes the drawer (pointerdown: fires before any re-render
+// can detach the pressed element, so in-drawer clicks can never read as
+// outside — the bug class that closed the drawer on tile/tab clicks).
+document.addEventListener('pointerdown', e => {
   if (!_pickerOpen) return;
   const host = document.getElementById('song-picker');
   const btn = document.getElementById('songbtn');
@@ -1506,7 +1508,7 @@ function closeThemePicker() {
   document.getElementById('themebtn')?.classList.remove('open');
 }
 document.getElementById('themebtn').onclick = () => { _themePickerOpen ? closeThemePicker() : openThemePicker(); };
-document.addEventListener('click', e => {
+document.addEventListener('pointerdown', e => {
   if (!_themePickerOpen) return;
   const host = document.getElementById('theme-picker');
   const btn = document.getElementById('themebtn');

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1513,7 +1513,7 @@ document.addEventListener('click', e => {
   // Picking a tile re-renders the drawer (to move the ✓), detaching the
   // clicked button before this listener runs — closest() on the detached
   // node still identifies it as a tile, so the drawer stays open.
-  if (e.target.closest?.('.ttile, .picker-done')) return;
+  if (e.target.closest?.('.ttile, .picker-done, .help-tab')) return;
   if (host && !host.contains(e.target) && e.target !== btn && !btn?.contains(e.target)) closeThemePicker();
 });
 // Screen picker (Settings) — override the theme's glass with a chosen LCD.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -439,6 +439,9 @@ function closePicker() {
 // outside — the bug class that closed the drawer on tile/tab clicks).
 document.addEventListener('pointerdown', e => {
   if (!_pickerOpen) return;
+  // Punch pads are performance, not navigation — auditioning while browsing
+  // the drawer is legitimate; don't dismiss on a pad press.
+  if (e.target.closest?.('.punchpad')) return;
   const host = document.getElementById('song-picker');
   const btn = document.getElementById('songbtn');
   if (host && !host.contains(e.target) && e.target !== btn && !btn?.contains(e.target)) closePicker();
@@ -1510,6 +1513,7 @@ function closeThemePicker() {
 document.getElementById('themebtn').onclick = () => { _themePickerOpen ? closeThemePicker() : openThemePicker(); };
 document.addEventListener('pointerdown', e => {
   if (!_themePickerOpen) return;
+  if (e.target.closest?.('.punchpad')) return;   // pads are performance, not dismissal
   const host = document.getElementById('theme-picker');
   const btn = document.getElementById('themebtn');
   // Picking a tile re-renders the drawer (to move the ✓), detaching the

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1389,6 +1389,15 @@ let _themePickerOpen = false;
 
 function currentTheme() { return document.documentElement.dataset.theme || 'oyster'; }
 
+const SCREEN_OPTIONS = [['default', 'Theme glass'], ['pearl', 'Pearl'], ['phosphor', 'Phosphor'], ['lime', 'Lime'], ['amber', 'Amber'], ['paper', 'Paper']];
+
+function applyScreen(v) {
+  if (v === 'default') delete document.documentElement.dataset.screen;
+  else document.documentElement.dataset.screen = v;
+  localStorage.setItem('gb-screen', v);
+  viz?.invalidateThemeColors?.();
+}
+
 function applyTheme(t) {
   if (t === 'oyster') delete document.documentElement.dataset.theme;
   else document.documentElement.dataset.theme = t;
@@ -1440,6 +1449,31 @@ function renderThemePicker() {
     }
     host.appendChild(grid);
   }
+
+  // The glass: swap any theme's LCD for another bundle (theme A, screen B).
+  const gs = document.createElement('div');
+  gs.className = 'picker-sect';
+  gs.textContent = 'Glass — swap the LCD';
+  host.appendChild(gs);
+  const curScreen = document.documentElement.dataset.screen || 'default';
+  const ggrid = document.createElement('div');
+  ggrid.className = 'theme-grid';
+  for (const [value, name] of SCREEN_OPTIONS) {
+    const b = document.createElement('button');
+    b.className = 'ttile' + (value === curScreen ? ' sel' : '');
+    b.title = name;
+    // data-screen paints the glass tile from its own bundle; the default tile
+    // carries the CURRENT theme instead, so it previews that theme's own LCD.
+    const attr = value === 'default'
+      ? `data-theme="${esc(currentTheme())}"`
+      : `data-screen="${esc(value)}"`;
+    b.innerHTML = `<span class="ttile-plate gtile" ${attr}>`
+      + `<span class="tp-scr"><span class="tp-nm">${value === curScreen ? '✓ ' : ''}${esc(name)}</span></span>`
+      + `</span>`;
+    b.onclick = () => { applyScreen(value); renderThemePicker(); };
+    ggrid.appendChild(b);
+  }
+  host.appendChild(ggrid);
 }
 
 
@@ -1469,13 +1503,6 @@ document.addEventListener('click', e => {
   if (host && !host.contains(e.target) && e.target !== btn && !btn?.contains(e.target)) closeThemePicker();
 });
 // Screen picker (Settings) — override the theme's glass with a chosen LCD.
-document.getElementById('screensel').onchange = e => {
-  const v = e.target.value;
-  if (v === 'default') delete document.documentElement.dataset.screen;
-  else document.documentElement.dataset.screen = v;
-  localStorage.setItem('gb-screen', v);
-  viz.invalidateThemeColors?.();
-};
 
 // (Scope + quick-edit lane tabs are built and wired in renderViewTabs().)
 
@@ -1503,8 +1530,6 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
   const screen = localStorage.getItem('gb-screen');
   if (screen && screen !== 'default') {
     document.documentElement.dataset.screen = screen;
-    const ssel = document.getElementById('screensel');
-    if (ssel) ssel.value = screen;
   }
 })();
 
@@ -1953,7 +1978,14 @@ document.addEventListener('contextmenu', e => {
     e.preventDefault();
   }
 });
-// Dev hook: ?devopen=theme|song auto-opens a picker — lets headless-browser
-// screenshots verify the drawers without a click. Inert in normal use.
+// Dev hooks: ?devopen=theme|song auto-opens a picker; ?devtheme= / ?devscreen=
+// force a cabinet/glass combo — lets headless-browser screenshots verify
+// visuals without clicks. Inert in normal use.
 if (location.search.includes('devopen=theme')) setTimeout(() => openThemePicker(), 300);
 if (location.search.includes('devopen=song')) setTimeout(() => openPicker(), 300);
+{
+  const q = new URLSearchParams(location.search);
+  const dt = q.get('devtheme'), ds = q.get('devscreen');
+  if (dt) { document.documentElement.dataset.theme = dt; viz?.invalidateThemeColors?.(); }
+  if (ds) { document.documentElement.dataset.screen = ds; viz?.invalidateThemeColors?.(); }
+}

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1948,3 +1948,7 @@ document.addEventListener('contextmenu', e => {
     e.preventDefault();
   }
 });
+// Dev hook: ?devopen=theme|song auto-opens a picker — lets headless-browser
+// screenshots verify the drawers without a click. Inert in normal use.
+if (location.search.includes('devopen=theme')) setTimeout(() => openThemePicker(), 300);
+if (location.search.includes('devopen=song')) setTimeout(() => openPicker(), 300);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -385,7 +385,7 @@ function renderPicker() {
 
   // The social shelf rides high — right under the house carts.
   if (_sharedItems.length) {
-    sect('SHARED — FROM OTHER PLAYERS');
+    sect('SHARED — FROM OTHER GROOVERS');
     for (const it of _sharedItems) {
       host.appendChild(cartEl({
         cls: 'shared',

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1371,16 +1371,89 @@ document.getElementById('play').onclick = async function() {
 };
 // (Tempo + transpose controls live on MASTER — built in renderMaster().)
 
-// The song slot opens the cartridge picker on the screen.
+// The song slot opens the cartridge drawer.
 document.getElementById('songbtn').onclick = () => { _pickerOpen ? closePicker() : openPicker(); };
-document.getElementById('themesel').onchange = e => {
-  const t = e.target.value;
+
+// ─── Theme picker — drawer with live swatches (Henry's request) ──────────────
+// Each row's swatches carry data-theme, so the theme's OWN css block resolves
+// the chip colours locally: cabinet · screen · accent · hot, never hardcoded.
+const THEME_GROUPS = [
+  ['', [['oyster', 'Oyster'], ['midnight', 'Midnight'], ['light', 'Light'], ['beige', 'Beige'], ['purple', 'Purple'], ['amber', 'Amber']]],
+  ['Handhelds', [['playdate', 'Playdate'], ['gameboy', 'Game Boy'], ['r1', 'Rabbit'], ['switch', 'Switch']]],
+  ['Consoles', [['atari2600', 'Atari 2600'], ['famicom', 'Famicom'], ['nes', 'NES'], ['snes', 'SNES'], ['snesus', 'SNES US'], ['megadrive', 'Sega'], ['ps1', 'PlayStation'], ['n64', 'N64'], ['dreamcast', 'Dreamcast'], ['gamecube', 'GameCube'], ['xbox', 'Xbox']]],
+  ['Computers', [['spectrum', 'ZX Spectrum'], ['amiga', 'Amiga']]],
+  ['Calculators', [['casiofx', 'Casio fx'], ['ti83', 'TI-83'], ['vl1', 'VL-Tone'], ['hp12c', 'HP-12C'], ['et66', 'Braun ET66'], ['littleprof', 'Little Professor']]],
+  ['Studio', [['tr808', 'TR-808'], ['mpc', 'MPC'], ['dx7', 'DX7']]],
+];
+const THEME_LABELS = new Map(THEME_GROUPS.flatMap(([, ts]) => ts));
+let _themePickerOpen = false;
+
+function currentTheme() { return document.documentElement.dataset.theme || 'oyster'; }
+
+function applyTheme(t) {
   if (t === 'oyster') delete document.documentElement.dataset.theme;
   else document.documentElement.dataset.theme = t;
   localStorage.setItem('gb-theme', t);
+  const btn = document.getElementById('themebtn');
+  if (btn) btn.textContent = THEME_LABELS.get(t) || t;
   // Invalidate canvas colour cache + repaint active view with new colours.
-  viz.invalidateThemeColors?.();
-};
+  viz?.invalidateThemeColors?.();
+}
+
+function renderThemePicker() {
+  const host = document.getElementById('theme-picker');
+  if (!host) return;
+  host.innerHTML = '';
+  const head = document.createElement('div');
+  head.className = 'picker-head';
+  head.innerHTML = '<span>SELECT THEME</span>';
+  const close = document.createElement('button');
+  close.className = 'picker-close';
+  close.textContent = '✕';
+  close.setAttribute('aria-label', 'Close theme picker');
+  close.onclick = () => closeThemePicker();
+  head.appendChild(close);
+  host.appendChild(head);
+  const cur = currentTheme();
+  for (const [label, themes] of THEME_GROUPS) {
+    if (label) {
+      const s = document.createElement('div');
+      s.className = 'picker-sect';
+      s.textContent = label;
+      host.appendChild(s);
+    }
+    for (const [value, name] of themes) {
+      const b = document.createElement('button');
+      b.className = 'trow' + (value === cur ? ' sel' : '');
+      b.innerHTML = `<span class="trow-t">${esc(name)}</span>`
+        + `<span class="swatches" data-theme="${esc(value)}"><i></i><i></i><i></i><i></i></span>`;
+      b.onclick = () => { applyTheme(value); renderThemePicker(); };   // stay open — theme browsing is the fun part
+      host.appendChild(b);
+    }
+  }
+}
+
+function openThemePicker() {
+  renderThemePicker();
+  _themePickerOpen = true;
+  const host = document.getElementById('theme-picker');
+  if (host) host.hidden = false;
+  document.getElementById('themebtn')?.classList.add('open');
+}
+function closeThemePicker() {
+  if (!_themePickerOpen) return;
+  _themePickerOpen = false;
+  const host = document.getElementById('theme-picker');
+  if (host) host.hidden = true;
+  document.getElementById('themebtn')?.classList.remove('open');
+}
+document.getElementById('themebtn').onclick = () => { _themePickerOpen ? closeThemePicker() : openThemePicker(); };
+document.addEventListener('click', e => {
+  if (!_themePickerOpen) return;
+  const host = document.getElementById('theme-picker');
+  const btn = document.getElementById('themebtn');
+  if (host && !host.contains(e.target) && e.target !== btn && !btn?.contains(e.target)) closeThemePicker();
+});
 // Screen picker (Settings) — override the theme's glass with a chosen LCD.
 document.getElementById('screensel').onchange = e => {
   const v = e.target.value;
@@ -1412,8 +1485,8 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
   if (saved === 'dark') saved = 'midnight';   // Dark was renamed; Oyster is the default now
   if (saved && saved !== 'oyster') {
     document.documentElement.dataset.theme = saved;
-    const sel = document.getElementById('themesel');
-    if (sel) sel.value = saved;
+    const btn = document.getElementById('themebtn');
+    if (btn) btn.textContent = THEME_LABELS.get(saved) || saved;
   }
   const screen = localStorage.getItem('gb-screen');
   if (screen && screen !== 'default') {
@@ -1447,7 +1520,7 @@ document.getElementById('help-modal-backdrop').onclick = () => {
   document.getElementById('help-modal').hidden = true;
 };
 document.addEventListener('keydown', e => {
-  if (e.key === 'Escape') { document.getElementById('help-modal').hidden = true; closePicker(); }
+  if (e.key === 'Escape') { document.getElementById('help-modal').hidden = true; closePicker(); closeThemePicker(); }
 });
 
 // ─── View-settings popover ────────────────────────────────────────────────────

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -14,7 +14,8 @@ import { scallywag } from '../songs/scallywag.js';
 import { booWaltz } from '../songs/boo-waltz.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
-import { initShare, maybeLoadShared, clearLoadedFrom } from './share.js';
+import { initShare, maybeLoadShared, loadSharedSong, clearLoadedFrom } from './share.js';
+import { listItems } from '../registry/client.js';
 import { openPunchEditor, isPunchEditorOpen } from './punch-editor.js';
 import { DEFAULT_PRESETS } from '../engine/punch-presets.js';
 
@@ -1234,7 +1235,21 @@ document.getElementById('play').onclick = async function() {
 };
 // (Tempo + transpose controls live on MASTER — built in renderMaster().)
 
-document.getElementById('songsel').onchange = e => loadSong(e.target.value);
+document.getElementById('songsel').onchange = async e => {
+  const v = e.target.value;
+  if (v.startsWith('s:')) {
+    // Shelf entry — a published song from the registry. Stop first, like loadSong.
+    eng.stop();
+    stopMeterLoop();
+    const play = document.getElementById('play');
+    play.classList.remove('on');
+    play.textContent = '▶ play';
+    try { await loadSharedSong(eng, shareHooks, v.slice(2)); }
+    catch (err) { gbNotice(`couldn't load (${err.message})`); }
+    return;
+  }
+  loadSong(v);
+};
 document.getElementById('themesel').onchange = e => {
   const t = e.target.value;
   if (t === 'oyster') delete document.documentElement.dataset.theme;
@@ -1713,8 +1728,10 @@ const shareHooks = {
   notice: gbNotice,
   onSongLoaded: (rec) => {
     afterSongLoad();
-    // songsel no longer matches a preset — park it on a hidden "(shared)" option.
     const sel = document.getElementById('songsel');
+    // Loaded from the shelf? The dropdown already sits on the right entry.
+    if (rec && sel.value === `s:${rec.id}`) return;
+    // Otherwise (boot-time /s/<id> link) — park it on a hidden option.
     let opt = document.getElementById('songsel-shared');
     if (!opt) {
       opt = document.createElement('option');
@@ -1738,6 +1755,27 @@ const shareHooks = {
 };
 initShare(eng, shareHooks);
 maybeLoadShared(eng, shareHooks);
+
+// ─── Discovery shelf — recent published songs in the song dropdown ───────────
+// Fire-and-forget: no registry (vite dev / offline) → no shelf, app unaffected.
+(async () => {
+  try {
+    const { items } = await listItems('song', 25);
+    if (!Array.isArray(items) || !items.length) return;
+    const sel = document.getElementById('songsel');
+    const grp = document.createElement('optgroup');
+    grp.label = 'Shared';
+    for (const it of items) {
+      const o = document.createElement('option');
+      o.value = `s:${it.id}`;
+      const plays = typeof it.plays === 'number' && it.plays > 0
+        ? ` · ${it.plays} play${it.plays === 1 ? '' : 's'}` : '';
+      o.textContent = `♫ ${it.name}${it.author ? ` — ${it.author}` : ''}${plays}`;
+      grp.appendChild(o);
+    }
+    sel.appendChild(grp);
+  } catch { /* shelf is best-effort */ }
+})();
 // Press-and-hold on a control must not open the browser context menu (Android
 // Chrome long-press → "more actions / translate"). Scoped to controls so
 // right-click elsewhere stays normal on desktop.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -368,10 +368,9 @@ function renderPicker() {
     host.appendChild(s);
   };
 
-  sect('PRESETS');
-  for (const key of PRESET_ORDER) {
+  const presetCart = (key) => {
     const s = SONGS[key];
-    if (!s) continue;
+    if (!s) return;
     host.appendChild(cartEl({
       cls: AI_PRESETS.has(key) ? 'ai' : 'cover',
       title: s.title || key,
@@ -379,7 +378,12 @@ function renderPicker() {
       selected: _currentSongKey === key,
       onPick: () => { closePicker(); loadSong(key); },
     }));
-  }
+  };
+
+  sect('BUILT-IN');
+  for (const key of PRESET_ORDER) if (AI_PRESETS.has(key)) presetCart(key);
+
+  // The social shelf rides high — right under the house carts.
   if (_sharedItems.length) {
     sect('SHARED — FROM OTHER PLAYERS');
     for (const it of _sharedItems) {
@@ -402,6 +406,9 @@ function renderPicker() {
       }));
     }
   }
+
+  sect('JUKEBOX — COVERS');
+  for (const key of PRESET_ORDER) if (!AI_PRESETS.has(key)) presetCart(key);
 }
 
 function openPicker() {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1429,15 +1429,49 @@ function renderThemePicker() {
       b.className = 'ttile' + (value === cur ? ' sel' : '');
       b.title = name;
       // The plate carries data-theme, so the theme's OWN css block paints the
-      // mini machine: cabinet, screen, accent play-bar, hot dot.
+      // miniature: cabinet, screen with strip line and REAL drum cells
+      // (.vrow/.vc/.hit — theme-specific rules like the 808's banded steps
+      // apply for free), then a play bar, hot dot and three knob caps.
+      const cells = (hits) => Array.from({ length: 9 }, (_, i) =>
+        `<i class="vc${hits.includes(i) ? ' hit' : ''}"></i>`).join('');
       b.innerHTML = `<span class="ttile-plate" data-theme="${esc(value)}">`
-        + `<i class="tp-scr"></i><i class="tp-acc"></i><i class="tp-hot"></i></span>`
+        + `<span class="tp-scr">`
+        + `<i class="tp-strip"></i>`
+        + `<span class="vrow">${cells([0, 4, 8])}</span>`
+        + `<span class="vrow">${cells([2, 6])}</span>`
+        + `<span class="vrow">${cells([0, 2, 4, 6, 8])}</span>`
+        + `</span>`
+        + `<span class="tp-ctl"><i class="tp-acc"></i><i class="tp-hot"></i>`
+        + `<i class="knob-dial"></i><i class="knob-dial"></i><i class="knob-dial"></i></span>`
+        + `</span>`
         + `<span class="ttile-nm">${esc(name)}</span>`;
       b.onclick = () => { applyTheme(value); renderThemePicker(); };   // stay open — theme browsing is the fun part
+      // Hover = live preview: the whole machine repaints (the app IS the
+      // high-def preview); leaving reverts to the committed theme.
+      if (window.matchMedia('(hover: hover)').matches) {
+        b.onmouseenter = () => {
+          if (value === 'oyster') delete document.documentElement.dataset.theme;
+          else document.documentElement.dataset.theme = value;
+          viz?.invalidateThemeColors?.();
+        };
+        b.onmouseleave = () => {
+          const committed = currentSavedTheme();
+          if (committed === 'oyster') delete document.documentElement.dataset.theme;
+          else document.documentElement.dataset.theme = committed;
+          viz?.invalidateThemeColors?.();
+        };
+      }
       grid.appendChild(b);
     }
     host.appendChild(grid);
   }
+}
+
+// The committed (saved) theme — hover previews never touch storage.
+function currentSavedTheme() {
+  let t = localStorage.getItem('gb-theme') || 'oyster';
+  if (t === 'dark') t = 'midnight';
+  return t;
 }
 
 function openThemePicker() {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -263,7 +263,6 @@ function renderViewTabs() {
 let _songTabOpen = false;
 function setLcdPane(songOpen) {
   _songTabOpen = songOpen;
-  closePicker();   // any tab/pane change dismisses the picker overlay
   const body = document.getElementById('lcd-body');
   const songPane = document.getElementById('lcd-song');
   if (body) body.hidden = songOpen;
@@ -310,11 +309,12 @@ function activateEditLane(id) {
   updateEditHighlight(id);
 }
 
-// ─── SELECT SONG — the cartridge picker, on the screen ───────────────────────
-// Tapping the song slot takes over the LCD (console game-select idiom): every
-// song is a cartridge card — notch colour says AI original / cover / shared,
-// shared carts carry a play-count badge. Picking loads + closes; ✕/Escape and
-// any tab change close back to the previous pane.
+// ─── SELECT SONG — the cartridge drawer ──────────────────────────────────────
+// Cartridges are hardware: tapping the song slot opens a rack panel anchored
+// under it (bottom sheet on mobile — the Help/Settings idiom). Every song is
+// a cartridge card — notch colour says AI original / cover / shared, shared
+// carts carry a play-count badge. Picking loads + closes; outside click,
+// ✕ and Escape close.
 const PRESET_ORDER = ['press-start', 'scallywag', 'boo-waltz', 'first-roll', 'kids',
   'rising-sun', 'electric-feel', 'heartbeats', 'digital-love', 'memory-reboot', 'take-on-me'];
 const AI_PRESETS = new Set(['press-start', 'scallywag', 'boo-waltz', 'first-roll']);
@@ -347,7 +347,7 @@ function cartEl({ cls, title, author, plays, onPick, selected }) {
 }
 
 function renderPicker() {
-  const host = document.getElementById('lcd-picker');
+  const host = document.getElementById('song-picker');
   if (!host) return;
   host.innerHTML = '';
   const head = document.createElement('div');
@@ -405,15 +405,11 @@ function renderPicker() {
 }
 
 function openPicker() {
-  const host = document.getElementById('lcd-picker');
+  const host = document.getElementById('song-picker');
   if (!host) return;
   renderPicker();
   _pickerOpen = true;
   host.hidden = false;
-  const body = document.getElementById('lcd-body');
-  const songPane = document.getElementById('lcd-song');
-  if (body) body.hidden = true;
-  if (songPane) songPane.hidden = true;
   document.getElementById('songbtn')?.classList.add('open');
   // Refresh the shelf in the background; re-render if anything changed.
   listItems('song', 25).then(({ items }) => {
@@ -426,15 +422,18 @@ function openPicker() {
 function closePicker() {
   if (!_pickerOpen) return;
   _pickerOpen = false;
-  const host = document.getElementById('lcd-picker');
+  const host = document.getElementById('song-picker');
   if (host) host.hidden = true;
-  // Restore whichever tab pane was current.
-  const body = document.getElementById('lcd-body');
-  const songPane = document.getElementById('lcd-song');
-  if (body) body.hidden = _songTabOpen;
-  if (songPane) songPane.hidden = !_songTabOpen;
   document.getElementById('songbtn')?.classList.remove('open');
 }
+
+// Outside click closes the drawer (same manners as the Settings popover).
+document.addEventListener('click', e => {
+  if (!_pickerOpen) return;
+  const host = document.getElementById('song-picker');
+  const btn = document.getElementById('songbtn');
+  if (host && !host.contains(e.target) && e.target !== btn && !btn?.contains(e.target)) closePicker();
+});
 
 function renderStrips() {
   const host = document.getElementById('strips');

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1462,6 +1462,10 @@ document.addEventListener('click', e => {
   if (!_themePickerOpen) return;
   const host = document.getElementById('theme-picker');
   const btn = document.getElementById('themebtn');
+  // Picking a tile re-renders the drawer (to move the ✓), detaching the
+  // clicked button before this listener runs — closest() on the detached
+  // node still identifies it as a tile, so the drawer stays open.
+  if (e.target.closest?.('.ttile, .picker-done')) return;
   if (host && !host.contains(e.target) && e.target !== btn && !btn?.contains(e.target)) closeThemePicker();
 });
 // Screen picker (Settings) — override the theme's glass with a chosen LCD.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -256,12 +256,14 @@ function renderViewTabs() {
   else if (_editingLaneId) updateEditHighlight(_editingLaneId);
 }
 
-// The screen has two panes: #lcd-body (viz: lane editors / scope) and
-// #lcd-song (song structure). Display toggle only — the viz is never disposed
-// here, so switching tabs is free.
+// The screen has two tab panes — #lcd-body (viz: lane editors / scope) and
+// #lcd-song (song structure) — plus the SELECT SONG picker, which overlays
+// whichever pane is current and closes back to it. Display toggles only —
+// the viz is never disposed here, so switching is free.
 let _songTabOpen = false;
 function setLcdPane(songOpen) {
   _songTabOpen = songOpen;
+  closePicker();   // any tab/pane change dismisses the picker overlay
   const body = document.getElementById('lcd-body');
   const songPane = document.getElementById('lcd-song');
   if (body) body.hidden = songOpen;
@@ -306,6 +308,132 @@ function activateEditLane(id) {
   setLcdPane(false);
   viz.editLane(id);
   updateEditHighlight(id);
+}
+
+// ─── SELECT SONG — the cartridge picker, on the screen ───────────────────────
+// Tapping the song slot takes over the LCD (console game-select idiom): every
+// song is a cartridge card — notch colour says AI original / cover / shared,
+// shared carts carry a play-count badge. Picking loads + closes; ✕/Escape and
+// any tab change close back to the previous pane.
+const PRESET_ORDER = ['press-start', 'scallywag', 'boo-waltz', 'first-roll', 'kids',
+  'rising-sun', 'electric-feel', 'heartbeats', 'digital-love', 'memory-reboot', 'take-on-me'];
+const AI_PRESETS = new Set(['press-start', 'scallywag', 'boo-waltz', 'first-roll']);
+let _pickerOpen = false;
+let _sharedItems = [];          // registry shelf rows — refreshed on each open
+let _currentSongKey = 'press-start';   // preset key, or 's:<id>' for a shared song
+
+function songButtonLabel(text) {
+  const btn = document.getElementById('songbtn');
+  if (btn) btn.innerHTML = `<span class="songbtn-t">${esc(text)}</span><span class="songbtn-caret">▾</span>`;
+}
+
+function presetLabel(key) {
+  const s = SONGS[key];
+  if (!s) return key;
+  return `${AI_PRESETS.has(key) ? '★ ' : ''}${s.title || key}${s.artist ? ` — ${s.artist}` : ''}`;
+}
+
+function cartEl({ cls, title, author, plays, onPick, selected }) {
+  const b = document.createElement('button');
+  b.className = 'kart' + (cls ? ` ${cls}` : '') + (selected ? ' sel' : '');
+  const badge = typeof plays === 'number' && plays > 0
+    ? `<span class="kart-plays">▶ ${plays}</span>` : '';
+  b.innerHTML = `<span class="kart-notch"></span><span class="kart-meta">`
+    + `<span class="kart-t">${esc(title)}</span>`
+    + (author ? `<span class="kart-a">${esc(author)}</span>` : '')
+    + `</span>${badge}`;
+  b.onclick = onPick;
+  return b;
+}
+
+function renderPicker() {
+  const host = document.getElementById('lcd-picker');
+  if (!host) return;
+  host.innerHTML = '';
+  const head = document.createElement('div');
+  head.className = 'picker-head';
+  head.innerHTML = `<span>SELECT SONG</span>`;
+  const close = document.createElement('button');
+  close.className = 'picker-close';
+  close.textContent = '✕';
+  close.setAttribute('aria-label', 'Close song picker');
+  close.onclick = () => closePicker();
+  head.appendChild(close);
+  host.appendChild(head);
+
+  const sect = (label) => {
+    const s = document.createElement('div');
+    s.className = 'picker-sect';
+    s.textContent = label;
+    host.appendChild(s);
+  };
+
+  sect('PRESETS');
+  for (const key of PRESET_ORDER) {
+    const s = SONGS[key];
+    if (!s) continue;
+    host.appendChild(cartEl({
+      cls: AI_PRESETS.has(key) ? 'ai' : 'cover',
+      title: s.title || key,
+      author: s.artist || '',
+      selected: _currentSongKey === key,
+      onPick: () => { closePicker(); loadSong(key); },
+    }));
+  }
+  if (_sharedItems.length) {
+    sect('SHARED — FROM OTHER PLAYERS');
+    for (const it of _sharedItems) {
+      host.appendChild(cartEl({
+        cls: 'shared',
+        title: it.name,
+        author: it.author || '',
+        plays: it.plays,
+        selected: _currentSongKey === `s:${it.id}`,
+        onPick: async () => {
+          closePicker();
+          eng.stop();
+          stopMeterLoop();
+          const play = document.getElementById('play');
+          play.classList.remove('on');
+          play.textContent = '▶ play';
+          try { await loadSharedSong(eng, shareHooks, it.id); }
+          catch (err) { gbNotice(`couldn't load (${err.message})`); }
+        },
+      }));
+    }
+  }
+}
+
+function openPicker() {
+  const host = document.getElementById('lcd-picker');
+  if (!host) return;
+  renderPicker();
+  _pickerOpen = true;
+  host.hidden = false;
+  const body = document.getElementById('lcd-body');
+  const songPane = document.getElementById('lcd-song');
+  if (body) body.hidden = true;
+  if (songPane) songPane.hidden = true;
+  document.getElementById('songbtn')?.classList.add('open');
+  // Refresh the shelf in the background; re-render if anything changed.
+  listItems('song', 25).then(({ items }) => {
+    if (!Array.isArray(items)) return;
+    _sharedItems = items;
+    if (_pickerOpen) renderPicker();
+  }).catch(() => {});
+}
+
+function closePicker() {
+  if (!_pickerOpen) return;
+  _pickerOpen = false;
+  const host = document.getElementById('lcd-picker');
+  if (host) host.hidden = true;
+  // Restore whichever tab pane was current.
+  const body = document.getElementById('lcd-body');
+  const songPane = document.getElementById('lcd-song');
+  if (body) body.hidden = _songTabOpen;
+  if (songPane) songPane.hidden = !_songTabOpen;
+  document.getElementById('songbtn')?.classList.remove('open');
 }
 
 function renderStrips() {
@@ -1203,6 +1331,8 @@ function loadSong(key) {
   play.textContent = '▶ play';
   eng.load(SONGS[key]);
   clearLoadedFrom();   // the registry item this session had loaded is gone
+  _currentSongKey = key;
+  songButtonLabel(presetLabel(key));
   afterSongLoad();
 }
 
@@ -1235,21 +1365,8 @@ document.getElementById('play').onclick = async function() {
 };
 // (Tempo + transpose controls live on MASTER — built in renderMaster().)
 
-document.getElementById('songsel').onchange = async e => {
-  const v = e.target.value;
-  if (v.startsWith('s:')) {
-    // Shelf entry — a published song from the registry. Stop first, like loadSong.
-    eng.stop();
-    stopMeterLoop();
-    const play = document.getElementById('play');
-    play.classList.remove('on');
-    play.textContent = '▶ play';
-    try { await loadSharedSong(eng, shareHooks, v.slice(2)); }
-    catch (err) { gbNotice(`couldn't load (${err.message})`); }
-    return;
-  }
-  loadSong(v);
-};
+// The song slot opens the cartridge picker on the screen.
+document.getElementById('songbtn').onclick = () => { _pickerOpen ? closePicker() : openPicker(); };
 document.getElementById('themesel').onchange = e => {
   const t = e.target.value;
   if (t === 'oyster') delete document.documentElement.dataset.theme;
@@ -1324,7 +1441,7 @@ document.getElementById('help-modal-backdrop').onclick = () => {
   document.getElementById('help-modal').hidden = true;
 };
 document.addEventListener('keydown', e => {
-  if (e.key === 'Escape') document.getElementById('help-modal').hidden = true;
+  if (e.key === 'Escape') { document.getElementById('help-modal').hidden = true; closePicker(); }
 });
 
 // ─── View-settings popover ────────────────────────────────────────────────────
@@ -1688,22 +1805,10 @@ function initSectionWrappers() {
 }
 
 // ─── Initial load ─────────────────────────────────────────────────────────────
-// Song dropdown = the record shelf: every option shows "title — artist",
-// straight from the song data. ("(AI)" goes — the artist credit says it.)
-{
-  const sel = document.getElementById('songsel');
-  for (const opt of sel.options) {
-    const s = SONGS[opt.value];
-    if (s?.artist) opt.textContent = `${opt.textContent.replace(' (AI)', '')} — ${s.artist}`;
-  }
-}
-
 const BOOT_SONG = 'press-start';
 eng.load(SONGS[BOOT_SONG]);
-// Pin the dropdown to the boot song so the selector, the loaded song, and the
-// credit line (set in mount from the loaded song) always agree — don't rely on
-// the option's `selected` attribute matching the boot song by coincidence.
-document.getElementById('songsel').value = BOOT_SONG;
+_currentSongKey = BOOT_SONG;
+songButtonLabel(presetLabel(BOOT_SONG));
 const initialSong = eng.getSong();
 currentBpm = initialSong.bpm;
 eng.setTempo(initialSong.bpm);
@@ -1728,25 +1833,11 @@ const shareHooks = {
   notice: gbNotice,
   onSongLoaded: (rec) => {
     afterSongLoad();
-    const sel = document.getElementById('songsel');
-    // Loaded from the shelf? The dropdown already sits on the right entry.
-    if (rec && sel.value === `s:${rec.id}`) return;
-    // Otherwise (boot-time /s/<id> link) — park it on a hidden option.
-    let opt = document.getElementById('songsel-shared');
-    if (!opt) {
-      opt = document.createElement('option');
-      opt.id = 'songsel-shared';
-      opt.hidden = true;
-      sel.appendChild(opt);
+    // The slot is the title surface — shared songs read "♫ name — author".
+    if (rec) {
+      _currentSongKey = `s:${rec.id}`;
+      songButtonLabel(`♫ ${rec.name}${rec.author ? ` — ${rec.author}` : ''}`);
     }
-    // The dropdown is the title surface — name, author and play count all
-    // live in the option text. No second line.
-    const n = typeof rec?.plays === 'number' ? rec.plays + 1 : null;
-    opt.textContent = rec?.name
-      ? ['♫ ' + rec.name, rec.author ? `by ${rec.author}` : '', n ? `${n} play${n === 1 ? '' : 's'}` : '']
-          .filter(Boolean).join(' · ')
-      : '(shared)';
-    opt.selected = true;
   },
   onGroovesChanged: () => { renderStrips(); refreshVizPattern(); },
   // v1: import into the first matching lane (multi-lane-same-type songs are
@@ -1756,26 +1847,11 @@ const shareHooks = {
 initShare(eng, shareHooks);
 maybeLoadShared(eng, shareHooks);
 
-// ─── Discovery shelf — recent published songs in the song dropdown ───────────
+// ─── Discovery shelf — prefetch the registry list for the picker ─────────────
 // Fire-and-forget: no registry (vite dev / offline) → no shelf, app unaffected.
-(async () => {
-  try {
-    const { items } = await listItems('song', 25);
-    if (!Array.isArray(items) || !items.length) return;
-    const sel = document.getElementById('songsel');
-    const grp = document.createElement('optgroup');
-    grp.label = 'Shared';
-    for (const it of items) {
-      const o = document.createElement('option');
-      o.value = `s:${it.id}`;
-      const plays = typeof it.plays === 'number' && it.plays > 0
-        ? ` · ${it.plays} play${it.plays === 1 ? '' : 's'}` : '';
-      o.textContent = `♫ ${it.name}${it.author ? ` — ${it.author}` : ''}${plays}`;
-      grp.appendChild(o);
-    }
-    sel.appendChild(grp);
-  } catch { /* shelf is best-effort */ }
-})();
+listItems('song', 25)
+  .then(({ items }) => { if (Array.isArray(items)) _sharedItems = items; })
+  .catch(() => { /* shelf is best-effort */ });
 // Press-and-hold on a control must not open the browser context menu (Android
 // Chrome long-press → "more actions / translate"). Scoped to controls so
 // right-click elsewhere stays normal on desktop.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1428,23 +1428,13 @@ function renderThemePicker() {
       const b = document.createElement('button');
       b.className = 'ttile' + (value === cur ? ' sel' : '');
       b.title = name;
-      // The plate carries data-theme, so the theme's OWN css block paints the
-      // miniature: cabinet, screen with strip line and REAL drum cells
-      // (.vrow/.vc/.hit — theme-specific rules like the 808's banded steps
-      // apply for free), then a play bar, hot dot and three knob caps.
-      const cells = (hits) => Array.from({ length: 9 }, (_, i) =>
-        `<i class="vc${hits.includes(i) ? ' hit' : ''}"></i>`).join('');
+      // Calm tile: cabinet plate + screen, with the theme's NAME shown on its
+      // own screen in its own ink — a boot screen. One accent LED. Detail at
+      // thumbnail scale is noise; the hover live-preview is the real preview.
       b.innerHTML = `<span class="ttile-plate" data-theme="${esc(value)}">`
-        + `<span class="tp-scr">`
-        + `<i class="tp-strip"></i>`
-        + `<span class="vrow">${cells([0, 4, 8])}</span>`
-        + `<span class="vrow">${cells([2, 6])}</span>`
-        + `<span class="vrow">${cells([0, 2, 4, 6, 8])}</span>`
-        + `</span>`
-        + `<span class="tp-ctl"><i class="tp-acc"></i><i class="tp-hot"></i>`
-        + `<i class="knob-dial"></i><i class="knob-dial"></i><i class="knob-dial"></i></span>`
-        + `</span>`
-        + `<span class="ttile-nm">${esc(name)}</span>`;
+        + `<span class="tp-scr"><span class="tp-nm">${esc(name)}</span></span>`
+        + `<i class="tp-led"></i>`
+        + `</span>`;
       b.onclick = () => { applyTheme(value); renderThemePicker(); };   // stay open — theme browsing is the fun part
       // Hover = live preview: the whole machine repaints (the app IS the
       // high-def preview); leaving reverts to the committed theme.

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1435,34 +1435,15 @@ function renderThemePicker() {
         + `<span class="tp-scr"><span class="tp-nm">${esc(name)}</span></span>`
         + `<i class="tp-led"></i>`
         + `</span>`;
-      b.onclick = () => { applyTheme(value); renderThemePicker(); };   // stay open — theme browsing is the fun part
-      // Hover = live preview: the whole machine repaints (the app IS the
-      // high-def preview); leaving reverts to the committed theme.
-      if (window.matchMedia('(hover: hover)').matches) {
-        b.onmouseenter = () => {
-          if (value === 'oyster') delete document.documentElement.dataset.theme;
-          else document.documentElement.dataset.theme = value;
-          viz?.invalidateThemeColors?.();
-        };
-        b.onmouseleave = () => {
-          const committed = currentSavedTheme();
-          if (committed === 'oyster') delete document.documentElement.dataset.theme;
-          else document.documentElement.dataset.theme = committed;
-          viz?.invalidateThemeColors?.();
-        };
-      }
+      // One gesture, one meaning: click tries the theme (and trying is
+      // having it — the app repaints live). Close the drawer when happy.
+      b.onclick = () => { applyTheme(value); renderThemePicker(); };
       grid.appendChild(b);
     }
     host.appendChild(grid);
   }
 }
 
-// The committed (saved) theme — hover previews never touch storage.
-function currentSavedTheme() {
-  let t = localStorage.getItem('gb-theme') || 'oyster';
-  if (t === 'dark') t = 'midnight';
-  return t;
-}
 
 function openThemePicker() {
   renderThemePicker();

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1422,14 +1422,21 @@ function renderThemePicker() {
       s.textContent = label;
       host.appendChild(s);
     }
+    const grid = document.createElement('div');
+    grid.className = 'theme-grid';
     for (const [value, name] of themes) {
       const b = document.createElement('button');
-      b.className = 'trow' + (value === cur ? ' sel' : '');
-      b.innerHTML = `<span class="trow-t">${esc(name)}</span>`
-        + `<span class="swatches" data-theme="${esc(value)}"><i></i><i></i><i></i><i></i></span>`;
+      b.className = 'ttile' + (value === cur ? ' sel' : '');
+      b.title = name;
+      // The plate carries data-theme, so the theme's OWN css block paints the
+      // mini machine: cabinet, screen, accent play-bar, hot dot.
+      b.innerHTML = `<span class="ttile-plate" data-theme="${esc(value)}">`
+        + `<i class="tp-scr"></i><i class="tp-acc"></i><i class="tp-hot"></i></span>`
+        + `<span class="ttile-nm">${esc(name)}</span>`;
       b.onclick = () => { applyTheme(value); renderThemePicker(); };   // stay open — theme browsing is the fun part
-      host.appendChild(b);
+      grid.appendChild(b);
     }
+    host.appendChild(grid);
   }
 }
 

--- a/docs/arcade/groovebox/ui/share.js
+++ b/docs/arcade/groovebox/ui/share.js
@@ -169,6 +169,26 @@ export function initShare(eng, hooks) {
   $('share-copy').onclick = () => { navigator.clipboard?.writeText($('share-link').value); hooks.notice('link copied'); };
 }
 
+// Apply a fetched song record: registry state, play beacon, engine load, UI hooks.
+// Shared by the boot loader (/s/<id>) and the dropdown's discovery shelf.
+function applySharedSong(eng, hooks, rec) {
+  loadedFrom = { id: rec.id, kind: rec.kind };
+  pingPlay(rec.id);
+  const n = typeof rec.plays === 'number' ? rec.plays + 1 : null;
+  const plays = n ? ` · ${n} play${n === 1 ? '' : 's'}` : '';
+  eng.load(rec.payload);
+  hooks.onSongLoaded(rec);
+  hooks.notice(`loaded "${rec.name}"${rec.author ? ` by ${rec.author}` : ''}${plays}`);
+}
+
+// Load a published song by id (the dropdown shelf). Throws on fetch errors /
+// non-song kinds — the caller owns the user-facing failure message.
+export async function loadSharedSong(eng, hooks, id) {
+  const rec = await getItem(id);
+  if (rec.kind !== 'song') throw new Error('not a song');
+  applySharedSong(eng, hooks, rec);
+}
+
 // Boot-time: /s/<id> was redirected to /?s=<id> by the worker. Returns true if
 // a share id was present (whether or not it loaded).
 export async function maybeLoadShared(eng, hooks) {
@@ -176,15 +196,11 @@ export async function maybeLoadShared(eng, hooks) {
   if (!id) return false;
   try {
     const rec = await getItem(id);
-    loadedFrom = { id: rec.id, kind: rec.kind };
-    pingPlay(rec.id);
-    const n = typeof rec.plays === 'number' ? rec.plays + 1 : null;
-    const plays = n ? ` · ${n} play${n === 1 ? '' : 's'}` : '';
     if (rec.kind === 'song') {
-      eng.load(rec.payload);
-      hooks.onSongLoaded(rec);
-      hooks.notice(`loaded "${rec.name}"${rec.author ? ` by ${rec.author}` : ''}${plays}`);
+      applySharedSong(eng, hooks, rec);
     } else {
+      loadedFrom = { id: rec.id, kind: rec.kind };
+      pingPlay(rec.id);
       const lanes = pickHostLanes(eng.getLanes(), rec.payload.laneType);
       const laneId = lanes.length === 0 ? eng.addLane(rec.payload.laneType).id
                    : lanes.length === 1 ? lanes[0].id

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -15,7 +15,7 @@ function themeColors() {
   const cs = getComputedStyle(document.getElementById('viz') || document.documentElement);
   const g = n => cs.getPropertyValue(n).trim() || '#888';
   _tc = {
-    acc:     g('--acc'),
+    acc:     g('--screen-acc'),   // canvas highlights live on the glass
     scope:   g('--scope'),
     note:    g('--roll-note'),
     grid:    g('--grid-line'),

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -49,6 +49,14 @@ function d1Db(d1: D1Database) {
     async bumpPlays(id: string) {
       await d1.prepare(`UPDATE ${T} SET plays = plays + 1 WHERE id = ?`).bind(id).run();
     },
+    // Discovery shelf — light rows, newest first (payload + edit_key_hash never leave D1 here).
+    async list(kind: string, limit: number) {
+      const { results } = await d1.prepare(
+        `SELECT id, kind, name, author, plays, remix_of, created_at FROM ${T}
+         WHERE kind = ? ORDER BY created_at DESC LIMIT ?`)
+        .bind(kind, limit).all();
+      return results;
+    },
   };
 }
 

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -53,7 +53,7 @@ function d1Db(d1: D1Database) {
     async list(kind: string, limit: number) {
       const { results } = await d1.prepare(
         `SELECT id, kind, name, author, plays, remix_of, created_at FROM ${T}
-         WHERE kind = ? ORDER BY created_at DESC LIMIT ?`)
+         WHERE kind = ? ORDER BY created_at DESC, id ASC LIMIT ?`)
         .bind(kind, limit).all();
       return results;
     },


### PR DESCRIPTION
## What

Four features that grew into one coherent appearance-and-discovery layer:

### Discovery shelf (the social loop's missing half)
- `GET /api/registry?kind=song|groove&limit=N` (≤50): light rows only (no payload / edit-key hash), `ORDER BY created_at DESC, id ASC`; `listItems()` client; `loadSharedSong()` extracted from the boot loader (same registry-state + play-beacon path as `/s/` links).

### The cartridge drawer (replaces the native song select)
- Song slot = button → anchored drawer (bottom sheet on mobile): **BUILT-IN** (AI originals) → **SHARED — FROM OTHER GROOVERS** (`♫ name — author · ▶ plays`, refreshed each open) → **JUKEBOX — COVERS**. Cart cards with notch colours (accent = AI / dim = cover / hot = shared); picking loads in place.

### Theme gallery (replaces the 32-entry native select)
- Titlebar **Theme** button → full gallery with **Chrome | LCD** tabs. Boot-screen tiles: each plate painted by its own theme's variables (cabinet + screen + name in its own ink + accent LED). Click tries live, ✓ marks current, **Done** dismisses; pointerdown-based outside-dismissal (immune to re-render orphaning); punch pads never dismiss.

### Glass system (theme A + LCD B)
- LCD tab: Theme default + **nine glasses** — Pearl / Phosphor / Signal / Lime / Backlit / Amber / Workbench / Sage / Paper (four mined from the Amiga/TI-83/DX7 skins + Oyster's first-draft cyan).
- New `--screen-acc`/`--screen-hot`: every glass carries its own highlight family (playhead, bar/snap selections, strip chips, Song-tab glows, canvas accents) so any cabinet × any glass stays coherent. Themes alias to cabinet accents — no glass override = pixel-identical to before.
- `?devopen` / `?devtheme` / `?devscreen` hooks for headless screenshot verification.

## Test plan
- [x] 298 tests green (parity untouched; 3 new registry-list tests)
- [x] vite build clean
- [x] `wrangler dev --remote`: shelf lists live data (Nuclear Testing Facility · 73 plays); headless screenshots verified desktop + mobile for both drawers and NES+Lime / TR-808+Workbench combos
- [ ] Matthew's phone pass

Needs a deploy after merge (worker change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)