### PR TITLE
feat(relay): cloud web UI — live artefact opens, ⌘K fan-out, presence chip (web half, read-only v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Oyster are documented here. The format follows [Keep a Ch
 
 ### Added
 
+- **Open your files from anywhere** — while a device is running Oyster, app.oyster.to can open its artefacts live: notes, docs and diagrams render right in the remote view, no publishing needed. Offline devices fall back to the read-only listing.
+- **Search transcripts from anywhere** — Cmd+K at app.oyster.to now searches the sessions on your online devices, with each hit labelled by the device it came from.
+- **Device switch in the remote view** — a topbar chip shows which devices are live; disable or re-enable live access per device with one click (sync is unaffected).
 - **Your artefact library appears in the cloud remote view** — the Artefacts tab at app.oyster.to now lists everything in your registry (read-only), with a chip showing which device each artefact lives on. Published artefacts stay the openable ones.
 
 ### Changed

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -308,6 +308,9 @@
 <h2 id="v-unreleased"><a class="release-version-link" href="https://github.com/oyster-to/oyster/compare/v0.11.0...HEAD" rel="noopener noreferrer"><span class="release-version">Unreleased</span></a></h2>
 <h3>Added</h3>
 <ul>
+<li><strong>Open your files from anywhere</strong> — while a device is running Oyster, app.oyster.to can open its artefacts live: notes, docs and diagrams render right in the remote view, no publishing needed. Offline devices fall back to the read-only listing.</li>
+<li><strong>Search transcripts from anywhere</strong> — Cmd+K at app.oyster.to now searches the sessions on your online devices, with each hit labelled by the device it came from.</li>
+<li><strong>Device switch in the remote view</strong> — a topbar chip shows which devices are live; disable or re-enable live access per device with one click (sync is unaffected).</li>
 <li><strong>Your artefact library appears in the cloud remote view</strong> — the Artefacts tab at app.oyster.to now lists everything in your registry (read-only), with a chip showing which device each artefact lives on. Published artefacts stay the openable ones.</li>
 </ul>
 <h3>Changed</h3>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -65,6 +65,10 @@ export interface Artifact {
    *  chip — the artefact's content lives on that machine, not in the cloud.
    *  Never set in local builds. */
   originDeviceLabel?: string | null;
+  /** Cloud remote view only: the origin device's UUID — routes relayed
+   *  opens to the owning device (/api/relay/d/<id>/…). Never set in
+   *  local builds. */
+  originDeviceId?: string | null;
 }
 
 export interface ArtefactPublication {

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1801,6 +1801,20 @@ body {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+/* Cloud relay fan-out: which online device a transcript hit came from.
+   Same blue as the home-remote-chip so "lives on a device" reads
+   consistently across surfaces. */
+.spotlight-result-device {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 0.66rem;
+  color: #8fb6ff;
+  white-space: nowrap;
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 .spotlight-token-chip {
   display: inline-flex;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,9 +117,9 @@ export default function App() {
   // Global keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      // Spotlight is unmounted in cloud (caps.canChat false), so ⌘K would
-      // toggle dead state with nothing to render — keep the shortcut inert there.
-      if (caps.canChat && (e.metaKey || e.ctrlKey) && e.key === "k") {
+      // Spotlight works locally (full FTS + ask row) and in cloud (artefact
+      // filter + relayed transcript search against online devices).
+      if ((caps.canChat || caps.cloud) && (e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setSpotlightOpen((v) => !v);
       }
@@ -915,7 +915,7 @@ export default function App() {
         />
       )}
 
-      {caps.canChat && spotlightOpen && (
+      {(caps.canChat || caps.cloud) && spotlightOpen && (
         <SpotlightSearch
           artifacts={artifacts}
           spaces={spaces}

--- a/web/src/components/Home/index.tsx
+++ b/web/src/components/Home/index.tsx
@@ -9,6 +9,7 @@ import { useMyDeviceId } from "../../hooks/useMyDeviceId";
 import { useSpaceProjects } from "../../hooks/useSpaceProjects";
 import { parseTimestamp } from "../../utils/parseTimestamp";
 import { AuthBadge } from "../AuthBadge";
+import { RelayDevicesChip } from "../RelayDevicesChip";
 import { Desktop } from "../Desktop";
 import { InspectorPanel, type ActivePanel } from "../InspectorPanel";
 import { SessionInspector } from "../SessionInspector";
@@ -859,6 +860,7 @@ export function Home({ activeSpace, spaces, desktopProps, onSpaceChange, onPromo
             <LayoutGroup id="home-breadcrumb">
             <div className="home-breadcrumb-inner">
             <AuthBadge />
+            {caps.cloud && <RelayDevicesChip />}
             {caps.hasSpaces && (<>
             <button
               type="button"

--- a/web/src/components/RelayDevicesChip.css
+++ b/web/src/components/RelayDevicesChip.css
@@ -1,0 +1,111 @@
+/* Relay presence chip — second token in the home-breadcrumb bar (cloud
+   builds only). Pill shape matches .auth-chip__pill; the popover reuses
+   .auth-chip__menu and adds device rows. */
+
+.relay-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.relay-chip__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: none;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text-dim);
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.relay-chip__pill:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.relay-chip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(232, 233, 240, 0.3);
+  flex-shrink: 0;
+}
+
+.relay-chip__dot--live {
+  background: #4ade80;
+  box-shadow: 0 0 6px rgba(74, 222, 128, 0.55);
+}
+
+.relay-chip__menu {
+  min-width: 230px;
+}
+
+.relay-chip__menu-title {
+  padding: 6px 12px 4px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.relay-chip__menu-empty {
+  padding: 6px 12px 10px;
+  font-size: 0.74rem;
+  line-height: 1.45;
+  color: var(--text-dim);
+  max-width: 230px;
+}
+
+.relay-chip__device {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+}
+
+.relay-chip__device-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.78rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.relay-chip__device--disabled .relay-chip__device-label {
+  color: var(--text-dim);
+}
+
+.relay-chip__device-action {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-dim);
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 3px 9px;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.relay-chip__device-action:hover:not(:disabled) {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.09);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.relay-chip__device-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/web/src/components/RelayDevicesChip.tsx
+++ b/web/src/components/RelayDevicesChip.tsx
@@ -54,7 +54,7 @@ export function RelayDevicesChip() {
         type="button"
         className="relay-chip__pill"
         onClick={() => setOpen((v) => !v)}
-        aria-haspopup="menu"
+        aria-haspopup="true"
         aria-expanded={open}
         title={live.length > 0
           ? `${live.length} device${live.length === 1 ? "" : "s"} serving live content`
@@ -65,7 +65,7 @@ export function RelayDevicesChip() {
       </button>
 
       {open && (
-        <div className="auth-chip__menu relay-chip__menu" role="menu">
+        <div className="auth-chip__menu relay-chip__menu">
           <div className="relay-chip__menu-title">Devices</div>
           {live.length === 0 && state.disabled.length === 0 && (
             <div className="relay-chip__menu-empty">
@@ -74,7 +74,7 @@ export function RelayDevicesChip() {
             </div>
           )}
           {live.map((d) => (
-            <div key={d.device_id} className="relay-chip__device" role="menuitem">
+            <div key={d.device_id} className="relay-chip__device">
               <span className="relay-chip__device-label" title={d.device_label ?? d.device_id}>
                 <span className="relay-chip__dot relay-chip__dot--live" aria-hidden="true" />
                 {d.device_label ?? d.device_id.slice(0, 8)}
@@ -91,7 +91,7 @@ export function RelayDevicesChip() {
             </div>
           ))}
           {state.disabled.map((d) => (
-            <div key={d.device_id} className="relay-chip__device relay-chip__device--disabled" role="menuitem">
+            <div key={d.device_id} className="relay-chip__device relay-chip__device--disabled">
               <span className="relay-chip__device-label" title={d.device_label ?? d.device_id}>
                 <span className="relay-chip__dot" aria-hidden="true" />
                 {d.device_label ?? d.device_id.slice(0, 8)}

--- a/web/src/components/RelayDevicesChip.tsx
+++ b/web/src/components/RelayDevicesChip.tsx
@@ -1,0 +1,114 @@
+// RelayDevicesChip — device presence + per-device relay kill switch for
+// the cloud remote view (spec 2026-06-07-device-relay-design). Sits in
+// the home-breadcrumb bar next to AuthBadge, cloud builds only. Shows
+// "● N live" when relay-connected devices can serve content; the popover
+// lists them with a Disable toggle (DO-storage flag — severs relay
+// without touching sync) and lets disabled devices be re-enabled.
+import { useEffect, useRef, useState } from "react";
+import {
+  getRelayState,
+  subscribeRelay,
+  disableRelayDevice,
+  enableRelayDevice,
+  type RelayState,
+} from "../data/relay";
+import "./RelayDevicesChip.css";
+
+export function RelayDevicesChip() {
+  const [state, setState] = useState<RelayState>(getRelayState());
+  const [open, setOpen] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => subscribeRelay(() => setState(getRelayState())), []);
+
+  // Same outside-click dismissal as AuthBadge's menu.
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  const live = state.online.filter((d) => d.ready);
+
+  async function toggle(deviceId: string, action: "disable" | "enable") {
+    setBusyId(deviceId);
+    try {
+      if (action === "disable") await disableRelayDevice(deviceId);
+      else await enableRelayDevice(deviceId);
+    } catch {
+      // Status poll will correct the view; nothing useful to render here.
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="relay-chip" ref={wrapRef}>
+      <button
+        type="button"
+        className="relay-chip__pill"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={live.length > 0
+          ? `${live.length} device${live.length === 1 ? "" : "s"} serving live content`
+          : "No devices online — showing the synced mirror"}
+      >
+        <span className={`relay-chip__dot${live.length > 0 ? " relay-chip__dot--live" : ""}`} aria-hidden="true" />
+        {live.length > 0 ? `${live.length} live` : "mirror"}
+      </button>
+
+      {open && (
+        <div className="auth-chip__menu relay-chip__menu" role="menu">
+          <div className="relay-chip__menu-title">Devices</div>
+          {live.length === 0 && state.disabled.length === 0 && (
+            <div className="relay-chip__menu-empty">
+              No devices online. Open Oyster on a device to browse its
+              files and search its sessions from here.
+            </div>
+          )}
+          {live.map((d) => (
+            <div key={d.device_id} className="relay-chip__device" role="menuitem">
+              <span className="relay-chip__device-label" title={d.device_label ?? d.device_id}>
+                <span className="relay-chip__dot relay-chip__dot--live" aria-hidden="true" />
+                {d.device_label ?? d.device_id.slice(0, 8)}
+              </span>
+              <button
+                type="button"
+                className="relay-chip__device-action"
+                disabled={busyId === d.device_id}
+                onClick={() => void toggle(d.device_id, "disable")}
+                title="Stop serving live content from this device (sync is unaffected)"
+              >
+                Disable
+              </button>
+            </div>
+          ))}
+          {state.disabled.map((d) => (
+            <div key={d.device_id} className="relay-chip__device relay-chip__device--disabled" role="menuitem">
+              <span className="relay-chip__device-label" title={d.device_label ?? d.device_id}>
+                <span className="relay-chip__dot" aria-hidden="true" />
+                {d.device_label ?? d.device_id.slice(0, 8)}
+              </span>
+              <button
+                type="button"
+                className="relay-chip__device-action"
+                disabled={busyId === d.device_id}
+                onClick={() => void toggle(d.device_id, "enable")}
+                title="Allow this device to serve live content again"
+              >
+                Enable
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/SpotlightSearch.tsx
+++ b/web/src/components/SpotlightSearch.tsx
@@ -7,6 +7,7 @@ import type { TranscriptHit } from "../data/sessions-api";
 import { searchMemories } from "../data/memories-api";
 import type { Memory } from "../data/memories-api";
 import { formatRelative } from "./Home/utils";
+import { caps } from "../caps";
 
 interface Props {
   artifacts: Artifact[];
@@ -239,8 +240,8 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
 
   // Any non-empty query gets an "Ask Oyster" row as the final hit — ⌘K is
   // the keyboard path to the Ask panel. No row on the empty-query recent
-  // feed (nothing to ask).
-  const askHit: SpotlightHit[] = query.trim() ? [{ kind: "ask" }] : [];
+  // feed (nothing to ask), and none in cloud (no Ask panel to send to).
+  const askHit: SpotlightHit[] = caps.canChat && query.trim() ? [{ kind: "ask" }] : [];
 
   // Whichever list is on screen drives keyboard nav. The recent feed only
   // shows when searchHits is empty AND query/filter are empty, so the two
@@ -286,7 +287,11 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
       window.dispatchEvent(new CustomEvent("oyster:open-session", {
         detail: {
           id: hit.hit.session_id,
-          eventId: hit.hit.event_id,
+          // Local FTS event_ids are sqlite rowids; the cloud transcript
+          // reader paginates by byte-offset cursor ids — a relayed hit's
+          // rowid means nothing there, so cloud opens the session without
+          // the deep-link (the query still pre-fills the find bar).
+          eventId: caps.cloud ? undefined : hit.hit.event_id,
           query: query.trim(),
         },
       }));
@@ -489,6 +494,11 @@ export function SpotlightSearch({ artifacts, spaces, onOpen, onClose }: Props) {
                     </div>
                   </div>
                   <div className="spotlight-result-session-meta">
+                    {h.originDeviceLabel && (
+                      <span className="spotlight-result-device" title={`Found on ${h.originDeviceLabel}`}>
+                        <span aria-hidden="true">⌂</span> {h.originDeviceLabel}
+                      </span>
+                    )}
                     {h.last_event_at && (
                       <span className="spotlight-result-session-date">{formatHitDate(h.last_event_at)}</span>
                     )}

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -4,6 +4,7 @@ import { getJson, patchJson, postJson, postEmpty, del, apiPath } from "./http";
 import { caps } from "../caps";
 import { fetchCloudPublications } from "./cloud-publications";
 import { fetchCloudArtifacts } from "./cloud-artifacts";
+import { freshRelayState, relayPath } from "./relay";
 
 export async function fetchArtifacts(signal?: AbortSignal): Promise<Artifact[]> {
   // Cloud Artefacts tab = the synced registry, plus orphan live publications
@@ -26,9 +27,56 @@ export async function fetchArtifacts(signal?: AbortSignal): Promise<Artifact[]> 
       return { ...a, url: pub.url, status: pub.status, publication: pub.publication };
     });
     // Orphans: live publications with no surviving registry row.
-    return [...merged, ...pubById.values()];
+    return enrichWithLiveDevices([...merged, ...pubById.values()], signal);
   }
   return getJson<Artifact[]>(apiPath("/api/artifacts"), signal);
+}
+
+/** Relay enrichment (spec 2026-06-07-device-relay-design): the registry
+ *  mirror deliberately carries no file URLs, so unpublished rows whose
+ *  origin device is ONLINE get their viewer URL from the device's live
+ *  /api/artifacts (relayed), rewritten through /api/relay/d/<id>/…. The
+ *  row then opens like any other. Strictly progressive: any failure —
+ *  no devices, device wedged, relay rolled back — returns the rows
+ *  untouched (today's inert mirror). */
+async function enrichWithLiveDevices(rows: Artifact[], signal?: AbortSignal): Promise<Artifact[]> {
+  try {
+    const online = (await freshRelayState(signal)).online.filter((d) => d.ready);
+    if (online.length === 0) return rows;
+    const lists = await Promise.all(online.map(async (d) => {
+      try {
+        const artifacts = await getJson<Artifact[]>(relayPath(d.device_id, "/api/artifacts"), signal);
+        return { deviceId: d.device_id, artifacts };
+      } catch {
+        return null; // one slow/offline device must not block the rest
+      }
+    }));
+    // artifact_id → live open target. Three cases from the device's own
+    // url field: redirect artefacts point at the public web (open as-is);
+    // /docs/ + /artifacts/ paths relay through the device; local_process
+    // localhost URLs are meaningless remotely (stay inert).
+    const liveById = new Map<string, string>();
+    for (const list of lists) {
+      if (!list) continue;
+      for (const a of list.artifacts) {
+        if (typeof a.url !== "string" || a.url.length === 0) continue;
+        if (a.runtimeKind === "redirect" && /^https?:\/\//.test(a.url)) {
+          liveById.set(a.id, a.url);
+        } else if (a.url.startsWith("/docs/") || a.url.startsWith("/artifacts/")) {
+          liveById.set(a.id, relayPath(list.deviceId, a.url));
+        }
+      }
+    }
+    if (liveById.size === 0) return rows;
+    return rows.map((row) => {
+      if (row.url) return row; // published — share page stays canonical
+      const liveUrl = liveById.get(row.id);
+      if (!liveUrl) return row;
+      return { ...row, url: liveUrl, status: "online" as const };
+    });
+  } catch {
+    return rows;
+  }
 }
 
 // startApp/stopApp keep their bespoke shape: server routes are GETs and the

--- a/web/src/data/artifacts-api.ts
+++ b/web/src/data/artifacts-api.ts
@@ -4,7 +4,7 @@ import { getJson, patchJson, postJson, postEmpty, del, apiPath } from "./http";
 import { caps } from "../caps";
 import { fetchCloudPublications } from "./cloud-publications";
 import { fetchCloudArtifacts } from "./cloud-artifacts";
-import { freshRelayState, relayPath } from "./relay";
+import { freshRelayState, relayPath, withRelayTimeout } from "./relay";
 
 export async function fetchArtifacts(signal?: AbortSignal): Promise<Artifact[]> {
   // Cloud Artefacts tab = the synced registry, plus orphan live publications
@@ -45,10 +45,16 @@ async function enrichWithLiveDevices(rows: Artifact[], signal?: AbortSignal): Pr
     if (online.length === 0) return rows;
     const lists = await Promise.all(online.map(async (d) => {
       try {
-        const artifacts = await getJson<Artifact[]>(relayPath(d.device_id, "/api/artifacts"), signal);
+        // 3s budget per device: a wedged device degrades that device's
+        // rows to the mirror; without it, Promise.all would hold the
+        // whole artefact list hostage until the relay's 30s timeout.
+        const artifacts = await getJson<Artifact[]>(
+          relayPath(d.device_id, "/api/artifacts"),
+          withRelayTimeout(signal, 3_000),
+        );
         return { deviceId: d.device_id, artifacts };
       } catch {
-        return null; // one slow/offline device must not block the rest
+        return null; // slow or offline — this device's rows stay inert
       }
     }));
     // artifact_id → live open target. Three cases from the device's own

--- a/web/src/data/cloud-artifacts.ts
+++ b/web/src/data/cloud-artifacts.ts
@@ -44,6 +44,9 @@ function toArtifact(r: CloudArtifactRow): Artifact {
     projectId: r.project_id,
     pinnedAt: r.pinned_at,
     originDeviceLabel: r.device_label,
+    // Routes relayed opens to the owning device when it's online
+    // (artifacts-api.ts does the live join).
+    originDeviceId: r.device_id,
   };
 }
 

--- a/web/src/data/memories-api.ts
+++ b/web/src/data/memories-api.ts
@@ -27,6 +27,10 @@ export async function searchMemories(
   query: string,
   opts: { spaceId?: string | null; limit?: number; signal?: AbortSignal } = {},
 ): Promise<Memory[]> {
+  // No /api/memories/search on the cloud worker (synced memories are an
+  // event log, not an FTS index) — return empty rather than 404 per
+  // keystroke. Spotlight's memory section just stays absent in cloud.
+  if (caps.cloud) return [];
   const params = new URLSearchParams({ q: query });
   if (opts.spaceId) params.set("space_id", opts.spaceId);
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));

--- a/web/src/data/relay.ts
+++ b/web/src/data/relay.ts
@@ -48,7 +48,23 @@ const listeners = new Set<() => void>();
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 
 function emit(): void {
-  for (const fn of listeners) fn();
+  for (const fn of listeners) {
+    try { fn(); }
+    catch (err) {
+      // One broken subscriber must not starve the others or break the
+      // poll flow that triggered the emit (same posture as ui-events).
+      console.warn("[relay] listener failed:", err);
+    }
+  }
+}
+
+/** Combine a caller's signal with a per-request timeout — used by the
+ *  fan-out callers (artefact enrichment, ⌘K) so one wedged device can't
+ *  stall a whole surface. AbortSignal.any is baseline in the browsers the
+ *  cloud build targets; the fallback drops the timeout, never the signal. */
+export function withRelayTimeout(signal: AbortSignal | undefined, ms: number): AbortSignal | undefined {
+  if (typeof AbortSignal.any !== "function" || typeof AbortSignal.timeout !== "function") return signal;
+  return signal ? AbortSignal.any([signal, AbortSignal.timeout(ms)]) : AbortSignal.timeout(ms);
 }
 
 async function fetchStatus(signal?: AbortSignal): Promise<RelayState> {

--- a/web/src/data/relay.ts
+++ b/web/src/data/relay.ts
@@ -1,0 +1,145 @@
+// relay.ts — device relay status store + helpers for the cloud remote view
+// (spec 2026-06-07-device-relay-design). The worker's per-user RelayDO
+// tracks which of the user's devices hold a live socket; this module polls
+// GET /api/relay/status (30s, visibility-aware — mirrors ui-events.ts'
+// cloud poller) and exposes:
+//
+//   subscribeRelay(fn)        — store subscription for UI (presence chip)
+//   getRelayState()           — current snapshot
+//   freshRelayState(signal)   — snapshot ≤10s old, fetching if needed
+//                               (data-layer callers: artifacts enrichment,
+//                               ⌘K fan-out)
+//   relayPath(deviceId, path) — /api/relay/d/<id><path>
+//   disable/enableRelayDevice — the per-device kill switch
+//
+// Everything no-ops outside cloud mode.
+
+import { caps } from "../caps";
+import { getJson, postEmpty, apiPath } from "./http";
+
+export interface RelayDevice {
+  device_id: string;
+  device_label: string | null;
+  connected_at: number;
+  /** False until the device's hello frame lands — not forwardable yet. */
+  ready: boolean;
+}
+
+export interface RelayDisabledDevice {
+  device_id: string;
+  device_label: string | null;
+  disabled_at: number;
+}
+
+export interface RelayState {
+  online: RelayDevice[];
+  disabled: RelayDisabledDevice[];
+}
+
+const POLL_INTERVAL_MS = 30_000;
+/** freshRelayState reuses the last poll within this window so data-layer
+ *  callers (artefact list, ⌘K) don't add a status request per call. */
+const FRESH_TTL_MS = 10_000;
+
+let state: RelayState = { online: [], disabled: [] };
+let fetchedAt = 0;
+let inFlight: Promise<RelayState> | null = null;
+const listeners = new Set<() => void>();
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
+async function fetchStatus(signal?: AbortSignal): Promise<RelayState> {
+  const data = await getJson<RelayState>(apiPath("/api/relay/status"), signal);
+  state = {
+    online: data.online ?? [],
+    disabled: data.disabled ?? [],
+  };
+  fetchedAt = Date.now();
+  emit();
+  return state;
+}
+
+export function getRelayState(): RelayState {
+  return state;
+}
+
+/** Online devices that can actually serve requests. */
+export function onlineRelayDevices(): RelayDevice[] {
+  return state.online.filter((d) => d.ready);
+}
+
+/** A snapshot no older than FRESH_TTL_MS, fetching if needed. Coalesces
+ *  concurrent callers onto one request. Returns the stale snapshot on
+ *  fetch failure — relay is progressive enhancement; callers degrade to
+ *  the mirror, never to an error. */
+export async function freshRelayState(signal?: AbortSignal): Promise<RelayState> {
+  if (!caps.cloud) return state;
+  if (Date.now() - fetchedAt < FRESH_TTL_MS) return state;
+  if (!inFlight) {
+    inFlight = fetchStatus(signal).finally(() => { inFlight = null; });
+  }
+  try {
+    return await inFlight;
+  } catch {
+    return state;
+  }
+}
+
+export function relayPath(deviceId: string, path: string): string {
+  return apiPath(`/api/relay/d/${encodeURIComponent(deviceId)}${path}`);
+}
+
+export async function disableRelayDevice(deviceId: string): Promise<void> {
+  await postEmpty(apiPath(`/api/relay/devices/${encodeURIComponent(deviceId)}/disable`));
+  fetchedAt = 0;
+  void freshRelayState();
+}
+
+export async function enableRelayDevice(deviceId: string): Promise<void> {
+  await postEmpty(apiPath(`/api/relay/devices/${encodeURIComponent(deviceId)}/enable`));
+  fetchedAt = 0;
+  void freshRelayState();
+}
+
+function startPoll(): void {
+  if (pollTimer !== null) return;
+  void freshRelayState();
+  pollTimer = setInterval(() => {
+    if (listeners.size === 0) return;
+    fetchedAt = 0; // force a real fetch each tick
+    void freshRelayState();
+  }, POLL_INTERVAL_MS);
+}
+
+function stopPoll(): void {
+  if (pollTimer !== null) { clearInterval(pollTimer); pollTimer = null; }
+}
+
+/** Subscribe to relay state changes. Starts the poller on the first
+ *  subscriber (cloud only); stops on the last unsubscribe. Pauses while
+ *  the tab is hidden, refreshes immediately on return — same posture as
+ *  ui-events.ts' cloud poll. */
+export function subscribeRelay(listener: () => void): () => void {
+  if (!caps.cloud) return () => { /* no-op outside cloud */ };
+  listeners.add(listener);
+  if (typeof document === "undefined" || document.visibilityState === "visible") {
+    startPoll();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) stopPoll();
+  };
+}
+
+if (caps.cloud && typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      if (listeners.size > 0) { fetchedAt = 0; startPoll(); void freshRelayState(); }
+    } else {
+      stopPoll();
+    }
+  });
+}

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../../shared/types";
 import { ApiError, getJson, apiPath } from "./http";
 import { caps } from "../caps";
+import { freshRelayState, relayPath } from "./relay";
 import {
   fetchCloudSessions,
   fetchCloudSession,
@@ -128,17 +129,51 @@ export interface TranscriptHit {
    *  hyper-broad prefix queries. Drives the "+N more" affordance,
    *  which treats it as a hint. */
   match_count: number;
+  /** Cloud remote view only: which online device answered this hit
+   *  (relay fan-out). Never set in local builds. */
+  originDeviceLabel?: string | null;
 }
 
 export async function searchTranscripts(
   query: string,
   opts: { limit?: number; spaceId?: string | null; signal?: AbortSignal } = {},
 ): Promise<TranscriptHit[]> {
-  if (caps.cloud) return [];
   const params = new URLSearchParams({ q: query });
   if (opts.limit !== undefined) params.set("limit", String(opts.limit));
   if (opts.spaceId) params.set("space_id", opts.spaceId);
+
+  // Cloud: the mirror has no transcript FTS (chunks are encrypted at
+  // rest), so ⌘K fans out to each ONLINE device's local index through the
+  // relay and concatenates — sessions live on exactly one device, so
+  // there's nothing to dedup. Offline devices' transcripts simply don't
+  // appear; no devices online → empty, the pre-relay behaviour. Each
+  // device gets a 3s budget so one wedged machine can't stall the panel.
+  if (caps.cloud) {
+    const devices = (await freshRelayState(opts.signal)).online.filter((d) => d.ready);
+    if (devices.length === 0) return [];
+    const perDevice = await Promise.all(devices.map(async (d) => {
+      try {
+        const hits = await getJson<TranscriptHit[]>(
+          relayPath(d.device_id, `/api/sessions/search?${params.toString()}`),
+          withTimeout(opts.signal, 3_000),
+        );
+        return hits.map((h) => ({ ...h, originDeviceLabel: d.device_label }));
+      } catch {
+        return [];
+      }
+    }));
+    return perDevice.flat();
+  }
+
   return getJson<TranscriptHit[]>(apiPath(`/api/sessions/search?${params.toString()}`), opts.signal);
+}
+
+/** Combine the caller's signal with a per-request timeout. AbortSignal.any
+ *  is baseline in every browser the cloud build targets; the fallback just
+ *  drops the timeout rather than the caller's signal. */
+function withTimeout(signal: AbortSignal | undefined, ms: number): AbortSignal | undefined {
+  if (typeof AbortSignal.any !== "function" || typeof AbortSignal.timeout !== "function") return signal;
+  return signal ? AbortSignal.any([signal, AbortSignal.timeout(ms)]) : AbortSignal.timeout(ms);
 }
 
 // The list endpoint strips `raw` from every event to keep the payload

--- a/web/src/data/sessions-api.ts
+++ b/web/src/data/sessions-api.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../../shared/types";
 import { ApiError, getJson, apiPath } from "./http";
 import { caps } from "../caps";
-import { freshRelayState, relayPath } from "./relay";
+import { freshRelayState, relayPath, withRelayTimeout } from "./relay";
 import {
   fetchCloudSessions,
   fetchCloudSession,
@@ -155,7 +155,7 @@ export async function searchTranscripts(
       try {
         const hits = await getJson<TranscriptHit[]>(
           relayPath(d.device_id, `/api/sessions/search?${params.toString()}`),
-          withTimeout(opts.signal, 3_000),
+          withRelayTimeout(opts.signal, 3_000),
         );
         return hits.map((h) => ({ ...h, originDeviceLabel: d.device_label }));
       } catch {
@@ -166,14 +166,6 @@ export async function searchTranscripts(
   }
 
   return getJson<TranscriptHit[]>(apiPath(`/api/sessions/search?${params.toString()}`), opts.signal);
-}
-
-/** Combine the caller's signal with a per-request timeout. AbortSignal.any
- *  is baseline in every browser the cloud build targets; the fallback just
- *  drops the timeout rather than the caller's signal. */
-function withTimeout(signal: AbortSignal | undefined, ms: number): AbortSignal | undefined {
-  if (typeof AbortSignal.any !== "function" || typeof AbortSignal.timeout !== "function") return signal;
-  return signal ? AbortSignal.any([signal, AbortSignal.timeout(ms)]) : AbortSignal.timeout(ms);
 }
 
 // The list endpoint strips `raw` from every event to keep the payload


### PR DESCRIPTION
## What

Web half of the **device relay** — PR 3 of 3 per the spec (#655). Pairs with #657 (RelayDO worker) and #661 (relay-client server). This is the slice that makes the whole thing user-visible, so the CHANGELOG entries ride here.

Everything is **progressive enhancement over the mirror**: any relay failure — no devices online, device wedged, worker rolled back — degrades to today's inert read-only view, never an error.

## Pieces

- **`data/relay.ts`** — status store polling `/api/relay/status` (30s, visibility-aware, same posture as ui-events' cloud poller), `freshRelayState` (10s TTL, coalesced) for data-layer callers, disable/enable calls, `relayPath()`.
- **Live artefact opens** — unpublished registry rows whose origin device is online get their viewer URL from the device's live `/api/artifacts` (relayed), rewritten through `/api/relay/d/<id>/…`. The existing inert logic (`!art.url`) then flips them openable with **zero component changes** — chips, click handling and context menus all behave correctly by construction. `redirect` artefacts open their public URL directly; `local_process` localhost URLs stay inert (meaningless remotely). Published rows untouched — the share page stays canonical.
- **⌘K in cloud** — SpotlightSearch now mounts at app.oyster.to: artefact filter (client-side, as local) + relayed transcript search **fanned out to each online device** (3s budget per device, concat-only — sessions live on exactly one device, so no dedup). Hits carry a `⌂ device` label. Two cloud-specific cuts: the event deep-link is dropped (local FTS rowids mean nothing to the cloud byte-offset reader — the query still pre-fills the find bar), and the Ask row is hidden (no Ask panel in cloud). `searchMemories` returns empty in cloud instead of 404-per-keystroke.
- **`RelayDevicesChip`** — "● N live" / "mirror" pill next to the account chip (cloud only). Popover lists online devices with per-device **Disable** (the DO-storage kill switch — severs relay, sync unaffected) and re-**Enable** for disabled ones.
- `Artifact.originDeviceId` added (the registry row already carried `device_id`; it just wasn't mapped).

## Verification

- `tsc --noEmit` clean; `npm run build` and `npm run build:cloud` both green.
- Hand-test plan (after #657 deploy + #661 release): phone → app.oyster.to → chip shows "1 live" → open an unpublished MD artefact (renders, CSP-sandboxed) → ⌘K finds a transcript string with the device label → Disable the device → rows go inert within a poll, reconnect attempts rejected → Enable → live again.

## Known v1 edges (deliberate)

- Icon-grid tiles don't carry the inert/chip treatment (pre-existing #644 gap; live tiles now genuinely open, which shrinks it).
- Live *session list* merging (relay `/api/sessions` into the mirror list) deferred — needs shape-mapping + dedup-vs-mirror care; tracked as the next small slice.
- HTML app bundles may render with missing subresources through the relay (absolute `/artifacts/…` refs resolve against app.oyster.to). v1 viewer targets notes/docs/diagrams/images per the spec.

Spec: `docs/superpowers/specs/2026-06-07-device-relay-design.md` (#655)

🤖 Generated with [Claude Code](https://claude.com/claude-code)