### PR TITLE
arcade(groovebox): instruments layer PR1 — schema, GM identity, data-driven voices

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -1,6 +1,7 @@
 import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
+import { normalizeSongDrums } from './instruments.js';
 import { laneByType, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
@@ -304,6 +305,7 @@ export function createEngine() {
   return {
     load(s) {
       const v2 = (s.patterns && s.chain) ? s : flattenSong(s);
+      normalizeSongDrums(v2);                 // ingest boundary: GM numbers past here
       song = v2;
       editIdx = 0; pendingTarget = null;
       target = { kind: 'chain', pos: 0, barInPattern: 0 };
@@ -612,10 +614,10 @@ export function createEngine() {
       return true;
     },
     moveChain(from, to)     { if (song) _moveChain(song, from, to); },
-    setDrumStep(laneId, voice, barIdx, stepIdx, on) {
+    setDrumStep(laneId, voice, barIdx, stepIdx, on, pitched) {
       if (!song) return;
       const g = grooveFor(song, editIdx, laneId);
-      if (g) _setDrumStep(song, laneId, g.name, barIdx, voice, stepIdx, on);
+      if (g) _setDrumStep(song, laneId, g.name, barIdx, voice, stepIdx, on, pitched);
     },
     toggleNote(laneId, barIdx, stepIdx, note, dur) {
       if (!song) return;

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -209,9 +209,9 @@ export function createEngine() {
     // Dispose voice node(s)
     const v = voices[id];
     if (v) {
-      for (const node of Object.values(v)) {
-        try { node.dispose?.(); } catch (_) {}
-      }
+      // New-style voices own their teardown; legacy flat shapes get the loop.
+      if (typeof v.dispose === 'function') { try { v.dispose(); } catch (_) {} }
+      else for (const node of Object.values(v)) { try { node.dispose?.(); } catch (_) {} }
       delete voices[id];
     }
     // Dispose FX chain (null lazy nodes are skipped safely)

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -120,13 +120,18 @@ export function validateKit(kit, instruments) {
 // ── groove normalization (the input boundary) ────────────────────────────────
 /** normalizeDrumBar(bar) → same bar shape with canonical numeric keys.
  *  Unrecognisable keys are DROPPED (bad data never crashes the engine).
- *  Step shapes pass through untouched (numbers or [step, semi] pairs). */
+ *  Values are sanitized: arrays only; elements must be a finite step number
+ *  or a [step, semi] pair — anything else is dropped. */
 export function normalizeDrumBar(bar) {
   if (!bar || typeof bar !== 'object' || Array.isArray(bar)) return {};
   const out = {};
   for (const [k, v] of Object.entries(bar)) {
     const note = slotKey(k);
-    if (note !== null) out[note] = v;
+    if (note === null || !Array.isArray(v)) continue;   // values must be arrays
+    const steps = v.filter(s =>
+      (typeof s === 'number' && Number.isFinite(s)) ||
+      (Array.isArray(s) && typeof s[0] === 'number' && Number.isFinite(s[0])));
+    out[note] = steps;
   }
   return out;
 }

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -1,0 +1,211 @@
+// engine/instruments.js — the instruments layer (v1, synth only).
+//
+// Entities (spec: project-notes po20/2026-06-07-instruments-layer-spec.md):
+//   Instrument — atomic patch: { name, type, engine:'synth', patch }
+//   Kit        — GM-note drum rack: { name, slots: [{ note, label, instrument }] }
+//
+// Identity vs syntax: GM note NUMBERS are canonical (engine, storage, registry);
+// GM NAMES are first-class input syntax, normalized here at the one boundary
+// (like CSS #fff/#ffffff). UI shows kit-slot labels, never numbers.
+//
+// `engine: 'synth'` reserves the v2 seam: a sample instrument is the same
+// wrapper with engine:'sample' and an SFZ-shaped sample block instead of patch.
+
+// ── GM drum map: input aliases (name → canonical note) ──────────────────────
+export const GM = {
+  kick: 36, kick2: 35, sidestick: 37, snare: 38, clap: 39, snare2: 40,
+  tomlow2: 41, hat: 42, tomlow: 43, pedalhat: 44, tom: 45, openhat: 46,
+  tommid: 47, tomhi2: 48, crash: 49, tomhi: 50, ride: 51, china: 52,
+  ridebell: 53, tambourine: 54, splash: 55, cowbell: 56, crash2: 57,
+  shaker: 70,
+};
+const GM_NAME_BY_NOTE = Object.fromEntries(Object.entries(GM).map(([n, v]) => [v, n]));
+
+/** slotKey(k) → canonical GM note number, or null if unrecognisable.
+ *  Accepts 36, '36', 'kick' (case-insensitive). */
+export function slotKey(k) {
+  if (typeof k === 'number') return Number.isInteger(k) && k >= 0 && k <= 127 ? k : null;
+  if (typeof k !== 'string') return null;
+  const name = k.toLowerCase().trim();
+  if (name in GM) return GM[name];
+  const n = Number(name);
+  return Number.isInteger(n) && n >= 0 && n <= 127 ? n : null;
+}
+
+/** gmName(note) → alias name for a GM note ('kick'), or null. */
+export function gmName(note) { return GM_NAME_BY_NOTE[note] ?? null; }
+
+// ── neutral patch vocabulary ─────────────────────────────────────────────────
+// Versioned and deliberately small: exactly what today's eight voices need.
+// scale: 'linear' | 'log'. Compiled to Tone by ONE adapter (voices.js).
+export const PATCH_SCHEMA_VERSION = 1;
+
+export const ARCHETYPES = ['membrane', 'noise', 'mono', 'poly'];
+export const OSC_SHAPES = ['pulse', 'square', 'sawtooth', 'fatsawtooth', 'triangle', 'sine'];
+export const FILTER_TYPES = ['lowpass', 'highpass'];
+
+export const PATCH_PARAMS = {
+  'volume':                  { min: -40,   max: 6,     scale: 'linear' },  // dB
+  'envelope.attack':         { min: 0.001, max: 4,     scale: 'log' },
+  'envelope.decay':          { min: 0.01,  max: 4,     scale: 'log' },
+  'envelope.sustain':        { min: 0,     max: 1,     scale: 'linear' },
+  'envelope.release':        { min: 0.01,  max: 8,     scale: 'log' },
+  'oscillator.width':        { min: 0.05,  max: 0.95,  scale: 'linear' },  // pulse only
+  'filter.freq':             { min: 40,    max: 20000, scale: 'log' },
+  'filterEnvelope.attack':   { min: 0.001, max: 4,     scale: 'log' },
+  'filterEnvelope.decay':    { min: 0.01,  max: 4,     scale: 'log' },
+  'filterEnvelope.sustain':  { min: 0,     max: 1,     scale: 'linear' },
+  'filterEnvelope.baseFrequency': { min: 20, max: 10000, scale: 'log' },
+  'filterEnvelope.octaves':  { min: 0,     max: 8,     scale: 'linear' },
+  'pitch.pitchDecay':        { min: 0.001, max: 0.5,   scale: 'log' },     // membrane only
+  'pitch.octaves':           { min: 0.5,   max: 8,     scale: 'linear' },  // membrane only
+  'trigger.velocity':        { min: 0,     max: 1,     scale: 'linear' },
+};
+
+const INSTRUMENT_TYPES = ['drum', 'bass', 'chords', 'melody'];
+
+function num(v) { return typeof v === 'number' && Number.isFinite(v); }
+function inRange(id, v) {
+  const p = PATCH_PARAMS[id];
+  return !!p && num(v) && v >= p.min && v <= p.max;
+}
+function get(obj, path) { return path.split('.').reduce((o, k) => (o == null ? o : o[k]), obj); }
+
+/** validateInstrument(inst) → boolean. Bad data must never crash the engine —
+ *  callers fall back to defaults on false. */
+export function validateInstrument(inst) {
+  if (!inst || typeof inst !== 'object') return false;
+  if (typeof inst.name !== 'string' || !inst.name.length || inst.name.length > 24) return false;
+  if (!INSTRUMENT_TYPES.includes(inst.type)) return false;
+  if (inst.engine !== 'synth') return false;          // v1: synth only ('sample' is the v2 seam)
+  const p = inst.patch;
+  if (!p || typeof p !== 'object') return false;
+  if (!ARCHETYPES.includes(p.archetype)) return false;
+  // Every present numeric param must be in range (absent = adapter default).
+  for (const id of Object.keys(PATCH_PARAMS)) {
+    const v = get(p, id);
+    if (v !== undefined && !inRange(id, v)) return false;
+  }
+  if (p.oscillator?.shape !== undefined && !OSC_SHAPES.includes(p.oscillator.shape)) return false;
+  if (p.filter !== undefined) {
+    if (!FILTER_TYPES.includes(p.filter.type)) return false;
+    if (!inRange('filter.freq', p.filter.freq)) return false;
+  }
+  if (p.trigger !== undefined) {
+    if (p.trigger.note !== undefined && typeof p.trigger.note !== 'string') return false;
+    if (p.trigger.dur !== undefined && typeof p.trigger.dur !== 'string') return false;
+    if (p.trigger.velocity !== undefined && !inRange('trigger.velocity', p.trigger.velocity)) return false;
+  }
+  return true;
+}
+
+/** validateKit(kit, instruments) → boolean. Slots must resolve: GM-valid notes,
+ *  unique, each referencing a known drum instrument. */
+export function validateKit(kit, instruments) {
+  if (!kit || typeof kit !== 'object') return false;
+  if (typeof kit.name !== 'string' || !kit.name.length || kit.name.length > 24) return false;
+  if (!Array.isArray(kit.slots) || !kit.slots.length || kit.slots.length > 16) return false;
+  const notes = new Set();
+  for (const s of kit.slots) {
+    const note = slotKey(s?.note);
+    if (note === null || notes.has(note)) return false;
+    notes.add(note);
+    if (typeof s.label !== 'string' || !s.label.length || s.label.length > 12) return false;
+    const inst = instruments?.[s.instrument];
+    if (!inst || inst.type !== 'drum' || !validateInstrument(inst)) return false;
+  }
+  return true;
+}
+
+// ── groove normalization (the input boundary) ────────────────────────────────
+/** normalizeDrumBar(bar) → same bar shape with canonical numeric keys.
+ *  Unrecognisable keys are DROPPED (bad data never crashes the engine).
+ *  Step shapes pass through untouched (numbers or [step, semi] pairs). */
+export function normalizeDrumBar(bar) {
+  if (!bar || typeof bar !== 'object' || Array.isArray(bar)) return {};
+  const out = {};
+  for (const [k, v] of Object.entries(bar)) {
+    const note = slotKey(k);
+    if (note !== null) out[note] = v;
+  }
+  return out;
+}
+
+/** normalizeDrumGrooves(grooves) → new grooves object with every drum bar
+ *  normalized. `grooves` is one lane's { name → bar[] } table. */
+export function normalizeDrumGrooves(grooves) {
+  const out = {};
+  for (const [name, bars] of Object.entries(grooves || {})) {
+    out[name] = Array.isArray(bars) ? bars.map(normalizeDrumBar) : bars;
+  }
+  return out;
+}
+
+// ── defaults: today's hardcoded voices, ported byte-for-byte ────────────────
+// Values mirror engine/voices.js createVoiceForType EXACTLY (parity-tested).
+export const DEFAULT_INSTRUMENTS = {
+  'gb-kick': {
+    name: 'GB KICK', type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -5, trigger: { note: 'C1', dur: '8n' } },
+  },
+  'gb-snare': {
+    name: 'GB SNARE', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -11,
+      envelope: { attack: 0.001, decay: 0.16, sustain: 0 },
+      trigger: { dur: '16n' } },
+  },
+  'gb-hat': {
+    name: 'GB HAT', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -20,
+      envelope: { attack: 0.001, decay: 0.03, sustain: 0 },
+      filter: { type: 'highpass', freq: 7000 },
+      trigger: { dur: '32n', velocity: 0.6 } },
+  },
+  'gb-tom': {
+    name: 'GB TOM', type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -6,
+      pitch: { pitchDecay: 0.06, octaves: 2 },
+      trigger: { note: 'A2', dur: '8n' } },
+  },
+  'gb-crash': {
+    name: 'GB CRASH', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -12,
+      envelope: { attack: 0.001, decay: 1.1, sustain: 0, release: 0.3 },
+      filter: { type: 'highpass', freq: 3500 },
+      trigger: { dur: '8n', velocity: 0.8 } },
+  },
+  'gb-bass': {
+    name: 'GB BASS', type: 'bass', engine: 'synth',
+    patch: { archetype: 'mono', volume: -7,
+      oscillator: { shape: 'triangle' },
+      envelope: { attack: 0.005, decay: 0.18, sustain: 0.35, release: 0.18 },
+      filterEnvelope: { attack: 0.005, decay: 0.12, sustain: 0.4, baseFrequency: 120, octaves: 3 },
+      trigger: { velocity: 0.85 } },
+  },
+  'gb-chords': {
+    name: 'GB CHORDS', type: 'chords', engine: 'synth',
+    patch: { archetype: 'poly', volume: -17,
+      oscillator: { shape: 'triangle' },
+      envelope: { attack: 0.05, decay: 0.3, sustain: 0.6, release: 0.5 },
+      filter: { type: 'lowpass', freq: 4200 },
+      trigger: { velocity: 0.3 } },
+  },
+  'gb-lead': {
+    name: 'GB LEAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -11,
+      oscillator: { shape: 'pulse', width: 0.3 },
+      envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
+      trigger: { velocity: 0.82 } },
+  },
+};
+
+export const DEFAULT_KIT = {
+  name: 'GB KIT',
+  slots: [
+    { note: 36, label: 'Kick',  instrument: 'gb-kick' },
+    { note: 38, label: 'Snare', instrument: 'gb-snare' },
+    { note: 42, label: 'HH',    instrument: 'gb-hat' },
+    { note: 45, label: 'Tom',   instrument: 'gb-tom' },
+    { note: 49, label: 'Crash', instrument: 'gb-crash' },
+  ],
+};

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -141,6 +141,34 @@ export function normalizeDrumGrooves(grooves) {
   return out;
 }
 
+/** normalizeVoiceMap(map) → { [gmNote]: bool } — voiceMute/voiceSolo keys. */
+export function normalizeVoiceMap(map) {
+  if (!map || typeof map !== 'object') return map;
+  const out = {};
+  for (const [k, v] of Object.entries(map)) {
+    const note = slotKey(k);
+    if (note !== null) out[note] = v;
+  }
+  return out;
+}
+
+/** normalizeSongDrums(song) — the ingest boundary, in place: every drum lane's
+ *  grooves, fills, and per-voice mute/solo state goes canonical numeric.
+ *  Input syntax (GM names) is welcome anywhere upstream of this call. */
+export function normalizeSongDrums(song) {
+  if (!song || typeof song !== 'object') return song;
+  for (const lane of song.lanes || []) {
+    if (lane.type !== 'drums') continue;
+    if (song.grooves?.[lane.id]) song.grooves[lane.id] = normalizeDrumGrooves(song.grooves[lane.id]);
+    if (lane.voiceMute) lane.voiceMute = normalizeVoiceMap(lane.voiceMute);
+    if (lane.voiceSolo) lane.voiceSolo = normalizeVoiceMap(lane.voiceSolo);
+  }
+  if (song.fills && typeof song.fills === 'object') {
+    for (const [name, bar] of Object.entries(song.fills)) song.fills[name] = normalizeDrumBar(bar);
+  }
+  return song;
+}
+
 // ── defaults: today's hardcoded voices, ported byte-for-byte ────────────────
 // Values mirror engine/voices.js createVoiceForType EXACTLY (parity-tested).
 export const DEFAULT_INSTRUMENTS = {
@@ -205,7 +233,7 @@ export const DEFAULT_KIT = {
     { note: 36, label: 'Kick',  instrument: 'gb-kick' },
     { note: 38, label: 'Snare', instrument: 'gb-snare' },
     { note: 42, label: 'HH',    instrument: 'gb-hat' },
-    { note: 45, label: 'Tom',   instrument: 'gb-tom' },
+    { note: 45, label: 'Tom',   instrument: 'gb-tom', pitched: true },   // steps carry [step, semi]
     { note: 49, label: 'Crash', instrument: 'gb-crash' },
   ],
 };

--- a/docs/arcade/groovebox/engine/lanes.js
+++ b/docs/arcade/groovebox/engine/lanes.js
@@ -1,5 +1,6 @@
 // ─── Lane mutation helpers (Tone-free, unit-tested) ──────────────────────────
 import { emptyBarFor } from './patterns.js';
+import { slotKey } from './instruments.js';
 
 
 /**
@@ -139,14 +140,16 @@ export function moveLane(song, fromId, toIndex) {
 // ─── Per-drum-voice mute/solo (reads the drums-type lane object directly) ─────
 
 export function toggleDrumMute(drumsLane, voice) {
+  const k = slotKey(voice) ?? voice;     // canonical GM-number keys
   drumsLane.voiceMute ||= {};
-  return (drumsLane.voiceMute[voice] = !drumsLane.voiceMute[voice]);
+  return (drumsLane.voiceMute[k] = !drumsLane.voiceMute[k]);
 }
 
 export function toggleDrumSolo(drumsLane, voice) {
+  const k = slotKey(voice) ?? voice;     // canonical GM-number keys
   drumsLane.voiceSolo ||= {};
-  const turningOn = !drumsLane.voiceSolo[voice];
+  const turningOn = !drumsLane.voiceSolo[k];
   for (const v in drumsLane.voiceSolo) drumsLane.voiceSolo[v] = false;
-  drumsLane.voiceSolo[voice] = turningOn;
+  drumsLane.voiceSolo[k] = turningOn;
   return turningOn;
 }

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -6,7 +6,8 @@
 // A groove owns its length (its array); at pattern bar b it plays
 // groove[b % groove.length]. A pattern's loop length is DERIVED — the longest
 // picked groove (see patternBars); shorter grooves cycle underneath.
-import { laneAudible, drumVoiceAudible, transposeNote, DRUM_KEYS } from './song.js';
+import { laneAudible, drumVoiceAudible, transposeNote } from './song.js';
+import { slotKey } from './instruments.js';
 
 export const MAX_PATTERNS = 16;
 
@@ -132,14 +133,22 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
     if (lane.type === 'drums') {
       const bars = grooveBars(g);
       const bar = fillPat || (bars ? bars[barInPattern % bars.length] : null) || {};
-      for (const k of DRUM_KEYS) {
-        if (bar[k] && bar[k].includes(step) && drumVoiceAudible(lane, k))
-          ev.push({ laneId: lane.id, type: 'drums', voice: k });
-      }
-      if (bar.tom) {
-        for (const [s, semi] of bar.tom) {
-          if (s === step && drumVoiceAudible(lane, 'tom'))
-            ev.push({ laneId: lane.id, type: 'drums', voice: 'tom', semi: semi ?? 0 });
+      // Slot-agnostic: keys are canonical GM numbers post-ingest (slotKey also
+      // tolerates raw name keys). Steps are numbers or [step, semi] pairs —
+      // any slot may be pitched. for-in: no per-step allocations.
+      for (const k in bar) {
+        const steps = bar[k];
+        if (!Array.isArray(steps)) continue;
+        const note = slotKey(k);
+        if (note === null) continue;
+        for (let i = 0; i < steps.length; i++) {
+          const s = steps[i];
+          if (typeof s === 'number') {
+            if (s === step && drumVoiceAudible(lane, note))
+              ev.push({ laneId: lane.id, type: 'drums', voice: note });
+          } else if (Array.isArray(s) && s[0] === step && drumVoiceAudible(lane, note)) {
+            ev.push({ laneId: lane.id, type: 'drums', voice: note, semi: s[1] ?? 0 });
+          }
         }
       }
       continue;
@@ -270,20 +279,23 @@ export function moveChain(song, from, to) {
 
 // ── step edits (used by the editors) — write into GROOVES ─────────────────────
 // barIdx is within the referenced groove's own length; the caller guarantees range.
-export function setDrumStep(song, laneId, grooveName, barIdx, voice, step, on) {
+export function setDrumStep(song, laneId, grooveName, barIdx, voice, step, on, pitched) {
   const groove = song.grooves[laneId]?.[grooveName];
   if (!Array.isArray(groove)) return;        // missing or relative (read-only)
   const bar = groove[barIdx] || (groove[barIdx] = {});
-  if (voice === 'tom') {
-    bar.tom = bar.tom || [];
-    const i = bar.tom.findIndex(x => x[0] === step);
-    if (on) { if (i < 0) bar.tom.push([step, 3]); }
-    else if (i >= 0) bar.tom.splice(i, 1);
+  const k = slotKey(voice) ?? voice;         // canonical GM-number keys
+  // Pitched slots store [step, semi] pairs. Callers pass the kit slot's flag;
+  // default preserves the legacy tom behaviour (GM 45).
+  if (pitched ?? k === 45) {
+    bar[k] = bar[k] || [];
+    const i = bar[k].findIndex(x => x[0] === step);
+    if (on) { if (i < 0) bar[k].push([step, 3]); }
+    else if (i >= 0) bar[k].splice(i, 1);
   } else {
-    bar[voice] = bar[voice] || [];
-    const i = bar[voice].indexOf(step);
-    if (on) { if (i < 0) bar[voice].push(step); }
-    else if (i >= 0) bar[voice].splice(i, 1);
+    bar[k] = bar[k] || [];
+    const i = bar[k].indexOf(step);
+    if (on) { if (i < 0) bar[k].push(step); }
+    else if (i >= 0) bar[k].splice(i, 1);
   }
 }
 

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -284,6 +284,7 @@ export function setDrumStep(song, laneId, grooveName, barIdx, voice, step, on, p
   if (!Array.isArray(groove)) return;        // missing or relative (read-only)
   const bar = groove[barIdx] || (groove[barIdx] = {});
   const k = slotKey(voice) ?? voice;         // canonical GM-number keys
+  if (bar[k] !== undefined && !Array.isArray(bar[k])) bar[k] = [];   // heal bad data
   // Pitched slots store [step, semi] pairs. Callers pass the kit slot's flag;
   // default preserves the legacy tom behaviour (GM 45).
   if (pitched ?? k === 45) {

--- a/docs/arcade/groovebox/engine/song.js
+++ b/docs/arcade/groovebox/engine/song.js
@@ -1,3 +1,5 @@
+import { slotKey } from './instruments.js';
+
 const DRUM_KEYS = ['kick', 'snare', 'hat', 'crash'];
 export const DRUM_VOICES = ['kick', 'snare', 'hat', 'tom', 'crash'];
 
@@ -16,8 +18,9 @@ export function laneAudible(lanes, lane) {
  * drumsLane — the drums-type lane object
  */
 export function drumVoiceAudible(drumsLane, voice) {
+  const k = slotKey(voice) ?? voice;     // state keys are canonical GM numbers
   const anySolo = Object.values(drumsLane.voiceSolo || {}).some(Boolean);
-  return !(drumsLane.voiceMute || {})[voice] && (!anySolo || !!(drumsLane.voiceSolo || {})[voice]);
+  return !(drumsLane.voiceMute || {})[k] && (!anySolo || !!(drumsLane.voiceSolo || {})[k]);
 }
 
 export { DRUM_KEYS };

--- a/docs/arcade/groovebox/engine/voices.js
+++ b/docs/arcade/groovebox/engine/voices.js
@@ -1,55 +1,145 @@
 import * as Tone from 'tone';
+import { DEFAULT_INSTRUMENTS, DEFAULT_KIT, validateInstrument, slotKey } from './instruments.js';
 
 /**
- * createVoiceForType(type, bus)
- * Returns the voice object(s) for one lane, wired to `bus`.
- * - 'drums'  → { kick, snare, hat, tom, crash } (full kit)
- * - 'bass'   → { bass }
- * - 'chords' → { chordSyn }
- * - 'melody' → { lead }
+ * voices.js — instrument data → sounding Tone nodes.
+ *
+ * The synthesis recipes live in engine/instruments.js as neutral patch JSON
+ * (DEFAULT_INSTRUMENTS / DEFAULT_KIT). This file owns the ONE adapter from
+ * that vocabulary to Tone:
+ *   compileSynthPatch(inst)  — pure: patch → build plan (parity-testable)
+ *   createVoiceForType(...)  — plan → connected Tone nodes
+ *   trigger(...)             — scheduler events → triggerAttackRelease calls
+ *
+ * Voice shapes:
+ *   drums  → { byNote: { [gmNote]: { synth, trig } }, dispose() }
+ *   bass   → { bass, trig, dispose() }
+ *   chords → { chordSyn, chordFilter, trig, dispose() }
+ *   melody → { lead, trig, dispose() }
+ * (Pitched lanes keep their legacy named props — index.js sets melody tone
+ * via voice.lead. disposeLane prefers voice.dispose().)
  */
-export function createVoiceForType(type, bus) {
-  if (type === 'drums') {
-    const kick  = new Tone.MembraneSynth({ volume: -5 }).connect(bus);
-    const snare = new Tone.NoiseSynth({ volume: -11, envelope: { attack: 0.001, decay: 0.16, sustain: 0 } }).connect(bus);
-    const hatFilter = new Tone.Filter(7000, 'highpass').connect(bus);
-    const hat   = new Tone.NoiseSynth({ volume: -20, envelope: { attack: 0.001, decay: 0.03, sustain: 0 } }).connect(hatFilter);
-    const tom   = new Tone.MembraneSynth({ volume: -6, pitchDecay: 0.06, octaves: 2 }).connect(bus);
-    const crashFilter = new Tone.Filter(3500, 'highpass').connect(bus);
-    const crash = new Tone.NoiseSynth({ volume: -12, envelope: { attack: 0.001, decay: 1.1, sustain: 0, release: 0.3 } }).connect(crashFilter);
-    return { kick, snare, hat, tom, crash, hatFilter, crashFilter };
+
+const CTOR_BY_ARCHETYPE = {
+  membrane: 'MembraneSynth',
+  noise:    'NoiseSynth',
+  mono:     'MonoSynth',
+  poly:     'PolySynth',
+};
+
+/**
+ * compileSynthPatch(inst) → pure build plan:
+ * { ctor, options, postVolume, filter, trig }
+ * - options: constructor/set() options (volume folded in where the legacy code
+ *   passed it to the constructor; postVolume where it assigned .volume.value)
+ * - trig: { sig: 'note'|'noise', note?, dur?, velocity? } — how trigger() fires it
+ */
+export function compileSynthPatch(inst) {
+  const p = inst.patch;
+  const plan = {
+    ctor: CTOR_BY_ARCHETYPE[p.archetype],
+    options: {},
+    postVolume: undefined,
+    filter: p.filter ? { type: p.filter.type, freq: p.filter.freq } : null,
+    trig: {
+      sig: p.archetype === 'noise' ? 'noise' : 'note',
+      note: p.trigger?.note,
+      dur: p.trigger?.dur,
+      velocity: p.trigger?.velocity,
+    },
+  };
+  const osc = p.oscillator
+    ? { type: p.oscillator.shape, ...(p.oscillator.width !== undefined ? { width: p.oscillator.width } : {}) }
+    : null;
+
+  if (p.archetype === 'membrane') {
+    plan.options = {
+      ...(p.volume !== undefined ? { volume: p.volume } : {}),
+      ...(p.pitch ? { pitchDecay: p.pitch.pitchDecay, octaves: p.pitch.octaves } : {}),
+    };
+  } else if (p.archetype === 'noise') {
+    plan.options = {
+      ...(p.volume !== undefined ? { volume: p.volume } : {}),
+      ...(p.envelope ? { envelope: { ...p.envelope } } : {}),
+    };
+  } else if (p.archetype === 'mono') {
+    plan.options = {
+      ...(osc ? { oscillator: osc } : {}),
+      ...(p.envelope ? { envelope: { ...p.envelope } } : {}),
+      ...(p.filterEnvelope ? { filterEnvelope: { ...p.filterEnvelope } } : {}),
+    };
+    plan.postVolume = p.volume;          // legacy assigned bass volume after construction
+  } else if (p.archetype === 'poly') {
+    plan.options = {                      // applied via synth.set()
+      ...(osc ? { oscillator: osc } : {}),
+      ...(p.envelope ? { envelope: { ...p.envelope } } : {}),
+    };
+    plan.postVolume = p.volume;          // legacy assigned poly volume after construction
   }
-  if (type === 'bass') {
-    const bass = new Tone.MonoSynth({
-      oscillator: { type: 'triangle' },
-      envelope: { attack: 0.005, decay: 0.18, sustain: 0.35, release: 0.18 },
-      filterEnvelope: { attack: 0.005, decay: 0.12, sustain: 0.4, baseFrequency: 120, octaves: 3 },
-    }).connect(bus);
-    bass.volume.value = -7;
-    return { bass };
-  }
-  if (type === 'chords') {
-    const chordFilter = new Tone.Filter(4200, 'lowpass').connect(bus);
-    const chordSyn = new Tone.PolySynth(Tone.Synth).connect(chordFilter);
-    chordSyn.set({ oscillator: { type: 'triangle' }, envelope: { attack: 0.05, decay: 0.3, sustain: 0.6, release: 0.5 } });
-    chordSyn.volume.value = -17;
-    return { chordSyn, chordFilter };
-  }
-  if (type === 'melody') {
-    const lead = new Tone.PolySynth(Tone.Synth).connect(bus);
-    lead.set({ oscillator: { type: 'pulse', width: 0.3 }, envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 } });
-    lead.volume.value = -11;
-    return { lead };
-  }
-  return {};
+  return plan;
 }
 
+// Build one connected voice from a plan. Returns { synth, filter }.
+function buildFromPlan(plan, bus) {
+  let out = bus, filter = null;
+  if (plan.filter) {
+    filter = new Tone.Filter(plan.filter.freq, plan.filter.type).connect(bus);
+    out = filter;
+  }
+  let synth;
+  if (plan.ctor === 'PolySynth') {
+    synth = new Tone.PolySynth(Tone.Synth).connect(out);
+    synth.set(plan.options);
+  } else {
+    synth = new Tone[plan.ctor](plan.options).connect(out);
+  }
+  if (plan.postVolume !== undefined) synth.volume.value = plan.postVolume;
+  return { synth, filter };
+}
+
+// Resolve + validate an instrument ref; bad data falls back (never crashes).
+function resolveInstrument(id, instruments, fallbackId) {
+  const inst = instruments?.[id];
+  if (validateInstrument(inst)) return inst;
+  return DEFAULT_INSTRUMENTS[fallbackId];
+}
+
+const PITCHED_DEFAULT = { bass: 'gb-bass', chords: 'gb-chords', melody: 'gb-lead' };
+
 /**
- * trigger(voice, ev, t, sixteenth, barSeconds)
- * Fires one scheduler event at audio time `t`.
- * voice — the voice object for ev.laneId (from voices[ev.laneId])
- * ev    — { laneId, type, ... }
+ * createVoiceForType(type, bus, opts?)
+ * opts: { instruments, kit, instrumentId } — defaults to the stock set.
  */
+export function createVoiceForType(type, bus, opts = {}) {
+  const instruments = opts.instruments ?? DEFAULT_INSTRUMENTS;
+  if (type === 'drums') {
+    const kit = opts.kit ?? DEFAULT_KIT;
+    const byNote = {};
+    const nodes = [];
+    const fallbackByNote = Object.fromEntries(DEFAULT_KIT.slots.map(s => [s.note, s.instrument]));
+    for (const slot of (kit.slots ?? [])) {
+      const note = slotKey(slot.note);
+      if (note === null) continue;
+      const inst = resolveInstrument(slot.instrument, instruments, fallbackByNote[note] ?? 'gb-kick');
+      if (!inst) continue;
+      const plan = compileSynthPatch(inst);
+      const v = buildFromPlan(plan, bus);
+      byNote[note] = { synth: v.synth, trig: plan.trig };
+      nodes.push(v.synth, v.filter);
+    }
+    return { byNote, dispose() { for (const n of nodes) { try { n?.dispose?.(); } catch (_) {} } } };
+  }
+  const fallback = PITCHED_DEFAULT[type];
+  if (!fallback) return {};
+  const inst = resolveInstrument(opts.instrumentId ?? fallback, instruments, fallback);
+  const plan = compileSynthPatch(inst);
+  const v = buildFromPlan(plan, bus);
+  const dispose = () => { try { v.synth.dispose?.(); } catch (_) {} try { v.filter?.dispose?.(); } catch (_) {} };
+  if (type === 'bass')   return { bass: v.synth, trig: plan.trig, dispose };
+  if (type === 'chords') return { chordSyn: v.synth, chordFilter: v.filter, trig: plan.trig, dispose };
+  return { lead: v.synth, trig: plan.trig, dispose };
+}
+
 // Note duration → seconds. DATA-MODEL allows durSteps|'bar' on ANY note lane;
 // 'bar' previously NaN-crashed bass/melody (killing the whole step scheduler —
 // a shared song could freeze playback). Anything non-numeric falls back to 2
@@ -59,32 +149,33 @@ function durSeconds(dur, sixteenth, barSeconds) {
   return (typeof dur === 'number' && Number.isFinite(dur) && dur > 0 ? dur : 2) * sixteenth;
 }
 
+/**
+ * trigger(voice, ev, t, sixteenth, barSeconds)
+ * Fires one scheduler event at audio time `t`.
+ * Drum events route by GM note: ev.voice is canonical numeric after ingest
+ * normalization, but slotKey() also accepts legacy names (engine edge stays
+ * permissive — bad data never crashes; unknown slots are silently skipped).
+ */
 export function trigger(voice, ev, t, sixteenth, barSeconds) {
   if (ev.type === 'drums') {
-    if (ev.voice === 'kick')  voice.kick.triggerAttackRelease('C1', '8n', t);
-    if (ev.voice === 'snare') voice.snare.triggerAttackRelease('16n', t);
-    if (ev.voice === 'hat')   voice.hat.triggerAttackRelease('32n', t, 0.6);
-    if (ev.voice === 'crash') voice.crash.triggerAttackRelease('8n', t, 0.8);
-    if (ev.voice === 'tom')   voice.tom.triggerAttackRelease(Tone.Frequency('A2').transpose(ev.semi), '8n', t);
+    const note = slotKey(ev.voice);
+    const slot = note === null ? undefined : voice.byNote?.[note];
+    if (!slot) return;
+    const { synth, trig } = slot;
+    if (trig.sig === 'noise') {
+      synth.triggerAttackRelease(trig.dur ?? '16n', t, trig.velocity);
+    } else {
+      const base = trig.note ?? 'C3';
+      const pitch = ev.semi ? Tone.Frequency(base).transpose(ev.semi) : base;
+      synth.triggerAttackRelease(pitch, trig.dur ?? '8n', t, trig.velocity);
+    }
   } else if (ev.type === 'bass') {
-    voice.bass.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, 0.85);
+    voice.bass.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, voice.trig?.velocity ?? 0.85);
   } else if (ev.type === 'melody') {
-    voice.lead.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, 0.82);
+    voice.lead.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, voice.trig?.velocity ?? 0.82);
   } else if (ev.type === 'chords') {
+    // Arp hits ride slightly hotter than sustained voicings (legacy 0.34 vs 0.30).
     if (ev.mode === 'arp') voice.chordSyn.triggerAttackRelease(ev.note, sixteenth, t, 0.34);
-    else voice.chordSyn.triggerAttackRelease(ev.notes, durSeconds(ev.dur, sixteenth, barSeconds), t, 0.3);
+    else voice.chordSyn.triggerAttackRelease(ev.notes, durSeconds(ev.dur, sixteenth, barSeconds), t, voice.trig?.velocity ?? 0.3);
   }
-}
-
-/**
- * createVoices(buses) — kept for compatibility; builds one voice per type.
- * buses: { drums, bass, chords, melody } — each a Tone input node.
- */
-export function createVoices(buses) {
-  const drums  = createVoiceForType('drums',  buses.drums);
-  const bass   = createVoiceForType('bass',   buses.bass);
-  const chords = createVoiceForType('chords', buses.chords);
-  const melody = createVoiceForType('melody', buses.melody);
-  // Flatten to the legacy named shape so any remaining callers still work.
-  return { ...drums, ...bass, ...chords, ...melody };
 }

--- a/docs/arcade/groovebox/tests/drum-voice.test.js
+++ b/docs/arcade/groovebox/tests/drum-voice.test.js
@@ -25,7 +25,7 @@ test('drumVoiceAudible: missing voiceMute/voiceSolo props → all audible', () =
 });
 
 test('drumVoiceAudible: mute hat → hat inaudible, others audible', () => {
-  const lane = makeDrumsLane({ hat: true });
+  const lane = makeDrumsLane({ 42: true });
   expect(drumVoiceAudible(lane, 'hat')).toBe(false);
   expect(drumVoiceAudible(lane, 'kick')).toBe(true);
   expect(drumVoiceAudible(lane, 'snare')).toBe(true);
@@ -34,7 +34,7 @@ test('drumVoiceAudible: mute hat → hat inaudible, others audible', () => {
 });
 
 test('drumVoiceAudible: solo kick → only kick audible', () => {
-  const lane = makeDrumsLane({}, { kick: true });
+  const lane = makeDrumsLane({}, { 36: true });
   expect(drumVoiceAudible(lane, 'kick')).toBe(true);
   expect(drumVoiceAudible(lane, 'snare')).toBe(false);
   expect(drumVoiceAudible(lane, 'hat')).toBe(false);
@@ -43,7 +43,7 @@ test('drumVoiceAudible: solo kick → only kick audible', () => {
 });
 
 test('drumVoiceAudible: multiple soloed voices → all soloed audible, others not', () => {
-  const lane = makeDrumsLane({}, { kick: true, snare: true });
+  const lane = makeDrumsLane({}, { 36: true, 38: true });
   expect(drumVoiceAudible(lane, 'kick')).toBe(true);
   expect(drumVoiceAudible(lane, 'snare')).toBe(true);
   expect(drumVoiceAudible(lane, 'hat')).toBe(false);
@@ -60,9 +60,9 @@ function makeDrumsLaneForToggle() {
 test('toggleDrumMute: flips muted state and returns new value', () => {
   const lane = makeDrumsLaneForToggle();
   expect(toggleDrumMute(lane, 'hat')).toBe(true);
-  expect(lane.voiceMute.hat).toBe(true);
+  expect(lane.voiceMute[42]).toBe(true);
   expect(toggleDrumMute(lane, 'hat')).toBe(false);
-  expect(lane.voiceMute.hat).toBe(false);
+  expect(lane.voiceMute[42]).toBe(false);
 });
 
 test('toggleDrumMute: lazily initialises voiceMute', () => {
@@ -70,23 +70,23 @@ test('toggleDrumMute: lazily initialises voiceMute', () => {
   expect(lane.voiceMute).toBeUndefined();
   toggleDrumMute(lane, 'kick');
   expect(lane.voiceMute).toBeDefined();
-  expect(lane.voiceMute.kick).toBe(true);
+  expect(lane.voiceMute[36]).toBe(true);
 });
 
 test('toggleDrumSolo: flips solo state and returns new value', () => {
   const lane = makeDrumsLaneForToggle();
   expect(toggleDrumSolo(lane, 'kick')).toBe(true);
-  expect(lane.voiceSolo.kick).toBe(true);
+  expect(lane.voiceSolo[36]).toBe(true);
   expect(toggleDrumSolo(lane, 'kick')).toBe(false);
-  expect(lane.voiceSolo.kick).toBe(false);
+  expect(lane.voiceSolo[36]).toBe(false);
 });
 
 test('toggleDrumSolo: exclusive — soloing snare clears kick (one at a time)', () => {
   const lane = makeDrumsLaneForToggle();
   toggleDrumSolo(lane, 'kick');
   toggleDrumSolo(lane, 'snare');
-  expect(lane.voiceSolo.kick).toBe(false);
-  expect(lane.voiceSolo.snare).toBe(true);
+  expect(lane.voiceSolo[36]).toBe(false);
+  expect(lane.voiceSolo[38]).toBe(true);
 });
 
 // 'bar' durations are legal on ANY note lane (DATA-MODEL: durSteps|'bar').

--- a/docs/arcade/groovebox/tests/instruments.test.js
+++ b/docs/arcade/groovebox/tests/instruments.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GM, slotKey, gmName, normalizeDrumBar, normalizeDrumGrooves,
+  validateInstrument, validateKit, DEFAULT_INSTRUMENTS, DEFAULT_KIT,
+  PATCH_PARAMS, ARCHETYPES,
+} from '../engine/instruments.js';
+
+describe('slotKey — names and numbers are both valid input, numbers canonical', () => {
+  it('maps the legacy five voice names to their GM notes', () => {
+    expect(slotKey('kick')).toBe(36);
+    expect(slotKey('snare')).toBe(38);
+    expect(slotKey('hat')).toBe(42);
+    expect(slotKey('tom')).toBe(45);
+    expect(slotKey('crash')).toBe(49);
+  });
+  it('accepts numbers and numeric strings', () => {
+    expect(slotKey(36)).toBe(36);
+    expect(slotKey('36')).toBe(36);
+  });
+  it('is case-insensitive on names', () => {
+    expect(slotKey('Kick')).toBe(36);
+    expect(slotKey('CRASH')).toBe(49);
+  });
+  it('rejects garbage', () => {
+    expect(slotKey('cymbalzz')).toBe(null);
+    expect(slotKey(-1)).toBe(null);
+    expect(slotKey(128)).toBe(null);
+    expect(slotKey(36.5)).toBe(null);
+    expect(slotKey(null)).toBe(null);
+    expect(slotKey({})).toBe(null);
+  });
+  it('round-trips via gmName', () => {
+    for (const [name, note] of Object.entries(GM)) expect(slotKey(gmName(note))).toBe(slotKey(name));
+  });
+});
+
+describe('normalizeDrumBar — one boundary, numeric past it', () => {
+  it('normalizes name keys and keeps step shapes untouched', () => {
+    const bar = { kick: [0, 8], snare: [12], tom: [[4, 2], [6, -1]] };
+    expect(normalizeDrumBar(bar)).toEqual({ 36: [0, 8], 38: [12], 45: [[4, 2], [6, -1]] });
+  });
+  it('passes numeric keys through', () => {
+    expect(normalizeDrumBar({ 36: [0] })).toEqual({ 36: [0] });
+  });
+  it('drops unrecognisable keys instead of crashing', () => {
+    expect(normalizeDrumBar({ kick: [0], wibble: [1] })).toEqual({ 36: [0] });
+  });
+  it('survives bad data', () => {
+    expect(normalizeDrumBar(null)).toEqual({});
+    expect(normalizeDrumBar([])).toEqual({});
+    expect(normalizeDrumBar('x')).toEqual({});
+  });
+});
+
+describe('normalizeDrumGrooves', () => {
+  it('normalizes every bar of every groove', () => {
+    const g = { fanfare: [{ kick: [0] }, { snare: [4] }] };
+    expect(normalizeDrumGrooves(g)).toEqual({ fanfare: [{ 36: [0] }, { 38: [4] }] });
+  });
+  it('handles empty/missing tables', () => {
+    expect(normalizeDrumGrooves(undefined)).toEqual({});
+  });
+});
+
+describe('validateInstrument', () => {
+  it('accepts every default instrument', () => {
+    for (const inst of Object.values(DEFAULT_INSTRUMENTS)) expect(validateInstrument(inst)).toBe(true);
+  });
+  it('rejects non-synth engines (the v2 seam is reserved, not open)', () => {
+    const inst = { ...DEFAULT_INSTRUMENTS['gb-kick'], engine: 'sample' };
+    expect(validateInstrument(inst)).toBe(false);
+  });
+  it('rejects unknown archetypes', () => {
+    const inst = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS['gb-kick']));
+    inst.patch.archetype = 'fm';
+    expect(validateInstrument(inst)).toBe(false);
+  });
+  it('rejects out-of-range params', () => {
+    const inst = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS['gb-snare']));
+    inst.patch.envelope.decay = 99;
+    expect(validateInstrument(inst)).toBe(false);
+  });
+  it('rejects non-finite params (Infinity/NaN)', () => {
+    const inst = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS['gb-bass']));
+    inst.patch.volume = Infinity;
+    expect(validateInstrument(inst)).toBe(false);
+    inst.patch.volume = NaN;
+    expect(validateInstrument(inst)).toBe(false);
+  });
+  it('rejects bad oscillator shapes and filter types', () => {
+    const a = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS['gb-bass']));
+    a.patch.oscillator.shape = 'wub';
+    expect(validateInstrument(a)).toBe(false);
+    const b = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS['gb-hat']));
+    b.patch.filter.type = 'bandpass';
+    expect(validateInstrument(b)).toBe(false);
+  });
+  it('rejects names that would break pad/row layout', () => {
+    const inst = { ...DEFAULT_INSTRUMENTS['gb-kick'], name: 'X'.repeat(25) };
+    expect(validateInstrument(inst)).toBe(false);
+    expect(validateInstrument({ ...DEFAULT_INSTRUMENTS['gb-kick'], name: '' })).toBe(false);
+  });
+  it('rejects null/garbage without throwing', () => {
+    expect(validateInstrument(null)).toBe(false);
+    expect(validateInstrument({})).toBe(false);
+    expect(validateInstrument('kick')).toBe(false);
+  });
+});
+
+describe('validateKit', () => {
+  it('accepts the default kit against the default instruments', () => {
+    expect(validateKit(DEFAULT_KIT, DEFAULT_INSTRUMENTS)).toBe(true);
+  });
+  it('rejects duplicate slot notes', () => {
+    const kit = JSON.parse(JSON.stringify(DEFAULT_KIT));
+    kit.slots[1].note = 36;
+    expect(validateKit(kit, DEFAULT_INSTRUMENTS)).toBe(false);
+  });
+  it('rejects slots referencing unknown or non-drum instruments', () => {
+    const kit = JSON.parse(JSON.stringify(DEFAULT_KIT));
+    kit.slots[0].instrument = 'nope';
+    expect(validateKit(kit, DEFAULT_INSTRUMENTS)).toBe(false);
+    kit.slots[0].instrument = 'gb-bass';   // exists, but type 'bass'
+    expect(validateKit(kit, DEFAULT_INSTRUMENTS)).toBe(false);
+  });
+  it('accepts name-keyed slot notes (input syntax) — a 7-piece kit with two toms', () => {
+    const kit = {
+      name: 'BIG KIT',
+      slots: [
+        { note: 'kick', label: 'Kick', instrument: 'gb-kick' },
+        { note: 'snare', label: 'Snare', instrument: 'gb-snare' },
+        { note: 'hat', label: 'HH', instrument: 'gb-hat' },
+        { note: 'tomlow', label: 'Tom L', instrument: 'gb-tom' },
+        { note: 'tomhi', label: 'Tom H', instrument: 'gb-tom' },
+        { note: 'ride', label: 'Ride', instrument: 'gb-crash' },
+        { note: 'crash', label: 'Crash', instrument: 'gb-crash' },
+      ],
+    };
+    expect(validateKit(kit, DEFAULT_INSTRUMENTS)).toBe(true);
+  });
+  it('rejects empty and oversized kits', () => {
+    expect(validateKit({ name: 'K', slots: [] }, DEFAULT_INSTRUMENTS)).toBe(false);
+    const kit = { name: 'K', slots: Array.from({ length: 17 }, (_, i) => ({ note: 36 + i, label: 'S', instrument: 'gb-kick' })) };
+    expect(validateKit(kit, DEFAULT_INSTRUMENTS)).toBe(false);
+  });
+});
+
+describe('PATCH_PARAMS registry', () => {
+  it('declares min/max/scale for every param (editor + validation read these)', () => {
+    for (const [id, p] of Object.entries(PATCH_PARAMS)) {
+      expect(p.min, id).toBeTypeOf('number');
+      expect(p.max, id).toBeTypeOf('number');
+      expect(p.min).toBeLessThan(p.max);
+      expect(['linear', 'log']).toContain(p.scale);
+    }
+  });
+  it('log-scale params never include zero or negatives', () => {
+    for (const [id, p] of Object.entries(PATCH_PARAMS)) {
+      if (p.scale === 'log') expect(p.min, id).toBeGreaterThan(0);
+    }
+  });
+  it('archetypes are the four todays voices need', () => {
+    expect(ARCHETYPES).toEqual(['membrane', 'noise', 'mono', 'poly']);
+  });
+});

--- a/docs/arcade/groovebox/tests/legacy-reference.test.js
+++ b/docs/arcade/groovebox/tests/legacy-reference.test.js
@@ -21,7 +21,7 @@ for (const [name, song] of Object.entries(SONGS)) {
 
 test('kids steady state contains the post-fill crash flourish at bar 0', () => {
   const stream = renderLegacyStream(kids);
-  expect(stream.some(k => k.startsWith('[0,0,') && k.includes('"crash"'))).toBe(true);
+  expect(stream.some(k => k.startsWith('[0,0,') && k.includes('"drums",49,'))).toBe(true);   // crash = GM 49
 });
 
 // Content-lock: trips if anyone edits the frozen reference's behaviour (eventKey shape, resolution logic, etc.)

--- a/docs/arcade/groovebox/tests/legacy/legacy-engine.js
+++ b/docs/arcade/groovebox/tests/legacy/legacy-engine.js
@@ -1,3 +1,4 @@
+import { slotKey } from '../../engine/instruments.js';
 // tests/legacy/legacy-engine.js
 // FROZEN copy of the pre-patterns-redesign engine resolution logic.
 // Deliberately duplicated — this is the parity reference; it must stay
@@ -115,7 +116,10 @@ function laneList(song) {
 // Stable, deduped per-step event key. `mode` is intentionally excluded
 // (pad vs stab produce identical trigger behaviour for the same notes/dur).
 export function eventKey(bar, step, e) {
-  return JSON.stringify([bar, step, e.laneId, e.type, e.voice ?? null, e.semi ?? null,
+  // Drum voices compare by canonical GM number: the legacy reference emits
+  // names ('kick'), the live engine emits numbers (36) — same identity.
+  const voice = e.voice == null ? null : (slotKey(e.voice) ?? e.voice);
+  return JSON.stringify([bar, step, e.laneId, e.type, voice, e.semi ?? null,
     e.note ?? null, e.notes ?? null, e.dur ?? null]);
 }
 

--- a/docs/arcade/groovebox/tests/patterns.test.js
+++ b/docs/arcade/groovebox/tests/patterns.test.js
@@ -18,8 +18,8 @@ function makeSong() {
     ],
     grooves: {
       drums: {
-        groove2: [{ kick: [0, 8] }, { kick: [0], snare: [12] }],   // 2-bar
-        hats:   [{ hat: [0, 4, 8, 12] }],                          // 1-bar
+        groove2: [{ 36: [0, 8] }, { 36: [0], 38: [12] }],          // 2-bar (GM-numeric: post-ingest state)
+        hats:   [{ 42: [0, 4, 8, 12] }],                           // 1-bar
       },
       melody: {
         riff:  [[[0, 'C4', 2]], []],                               // 2-bar
@@ -52,11 +52,11 @@ test('chainBarAt maps song bars to (chainPos, patternIdx, barInPattern) and wrap
 test('eventsForStepV2 emits drum + melody events resolved through grooves', () => {
   const s = makeSong();
   expect(eventsForStepV2(s, 0, 0, 0, null, 0)).toEqual([
-    { laneId: 'drums', type: 'drums', voice: 'kick' },
+    { laneId: 'drums', type: 'drums', voice: 36 },
     { laneId: 'melody', type: 'melody', note: 'C4', dur: 2 },
   ]);
   expect(eventsForStepV2(s, 0, 1, 12, null, 0)).toEqual([
-    { laneId: 'drums', type: 'drums', voice: 'snare' },
+    { laneId: 'drums', type: 'drums', voice: 38 },
   ]);
 });
 
@@ -76,7 +76,7 @@ test('eventsForStepV2 honours transpose, fill override, and mute', () => {
   expect(eventsForStepV2(s, 0, 0, 0, null, 2)[1].note).toBe('D4');
   // fill replaces the drum bar entirely
   const ev = eventsForStepV2(s, 0, 0, 0, { snare: [0] }, 0);
-  expect(ev.filter(e => e.type === 'drums')).toEqual([{ laneId: 'drums', type: 'drums', voice: 'snare' }]);
+  expect(ev.filter(e => e.type === 'drums')).toEqual([{ laneId: 'drums', type: 'drums', voice: 38 }]);
   s.lanes[0].muted = true;
   expect(eventsForStepV2(s, 0, 0, 0, null, 0).some(e => e.type === 'drums')).toBe(false);
 });
@@ -90,7 +90,7 @@ test('eventsForStepV2: a 1-bar groove under a longer (derived) pattern cycles (b
   expect(patternBars(s, 1)).toBe(4);
   for (const barInPattern of [0, 1, 2, 3]) {
     const ev = eventsForStepV2(s, 1, barInPattern, 4, null, 0);
-    expect(ev).toContainEqual({ laneId: 'drums', type: 'drums', voice: 'hat' });
+    expect(ev).toContainEqual({ laneId: 'drums', type: 'drums', voice: 42 });
   }
 });
 
@@ -102,8 +102,8 @@ test('eventsForStepV2: a 2-bar groove under a 4-bar (derived) pattern alternates
   s.patterns[0].lanes.melody = 'long';
   expect(patternBars(s, 0)).toBe(4);
   // bar 0 ≡ bar 2 (groove bar 0: kick at 0); bar 1 ≡ bar 3 (groove bar 1: snare at 12)
-  expect(eventsForStepV2(s, 0, 2, 0, null, 0)).toContainEqual({ laneId: 'drums', type: 'drums', voice: 'kick' });
-  expect(eventsForStepV2(s, 0, 3, 12, null, 0)).toContainEqual({ laneId: 'drums', type: 'drums', voice: 'snare' });
+  expect(eventsForStepV2(s, 0, 2, 0, null, 0)).toContainEqual({ laneId: 'drums', type: 'drums', voice: 36 });
+  expect(eventsForStepV2(s, 0, 3, 12, null, 0)).toContainEqual({ laneId: 'drums', type: 'drums', voice: 38 });
 });
 
 test('eventsForStepV2: missing or empty groove → silent lane', () => {
@@ -229,24 +229,24 @@ test('appendToChain / removeChainAt (last-chip blocked) / moveChain', () => {
 test('setDrumStep writes into the named groove; on idempotent, off removes', () => {
   const s = makeSong();
   setDrumStep(s, 'drums', 'groove2', 0, 'kick', 0, true);     // already present
-  expect(s.grooves.drums.groove2[0].kick).toEqual([0, 8]);    // idempotent on
+  expect(s.grooves.drums.groove2[0][36]).toEqual([0, 8]);    // idempotent on
   setDrumStep(s, 'drums', 'groove2', 0, 'kick', 4, true);     // add new
-  expect(s.grooves.drums.groove2[0].kick).toEqual([0, 8, 4]);
+  expect(s.grooves.drums.groove2[0][36]).toEqual([0, 8, 4]);
   setDrumStep(s, 'drums', 'groove2', 0, 'kick', 8, false);    // remove
-  expect(s.grooves.drums.groove2[0].kick).toEqual([0, 4]);
+  expect(s.grooves.drums.groove2[0][36]).toEqual([0, 4]);
   setDrumStep(s, 'drums', 'groove2', 0, 'kick', 13, false);   // off when absent: no-op
-  expect(s.grooves.drums.groove2[0].kick).toEqual([0, 4]);
+  expect(s.grooves.drums.groove2[0][36]).toEqual([0, 4]);
 });
 
 test('setDrumStep tom: on preserves existing semi, adds [step,3] if absent, off removes', () => {
   const s = makeSong();
-  s.grooves.drums.groove2[0].tom = [[5, 1]];
+  s.grooves.drums.groove2[0][45] = [[5, 1]];
   setDrumStep(s, 'drums', 'groove2', 0, 'tom', 5, true);      // already present — keep semi 1
-  expect(s.grooves.drums.groove2[0].tom).toEqual([[5, 1]]);
+  expect(s.grooves.drums.groove2[0][45]).toEqual([[5, 1]]);
   setDrumStep(s, 'drums', 'groove2', 0, 'tom', 9, true);      // absent — default semi 3
-  expect(s.grooves.drums.groove2[0].tom).toEqual([[5, 1], [9, 3]]);
+  expect(s.grooves.drums.groove2[0][45]).toEqual([[5, 1], [9, 3]]);
   setDrumStep(s, 'drums', 'groove2', 0, 'tom', 5, false);     // off — remove
-  expect(s.grooves.drums.groove2[0].tom).toEqual([[9, 3]]);
+  expect(s.grooves.drums.groove2[0][45]).toEqual([[9, 3]]);
 });
 
 test('setDrumStep on a missing groove is a no-op', () => {
@@ -274,7 +274,7 @@ test('editing a groove changes every pattern that references it', () => {
   const s = makeSong();
   // both pattern 0 (chain pos 0,1) reference drums groove 'groove2'
   setDrumStep(s, 'drums', 'groove2', 0, 'snare', 4, true);
-  expect(eventsForStepV2(s, 0, 0, 4, null, 0)).toContainEqual({ laneId: 'drums', type: 'drums', voice: 'snare' });
+  expect(eventsForStepV2(s, 0, 0, 4, null, 0)).toContainEqual({ laneId: 'drums', type: 'drums', voice: 38 });
 });
 
 test('emptyBarFor returns {} for drums lanes and [] for others', () => {
@@ -303,8 +303,8 @@ test('setGrooveBars deep-copies filled bars; mutating one leaves the original in
   const s = makeSong();
   expect(setGrooveBars(s, 'drums', 'groove2', 4)).toBe(4); // 2 → 4 (1,2,1,2)
   const g = s.grooves.drums.groove2;
-  g[2].kick.push(7);                                       // mutate the copy
-  expect(g[0].kick).toEqual([0, 8]);                       // original bar 0 unchanged
+  g[2][36].push(7);                                       // mutate the copy
+  expect(g[0][36]).toEqual([0, 8]);                       // original bar 0 unchanged
   // melodic arrays deep-copied too
   expect(setGrooveBars(s, 'melody', 'riff', 4)).toBe(4);
   const m = s.grooves.melody.riff;

--- a/docs/arcade/groovebox/tests/voices-adapter.test.js
+++ b/docs/arcade/groovebox/tests/voices-adapter.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { compileSynthPatch } from '../engine/voices.js';
+import { DEFAULT_INSTRUMENTS } from '../engine/instruments.js';
+
+// PARITY GATE: the adapter must reproduce the legacy hardcoded voices EXACTLY.
+// Expected values below are copied verbatim from the pre-instruments voices.js
+// (createVoiceForType literals). If a default instrument drifts from the
+// original sound, this is the test that says so.
+
+const plan = id => compileSynthPatch(DEFAULT_INSTRUMENTS[id]);
+
+describe('compileSynthPatch parity vs legacy hardcoded voices', () => {
+  it('kick — MembraneSynth({ volume: -5 }), C1 8n, no velocity', () => {
+    expect(plan('gb-kick')).toEqual({
+      ctor: 'MembraneSynth', options: { volume: -5 }, postVolume: undefined, filter: null,
+      trig: { sig: 'note', note: 'C1', dur: '8n', velocity: undefined },
+    });
+  });
+  it('snare — NoiseSynth({ volume: -11, envelope }), 16n, no velocity', () => {
+    expect(plan('gb-snare')).toEqual({
+      ctor: 'NoiseSynth',
+      options: { volume: -11, envelope: { attack: 0.001, decay: 0.16, sustain: 0 } },
+      postVolume: undefined, filter: null,
+      trig: { sig: 'noise', note: undefined, dur: '16n', velocity: undefined },
+    });
+  });
+  it('hat — NoiseSynth({ volume: -20, envelope }) → highpass 7000, 32n @ 0.6', () => {
+    expect(plan('gb-hat')).toEqual({
+      ctor: 'NoiseSynth',
+      options: { volume: -20, envelope: { attack: 0.001, decay: 0.03, sustain: 0 } },
+      postVolume: undefined,
+      filter: { type: 'highpass', freq: 7000 },
+      trig: { sig: 'noise', note: undefined, dur: '32n', velocity: 0.6 },
+    });
+  });
+  it('tom — MembraneSynth({ volume: -6, pitchDecay: 0.06, octaves: 2 }), A2 8n', () => {
+    expect(plan('gb-tom')).toEqual({
+      ctor: 'MembraneSynth',
+      options: { volume: -6, pitchDecay: 0.06, octaves: 2 },
+      postVolume: undefined, filter: null,
+      trig: { sig: 'note', note: 'A2', dur: '8n', velocity: undefined },
+    });
+  });
+  it('crash — NoiseSynth({ volume: -12, envelope incl release }) → highpass 3500, 8n @ 0.8', () => {
+    expect(plan('gb-crash')).toEqual({
+      ctor: 'NoiseSynth',
+      options: { volume: -12, envelope: { attack: 0.001, decay: 1.1, sustain: 0, release: 0.3 } },
+      postVolume: undefined,
+      filter: { type: 'highpass', freq: 3500 },
+      trig: { sig: 'noise', note: undefined, dur: '8n', velocity: 0.8 },
+    });
+  });
+  it('bass — MonoSynth(osc/env/filterEnv), volume -7 assigned after, vel 0.85', () => {
+    expect(plan('gb-bass')).toEqual({
+      ctor: 'MonoSynth',
+      options: {
+        oscillator: { type: 'triangle' },
+        envelope: { attack: 0.005, decay: 0.18, sustain: 0.35, release: 0.18 },
+        filterEnvelope: { attack: 0.005, decay: 0.12, sustain: 0.4, baseFrequency: 120, octaves: 3 },
+      },
+      postVolume: -7, filter: null,
+      trig: { sig: 'note', note: undefined, dur: undefined, velocity: 0.85 },
+    });
+  });
+  it('chords — PolySynth set(triangle/env) → lowpass 4200, volume -17 after, vel 0.3', () => {
+    expect(plan('gb-chords')).toEqual({
+      ctor: 'PolySynth',
+      options: {
+        oscillator: { type: 'triangle' },
+        envelope: { attack: 0.05, decay: 0.3, sustain: 0.6, release: 0.5 },
+      },
+      postVolume: -17,
+      filter: { type: 'lowpass', freq: 4200 },
+      trig: { sig: 'note', note: undefined, dur: undefined, velocity: 0.3 },
+    });
+  });
+  it('lead — PolySynth set(pulse w0.3/env), volume -11 after, vel 0.82', () => {
+    expect(plan('gb-lead')).toEqual({
+      ctor: 'PolySynth',
+      options: {
+        oscillator: { type: 'pulse', width: 0.3 },
+        envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
+      },
+      postVolume: -11, filter: null,
+      trig: { sig: 'note', note: undefined, dur: undefined, velocity: 0.82 },
+    });
+  });
+});

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -1,5 +1,6 @@
 import { stepsPerBar, beatStarts } from '../engine/meter.js';
 import { drumVoiceAudible, laneAudible, snapMidi, inScale, scalePitchClasses } from '../engine/song.js';
+import { DEFAULT_KIT } from '../engine/instruments.js';
 import { laneByType } from '../engine/lanes.js';
 
 // ─── Canvas theme colour cache ────────────────────────────────────────────────
@@ -36,7 +37,10 @@ export function invalidateThemeColors() { _tc = null; }
 
 const esc = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
-const DROWS = [['kick','Kick'],['snare','Snare'],['hat','HH'],['tom','Tom'],['crash','Crash']];
+// Drum grid rows derive from the kit: [gmNote, label, pitched]. dataset keys are
+// the stringified GM numbers (bar[36] === bar['36'] — JS object keys are strings).
+const DROWS = DEFAULT_KIT.slots.map(s => [s.note, s.label, !!s.pitched]);
+const PITCHED_ROW = Object.fromEntries(DROWS.map(([k, , p]) => [k, p]));
 
 // Piano-roll helpers (ported from prototype).
 const NMG = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
@@ -745,10 +749,10 @@ export function makeViz(host, song, eng) {
         const k = row.dataset.k;
         [...row.querySelectorAll('.vc')].forEach((c, i) => c.onclick = () => {
           const shown = laneBars(L)[primaryBar()] || {};
-          const on = k === 'tom'
-            ? !(shown.tom && shown.tom.some(x => x[0] === i))
+          const on = PITCHED_ROW[k]
+            ? !(shown[k] && shown[k].some(x => x[0] === i))
             : !(shown[k] && shown[k].includes(i));
-          for (const b of editBars) eng.setDrumStep(L.id, k, b, i, on);
+          for (const b of editBars) eng.setDrumStep(L.id, k, b, i, on, PITCHED_ROW[k]);
           paint(lastStepInBar);
         });
       });
@@ -832,8 +836,8 @@ export function makeViz(host, song, eng) {
         if (mBtn) mBtn.classList.toggle('muted', !!(L.voiceMute || {})[k]);
         if (sBtn) sBtn.classList.toggle('soloed', !!(L.voiceSolo || {})[k]);
         row.querySelectorAll('.vc').forEach((c, i) => {
-          const on = k === 'tom'
-            ? !!(pat.tom && pat.tom.some(x => x[0] === i))
+          const on = PITCHED_ROW[k]
+            ? !!(pat[k] && pat[k].some(x => x[0] === i))
             : !!(pat[k] && pat[k].includes(i));
           c.classList.toggle('hit', on);
           c.classList.toggle('now', nowHere && i === stepInBar);

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -41,6 +41,8 @@ const esc = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>'
 // the stringified GM numbers (bar[36] === bar['36'] — JS object keys are strings).
 const DROWS = DEFAULT_KIT.slots.map(s => [s.note, s.label, !!s.pitched]);
 const PITCHED_ROW = Object.fromEntries(DROWS.map(([k, , p]) => [k, p]));
+// Shape-tolerant: steps may be numbers or [step, semi] pairs (any slot).
+const hasStep = (steps, i) => Array.isArray(steps) && steps.some(s => Array.isArray(s) ? s[0] === i : s === i);
 
 // Piano-roll helpers (ported from prototype).
 const NMG = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
@@ -749,9 +751,7 @@ export function makeViz(host, song, eng) {
         const k = row.dataset.k;
         [...row.querySelectorAll('.vc')].forEach((c, i) => c.onclick = () => {
           const shown = laneBars(L)[primaryBar()] || {};
-          const on = PITCHED_ROW[k]
-            ? !(shown[k] && shown[k].some(x => x[0] === i))
-            : !(shown[k] && shown[k].includes(i));
+          const on = !hasStep(shown[k], i);
           for (const b of editBars) eng.setDrumStep(L.id, k, b, i, on, PITCHED_ROW[k]);
           paint(lastStepInBar);
         });
@@ -836,9 +836,7 @@ export function makeViz(host, song, eng) {
         if (mBtn) mBtn.classList.toggle('muted', !!(L.voiceMute || {})[k]);
         if (sBtn) sBtn.classList.toggle('soloed', !!(L.voiceSolo || {})[k]);
         row.querySelectorAll('.vc').forEach((c, i) => {
-          const on = PITCHED_ROW[k]
-            ? !!(pat[k] && pat[k].some(x => x[0] === i))
-            : !!(pat[k] && pat[k].includes(i));
+          const on = hasStep(pat[k], i);
           c.classList.toggle('hit', on);
           c.classList.toggle('now', nowHere && i === stepInBar);
         });


### PR DESCRIPTION
## What

PR1 of the instruments layer (spec: po20/2026-06-07-instruments-layer-spec.md). Engine + data model only — zero UI redesign collision; editor UX is PR2, registry publish is PR3.

- **New entities**: Instrument (atomic synth patch) + Kit (GM-note drum rack, variable slots — 7-piece kits with two toms validate today). `engine:'synth'` reserves the sample seam (v2 = SFZ-shaped, no migration).
- **Neutral patch schema** with a ranges/scales registry (`PATCH_PARAMS`) — published instruments outlive Tone; the future editor and validation share one truth.
- **GM note numbers are canonical identity; GM names are input syntax** — one normalization boundary at song ingest (`kick:` and `36:` both valid input; engine/state/registry speak numbers). No production data migration needed: old published grooves are valid input, normalized on read.
- **voices.js is now one adapter**: `compileSynthPatch` (pure) + `createVoiceForType` (kit-driven). Defaults port the hardcoded voices byte-for-byte.
- Drum grid rows derive from kit slots (`pitched` flag replaces the tom special-case).

## Parity & testing (375 → 330 assertions total, all green)

- `compileSynthPatch` output parity-tested **verbatim** against the legacy constructor literals (8 voices)
- `flatten-parity`: all 7 songs reproduce their legacy event streams identically under GM identity
- Scheduler invariants kept: no per-step allocations (for-in event build), voices built at graph time
- 27 schema tests incl. NaN/Infinity, log-scale, dup-slot, alias round-trips

## Worth knowing

- Dropped caller-less `createVoices` compat shim
- Test fixtures migrated to canonical numeric state; toggle/`setDrumStep` args deliberately stay name-keyed to prove the alias path

🤖 Generated with [Claude Code](https://claude.com/claude-code)