### PR TITLE
arcade(groovebox): instrument editor — design your own sounds (PR2)

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -561,6 +561,26 @@ export function createEngine() {
       return _kit;
     },
     getKit() { return _kit; },
+    // One-shot audition: fire a single hit of an instrument (no transport
+    // needed — TEST in the editor must work before pressing play). Builds a
+    // throwaway voice on the master input and disposes it after the tail.
+    async auditionInstrument(inst) {
+      if (!validateInstrument(inst)) return;
+      await Tone.start(); ensure();
+      const v = createVoiceForType(
+        inst.type === 'drum' ? 'drums' : inst.type,
+        _masterIn,
+        inst.type === 'drum'
+          ? { instruments: { _a: inst }, kit: { name: 'A', slots: [{ note: 36, label: 'A', instrument: '_a' }] } }
+          : { instruments: { _a: inst }, instrumentId: '_a' });
+      const now = Tone.now() + 0.02;
+      const ev = inst.type === 'drum' ? { type: 'drums', voice: 36 }
+        : inst.type === 'bass' ? { type: 'bass', note: 'C2', dur: 4 }
+        : inst.type === 'chords' ? { type: 'chords', notes: ['C3', 'E3', 'G3'], dur: 4 }
+        : { type: 'melody', note: 'C4', dur: 4 };
+      trigger(v, ev, now, 0.12, 1.9);
+      setTimeout(() => { try { v.dispose?.(); } catch (_) {} }, 2500);
+    },
     // v3.5 editor TEST pad: audition an UNSAVED draft preset momentarily.
     // Same runner path as punch(); no slot state. UI gates on isPlaying().
     punchPreview(preset, on) {

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -1,7 +1,7 @@
 import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
-import { normalizeSongDrums } from './instruments.js';
+import { normalizeSongDrums, DEFAULT_INSTRUMENTS, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
 import { laneByType, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
@@ -33,6 +33,10 @@ export function createEngine() {
   let punchGate = null, punchCrush = null, punchFilter = null, punchThrow = null, punchTape = null;
   const _punchCaptures = new Map();              // 'laneId|paramId' → { value: knob value at first engage, count }
   let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
+  // Instruments layer (PR2): user instruments/kit override the stock set.
+  // Same contract as punch presets: validated on set, defaults on bad data.
+  let _instruments = DEFAULT_INSTRUMENTS;
+  let _kit = DEFAULT_KIT;
   const _slotHeld = new Array(DEFAULT_PRESETS.length).fill(false);
   const _gates = new Map();                      // slot → { depth, division, laneIds } (preview uses 'preview')
   let _tapeActive = false;                       // transport.tapeStop engaged (owns the BUS punchGate; lane-fader gate is independent)
@@ -188,7 +192,8 @@ export function createEngine() {
 
   function buildLane(lane) {
     fx[lane.id]     = _makeFX(_masterIn);
-    voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input);
+    voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input,
+      { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
     // Apply saved tone to melody lanes
     if (lane.type === 'melody' && lane.tone) {
       voices[lane.id].lead?.set({ oscillator: { type: lane.tone, width: 0.3 } });
@@ -204,6 +209,22 @@ export function createEngine() {
 
   function buildLaneGraph(lanes) {
     for (const lane of lanes) buildLane(lane);
+  }
+
+  // Rebuild voices only (FX chains, meters, captures untouched) — used when
+  // the instrument set or kit changes. Safe while playing: voices swap at
+  // graph time; the next scheduled step triggers the new nodes.
+  function _rebuildVoices() {
+    if (!started || !song) return;
+    for (const lane of song.lanes) {
+      const v = voices[lane.id];
+      if (v?.dispose) { try { v.dispose(); } catch (_) {} }
+      voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input,
+        { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
+      if (lane.type === 'melody' && lane.tone) {
+        voices[lane.id].lead?.set({ oscillator: { type: lane.tone, width: 0.3 } });
+      }
+    }
   }
 
   function disposeLane(id) {
@@ -520,6 +541,26 @@ export function createEngine() {
       return punchPresets;
     },
     getPunchPresets() { return punchPresets; },
+    // ── instruments layer (PR2) ──────────────────────────────────────────
+    // Replace the instrument set / kit. Validated; live voices rebuild so
+    // edits are audible immediately (graph-time work, never per-step).
+    setInstruments(insts) {
+      if (insts && typeof insts === 'object'
+          && Object.values(insts).every(validateInstrument)) {
+        _instruments = insts;
+        _rebuildVoices();
+      }
+      return _instruments;
+    },
+    getInstruments() { return _instruments; },
+    setKit(kit) {
+      if (validateKit(kit, _instruments)) {
+        _kit = kit;
+        _rebuildVoices();
+      }
+      return _kit;
+    },
+    getKit() { return _kit; },
     // v3.5 editor TEST pad: audition an UNSAVED draft preset momentarily.
     // Same runner path as punch(); no slot state. UI gates on isPlaying().
     punchPreview(preset, on) {

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -145,6 +145,7 @@
                 <dt>M</dt><dd>Mute a lane (silences it; FX state preserved)</dd>
                 <dt>S</dt><dd>Solo a lane (silences all others)</dd>
                 <dt>VIEW</dt><dd>Open that lane in the step editor / piano roll</dd>
+                <dt><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/></svg></dt><dd>Redesign that drum's sound from scratch (beside each drum row's M/S). Bass and melody have a SOUND button on their strip. Hold TEST to hear your edit before saving</dd>
                 <dt>FILLS</dt><dd>Queue fill patterns — click a chip to remove it from the queue</dd>
                 <dt>PUNCH</dt><dd>Hold a pad (or keys 1–5) for momentary FX — release to snap back clean</dd>
                 <dt>TEMPO</dt><dd>Song speed in BPM — on MASTER</dd>
@@ -166,7 +167,6 @@
                 <dt>DRV</dt><dd>Crunch — pushes the sound like a guitar amp turned up too far</dd>
                 <dt>LO</dt><dd>More or less bass, for everything at once</dd>
                 <dt>HI</dt><dd>More or less sparkle, for everything at once</dd>
-                <dt>SOUND</dt><dd>Redesign an instrument from scratch — waveform, envelope, filter. On a lane strip, or the pencil beside each drum row's M/S. Hold TEST to hear your edit before saving</dd>
               </dl>
             </div>
             <div class="help-section" data-help="fx">

--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -166,6 +166,7 @@
                 <dt>DRV</dt><dd>Crunch — pushes the sound like a guitar amp turned up too far</dd>
                 <dt>LO</dt><dd>More or less bass, for everything at once</dd>
                 <dt>HI</dt><dd>More or less sparkle, for everything at once</dd>
+                <dt>SOUND</dt><dd>Redesign an instrument from scratch — waveform, envelope, filter. On a lane strip, or the pencil beside each drum row's M/S. Hold TEST to hear your edit before saving</dd>
               </dl>
             </div>
             <div class="help-section" data-help="fx">

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1220,6 +1220,48 @@ body.gb-knob-values .knob-val { display: block; }
 }
 .pe-save:disabled { filter: grayscale(1); opacity: 0.5; cursor: default; }
 
+/* ─── instrument editor (PR2) — same family as the punch editor ─────────── */
+.lane-sound { font-size: 9px; letter-spacing: 0.06em; padding: 2px 8px; }
+.vr .dve { opacity: 0.55; }
+.vr .dve:hover { opacity: 1; color: var(--acc); }
+#inst-editor-backdrop {
+  position: fixed; inset: 0; z-index: 60;
+  background: rgba(0,0,0,0.55); backdrop-filter: blur(2px);
+  display: flex; align-items: center; justify-content: center;
+}
+#inst-editor {
+  width: min(480px, calc(100vw - 32px)); max-height: calc(100vh - 64px); overflow-y: auto;
+  background: var(--panel); border: 1px solid var(--acc); border-radius: 12px;
+  box-shadow: 0 0 30px color-mix(in srgb, var(--acc) 18%, transparent), 0 12px 40px rgba(0,0,0,0.6);
+  padding: 16px; font-size: 12px; color: var(--text, #c9d4e3);
+}
+.ie-hd { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.ie-name {
+  background: var(--panel-2); border: 1px dashed var(--line); border-radius: 6px;
+  padding: 5px 10px; color: var(--ink); font: 700 13px ui-monospace, Menlo, monospace;
+  letter-spacing: 0.06em; flex: 1; min-width: 0; text-transform: uppercase;
+}
+.ie-test {
+  margin-left: auto; border: 0; border-radius: 8px; padding: 6px 16px; cursor: pointer;
+  background: linear-gradient(180deg, #63f8d4, #3dd6b0); color: #04201a; font-weight: 700;
+  box-shadow: 0 0 14px rgba(84, 240, 200, 0.4); user-select: none; touch-action: none;
+}
+.ie-test small { display: block; font-weight: 400; font-size: 9px; opacity: 0.7; }
+.ie-test.idle { filter: grayscale(1); opacity: 0.5; box-shadow: none; }
+.ie-row { display: flex; align-items: center; gap: 10px; margin: 7px 0; }
+.ie-rl { width: 84px; flex: 0 0 84px; color: var(--faint); font-size: 11px; }
+.ie-slider { flex: 1; min-width: 0; accent-color: var(--acc); }
+.ie-val { width: 64px; flex: 0 0 64px; text-align: right; color: var(--ink); }
+.ie-sel { background: var(--panel-3); border: 1px solid var(--line); border-radius: 5px; padding: 2px 8px; color: var(--dim); font: inherit; }
+.ie-ft { display: flex; align-items: center; gap: 14px; margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--line); }
+.ie-reset { background: none; border: 0; color: var(--hot); cursor: pointer; font: inherit; }
+.ie-cancel { background: none; border: 0; color: var(--faint); cursor: pointer; font: inherit; }
+.ie-save {
+  margin-left: auto; border: 0; border-radius: 6px; padding: 6px 18px; cursor: pointer;
+  background: var(--acc); color: #04201a; font-weight: 700;
+}
+.ie-save:disabled { filter: grayscale(1); opacity: 0.5; cursor: default; }
+
 /* ─── fills row (panel chrome via #fills) ───────────────────────────────── */
 .fillsrow {
   display: flex;
@@ -3827,8 +3869,20 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   /* ── Display setting: wrap knobs onto extra rows instead of swiping ── */
   body.gb-knob-wrap .knobrow { flex-wrap: wrap; row-gap: 10px; overflow-x: hidden; }
 
-  /* ── punch preset editor: bottom sheet, thumb-sized, nothing clips ── */
-  #punch-editor-backdrop { align-items: flex-end; }
+  /* ── punch + instrument editors: bottom sheets, thumb-sized, nothing clips ── */
+  #punch-editor-backdrop, #inst-editor-backdrop { align-items: flex-end; }
+  #inst-editor {
+    width: 100vw;
+    max-height: calc(100vh - 32px);
+    max-height: calc(100dvh - 32px);
+    border-radius: 14px 14px 0 0;
+    border-left: 0; border-right: 0; border-bottom: 0;
+    padding: 14px 12px calc(16px + env(safe-area-inset-bottom));
+  }
+  .ie-rl { width: 70px; flex: 0 0 70px; }
+  .ie-val { width: 56px; flex: 0 0 56px; }
+  .ie-row { gap: 6px; }
+  .ie-name { font-size: 16px; }   /* ≥16px = no iOS focus-zoom */
   #punch-editor {
     width: 100vw;
     max-height: calc(100vh - 32px);    /* fallback where dvh is unsupported */

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1222,8 +1222,14 @@ body.gb-knob-values .knob-val { display: block; }
 
 /* ─── instrument editor (PR2) — same family as the punch editor ─────────── */
 .lane-sound { font-size: 9px; letter-spacing: 0.06em; padding: 2px 8px; }
-.vr .dve { opacity: 0.55; }
-.vr .dve:hover { opacity: 1; color: var(--acc); }
+.vr .dve {
+  width: 14px; height: 14px; flex: 0 0 14px; padding: 0; border-radius: 3px;
+  color: var(--dim); border: 1px solid var(--line); cursor: pointer; transition: .12s;
+  background: linear-gradient(180deg, #22252f, #15171f);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.04), 0 1px 2px rgba(0,0,0,.4);
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.vr .dve:hover { border-color: var(--acc-dim); color: var(--acc); }
 #inst-editor-backdrop {
   position: fixed; inset: 0; z-index: 60;
   background: rgba(0,0,0,0.55); backdrop-filter: blur(2px);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -16,6 +16,11 @@ import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 import { initShare, maybeLoadShared, clearLoadedFrom } from './share.js';
 import { openPunchEditor, isPunchEditorOpen } from './punch-editor.js';
+import { openInstrumentEditor, isInstrumentEditorOpen } from './instrument-editor.js';
+
+// Lane type → instrument id in the engine set (PR2 v1: one per type; per-lane
+// refs ride lane.instrument when the picker lands).
+const LANE_INSTRUMENT = { bass: 'gb-bass', chords: 'gb-chords', melody: 'gb-lead' };
 import { DEFAULT_PRESETS } from '../engine/punch-presets.js';
 
 const eng = createEngine();
@@ -322,6 +327,9 @@ function renderStrips() {
     // Groove dropdown — picks the groove the EDIT pattern plays for this lane.
     const laneGrooves = grooves[lane.id] || {};
     const picked = editPat?.lanes?.[lane.id];
+    const soundBtn = lane.type !== 'drums'
+      ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">SOUND</button>`
+      : '';
     const grooveSel = `<select data-groove data-lane="${lane.id}">${Object.keys(laneGrooves).map(n=>`<option value="${esc(n)}"${n===picked?' selected':''}>${esc(n)}</option>`).join('')}</select>`;
     // Edit button — present for types with an editor (drums, melody, bass); skip chords.
     const hasEditor = lane.type !== 'chords';
@@ -332,7 +340,7 @@ function renderStrips() {
     return `<div class="lane" data-lane="${lane.id}" data-type="${lane.type}">
       <span class="lane-drag" title="Drag to reorder">⠿</span>
       <span class="name" title="double-click to rename">${esc(lane.name)}</span>
-      <div class="mctl">${grooveSel}${tone}</div>
+      <div class="mctl">${grooveSel}${tone}${soundBtn}</div>
       <div class="lvl"><div class="lvl-fill"></div></div>
       <div class="msgroup">
         <button class="mute" data-lane="${lane.id}" aria-label="mute ${esc(lane.name)}" title="Mute">M</button>
@@ -388,6 +396,11 @@ function renderStrips() {
   });
 
   host.querySelectorAll('select[data-tone]').forEach(s => s.onchange = e => eng.setTone(s.dataset.lane, e.target.value));
+  host.querySelectorAll('.lane-sound').forEach(b => b.onclick = e => {
+    e.stopPropagation();
+    const id = LANE_INSTRUMENT[b.dataset.type];
+    if (id) openInstrumentEditor({ id, eng, onSaved: renderStrips });
+  });
   host.querySelectorAll('select[data-groove]').forEach(s => s.onchange = () => {
     eng.setLaneGroove(s.dataset.lane, s.value);
     refreshVizPattern();   // editor must re-target the new groove
@@ -696,7 +709,7 @@ function isTypingTarget(el) {
 }
 document.addEventListener('keydown', e => {
   const slot = PUNCH_BY_KEY[e.key];
-  if (slot === undefined || e.repeat || isTypingTarget(document.activeElement) || isPunchEditorOpen()) return;
+  if (slot === undefined || e.repeat || isTypingTarget(document.activeElement) || isPunchEditorOpen() || isInstrumentEditorOpen()) return;
   e.preventDefault();
   setPunch(slot, true);
 });

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1736,6 +1736,22 @@ const shareHooks = {
   // rare; the groove still lands correctly, just without a picker).
   pickLane: lanes => Promise.resolve(lanes[0].id),
 };
+// localStorage 'gb-instruments' / 'gb-kit' override the stock sounds when
+// valid (engine validates; invalid → defaults kept — same contract as punch).
+function loadInstruments() {
+  try {
+    const saved = JSON.parse(localStorage.getItem('gb-instruments') || 'null');
+    if (saved && typeof saved === 'object' && !Array.isArray(saved)) {
+      eng.setInstruments({ ...eng.getInstruments(), ...saved });
+    }
+  } catch (_) { /* corrupt JSON → defaults */ }
+  try {
+    const kit = JSON.parse(localStorage.getItem('gb-kit') || 'null');
+    if (kit) eng.setKit(kit);
+  } catch (_) { /* corrupt JSON → defaults */ }
+}
+loadInstruments();
+
 initShare(eng, shareHooks);
 maybeLoadShared(eng, shareHooks);
 // Press-and-hold on a control must not open the browser context menu (Android

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1759,6 +1759,8 @@ function loadInstruments() {
     }
   } catch (_) { /* corrupt JSON → defaults */ }
   try {
+    // No UI writes 'gb-kit' yet (kit editor = next PR) — but the engine honors
+    // a hand-authored kit JSON here today (e.g. a 7-piece kit with two toms).
     const kit = JSON.parse(localStorage.getItem('gb-kit') || 'null');
     if (kit) eng.setKit(kit);
   } catch (_) { /* corrupt JSON → defaults */ }

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -59,8 +59,9 @@ export const isInstrumentEditorOpen = () => _open;
  */
 export function openInstrumentEditor({ id, eng, onSaved }) {
   if (_open) return;
-  _open = true;
   const stash = eng.getInstruments();
+  if (!stash[id]) return;                   // stale/unknown id — never open broken
+  _open = true;
   let draft = JSON.parse(JSON.stringify(stash[id]));
   let previewing = false;
   let _tweakTimer = null, _tweakLast = 0;

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -1,0 +1,202 @@
+// ui/instrument-editor.js — edit one instrument's patch (PR2 slice 3).
+// Pattern follows ui/punch-editor.js: deep-cloned draft, sliders read ranges
+// from the engine registry (PATCH_PARAMS), hold-to-TEST auditions the UNSAVED
+// draft live (the playing loop sounds it), SAVE persists to localStorage.
+import { PATCH_PARAMS, OSC_SHAPES, validateInstrument } from '../engine/instruments.js';
+
+// UI metadata only — ranges/scales live in PATCH_PARAMS (one source of truth).
+const PARAM_UI = {
+  'volume':                 { label: 'volume',      fmt: v => `${v.toFixed(1)} dB` },
+  'envelope.attack':        { label: 'attack',      fmt: v => `${(v * 1000).toFixed(0)} ms` },
+  'envelope.decay':         { label: 'decay',       fmt: v => `${(v * 1000).toFixed(0)} ms` },
+  'envelope.sustain':       { label: 'sustain',     fmt: v => v.toFixed(2) },
+  'envelope.release':       { label: 'release',     fmt: v => `${(v * 1000).toFixed(0)} ms` },
+  'oscillator.width':       { label: 'pulse width', fmt: v => v.toFixed(2) },
+  'filter.freq':            { label: 'filter Hz',   fmt: v => `${Math.round(v)} Hz` },
+  'filterEnvelope.baseFrequency': { label: 'flt base', fmt: v => `${Math.round(v)} Hz` },
+  'filterEnvelope.octaves': { label: 'flt sweep',   fmt: v => v.toFixed(1) },
+  'pitch.pitchDecay':       { label: 'pitch drop',  fmt: v => `${(v * 1000).toFixed(0)} ms` },
+  'pitch.octaves':          { label: 'pitch range', fmt: v => v.toFixed(1) },
+  'trigger.velocity':       { label: 'hit level',   fmt: v => v.toFixed(2) },
+};
+
+// Which params each archetype exposes (only ones the synth actually reads).
+const ARCHETYPE_PARAMS = {
+  membrane: ['volume', 'pitch.pitchDecay', 'pitch.octaves', 'trigger.velocity'],
+  noise:    ['volume', 'envelope.attack', 'envelope.decay', 'envelope.sustain', 'envelope.release', 'filter.freq', 'trigger.velocity'],
+  mono:     ['volume', 'envelope.attack', 'envelope.decay', 'envelope.sustain', 'envelope.release',
+             'filterEnvelope.baseFrequency', 'filterEnvelope.octaves', 'trigger.velocity'],
+  poly:     ['volume', 'envelope.attack', 'envelope.decay', 'envelope.sustain', 'envelope.release',
+             'oscillator.width', 'trigger.velocity'],
+};
+
+// slider position (0..1) ↔ value, honouring the registry's scale
+function posToVal(id, pos) {
+  const { min, max, scale } = PATCH_PARAMS[id];
+  if (scale === 'log') return min * Math.pow(max / min, pos);
+  return min + (max - min) * pos;
+}
+function valToPos(id, v) {
+  const { min, max, scale } = PATCH_PARAMS[id];
+  if (scale === 'log') return Math.log(v / min) / Math.log(max / min);
+  return (v - min) / (max - min);
+}
+
+const get = (o, p) => p.split('.').reduce((x, k) => (x == null ? x : x[k]), o);
+function set(o, p, v) {
+  const ks = p.split('.');
+  let t = o;
+  for (const k of ks.slice(0, -1)) t = (t[k] = t[k] || {});
+  t[ks.at(-1)] = v;
+}
+
+let _open = false;
+export const isInstrumentEditorOpen = () => _open;
+
+/**
+ * openInstrumentEditor({ id, eng, onSaved })
+ * id — instrument id in the engine's set (e.g. 'gb-kick', 'gb-bass')
+ */
+export function openInstrumentEditor({ id, eng, onSaved }) {
+  if (_open) return;
+  _open = true;
+  const stash = eng.getInstruments();
+  let draft = JSON.parse(JSON.stringify(stash[id]));
+  let previewing = false;
+
+  const backdrop = document.createElement('div');
+  backdrop.id = 'inst-editor-backdrop';
+  const modal = document.createElement('div');
+  modal.id = 'inst-editor';
+  backdrop.appendChild(modal);
+  document.body.appendChild(backdrop);
+
+  function stopPreview() {
+    if (!previewing) return;
+    previewing = false;
+    eng.setInstruments(stash);              // restore the saved set
+  }
+  function close() {
+    stopPreview();
+    _open = false;
+    backdrop.remove();
+    document.removeEventListener('keydown', onKey, true);
+  }
+  function onKey(e) {
+    if (e.key === 'Escape') { e.stopPropagation(); close(); }
+  }
+  document.addEventListener('keydown', onKey, true);
+  backdrop.addEventListener('pointerdown', e => { if (e.target === backdrop) close(); });
+
+  function save() {
+    if (!validateInstrument(draft)) return;
+    draft.name = (draft.name || 'SOUND').toUpperCase().slice(0, 24);
+    const next = { ...stash, [id]: draft };
+    eng.setInstruments(next);
+    // Persist only non-stock-identical entries? v1: persist the whole user set.
+    localStorage.setItem('gb-instruments', JSON.stringify(next));
+    close();
+    onSaved?.();
+  }
+
+  const label = t => { const s = document.createElement('span'); s.className = 'ie-rl'; s.textContent = t; return s; };
+  const value = t => { const s = document.createElement('span'); s.className = 'ie-val'; s.textContent = t; return s; };
+
+  function refreshSave() {
+    const btn = modal.querySelector('.ie-save');
+    if (btn) btn.disabled = !validateInstrument(draft);
+  }
+
+  function render() {
+    modal.innerHTML = '';
+    // header: name + hold-to-TEST (auditions the UNSAVED draft over the loop)
+    const hd = document.createElement('div');
+    hd.className = 'ie-hd';
+    const name = document.createElement('input');
+    name.className = 'ie-name';
+    name.maxLength = 24;
+    name.value = draft.name;
+    name.oninput = () => { draft.name = name.value; refreshSave(); };
+    const test = document.createElement('button');
+    test.className = 'ie-test' + (eng.isPlaying() ? '' : ' idle');
+    test.innerHTML = 'TEST<small>hold to hear</small>';
+    test.addEventListener('pointerdown', e => {
+      e.preventDefault(); test.setPointerCapture(e.pointerId);
+      if (!eng.isPlaying()) { test.innerHTML = 'TEST<small>press ▶ first</small>'; return; }
+      if (!validateInstrument(draft)) return;
+      previewing = true;
+      eng.setInstruments({ ...stash, [id]: draft });   // draft is live while held
+    });
+    test.addEventListener('pointerup', stopPreview);
+    test.addEventListener('pointercancel', stopPreview);
+    hd.append(name, test);
+    modal.appendChild(hd);
+
+    // oscillator shape (mono/poly only)
+    if (draft.patch.archetype === 'mono' || draft.patch.archetype === 'poly') {
+      const row = document.createElement('div');
+      row.className = 'ie-row';
+      row.appendChild(label('waveform'));
+      const sel = document.createElement('select');
+      sel.className = 'ie-sel';
+      for (const sh of OSC_SHAPES) {
+        const o = document.createElement('option');
+        o.value = sh; o.textContent = sh === 'fatsawtooth' ? 'fat saw' : sh;
+        if ((draft.patch.oscillator?.shape ?? 'triangle') === sh) o.selected = true;
+        sel.appendChild(o);
+      }
+      sel.onchange = () => { set(draft.patch, 'oscillator.shape', sel.value); refreshSave(); };
+      row.appendChild(sel);
+      modal.appendChild(row);
+    }
+
+    // param sliders — ranges/scales straight from the registry
+    for (const pid of ARCHETYPE_PARAMS[draft.patch.archetype] ?? []) {
+      if (pid === 'filter.freq' && !draft.patch.filter) continue;   // no filter on this patch
+      const ui = PARAM_UI[pid];
+      const cur = get(draft.patch, pid);
+      const reg = PATCH_PARAMS[pid];
+      const shown = cur ?? (pid === 'trigger.velocity' ? 1 : (reg.min + reg.max) / 2);
+      const row = document.createElement('div');
+      row.className = 'ie-row';
+      const v = value(ui.fmt(shown));
+      const s = document.createElement('input');
+      s.type = 'range'; s.min = 0; s.max = 1000; s.step = 1;
+      s.className = 'ie-slider';
+      s.value = Math.round(valToPos(pid, shown) * 1000);
+      s.oninput = () => {
+        const nv = posToVal(pid, s.value / 1000);
+        set(draft.patch, pid, Math.round(nv * 1000) / 1000);
+        v.textContent = ui.fmt(get(draft.patch, pid));
+        if (previewing) eng.setInstruments({ ...stash, [id]: draft });   // live-tweak while held… cheap graph swap
+        refreshSave();
+      };
+      row.append(label(ui.label), s, v);
+      modal.appendChild(row);
+    }
+
+    // footer
+    const ft = document.createElement('div');
+    ft.className = 'ie-ft';
+    const reset = document.createElement('button');
+    reset.className = 'ie-reset';
+    reset.textContent = 'reset to default';
+    reset.onclick = async () => {
+      const { DEFAULT_INSTRUMENTS } = await import('../engine/instruments.js');
+      if (DEFAULT_INSTRUMENTS[id]) { draft = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS[id])); render(); }
+    };
+    const cancel = document.createElement('button');
+    cancel.className = 'ie-cancel';
+    cancel.textContent = 'cancel';
+    cancel.onclick = close;
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'ie-save';
+    saveBtn.textContent = 'SAVE';
+    saveBtn.onclick = save;
+    ft.append(reset, cancel, saveBtn);
+    modal.appendChild(ft);
+    refreshSave();
+  }
+
+  render();
+}

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -118,12 +118,12 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
     name.value = draft.name;
     name.oninput = () => { draft.name = name.value; refreshSave(); };
     const test = document.createElement('button');
-    test.className = 'ie-test' + (eng.isPlaying() ? '' : ' idle');
-    test.innerHTML = 'TEST<small>hold to hear</small>';
+    test.className = 'ie-test';
+    test.innerHTML = eng.isPlaying() ? 'TEST<small>hold to hear</small>' : 'TEST<small>tap to hear</small>';
     test.addEventListener('pointerdown', e => {
       e.preventDefault(); test.setPointerCapture(e.pointerId);
-      if (!eng.isPlaying()) { test.innerHTML = 'TEST<small>press ▶ first</small>'; return; }
       if (!validateInstrument(draft)) return;
+      if (!eng.isPlaying()) { eng.auditionInstrument(draft); return; }   // one-shot, no transport needed
       previewing = true;
       eng.setInstruments({ ...stash, [id]: draft });   // draft is live while held
     });

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -2,7 +2,7 @@
 // Pattern follows ui/punch-editor.js: deep-cloned draft, sliders read ranges
 // from the engine registry (PATCH_PARAMS), hold-to-TEST auditions the UNSAVED
 // draft live (the playing loop sounds it), SAVE persists to localStorage.
-import { PATCH_PARAMS, OSC_SHAPES, validateInstrument } from '../engine/instruments.js';
+import { PATCH_PARAMS, OSC_SHAPES, validateInstrument, DEFAULT_INSTRUMENTS } from '../engine/instruments.js';
 
 // UI metadata only — ranges/scales live in PATCH_PARAMS (one source of truth).
 const PARAM_UI = {
@@ -63,6 +63,14 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
   const stash = eng.getInstruments();
   let draft = JSON.parse(JSON.stringify(stash[id]));
   let previewing = false;
+  let _tweakTimer = null, _tweakLast = 0;
+  function applyDraftLive() {
+    if (!previewing) return;
+    const now = Date.now();
+    const run = () => { _tweakLast = Date.now(); if (previewing) eng.setInstruments({ ...stash, [id]: draft }); };
+    if (now - _tweakLast > 150) run();
+    else { clearTimeout(_tweakTimer); _tweakTimer = setTimeout(run, 150 - (now - _tweakLast)); }
+  }
 
   const backdrop = document.createElement('div');
   backdrop.id = 'inst-editor-backdrop';
@@ -90,6 +98,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
 
   function save() {
     if (!validateInstrument(draft)) return;
+    previewing = false;                     // a still-held TEST must not restore over the save
     draft.name = (draft.name || 'SOUND').toUpperCase().slice(0, 24);
     const next = { ...stash, [id]: draft };
     eng.setInstruments(next);
@@ -168,7 +177,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
         const nv = posToVal(pid, s.value / 1000);
         set(draft.patch, pid, Math.round(nv * 1000) / 1000);
         v.textContent = ui.fmt(get(draft.patch, pid));
-        if (previewing) eng.setInstruments({ ...stash, [id]: draft });   // live-tweak while held… cheap graph swap
+        applyDraftLive();                            // throttled — see above
         refreshSave();
       };
       row.append(label(ui.label), s, v);
@@ -181,8 +190,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
     const reset = document.createElement('button');
     reset.className = 'ie-reset';
     reset.textContent = 'reset to default';
-    reset.onclick = async () => {
-      const { DEFAULT_INSTRUMENTS } = await import('../engine/instruments.js');
+    reset.onclick = () => {
       if (DEFAULT_INSTRUMENTS[id]) { draft = JSON.parse(JSON.stringify(DEFAULT_INSTRUMENTS[id])); render(); }
     };
     const cancel = document.createElement('button');

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -1,6 +1,7 @@
 import { stepsPerBar, beatStarts } from '../engine/meter.js';
 import { drumVoiceAudible, laneAudible, snapMidi, inScale, scalePitchClasses } from '../engine/song.js';
 import { DEFAULT_KIT } from '../engine/instruments.js';
+import { openInstrumentEditor } from './instrument-editor.js';
 import { laneByType } from '../engine/lanes.js';
 
 // ─── Canvas theme colour cache ────────────────────────────────────────────────
@@ -729,7 +730,7 @@ export function makeViz(host, song, eng) {
       // ONE bar tall: 5 voice rows for the shown (primary) bar.
       html += DROWS.map(([k, l]) =>
         `<div class="vrow" data-k="${k}"><span class="vl"><span class="vl-lbl">${l}</span></span>${cells(spb)}` +
-        `<span class="vr"><button class="dvm" data-voice="${k}" title="mute ${l}">M</button><button class="dvs" data-voice="${k}" title="solo ${l}">S</button></span>`
+        `<span class="vr"><button class="dvm" data-voice="${k}" title="mute ${l}">M</button><button class="dvs" data-voice="${k}" title="solo ${l}">S</button><button class="dve" data-voice="${k}" title="edit ${l} sound">✎</button></span>`
         + `</div>`).join('');
       host.innerHTML = html;
 
@@ -762,6 +763,15 @@ export function makeViz(host, song, eng) {
       });
       host.querySelectorAll('.dvs').forEach(btn => {
         btn.onclick = e => { e.stopPropagation(); eng.toggleDrumSolo(btn.dataset.voice); paint(lastStepInBar); };
+      });
+      // ✎ — edit this slot's instrument (design your own kick).
+      host.querySelectorAll('.dve').forEach(btn => {
+        btn.onclick = e => {
+          e.stopPropagation();
+          const note = Number(btn.dataset.voice);
+          const slot = (eng.getKit?.()?.slots ?? []).find(s => Number(s.note) === note);
+          if (slot) openInstrumentEditor({ id: slot.instrument, eng, onSaved: () => paint(lastStepInBar) });
+        };
       });
 
       // Cache: _drumVcCache[voice] = [cells] for the fast playhead path.

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -730,7 +730,7 @@ export function makeViz(host, song, eng) {
       // ONE bar tall: 5 voice rows for the shown (primary) bar.
       html += DROWS.map(([k, l]) =>
         `<div class="vrow" data-k="${k}"><span class="vl"><span class="vl-lbl">${l}</span></span>${cells(spb)}` +
-        `<span class="vr"><button class="dvm" data-voice="${k}" title="mute ${l}">M</button><button class="dvs" data-voice="${k}" title="solo ${l}">S</button><button class="dve" data-voice="${k}" title="edit ${l} sound">✎</button></span>`
+        `<span class="vr"><button class="dvm" data-voice="${k}" title="mute ${l}">M</button><button class="dvs" data-voice="${k}" title="solo ${l}">S</button><button class="dve" data-voice="${k}" title="edit ${l} sound"><svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/></svg></button></span>`
         + `</div>`).join('');
       host.innerHTML = html;
 


### PR DESCRIPTION


## Corrections (post-review)

- Chords SOUND **does** ship (poly patch, same editor path as melody) — the "deliberate cut" line above was stale
- Persistence: instrument edits persist via `gb-instruments`; `gb-kit` is a **read-only forward-compat tier** (engine honors hand-authored kit JSON; the writer arrives with the kit editor PR)
