### PR TITLE
fix(groovebox): transposeNote accepts flat note spellings

### DIFF
--- a/docs/arcade/groovebox/engine/song.js
+++ b/docs/arcade/groovebox/engine/song.js
@@ -26,10 +26,13 @@ export function drumVoiceAudible(drumsLane, voice) {
 export { DRUM_KEYS };
 
 export function transposeNote(note, semis) {
-  const m = note.match(/^([A-G]#?)(-?\d+)$/); if (!m) return note;
+  // Flats accepted (noteToPc below and the chord-line parser both produce/take
+  // them); output is sharp-canonical. Accidental as ±1 offset keeps Cb4 → B3
+  // octave-correct, matching Tone's parsing.
+  const m = note.match(/^([A-G])(#|b)?(-?\d+)$/); if (!m) return note;
   const N = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
-  const i = N.indexOf(m[1]); if (i < 0) return note;
-  const t = i + (parseInt(m[2]) + 1) * 12 + semis;
+  const i = N.indexOf(m[1]) + (m[2] === '#' ? 1 : m[2] === 'b' ? -1 : 0);
+  const t = i + (parseInt(m[3]) + 1) * 12 + semis;
   return N[((t % 12) + 12) % 12] + (Math.floor(t / 12) - 1);
 }
 

--- a/docs/arcade/groovebox/tests/harmony.test.js
+++ b/docs/arcade/groovebox/tests/harmony.test.js
@@ -151,3 +151,11 @@ test('chordAt cycles and wraps negative bars; empty → undefined', () => {
   expect(chordAt(prog, -1)).toBe(prog[1]);
   expect(chordAt([], 0)).toBeUndefined();
 });
+
+// The original symptom (Mother of Pearl authoring, 2026-06-07): a flat-spelled
+// voicing left ±N refs unshifted — V1+12 over Eb3 played Eb3, not Eb4.
+test('resolveRef: ±N over a flat-spelled chord shifts (sharp-canonical out)', () => {
+  const Cm = { name: 'Cm', root: 'C2', voicing: ['C3', 'Eb3', 'G3'] };
+  expect(resolveRef('V1+12', Cm)).toBe('D#4');
+  expect(resolveRef('R+10', { ...Cm, root: 'Bb1' })).toBe('G#2');
+});

--- a/docs/arcade/groovebox/tests/transpose.test.js
+++ b/docs/arcade/groovebox/tests/transpose.test.js
@@ -28,3 +28,21 @@ test('transposeNote: invalid input passes through unchanged', () => {
   expect(transposeNote('', 3)).toBe('');
   expect(transposeNote('X9', 2)).toBe('X9');
 });
+
+// Flat spellings are valid input (the chord-line parser accepts "Ebm" etc.) —
+// they must SHIFT, not silently pass through. Output stays sharp-canonical.
+test('transposeNote: Eb3 +12 → D#4 (flats accepted, shifted)', () => {
+  expect(transposeNote('Eb3', 12)).toBe('D#4');
+});
+
+test('transposeNote: Bb1 +2 → C2 (flat across octave roll)', () => {
+  expect(transposeNote('Bb1', 2)).toBe('C2');
+});
+
+test('transposeNote: Ab4 +0 → G#4 (flats normalize to sharps)', () => {
+  expect(transposeNote('Ab4', 0)).toBe('G#4');
+});
+
+test('transposeNote: Cb4 +0 → B3 (theory-correct octave, matches Tone)', () => {
+  expect(transposeNote('Cb4', 0)).toBe('B3');
+});


### PR DESCRIPTION
## The bug

`transposeNote` (engine/song.js) used a sharps-only regex, and its no-match fallback returns the input unchanged. Both call sites inherit the silent failure:

- **Chord-relative ±N refs** (`V1+12`, `R+10`, `V*-12`) over a flat-spelled voicing note returned it **unshifted** — `V1+12` over `["C3","Eb3","G3"]` played Eb3 instead of Eb4.
- **Global `transpose`** silently skipped flat-spelled literal notes.

What makes it sneaky: plain refs (`V1`, `V*`, `R`) and literal notes bypass `transposeNote` and go straight to Tone, which parses flats fine — so a flat-spelled song sounds ~95% right, with only octave-shifted refs and transpose quietly staying put.

Flat data is legitimately reachable: the chord-line parser (`chords.js` `TOKEN_RE`) accepts `Ebm` etc., and `noteToPc` ten lines below `transposeNote` already handles flats. LLM-authored songs (the upcoming AI mode) naturally produce flat spellings in flat keys too — this was found authoring "Mother of Pearl" via the rendered-stream probe.

## The fix

Accidental parsed as a ±1 offset — the same idiom `noteToPc` already uses — which also makes `Cb4 → B3` octave-correct, matching Tone's parsing. Output stays sharp-canonical. Two lines of behavior change.

## Tests

- 4 new unit tests in `transpose.test.js` (flat shift, octave roll, sharp-canonical normalization, Cb octave edge)
- 1 symptom-level test in `harmony.test.js` pinning the original `resolveRef` failure
- Full suite: **338 passed** (TDD: all 5 new tests failed before the fix)

No CHANGELOG entry (arcade scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)