### PR TITLE
arcade(groovebox): velocity p-locks — per-step { v } lock object + brightness

### DIFF
--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -38,7 +38,10 @@ song = {
       // LOCK (per-step parameter lock) — optional trailing object, the ONE
       //   extensible per-step slot: { v }. v multiplies the voice's base
       //   velocity (0 < v <= 2; product clamped to 0..1). Absent → base
-      //   velocity unchanged. Strict-keyed, so a typo'd/unknown key is rejected
+      //   velocity unchanged. On drum voices that carry a tone filter (e.g.
+      //   hat/crash) v ALSO shifts the cutoff (accents fuller, ghosts thinner) —
+      //   an engine rendering of v, not a separate field. Strict-keyed, so a
+      //   typo'd/unknown key is rejected
       //   at publish (validate.js) rather than silently ignored. Future per-step
       //   params (e.g. micro-timing 't') join this same object — no new tuple
       //   position. Drum 2-element tuple is type-discriminated: a number is a

--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -38,10 +38,11 @@ song = {
       // LOCK (per-step parameter lock) — optional trailing object, the ONE
       //   extensible per-step slot: { v }. v multiplies the voice's base
       //   velocity (0 < v <= 2; product clamped to 0..1). Absent → base
-      //   velocity unchanged. On drum voices that carry a tone filter (e.g.
-      //   hat/crash) v ALSO shifts the cutoff (accents fuller, ghosts thinner) —
-      //   an engine rendering of v, not a separate field. Strict-keyed, so a
-      //   typo'd/unknown key is rejected
+      //   velocity unchanged. v ALSO shifts a tone-filter cutoff (accents
+      //   brighter/fuller, ghosts darker/thinner): drums via their hat/crash
+      //   filter, pitched lanes via the chords' character lowpass or a
+      //   transparent insert on bass/melody — an engine rendering of v, not a
+      //   separate field. Strict-keyed, so a typo'd/unknown key is rejected
       //   at publish (validate.js) rather than silently ignored. Future per-step
       //   params (e.g. micro-timing 't') join this same object — no new tuple
       //   position. Drum 2-element tuple is type-discriminated: a number is a

--- a/docs/arcade/groovebox/DATA-MODEL.md
+++ b/docs/arcade/groovebox/DATA-MODEL.md
@@ -31,9 +31,19 @@ song = {
       // LITERAL bars[] — each bar:
       // drums lane:   { kick:[steps], snare:[steps], hat:[steps], crash:[steps],
       //                 tom:[[step, semitoneOffset], …] }
-      // other lanes:  [ [step, note|notes[], durSteps|'bar'], … ]
+      //               a drum step is a number, OR a tuple carrying a lock:
+      //               [step, lock] (noise slot) | [step, semitoneOffset, lock] (tom)
+      // other lanes:  [ [step, note|notes[], durSteps|'bar', lock?], … ]
       //               note = 'C4' style; notes[] = simultaneous (chords)
-      // RELATIVE relBars[] — each bar: [ [step, REF, durSteps|'bar'], … ]
+      // LOCK (per-step parameter lock) — optional trailing object, the ONE
+      //   extensible per-step slot: { v }. v multiplies the voice's base
+      //   velocity (0 < v <= 2; product clamped to 0..1). Absent → base
+      //   velocity unchanged. Strict-keyed, so a typo'd/unknown key is rejected
+      //   at publish (validate.js) rather than silently ignored. Future per-step
+      //   params (e.g. micro-timing 't') join this same object — no new tuple
+      //   position. Drum 2-element tuple is type-discriminated: a number is a
+      //   semitone, an object is a lock.
+      // RELATIVE relBars[] — each bar: [ [step, REF, durSteps|'bar', lock?], … ]
       //   REFs resolve against the PATTERN's chord for that bar
       //   (pattern.chords[barInPattern % chords.length]):
       //     'R'        → chord.root
@@ -77,6 +87,7 @@ song = {
 4. Groove lengths are 1–8 bars. **The schema permits any length 1–8** (`bar % groove.length` cycling is length-agnostic; non-dividing lengths truncate their cycle at each pattern repeat) — but **the UI stays opinionated at 1/2/4/8**: powers of two always nest evenly, so nothing drifts. Arbitrary 3/5/7-bar grooves are musically surprising and stay a deliberate future decision, not a default.
 5. The whole song is **pure JSON** — no functions, no hidden state. This is the property that makes grooves/patterns/songs shareable and LLM-authorable. Never add a non-serializable field.
 6. Playback state (the chain-position/pattern-loop target, edit selection, fill queue) is **engine runtime, never part of the song**.
+7. **Per-step locks are additive and inert by default:** a lock-less step plays exactly as before (byte-identical legacy songs). The lock object never adds, removes, or retimes a note — it only modulates the voice at trigger time. A song with no locks is indistinguishable from a pre-lock song; the parity suite (legacy note stream, no velocity) therefore stays valid unchanged.
 
 ## The legacy bridge (read-only, temporary)
 

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -149,10 +149,14 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
               ev.push({ laneId: lane.id, type: 'drums', voice: note });
           } else if (Array.isArray(s) && s[0] === step && drumVoiceAudible(lane, note)) {
             const a = s[1];
-            const lock = (a !== null && typeof a === 'object') ? a : s[2];
-            const e = (a !== null && typeof a === 'object')
+            // Position 1 is a semitone (number) or a lock (PLAIN object) — never
+            // an array (matches the validator + contract). Garbage falls through
+            // to no-semi/base, and the lock is read from s[2].
+            const isLock = a !== null && typeof a === 'object' && !Array.isArray(a);
+            const lock = isLock ? a : s[2];
+            const e = isLock
               ? { laneId: lane.id, type: 'drums', voice: note }
-              : { laneId: lane.id, type: 'drums', voice: note, semi: a ?? 0 };
+              : { laneId: lane.id, type: 'drums', voice: note, semi: typeof a === 'number' ? a : 0 };
             if (lock && typeof lock.v === 'number') e.vel = lock.v;
             ev.push(e);
           }

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -134,8 +134,9 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
       const bars = grooveBars(g);
       const bar = fillPat || (bars ? bars[barInPattern % bars.length] : null) || {};
       // Slot-agnostic: keys are canonical GM numbers post-ingest (slotKey also
-      // tolerates raw name keys). Steps are numbers or [step, semi] pairs —
-      // any slot may be pitched. for-in: no per-step allocations.
+      // tolerates raw name keys). Steps are numbers, [step, semi] pairs, or
+      // lock-carrying [step, lock] / [step, semi, lock] (type-discriminated:
+      // number = semi, object = lock). for-in: no per-step allocations.
       for (const k in bar) {
         const steps = bar[k];
         if (!Array.isArray(steps)) continue;
@@ -147,7 +148,13 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
             if (s === step && drumVoiceAudible(lane, note))
               ev.push({ laneId: lane.id, type: 'drums', voice: note });
           } else if (Array.isArray(s) && s[0] === step && drumVoiceAudible(lane, note)) {
-            ev.push({ laneId: lane.id, type: 'drums', voice: note, semi: s[1] ?? 0 });
+            const a = s[1];
+            const lock = (a !== null && typeof a === 'object') ? a : s[2];
+            const e = (a !== null && typeof a === 'object')
+              ? { laneId: lane.id, type: 'drums', voice: note }
+              : { laneId: lane.id, type: 'drums', voice: note, semi: a ?? 0 };
+            if (lock && typeof lock.v === 'number') e.vel = lock.v;
+            ev.push(e);
           }
         }
       }
@@ -158,29 +165,35 @@ export function eventsForStepV2(song, patternIdx, barInPattern, step, fillPat = 
     if (g && g.relative) {
       // Chord-relative: resolve each REF against the pattern's chord for this bar.
       // No chords on the pattern → the lane is silent (resolveRef → null).
-      for (const [s, ref, dur] of notes) {
+      for (const [s, ref, dur, lock] of notes) {
         if (s !== step) continue;
         const resolved = resolveRef(ref, chord);
         if (resolved == null) continue;
+        let e;
         if (Array.isArray(resolved)) {
-          ev.push({ laneId: lane.id, type: 'chords', mode: 'pad', notes: resolved.map(T), dur });
+          e = { laneId: lane.id, type: 'chords', mode: 'pad', notes: resolved.map(T), dur };
         } else if (lane.type === 'chords') {
-          ev.push({ laneId: lane.id, type: 'chords', mode: 'arp', note: T(resolved), dur });
+          e = { laneId: lane.id, type: 'chords', mode: 'arp', note: T(resolved), dur };
         } else {
-          ev.push({ laneId: lane.id, type: lane.type, note: T(resolved), dur });
+          e = { laneId: lane.id, type: lane.type, note: T(resolved), dur };
         }
+        if (lock && typeof lock.v === 'number') e.vel = lock.v;
+        ev.push(e);
       }
       continue;
     }
-    // Literal groove — untouched behaviour.
-    for (const [s, n, dur] of notes) {
+    // Literal groove — untouched behaviour (plus the optional 4th-element lock).
+    for (const [s, n, dur, lock] of notes) {
       if (s !== step) continue;
+      let e;
       if (lane.type === 'chords') {
-        if (Array.isArray(n)) ev.push({ laneId: lane.id, type: 'chords', mode: 'pad', notes: n.map(T), dur });
-        else ev.push({ laneId: lane.id, type: 'chords', mode: 'arp', note: T(n), dur });
+        if (Array.isArray(n)) e = { laneId: lane.id, type: 'chords', mode: 'pad', notes: n.map(T), dur };
+        else e = { laneId: lane.id, type: 'chords', mode: 'arp', note: T(n), dur };
       } else {
-        ev.push({ laneId: lane.id, type: lane.type, note: T(n), dur });
+        e = { laneId: lane.id, type: lane.type, note: T(n), dur };
       }
+      if (lock && typeof lock.v === 'number') e.vel = lock.v;
+      ev.push(e);
     }
   }
   return ev;

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -307,7 +307,9 @@ export function setDrumStep(song, laneId, grooveName, barIdx, voice, step, on, p
     else if (i >= 0) bar[k].splice(i, 1);
   } else {
     bar[k] = bar[k] || [];
-    const i = bar[k].indexOf(step);
+    // A non-pitched step is a plain number, OR a lock tuple [step, lock] — match
+    // both so a locked hit can still be toggled off / isn't duplicated.
+    const i = bar[k].findIndex(x => x === step || (Array.isArray(x) && x[0] === step));
     if (on) { if (i < 0) bar[k].push(step); }
     else if (i >= 0) bar[k].splice(i, 1);
   }

--- a/docs/arcade/groovebox/engine/voices.js
+++ b/docs/arcade/groovebox/engine/voices.js
@@ -149,6 +149,16 @@ function durSeconds(dur, sixteenth, barSeconds) {
   return (typeof dur === 'number' && Number.isFinite(dur) && dur > 0 ? dur : 2) * sixteenth;
 }
 
+// Velocity p-lock: ev.vel multiplies the voice's base velocity, product clamped
+// to 0..1. Unlocked events (ev.vel == null) pass the base through UNCHANGED —
+// undefined base stays undefined (Tone defaults it), so legacy songs are
+// byte-identical. Scalar math only: nothing here allocates in the hot path.
+function lockVel(base, vel) {
+  if (vel == null) return base;
+  const v = (base ?? 1) * vel;
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
 /**
  * trigger(voice, ev, t, sixteenth, barSeconds)
  * Fires one scheduler event at audio time `t`.
@@ -163,19 +173,19 @@ export function trigger(voice, ev, t, sixteenth, barSeconds) {
     if (!slot) return;
     const { synth, trig } = slot;
     if (trig.sig === 'noise') {
-      synth.triggerAttackRelease(trig.dur ?? '16n', t, trig.velocity);
+      synth.triggerAttackRelease(trig.dur ?? '16n', t, lockVel(trig.velocity, ev.vel));
     } else {
       const base = trig.note ?? 'C3';
       const pitch = ev.semi ? Tone.Frequency(base).transpose(ev.semi) : base;
-      synth.triggerAttackRelease(pitch, trig.dur ?? '8n', t, trig.velocity);
+      synth.triggerAttackRelease(pitch, trig.dur ?? '8n', t, lockVel(trig.velocity, ev.vel));
     }
   } else if (ev.type === 'bass') {
-    voice.bass.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, voice.trig?.velocity ?? 0.85);
+    voice.bass.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, lockVel(voice.trig?.velocity ?? 0.85, ev.vel));
   } else if (ev.type === 'melody') {
-    voice.lead.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, voice.trig?.velocity ?? 0.82);
+    voice.lead.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, lockVel(voice.trig?.velocity ?? 0.82, ev.vel));
   } else if (ev.type === 'chords') {
     // Arp hits ride slightly hotter than sustained voicings (legacy 0.34 vs 0.30).
-    if (ev.mode === 'arp') voice.chordSyn.triggerAttackRelease(ev.note, sixteenth, t, 0.34);
-    else voice.chordSyn.triggerAttackRelease(ev.notes, durSeconds(ev.dur, sixteenth, barSeconds), t, voice.trig?.velocity ?? 0.3);
+    if (ev.mode === 'arp') voice.chordSyn.triggerAttackRelease(ev.note, sixteenth, t, lockVel(0.34, ev.vel));
+    else voice.chordSyn.triggerAttackRelease(ev.notes, durSeconds(ev.dur, sixteenth, barSeconds), t, lockVel(voice.trig?.velocity ?? 0.3, ev.vel));
   }
 }

--- a/docs/arcade/groovebox/engine/voices.js
+++ b/docs/arcade/groovebox/engine/voices.js
@@ -20,6 +20,8 @@ import { DEFAULT_INSTRUMENTS, DEFAULT_KIT, validateInstrument, slotKey } from '.
  * via voice.lead. disposeLane prefers voice.dispose().)
  */
 
+const BRIGHT_OPEN = 18000;   // transparent lowpass base for pitched brightness inserts
+
 const CTOR_BY_ARCHETYPE = {
   membrane: 'MembraneSynth',
   noise:    'NoiseSynth',
@@ -80,10 +82,16 @@ export function compileSynthPatch(inst) {
 }
 
 // Build one connected voice from a plan. Returns { synth, filter }.
-function buildFromPlan(plan, bus) {
+// openInsert: when the plan has no filter, add a transparent open lowpass so a
+// velocity lock has a cutoff to modulate (pitched brightness). Drums pass false
+// and keep using their plan filter (or none).
+function buildFromPlan(plan, bus, openInsert = false) {
   let out = bus, filter = null;
   if (plan.filter) {
     filter = new Tone.Filter(plan.filter.freq, plan.filter.type).connect(bus);
+    out = filter;
+  } else if (openInsert) {
+    filter = new Tone.Filter(BRIGHT_OPEN, 'lowpass').connect(bus);
     out = filter;
   }
   let synth;
@@ -140,11 +148,14 @@ export function createVoiceForType(type, bus, opts = {}) {
   if (!fallback) return {};
   const inst = resolveInstrument(opts.instrumentId ?? fallback, instruments, fallback);
   const plan = compileSynthPatch(inst);
-  const v = buildFromPlan(plan, bus);
+  const v = buildFromPlan(plan, bus, true);   // openInsert: a cutoff for velocity to modulate
   const dispose = () => { try { v.synth.dispose?.(); } catch (_) {} try { v.filter?.dispose?.(); } catch (_) {} };
-  if (type === 'bass')   return { bass: v.synth, trig: plan.trig, dispose };
-  if (type === 'chords') return { chordSyn: v.synth, chordFilter: v.filter, trig: plan.trig, dispose };
-  return { lead: v.synth, trig: plan.trig, dispose };
+  // Brightness modulates the character filter where one exists (chords @ 4200),
+  // else the open insert (bass/melody @ BRIGHT_OPEN — transparent at rest).
+  const tone = { toneFilter: v.filter, toneBase: plan.filter ? plan.filter.freq : BRIGHT_OPEN, toneType: plan.filter ? plan.filter.type : 'lowpass' };
+  if (type === 'bass')   return { bass: v.synth, trig: plan.trig, ...tone, dispose };
+  if (type === 'chords') return { chordSyn: v.synth, chordFilter: v.filter, trig: plan.trig, ...tone, dispose };
+  return { lead: v.synth, trig: plan.trig, ...tone, dispose };
 }
 
 // Note duration → seconds. DATA-MODEL allows durSteps|'bar' on ANY note lane;
@@ -166,22 +177,27 @@ function lockVel(base, vel) {
   return v < 0 ? 0 : v > 1 ? 1 : v;
 }
 
-// Velocity → brightness on a drum slot's tone filter. A lock shifts the cutoff
-// by up to ~1.5 octaves: accents (vel>1) pass MORE energy, ghosts less — so a
-// HIGHPASS moves DOWN on an accent (fuller), a LOWPASS moves UP. Scheduled at
-// audio time t; every filtered hit re-asserts a value (base when unlocked) so
-// the filter never sticks. No-op for unfiltered slots. Scalar math, no allocs.
+// Velocity → brightness: a lock shifts a tone filter's cutoff by up to ~1.5
+// octaves so accents pass MORE energy and ghosts less — a HIGHPASS moves DOWN on
+// an accent (fuller), a LOWPASS moves UP (brighter). Scheduled at audio time t;
+// every locked-or-not hit re-asserts a value (base when unlocked) so the filter
+// never sticks. No-op when there's no filter. Scalar math, no allocs.
+// Drums modulate their slot's own tone filter (hat/crash highpass). Pitched
+// lanes modulate either their character lowpass (chords @ 4200) or an OPEN insert
+// (bass/melody @ ~18k — transparent at rest, so unlocked notes are unchanged;
+// ghosts darken, accents stay bright). Same-lane note overlaps share the filter
+// (a soft tail can be nudged by the next note) — mild and musical, Elektron-ish.
 const BRIGHT_OCT = 1.5;
-function applyBrightness(slot, vel, t) {
-  if (!slot.filter) return;
-  let freq = slot.filterBase;
+function shiftCutoff(filter, base, type, vel, t) {
+  if (!filter) return;
+  let freq = base;
   if (vel != null) {
     let shift = (vel - 1) * BRIGHT_OCT;
     if (shift > BRIGHT_OCT) shift = BRIGHT_OCT; else if (shift < -BRIGHT_OCT) shift = -BRIGHT_OCT;
-    const dir = slot.filterType === 'highpass' ? -1 : 1;
-    freq = slot.filterBase * Math.pow(2, dir * shift);
+    const dir = type === 'highpass' ? -1 : 1;
+    freq = base * Math.pow(2, dir * shift);
   }
-  slot.filter.frequency.setValueAtTime(freq, t);
+  filter.frequency.setValueAtTime(freq, t);
 }
 
 /**
@@ -197,7 +213,7 @@ export function trigger(voice, ev, t, sixteenth, barSeconds) {
     const slot = note === null ? undefined : voice.byNote?.[note];
     if (!slot) return;
     const { synth, trig } = slot;
-    applyBrightness(slot, ev.vel, t);
+    shiftCutoff(slot.filter, slot.filterBase, slot.filterType, ev.vel, t);
     if (trig.sig === 'noise') {
       synth.triggerAttackRelease(trig.dur ?? '16n', t, lockVel(trig.velocity, ev.vel));
     } else {
@@ -206,10 +222,13 @@ export function trigger(voice, ev, t, sixteenth, barSeconds) {
       synth.triggerAttackRelease(pitch, trig.dur ?? '8n', t, lockVel(trig.velocity, ev.vel));
     }
   } else if (ev.type === 'bass') {
+    shiftCutoff(voice.toneFilter, voice.toneBase, voice.toneType, ev.vel, t);
     voice.bass.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, lockVel(voice.trig?.velocity ?? 0.85, ev.vel));
   } else if (ev.type === 'melody') {
+    shiftCutoff(voice.toneFilter, voice.toneBase, voice.toneType, ev.vel, t);
     voice.lead.triggerAttackRelease(ev.note, durSeconds(ev.dur, sixteenth, barSeconds), t, lockVel(voice.trig?.velocity ?? 0.82, ev.vel));
   } else if (ev.type === 'chords') {
+    shiftCutoff(voice.toneFilter, voice.toneBase, voice.toneType, ev.vel, t);
     // Arp hits ride slightly hotter than sustained voicings (legacy 0.34 vs 0.30).
     if (ev.mode === 'arp') voice.chordSyn.triggerAttackRelease(ev.note, sixteenth, t, lockVel(0.34, ev.vel));
     else voice.chordSyn.triggerAttackRelease(ev.notes, durSeconds(ev.dur, sixteenth, barSeconds), t, lockVel(voice.trig?.velocity ?? 0.3, ev.vel));

--- a/docs/arcade/groovebox/engine/voices.js
+++ b/docs/arcade/groovebox/engine/voices.js
@@ -124,7 +124,14 @@ export function createVoiceForType(type, bus, opts = {}) {
       if (!inst) continue;
       const plan = compileSynthPatch(inst);
       const v = buildFromPlan(plan, bus);
-      byNote[note] = { synth: v.synth, trig: plan.trig };
+      // Carry the slot's tone filter so a velocity lock can move its cutoff per
+      // hit (brightness, not just loudness). Unfiltered slots stay volume-only.
+      byNote[note] = {
+        synth: v.synth, trig: plan.trig,
+        filter: v.filter,
+        filterBase: plan.filter ? plan.filter.freq : 0,
+        filterType: plan.filter ? plan.filter.type : null,
+      };
       nodes.push(v.synth, v.filter);
     }
     return { byNote, dispose() { for (const n of nodes) { try { n?.dispose?.(); } catch (_) {} } } };
@@ -159,6 +166,24 @@ function lockVel(base, vel) {
   return v < 0 ? 0 : v > 1 ? 1 : v;
 }
 
+// Velocity → brightness on a drum slot's tone filter. A lock shifts the cutoff
+// by up to ~1.5 octaves: accents (vel>1) pass MORE energy, ghosts less — so a
+// HIGHPASS moves DOWN on an accent (fuller), a LOWPASS moves UP. Scheduled at
+// audio time t; every filtered hit re-asserts a value (base when unlocked) so
+// the filter never sticks. No-op for unfiltered slots. Scalar math, no allocs.
+const BRIGHT_OCT = 1.5;
+function applyBrightness(slot, vel, t) {
+  if (!slot.filter) return;
+  let freq = slot.filterBase;
+  if (vel != null) {
+    let shift = (vel - 1) * BRIGHT_OCT;
+    if (shift > BRIGHT_OCT) shift = BRIGHT_OCT; else if (shift < -BRIGHT_OCT) shift = -BRIGHT_OCT;
+    const dir = slot.filterType === 'highpass' ? -1 : 1;
+    freq = slot.filterBase * Math.pow(2, dir * shift);
+  }
+  slot.filter.frequency.setValueAtTime(freq, t);
+}
+
 /**
  * trigger(voice, ev, t, sixteenth, barSeconds)
  * Fires one scheduler event at audio time `t`.
@@ -172,6 +197,7 @@ export function trigger(voice, ev, t, sixteenth, barSeconds) {
     const slot = note === null ? undefined : voice.byNote?.[note];
     if (!slot) return;
     const { synth, trig } = slot;
+    applyBrightness(slot, ev.vel, t);
     if (trig.sig === 'noise') {
       synth.triggerAttackRelease(trig.dur ?? '16n', t, lockVel(trig.velocity, ev.vel));
     } else {

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -33,13 +33,36 @@ function meterValid(m) {
     (m.group === undefined || (Number.isInteger(m.group) && m.group >= 1 && m.group <= 64));
 }
 
-// Bar-shape depth only: drums bar = plain object of arrays; note bar
-// (bass/chords/melody) = array of note events. Per-step tuples are not
-// re-validated here — the engine is robust to bad picks by contract.
+// A per-step lock (DATA-MODEL "the lock object"): the one extensible slot on a
+// step. Today only velocity — { v } where v multiplies the voice's base
+// velocity (0 < v <= 2). Strict-keyed so a typo or a future-only key fails loud
+// instead of silently no-op'ing. New lock params join `v` here, with this doc.
+function lockValid(x) {
+  return isObj(x) && strictKeys(x, ['v'], 'lock') === null &&
+    typeof x.v === 'number' && Number.isFinite(x.v) && x.v > 0 && x.v <= 2;
+}
+
+// A pitched step tuple is [step, note, dur] with an OPTIONAL trailing lock
+// object: [step, note, dur, lock]. A drum step is a plain number, or a tuple
+// [step, ...] whose trailing element MAY be a lock ([step, lock] or
+// [step, semi, lock]). Trailing object ⇒ must be a valid lock.
+function stepTrailingLockOk(step) {
+  if (!Array.isArray(step) || step.length === 0) return typeof step === 'number';
+  const last = step[step.length - 1];
+  return (last !== null && typeof last === 'object') ? lockValid(last) : true;
+}
+
+// Bar-shape depth: drums bar = plain object of arrays; note bar
+// (bass/chords/melody) = array of note events. Step tuples are otherwise NOT
+// re-validated here (the engine is robust to bad picks) — the one exception is
+// the lock object, which is strict contract surface.
 function barsValid(laneType, bars) {
   if (!Array.isArray(bars) || bars.length < 1 || bars.length > 8) return false;
-  if (laneType === 'drums') return bars.every((b) => isObj(b) && Object.values(b).every(Array.isArray));
-  return bars.every((b) => Array.isArray(b) && b.every(Array.isArray));
+  if (laneType === 'drums') {
+    return bars.every((b) => isObj(b) &&
+      Object.values(b).every((steps) => Array.isArray(steps) && steps.every(stepTrailingLockOk)));
+  }
+  return bars.every((b) => Array.isArray(b) && b.every((t) => Array.isArray(t) && stepTrailingLockOk(t)));
 }
 
 // A groove VALUE in song.grooves: bars[] (literal) or — note lanes only —

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -49,7 +49,9 @@ function lockValid(x) {
 function stepTrailingLockOk(step) {
   if (!Array.isArray(step) || step.length === 0) return typeof step === 'number';
   const last = step[step.length - 1];
-  return (last !== null && typeof last === 'object') ? lockValid(last) : true;
+  // Only a plain object is a lock. A trailing ARRAY is a chord voicing (e.g.
+  // [step, ['E4','G4']] with dur omitted) — not a lock, and was valid before.
+  return (last !== null && typeof last === 'object' && !Array.isArray(last)) ? lockValid(last) : true;
 }
 
 // Bar-shape depth: drums bar = plain object of arrays; note bar

--- a/docs/arcade/groovebox/tests/plocks.test.js
+++ b/docs/arcade/groovebox/tests/plocks.test.js
@@ -201,6 +201,39 @@ test('a locked hit on an unfiltered slot still fires (volume-only, no crash)', (
   expect(lastVel(synth)).toBe(0.5);
 });
 
+// ── pitched lanes get brightness too: chords modulate their own lowpass
+//    (around its 4200 character), bass/melody an OPEN insert (transparent at
+//    rest; ghosts darken, accents stay bright). dir: lowpass opens on accent. ──
+test('chord accent raises the lowpass cutoff above its base', () => {
+  const synth = fakeSynth(), filter = fakeFilter('lowpass', 4200);
+  const voice = { chordSyn: synth, trig: { velocity: 0.3 }, toneFilter: filter, toneBase: 4200, toneType: 'lowpass' };
+  trigger(voice, { type: 'chords', mode: 'arp', note: 'E4', dur: 1, vel: 1.8 }, 3, 0.1, 1.6);
+  expect(lastFreq(filter)).toBeGreaterThan(4200);
+});
+
+test('melody ghost lowers the open insert cutoff below base; unlocked resets to base', () => {
+  const synth = fakeSynth(), filter = fakeFilter('lowpass', 18000);
+  const voice = { lead: synth, trig: { velocity: 0.82 }, toneFilter: filter, toneBase: 18000, toneType: 'lowpass' };
+  trigger(voice, { type: 'melody', note: 'C5', dur: 2, vel: 0.3 }, 3, 0.1, 1.6);
+  expect(lastFreq(filter)).toBeLessThan(18000);
+  trigger(voice, { type: 'melody', note: 'C5', dur: 2 }, 4, 0.1, 1.6);
+  expect(lastFreq(filter)).toBe(18000);
+});
+
+test('bass brightness is scheduled at the hit time t', () => {
+  const synth = fakeSynth(), filter = fakeFilter('lowpass', 18000);
+  const voice = { bass: synth, trig: { velocity: 0.85 }, toneFilter: filter, toneBase: 18000, toneType: 'lowpass' };
+  trigger(voice, { type: 'bass', note: 'C2', dur: 2, vel: 0.4 }, 7, 0.1, 1.6);
+  expect(filter.calls.at(-1)[1]).toBe(7);
+});
+
+test('pitched voices without a tone filter still fire (no crash)', () => {
+  const synth = fakeSynth();
+  const voice = { lead: synth, trig: { velocity: 0.82 } };
+  expect(() => trigger(voice, { type: 'melody', note: 'C5', dur: 2, vel: 0.5 }, 0, 0.1, 1.6)).not.toThrow();
+  expect(lastVel(synth)).toBeCloseTo(0.41);
+});
+
 // ── validator: the lock object is the strict contract surface ──
 const groove = bars => ({ laneType: 'melody', meter: meter44, relative: true, bars });
 

--- a/docs/arcade/groovebox/tests/plocks.test.js
+++ b/docs/arcade/groovebox/tests/plocks.test.js
@@ -1,0 +1,203 @@
+import { test, expect } from 'vitest';
+import { eventsForStepV2, setDrumStep, toggleNote } from '../engine/patterns.js';
+import { trigger } from '../engine/voices.js';
+import { validateSongPayload, validateGroovePayload } from '../registry/validate.js';
+
+const meter44 = { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 };
+
+// Velocity p-locks: a step's optional lock object ({ v }) rides the tuple —
+// pitched [s, n, dur, lock], drums [s, lock] | [s, semi, lock] (type-discriminated:
+// number = semi, object = lock). Events carry vel; absent lock → no vel.
+function makeSong() {
+  return {
+    meter: meter44,
+    lanes: [
+      { id: 'drums', type: 'drums', name: 'drums', muted: false, soloed: false },
+      { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false },
+      { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
+      { id: 'bass', type: 'bass', name: 'bass', muted: false, soloed: false },
+    ],
+    grooves: {
+      drums: {
+        beat: [{ 42: [0, [4, { v: 0.4 }], 8], 45: [[2, -3], [6, -3, { v: 0.6 }]] }],
+      },
+      melody: {
+        riff: [[[0, 'C4', 2, { v: 0.5 }], [4, 'D4', 2]]],
+      },
+      chords: {
+        pad: [[[0, ['E4', 'G4'], 'bar', { v: 0.7 }]]],
+      },
+      bass: {
+        pump: { relative: true, bars: [[[0, 'R', 2, { v: 0.3 }]]] },
+      },
+    },
+    patterns: [{
+      lanes: { drums: 'beat', melody: 'riff', chords: 'pad', bass: 'pump' },
+      chords: [{ name: 'Cm', root: 'C2', voicing: ['C3', 'D#3', 'G3'] }],
+    }],
+    chain: [0],
+    fills: {},
+  };
+}
+
+const at = (song, step) => eventsForStepV2(song, 0, 0, step);
+const lane = (evs, id) => evs.find(e => e.laneId === id);
+
+// ── lock parsing → event.vel ──
+test('pitched literal step with lock carries vel', () => {
+  expect(lane(at(makeSong(), 0), 'melody').vel).toBe(0.5);
+});
+
+test('pitched literal step without lock has no vel', () => {
+  expect(lane(at(makeSong(), 4), 'melody').vel).toBeUndefined();
+});
+
+test('drum step [s, lock] carries vel; plain steps do not', () => {
+  const hit = at(makeSong(), 4).find(e => e.type === 'drums' && e.voice === 42);
+  expect(hit.vel).toBe(0.4);
+  expect(hit.semi).toBeUndefined();
+  const plain = at(makeSong(), 0).find(e => e.type === 'drums' && e.voice === 42);
+  expect(plain.vel).toBeUndefined();
+});
+
+test('pitched drum step [s, semi, lock] carries both semi and vel', () => {
+  const hit = at(makeSong(), 6).find(e => e.type === 'drums' && e.voice === 45);
+  expect(hit.semi).toBe(-3);
+  expect(hit.vel).toBe(0.6);
+  const plain = at(makeSong(), 2).find(e => e.type === 'drums' && e.voice === 45);
+  expect(plain.semi).toBe(-3);
+  expect(plain.vel).toBeUndefined();
+});
+
+test('chord pad step with lock carries vel', () => {
+  expect(lane(at(makeSong(), 0), 'chords').vel).toBe(0.7);
+});
+
+test('relative groove step with lock carries vel through REF resolution', () => {
+  expect(lane(at(makeSong(), 0), 'bass').vel).toBe(0.3);
+});
+
+test('fill bar drum locks are honoured', () => {
+  const fill = { 38: [[8, { v: 1.3 }]] };
+  const evs = eventsForStepV2(makeSong(), 0, 0, 8, fill);
+  expect(evs.find(e => e.voice === 38).vel).toBe(1.3);
+});
+
+// ── editor preservation: edits must not strip other steps' locks ──
+test('setDrumStep toggling one step preserves locks on other steps', () => {
+  const song = makeSong();
+  setDrumStep(song, 'drums', 0, 42, 10, true);   // add step 10
+  setDrumStep(song, 'drums', 0, 42, 0, false);   // remove step 0
+  expect(at(song, 4).find(e => e.voice === 42).vel).toBe(0.4);
+});
+
+test('toggleNote on one step preserves locks on other steps', () => {
+  const song = makeSong();
+  toggleNote(song, 'melody', 0, 8, 'E4');        // add a note at step 8
+  expect(lane(at(song, 0), 'melody').vel).toBe(0.5);
+});
+
+// ── trigger: vel multiplies the voice's base velocity, clamped to 0..1 ──
+// Unlocked events must pass the base velocity through UNCHANGED (parity).
+function fakeSynth() {
+  const calls = [];
+  return { calls, triggerAttackRelease: (...a) => { calls.push(a); } };
+}
+const lastVel = synth => synth.calls.at(-1).at(-1);
+
+test('locked noise drum: vel multiplies trig.velocity', () => {
+  const synth = fakeSynth();
+  const voice = { byNote: { 42: { synth, trig: { sig: 'noise', dur: '16n', velocity: 0.6 } } } };
+  trigger(voice, { type: 'drums', voice: 42, vel: 0.5 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBeCloseTo(0.3);
+});
+
+test('unlocked noise drum passes base velocity through unchanged', () => {
+  const synth = fakeSynth();
+  const voice = { byNote: { 42: { synth, trig: { sig: 'noise', dur: '16n', velocity: 0.6 } } } };
+  trigger(voice, { type: 'drums', voice: 42 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBe(0.6);
+});
+
+test('locked drum with undefined base velocity treats base as 1', () => {
+  const synth = fakeSynth();
+  const voice = { byNote: { 36: { synth, trig: { sig: 'note', note: 'C1', dur: '8n', velocity: undefined } } } };
+  trigger(voice, { type: 'drums', voice: 36, vel: 0.5 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBe(0.5);
+});
+
+test('unlocked drum with undefined base velocity stays undefined (parity)', () => {
+  const synth = fakeSynth();
+  const voice = { byNote: { 36: { synth, trig: { sig: 'note', note: 'C1', dur: '8n', velocity: undefined } } } };
+  trigger(voice, { type: 'drums', voice: 36 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBeUndefined();
+});
+
+test('locked bass: vel multiplies the 0.85 base', () => {
+  const synth = fakeSynth();
+  trigger({ bass: synth, trig: { velocity: 0.85 } }, { type: 'bass', note: 'C2', dur: 2, vel: 0.4 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBeCloseTo(0.34);
+});
+
+test('accent lock above 1 clamps the product at 1', () => {
+  const synth = fakeSynth();
+  trigger({ bass: synth, trig: { velocity: 0.85 } }, { type: 'bass', note: 'C2', dur: 2, vel: 1.5 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBe(1);
+});
+
+test('locked chord arp: vel multiplies the 0.34 arp base', () => {
+  const synth = fakeSynth();
+  trigger({ chordSyn: synth, trig: { velocity: 0.3 } }, { type: 'chords', mode: 'arp', note: 'E4', dur: 1, vel: 0.5 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBeCloseTo(0.17);
+});
+
+test('locked melody: vel multiplies the 0.82 base', () => {
+  const synth = fakeSynth();
+  trigger({ lead: synth, trig: { velocity: 0.82 } }, { type: 'melody', note: 'C5', dur: 2, vel: 0.5 }, 0, 0.1, 1.6);
+  expect(lastVel(synth)).toBeCloseTo(0.41);
+});
+
+// ── validator: the lock object is the strict contract surface ──
+const groove = bars => ({ laneType: 'melody', meter: meter44, relative: true, bars });
+
+test('groove payload accepts a valid velocity lock', () => {
+  expect(validateGroovePayload(groove([[[0, 'R', 2, { v: 0.5 }]]])).ok).toBe(true);
+});
+
+test('groove payload rejects a lock with an unknown key', () => {
+  expect(validateGroovePayload(groove([[[0, 'R', 2, { v: 0.5, x: 1 }]]])).ok).toBe(false);
+});
+
+test('groove payload rejects v out of (0,2]', () => {
+  expect(validateGroovePayload(groove([[[0, 'R', 2, { v: 0 }]]])).ok).toBe(false);
+  expect(validateGroovePayload(groove([[[0, 'R', 2, { v: 2.5 }]]])).ok).toBe(false);
+  expect(validateGroovePayload(groove([[[0, 'R', 2, { v: -1 }]]])).ok).toBe(false);
+});
+
+test('groove payload rejects non-number v', () => {
+  expect(validateGroovePayload(groove([[[0, 'R', 2, { v: 'loud' }]]])).ok).toBe(false);
+});
+
+test('song payload accepts pitched, drum, and tom locks', () => {
+  const drumSong = {
+    version: 2, title: 'T', artist: 'A', meter: meter44, bpm: 120,
+    lanes: [{ id: 'd', type: 'drums', name: 'D', muted: false, soloed: false }],
+    grooves: { d: { g: [{ 42: [0, [4, { v: 0.4 }]], 45: [[6, -3, { v: 0.6 }]] }] } },
+    patterns: [{ lanes: { d: 'g' } }], chain: [0], fills: {},
+  };
+  expect(validateSongPayload(drumSong).ok).toBe(true);
+});
+
+test('song payload rejects a malformed drum lock', () => {
+  const drumSong = {
+    version: 2, title: 'T', artist: 'A', meter: meter44, bpm: 120,
+    lanes: [{ id: 'd', type: 'drums', name: 'D', muted: false, soloed: false }],
+    grooves: { d: { g: [{ 42: [0, [4, { v: 9 }]] }] } },
+    patterns: [{ lanes: { d: 'g' } }], chain: [0], fills: {},
+  };
+  expect(validateSongPayload(drumSong).ok).toBe(false);
+});
+
+test('unlocked songs and grooves still validate (additive, no regression)', () => {
+  expect(validateGroovePayload(groove([[[0, 'R', 2]]])).ok).toBe(true);
+});

--- a/docs/arcade/groovebox/tests/plocks.test.js
+++ b/docs/arcade/groovebox/tests/plocks.test.js
@@ -60,6 +60,16 @@ test('drum step [s, lock] carries vel; plain steps do not', () => {
   expect(plain.vel).toBeUndefined();
 });
 
+test('drum position-1 array is not mistaken for the lock — a real trailing lock still reads', () => {
+  // Malformed [step, array, lock]: only a PLAIN object is a lock (matches the
+  // validator + contract). The array must not shadow the real lock at s[2].
+  const song = makeSong();
+  song.grooves.drums.beat[0][42] = [[4, ['oops'], { v: 0.5 }]];
+  const hit = eventsForStepV2(song, 0, 0, 4).find(e => e.type === 'drums' && e.voice === 42);
+  expect(hit.vel).toBe(0.5);
+  expect(hit.semi ?? 0).toBe(0);          // garbage array never becomes a semitone
+});
+
 test('pitched drum step [s, semi, lock] carries both semi and vel', () => {
   const hit = at(makeSong(), 6).find(e => e.type === 'drums' && e.voice === 45);
   expect(hit.semi).toBe(-3);

--- a/docs/arcade/groovebox/tests/plocks.test.js
+++ b/docs/arcade/groovebox/tests/plocks.test.js
@@ -85,16 +85,29 @@ test('fill bar drum locks are honoured', () => {
 
 // ── editor preservation: edits must not strip other steps' locks ──
 test('setDrumStep toggling one step preserves locks on other steps', () => {
-  const song = makeSong();
-  setDrumStep(song, 'drums', 0, 42, 10, true);   // add step 10
-  setDrumStep(song, 'drums', 0, 42, 0, false);   // remove step 0
+  const song = makeSong();                                  // hat: [0, [4,{v:0.4}], 8]
+  setDrumStep(song, 'drums', 'beat', 0, 42, 10, true, false);   // add step 10
+  setDrumStep(song, 'drums', 'beat', 0, 42, 0, false, false);   // remove step 0
   expect(at(song, 4).find(e => e.voice === 42).vel).toBe(0.4);
 });
 
 test('toggleNote on one step preserves locks on other steps', () => {
   const song = makeSong();
-  toggleNote(song, 'melody', 0, 8, 'E4');        // add a note at step 8
+  toggleNote(song, 'melody', 'riff', 0, 8, 'E4');          // add a note at step 8
   expect(lane(at(song, 0), 'melody').vel).toBe(0.5);
+});
+
+test('setDrumStep can remove a LOCKED non-pitched step (stored as [step, lock])', () => {
+  const song = makeSong();                                  // hat: [0, [4,{v:0.4}], 8]
+  setDrumStep(song, 'drums', 'beat', 0, 42, 4, false, false);
+  expect(at(song, 4).some(e => e.type === 'drums' && e.voice === 42)).toBe(false);
+});
+
+test('setDrumStep toggling a locked step ON does not duplicate it', () => {
+  const song = makeSong();
+  setDrumStep(song, 'drums', 'beat', 0, 42, 4, true, false);    // already present as a lock
+  const hits = at(song, 4).filter(e => e.type === 'drums' && e.voice === 42);
+  expect(hits.length).toBe(1);
 });
 
 // ── trigger: vel multiplies the voice's base velocity, clamped to 0..1 ──
@@ -277,4 +290,11 @@ test('song payload rejects a malformed drum lock', () => {
 
 test('unlocked songs and grooves still validate (additive, no regression)', () => {
   expect(validateGroovePayload(groove([[[0, 'R', 2]]])).ok).toBe(true);
+});
+
+test('a chord tuple whose last element is a notes-array (dur omitted) is NOT mistaken for a lock', () => {
+  // [step, notesArray] — old validator accepted it (b.every(Array.isArray)); the
+  // trailing array must not be routed through lockValid and rejected.
+  const chordGroove = { laneType: 'chords', meter: meter44, bars: [[[0, ['E4', 'G4']]]] };
+  expect(validateGroovePayload(chordGroove).ok).toBe(true);
 });

--- a/docs/arcade/groovebox/tests/plocks.test.js
+++ b/docs/arcade/groovebox/tests/plocks.test.js
@@ -157,6 +157,50 @@ test('locked melody: vel multiplies the 0.82 base', () => {
   expect(lastVel(synth)).toBeCloseTo(0.41);
 });
 
+// ── velocity → brightness: a locked drum hit also moves its filter cutoff ──
+// Accent (vel>1) pulls a HIGHPASS down (fuller); ghost (vel<1) pushes it up
+// (thinner). Unfiltered slots are volume-only. Cutoff is set at audio time t.
+function fakeFilter(type, base) {
+  const calls = [];
+  return { type, _base: base, frequency: { setValueAtTime: (v, t) => calls.push([v, t]) }, calls };
+}
+const lastFreq = f => f.calls.at(-1)[0];
+
+test('accent on a highpass-filtered drum lowers the cutoff below base', () => {
+  const synth = fakeSynth(), filter = fakeFilter('highpass', 7000);
+  const voice = { byNote: { 42: { synth, trig: { sig: 'noise', dur: '32n', velocity: 0.6 }, filter, filterBase: 7000, filterType: 'highpass' } } };
+  trigger(voice, { type: 'drums', voice: 42, vel: 1.9 }, 5, 0.1, 1.6);
+  expect(lastFreq(filter)).toBeLessThan(7000);
+});
+
+test('ghost on a highpass-filtered drum raises the cutoff above base', () => {
+  const synth = fakeSynth(), filter = fakeFilter('highpass', 7000);
+  const voice = { byNote: { 42: { synth, trig: { sig: 'noise', dur: '32n', velocity: 0.6 }, filter, filterBase: 7000, filterType: 'highpass' } } };
+  trigger(voice, { type: 'drums', voice: 42, vel: 0.3 }, 5, 0.1, 1.6);
+  expect(lastFreq(filter)).toBeGreaterThan(7000);
+});
+
+test('an unlocked hit on a filtered slot resets the cutoff to base (no stuck filter)', () => {
+  const synth = fakeSynth(), filter = fakeFilter('highpass', 7000);
+  const voice = { byNote: { 42: { synth, trig: { sig: 'noise', dur: '32n', velocity: 0.6 }, filter, filterBase: 7000, filterType: 'highpass' } } };
+  trigger(voice, { type: 'drums', voice: 42 }, 5, 0.1, 1.6);
+  expect(lastFreq(filter)).toBe(7000);
+});
+
+test('brightness is scheduled at the hit time t', () => {
+  const synth = fakeSynth(), filter = fakeFilter('highpass', 7000);
+  const voice = { byNote: { 42: { synth, trig: { sig: 'noise', dur: '32n', velocity: 0.6 }, filter, filterBase: 7000, filterType: 'highpass' } } };
+  trigger(voice, { type: 'drums', voice: 42, vel: 1.5 }, 9, 0.1, 1.6);
+  expect(filter.calls.at(-1)[1]).toBe(9);
+});
+
+test('a locked hit on an unfiltered slot still fires (volume-only, no crash)', () => {
+  const synth = fakeSynth();
+  const voice = { byNote: { 36: { synth, trig: { sig: 'note', note: 'C1', dur: '8n', velocity: undefined }, filter: null, filterBase: 0, filterType: null } } };
+  expect(() => trigger(voice, { type: 'drums', voice: 36, vel: 0.5 }, 0, 0.1, 1.6)).not.toThrow();
+  expect(lastVel(synth)).toBe(0.5);
+});
+
 // ── validator: the lock object is the strict contract surface ──
 const groove = bars => ({ laneType: 'melody', meter: meter44, relative: true, bars });
 


### PR DESCRIPTION
## What

Per-step **parameter locks** (p-locks), velocity first. A step may carry an optional trailing lock object `{ v }` where `v` multiplies the voice's base velocity (`0 < v <= 2`, product clamped to `0..1`). Purely additive — a lock-less step is byte-identical to before, so the legacy parity suite holds unchanged.

`v` also drives a **brightness** shift on tone filters: accents pull a cutoff to pass more energy (highpass down / lowpass up), ghosts less — so dynamics read as timbre, not just level. Drums use their hat/crash filter; pitched lanes use the chords' character lowpass or a transparent open insert on bass/melody.

## Schema (additive to song v2 — no version bump)

- pitched step: `[s, n, dur, lock?]`
- drum step: `number | [s, lock] | [s, semi, lock]` (type-discriminated — number = semitone, object = lock)
- relative grooves + fills included
- `lock` is strict contract surface in `registry/validate.js`: only key `v`, finite, `(0, 2]`

Old clients degrade gracefully (the deployed validator already accepts longer tuples; the deployed engine destructures `[s,n,dur]` and ignores the rest), so a locked song shared today plays everywhere — just flat. No registry migration.

## Engine

- `eventsForStepV2` reads the lock → `event.vel`
- `voices.js` `trigger()` multiplies base velocity + `shiftCutoff()` modulates the filter at audio time `t`. Scalar math, no hot-path allocs. Unlocked notes pass the exact pre-diff velocities through (`lockVel(base, null) === base`).

## Review

Reviewed by two independent agents before this PR; both findings fixed with regression tests:
1. `setDrumStep` couldn't toggle off a **locked** non-pitched drum step (`indexOf(number)` never matched `[step, lock]`) → matched both shapes.
2. Validator narrowed acceptance of a chord tuple whose last element is a voicing array → only a *plain* object is treated as a lock.

**374 tests green.** `compileSynthPatch` unchanged → `voices-adapter` parity holds.

## Known, accepted

Every pitched voice now routes through an always-on ~18 kHz lowpass insert (transparent at rest) so velocity has a cutoff to modulate — including legacy presets. Practically inaudible, but it's an audio-graph change no test guards (parity tests check the patch plan / note stream, not the node graph). The clean alternative (lazy filter creation) would add hot-path allocation, so it was left in deliberately.

## Not included

Slice 2 (conditional trigs `{ c }`) and micro-timing `{ t }` live in the same lock object — future work. No CHANGELOG entry (arcade scope). Ear-test artifact (Mother of Pearl, locked) and the dev A/B picker wiring stay local, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)