### PR TITLE
arcade(groovebox): song-row clarity — colour-coded patterns, verbs, captions

### DIFF
--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -610,9 +610,11 @@ input[type=range] {
 #lcd-song .pat-lbl { color: var(--screen-dim); }
 #lcd-song .h-chip.h-empty { color: var(--screen-dim); }
 #lcd-song .pat-slot.sel {
-  background: var(--screen-acc);
+  background: color-mix(in srgb, var(--screen-acc) 14%, transparent);
   border-color: var(--screen-acc);
-  color: var(--screen-bg);
+  color: var(--screen-ink);
+  box-shadow: 0 0 0 1px var(--screen-acc);
+  font-weight: 700;
 }
 #lcd-song .pat-slot.playing { border-color: var(--screen-hot); box-shadow: 0 0 8px var(--screen-hot); }
 #lcd-song .chain-chip.playing { border-color: var(--screen-hot); color: var(--screen-hot); box-shadow: 0 0 6px var(--screen-hot); }
@@ -621,14 +623,15 @@ input[type=range] {
    chip rows read as a table. */
 #lcd-song .pat-row > .pat-lbl,
 #lcd-song .chain-row > .pat-lbl {
-  flex: 0 0 64px;
-  width: 64px;
+  flex: 0 0 72px;
+  width: 72px;
   text-align: right;
   margin-right: 4px;
+  line-height: 1.25;
 }
 /* Chords nest under their pattern: indent + accent spine = "this pattern's chords". */
 #lcd-song .chord-row {
-  margin-left: 68px;
+  margin-left: 76px;
   padding-left: 10px;
   border-left: 2px solid color-mix(in srgb, var(--screen-acc) 40%, transparent);
 }
@@ -641,6 +644,43 @@ input[type=range] {
   margin-left: 10px;
   white-space: nowrap;
 }
+/* Row sub-captions — persistent "what is this row" teaching under each label. */
+#lcd-song .pat-lbl small {
+  display: block;
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--screen-dim);
+  margin-top: 1px;
+}
+/* "Add" affordances read as create slots (dashed), distinct from real chips. */
+#lcd-song .pat-add, #lcd-song .chain-add { border-style: dashed; opacity: .85; }
+/* First-run hint banner above the rows. */
+.song-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  padding: 7px 10px;
+  font-size: 11.5px;
+  color: var(--screen-dim);
+  background: color-mix(in srgb, var(--screen-acc) 9%, transparent);
+  border: 1px solid color-mix(in srgb, var(--screen-acc) 30%, transparent);
+  border-radius: 7px;
+}
+.song-hint b { color: var(--screen-acc); }
+.song-hint-x {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--screen-dim);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 4px;
+}
+.song-hint-x:hover { color: var(--screen-ink); }
 
 /* ─── Theme picker — drawer with live swatches under the titlebar button ──── */
 #themebtn.open { border-color: var(--acc); color: var(--acc); }
@@ -1798,7 +1838,8 @@ body.gb-knob-values .knob-val { display: block; }
 .pat-row, .chain-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 6px 0; transition: opacity .2s; }
 .pat-row.dimmed, .chain-row.dimmed { opacity: .45; }
 .pat-lbl { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--dim); margin-right: 4px; }
-.pat-slot { min-width: 34px; height: 30px; border-radius: 6px; border: 1px solid var(--line); background: var(--panel); color: var(--ink); cursor: pointer; }
+.pat-slot { min-width: 34px; height: 30px; border-radius: 6px; border: 1px solid var(--line); background: var(--panel); color: var(--ink); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 5px; padding: 0 9px; }
+.pat-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 8px; display: inline-block; }
 .pat-slot.sel { background: var(--acc); color: var(--bg); border-color: var(--acc); font-weight: 700; }
 .pat-slot.playing { box-shadow: 0 0 8px var(--hot); border-color: var(--hot); }
 .pat-add { opacity: .6; }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -979,6 +979,20 @@ function fmtKeyName(key) {
 
 let _chainDragFrom = null;
 
+// Per-pattern identity colour, derived from index. The same dot rides the
+// pattern slot and every song slot that plays it, so the song reads as a
+// sequence of *references* rather than a second bank of numbers. (Colour tracks
+// position; it shifts if patterns are added/removed — stable per-pattern IDs are
+// future work.)
+const PATTERN_COLORS = [
+  '#e8742a', '#2a9d8f', '#5566d8', '#c44ec9',
+  '#3a9d4a', '#d8443a', '#caa02a', '#8a5cd8',
+  '#2aa3c4', '#d86aa0', '#6a9d2a', '#a05cd8',
+  '#d8902a', '#3a78d8', '#c43a78', '#2a9d6a',
+];
+const patternColor = i => PATTERN_COLORS[i % PATTERN_COLORS.length];
+const patDot = i => `<span class="pat-dot" style="background:${patternColor(i)}"></span>`;
+
 function renderPatterns() {
   const host = document.getElementById('lcd-song-rows');
   if (!host) return;
@@ -987,26 +1001,39 @@ function renderPatterns() {
   const chain = eng.getChain();
   const editIdx = eng.getEditPatternIndex();
 
+  // First-run teaching: a dismissible one-liner naming the make-loops → arrange
+  // flow. Persistent inline labels (below) carry the lesson after it's dismissed.
+  if (!localStorage.getItem('gb-song-hint-off')) {
+    const hint = document.createElement('div');
+    hint.className = 'song-hint';
+    hint.innerHTML = `<span>💡 Make loops in <b>Patterns</b>, then line them up in the <b>Song</b> below.</span><button class="song-hint-x" title="dismiss">✕</button>`;
+    hint.querySelector('.song-hint-x').onclick = () => {
+      try { localStorage.setItem('gb-song-hint-off', '1'); } catch (e) { /* private mode */ }
+      hint.remove();
+    };
+    host.appendChild(hint);
+  }
+
   // Patterns row: small "patterns" label (matching chords/chain rows) + slots +
   // duplicate/delete for the selected pattern.
   const prow = document.createElement('div');
   prow.className = 'pat-row';
   const plbl = document.createElement('span');
   plbl.className = 'pat-lbl';
-  plbl.textContent = 'patterns';
+  plbl.innerHTML = 'patterns<small>your loops</small>';
   prow.appendChild(plbl);
   patterns.forEach((p, i) => {
     const b = document.createElement('button');
     b.className = 'pat-slot' + (i === editIdx ? ' sel' : '');
     b.dataset.idx = i;
-    b.textContent = i === editIdx ? `${i + 1} ✎` : `${i + 1}`;
+    b.innerHTML = `${patDot(i)}<span>${i + 1}${i === editIdx ? ' ✎' : ''}</span>`;
     b.title = 'click: edit this pattern — play will loop it';
     b.onclick = () => { eng.selectPattern(i); renderPatterns(); refreshVizPattern(); };
     prow.appendChild(b);
   });
   const add = document.createElement('button');
   add.className = 'pat-slot pat-add';
-  add.textContent = '＋';
+  add.textContent = '＋ New';
   add.title = 'add pattern';
   add.disabled = patterns.length >= 16;
   add.onclick = () => {
@@ -1016,7 +1043,7 @@ function renderPatterns() {
   prow.appendChild(add);
 
   const dup = document.createElement('button');
-  dup.className = 'pat-act'; dup.textContent = '⧉'; dup.title = 'duplicate pattern';
+  dup.className = 'pat-act'; dup.textContent = '⧉ Copy'; dup.title = 'duplicate pattern';
   dup.disabled = patterns.length >= 16;
   dup.onclick = () => {
     const idx = eng.duplicatePattern(editIdx);
@@ -1025,7 +1052,7 @@ function renderPatterns() {
   prow.appendChild(dup);
 
   const del = document.createElement('button');
-  del.className = 'pat-act'; del.textContent = '✕'; del.title = 'delete pattern';
+  del.className = 'pat-act'; del.textContent = '✕ Delete'; del.title = 'delete pattern';
   del.disabled = patterns.length <= 1;
   del.onclick = () => { eng.removePattern(editIdx); renderPatterns(); refreshVizPattern(); };
   prow.appendChild(del);
@@ -1041,13 +1068,13 @@ function renderPatterns() {
   // Chain row: chips (click = play chain from there; hover-✕ removes; drag reorders) + append.
   const crow = document.createElement('div');
   crow.className = 'chain-row';
-  crow.innerHTML = `<span class="pat-lbl">chain</span>`;
+  crow.innerHTML = `<span class="pat-lbl">song<small>play order →</small></span>`;
   chain.forEach((pi, pos) => {
     const chip = document.createElement('button');
     chip.className = 'chain-chip';
     chip.dataset.pos = pos;
     chip.draggable = true;
-    chip.innerHTML = `<span>${pi + 1}</span><span class="chip-x" title="remove">✕</span>`;
+    chip.innerHTML = `${patDot(pi)}<span>${pi + 1}</span><span class="chip-x" title="remove">✕</span>`;
     chip.onclick = e => {
       if (e.target.classList.contains('chip-x')) { if (eng.removeChainAt(pos)) renderPatterns(); return; }
       eng.playChain(pos);
@@ -1070,7 +1097,7 @@ function renderPatterns() {
   });
   const append = document.createElement('button');
   append.className = 'chain-chip chain-add';
-  append.textContent = '＋';
+  append.textContent = '＋ Add';
   append.title = 'append selected pattern to chain';
   append.onclick = () => { eng.appendToChain(eng.getEditPatternIndex()); renderPatterns(); };
   crow.appendChild(append);
@@ -1193,7 +1220,7 @@ function buildChordLine(idx) {
   row.dataset.idx = idx;
   const lbl = document.createElement('span');
   lbl.className = 'pat-lbl';
-  lbl.textContent = 'chords';
+  lbl.innerHTML = `chords<small>of pattern ${idx + 1}</small>`;
   row.appendChild(lbl);
 
   const chips = document.createElement('div');


### PR DESCRIPTION
**Story 0** of the groovebox song-editor redesign epic (`~/Dev/project-notes/oyster/po20/song-editor-redesign/EPIC.md`) — the low-risk presentational clarity polish, landed to clear the branch before the structural work begins.

## What
- **Per-pattern identity colour** — the same dot rides a pattern slot and every song chip that references it, so the song row reads as a *sequence of references*, not a second bank of numbers.
- **Verb buttons** — `＋ New` / `⧉ Copy` / `✕ Delete` / `＋ Add` (were bare glyphs).
- **Persistent row sub-captions** — "your loops" under *patterns*, "play order →" under *song*, "of pattern N" under *chords* — teaching that survives after the hint is gone.
- **Dismissible first-run hint** naming the make-loops → arrange flow (persists via localStorage).
- **"chain" → "song"**; selected-slot fill softened from a solid block to a tint + ring (legible without shouting).

## Scope
Presentational only — no engine/schema change. Pattern colour is index-derived (shifts if patterns are added/removed; stable per-pattern IDs are future work, noted inline).

## Verify
- ✅ 338/338 tests green (`npm test` in `docs/arcade/groovebox`)
- Colours match between the patterns row and the chain row (same `patternColor(i)`).
- Hint dismisses and stays dismissed across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)