### PR TITLE
arcade(groovebox): named sections — optional pattern.name + inline rename

### DIFF
--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -837,6 +837,13 @@ export function createEngine() {
       const key = deriveKey(all);
       if (key) song.key = key; else delete song.key;
     },
+    // Section name (optional, UI-only — engine never reads it). Empty = unnamed,
+    // the UI falls back to "P{n}". Capped short; sharing validates ≤ NAME_MAX.
+    getPatternName(i) { return song?.patterns[i]?.name ?? ''; },
+    setPatternName(i, name) {
+      if (!song || !song.patterns[i]) return;
+      song.patterns[i].name = String(name ?? '').trim().slice(0, 40);
+    },
     setTranspose(semis) {
       if (!song) return;
       song.transpose = semis | 0;

--- a/docs/arcade/groovebox/engine/patterns.js
+++ b/docs/arcade/groovebox/engine/patterns.js
@@ -212,7 +212,7 @@ export function addPattern(song, fromIdx = 0) {
   if (song.patterns.length >= MAX_PATTERNS) return null;
   const src = song.patterns[fromIdx] || song.patterns[0];
   if (!src) return null;
-  song.patterns.push({ lanes: { ...src.lanes } });
+  song.patterns.push({ lanes: { ...src.lanes }, name: '' });
   return song.patterns.length - 1;
 }
 

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -124,7 +124,8 @@ export function validateSongPayload(p) {
   }
   if (!Array.isArray(p.patterns) || p.patterns.length < 1 || p.patterns.length > 16) return err('patterns must be 1..16');
   for (const pat of p.patterns) {
-    if (!isObj(pat) || strictKeys(pat, ['lanes', 'chords'], 'pattern') !== null || !isObj(pat.lanes)) return err('invalid pattern');
+    if (!isObj(pat) || strictKeys(pat, ['lanes', 'chords', 'name'], 'pattern') !== null || !isObj(pat.lanes)) return err('invalid pattern');
+    if (pat.name !== undefined && (typeof pat.name !== 'string' || pat.name.length > NAME_MAX)) return err('invalid pattern name');
     if (pat.chords !== undefined && pat.chords !== null && !chordsValid(pat.chords)) return err('invalid pattern chords');
     for (const [laneId, name] of Object.entries(pat.lanes)) {
       if (name === null || name === undefined) continue;     // explicit no-pick is allowed

--- a/docs/arcade/groovebox/tests/engine-api.test.js
+++ b/docs/arcade/groovebox/tests/engine-api.test.js
@@ -77,6 +77,19 @@ test('pattern/chain mutation APIs are wired through', () => {
   expect(eng.getSong().chain.length).toBe(len - 1);
 });
 
+test('addPattern seeds an empty name; setPatternName trims and caps it', () => {
+  const eng = loaded();
+  const i = eng.addPattern();
+  expect(eng.getSong().patterns[i].name).toBe('');
+  expect(eng.getPatternName(i)).toBe('');
+  eng.setPatternName(i, '  Verse  ');
+  expect(eng.getPatternName(i)).toBe('Verse');               // trimmed
+  eng.setPatternName(i, 'x'.repeat(60));
+  expect(eng.getPatternName(i).length).toBe(40);             // capped
+  eng.setPatternName(i, '');
+  expect(eng.getPatternName(i)).toBe('');                    // clears
+});
+
 test('getGrooves lists named grooves; flattened kids has a drums groove named from "four"', () => {
   const eng = loaded();
   const grooves = eng.getGrooves();

--- a/docs/arcade/groovebox/tests/patterns.test.js
+++ b/docs/arcade/groovebox/tests/patterns.test.js
@@ -130,7 +130,7 @@ test('addPattern clones the picks of patterns[fromIdx] (groove refs shared); cap
   const s = makeSong();
   const idx = addPattern(s, 1);
   expect(idx).toBe(2);
-  expect(s.patterns[2]).toEqual({ lanes: { drums: 'hats', melody: 'chord' } });
+  expect(s.patterns[2]).toEqual({ lanes: { drums: 'hats', melody: 'chord' }, name: '' });
   // picks are a shallow copy — editing the new pattern's pick doesn't touch the source
   s.patterns[2].lanes.drums = 'groove2';
   expect(s.patterns[1].lanes.drums).toBe('hats');
@@ -142,7 +142,7 @@ test('duplicatePattern is the same affordance as addPattern (clones picks)', () 
   const s = makeSong();
   expect(duplicatePattern).toBe(addPattern);
   const idx = duplicatePattern(s, 0);
-  expect(s.patterns[idx]).toEqual({ lanes: { drums: 'groove2', melody: 'riff' } });
+  expect(s.patterns[idx]).toEqual({ lanes: { drums: 'groove2', melody: 'riff' }, name: '' });
 });
 
 test('removePattern: blocked on last; reindexes chain; falls back to [0] if chain empties', () => {

--- a/docs/arcade/groovebox/tests/registry-validate.test.js
+++ b/docs/arcade/groovebox/tests/registry-validate.test.js
@@ -83,6 +83,14 @@ describe('validateSongPayload — invariants', () => {
     expect(validateSongPayload({ ...song(), key: { root: 'A', mode: 'major' } }).ok).toBe(true);
     expect(validateSongPayload({ ...song(), key: 'A major' }).ok).toBe(false);
   });
+  it('accepts optional pattern.name, rejects non-string or oversized', () => {
+    const s = song(); s.patterns[0].name = 'Verse';
+    expect(validateSongPayload(s).ok).toBe(true);
+    const s2 = song(); s2.patterns[0].name = 123;
+    expect(validateSongPayload(s2).ok).toBe(false);
+    const s3 = song(); s3.patterns[0].name = 'x'.repeat(81);   // > NAME_MAX (80)
+    expect(validateSongPayload(s3).ok).toBe(false);
+  });
   it('rejects empty chain and out-of-range chain entries', () => {
     expect(validateSongPayload({ ...song(), chain: [] }).ok).toBe(false);
     expect(validateSongPayload({ ...song(), chain: [1] }).ok).toBe(false);   // only pattern 0 exists

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1026,9 +1026,28 @@ function renderPatterns() {
     const b = document.createElement('button');
     b.className = 'pat-slot' + (i === editIdx ? ' sel' : '');
     b.dataset.idx = i;
-    b.innerHTML = `${patDot(i)}<span>${i + 1}${i === editIdx ? ' ✎' : ''}</span>`;
-    b.title = 'click: edit this pattern — play will loop it';
-    b.onclick = () => { eng.selectPattern(i); renderPatterns(); refreshVizPattern(); };
+    // Named sections read as their name; unnamed fall back to the number.
+    const label = p.name ? esc(p.name) : (i + 1);
+    b.innerHTML = `${patDot(i)}<span class="pat-name">${label}${i === editIdx ? ' ✎' : ''}</span>`;
+    b.title = 'click: edit this pattern — double-click: rename — play will loop it';
+    // No-op when already selected so the node survives a double-click (rename).
+    b.onclick = () => { if (i !== editIdx) { eng.selectPattern(i); renderPatterns(); refreshVizPattern(); } };
+    b.ondblclick = () => {
+      const span = b.querySelector('.pat-name');
+      if (!span) return;
+      const input = document.createElement('input');
+      input.className = 'lane-rename-input';
+      input.value = p.name || '';
+      input.placeholder = `${i + 1}`;
+      span.replaceWith(input);
+      input.focus(); input.select();
+      const commit = () => { eng.setPatternName(i, input.value); renderPatterns(); };
+      input.onblur = commit;
+      input.onkeydown = e => {
+        if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+        if (e.key === 'Escape') { input.value = p.name || ''; input.blur(); }
+      };
+    };
     prow.appendChild(b);
   });
   const add = document.createElement('button');


### PR DESCRIPTION
**Story 1** of the groovebox song-editor redesign epic (`~/Dev/project-notes/oyster/po20/song-editor-redesign/EPIC.md`). Adds the single additive schema field the redesign needs — section names — so people think in song structure (Verse/Build/Drop), not "P1 P2 P3".

## What
- **Engine** — `addPattern` seeds `name: ''`; new `getPatternName(i)` / `setPatternName(i, name)` (trims, caps 40 chars). Engine never reads the name — it's pure UI data.
- **Validator** — shared songs may carry an optional `pattern.name` (string, ≤ NAME_MAX 80); strict-key list updated so named songs validate instead of being rejected. Backward-compatible: songs without a name still pass.
- **UI** — the pattern slot shows the name (falls back to the number when unset); **double-click a selected slot to rename inline** (mirrors lane rename). Names are HTML-escaped on render.

## Scope
Additive schema only — no engine behaviour change. Rename affordance is intentionally minimal here; Story 4 (Patterns composer) gives names a proper inline header rename.

## Verify
- ✅ 377/377 tests green (`npm test` in `docs/arcade/groovebox`) — +2 new (engine setter, validator accept/reject), 2 existing exact-shape assertions updated for `name: ''`.
- Rename a pattern → name shows + persists across re-renders; unnamed slots show the number; preset/shared songs load fine (fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)