### PR TITLE
arcade(groovebox): song-editor IA — HOME hub + breadcrumb + Grooves/Patterns/Song editors

### DIFF
--- a/docs/arcade/groovebox/index.html
+++ b/docs/arcade/groovebox/index.html
@@ -89,7 +89,10 @@
           <div class="help-sections">
             <div class="help-section active" data-help="controls">
               <dl>
-                <dt>SONG</dt><dd>The song's structure on the screen — click a pattern to edit it (it loops while playing), click a chain chip to play the song from there. ＋ adds, ⧉ duplicates.</dd>
+                <dt>HOME</dt><dd>The screen's menu — pick what to make: Grooves (loops), Patterns (sections), or Song (the play order). The breadcrumb at the top navigates back.</dd>
+                <dt>GROOVES</dt><dd>Pick an instrument, then edit its loop in the step grid / piano roll.</dd>
+                <dt>PATTERNS</dt><dd>Compose a section by swapping a loop per instrument, plus its chords.</dd>
+                <dt>SONG</dt><dd>Arrange your sections into the play order — drag to reorder, tap a chip to play from there.</dd>
                 <dt>M</dt><dd>Mute a lane (silences it; FX state preserved)</dd>
                 <dt>S</dt><dd>Solo a lane (silences all others)</dd>
                 <dt>VIEW</dt><dd>Open that lane in the step editor / piano roll</dd>
@@ -131,15 +134,17 @@
           </div>
         </div>
       </div>
-      <!-- Tier 3 — the screen: status strip + tabs (built by renderViewTabs)
-           + body. makeViz owns #lcd-body's innerHTML; the Song tab body
-           (#lcd-song) is a sibling so the two can swap via display toggle. -->
-      <div id="viz">
-        <div id="lcd-strip"></div>
-        <div class="vtabs"></div>
-        <div id="lcd-body"></div>
-        <div id="lcd-song" hidden>
-          <div id="lcd-song-rows"></div>
+      <!-- Tier 3 — the screen: a routed surface. #lcd-strip = breadcrumb +
+           status. #lcd-body = the active screen (HOME / Grooves list / Patterns
+           composer / Song arranger). #lcd-viz is a PERSISTENT sibling that
+           makeViz owns — it's the Grooves detail pane (and the scope monitor),
+           shown beside/over #lcd-body by route so router re-renders of #lcd-body
+           never destroy its canvas. -->
+      <div id="viz" class="route-home">
+        <div id="lcd-strip" class="lcdbar"></div>
+        <div id="lcd-screen">
+          <div id="lcd-body"></div>
+          <div id="lcd-viz"></div>
         </div>
       </div>
       <div id="master"></div>

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4482,3 +4482,115 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
     0 0 0 1px var(--line),
     0 0 24px var(--screen-glow);
 }
+
+/* ═══ New IA — HOME hub + breadcrumb + routed screens (Stories 2–6) ═══════════
+   The LCD is a routed surface: #lcd-screen holds the content (#lcd-body) and the
+   persistent viz (#lcd-viz); route classes on #viz decide what shows. */
+#lcd-screen { display: flex; gap: 10px; align-items: flex-start; }
+#lcd-body { flex: 1 1 auto; min-width: 0; }
+#lcd-viz  { flex: 1 1 auto; min-width: 0; }
+
+/* Home / Patterns / Song: only #lcd-body shows. */
+#viz.route-home #lcd-viz,
+#viz.route-patterns #lcd-viz,
+#viz.route-song #lcd-viz { display: none; }
+
+/* Grooves: lane list (#lcd-body) beside the editor (#lcd-viz). */
+#viz.route-grooves #lcd-body { flex: 0 0 200px; }
+#viz.route-grooves #lcd-viz  { flex: 1 1 auto; }
+
+/* Scope monitor overlay: the viz takes the screen. */
+#viz.scope #lcd-body { display: none; }
+#viz.scope #lcd-viz  { display: block; flex: 1 1 auto; min-height: 180px; }
+
+/* ── Breadcrumb bar (replaces the old read-only status strip) ────────────── */
+#lcd-strip.lcdbar { cursor: default; justify-content: space-between; }
+.crumb { display: inline-flex; align-items: center; gap: 2px; flex-wrap: wrap; }
+.cseg {
+  background: none; border: none; padding: 2px 6px; border-radius: 5px;
+  font-size: 11px; font-weight: 700; cursor: pointer; font-family: inherit;
+  color: var(--screen-dim);
+}
+.cseg:not(.cur):hover { background: color-mix(in srgb, var(--screen-acc) 12%, transparent); color: var(--screen-ink); }
+.cseg.cur { color: var(--screen-ink); cursor: default; }
+.csep { color: var(--screen-dim); opacity: .55; font-size: 11px; }
+.lcd-status { display: inline-flex; align-items: center; gap: 8px; }
+.scope-btn {
+  background: none; color: var(--screen-dim); cursor: pointer; line-height: 1;
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent);
+  border-radius: 5px; padding: 0 6px; height: 18px; font-size: 11px;
+}
+.scope-btn.on { color: var(--screen-acc); border-color: var(--screen-acc); }
+
+/* ── HOME hub cards ──────────────────────────────────────────────────────── */
+.home-q { font-size: 11px; letter-spacing: .04em; color: var(--screen-dim); margin: 4px 2px 10px; }
+.homecard {
+  display: flex; align-items: center; gap: 12px; width: 100%; cursor: pointer;
+  background: color-mix(in srgb, var(--screen-ink) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 18%, transparent);
+  border-radius: 10px; padding: 13px 14px; margin-bottom: 8px;
+  color: var(--screen-ink); text-align: left;
+}
+.homecard:hover { border-color: var(--screen-acc); background: color-mix(in srgb, var(--screen-acc) 8%, transparent); }
+.hc-ic { font-size: 22px; }
+.hc-tx { display: flex; flex-direction: column; }
+.hc-t { font-size: 14px; font-weight: 800; }
+.hc-s { font-size: 11px; color: var(--screen-dim); }
+.hc-chev { margin-left: auto; font-size: 16px; font-weight: 800; color: var(--screen-dim); }
+
+/* ── Two-pane (patterns composer) + shared list items ────────────────────── */
+.panes.two { display: grid; grid-template-columns: 200px 1fr; gap: 12px; align-items: start; }
+.pane-ttl { font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--screen-dim); font-weight: 700; margin: 2px 2px 8px; }
+.pane-ttl small { text-transform: none; letter-spacing: 0; font-weight: 500; }
+.pane-back { display: none; background: none; border: none; color: var(--screen-acc); font-weight: 700; font-size: 11px; cursor: pointer; margin-bottom: 6px; padding: 0; }
+.mini-btn { background: none; border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); color: var(--screen-dim); border-radius: 5px; font-size: 9px; padding: 1px 6px; cursor: pointer; font-weight: 700; }
+.li {
+  display: flex; align-items: center; gap: 8px; width: 100%; cursor: pointer;
+  background: color-mix(in srgb, var(--screen-ink) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 16%, transparent);
+  border-radius: 8px; padding: 8px 10px; margin-bottom: 5px;
+  color: var(--screen-ink); font-size: 12px; font-weight: 700; text-align: left;
+}
+.li:hover { border-color: color-mix(in srgb, var(--screen-acc) 50%, transparent); }
+.li.sel { box-shadow: 0 0 0 1.5px var(--screen-acc); border-color: var(--screen-acc); }
+.li.playing { box-shadow: 0 0 6px var(--screen-hot); border-color: var(--screen-hot); }
+.li-ic { font-size: 15px; }
+.li-dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 9px; }
+.li-nm { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.li-sub { margin-left: auto; font-size: 10px; font-weight: 600; color: var(--screen-dim); white-space: nowrap; }
+.li-chev { margin-left: auto; color: var(--screen-dim); font-weight: 800; }
+.li-sub + .li-chev { margin-left: 6px; }
+.li-add { justify-content: center; color: var(--screen-dim); border-style: dashed; }
+.li-addx { margin-left: auto; color: var(--screen-acc); font-size: 10px; font-weight: 700; }
+
+/* ── Compose rows (swap a loop per instrument) ───────────────────────────── */
+.crow { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; padding: 8px 10px; border-radius: 8px; background: color-mix(in srgb, var(--screen-ink) 4%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 16%, transparent); }
+.crow-fl { font-size: 12px; font-weight: 700; color: var(--screen-ink); min-width: 84px; }
+select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-ink) 8%, transparent); color: var(--screen-ink); border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent); border-radius: 6px; padding: 4px 8px; font-size: 12px; font-weight: 700; font-family: inherit; cursor: pointer; }
+.prog { margin-left: auto; display: inline-flex; gap: 4px; cursor: pointer; }
+.progc { font-family: ui-monospace, Menlo, monospace; font-weight: 800; font-size: 11px; background: color-mix(in srgb, var(--screen-ink) 8%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); border-radius: 5px; padding: 2px 7px; color: var(--screen-ink); }
+.progc-empty { color: var(--screen-dim); border-style: dashed; }
+
+/* ── Song arranger — chain chips + add list ──────────────────────────────── */
+.chain-row.big { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 14px; }
+#lcd-body .chain-chip { display: inline-flex; align-items: center; gap: 5px; background: color-mix(in srgb, var(--screen-ink) 6%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent); color: var(--screen-ink); border-radius: 7px; padding: 6px 10px; font-size: 13px; font-weight: 700; cursor: pointer; font-family: ui-monospace, Menlo, monospace; }
+#lcd-body .chain-chip.playing { border-color: var(--screen-hot); box-shadow: 0 0 6px var(--screen-hot); }
+#lcd-body .chain-chip.dragging { opacity: .4; }
+#lcd-body .chain-chip .chip-x { color: var(--screen-dim); font-size: 9px; }
+.add-secs { display: flex; flex-direction: column; }
+
+/* ── Add-instrument inline menu (Grooves) ────────────────────────────────── */
+.addinstr-menu { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0; }
+.addinstr-menu button { background: color-mix(in srgb, var(--screen-ink) 8%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); color: var(--screen-ink); border-radius: 7px; padding: 7px 11px; font-size: 12px; font-weight: 700; cursor: pointer; font-family: inherit; }
+.addinstr-menu button:hover { border-color: var(--screen-acc); }
+
+/* ── Responsive: mobile = drill (one pane at a time) ─────────────────────── */
+@media (max-width: 900px) {
+  #viz.route-grooves #lcd-body { flex: 1 1 auto; }
+  #viz.route-grooves:not(.drilled) #lcd-viz { display: none; }
+  #viz.route-grooves.drilled #lcd-body { display: none; }
+  .panes.two { grid-template-columns: 1fr; }
+  #viz.route-patterns.drilled .pane-list { display: none; }
+  #viz.route-patterns:not(.drilled) .pane-detail { display: none; }
+  #viz.route-patterns.drilled .pane-back { display: block; }
+}

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4490,6 +4490,11 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 #lcd-body { flex: 1 1 auto; min-width: 0; }
 #lcd-viz  { flex: 1 1 auto; min-width: 0; }
 
+/* These are <button>s; escape the global button height:30px so the padded
+   cards/chips/breadcrumb segments size to their content (not a 30px box). */
+.homecard, .li, #lcd-body .chain-chip, .cseg, .pane-back, .mini-btn,
+.addinstr-menu button, .scope-btn { height: auto; }
+
 /* Home / Patterns / Song: only #lcd-body shows. */
 #viz.route-home #lcd-viz,
 #viz.route-patterns #lcd-viz,

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4585,7 +4585,11 @@ select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-in
 .chain-row.big { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 14px; }
 #lcd-body .chain-chip { display: inline-flex; align-items: center; gap: 5px; background: color-mix(in srgb, var(--screen-ink) 6%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent); color: var(--screen-ink); border-radius: 7px; padding: 6px 10px; font-size: 13px; font-weight: 700; cursor: pointer; font-family: ui-monospace, Menlo, monospace; }
 #lcd-body .chain-chip.playing { border-color: var(--screen-hot); box-shadow: 0 0 6px var(--screen-hot); }
-#lcd-body .chain-chip.dragging { opacity: .4; }
+/* Reorder feedback: a light lift on the grabbed chip + an insertion line in the
+   gap where it will drop (no heavy grey-out). */
+#lcd-body .chain-chip.dragging { opacity: .7; border-color: var(--screen-acc); }
+#lcd-body .chain-chip.drop-left  { box-shadow: -5px 0 0 -1px var(--screen-acc); }
+#lcd-body .chain-chip.drop-right { box-shadow:  5px 0 0 -1px var(--screen-acc); }
 #lcd-body .chain-chip .chip-x { color: var(--screen-dim); font-size: 9px; }
 .add-secs { display: flex; flex-direction: column; }
 

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4587,7 +4587,7 @@ select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-in
 #lcd-body .chain-chip.playing { border-color: var(--screen-hot); box-shadow: 0 0 6px var(--screen-hot); }
 /* Reorder feedback: a light lift on the grabbed chip + an insertion line in the
    gap where it will drop (no heavy grey-out). */
-#lcd-body .chain-chip.dragging { opacity: .7; border-color: var(--screen-acc); }
+#lcd-body .chain-chip.dragging { border-color: var(--screen-acc); box-shadow: 0 0 0 1px var(--screen-acc); }
 #lcd-body .chain-chip.drop-left  { box-shadow: -5px 0 0 -1px var(--screen-acc); }
 #lcd-body .chain-chip.drop-right { box-shadow:  5px 0 0 -1px var(--screen-acc); }
 #lcd-body .chain-chip .chip-x { color: var(--screen-dim); font-size: 9px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4512,20 +4512,21 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 #lcd-strip.lcdbar { cursor: default; justify-content: space-between; }
 .crumb { display: inline-flex; align-items: center; gap: 2px; flex-wrap: wrap; }
 .cseg {
-  background: none; border: none; padding: 2px 6px; border-radius: 5px;
-  font-size: 11px; font-weight: 700; cursor: pointer; font-family: inherit;
+  background: none; border: none; box-shadow: none; padding: 2px 5px; border-radius: 5px;
+  font-size: 12px; font-weight: 700; cursor: pointer; font-family: inherit;
   color: var(--screen-dim);
 }
-.cseg:not(.cur):hover { background: color-mix(in srgb, var(--screen-acc) 12%, transparent); color: var(--screen-ink); }
+.cseg:not(.cur):hover { background: color-mix(in srgb, var(--screen-acc) 14%, transparent); color: var(--screen-ink); }
 .cseg.cur { color: var(--screen-ink); cursor: default; }
 .csep { color: var(--screen-dim); opacity: .55; font-size: 11px; }
 .lcd-status { display: inline-flex; align-items: center; gap: 8px; }
 .scope-btn {
-  background: none; color: var(--screen-dim); cursor: pointer; line-height: 1;
-  border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent);
-  border-radius: 5px; padding: 0 6px; height: 18px; font-size: 11px;
+  background: none; box-shadow: none; color: var(--screen-ink); cursor: pointer; line-height: 1;
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 45%, transparent);
+  border-radius: 5px; padding: 1px 7px; height: 20px; font-size: 14px;
 }
-.scope-btn.on { color: var(--screen-acc); border-color: var(--screen-acc); }
+.scope-btn:hover { border-color: var(--screen-acc); color: var(--screen-acc); }
+.scope-btn.on { color: var(--screen-bg); background: var(--screen-acc); border-color: var(--screen-acc); }
 
 /* ── HOME hub cards ──────────────────────────────────────────────────────── */
 .home-q { font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; font-weight: 700; color: var(--screen-dim); margin: 4px 2px 10px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4551,8 +4551,10 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 .panes.two { display: grid; grid-template-columns: 200px 1fr; gap: 12px; align-items: start; }
 .pane-ttl { font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--screen-dim); font-weight: 700; margin: 2px 2px 8px; }
 .pane-ttl small { text-transform: none; letter-spacing: 0; font-weight: 500; }
-.pane-back { display: none; background: none; border: none; color: var(--screen-acc); font-weight: 700; font-size: 11px; cursor: pointer; margin-bottom: 6px; padding: 0; }
-.mini-btn { background: none; border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); color: var(--screen-dim); border-radius: 5px; font-size: 9px; padding: 1px 6px; cursor: pointer; font-weight: 700; }
+.pane-back { display: none; background: none; box-shadow: none; border: none; color: var(--screen-acc); font-weight: 700; font-size: 12px; cursor: pointer; margin-bottom: 8px; padding: 0; }
+.pane-back:hover { text-decoration: underline; }
+.mini-btn { background: none; box-shadow: none; text-transform: none; letter-spacing: 0; border: 1px solid color-mix(in srgb, var(--screen-ink) 28%, transparent); color: var(--screen-dim); border-radius: 5px; font-size: 10px; padding: 2px 8px; cursor: pointer; font-weight: 700; margin-left: 6px; vertical-align: middle; }
+.mini-btn:hover { border-color: var(--screen-acc); color: var(--screen-acc); }
 .li {
   display: flex; align-items: center; gap: 8px; width: 100%; cursor: pointer;
   background: color-mix(in srgb, #fff 26%, var(--screen-bg));

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4587,7 +4587,7 @@ select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-in
 #lcd-body .chain-chip.playing { border-color: var(--screen-hot); box-shadow: 0 0 6px var(--screen-hot); }
 /* Reorder feedback: a light lift on the grabbed chip + an insertion line in the
    gap where it will drop (no heavy grey-out). */
-#lcd-body .chain-chip.dragging { border-color: var(--screen-acc); box-shadow: 0 0 0 1px var(--screen-acc); }
+#lcd-body .chain-chip.dragging { opacity: 1; border-color: var(--screen-acc); box-shadow: 0 0 0 1px var(--screen-acc); }
 #lcd-body .chain-chip.drop-left  { box-shadow: -5px 0 0 -1px var(--screen-acc); }
 #lcd-body .chain-chip.drop-right { box-shadow:  5px 0 0 -1px var(--screen-acc); }
 #lcd-body .chain-chip .chip-x { color: var(--screen-dim); font-size: 9px; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4523,18 +4523,21 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 .scope-btn.on { color: var(--screen-acc); border-color: var(--screen-acc); }
 
 /* ── HOME hub cards ──────────────────────────────────────────────────────── */
-.home-q { font-size: 11px; letter-spacing: .04em; color: var(--screen-dim); margin: 4px 2px 10px; }
+.home-q { font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; font-weight: 700; color: var(--screen-dim); margin: 4px 2px 10px; }
 .homecard {
-  display: flex; align-items: center; gap: 12px; width: 100%; cursor: pointer;
-  background: color-mix(in srgb, var(--screen-ink) 5%, transparent);
-  border: 1px solid color-mix(in srgb, var(--screen-ink) 18%, transparent);
-  border-radius: 10px; padding: 13px 14px; margin-bottom: 8px;
+  display: flex; align-items: center; gap: 13px; width: 100%; cursor: pointer;
+  /* Raised tile: a #fff-lift of the screen bg (near-white on pearl, a lifted
+     panel on dark themes) + elevation cues, so it reads as a card everywhere. */
+  background: color-mix(in srgb, #fff 38%, var(--screen-bg));
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 14%, transparent);
+  border-radius: 11px; padding: 14px; margin-bottom: 9px;
   color: var(--screen-ink); text-align: left;
+  box-shadow: 0 1px 3px rgba(0,0,0,.13), inset 0 1px 0 color-mix(in srgb, #fff 55%, transparent);
 }
-.homecard:hover { border-color: var(--screen-acc); background: color-mix(in srgb, var(--screen-acc) 8%, transparent); }
-.hc-ic { font-size: 22px; }
+.homecard:hover { border-color: var(--screen-acc); background: color-mix(in srgb, #fff 50%, var(--screen-bg)); }
+.hc-ic { font-size: 24px; }
 .hc-tx { display: flex; flex-direction: column; }
-.hc-t { font-size: 14px; font-weight: 800; }
+.hc-t { font-size: 15px; font-weight: 800; }
 .hc-s { font-size: 11px; color: var(--screen-dim); }
 .hc-chev { margin-left: auto; font-size: 16px; font-weight: 800; color: var(--screen-dim); }
 
@@ -4546,8 +4549,9 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 .mini-btn { background: none; border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); color: var(--screen-dim); border-radius: 5px; font-size: 9px; padding: 1px 6px; cursor: pointer; font-weight: 700; }
 .li {
   display: flex; align-items: center; gap: 8px; width: 100%; cursor: pointer;
-  background: color-mix(in srgb, var(--screen-ink) 4%, transparent);
-  border: 1px solid color-mix(in srgb, var(--screen-ink) 16%, transparent);
+  background: color-mix(in srgb, #fff 26%, var(--screen-bg));
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 12%, transparent);
+  box-shadow: 0 1px 2px rgba(0,0,0,.07);
   border-radius: 8px; padding: 8px 10px; margin-bottom: 5px;
   color: var(--screen-ink); font-size: 12px; font-weight: 700; text-align: left;
 }
@@ -4564,7 +4568,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 .li-addx { margin-left: auto; color: var(--screen-acc); font-size: 10px; font-weight: 700; }
 
 /* ── Compose rows (swap a loop per instrument) ───────────────────────────── */
-.crow { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; padding: 8px 10px; border-radius: 8px; background: color-mix(in srgb, var(--screen-ink) 4%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 16%, transparent); }
+.crow { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; padding: 8px 10px; border-radius: 8px; background: color-mix(in srgb, #fff 26%, var(--screen-bg)); border: 1px solid color-mix(in srgb, var(--screen-ink) 12%, transparent); box-shadow: 0 1px 2px rgba(0,0,0,.07); }
 .crow-fl { font-size: 12px; font-weight: 700; color: var(--screen-ink); min-width: 84px; }
 select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-ink) 8%, transparent); color: var(--screen-ink); border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent); border-radius: 6px; padding: 4px 8px; font-size: 12px; font-weight: 700; font-family: inherit; cursor: pointer; }
 .prog { margin-left: auto; display: inline-flex; gap: 4px; cursor: pointer; }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1028,8 +1028,8 @@ function renderPatternsComposer(body) {
   list += `<button class="li li-add" data-newsec="1">＋ new section</button>`;
 
   let detail = `<button class="pane-back" data-back="1">‹ sections</button>` +
-    `<div class="pane-ttl">compose “${s && s.name ? esc(s.name) : 'P' + (editIdx + 1)}” — swap a loop ▾` +
-    ` <button class="mini-btn" data-ren="1">rename</button></div>`;
+    `<div class="pane-ttl">compose “${s && s.name ? esc(s.name) : 'P' + (editIdx + 1)}” — swap a loop` +
+    ` <button class="mini-btn" data-ren="1">✎ rename</button></div>`;
   lanes.filter(l => l.type !== 'chords').forEach(l => {
     const laneGrooves = grooves[l.id] || {};
     const picked = s && s.lanes ? s.lanes[l.id] : undefined;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -225,93 +225,79 @@ function updateEditHighlight(id) {
       if (editBtn) editBtn.classList.toggle('editing', isEditing);
     });
   }
-  const bar = document.querySelector('.vtabs');
-  if (bar) {
-    bar.querySelectorAll('.vtab-lane').forEach(t => t.classList.toggle('on', t.dataset.edit === id));
-    bar.querySelectorAll('[data-view]').forEach(x => x.classList.remove('on'));
-  }
 }
 
-// Screen tabs in the LCD: Song first, then one per editable lane, then Scope.
-// Rebuilt on every renderStrips() so it tracks add/dup/remove/rename.
-function renderViewTabs() {
-  const bar = document.querySelector('.vtabs');
-  if (!bar) return;
-  bar.innerHTML = '';
-  const songTab = document.createElement('button');
-  songTab.dataset.view = 'song';
-  songTab.textContent = 'Song';
-  songTab.onclick = () => activateSongTab();
-  bar.appendChild(songTab);
-  for (const lane of eng.getLanes()) {
-    if (lane.type === 'chords') continue;   // chords has no grid/roll editor
-    const b = document.createElement('button');
-    b.className = 'vtab-lane';
-    b.dataset.edit = lane.id;
-    b.textContent = lane.name;
-    b.onclick = () => activateEditLane(lane.id);
-    bar.appendChild(b);
-  }
-  const scope = document.createElement('button');
-  scope.dataset.view = 'scope';
-  scope.textContent = 'Scope';
-  scope.onclick = () => toggleScope(scope);
-  bar.appendChild(scope);
-  if (_songTabOpen) songTab.classList.add('on');
-  else if (_editingLaneId) updateEditHighlight(_editingLaneId);
-}
+// ─── Screen router — HOME hub → Grooves / Patterns / Song, with a breadcrumb ──
+// The LCD is one routed surface. #lcd-body holds the active screen; #lcd-viz is
+// a PERSISTENT sibling that makeViz owns (re-rendering #lcd-body never destroys
+// its canvas). Grooves shows #lcd-body (lane list) beside #lcd-viz (the editor);
+// other routes hide #lcd-viz. The breadcrumb in #lcd-strip is the navigation.
+let _route = 'home';        // 'home' | 'grooves' | 'patterns' | 'song'
+let _drilled = false;       // mobile: show the detail pane instead of the list
+let _scopeOpen = false;     // scope monitor overlay (Story 6) — independent of route
+const isWide = () => matchMedia('(min-width: 901px)').matches;   // complements the 900px mobile breakpoint
+const LANE_ICONS = { drums: '🥁', bass: '🎸', melody: '🎹', chords: '🎵' };
+const patLabel = i => { const p = eng.getPatterns()[i]; return p && p.name ? p.name : `P${i + 1}`; };
 
-// The screen has two tab panes — #lcd-body (viz: lane editors / scope) and
-// #lcd-song (song structure) — plus the SELECT SONG picker, which overlays
-// whichever pane is current and closes back to it. Display toggles only —
-// the viz is never disposed here, so switching is free.
-let _songTabOpen = false;
-function setLcdPane(songOpen) {
-  _songTabOpen = songOpen;
-  const body = document.getElementById('lcd-body');
-  const songPane = document.getElementById('lcd-song');
-  if (body) body.hidden = songOpen;
-  if (songPane) songPane.hidden = !songOpen;
-}
-
-// Song tab: show the song structure pane, clear lane-editing highlights.
-function activateSongTab() {
-  const bar = document.querySelector('.vtabs');
-  if (bar) {
-    bar.querySelectorAll('button').forEach(x => x.classList.remove('on'));
-    bar.querySelector('[data-view="song"]')?.classList.add('on');
-  }
-  const host = document.getElementById('strips');
-  if (host) {
-    host.querySelectorAll('.lane').forEach(row => row.classList.remove('editing'));
-    host.querySelectorAll('.lane-edit').forEach(b => b.classList.remove('editing'));
-  }
-  setLcdPane(true);
-}
-
-// Scope toggle: on → show oscilloscope; off (click again) → back to last lane editor.
-function toggleScope(btn) {
-  if (btn.classList.contains('on')) {
-    btn.classList.remove('on');
-    if (_editingLaneId) activateEditLane(_editingLaneId);
-  } else {
-    document.querySelector('.vtabs').querySelectorAll('button').forEach(x => x.classList.remove('on'));
-    btn.classList.add('on');
-    const host = document.getElementById('strips');
-    if (host) {
-      host.querySelectorAll('.lane').forEach(row => row.classList.remove('editing'));
-      host.querySelectorAll('.lane-edit').forEach(b => b.classList.remove('editing'));
-    }
-    setLcdPane(false);
-    viz.setView('scope');
-  }
-}
-
-// Open a lane editor in the viz + update highlight.
+// Open a lane's editor in the viz (no route change) + highlight its strip.
 function activateEditLane(id) {
-  setLcdPane(false);
   viz.editLane(id);
   updateEditHighlight(id);
+}
+
+// Navigate. opts: { laneId } selects a Grooves lane; { patternIdx } a section;
+// { drilled } sets the mobile list↔detail state.
+function setRoute(route, opts = {}) {
+  _scopeOpen = false;                       // any nav closes the scope monitor
+  _route = route;
+  if (route === 'home' || route === 'song') _drilled = false;
+  if (opts.drilled !== undefined) _drilled = opts.drilled;
+  if (opts.patternIdx !== undefined) eng.selectPattern(opts.patternIdx);
+  let grooveLane = null;
+  if (route === 'grooves') {
+    const lanes = eng.getLanes().filter(l => l.type !== 'chords');
+    let id = opts.laneId || _editingLaneId;
+    if (!id || !lanes.some(l => l.id === id)) id = lanes[0] && lanes[0].id;
+    if (id) { _editingLaneId = id; grooveLane = id; }   // set before render so the list highlights
+  }
+  renderScreen();                           // sets the route class → #lcd-viz gets its real width
+  if (grooveLane) activateEditLane(grooveLane);   // THEN build the editor (correct width — R1)
+}
+
+// Paint the whole screen for the current route.
+function renderScreen() {
+  const vizEl = document.getElementById('viz');
+  if (vizEl) vizEl.className = `route-${_route}` + (_drilled ? ' drilled' : '') + (_scopeOpen ? ' scope' : '');
+  renderLcdBar();
+  const body = document.getElementById('lcd-body');
+  if (!body) return;
+  if (_route === 'home') renderHome(body);
+  else if (_route === 'grooves') renderGroovesEditor(body);
+  else if (_route === 'patterns') renderPatternsComposer(body);
+  else if (_route === 'song') renderSongArranger(body);
+  updatePlayback(eng.getPlaybackTarget());
+}
+
+// Scope monitor (Story 6): overlay the oscilloscope over the screen; toggling
+// off returns to the route (re-opening the lane editor if we were in Grooves).
+function toggleScope() {
+  _scopeOpen = !_scopeOpen;
+  renderScreen();                           // set visibility first, then build at the right width
+  if (_scopeOpen) viz.setView('scope');
+  else if (_route === 'grooves' && _editingLaneId) activateEditLane(_editingLaneId);
+}
+
+// Live playback paint across whatever screen is showing (+ the status bar).
+function updatePlayback(target) {
+  if (!target) return;
+  updateLcdBar(target);
+  const body = document.getElementById('lcd-body');
+  if (!body) return;
+  const isPattern = target.kind === 'pattern';
+  body.querySelectorAll('.chain-chip[data-pos]').forEach(c =>
+    c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos));
+  body.querySelectorAll('.li[data-sec]').forEach(b =>
+    b.classList.toggle('playing', isPattern && +b.dataset.sec === target.patternIdx));
 }
 
 // ─── SELECT SONG — the cartridge drawer ──────────────────────────────────────
@@ -457,20 +443,15 @@ function renderStrips() {
   const lanes = eng.getLanes();
   const isLast = lanes.length === 1;
 
-  const grooves = eng.getGrooves();
-  const patterns = eng.getPatterns();
-  const editPat = patterns[eng.getEditPatternIndex()];
   host.innerHTML = lanes.map(lane => {
     const tone = lane.type === 'melody'
       ? `<select data-tone data-lane="${lane.id}">${TONES.map(t=>`<option value="${t}"${t===(lane.tone||'pulse')?' selected':''}>${t==='fatsawtooth'?'fat saw':t}</option>`).join('')}</select>`
       : '';
-    // Groove dropdown — picks the groove the EDIT pattern plays for this lane.
-    const laneGrooves = grooves[lane.id] || {};
-    const picked = editPat?.lanes?.[lane.id];
+    // The strip selects the lane's SOUND (not the groove — the loop is chosen on
+    // the screen, in Grooves / Patterns).
     const soundBtn = lane.type !== 'drums'
       ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">SOUND</button>`
       : '';
-    const grooveSel = `<select data-groove data-lane="${lane.id}">${Object.keys(laneGrooves).map(n=>`<option value="${esc(n)}"${n===picked?' selected':''}>${esc(n)}</option>`).join('')}</select>`;
     // Edit button — present for types with an editor (drums, melody, bass); skip chords.
     const hasEditor = lane.type !== 'chords';
     const editBtn = hasEditor
@@ -480,7 +461,7 @@ function renderStrips() {
     return `<div class="lane" data-lane="${lane.id}" data-type="${lane.type}">
       <span class="lane-drag" title="Drag to reorder">⠿</span>
       <span class="name" title="double-click to rename">${esc(lane.name)}</span>
-      <div class="mctl">${grooveSel}${tone}${soundBtn}</div>
+      <div class="mctl">${tone}${soundBtn}</div>
       <div class="lvl"><div class="lvl-fill"></div></div>
       <div class="msgroup">
         <button class="mute" data-lane="${lane.id}" aria-label="mute ${esc(lane.name)}" title="Mute">M</button>
@@ -498,7 +479,7 @@ function renderStrips() {
   // Add-lane button at the bottom of strips
   const addBtn = document.createElement('div');
   addBtn.className = 'addlane-wrap';
-  addBtn.innerHTML = `<button class="addlane-btn" title="Add a new lane">＋ add lane</button>
+  addBtn.innerHTML = `<button class="addlane-btn" title="Add a new instrument">＋ add instrument</button>
     <div class="addlane-menu" hidden>
       <button data-addtype="drums">Drums</button>
       <button data-addtype="bass">Bass</button>
@@ -541,10 +522,6 @@ function renderStrips() {
     const id = LANE_INSTRUMENT[b.dataset.type];
     if (id) openInstrumentEditor({ id, eng, onSaved: renderStrips });
   });
-  host.querySelectorAll('select[data-groove]').forEach(s => s.onchange = () => {
-    eng.setLaneGroove(s.dataset.lane, s.value);
-    refreshVizPattern();   // editor must re-target the new groove
-  });
   host.querySelectorAll('.mute').forEach(b => b.onclick = () => {
     eng.toggleMute(b.dataset.lane);
     refreshStates();
@@ -568,10 +545,10 @@ function renderStrips() {
     };
   });
 
-  // Edit button — open that lane's editor in the viz
+  // VIEW — jump to this lane's loop in the Grooves editor on the screen.
   host.querySelectorAll('.lane-edit:not(:disabled)').forEach(b => {
     b.onclick = () => {
-      activateEditLane(b.dataset.lane);
+      setRoute('grooves', { laneId: b.dataset.lane, drilled: true });
     };
   });
 
@@ -692,25 +669,11 @@ function renderStrips() {
 
   refreshStates();
   cacheMeterFills();  // re-cache .lvl-fill refs after DOM rebuild
-  renderViewTabs();   // rebuild quick-edit tabs to track the current lane list
+  if (_editingLaneId) updateEditHighlight(_editingLaneId);  // re-apply lane-edit highlight
   updateEmptyGroups(); // hide kgroups where all knobs are hidden
   // Re-apply the accordion's open lane across the innerHTML rebuild (drop it
   // if that lane was removed).
   setOpenLane(host.querySelector(`.lane[data-lane="${_openLaneId}"]`) ? _openLaneId : null);
-}
-
-// Sync every strip groove dropdown to the EDIT pattern's picks. Called whenever
-// the edit pattern changes (from renderPatterns). Reflects the edit pattern only
-// — never chain playback.
-function syncStripGrooves() {
-  const host = document.getElementById('strips');
-  if (!host) return;
-  const editPat = eng.getPatterns()[eng.getEditPatternIndex()];
-  if (!editPat) return;
-  host.querySelectorAll('select[data-groove]').forEach(s => {
-    const picked = editPat.lanes?.[s.dataset.lane];
-    if (picked !== undefined && s.value !== picked) s.value = picked;
-  });
 }
 
 // ─── Fills row ───────────────────────────────────────────────────────────────
@@ -993,209 +956,265 @@ const PATTERN_COLORS = [
 const patternColor = i => PATTERN_COLORS[i % PATTERN_COLORS.length];
 const patDot = i => `<span class="pat-dot" style="background:${patternColor(i)}"></span>`;
 
-function renderPatterns() {
-  const host = document.getElementById('lcd-song-rows');
-  if (!host) return;
-  host.innerHTML = '';
-  const patterns = eng.getPatterns();
-  const chain = eng.getChain();
-  const editIdx = eng.getEditPatternIndex();
+// ─── HOME hub ─────────────────────────────────────────────────────────────────
+function renderHome(body) {
+  body.innerHTML =
+    `<div class="home-q">what do you want to make?</div>` +
+    homecard('grooves', '🥁', 'Grooves', 'make &amp; edit loops') +
+    homecard('patterns', '🧩', 'Patterns', 'compose sections from loops') +
+    homecard('song', '🎚', 'Song', 'arrange sections in order');
+  body.querySelectorAll('.homecard').forEach(c => c.onclick = () => setRoute(c.dataset.route));
+}
+function homecard(route, ic, t, s) {
+  return `<button class="homecard" data-route="${route}"><span class="hc-ic">${ic}</span>` +
+    `<span class="hc-tx"><span class="hc-t">${t}</span><span class="hc-s">${s}</span></span>` +
+    `<span class="hc-chev">›</span></button>`;
+}
 
-  // First-run teaching: a dismissible one-liner naming the make-loops → arrange
-  // flow. Persistent inline labels (below) carry the lesson after it's dismissed.
-  if (!localStorage.getItem('gb-song-hint-off')) {
-    const hint = document.createElement('div');
-    hint.className = 'song-hint';
-    hint.innerHTML = `<span>💡 Make loops in <b>Patterns</b>, then line them up in the <b>Song</b> below.</span><button class="song-hint-x" title="dismiss">✕</button>`;
-    hint.querySelector('.song-hint-x').onclick = () => {
-      try { localStorage.setItem('gb-song-hint-off', '1'); } catch (e) { /* private mode */ }
-      hint.remove();
-    };
-    host.appendChild(hint);
+// ─── Grooves editor — instrument list (here) + the step editor (in #lcd-viz) ──
+function renderGroovesEditor(body) {
+  const lanes = eng.getLanes().filter(l => l.type !== 'chords');
+  const editPat = eng.getPatterns()[eng.getEditPatternIndex()];
+  let h = `<div class="pane-list"><div class="pane-ttl">instruments</div>`;
+  lanes.forEach(l => {
+    const g = (editPat && editPat.lanes && editPat.lanes[l.id]) || '—';
+    h += `<button class="li ${l.id === _editingLaneId ? 'sel' : ''}" data-lane="${l.id}">` +
+      `<span class="li-ic">${LANE_ICONS[l.type] || '🎛'}</span>` +
+      `<span class="li-nm">${esc(l.name)}</span>` +
+      `<span class="li-sub">${esc(g)}</span><span class="li-chev">›</span></button>`;
+  });
+  h += `<button class="li li-add" data-addinstr="1">＋ add instrument</button></div>`;
+  body.innerHTML = h;
+  body.querySelectorAll('.li[data-lane]').forEach(b =>
+    b.onclick = () => setRoute('grooves', { laneId: b.dataset.lane, drilled: true }));
+  wireAddInstr(body.querySelector('[data-addinstr]'));
+}
+
+// Inline 4-type instrument picker (mirrors the strips add-lane menu).
+function wireAddInstr(btn) {
+  if (!btn) return;
+  btn.onclick = () => {
+    const menu = document.createElement('div');
+    menu.className = 'addinstr-menu';
+    menu.innerHTML = ['drums', 'bass', 'melody', 'chords']
+      .map(t => `<button data-t="${t}">${LANE_ICONS[t]} ${t[0].toUpperCase() + t.slice(1)}</button>`).join('');
+    btn.replaceWith(menu);
+    menu.querySelectorAll('[data-t]').forEach(b => b.onclick = () => {
+      eng.addLane(b.dataset.t);
+      renderStrips();
+      const ls = eng.getLanes().filter(l => l.type !== 'chords');
+      const last = ls[ls.length - 1];
+      if (b.dataset.t !== 'chords' && last) setRoute('grooves', { laneId: last.id, drilled: true });
+      else renderScreen();
+    });
+  };
+}
+
+// ─── Patterns composer — sections list + compose (swap a loop per instrument) ─
+function renderPatternsComposer(body) {
+  const patterns = eng.getPatterns();
+  const editIdx = eng.getEditPatternIndex();
+  const grooves = eng.getGrooves();
+  const lanes = eng.getLanes();
+  const s = patterns[editIdx];
+
+  let list = `<div class="pane-ttl">sections</div>`;
+  patterns.forEach((p, i) => {
+    list += `<button class="li ${i === editIdx ? 'sel' : ''}" data-sec="${i}">` +
+      `<span class="li-dot" style="background:${patternColor(i)}"></span>` +
+      `<span class="li-nm">${p.name ? esc(p.name) : 'P' + (i + 1)}</span>` +
+      `<span class="li-chev">›</span></button>`;
+  });
+  list += `<button class="li li-add" data-newsec="1">＋ new section</button>`;
+
+  let detail = `<button class="pane-back" data-back="1">‹ sections</button>` +
+    `<div class="pane-ttl">compose “${s && s.name ? esc(s.name) : 'P' + (editIdx + 1)}” — swap a loop ▾` +
+    ` <button class="mini-btn" data-ren="1">rename</button></div>`;
+  lanes.filter(l => l.type !== 'chords').forEach(l => {
+    const laneGrooves = grooves[l.id] || {};
+    const picked = s && s.lanes ? s.lanes[l.id] : undefined;
+    const opts = Object.keys(laneGrooves).map(n =>
+      `<option value="${esc(n)}"${n === picked ? ' selected' : ''}>${esc(n)}</option>`).join('');
+    detail += `<div class="crow"><span class="crow-fl">${LANE_ICONS[l.type] || '🎛'} ${esc(l.name)}</span>` +
+      `<select class="gpick" data-swap="${l.id}">${opts}</select></div>`;
+  });
+  const chordLane = lanes.find(l => l.type === 'chords');
+  if (chordLane) {
+    const chords = eng.getPatternChords(editIdx) || [];
+    const chips = chords.length
+      ? chords.map(c => `<span class="progc">${esc(c.name)}</span>`).join('')
+      : `<span class="progc progc-empty">＋ chords</span>`;
+    detail += `<div class="crow crow-chords"><span class="crow-fl">🎵 ${esc(chordLane.name)}</span>` +
+      `<span class="prog" data-chords="1">${chips}</span></div>`;
   }
 
-  // Patterns row: small "patterns" label (matching chords/chain rows) + slots +
-  // duplicate/delete for the selected pattern.
-  const prow = document.createElement('div');
-  prow.className = 'pat-row';
-  const plbl = document.createElement('span');
-  plbl.className = 'pat-lbl';
-  plbl.innerHTML = 'patterns<small>your loops</small>';
-  prow.appendChild(plbl);
-  patterns.forEach((p, i) => {
-    const b = document.createElement('button');
-    b.className = 'pat-slot' + (i === editIdx ? ' sel' : '');
-    b.dataset.idx = i;
-    // Named sections read as their name; unnamed fall back to the number.
-    const label = p.name ? esc(p.name) : (i + 1);
-    b.innerHTML = `${patDot(i)}<span class="pat-name">${label}${i === editIdx ? ' ✎' : ''}</span>`;
-    b.title = 'click: edit this pattern — double-click: rename — play will loop it';
-    // No-op when already selected so the node survives a double-click (rename).
-    b.onclick = () => { if (i !== editIdx) { eng.selectPattern(i); renderPatterns(); refreshVizPattern(); } };
-    b.ondblclick = () => {
-      const span = b.querySelector('.pat-name');
-      if (!span) return;
-      const input = document.createElement('input');
-      input.className = 'lane-rename-input';
-      input.value = p.name || '';
-      input.placeholder = `${i + 1}`;
-      span.replaceWith(input);
-      input.focus(); input.select();
-      const commit = () => { eng.setPatternName(i, input.value); renderPatterns(); };
-      input.onblur = commit;
-      input.onkeydown = e => {
-        if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
-        if (e.key === 'Escape') { input.value = p.name || ''; input.blur(); }
-      };
-    };
-    prow.appendChild(b);
+  body.innerHTML = `<div class="panes two"><div class="pane-list">${list}</div><div class="pane-detail">${detail}</div></div>`;
+
+  body.querySelectorAll('.li[data-sec]').forEach(b => b.onclick = () => {
+    eng.selectPattern(+b.dataset.sec); refreshVizPattern(); setRoute('patterns', { drilled: true });
   });
-  const add = document.createElement('button');
-  add.className = 'pat-slot pat-add';
-  add.textContent = '＋ New';
-  add.title = 'add pattern';
-  add.disabled = patterns.length >= 16;
-  add.onclick = () => {
-    const idx = eng.addPattern();
-    if (idx !== null) { eng.selectPattern(idx); renderPatterns(); refreshVizPattern(); }
+  body.querySelector('[data-newsec]').onclick = () => {
+    const i = eng.addPattern();
+    if (i !== null) { eng.setPatternName(i, 'Part ' + (i + 1)); eng.selectPattern(i); refreshVizPattern(); setRoute('patterns', { drilled: true }); }
   };
-  prow.appendChild(add);
+  const back = body.querySelector('[data-back]');
+  if (back) back.onclick = () => { _drilled = false; renderScreen(); };
+  const ren = body.querySelector('[data-ren]');
+  if (ren) ren.onclick = () => renameSectionInline(editIdx, ren);
+  body.querySelectorAll('select[data-swap]').forEach(sel => sel.onchange = () => {
+    eng.setLaneGroove(sel.dataset.swap, sel.value);
+    refreshVizPattern();
+  });
+  const prog = body.querySelector('[data-chords]');
+  if (prog) prog.onclick = () => openComposerChordEdit(editIdx, prog);
+}
 
-  const dup = document.createElement('button');
-  dup.className = 'pat-act'; dup.textContent = '⧉ Copy'; dup.title = 'duplicate pattern';
-  dup.disabled = patterns.length >= 16;
-  dup.onclick = () => {
-    const idx = eng.duplicatePattern(editIdx);
-    if (idx !== null) { eng.selectPattern(idx); renderPatterns(); refreshVizPattern(); }
+function renameSectionInline(idx, anchor) {
+  const input = document.createElement('input');
+  input.className = 'lane-rename-input';
+  input.value = eng.getPatternName(idx) || '';
+  input.placeholder = `P${idx + 1}`;
+  anchor.replaceWith(input);
+  input.focus(); input.select();
+  const commit = () => { eng.setPatternName(idx, input.value); renderScreen(); };
+  input.onblur = commit;
+  input.onkeydown = e => {
+    if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
+    if (e.key === 'Escape') { input.value = eng.getPatternName(idx) || ''; input.blur(); }
   };
-  prow.appendChild(dup);
+}
 
-  const del = document.createElement('button');
-  del.className = 'pat-act'; del.textContent = '✕ Delete'; del.title = 'delete pattern';
-  del.disabled = patterns.length <= 1;
-  del.onclick = () => { eng.removePattern(editIdx); renderPatterns(); refreshVizPattern(); };
-  prow.appendChild(del);
-  host.appendChild(prow);
-
-  // Chord line for the SELECTED pattern, nested under the patterns row (the
-  // indent + spine say "this pattern's chords"). Chords belong to the pattern
-  // (one per bar, cycling). Click anywhere → text input to edit (parser-backed);
-  // empty → a "＋ chords" affordance. The status strip carries the SOUNDING
-  // pattern's chords — this row is purely the edit pattern's.
-  host.appendChild(buildChordLine(editIdx));
-
-  // Chain row: chips (click = play chain from there; hover-✕ removes; drag reorders) + append.
-  const crow = document.createElement('div');
-  crow.className = 'chain-row';
-  crow.innerHTML = `<span class="pat-lbl">song<small>play order →</small></span>`;
+// ─── Song arranger — the play order (chain) + add a section ────────────────────
+function renderSongArranger(body) {
+  const patterns = eng.getPatterns();
+  const chain = eng.getChain();
+  let h = `<div class="pane-ttl">song order <small>— tap to play from there · drag to reorder</small></div>`;
+  h += `<div class="chain-row big">`;
   chain.forEach((pi, pos) => {
-    const chip = document.createElement('button');
-    chip.className = 'chain-chip';
-    chip.dataset.pos = pos;
-    chip.draggable = true;
-    chip.innerHTML = `${patDot(pi)}<span>${pi + 1}</span><span class="chip-x" title="remove">✕</span>`;
+    h += `<button class="chain-chip" data-pos="${pos}" draggable="true">${patDot(pi)}` +
+      `<span>${pi + 1}</span><span class="chip-x" title="remove">✕</span></button>`;
+  });
+  h += `</div>`;
+  h += `<div class="pane-ttl">add a section to the order</div><div class="add-secs">`;
+  patterns.forEach((p, i) => {
+    h += `<button class="li" data-add="${i}"><span class="li-dot" style="background:${patternColor(i)}"></span>` +
+      `<span class="li-nm">${p.name ? esc(p.name) : 'P' + (i + 1)}</span>` +
+      `<span class="li-addx">＋ add</span></button>`;
+  });
+  h += `</div>`;
+  body.innerHTML = h;
+
+  body.querySelectorAll('.chain-chip[data-pos]').forEach(chip => {
+    const pos = +chip.dataset.pos;
     chip.onclick = e => {
-      if (e.target.classList.contains('chip-x')) { if (eng.removeChainAt(pos)) renderPatterns(); return; }
-      eng.playChain(pos);
-      renderPatterns();
+      if (e.target.classList.contains('chip-x')) { if (eng.removeChainAt(pos)) renderScreen(); return; }
+      eng.playChain(pos); renderScreen();
     };
     chip.ondragstart = () => { _chainDragFrom = pos; chip.classList.add('dragging'); };
     chip.ondragend = () => { _chainDragFrom = null; chip.classList.remove('dragging'); };
-    chip.ondragover = e => { e.preventDefault(); };
+    chip.ondragover = e => e.preventDefault();
     chip.ondrop = e => {
       e.preventDefault();
       if (_chainDragFrom === null || _chainDragFrom === pos) return;
       const rect = chip.getBoundingClientRect();
       const before = e.clientX < rect.left + rect.width / 2;
       let to = before ? pos : pos + 1;
-      if (_chainDragFrom < to) to--;           // account for the splice-out shifting targets left
+      if (_chainDragFrom < to) to--;
       eng.moveChain(_chainDragFrom, to);
-      renderPatterns();
+      renderScreen();
     };
-    crow.appendChild(chip);
   });
-  const append = document.createElement('button');
-  append.className = 'chain-chip chain-add';
-  append.textContent = '＋ Add';
-  append.title = 'append selected pattern to chain';
-  append.onclick = () => { eng.appendToChain(eng.getEditPatternIndex()); renderPatterns(); };
-  crow.appendChild(append);
-  host.appendChild(crow);
-
-  renderStrip();        // chain/chords may have changed → rebuild the readout
-  updatePatternsPlayback(eng.getPlaybackTarget());
-  syncStripGrooves();   // edit pattern may have changed → resync strip dropdowns
+  body.querySelectorAll('[data-add]').forEach(b => b.onclick = () => {
+    eng.appendToChain(+b.dataset.add); renderScreen();
+  });
 }
 
 // ─── LCD status strip (read-only narrator: title · chain · chords · key · bpm) ─
-function renderStrip() {
+// ─── LCD bar — breadcrumb (navigation) + status (song-order playhead · bpm) ───
+function renderLcdBar() {
   const host = document.getElementById('lcd-strip');
   if (!host) return;
   host.innerHTML = '';
-  const s = eng.getSong();
-  if (!s) return;
-  const title = document.createElement('span');
-  title.className = 'strip-title';
-  title.textContent = (s.title || '').toUpperCase();
-  host.appendChild(title);
-  if (s.artist) {
-    const credit = document.createElement('span');
-    credit.className = 'strip-credit';
-    credit.textContent = s.artist;
-    host.appendChild(credit);
+  host.removeAttribute('role'); host.removeAttribute('tabindex'); host.title = '';
+  host.onclick = null; host.onkeydown = null;
+
+  // Breadcrumb — every segment above the current one navigates up.
+  const crumb = document.createElement('div');
+  crumb.className = 'crumb';
+  crumb.appendChild(crumbSeg('Home', _route === 'home' ? null : () => setRoute('home'), _route === 'home'));
+  if (_route !== 'home') {
+    crumb.appendChild(crumbSep());
+    if (_route === 'song') {
+      crumb.appendChild(crumbSeg('Song', null, true));
+    } else {
+      const ed = _route === 'grooves' ? 'Grooves' : 'Patterns';
+      const showItem = isWide() || _drilled;
+      crumb.appendChild(crumbSeg(ed, showItem ? () => { _drilled = false; renderScreen(); } : null, !showItem));
+      if (showItem) {
+        crumb.appendChild(crumbSep());
+        let item;
+        if (_route === 'grooves') {
+          const lane = eng.getLanes().find(l => l.id === _editingLaneId);
+          item = lane ? lane.name : '—';
+        } else {
+          item = patLabel(eng.getEditPatternIndex());
+        }
+        crumb.appendChild(crumbSeg(item, null, true));
+      }
+    }
   }
+  host.appendChild(crumb);
+
+  // Status — the song-order playhead + a scope toggle + BPM, always visible.
+  const status = document.createElement('div');
+  status.className = 'lcd-status';
   const chainWrap = document.createElement('span');
   chainWrap.className = 'strip-chain';
   eng.getChain().forEach((pi, pos) => {
     const seg = document.createElement('span');
     seg.className = 'strip-seg';
     seg.dataset.pos = pos;
-    seg.textContent = pi + 1;
+    seg.innerHTML = `${patDot(pi)}<span>${pi + 1}</span>`;
     chainWrap.appendChild(seg);
   });
   const loop = document.createElement('span');
   loop.className = 'strip-seg strip-loop hot';
   loop.hidden = true;
   chainWrap.appendChild(loop);
-  host.appendChild(chainWrap);
-  // Which pattern the editors are pointed at — visible from every view, in the
-  // editing colour (teal), not the sounding colour (pink).
-  const edit = document.createElement('span');
-  edit.className = 'strip-seg strip-edit';
-  edit.textContent = `✎ P${eng.getEditPatternIndex() + 1}`;
-  host.appendChild(edit);
-  // The strip is the door to the song's structure: tap it → Song tab.
-  // It's a div, so make it a real control for keyboards / assistive tech.
-  host.title = 'Open the Song editor';
-  host.setAttribute('role', 'button');
-  host.setAttribute('aria-label', 'Open the Song editor');
-  host.tabIndex = 0;
-  host.onclick = () => activateSongTab();
-  host.onkeydown = e => {
-    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activateSongTab(); }
-  };
-  const chordWrap = document.createElement('span');
-  chordWrap.className = 'strip-chords';
-  chordWrap.dataset.idx = -1;
-  host.appendChild(chordWrap);
-  const key = eng.getKey();
-  if (key) {
-    const keyEl = document.createElement('span');
-    keyEl.className = 'strip-key';
-    keyEl.textContent = fmtKeyName(key).toUpperCase();
-    host.appendChild(keyEl);
-  }
+  status.appendChild(chainWrap);
+  const scopeBtn = document.createElement('button');
+  scopeBtn.className = 'scope-btn' + (_scopeOpen ? ' on' : '');
+  scopeBtn.title = 'Oscilloscope';
+  scopeBtn.textContent = '⌁';
+  scopeBtn.onclick = () => toggleScope();
+  status.appendChild(scopeBtn);
   const bpmEl = document.createElement('span');
   bpmEl.className = 'strip-bpm';
   bpmEl.id = 'strip-bpm';
   bpmEl.textContent = `${currentBpm} BPM`;
-  host.appendChild(bpmEl);
-  updateStrip(eng.getPlaybackTarget());
+  status.appendChild(bpmEl);
+  host.appendChild(status);
+
+  updateLcdBar(eng.getPlaybackTarget());
 }
 
-// Per-step strip update: hot-class moves only — chord segs rebuild only when
-// the sounding pattern changes (a handful of nodes, on a bar boundary).
-function updateStrip(target) {
+function crumbSeg(label, go, cur) {
+  const b = document.createElement('button');
+  b.className = 'cseg' + (cur ? ' cur' : '');
+  b.textContent = label;
+  if (go && !cur) b.onclick = go; else b.disabled = !!cur;
+  return b;
+}
+function crumbSep() {
+  const s = document.createElement('span');
+  s.className = 'csep';
+  s.textContent = '›';
+  return s;
+}
+
+// Per-step status update: move the hot class on the song-order chips; show a
+// LOOP marker when a single pattern is looping instead of the chain.
+function updateLcdBar(target) {
   const host = document.getElementById('lcd-strip');
   if (!host || !target) return;
   const isPattern = target.kind === 'pattern';
@@ -1205,142 +1224,40 @@ function updateStrip(target) {
   const loop = host.querySelector('.strip-loop');
   if (loop) {
     loop.hidden = !isPattern;
-    if (isPattern) loop.textContent = `LOOP P${target.patternIdx + 1}`;
-  }
-  const wrap = host.querySelector('.strip-chords');
-  if (wrap) {
-    if (+wrap.dataset.idx !== target.patternIdx) {
-      wrap.dataset.idx = target.patternIdx;
-      wrap.innerHTML = '';
-      (eng.getPatternChords(target.patternIdx) || []).forEach((c, i) => {
-        const seg = document.createElement('span');
-        seg.className = 'strip-seg';
-        seg.dataset.i = i;
-        seg.textContent = c.name;
-        wrap.appendChild(seg);
-      });
-    }
-    const segs = wrap.querySelectorAll('.strip-seg');
-    if (segs.length) {
-      const hot = target.barInPattern % segs.length;
-      segs.forEach(seg => seg.classList.toggle('hot', +seg.dataset.i === hot));
-    }
+    if (isPattern) loop.textContent = `LOOP ${patLabel(target.patternIdx)}`;
   }
 }
 
-// Build the chord line for pattern `idx`: "chords" label + chord chips (or a
-// "＋ chords" affordance when empty). Nested under the patterns row — the
-// indent says whose chords they are, so no P-marker. The chip area is
-// clickable → beginChordEdit swaps in the text input. Watching the sounding
-// pattern's chords is the strip's job; this row is the edit pattern's.
-function buildChordLine(idx) {
-  const row = document.createElement('div');
-  row.className = 'chord-row';
-  row.dataset.idx = idx;
-  const lbl = document.createElement('span');
-  lbl.className = 'pat-lbl';
-  lbl.innerHTML = `chords<small>of pattern ${idx + 1}</small>`;
-  row.appendChild(lbl);
-
-  const chips = document.createElement('div');
-  chips.className = 'h-chips';
-  const chords = eng.getPatternChords(idx) || [];
-  if (chords.length) {
-    chords.forEach((c, i) => {
-      const chip = document.createElement('span');
-      chip.className = 'h-chip';
-      chip.dataset.idx = i;
-      chip.textContent = c.name;
-      chips.appendChild(chip);
-    });
-  } else {
-    const add = document.createElement('span');
-    add.className = 'h-chip h-empty';
-    add.textContent = '＋ chords';
-    chips.appendChild(add);
-  }
-  chips.onclick = () => beginChordEdit(idx);
-  row.appendChild(chips);
-  // The song's key rides the chords row — it's harmony information.
-  const key = eng.getKey();
-  if (key) {
-    const badge = document.createElement('span');
-    badge.className = 'h-key';
-    badge.textContent = fmtKeyName(key);
-    row.appendChild(badge);
-  }
-  return row;
-}
-
-// Swap the chip area for a text input prefilled from the pattern's chords.
-// Enter / blur commit (parse → setPatternChords); Escape cancels; invalid input
-// keeps a red border and stays editing.
-function beginChordEdit(idx) {
-  const host = document.getElementById('lcd-song-rows');
-  const chips = host?.querySelector('.chord-row .h-chips');
-  if (!chips) return;
+// Composer chord edit: swap the progression chips for a text input
+// (parser-backed). Enter / blur commit; Escape cancels; invalid stays editing.
+function openComposerChordEdit(idx, anchor) {
   const chords = eng.getPatternChords(idx) || [];
   const input = document.createElement('input');
   input.className = 'h-edit';
   input.value = formatProgression(chords);
   input.placeholder = 'e.g. F#m D A E/G#';
-  chips.replaceWith(input);
+  anchor.replaceWith(input);
   input.focus();
   input.select();
   let done = false;
-  const cancel = () => { if (done) return; done = true; renderPatterns(); refreshVizPattern(); };
+  const finish = () => { renderScreen(); refreshVizPattern(); };
   const commit = () => {
     if (done) return;
     const text = input.value.trim();
-    if (text === '') {                         // empty → clear the pattern's chords
-      done = true;
-      eng.selectPattern(idx);
-      eng.setPatternChords([]);
-      renderPatterns();
-      refreshVizPattern();
-      return;
-    }
+    if (text === '') { done = true; eng.selectPattern(idx); eng.setPatternChords([]); finish(); return; }
     const { chords: parsed, errors } = parseProgression(text);
     if (errors.length || !parsed.length) { input.classList.add('invalid'); return; }
     done = true;
-    eng.selectPattern(idx);                    // setPatternChords targets the edit pattern
+    eng.selectPattern(idx);
     eng.setPatternChords(parsed);
-    renderPatterns();
-    refreshVizPattern();   // melody/bass tinting reads the new chords/key
+    finish();
   };
   input.oninput = () => input.classList.remove('invalid');
   input.onkeydown = e => {
     if (e.key === 'Enter') { e.preventDefault(); commit(); }
-    else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    else if (e.key === 'Escape') { e.preventDefault(); if (!done) { done = true; finish(); } }
   };
   input.onblur = commit;
-}
-
-// Glow + row dimming — called from renderPatterns and every step.
-function updatePatternsPlayback(target) {
-  const host = document.getElementById('lcd-song-rows');
-  if (!host || !target) return;
-  const isPattern = target.kind === 'pattern';
-  const prow = host.querySelector('.pat-row');
-  const crow = host.querySelector('.chain-row');
-  if (prow) prow.classList.toggle('dimmed', !isPattern);
-  if (crow) crow.classList.toggle('dimmed', isPattern);
-  host.querySelectorAll('.pat-slot').forEach(b => {
-    b.classList.toggle('playing', isPattern && +b.dataset.idx === target.patternIdx);
-  });
-  host.querySelectorAll('.chain-chip').forEach(c => {
-    c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos);
-  });
-  // The chord row shows the EDIT pattern's chords; light the live chord only
-  // when the edit pattern happens to be the one sounding. (The strip narrates
-  // the sounding pattern; no prose status — the chips ARE the status.)
-  const liveRow = host.querySelector('.chord-row');
-  const chordChips = liveRow ? liveRow.querySelectorAll('.h-chip:not(.h-empty)') : [];
-  if (chordChips.length) {
-    const isSounding = +liveRow.dataset.idx === target.patternIdx;
-    const sounding = target.barInPattern % chordChips.length;
-    chordChips.forEach(chip => chip.classList.toggle('sounding', isSounding && +chip.dataset.idx === sounding));
-  }
 }
 
 // Tell the viz the edit pattern changed (rebuilds the open editor).
@@ -1376,20 +1293,19 @@ function resetFX() {
 // ─── Mount: (re)build all per-song UI ────────────────────────────────────────
 function mount() {
   song = eng.getSong();
-  // No credit line — the strip carries title + artist; the dropdown carries the title.
+  // No credit line — the breadcrumb/title carry it.
   renderStrips();
   renderFills();
   renderPunch();
   renderMaster();
-  renderPatterns();   // also rebuilds the LCD status strip
   viz?.dispose?.();   // stop the outgoing viz's rAF loops before replacing it
-  viz = makeViz(document.getElementById('lcd-body'), song, eng);
-  // Scope/Song tabs off — lane editor takes over.
-  document.querySelectorAll('[data-view]').forEach(x => x.classList.remove('on'));
-  // Auto-open the first editable lane (drums or first non-chords lane).
+  viz = makeViz(document.getElementById('lcd-viz'), song, eng);
+  // Point the viz at the first editable lane so Grooves has a default; then
+  // route to HOME — the hub is the entry, Song is not forced.
   const lanes = eng.getLanes();
   const firstEditable = lanes.find(l => l.type !== 'chords') || lanes[0];
-  if (firstEditable) activateEditLane(firstEditable.id);
+  if (firstEditable) _editingLaneId = firstEditable.id;
+  setRoute('home');
 }
 
 // ─── Load a different song ────────────────────────────────────────────────────
@@ -1424,13 +1340,11 @@ document.getElementById('play').onclick = async function() {
   if (this.classList.contains('on')) {
     eng.stop(); this.classList.remove('on'); this.textContent='▶ play';
     stopMeterLoop();
-    updatePatternsPlayback(eng.getPlaybackTarget());
-    updateStrip(eng.getPlaybackTarget());
+    updatePlayback(eng.getPlaybackTarget());
   } else {
     await eng.play(); this.classList.add('on'); this.textContent='⏹ stop';
     startMeterLoop();
-    updatePatternsPlayback(eng.getPlaybackTarget());
-    updateStrip(eng.getPlaybackTarget());
+    updatePlayback(eng.getPlaybackTarget());
   }
 };
 // (Tempo + transpose controls live on MASTER — built in renderMaster().)
@@ -1583,7 +1497,7 @@ document.addEventListener('pointerdown', e => {
 });
 // Screen picker (Settings) — override the theme's glass with a chosen LCD.
 
-// (Scope + quick-edit lane tabs are built and wired in renderViewTabs().)
+// (The screen is routed by setRoute(); the scope monitor toggles via toggleScope().)
 
 // ─── Step callback (registered once; closes over module-level song/viz) ──────
 eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
@@ -1595,8 +1509,7 @@ eng.onStep(({ absStep, bar, stepInBar, fill, queue, target }) => {
     });
     renderChain(queue);
   }
-  updatePatternsPlayback(target);
-  updateStrip(target);
+  updatePlayback(target);
 });
 
 // ─── Restore saved theme ──────────────────────────────────────────────────────

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1038,7 +1038,8 @@ function renderPatternsComposer(body) {
       `<span class="li-nm">${p.name ? esc(p.name) : 'P' + (i + 1)}</span>` +
       `<span class="li-chev">›</span></button>`;
   });
-  list += `<button class="li li-add" data-newsec="1">＋ new section</button>`;
+  const atCap = patterns.length >= 16;
+  list += `<button class="li li-add" data-newsec="1"${atCap ? ' disabled title="Maximum 16 sections"' : ''}>＋ new section</button>`;
 
   let detail = `<button class="pane-back" data-back="1">‹ sections</button>` +
     `<div class="pane-ttl">compose “${s && s.name ? esc(s.name) : 'P' + (editIdx + 1)}” — swap a loop` +
@@ -1238,7 +1239,10 @@ function crumbSeg(label, go, cur) {
   const b = document.createElement('button');
   b.className = 'cseg' + (cur ? ' cur' : '');
   b.textContent = label;
-  if (go && !cur) b.onclick = go; else b.disabled = !!cur;
+  // Current location: stays keyboard-focusable, state via aria-current, no action
+  // (don't use `disabled` — it drops focusability and muddies "where am I").
+  if (cur) b.setAttribute('aria-current', 'true');
+  else if (go) b.onclick = go;
   return b;
 }
 function crumbSep() {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -287,17 +287,22 @@ function toggleScope() {
   else if (_route === 'grooves' && _editingLaneId) activateEditLane(_editingLaneId);
 }
 
-// Live playback paint across whatever screen is showing (+ the status bar).
+// Live playback paint (called every step). The status strip always updates;
+// the in-screen chips only exist on Song/Patterns, so gate those queries by
+// route to avoid per-step DOM work on Home/Grooves.
 function updatePlayback(target) {
   if (!target) return;
   updateLcdBar(target);
+  const isPattern = target.kind === 'pattern';
   const body = document.getElementById('lcd-body');
   if (!body) return;
-  const isPattern = target.kind === 'pattern';
-  body.querySelectorAll('.chain-chip[data-pos]').forEach(c =>
-    c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos));
-  body.querySelectorAll('.li[data-sec]').forEach(b =>
-    b.classList.toggle('playing', isPattern && +b.dataset.sec === target.patternIdx));
+  if (_route === 'song') {
+    body.querySelectorAll('.chain-chip[data-pos]').forEach(c =>
+      c.classList.toggle('playing', !isPattern && +c.dataset.pos === target.chainPos));
+  } else if (_route === 'patterns') {
+    body.querySelectorAll('.li[data-sec]').forEach(b =>
+      b.classList.toggle('playing', isPattern && +b.dataset.sec === target.patternIdx));
+  }
 }
 
 // ─── SELECT SONG — the cartridge drawer ──────────────────────────────────────
@@ -1214,6 +1219,8 @@ function renderLcdBar() {
   const scopeBtn = document.createElement('button');
   scopeBtn.className = 'scope-btn' + (_scopeOpen ? ' on' : '');
   scopeBtn.title = 'Oscilloscope';
+  scopeBtn.setAttribute('aria-label', 'Oscilloscope');
+  scopeBtn.setAttribute('aria-pressed', String(_scopeOpen));
   scopeBtn.textContent = '∿';
   scopeBtn.onclick = () => toggleScope();
   status.appendChild(scopeBtn);
@@ -1223,8 +1230,8 @@ function renderLcdBar() {
   bpmEl.textContent = `${currentBpm} BPM`;
   status.appendChild(bpmEl);
   host.appendChild(status);
-
-  updateLcdBar(eng.getPlaybackTarget());
+  // (No updateLcdBar here — renderScreen() calls updatePlayback() right after,
+  // which paints the playhead. renderLcdBar is only ever called from there.)
 }
 
 function crumbSeg(label, go, cur) {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1104,6 +1104,12 @@ function renderSongArranger(body) {
   h += `</div>`;
   body.innerHTML = h;
 
+  // Clear the drag-dim from EVERY chip (not just one) on any drag end — HTML5 DnD
+  // doesn't reliably fire dragend when the source node is replaced by a re-render.
+  const clearChainDrag = () => {
+    _chainDragFrom = null;
+    body.querySelectorAll('.chain-chip').forEach(c => c.classList.remove('dragging', 'drop-left', 'drop-right'));
+  };
   body.querySelectorAll('.chain-chip[data-pos]').forEach(chip => {
     const pos = +chip.dataset.pos;
     chip.onclick = e => {
@@ -1111,16 +1117,27 @@ function renderSongArranger(body) {
       eng.playChain(pos); renderScreen();
     };
     chip.ondragstart = () => { _chainDragFrom = pos; chip.classList.add('dragging'); };
-    chip.ondragend = () => { _chainDragFrom = null; chip.classList.remove('dragging'); };
-    chip.ondragover = e => e.preventDefault();
-    chip.ondrop = e => {
+    chip.ondragend = clearChainDrag;
+    // Show an insertion line on the side the chip would drop into.
+    chip.ondragover = e => {
       e.preventDefault();
       if (_chainDragFrom === null || _chainDragFrom === pos) return;
       const rect = chip.getBoundingClientRect();
       const before = e.clientX < rect.left + rect.width / 2;
+      body.querySelectorAll('.chain-chip').forEach(c => c.classList.remove('drop-left', 'drop-right'));
+      chip.classList.add(before ? 'drop-left' : 'drop-right');
+    };
+    chip.ondragleave = () => chip.classList.remove('drop-left', 'drop-right');
+    chip.ondrop = e => {
+      e.preventDefault();
+      const from = _chainDragFrom;
+      const rect = chip.getBoundingClientRect();
+      const before = e.clientX < rect.left + rect.width / 2;
+      clearChainDrag();                  // clear feedback before the re-render replaces nodes
+      if (from === null || from === pos) return;
       let to = before ? pos : pos + 1;
-      if (_chainDragFrom < to) to--;
-      eng.moveChain(_chainDragFrom, to);
+      if (from < to) to--;
+      eng.moveChain(from, to);
       renderScreen();
     };
   });

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1116,11 +1116,14 @@ function renderSongArranger(body) {
       if (e.target.classList.contains('chip-x')) { if (eng.removeChainAt(pos)) renderScreen(); return; }
       eng.playChain(pos); renderScreen();
     };
-    chip.ondragstart = () => { _chainDragFrom = pos; chip.classList.add('dragging'); };
-    chip.ondragend = clearChainDrag;
+    // stopPropagation on every drag event: the screen is wrapped in a draggable
+    // .sec (cabinet panel reorder) whose handlers would otherwise fire on this
+    // chip drag and dim the whole section (.sec-dragging { opacity:.45 }).
+    chip.ondragstart = e => { e.stopPropagation(); _chainDragFrom = pos; chip.classList.add('dragging'); };
+    chip.ondragend = e => { e.stopPropagation(); clearChainDrag(); };
     // Show an insertion line on the side the chip would drop into.
     chip.ondragover = e => {
-      e.preventDefault();
+      e.preventDefault(); e.stopPropagation();
       if (_chainDragFrom === null || _chainDragFrom === pos) return;
       const rect = chip.getBoundingClientRect();
       const before = e.clientX < rect.left + rect.width / 2;
@@ -1129,7 +1132,7 @@ function renderSongArranger(body) {
     };
     chip.ondragleave = () => chip.classList.remove('drop-left', 'drop-right');
     chip.ondrop = e => {
-      e.preventDefault();
+      e.preventDefault(); e.stopPropagation();
       const from = _chainDragFrom;
       const rect = chip.getBoundingClientRect();
       const before = e.clientX < rect.left + rect.width / 2;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -624,13 +624,18 @@ function renderStrips() {
     handle.addEventListener('mousedown', () => { row.draggable = true; });
     handle.addEventListener('mouseup',   () => { row.draggable = false; });
 
+    // stopPropagation on a lane drag so it doesn't bubble to the .sec panel
+    // reorder (which would dim the whole strips section, .sec-dragging). Gated on
+    // _draggedLaneId so a panel drag passing over a lane still reaches the .sec.
     row.addEventListener('dragstart', e => {
+      e.stopPropagation();
       _draggedLaneId = row.dataset.lane;
       row.classList.add('dragging');
       e.dataTransfer.effectAllowed = 'move';
     });
 
-    row.addEventListener('dragend', () => {
+    row.addEventListener('dragend', e => {
+      e.stopPropagation();
       row.classList.remove('dragging');
       row.draggable = false;
       _draggedLaneId = null;
@@ -641,6 +646,7 @@ function renderStrips() {
     row.addEventListener('dragover', e => {
       if (!_draggedLaneId || _draggedLaneId === row.dataset.lane) return;
       e.preventDefault();
+      e.stopPropagation();
       e.dataTransfer.dropEffect = 'move';
       const rect = row.getBoundingClientRect();
       const midY = rect.top + rect.height / 2;
@@ -654,8 +660,10 @@ function renderStrips() {
     });
 
     row.addEventListener('drop', e => {
+      if (!_draggedLaneId) return;            // panel drag — let the .sec reorder handle it
+      e.stopPropagation();
       e.preventDefault();
-      if (!_draggedLaneId || _draggedLaneId === row.dataset.lane) return;
+      if (_draggedLaneId === row.dataset.lane) return;
       const lanes = eng.getLanes();
       const targetIdx = lanes.findIndex(l => l.id === row.dataset.lane);
       const rect = row.getBoundingClientRect();
@@ -1123,8 +1131,8 @@ function renderSongArranger(body) {
     chip.ondragend = e => { e.stopPropagation(); clearChainDrag(); };
     // Show an insertion line on the side the chip would drop into.
     chip.ondragover = e => {
+      if (_chainDragFrom === null || _chainDragFrom === pos) return;   // only our own reorder
       e.preventDefault(); e.stopPropagation();
-      if (_chainDragFrom === null || _chainDragFrom === pos) return;
       const rect = chip.getBoundingClientRect();
       const before = e.clientX < rect.left + rect.width / 2;
       body.querySelectorAll('.chain-chip').forEach(c => c.classList.remove('drop-left', 'drop-right'));
@@ -1132,12 +1140,13 @@ function renderSongArranger(body) {
     };
     chip.ondragleave = () => chip.classList.remove('drop-left', 'drop-right');
     chip.ondrop = e => {
+      if (_chainDragFrom === null) return;     // panel drag passing over a chip — let it bubble
       e.preventDefault(); e.stopPropagation();
       const from = _chainDragFrom;
       const rect = chip.getBoundingClientRect();
       const before = e.clientX < rect.left + rect.width / 2;
       clearChainDrag();                  // clear feedback before the re-render replaces nodes
-      if (from === null || from === pos) return;
+      if (from === pos) return;
       let to = before ? pos : pos + 1;
       if (from < to) to--;
       eng.moveChain(from, to);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -1185,7 +1185,7 @@ function renderLcdBar() {
   const scopeBtn = document.createElement('button');
   scopeBtn.className = 'scope-btn' + (_scopeOpen ? ' on' : '');
   scopeBtn.title = 'Oscilloscope';
-  scopeBtn.textContent = '⌁';
+  scopeBtn.textContent = '∿';
   scopeBtn.onclick = () => toggleScope();
   status.appendChild(scopeBtn);
   const bpmEl = document.createElement('span');


### PR DESCRIPTION
**Stories 2–6** of the song-editor redesign epic, built as one branch (the new IA isn't coherent until the editors exist). Reference: the playable prototype `mocks/15-responsive-combined.html`.

## What changed
- **HOME hub + breadcrumb** inside the LCD — boots to a three-card menu (Grooves / Patterns / Song); the breadcrumb (`Home › Patterns › Verse`) is the navigation. Replaces the old `Song / Drums / Bass / Melody / Scope` tab bar.
- **Grooves editor** — instrument list → that lane's step editor. The viz now lives in a **persistent `#lcd-viz` sibling** so router re-renders of `#lcd-body` never destroy its canvas; it's rebuilt at the visible width on entry (handles the R1 reflow risk).
- **Patterns composer** — sections list → compose by **swapping a loop per instrument** (selects) + the chord progression. No note-editing here (that's Grooves).
- **Song arranger** — the chain (drag-reorder, remove) + an add-a-section list.
- **Hardware strips → instrument/sound** — the groove dropdown is gone (the loop is chosen on the screen); VIEW jumps to that lane in Grooves; `add lane` → `add instrument`.
- **Scope is a monitor** — a `⌁` toggle in the status bar overlays the oscilloscope; it's no longer a content tab.
- **Responsive** — desktop two-pane, mobile drill (one pane at a time) at the existing 900px breakpoint.

## Verification
- ✅ 377/377 tests green; `node --check` clean on app.js. Engine + validator unchanged.
- ⚠️ **Not yet runtime-tested in a browser** — needs a hands-on pass (load, click through HOME → each editor, play, resize). Serve: `python3 -m http.server` in `docs/arcade/groovebox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)