### PR TITLE
arcade(groovebox): post-redesign polish — LOAD SONG, tool-chrome buttons, scope pills, SNES knob colours, punch fixes

### DIFF
--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -57,7 +57,7 @@ export const DEFAULT_PRESETS = [
   { name: 'STUTTER BASS', key: '2', engageQuantize: 'immediate', releaseQuantize: 'immediate',
     lanes: ['drums', 'bass'],   // chop the rhythm section; pads/melody ride on top
     automations: [
-      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/8',
+      { module: 'gate', param: 'depth', from: 'neutral', to: 1, division: '1/4',
         engage: { ramp: { unit: 'steps', value: 0 } }, release: { ramp: { unit: 'steps', value: 0.1 } } },
     ] },
   { name: 'CRUSH', key: '3', engageQuantize: 'immediate', releaseQuantize: 'immediate',

--- a/docs/arcade/groovebox/engine/punch-presets.js
+++ b/docs/arcade/groovebox/engine/punch-presets.js
@@ -80,12 +80,4 @@ export const DEFAULT_PRESETS = [
       { module: 'delay', param: 'wet', from: 'neutral', to: 0.5,
         engage: { ramp: { unit: 'steps', value: 0.5 } }, release: { ramp: { unit: 'beats', value: 3 } } },
     ] },
-  { name: 'STOP', key: '6', engageQuantize: 'immediate', releaseQuantize: 'immediate',
-    automations: [
-      // Semantic module (spec decision 6): the engine implements tapeStop
-      // internally (gate fade + tape slump + on-grid return). Engage ramp =
-      // slump duration; release handling is internal to the module.
-      { module: 'transport', param: 'tapeStop', from: 'neutral', to: 1,
-        engage: { ramp: { unit: 'beats', value: 1.5 } }, release: { ramp: { unit: 'steps', value: 0 } } },
-    ] },
 ];

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -3,9 +3,9 @@ import { DEFAULT_PRESETS, validatePreset } from '../engine/punch-presets.js';
 import { MODULE_PARAMS } from '../engine/punch.js';
 
 describe('DEFAULT_PRESETS', () => {
-  it('ships six slots with keys 1-6', () => {
-    expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5', '6']);
-    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'STUTTER BASS', 'CRUSH', 'DIVE', 'THROW', 'STOP']);
+  it('ships five slots with keys 1-5', () => {
+    expect(DEFAULT_PRESETS.map(p => p.key)).toEqual(['1', '2', '3', '4', '5']);
+    expect(DEFAULT_PRESETS.map(p => p.name)).toEqual(['STUTTER', 'STUTTER BASS', 'CRUSH', 'DIVE', 'THROW']);
   });
   it('every preset validates', () => {
     for (const p of DEFAULT_PRESETS) expect(validatePreset(p)).toBe(true);
@@ -102,9 +102,8 @@ describe('lane masks (v3.5 — per-preset targeting)', () => {
     expect(th.automations[0].to).toBe(0.5);
     expect(th.lanes).toEqual(['drums', 'bass', 'chords']);
   });
-  it('omitted lanes means all (DIVE/STOP carry no mask)', () => {
+  it('omitted lanes means all (DIVE carries no mask)', () => {
     expect(DEFAULT_PRESETS.find(p => p.name === 'DIVE').lanes).toBeUndefined();
-    expect(DEFAULT_PRESETS.find(p => p.name === 'STOP').lanes).toBeUndefined();
   });
 });
 

--- a/docs/arcade/groovebox/tests/punch-presets.test.js
+++ b/docs/arcade/groovebox/tests/punch-presets.test.js
@@ -15,12 +15,12 @@ describe('DEFAULT_PRESETS', () => {
       for (const a of p.automations)
         expect(MODULE_PARAMS[`${a.module}.${a.param}`]).toBeDefined();
   });
-  it('both stutters chop at 1/8 with their own sections', () => {
+  it('stutters chop their own sections (melody 1/8, bass 1/4)', () => {
     const mel = DEFAULT_PRESETS.find(p => p.name === 'STUTTER');
     const bas = DEFAULT_PRESETS.find(p => p.name === 'STUTTER BASS');
     expect(mel.automations[0].division).toBe('1/8');
     expect(mel.lanes).toEqual(['melody']);
-    expect(bas.automations[0].division).toBe('1/8');
+    expect(bas.automations[0].division).toBe('1/4');
     expect(bas.lanes).toEqual(['drums', 'bass']);
   });
 });

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1549,7 +1549,7 @@ body.gb-knob-values .knob-val { display: block; }
    armed, fills while you hold it, muted when the transport is stopped. */
 .pe-test {
   margin-left: auto; border: 1px solid var(--acc); border-radius: 6px;
-  padding: 6px 16px; cursor: pointer;
+  height: auto; padding: 7px 16px; cursor: pointer; line-height: 1.2;
   background: color-mix(in srgb, var(--acc) 14%, transparent); color: var(--acc);
   font-weight: 700; user-select: none; touch-action: none;
 }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -258,14 +258,15 @@ body {
   gap: 6px;
   flex-shrink: 0;
 }
-/* Tool chrome — smaller, visually secondary vs transport */
+/* Tool chrome — smaller, visually secondary vs transport, but still read as
+   tappable buttons (a subtle fill + legible label, not flat text). */
 .titlebar-tools select,
 .titlebar-tools button {
   height: 26px;
   font-size: 11px;
   padding: 0 10px;
-  color: var(--dim);
-  background: transparent;
+  color: var(--ink);
+  background: var(--panel-2);
   border-color: var(--line);
   box-shadow: none;
 }
@@ -282,7 +283,7 @@ body {
 }
 .titlebar-tools button:hover,
 .titlebar-tools select:hover {
-  background-color: var(--panel-2);
+  background-color: var(--panel-3);
   border-color: var(--acc-dim);
   color: var(--ink);
 }
@@ -1172,6 +1173,8 @@ input[type=range] {
   position: relative;
   z-index: 2;
 }
+/* The scope is a screen monitor (lives on the pearl LCD), so it speaks the
+   screen palette — not the dark cabinet tokens. Match the .gpick control look. */
 .scope-bar {
   display: flex;
   align-items: center;
@@ -1180,18 +1183,24 @@ input[type=range] {
   position: relative;
   z-index: 2;
   font-size: 11px;
-  color: var(--dim);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--screen-dim);
 }
 .scope-bar select {
-  background: var(--panel-2);
-  color: var(--acc);
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  padding: 0 28px 0 4px;
+  background: color-mix(in srgb, var(--screen-ink) 8%, transparent);
+  color: var(--screen-ink);
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent);
+  border-radius: 6px;
+  padding: 4px 8px;
   font: inherit;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
   cursor: pointer;
-  height: 26px;
+  height: auto;
 }
+.scope-bar select:hover { border-color: var(--screen-acc); }
 
 /* ─── § 5 — lane strips: aligned shared grid ────────────────────────────── */
 .lane {

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1545,13 +1545,22 @@ body.gb-knob-values .knob-val { display: block; }
   letter-spacing: 0.06em; width: 130px; text-transform: uppercase;
 }
 .pe-badge { font-size: 10px; color: var(--faint); }
+/* Ghost-accent momentary button (on-theme, not a candy gradient): outlined when
+   armed, fills while you hold it, muted when the transport is stopped. */
 .pe-test {
-  margin-left: auto; border: 0; border-radius: 8px; padding: 6px 16px; cursor: pointer;
-  background: linear-gradient(180deg, #63f8d4, #3dd6b0); color: #04201a; font-weight: 700;
-  box-shadow: 0 0 14px rgba(84, 240, 200, 0.4); user-select: none; touch-action: none;
+  margin-left: auto; border: 1px solid var(--acc); border-radius: 6px;
+  padding: 6px 16px; cursor: pointer;
+  background: color-mix(in srgb, var(--acc) 14%, transparent); color: var(--acc);
+  font-weight: 700; user-select: none; touch-action: none;
 }
-.pe-test small { display: block; font-weight: 400; font-size: 9px; opacity: 0.7; }
-.pe-test.idle { filter: grayscale(1); opacity: 0.5; box-shadow: none; }
+.pe-test small { display: block; font-weight: 400; font-size: 9px; opacity: 0.8; }
+.pe-test:active {
+  background: var(--acc); color: #04201a;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--acc) 45%, transparent);
+}
+.pe-test.idle {
+  border-color: var(--line); background: none; color: var(--faint); box-shadow: none;
+}
 .pe-fx { border: 1px solid var(--line); border-radius: 8px; background: var(--panel-2); padding: 10px; margin: 8px 0; }
 .pe-fxhd { display: flex; align-items: center; margin-bottom: 6px; }
 .pe-fxname { color: var(--ink); font-weight: 700; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1187,12 +1187,15 @@ input[type=range] {
   text-transform: uppercase;
   color: var(--screen-dim);
 }
-.scope-bar select {
+.scope-bar-lbl { flex-shrink: 0; }
+.scope-segs { display: flex; flex-wrap: wrap; gap: 4px; }
+.scope-seg {
+  appearance: none;
   background: color-mix(in srgb, var(--screen-ink) 8%, transparent);
   color: var(--screen-ink);
-  border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent);
+  border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent);
   border-radius: 6px;
-  padding: 4px 8px;
+  padding: 3px 9px;
   font: inherit;
   font-weight: 700;
   text-transform: none;
@@ -1200,7 +1203,12 @@ input[type=range] {
   cursor: pointer;
   height: auto;
 }
-.scope-bar select:hover { border-color: var(--screen-acc); }
+.scope-seg:hover { border-color: var(--screen-acc); }
+.scope-seg.on {
+  background: var(--screen-acc);
+  border-color: var(--screen-acc);
+  color: var(--screen-bg);
+}
 
 /* ─── § 5 — lane strips: aligned shared grid ────────────────────────────── */
 .lane {
@@ -2860,6 +2868,11 @@ html:not([data-theme]) .vc.now:not(.hit),
   --hit1:        #4ab44a;   /* Y-green drum hits */
   --hit2:        #2a7a30;
 }
+/* Knob indicators cycle the ABXY button colours (blue → yellow → red → green). */
+[data-theme="snes"] .knob[data-kc="0"] .knob-ind { background: #3a6ee0; box-shadow: 0 0 4px #3a6ee0; }
+[data-theme="snes"] .knob[data-kc="1"] .knob-ind { background: #d8b43a; box-shadow: 0 0 4px #d8b43a; }
+[data-theme="snes"] .knob[data-kc="2"] .knob-ind { background: #d8403a; box-shadow: 0 0 4px #d8403a; }
+[data-theme="snes"] .knob[data-kc="3"] .knob-ind { background: #4ab44a; box-shadow: 0 0 4px #4ab44a; }
 [data-theme="snes"] h1 { text-shadow: none; }
 [data-theme="snes"] .vc.hit { box-shadow: 0 0 6px rgba(74,180,74,0.35), inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -1px 0 rgba(0,0,0,0.3); }
 [data-theme="snes"] .vc.now:not(.hit) { box-shadow: 0 0 8px rgba(216,180,58,0.3); background: rgba(216,180,58,0.07); }

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -348,7 +348,7 @@ function renderPicker() {
   host.innerHTML = '';
   const head = document.createElement('div');
   head.className = 'picker-head';
-  head.innerHTML = `<span>SELECT SONG</span>`;
+  head.innerHTML = `<span>LOAD SONG</span>`;
   const close = document.createElement('button');
   close.className = 'picker-close';
   close.textContent = '✕';

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -161,6 +161,9 @@ function makeKnobrow(groups) {
   row.appendChild(mkHint('l'));
   for (const g of groups) row.appendChild(g);
   row.appendChild(mkHint('r'));
+  // Rotation index per knob (0-3) — themes can colour the indicator by position
+  // (e.g. SNES cycles the ABXY button colours blue/yellow/red/green).
+  row.querySelectorAll('.knob').forEach((k, i) => { k.dataset.kc = String(i % 4); });
   row.addEventListener('scroll', () => updateKnobrowFade(row), { passive: true });
   requestAnimationFrame(() => updateKnobrowFade(row));
   return row;

--- a/docs/arcade/groovebox/ui/viz.js
+++ b/docs/arcade/groovebox/ui/viz.js
@@ -798,18 +798,22 @@ export function makeViz(host, song, eng) {
         drawRoll(-1);
       }
     } else if (view === 'scope') {
-      // Build source list: master + each lane (id as value, name as label).
+      // Source = master + each lane. Segmented pills (not a native <select>): one
+      // tap, no OS popup, and they speak the pearl-LCD palette.
       const laneSources = eng.getLanes().map(l => ({ value: l.id, label: l.name }));
       const SOURCES = [{ value: 'master', label: 'master' }, ...laneSources];
-      const opts = SOURCES.map(s =>
-        `<option value="${s.value}"${s.value === scopeSource ? ' selected' : ''}>${s.label}</option>`
+      const segs = SOURCES.map(s =>
+        `<button class="scope-seg${s.value === scopeSource ? ' on' : ''}" data-src="${esc(s.value)}">${esc(s.label)}</button>`
       ).join('');
-      host.innerHTML = `<div class="scope-bar"><label>source <select id="scope-src">${opts}</select></label></div>`
+      host.innerHTML = `<div class="scope-bar"><span class="scope-bar-lbl">source</span><div class="scope-segs">${segs}</div></div>`
         + `<canvas id="scope-canvas"></canvas>`;
       const cv = host.querySelector('#scope-canvas');
       cv.width = host.clientWidth || 680;
       cv.height = 140;
-      host.querySelector('#scope-src').onchange = e => { scopeSource = e.target.value; };
+      host.querySelectorAll('.scope-seg').forEach(b => b.onclick = () => {
+        scopeSource = b.dataset.src;
+        host.querySelectorAll('.scope-seg').forEach(x => x.classList.toggle('on', x === b));
+      });
       startScopeLoop();
     } else if (view === 'bass') {
       if (rollMode === 'blocks') {


### PR DESCRIPTION
Follow-up polish on the song-editor redesign (#672), from hands-on review. Visual/UX only — no changelog (arcade is consumer-invisible).

### Changes
- **Song drawer header reads "LOAD SONG"** (was "SELECT SONG").
- **Theme / Settings / Help** get a subtle fill + legible label so they read as buttons, not flat text — still secondary to the transport.
- **Scope source picker** → inline segmented pills (master · drums · bass …) instead of a native `<select>`: one tap, no OS popup, speaks the pearl-LCD palette. (The scope is a screen monitor now, so it uses screen tokens, not the dark cabinet ones.)
- **SNES theme**: knob indicators cycle the ABXY button colours (blue → yellow → red → green) by position.
- **Punch**: removed the **STOP** (tape-stop) pad — defaults are now 5 pads / keys 1–5 (matches the existing help copy); `transport.tapeStop` engine module stays available. **STUTTER BASS** now chops at **1/4** by default (was 1/8) — reads as a groove, not a buzz.

### Tests
377 passing (punch-preset tests updated for the 5-pad default + STUTTER BASS 1/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)