### PR TITLE
arcade(groovebox): punch TEST button fixes + song-switch tempo-stick fix

### DIFF
--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1554,7 +1554,7 @@ body.gb-knob-values .knob-val { display: block; }
   font-weight: 700; user-select: none; touch-action: none;
 }
 .pe-test small { display: block; font-weight: 400; font-size: 9px; opacity: 0.8; }
-.pe-test:active {
+.pe-test:active, .pe-test.held {
   background: var(--acc); color: #04201a;
   box-shadow: 0 0 10px color-mix(in srgb, var(--acc) 45%, transparent);
 }

--- a/docs/arcade/groovebox/ui/punch-editor.js
+++ b/docs/arcade/groovebox/ui/punch-editor.js
@@ -132,18 +132,22 @@ export function openPunchEditor({ slot, eng, onSaved }) {
     const badge = document.createElement('span');
     badge.className = 'pe-badge';
     badge.textContent = (COARSE ? '' : `key ${draft.key} · `) + `slot ${slot + 1} of ${eng.getPunchPresets().length}`;
+    // Label tracks transport state ONLY (never changes on press): armed when
+    // playing, "press ▶ first" when stopped (which explains the greyed look).
+    const armedLabel = COARSE ? 'TEST<small>hold to hear</small>' : `TEST<small>hold · or key ${draft.key}</small>`;
+    const idleLabel = 'TEST<small>press ▶ first</small>';
     const test = document.createElement('button');
     test.className = 'pe-test' + (playing ? '' : ' idle');
-    test.innerHTML = COARSE ? 'TEST<small>hold to hear</small>' : `TEST<small>hold · or key ${draft.key}</small>`;
+    test.innerHTML = playing ? armedLabel : idleLabel;
     test.addEventListener('pointerdown', e => {
       e.preventDefault(); test.setPointerCapture(e.pointerId);
       if (!eng.isPlaying()) {            // live check — not the render-time snapshot
         test.classList.add('idle');
-        test.innerHTML = 'TEST<small>press ▶ first</small>';
+        test.innerHTML = idleLabel;
         return;
       }
       test.classList.remove('idle');
-      test.innerHTML = 'TEST<small>hold to hear</small>';
+      test.innerHTML = armedLabel;
       if (validatePreset(draft)) { eng.punchPreview(draft, true); previewHeld = true; }
     });
     const off = () => stopPreview();

--- a/docs/arcade/groovebox/ui/punch-editor.js
+++ b/docs/arcade/groovebox/ui/punch-editor.js
@@ -81,6 +81,7 @@ export function openPunchEditor({ slot, eng, onSaved }) {
 
   function stopPreview() {
     if (previewHeld) { eng.punchPreview(draft, false); previewHeld = false; }
+    modal.querySelector('.pe-test')?.classList.remove('held');
   }
   function close() {
     stopPreview();
@@ -96,6 +97,7 @@ export function openPunchEditor({ slot, eng, onSaved }) {
       e.stopPropagation(); e.preventDefault();
       if (!previewHeld && eng.isPlaying() && validatePreset(draft)) {
         eng.punchPreview(draft, true); previewHeld = true;
+        modal.querySelector('.pe-test')?.classList.add('held');   // key-hold lights the button like a click
       }
     }
   }
@@ -148,7 +150,7 @@ export function openPunchEditor({ slot, eng, onSaved }) {
       }
       test.classList.remove('idle');
       test.innerHTML = armedLabel;
-      if (validatePreset(draft)) { eng.punchPreview(draft, true); previewHeld = true; }
+      if (validatePreset(draft)) { eng.punchPreview(draft, true); previewHeld = true; test.classList.add('held'); }
     });
     const off = () => stopPreview();
     test.addEventListener('pointerup', off);


### PR DESCRIPTION
Follow-up to #673. Pressing the punch-editor TEST button no longer swaps its hint text ("hold · or key 1" → "hold to hear") for the same state.

The label now tracks **transport state only**:
- **Playing** → `hold · or key 1` (desktop) / `hold to hear` (touch) — constant, unaffected by pressing.
- **Stopped** → `press ▶ first`, which also makes the greyed-out idle look read correctly.

The only time the text changes is when the transport actually starts/stops.

(This was committed to the #673 branch a moment after it was squash-merged, so it didn't ride along — hence the tiny standalone PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)