### PR TITLE
arcade(groovebox): type-to-set TEMPO (editable BPM field)

### DIFF
--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1924,13 +1924,13 @@ body.gb-knob-values .knob-val { display: block; }
 }
 /* Editable value cell (TEMPO): looks like the span, but type-to-set. */
 .key-stepper input {
-  width: 3.4ch;
+  width: 5ch;
   height: 22px;
   font-size: 12px;
   font-family: ui-monospace, Menlo, monospace;
   color: var(--ink);
   text-align: center;
-  padding: 0 2px;
+  padding: 0 6px;
   border: none;
   border-left: 1px solid var(--line);
   border-right: 1px solid var(--line);

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1944,6 +1944,8 @@ body.gb-knob-values .knob-val { display: block; }
   cursor: text;
 }
 .key-stepper input:focus { background: color-mix(in srgb, var(--acc) 16%, transparent); }
+/* Keyboard focus ring, inset so the stepper's overflow:hidden doesn't clip it. */
+.key-stepper input:focus-visible { outline: 2px solid var(--acc); outline-offset: -2px; }
 
 /* ─── colour themes — each block overrides design tokens only ────────────── */
 

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1922,6 +1922,28 @@ body.gb-knob-values .knob-val { display: block; }
   align-items: center;
   justify-content: center;
 }
+/* Editable value cell (TEMPO): looks like the span, but type-to-set. */
+.key-stepper input {
+  width: 3.4ch;
+  height: 22px;
+  font-size: 12px;
+  font-family: ui-monospace, Menlo, monospace;
+  color: var(--ink);
+  text-align: center;
+  padding: 0 2px;
+  border: none;
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+  border-radius: 0;
+  background: transparent;
+  outline: none;
+  box-shadow: none;
+  -webkit-appearance: none;
+  appearance: none;
+  box-sizing: border-box;
+  cursor: text;
+}
+.key-stepper input:focus { background: color-mix(in srgb, var(--acc) 16%, transparent); }
 
 /* ─── colour themes — each block overrides design tokens only ────────────── */
 

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -859,7 +859,12 @@ function makeTempoGroup() {
   const stepper = document.createElement('div');
   stepper.className = 'key-stepper';
   const dn = document.createElement('button'); dn.textContent = '−';
-  const val = document.createElement('span'); val.className = 'mono'; val.textContent = String(Math.round(currentBpm));
+  // Editable: type a BPM directly, or use ± to step. inputmode=numeric brings up
+  // the number pad on mobile; type=text avoids the native spinner arrows.
+  const val = document.createElement('input');
+  val.className = 'mono'; val.type = 'text'; val.inputMode = 'numeric';
+  val.setAttribute('aria-label', 'Tempo (BPM)');
+  val.value = String(Math.round(currentBpm));
   const up = document.createElement('button'); up.textContent = '＋';
   // Clamp matches the registry's valid bpm range (20–999), so a loaded song is
   // never outside it — the displayed value always equals the stepper's value and
@@ -867,14 +872,26 @@ function makeTempoGroup() {
   const setBpm = n => {
     currentBpm = Math.max(20, Math.min(999, n));
     eng.setTempo(currentBpm);
-    val.textContent = String(currentBpm);
+    val.value = String(currentBpm);
     const sb = document.getElementById('strip-bpm');
     if (sb) sb.textContent = `${currentBpm} BPM`;
   };
   dn.onclick = () => setBpm(Math.round(currentBpm) - 1);
   up.onclick = () => setBpm(Math.round(currentBpm) + 1);
+  // Commit typed input on Enter/blur; revert junk to the current value.
+  const commit = () => {
+    const n = parseInt(val.value, 10);
+    if (Number.isFinite(n)) setBpm(n); else val.value = String(Math.round(currentBpm));
+  };
+  val.onfocus = () => val.select();
+  val.onchange = commit;
+  val.onkeydown = e => {
+    e.stopPropagation();   // keep punch/keyboard shortcuts out while typing
+    if (e.key === 'Enter') { commit(); val.blur(); }
+    else if (e.key === 'Escape') { val.value = String(Math.round(currentBpm)); val.blur(); }
+  };
   stepper.appendChild(dn); stepper.appendChild(val); stepper.appendChild(up);
-  stepper.title = 'Tempo (BPM)';
+  stepper.title = 'Tempo (BPM) — type or ±';
   row.appendChild(stepper);
   grp.appendChild(row);
   return grp;

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -878,16 +878,18 @@ function makeTempoGroup() {
   };
   dn.onclick = () => setBpm(Math.round(currentBpm) - 1);
   up.onclick = () => setBpm(Math.round(currentBpm) + 1);
-  // Commit typed input on Enter/blur; revert junk to the current value.
+  // Commit on blur (Enter blurs → one commit, no double-fire). Only a pure
+  // integer string counts; anything else ("120abc", "") reverts to current.
   const commit = () => {
-    const n = parseInt(val.value, 10);
-    if (Number.isFinite(n)) setBpm(n); else val.value = String(Math.round(currentBpm));
+    const t = val.value.trim();
+    if (/^\d+$/.test(t)) setBpm(parseInt(t, 10));
+    else val.value = String(Math.round(currentBpm));
   };
   val.onfocus = () => val.select();
-  val.onchange = commit;
+  val.onblur = commit;
   val.onkeydown = e => {
     e.stopPropagation();   // keep punch/keyboard shortcuts out while typing
-    if (e.key === 'Enter') { commit(); val.blur(); }
+    if (e.key === 'Enter') val.blur();
     else if (e.key === 'Escape') { val.value = String(Math.round(currentBpm)); val.blur(); }
   };
   stepper.appendChild(dn); stepper.appendChild(val); stepper.appendChild(up);


### PR DESCRIPTION
Follow-up to #676. The TEMPO value is now an **editable field** — click it and type a BPM directly instead of only stepping ±1 (going 88→140 by clicking was tedious).

- Click the number → type → **Enter/blur commits**, **Escape reverts**.
- Invalid input reverts to the current value; the **± buttons still step**.
- Same 20–999 clamp; `inputmode=numeric` shows the number pad on mobile; `type=text` avoids the native spinner arrows.
- **TRANSPOSE unchanged** (per request).

### Tests
377 passing. (Browser auto-verify skipped — the in-session Chrome extension was dropping tabs; logic is parseInt + the existing clamp.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)