### PR TITLE
arcade(groovebox): LCD button hover uses screen theme, not cabinet

### DIFF
--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -4602,7 +4602,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   border: 1px solid color-mix(in srgb, var(--screen-ink) 45%, transparent);
   border-radius: 5px; padding: 1px 7px; height: 20px; font-size: 14px;
 }
-.scope-btn:hover { border-color: var(--screen-acc); color: var(--screen-acc); }
+.scope-btn:hover { background-color: transparent; border-color: var(--screen-acc); color: var(--screen-acc); }
 .scope-btn.on { color: var(--screen-bg); background: var(--screen-acc); border-color: var(--screen-acc); }
 
 /* ── HOME hub cards ──────────────────────────────────────────────────────── */
@@ -4629,9 +4629,9 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 .pane-ttl { font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--screen-dim); font-weight: 700; margin: 2px 2px 8px; }
 .pane-ttl small { text-transform: none; letter-spacing: 0; font-weight: 500; }
 .pane-back { display: none; background: none; box-shadow: none; border: none; color: var(--screen-acc); font-weight: 700; font-size: 12px; cursor: pointer; margin-bottom: 8px; padding: 0; }
-.pane-back:hover { text-decoration: underline; }
+.pane-back:hover { background-color: transparent; text-decoration: underline; }
 .mini-btn { background: none; box-shadow: none; text-transform: none; letter-spacing: 0; border: 1px solid color-mix(in srgb, var(--screen-ink) 28%, transparent); color: var(--screen-dim); border-radius: 5px; font-size: 10px; padding: 2px 8px; cursor: pointer; font-weight: 700; margin-left: 6px; vertical-align: middle; }
-.mini-btn:hover { border-color: var(--screen-acc); color: var(--screen-acc); }
+.mini-btn:hover { background-color: transparent; border-color: var(--screen-acc); color: var(--screen-acc); }
 .li {
   display: flex; align-items: center; gap: 8px; width: 100%; cursor: pointer;
   background: color-mix(in srgb, #fff 26%, var(--screen-bg));
@@ -4640,7 +4640,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
   border-radius: 8px; padding: 8px 10px; margin-bottom: 5px;
   color: var(--screen-ink); font-size: 12px; font-weight: 700; text-align: left;
 }
-.li:hover { border-color: color-mix(in srgb, var(--screen-acc) 50%, transparent); }
+.li:hover { background-color: color-mix(in srgb, #fff 40%, var(--screen-bg)); border-color: color-mix(in srgb, var(--screen-acc) 50%, transparent); }
 .li.sel { box-shadow: 0 0 0 1.5px var(--screen-acc); border-color: var(--screen-acc); }
 .li.playing { box-shadow: 0 0 6px var(--screen-hot); border-color: var(--screen-hot); }
 .li-ic { font-size: 15px; }
@@ -4669,13 +4669,14 @@ select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-in
 #lcd-body .chain-chip.dragging { opacity: 1; border-color: var(--screen-acc); box-shadow: 0 0 0 1px var(--screen-acc); }
 #lcd-body .chain-chip.drop-left  { box-shadow: -5px 0 0 -1px var(--screen-acc); }
 #lcd-body .chain-chip.drop-right { box-shadow:  5px 0 0 -1px var(--screen-acc); }
+#lcd-body .chain-chip:hover { background-color: color-mix(in srgb, var(--screen-ink) 6%, transparent); }
 #lcd-body .chain-chip .chip-x { color: var(--screen-dim); font-size: 9px; }
 .add-secs { display: flex; flex-direction: column; }
 
 /* ── Add-instrument inline menu (Grooves) ────────────────────────────────── */
 .addinstr-menu { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0; }
 .addinstr-menu button { background: color-mix(in srgb, var(--screen-ink) 8%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); color: var(--screen-ink); border-radius: 7px; padding: 7px 11px; font-size: 12px; font-weight: 700; cursor: pointer; font-family: inherit; }
-.addinstr-menu button:hover { border-color: var(--screen-acc); }
+.addinstr-menu button:hover { background-color: color-mix(in srgb, var(--screen-ink) 8%, transparent); border-color: var(--screen-acc); }
 
 /* ── Responsive: mobile = drill (one pane at a time) ─────────────────────── */
 @media (max-width: 900px) {


### PR DESCRIPTION
## Problem

Hover states for the LCD instrument rows (and other LCD controls) were styled by the **cabinet** theme instead of the **LCD/screen** theme. Because `.li` and friends are `<button>` elements, the global `button:hover { background-color: var(--panel-3); border-color: var(--acc-dim) }` painted them with the cabinet's hover surface. Each LCD button's own `:hover` only overrode border/color, so the cabinet grey `--panel-3` leaked through onto the screen.

It's most obvious on themes whose LCD differs from the cabinet — e.g. on **Game Boy**, hovering an instrument row gave it a grey fill + magenta edge that clashed with the olive-green screen:

| | before | after |
|---|---|---|
| Game Boy LCD | grey cabinet fill leaks in | pale screen-bg lift, on-palette |

## Fix

`docs/arcade/groovebox/ui/app.css` — pin each leaking LCD button's hover background to the screen palette:

- `.li` → subtle screen-bg lift (mirrors how `.homecard` lifts on hover)
- ghost buttons (`.scope-btn`, `.mini-btn`, `.pane-back`) → `transparent`
- filled buttons (`.addinstr-menu button`, `#lcd-body .chain-chip`) → restate their resting screen-ink fill

`.homecard` and `.cseg` already set their own hover background and are left as-is. Cabinet (non-LCD) buttons are untouched.

## Note

The hover/selection **border** uses `--screen-acc`, which is an LCD token — but for cabinet themes that don't define a distinct screen accent (e.g. Game Boy) it aliases to the cabinet accent (magenta). That's existing by-design behaviour and also drives the selected state, so it's left alone here. Happy to give Game Boy its own green-family `--screen-acc` in a follow-up if desired.

## Testing

Verified hover in Chrome on the Game Boy (olive LCD) and Oyster (pearl LCD) themes — hovered rows/buttons now stay on the screen palette with no cabinet-grey leak. CSS-only change; no behaviour or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)