### PR TITLE
arcade(groovebox): instrument & kit preset picker + fork-to-Custom

### DIFF
--- a/docs/arcade/groovebox/engine/flatten.js
+++ b/docs/arcade/groovebox/engine/flatten.js
@@ -320,7 +320,7 @@ export function flattenSong(rich) {
   const lanes = working.map(l => ({
     id: l.id, type: l.type, name: l.name || l.id,
     muted: !!l.muted, soloed: !!l.soloed,
-    ...(l.type === 'melody' ? { tone: l.tone || 'pulse' } : {}),
+    ...(l.instrument ? { instrument: l.instrument } : {}),
   }));
 
   // Song key (for melody snap-to-scale + editor tinting). The chord progression

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -692,11 +692,14 @@ export function createEngine() {
       const g = grooveFor(song, editIdx, laneId);
       if (g) _toggleNote(song, laneId, g.name, barIdx, stepIdx, note, dur);
     },
-    // Select a preset instrument for a pitched lane. Unknown id = no-op.
+    // Select a preset instrument for a pitched lane. Rejects unknown ids and any
+    // type mismatch (a lane only takes an instrument of its own type; drums use
+    // a kit, not an instrument).
     setLaneInstrument(id, instrumentId) {
-      if (!song || !instrumentSet()[instrumentId]) return;
+      if (!song) return;
       const lane = song.lanes.find(l => l.id === id);
-      if (!lane) return;
+      const inst = instrumentSet()[instrumentId];
+      if (!lane || lane.type === 'drums' || !inst || inst.type !== lane.type) return;
       lane.instrument = instrumentId;
       _rebuildVoice(id);
     },
@@ -714,7 +717,7 @@ export function createEngine() {
     setLaneCustom(id, patch) {
       if (!song) return;
       const lane = song.lanes.find(l => l.id === id);
-      if (!lane || !validateInstrument(patch)) return;
+      if (!lane || lane.type === 'drums' || !validateInstrument(patch) || patch.type !== lane.type) return;
       const cid = 'custom-' + id;
       if (!song.instruments) song.instruments = {};
       song.instruments[cid] = JSON.parse(JSON.stringify(patch));
@@ -725,7 +728,7 @@ export function createEngine() {
     previewLaneInstrument(id, patch) {
       if (!started || !song || !fx[id] || !validateInstrument(patch)) return;
       const lane = song.lanes.find(l => l.id === id);
-      if (!lane) return;
+      if (!lane || patch.type !== lane.type) return;
       const v = voices[id];
       if (v?.dispose) { try { v.dispose(); } catch (_) {} }
       voices[id] = createVoiceForType(lane.type, fx[id].input,

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -2,7 +2,7 @@ import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
 import { normalizeSongDrums, DEFAULT_INSTRUMENTS, ALL_INSTRUMENTS, LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
-import { laneByType, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
+import { laneByType, DEFAULT_LANE_INSTRUMENT, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
 import {
@@ -190,10 +190,17 @@ export function createEngine() {
     }
   }
 
+  // Resolvable instrument set for the CURRENT song: stock/global + the song's
+  // own custom (forked) patches in song.instruments. Custom ids resolve here
+  // without polluting the global _instruments set across songs.
+  function instrumentSet() {
+    return song?.instruments ? { ..._instruments, ...song.instruments } : _instruments;
+  }
+
   function buildLane(lane) {
     fx[lane.id]     = _makeFX(_masterIn);
     voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input,
-      { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
+      { instruments: instrumentSet(), kit: _kit, instrumentId: lane.instrument });
     // Per-lane scope analyser — lazy: created on first getScope(id) call.
     // scopeLane[lane.id] intentionally NOT created here.
     // Per-lane level meter
@@ -219,7 +226,7 @@ export function createEngine() {
     const v = voices[laneId];
     if (v?.dispose) { try { v.dispose(); } catch (_) {} }
     voices[laneId] = createVoiceForType(lane.type, fx[laneId].input,
-      { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
+      { instruments: instrumentSet(), kit: _kit, instrumentId: lane.instrument });
   }
   function _rebuildVoices() {
     if (!started || !song) return;
@@ -687,12 +694,45 @@ export function createEngine() {
     },
     // Select a preset instrument for a pitched lane. Unknown id = no-op.
     setLaneInstrument(id, instrumentId) {
-      if (!song || !_instruments[instrumentId]) return;
+      if (!song || !instrumentSet()[instrumentId]) return;
       const lane = song.lanes.find(l => l.id === id);
       if (!lane) return;
       lane.instrument = instrumentId;
       _rebuildVoice(id);
     },
+    // The resolved patch a lane currently sounds (stock preset or song-local
+    // custom), for the editor to open. Falls back to the type default.
+    resolveLaneInstrument(id) {
+      const lane = song?.lanes.find(l => l.id === id);
+      if (!lane) return null;
+      const set = instrumentSet();
+      return set[lane.instrument] || set[DEFAULT_LANE_INSTRUMENT[lane.type]] || null;
+    },
+    // Fork-to-Custom: store an edited patch as a SONG-LOCAL custom for this lane
+    // (travels with the song), point the lane at it, rebuild. The stock preset is
+    // never mutated. id scheme: one custom slot per lane (`custom-<laneId>`).
+    setLaneCustom(id, patch) {
+      if (!song) return;
+      const lane = song.lanes.find(l => l.id === id);
+      if (!lane || !validateInstrument(patch)) return;
+      const cid = 'custom-' + id;
+      if (!song.instruments) song.instruments = {};
+      song.instruments[cid] = JSON.parse(JSON.stringify(patch));
+      lane.instrument = cid;
+      _rebuildVoice(id);
+    },
+    // Live-audition a draft patch on one lane's voice (transient — not stored).
+    previewLaneInstrument(id, patch) {
+      if (!started || !song || !fx[id] || !validateInstrument(patch)) return;
+      const lane = song.lanes.find(l => l.id === id);
+      if (!lane) return;
+      const v = voices[id];
+      if (v?.dispose) { try { v.dispose(); } catch (_) {} }
+      voices[id] = createVoiceForType(lane.type, fx[id].input,
+        { instruments: { _preview: patch }, instrumentId: '_preview', kit: _kit });
+    },
+    // Undo a preview — rebuild the lane from its stored instrument.
+    clearLanePreview(id) { _rebuildVoice(id); },
     getLevel(id) {
       if (!started || !meters[id]) return 0;
       let db = meters[id].getValue();

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -1,7 +1,7 @@
 import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
-import { normalizeSongDrums, DEFAULT_INSTRUMENTS, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
+import { normalizeSongDrums, DEFAULT_INSTRUMENTS, ALL_INSTRUMENTS, LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
 import { laneByType, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
@@ -35,7 +35,7 @@ export function createEngine() {
   let punchPresets = DEFAULT_PRESETS;            // replaced via setPunchPresets (validated)
   // Instruments layer (PR2): user instruments/kit override the stock set.
   // Same contract as punch presets: validated on set, defaults on bad data.
-  let _instruments = DEFAULT_INSTRUMENTS;
+  let _instruments = ALL_INSTRUMENTS;   // stock defaults + selectable preset banks
   let _kit = DEFAULT_KIT;
   const _slotHeld = new Array(DEFAULT_PRESETS.length).fill(false);
   const _gates = new Map();                      // slot → { depth, division, laneIds } (preview uses 'preview')
@@ -194,10 +194,6 @@ export function createEngine() {
     fx[lane.id]     = _makeFX(_masterIn);
     voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input,
       { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
-    // Apply saved tone to melody lanes
-    if (lane.type === 'melody' && lane.tone) {
-      voices[lane.id].lead?.set({ oscillator: { type: lane.tone, width: 0.3 } });
-    }
     // Per-lane scope analyser — lazy: created on first getScope(id) call.
     // scopeLane[lane.id] intentionally NOT created here.
     // Per-lane level meter
@@ -214,17 +210,20 @@ export function createEngine() {
   // Rebuild voices only (FX chains, meters, captures untouched) — used when
   // the instrument set or kit changes. Safe while playing: voices swap at
   // graph time; the next scheduled step triggers the new nodes.
+  // Rebuild a single lane's voice in place (targeted — used by setLaneInstrument
+  // so a preset change doesn't churn every voice).
+  function _rebuildVoice(laneId) {
+    if (!started || !song) return;
+    const lane = song.lanes.find(l => l.id === laneId);
+    if (!lane || !fx[laneId]) return;
+    const v = voices[laneId];
+    if (v?.dispose) { try { v.dispose(); } catch (_) {} }
+    voices[laneId] = createVoiceForType(lane.type, fx[laneId].input,
+      { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
+  }
   function _rebuildVoices() {
     if (!started || !song) return;
-    for (const lane of song.lanes) {
-      const v = voices[lane.id];
-      if (v?.dispose) { try { v.dispose(); } catch (_) {} }
-      voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input,
-        { instruments: _instruments, kit: _kit, instrumentId: lane.instrument });
-      if (lane.type === 'melody' && lane.tone) {
-        voices[lane.id].lead?.set({ oscillator: { type: lane.tone, width: 0.3 } });
-      }
-    }
+    for (const lane of song.lanes) _rebuildVoice(lane.id);
   }
 
   function disposeLane(id) {
@@ -327,6 +326,12 @@ export function createEngine() {
     load(s) {
       const v2 = (s.patterns && s.chain) ? s : flattenSong(s);
       normalizeSongDrums(v2);                 // ingest boundary: GM numbers past here
+      // Migrate the retired per-lane `tone` (oscillator override) → a melody
+      // preset. Old/shared songs upgrade here; nothing downstream reads `tone`.
+      for (const lane of v2.lanes) {
+        if (lane.tone && !lane.instrument) lane.instrument = LEGACY_TONE_PRESET[lane.tone] || 'gb-lead';
+        delete lane.tone;
+      }
       song = v2;
       editIdx = 0; pendingTarget = null;
       target = { kind: 'chain', pos: 0, barInPattern: 0 };
@@ -335,16 +340,11 @@ export function createEngine() {
         for (const id of Object.keys(voices)) {
           if (!v2.lanes.some(l => l.id === id)) disposeLane(id);
         }
+        // New lanes get a full build; surviving lanes (reused id) rebuild their
+        // voice so the switched song's instrument takes effect (FX chain kept).
         for (const lane of v2.lanes) {
           if (!voices[lane.id]) buildLane(lane);
-          // Re-apply tone to SURVIVING melody voices: the voice (keyed by lane id)
-          // is reused across a song switch, but the new song carries its own
-          // lane.tone. Without this the reused oscillator keeps the previous
-          // song's (or the user's last-dialed) tone while the UI shows the new
-          // one — an audible/visual desync after switching songs.
-          else if (lane.type === 'melody' && lane.tone && voices[lane.id]?.lead) {
-            voices[lane.id].lead.set({ oscillator: { type: lane.tone, width: 0.3 } });
-          }
+          else _rebuildVoice(lane.id);
         }
         // Re-sync punch routing for REUSED lane graphs (song-switch desync).
         _recomputePunchRouting();
@@ -685,15 +685,13 @@ export function createEngine() {
       const g = grooveFor(song, editIdx, laneId);
       if (g) _toggleNote(song, laneId, g.name, barIdx, stepIdx, note, dur);
     },
-    // setTone by lane id (melody lanes)
-    setTone(id, type) {
-      // Back-compat: if called with one arg (old API), treat it as the melody lane
-      if (type === undefined) { type = id; id = laneByType(song?.lanes ?? [], 'melody')?.id; }
-      if (!id || !song) return;
+    // Select a preset instrument for a pitched lane. Unknown id = no-op.
+    setLaneInstrument(id, instrumentId) {
+      if (!song || !_instruments[instrumentId]) return;
       const lane = song.lanes.find(l => l.id === id);
-      if (lane) lane.tone = type;
-      const v = voices[id];
-      if (v?.lead) v.lead.set({ oscillator: { type, width: 0.3 } });
+      if (!lane) return;
+      lane.instrument = instrumentId;
+      _rebuildVoice(id);
     },
     getLevel(id) {
       if (!started || !meters[id]) return 0;

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -412,6 +412,34 @@ export const DRUM_PRESETS = {
     patch: { archetype: 'noise', volume: -12, envelope: { attack: 0.002, decay: 0.25, sustain: 0 }, filter: { type: 'highpass', freq: 700 }, trigger: { dur: '8n', velocity: 0.7 } } },
   'drum-lofi-hat':   { name: 'Lo-Fi Hat',   type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -22, envelope: { attack: 0.001, decay: 0.06, sustain: 0 }, filter: { type: 'highpass', freq: 5000 }, trigger: { dur: '32n', velocity: 0.5 } } },
+  // Boom Bap — punchy mid kick, fat cracky snare, dark short hats
+  'drum-boombap-kick':  { name: 'Boom Bap Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -4, pitch: { pitchDecay: 0.04, octaves: 2 }, filter: { type: 'lowpass', freq: 4000 }, trigger: { note: 'C1', dur: '8n', velocity: 0.95 } } },
+  'drum-boombap-snare': { name: 'Boom Bap Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -8, envelope: { attack: 0.001, decay: 0.3, sustain: 0 }, filter: { type: 'highpass', freq: 900 }, trigger: { dur: '8n', velocity: 0.95 } } },
+  'drum-boombap-hat':   { name: 'Boom Bap Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -20, envelope: { attack: 0.001, decay: 0.035, sustain: 0 }, filter: { type: 'highpass', freq: 6500 }, trigger: { dur: '32n', velocity: 0.55 } } },
+  // Techno — hard clicky kick, bright snare, OPEN sizzly hats
+  'drum-techno-kick':  { name: 'Techno Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -3, pitch: { pitchDecay: 0.025, octaves: 3.5 }, trigger: { note: 'C1', dur: '8n', velocity: 1 } } },
+  'drum-techno-snare': { name: 'Techno Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -9, envelope: { attack: 0.001, decay: 0.16, sustain: 0 }, filter: { type: 'highpass', freq: 2600 }, trigger: { dur: '16n', velocity: 0.95 } } },
+  'drum-techno-hat':   { name: 'Techno Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -16, envelope: { attack: 0.001, decay: 0.12, sustain: 0 }, filter: { type: 'highpass', freq: 8500 }, trigger: { dur: '16n', velocity: 0.7 } } },
+  // Electro — ultra-short zappy everything
+  'drum-electro-kick':  { name: 'Electro Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -4, pitch: { pitchDecay: 0.015, octaves: 5 }, trigger: { note: 'C1', dur: '16n', velocity: 1 } } },
+  'drum-electro-snare': { name: 'Electro Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -11, envelope: { attack: 0.001, decay: 0.08, sustain: 0 }, filter: { type: 'highpass', freq: 3500 }, trigger: { dur: '32n', velocity: 0.9 } } },
+  'drum-electro-hat':   { name: 'Electro Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -19, envelope: { attack: 0.001, decay: 0.025, sustain: 0 }, filter: { type: 'highpass', freq: 10000 }, trigger: { dur: '32n', velocity: 0.55 } } },
+  // Brush — soft low kick, long swept warm snare, brushy hats
+  'drum-brush-kick':  { name: 'Brush Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -7, pitch: { pitchDecay: 0.04, octaves: 2 }, filter: { type: 'lowpass', freq: 1800 }, trigger: { note: 'C1', dur: '8n', velocity: 0.75 } } },
+  'drum-brush-snare': { name: 'Brush Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -13, envelope: { attack: 0.003, decay: 0.35, sustain: 0 }, filter: { type: 'highpass', freq: 500 }, trigger: { dur: '4n', velocity: 0.6 } } },
+  'drum-brush-hat':   { name: 'Brush Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -23, envelope: { attack: 0.002, decay: 0.08, sustain: 0 }, filter: { type: 'highpass', freq: 4500 }, trigger: { dur: '16n', velocity: 0.45 } } },
 };
 
 // The full selectable set: stock defaults + preset banks. Engine inits
@@ -437,6 +465,10 @@ export const DRUM_KITS = {
   'kit-909':      kit('909',      'drum-909-kick',      'drum-909-snare',      'drum-909-hat'),
   'kit-acoustic': kit('Acoustic', 'drum-acoustic-kick', 'drum-acoustic-snare', 'drum-acoustic-hat'),
   'kit-lofi':     kit('Lo-Fi',    'drum-lofi-kick',     'drum-lofi-snare',     'drum-lofi-hat'),
+  'kit-boombap':  kit('Boom Bap', 'drum-boombap-kick',  'drum-boombap-snare',  'drum-boombap-hat'),
+  'kit-techno':   kit('Techno',   'drum-techno-kick',   'drum-techno-snare',   'drum-techno-hat'),
+  'kit-electro':  kit('Electro',  'drum-electro-kick',  'drum-electro-snare',  'drum-electro-hat'),
+  'kit-brush':    kit('Brush',    'drum-brush-kick',    'drum-brush-snare',    'drum-brush-hat'),
 };
 // Selectable kits: the Oyster default + the banks.
 export const ALL_KITS = { 'oyster-kit': DEFAULT_KIT, ...DRUM_KITS };

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -178,37 +178,37 @@ export function normalizeSongDrums(song) {
 // Values mirror engine/voices.js createVoiceForType EXACTLY (parity-tested).
 export const DEFAULT_INSTRUMENTS = {
   'gb-kick': {
-    name: 'GB Kick', type: 'drum', engine: 'synth',
+    name: 'Oyster Kick', type: 'drum', engine: 'synth',
     patch: { archetype: 'membrane', volume: -5, trigger: { note: 'C1', dur: '8n' } },
   },
   'gb-snare': {
-    name: 'GB Snare', type: 'drum', engine: 'synth',
+    name: 'Oyster Snare', type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -11,
       envelope: { attack: 0.001, decay: 0.16, sustain: 0 },
       trigger: { dur: '16n' } },
   },
   'gb-hat': {
-    name: 'GB Hat', type: 'drum', engine: 'synth',
+    name: 'Oyster Hat', type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -20,
       envelope: { attack: 0.001, decay: 0.03, sustain: 0 },
       filter: { type: 'highpass', freq: 7000 },
       trigger: { dur: '32n', velocity: 0.6 } },
   },
   'gb-tom': {
-    name: 'GB Tom', type: 'drum', engine: 'synth',
+    name: 'Oyster Tom', type: 'drum', engine: 'synth',
     patch: { archetype: 'membrane', volume: -6,
       pitch: { pitchDecay: 0.06, octaves: 2 },
       trigger: { note: 'A2', dur: '8n' } },
   },
   'gb-crash': {
-    name: 'GB Crash', type: 'drum', engine: 'synth',
+    name: 'Oyster Crash', type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -12,
       envelope: { attack: 0.001, decay: 1.1, sustain: 0, release: 0.3 },
       filter: { type: 'highpass', freq: 3500 },
       trigger: { dur: '8n', velocity: 0.8 } },
   },
   'gb-bass': {
-    name: 'GB Bass', type: 'bass', engine: 'synth',
+    name: 'Oyster Bass', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -7,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.005, decay: 0.18, sustain: 0.35, release: 0.18 },
@@ -216,7 +216,7 @@ export const DEFAULT_INSTRUMENTS = {
       trigger: { velocity: 0.85 } },
   },
   'gb-chords': {
-    name: 'GB Chords', type: 'chords', engine: 'synth',
+    name: 'Oyster Chords', type: 'chords', engine: 'synth',
     patch: { archetype: 'poly', volume: -17,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.05, decay: 0.3, sustain: 0.6, release: 0.5 },
@@ -224,7 +224,7 @@ export const DEFAULT_INSTRUMENTS = {
       trigger: { velocity: 0.3 } },
   },
   'gb-lead': {
-    name: 'GB Lead', type: 'melody', engine: 'synth',
+    name: 'Oyster Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -11,
       oscillator: { shape: 'pulse', width: 0.3 },
       envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
@@ -233,7 +233,7 @@ export const DEFAULT_INSTRUMENTS = {
 };
 
 export const DEFAULT_KIT = {
-  name: 'GB Kit',
+  name: 'Oyster Kit',
   slots: [
     { note: 36, label: 'Kick',  instrument: 'gb-kick' },
     { note: 38, label: 'Snare', instrument: 'gb-snare' },

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -242,3 +242,143 @@ export const DEFAULT_KIT = {
     { note: 49, label: 'Crash', instrument: 'gb-crash' },
   ],
 };
+
+// ─── Synth preset banks (Slice 1) ─────────────────────────────────────────────
+// Read-only starting points per pitched lane type. Same patch schema as
+// DEFAULT_INSTRUMENTS; all values stay inside PATCH_PARAMS so validateInstrument
+// passes. STARTER values — ear-test gated; tune freely. The strip dropdown lists
+// these + the gb-* defaults (by type); EDIT forks to a song-local Custom patch.
+export const SYNTH_PRESETS = {
+  // Bass (mono)
+  'preset-sub-bass': {
+    name: 'SUB BASS', type: 'bass', engine: 'synth',
+    patch: { archetype: 'mono', volume: -6,
+      oscillator: { shape: 'sine' },
+      envelope: { attack: 0.008, decay: 0.2, sustain: 0.7, release: 0.25 },
+      filterEnvelope: { attack: 0.005, decay: 0.15, sustain: 0.5, baseFrequency: 60, octaves: 2 },
+      trigger: { velocity: 0.9 } },
+  },
+  'preset-reese': {
+    name: 'REESE', type: 'bass', engine: 'synth',
+    patch: { archetype: 'mono', volume: -8,
+      oscillator: { shape: 'sawtooth' },
+      envelope: { attack: 0.005, decay: 0.25, sustain: 0.6, release: 0.2 },
+      filterEnvelope: { attack: 0.005, decay: 0.3, sustain: 0.4, baseFrequency: 180, octaves: 4.5 },
+      trigger: { velocity: 0.85 } },
+  },
+  'preset-pluck-bass': {
+    name: 'PLUCK BASS', type: 'bass', engine: 'synth',
+    patch: { archetype: 'mono', volume: -7,
+      oscillator: { shape: 'square' },
+      envelope: { attack: 0.003, decay: 0.09, sustain: 0.05, release: 0.1 },
+      filterEnvelope: { attack: 0.003, decay: 0.08, sustain: 0.2, baseFrequency: 400, octaves: 3 },
+      trigger: { velocity: 0.85 } },
+  },
+  'preset-moog-bass': {
+    name: 'MOOG', type: 'bass', engine: 'synth',
+    patch: { archetype: 'mono', volume: -7,
+      oscillator: { shape: 'sawtooth' },
+      envelope: { attack: 0.01, decay: 0.35, sustain: 0.5, release: 0.25 },
+      filterEnvelope: { attack: 0.008, decay: 0.3, sustain: 0.45, baseFrequency: 300, octaves: 3.5 },
+      trigger: { velocity: 0.85 } },
+  },
+  // Chords (poly)
+  'preset-poly-pad': {
+    name: 'POLY PAD', type: 'chords', engine: 'synth',
+    patch: { archetype: 'poly', volume: -16,
+      oscillator: { shape: 'triangle' },
+      envelope: { attack: 0.08, decay: 0.4, sustain: 0.7, release: 0.8 },
+      filter: { type: 'lowpass', freq: 2000 },
+      trigger: { velocity: 0.3 } },
+  },
+  'preset-stab': {
+    name: 'STAB', type: 'chords', engine: 'synth',
+    patch: { archetype: 'poly', volume: -16,
+      oscillator: { shape: 'sawtooth' },
+      envelope: { attack: 0.005, decay: 0.12, sustain: 0, release: 0.15 },
+      filter: { type: 'lowpass', freq: 5000 },
+      trigger: { velocity: 0.35 } },
+  },
+  'preset-organ': {
+    name: 'ORGAN', type: 'chords', engine: 'synth',
+    patch: { archetype: 'poly', volume: -18,
+      oscillator: { shape: 'square' },
+      envelope: { attack: 0.005, decay: 0.1, sustain: 1, release: 0.2 },
+      filter: { type: 'lowpass', freq: 6000 },
+      trigger: { velocity: 0.3 } },
+  },
+  'preset-glass': {
+    name: 'GLASS', type: 'chords', engine: 'synth',
+    patch: { archetype: 'poly', volume: -16,
+      oscillator: { shape: 'sine' },
+      envelope: { attack: 0.06, decay: 0.3, sustain: 0.25, release: 0.5 },
+      filter: { type: 'lowpass', freq: 8000 },
+      trigger: { velocity: 0.3 } },
+  },
+  // Melody (poly)
+  'preset-square-lead': {
+    name: 'SQUARE LEAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -11,
+      oscillator: { shape: 'square' },
+      envelope: { attack: 0.004, decay: 0.16, sustain: 0.25, release: 0.18 },
+      trigger: { velocity: 0.82 } },
+  },
+  'preset-saw-lead': {
+    name: 'SAW LEAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -12,
+      oscillator: { shape: 'sawtooth' },
+      envelope: { attack: 0.004, decay: 0.2, sustain: 0.3, release: 0.2 },
+      trigger: { velocity: 0.82 } },
+  },
+  'preset-soft-pad': {
+    name: 'SOFT PAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -12,
+      oscillator: { shape: 'triangle' },
+      envelope: { attack: 0.07, decay: 0.4, sustain: 0.65, release: 0.5 },
+      trigger: { velocity: 0.75 } },
+  },
+  'preset-pluck-lead': {
+    name: 'PLUCK LEAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -11,
+      oscillator: { shape: 'pulse', width: 0.25 },
+      envelope: { attack: 0.004, decay: 0.08, sustain: 0, release: 0.12 },
+      trigger: { velocity: 0.82 } },
+  },
+  'preset-fat-saw': {
+    name: 'FAT SAW', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -12,
+      oscillator: { shape: 'fatsawtooth' },
+      envelope: { attack: 0.006, decay: 0.22, sustain: 0.35, release: 0.2 },
+      trigger: { velocity: 0.82 } },
+  },
+  'preset-triangle-lead': {
+    name: 'TRIANGLE LEAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -11,
+      oscillator: { shape: 'triangle' },
+      envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
+      trigger: { velocity: 0.82 } },
+  },
+  'preset-sine-lead': {
+    name: 'SINE LEAD', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -10,
+      oscillator: { shape: 'sine' },
+      envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
+      trigger: { velocity: 0.82 } },
+  },
+};
+
+// One-time migration: the retired per-lane `tone` (oscillator override on the
+// default lead) maps to the matching melody preset. Used at the load boundary
+// to upgrade old/shared songs; nothing downstream reads `tone`.
+export const LEGACY_TONE_PRESET = {
+  pulse: 'gb-lead',
+  square: 'preset-square-lead',
+  sawtooth: 'preset-saw-lead',
+  fatsawtooth: 'preset-fat-saw',
+  triangle: 'preset-triangle-lead',
+  sine: 'preset-sine-lead',
+};
+
+// The full selectable set: stock defaults + preset banks. Engine inits
+// `_instruments` from this so every preset id resolves.
+export const ALL_INSTRUMENTS = { ...DEFAULT_INSTRUMENTS, ...SYNTH_PRESETS };

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -207,6 +207,27 @@ export const DEFAULT_INSTRUMENTS = {
       filter: { type: 'highpass', freq: 3500 },
       trigger: { dur: '8n', velocity: 0.8 } },
   },
+  'gb-clap': {
+    name: 'Oyster Clap', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -11,
+      envelope: { attack: 0.001, decay: 0.15, sustain: 0 },
+      filter: { type: 'highpass', freq: 1200 },
+      trigger: { dur: '16n', velocity: 0.8 } },
+  },
+  'gb-openhat': {
+    name: 'Oyster Open Hat', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -19,
+      envelope: { attack: 0.001, decay: 0.35, sustain: 0 },
+      filter: { type: 'highpass', freq: 7000 },
+      trigger: { dur: '8n', velocity: 0.6 } },
+  },
+  'gb-ride': {
+    name: 'Oyster Ride', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -20,
+      envelope: { attack: 0.001, decay: 0.6, sustain: 0 },
+      filter: { type: 'highpass', freq: 6000 },
+      trigger: { dur: '4n', velocity: 0.5 } },
+  },
   'gb-bass': {
     name: 'Oyster Bass', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -7,
@@ -232,14 +253,19 @@ export const DEFAULT_INSTRUMENTS = {
   },
 };
 
+// The canonical 8-slot layout: every kit fills these GM notes. The drum editor
+// derives its rows from this (viz.js DROWS), so slot order = row order.
 export const DEFAULT_KIT = {
   name: 'Oyster Kit',
   slots: [
     { note: 36, label: 'Kick',  instrument: 'gb-kick' },
     { note: 38, label: 'Snare', instrument: 'gb-snare' },
+    { note: 39, label: 'Clap',  instrument: 'gb-clap' },
     { note: 42, label: 'HH',    instrument: 'gb-hat' },
+    { note: 46, label: 'OH',    instrument: 'gb-openhat' },
     { note: 45, label: 'Tom',   instrument: 'gb-tom', pitched: true },   // steps carry [step, semi]
     { note: 49, label: 'Crash', instrument: 'gb-crash' },
+    { note: 51, label: 'Ride',  instrument: 'gb-ride' },
   ],
 };
 
@@ -440,6 +466,56 @@ export const DRUM_PRESETS = {
     patch: { archetype: 'noise', volume: -13, envelope: { attack: 0.003, decay: 0.35, sustain: 0 }, filter: { type: 'highpass', freq: 500 }, trigger: { dur: '4n', velocity: 0.6 } } },
   'drum-brush-hat':   { name: 'Brush Hat',   type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -23, envelope: { attack: 0.002, decay: 0.08, sustain: 0 }, filter: { type: 'highpass', freq: 4500 }, trigger: { dur: '16n', velocity: 0.45 } } },
+
+  // ─ Clap · Open Hat · Tom · Crash · Ride per kit (the 8-slot completion) ─
+  // 808
+  'drum-808-clap':    { name: '808 Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -10, envelope: { attack: 0.001, decay: 0.18, sustain: 0 }, filter: { type: 'highpass', freq: 1300 }, trigger: { dur: '16n', velocity: 0.85 } } },
+  'drum-808-openhat': { name: '808 Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -17, envelope: { attack: 0.001, decay: 0.4, sustain: 0 }, filter: { type: 'highpass', freq: 9000 }, trigger: { dur: '8n', velocity: 0.6 } } },
+  'drum-808-tom':     { name: '808 Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -5, pitch: { pitchDecay: 0.3, octaves: 4 }, trigger: { note: 'A2', dur: '8n', velocity: 0.85 } } },
+  'drum-808-crash':   { name: '808 Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -13, envelope: { attack: 0.001, decay: 1.3, sustain: 0, release: 0.3 }, filter: { type: 'highpass', freq: 4000 }, trigger: { dur: '8n', velocity: 0.7 } } },
+  'drum-808-ride':    { name: '808 Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -19, envelope: { attack: 0.001, decay: 0.5, sustain: 0 }, filter: { type: 'highpass', freq: 8500 }, trigger: { dur: '4n', velocity: 0.5 } } },
+  // 909
+  'drum-909-clap':    { name: '909 Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -10, envelope: { attack: 0.001, decay: 0.16, sustain: 0 }, filter: { type: 'highpass', freq: 1500 }, trigger: { dur: '16n', velocity: 0.85 } } },
+  'drum-909-openhat': { name: '909 Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -16, envelope: { attack: 0.001, decay: 0.45, sustain: 0 }, filter: { type: 'highpass', freq: 8000 }, trigger: { dur: '8n', velocity: 0.65 } } },
+  'drum-909-tom':     { name: '909 Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -5, pitch: { pitchDecay: 0.08, octaves: 4 }, trigger: { note: 'A2', dur: '8n', velocity: 0.85 } } },
+  'drum-909-crash':   { name: '909 Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -12, envelope: { attack: 0.001, decay: 1.2, sustain: 0, release: 0.3 }, filter: { type: 'highpass', freq: 3500 }, trigger: { dur: '8n', velocity: 0.75 } } },
+  'drum-909-ride':    { name: '909 Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -18, envelope: { attack: 0.001, decay: 0.55, sustain: 0 }, filter: { type: 'highpass', freq: 8000 }, trigger: { dur: '4n', velocity: 0.55 } } },
+  // Acoustic
+  'drum-acoustic-clap':    { name: 'Acoustic Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -11, envelope: { attack: 0.002, decay: 0.2, sustain: 0 }, filter: { type: 'highpass', freq: 1000 }, trigger: { dur: '8n', velocity: 0.8 } } },
+  'drum-acoustic-openhat': { name: 'Acoustic Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -18, envelope: { attack: 0.001, decay: 0.4, sustain: 0 }, filter: { type: 'highpass', freq: 7500 }, trigger: { dur: '8n', velocity: 0.55 } } },
+  'drum-acoustic-tom':     { name: 'Acoustic Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -6, pitch: { pitchDecay: 0.04, octaves: 3 }, trigger: { note: 'A2', dur: '8n', velocity: 0.85 } } },
+  'drum-acoustic-crash':   { name: 'Acoustic Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -12, envelope: { attack: 0.001, decay: 1.4, sustain: 0, release: 0.4 }, filter: { type: 'highpass', freq: 3500 }, trigger: { dur: '8n', velocity: 0.8 } } },
+  'drum-acoustic-ride':    { name: 'Acoustic Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -19, envelope: { attack: 0.001, decay: 0.6, sustain: 0 }, filter: { type: 'highpass', freq: 7000 }, trigger: { dur: '4n', velocity: 0.5 } } },
+  // Lo-Fi
+  'drum-lofi-clap':    { name: 'Lo-Fi Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -13, envelope: { attack: 0.003, decay: 0.2, sustain: 0 }, filter: { type: 'highpass', freq: 700 }, trigger: { dur: '8n', velocity: 0.65 } } },
+  'drum-lofi-openhat': { name: 'Lo-Fi Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -21, envelope: { attack: 0.001, decay: 0.4, sustain: 0 }, filter: { type: 'highpass', freq: 5000 }, trigger: { dur: '8n', velocity: 0.5 } } },
+  'drum-lofi-tom':     { name: 'Lo-Fi Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -7, pitch: { pitchDecay: 0.05, octaves: 2.5 }, filter: { type: 'lowpass', freq: 2000 }, trigger: { note: 'A2', dur: '8n', velocity: 0.8 } } },
+  'drum-lofi-crash':   { name: 'Lo-Fi Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -15, envelope: { attack: 0.002, decay: 1.2, sustain: 0, release: 0.4 }, filter: { type: 'highpass', freq: 2500 }, trigger: { dur: '8n', velocity: 0.65 } } },
+  'drum-lofi-ride':    { name: 'Lo-Fi Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -22, envelope: { attack: 0.001, decay: 0.5, sustain: 0 }, filter: { type: 'highpass', freq: 4500 }, trigger: { dur: '4n', velocity: 0.45 } } },
+  // Boom Bap
+  'drum-boombap-clap':    { name: 'Boom Bap Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -9, envelope: { attack: 0.001, decay: 0.22, sustain: 0 }, filter: { type: 'highpass', freq: 1000 }, trigger: { dur: '8n', velocity: 0.9 } } },
+  'drum-boombap-openhat': { name: 'Boom Bap Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -19, envelope: { attack: 0.001, decay: 0.3, sustain: 0 }, filter: { type: 'highpass', freq: 6500 }, trigger: { dur: '8n', velocity: 0.55 } } },
+  'drum-boombap-tom':     { name: 'Boom Bap Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -5, pitch: { pitchDecay: 0.04, octaves: 2.2 }, filter: { type: 'lowpass', freq: 4000 }, trigger: { note: 'A2', dur: '8n', velocity: 0.85 } } },
+  'drum-boombap-crash':   { name: 'Boom Bap Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -13, envelope: { attack: 0.001, decay: 1.2, sustain: 0, release: 0.3 }, filter: { type: 'highpass', freq: 3000 }, trigger: { dur: '8n', velocity: 0.75 } } },
+  'drum-boombap-ride':    { name: 'Boom Bap Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -20, envelope: { attack: 0.001, decay: 0.55, sustain: 0 }, filter: { type: 'highpass', freq: 6500 }, trigger: { dur: '4n', velocity: 0.5 } } },
+  // Techno
+  'drum-techno-clap':    { name: 'Techno Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -9, envelope: { attack: 0.001, decay: 0.14, sustain: 0 }, filter: { type: 'highpass', freq: 2000 }, trigger: { dur: '16n', velocity: 0.9 } } },
+  'drum-techno-openhat': { name: 'Techno Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -15, envelope: { attack: 0.001, decay: 0.5, sustain: 0 }, filter: { type: 'highpass', freq: 8500 }, trigger: { dur: '8n', velocity: 0.7 } } },
+  'drum-techno-tom':     { name: 'Techno Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -5, pitch: { pitchDecay: 0.03, octaves: 3.5 }, trigger: { note: 'A2', dur: '8n', velocity: 0.85 } } },
+  'drum-techno-crash':   { name: 'Techno Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -12, envelope: { attack: 0.001, decay: 1.3, sustain: 0, release: 0.3 }, filter: { type: 'highpass', freq: 4000 }, trigger: { dur: '8n', velocity: 0.8 } } },
+  'drum-techno-ride':    { name: 'Techno Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -17, envelope: { attack: 0.001, decay: 0.6, sustain: 0 }, filter: { type: 'highpass', freq: 9000 }, trigger: { dur: '4n', velocity: 0.6 } } },
+  // Electro
+  'drum-electro-clap':    { name: 'Electro Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -11, envelope: { attack: 0.001, decay: 0.09, sustain: 0 }, filter: { type: 'highpass', freq: 3000 }, trigger: { dur: '32n', velocity: 0.85 } } },
+  'drum-electro-openhat': { name: 'Electro Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -18, envelope: { attack: 0.001, decay: 0.2, sustain: 0 }, filter: { type: 'highpass', freq: 10000 }, trigger: { dur: '16n', velocity: 0.6 } } },
+  'drum-electro-tom':     { name: 'Electro Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -5, pitch: { pitchDecay: 0.015, octaves: 5 }, trigger: { note: 'A2', dur: '16n', velocity: 0.85 } } },
+  'drum-electro-crash':   { name: 'Electro Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -13, envelope: { attack: 0.001, decay: 0.9, sustain: 0, release: 0.2 }, filter: { type: 'highpass', freq: 5000 }, trigger: { dur: '8n', velocity: 0.75 } } },
+  'drum-electro-ride':    { name: 'Electro Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -19, envelope: { attack: 0.001, decay: 0.35, sustain: 0 }, filter: { type: 'highpass', freq: 10000 }, trigger: { dur: '8n', velocity: 0.5 } } },
+  // Brush
+  'drum-brush-clap':    { name: 'Brush Clap',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -14, envelope: { attack: 0.004, decay: 0.25, sustain: 0 }, filter: { type: 'highpass', freq: 600 }, trigger: { dur: '4n', velocity: 0.55 } } },
+  'drum-brush-openhat': { name: 'Brush Open Hat', type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -22, envelope: { attack: 0.002, decay: 0.4, sustain: 0 }, filter: { type: 'highpass', freq: 4500 }, trigger: { dur: '8n', velocity: 0.45 } } },
+  'drum-brush-tom':     { name: 'Brush Tom',     type: 'drum', engine: 'synth', patch: { archetype: 'membrane', volume: -8, pitch: { pitchDecay: 0.04, octaves: 2 }, filter: { type: 'lowpass', freq: 1800 }, trigger: { note: 'A2', dur: '8n', velocity: 0.7 } } },
+  'drum-brush-crash':   { name: 'Brush Crash',   type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -15, envelope: { attack: 0.003, decay: 1.4, sustain: 0, release: 0.5 }, filter: { type: 'highpass', freq: 2500 }, trigger: { dur: '8n', velocity: 0.6 } } },
+  'drum-brush-ride':    { name: 'Brush Ride',    type: 'drum', engine: 'synth', patch: { archetype: 'noise', volume: -21, envelope: { attack: 0.002, decay: 0.7, sustain: 0 }, filter: { type: 'highpass', freq: 5500 }, trigger: { dur: '4n', velocity: 0.45 } } },
 };
 
 // The full selectable set: stock defaults + preset banks. Engine inits
@@ -447,28 +523,31 @@ export const DRUM_PRESETS = {
 export const ALL_INSTRUMENTS = { ...DEFAULT_INSTRUMENTS, ...SYNTH_PRESETS, ...DRUM_PRESETS };
 
 // ─── Drum kits (Slice 2) ──────────────────────────────────────────────────────
-// Each kit keeps the SAME GM notes/labels as DEFAULT_KIT (36/38/42/45/49) so the
-// drum grooves trigger the same slots; only the instrument per slot differs.
-// Tom + Crash reuse the Oyster voices for now.
-const kit = (name, kick, snare, hat) => ({
+// Every kit fills the SAME 8 GM slots (36/38/39/42/46/45/49/51) so any groove
+// triggers the same slots — only the per-slot instrument differs. The 8 sounds
+// follow a `drum-<prefix>-<piece>` id convention, so a kit is named by its prefix.
+const kit = (name, p) => ({
   name,
   slots: [
-    { note: 36, label: 'Kick',  instrument: kick },
-    { note: 38, label: 'Snare', instrument: snare },
-    { note: 42, label: 'HH',    instrument: hat },
-    { note: 45, label: 'Tom',   instrument: 'gb-tom', pitched: true },
-    { note: 49, label: 'Crash', instrument: 'gb-crash' },
+    { note: 36, label: 'Kick',  instrument: `drum-${p}-kick` },
+    { note: 38, label: 'Snare', instrument: `drum-${p}-snare` },
+    { note: 39, label: 'Clap',  instrument: `drum-${p}-clap` },
+    { note: 42, label: 'HH',    instrument: `drum-${p}-hat` },
+    { note: 46, label: 'OH',    instrument: `drum-${p}-openhat` },
+    { note: 45, label: 'Tom',   instrument: `drum-${p}-tom`, pitched: true },
+    { note: 49, label: 'Crash', instrument: `drum-${p}-crash` },
+    { note: 51, label: 'Ride',  instrument: `drum-${p}-ride` },
   ],
 });
 export const DRUM_KITS = {
-  'kit-808':      kit('808',      'drum-808-kick',      'drum-808-snare',      'drum-808-hat'),
-  'kit-909':      kit('909',      'drum-909-kick',      'drum-909-snare',      'drum-909-hat'),
-  'kit-acoustic': kit('Acoustic', 'drum-acoustic-kick', 'drum-acoustic-snare', 'drum-acoustic-hat'),
-  'kit-lofi':     kit('Lo-Fi',    'drum-lofi-kick',     'drum-lofi-snare',     'drum-lofi-hat'),
-  'kit-boombap':  kit('Boom Bap', 'drum-boombap-kick',  'drum-boombap-snare',  'drum-boombap-hat'),
-  'kit-techno':   kit('Techno',   'drum-techno-kick',   'drum-techno-snare',   'drum-techno-hat'),
-  'kit-electro':  kit('Electro',  'drum-electro-kick',  'drum-electro-snare',  'drum-electro-hat'),
-  'kit-brush':    kit('Brush',    'drum-brush-kick',    'drum-brush-snare',    'drum-brush-hat'),
+  'kit-808':      kit('808',      '808'),
+  'kit-909':      kit('909',      '909'),
+  'kit-acoustic': kit('Acoustic', 'acoustic'),
+  'kit-lofi':     kit('Lo-Fi',    'lofi'),
+  'kit-boombap':  kit('Boom Bap', 'boombap'),
+  'kit-techno':   kit('Techno',   'techno'),
+  'kit-electro':  kit('Electro',  'electro'),
+  'kit-brush':    kit('Brush',    'brush'),
 };
 // Selectable kits: the Oyster default + the banks.
 export const ALL_KITS = { 'oyster-kit': DEFAULT_KIT, ...DRUM_KITS };

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -178,37 +178,37 @@ export function normalizeSongDrums(song) {
 // Values mirror engine/voices.js createVoiceForType EXACTLY (parity-tested).
 export const DEFAULT_INSTRUMENTS = {
   'gb-kick': {
-    name: 'GB KICK', type: 'drum', engine: 'synth',
+    name: 'GB Kick', type: 'drum', engine: 'synth',
     patch: { archetype: 'membrane', volume: -5, trigger: { note: 'C1', dur: '8n' } },
   },
   'gb-snare': {
-    name: 'GB SNARE', type: 'drum', engine: 'synth',
+    name: 'GB Snare', type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -11,
       envelope: { attack: 0.001, decay: 0.16, sustain: 0 },
       trigger: { dur: '16n' } },
   },
   'gb-hat': {
-    name: 'GB HAT', type: 'drum', engine: 'synth',
+    name: 'GB Hat', type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -20,
       envelope: { attack: 0.001, decay: 0.03, sustain: 0 },
       filter: { type: 'highpass', freq: 7000 },
       trigger: { dur: '32n', velocity: 0.6 } },
   },
   'gb-tom': {
-    name: 'GB TOM', type: 'drum', engine: 'synth',
+    name: 'GB Tom', type: 'drum', engine: 'synth',
     patch: { archetype: 'membrane', volume: -6,
       pitch: { pitchDecay: 0.06, octaves: 2 },
       trigger: { note: 'A2', dur: '8n' } },
   },
   'gb-crash': {
-    name: 'GB CRASH', type: 'drum', engine: 'synth',
+    name: 'GB Crash', type: 'drum', engine: 'synth',
     patch: { archetype: 'noise', volume: -12,
       envelope: { attack: 0.001, decay: 1.1, sustain: 0, release: 0.3 },
       filter: { type: 'highpass', freq: 3500 },
       trigger: { dur: '8n', velocity: 0.8 } },
   },
   'gb-bass': {
-    name: 'GB BASS', type: 'bass', engine: 'synth',
+    name: 'GB Bass', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -7,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.005, decay: 0.18, sustain: 0.35, release: 0.18 },
@@ -216,7 +216,7 @@ export const DEFAULT_INSTRUMENTS = {
       trigger: { velocity: 0.85 } },
   },
   'gb-chords': {
-    name: 'GB CHORDS', type: 'chords', engine: 'synth',
+    name: 'GB Chords', type: 'chords', engine: 'synth',
     patch: { archetype: 'poly', volume: -17,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.05, decay: 0.3, sustain: 0.6, release: 0.5 },
@@ -224,7 +224,7 @@ export const DEFAULT_INSTRUMENTS = {
       trigger: { velocity: 0.3 } },
   },
   'gb-lead': {
-    name: 'GB LEAD', type: 'melody', engine: 'synth',
+    name: 'GB Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -11,
       oscillator: { shape: 'pulse', width: 0.3 },
       envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
@@ -233,7 +233,7 @@ export const DEFAULT_INSTRUMENTS = {
 };
 
 export const DEFAULT_KIT = {
-  name: 'GB KIT',
+  name: 'GB Kit',
   slots: [
     { note: 36, label: 'Kick',  instrument: 'gb-kick' },
     { note: 38, label: 'Snare', instrument: 'gb-snare' },
@@ -251,7 +251,7 @@ export const DEFAULT_KIT = {
 export const SYNTH_PRESETS = {
   // Bass (mono)
   'preset-sub-bass': {
-    name: 'SUB BASS', type: 'bass', engine: 'synth',
+    name: 'Sub Bass', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -6,
       oscillator: { shape: 'sine' },
       envelope: { attack: 0.008, decay: 0.2, sustain: 0.7, release: 0.25 },
@@ -259,7 +259,7 @@ export const SYNTH_PRESETS = {
       trigger: { velocity: 0.9 } },
   },
   'preset-reese': {
-    name: 'REESE', type: 'bass', engine: 'synth',
+    name: 'Reese', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -8,
       oscillator: { shape: 'sawtooth' },
       envelope: { attack: 0.005, decay: 0.25, sustain: 0.6, release: 0.2 },
@@ -267,7 +267,7 @@ export const SYNTH_PRESETS = {
       trigger: { velocity: 0.85 } },
   },
   'preset-pluck-bass': {
-    name: 'PLUCK BASS', type: 'bass', engine: 'synth',
+    name: 'Pluck Bass', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -7,
       oscillator: { shape: 'square' },
       envelope: { attack: 0.003, decay: 0.09, sustain: 0.05, release: 0.1 },
@@ -275,7 +275,7 @@ export const SYNTH_PRESETS = {
       trigger: { velocity: 0.85 } },
   },
   'preset-moog-bass': {
-    name: 'MOOG', type: 'bass', engine: 'synth',
+    name: 'Moog', type: 'bass', engine: 'synth',
     patch: { archetype: 'mono', volume: -7,
       oscillator: { shape: 'sawtooth' },
       envelope: { attack: 0.01, decay: 0.35, sustain: 0.5, release: 0.25 },
@@ -284,7 +284,7 @@ export const SYNTH_PRESETS = {
   },
   // Chords (poly)
   'preset-poly-pad': {
-    name: 'POLY PAD', type: 'chords', engine: 'synth',
+    name: 'Poly Pad', type: 'chords', engine: 'synth',
     patch: { archetype: 'poly', volume: -16,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.08, decay: 0.4, sustain: 0.7, release: 0.8 },
@@ -292,7 +292,7 @@ export const SYNTH_PRESETS = {
       trigger: { velocity: 0.3 } },
   },
   'preset-stab': {
-    name: 'STAB', type: 'chords', engine: 'synth',
+    name: 'Stab', type: 'chords', engine: 'synth',
     patch: { archetype: 'poly', volume: -16,
       oscillator: { shape: 'sawtooth' },
       envelope: { attack: 0.005, decay: 0.12, sustain: 0, release: 0.15 },
@@ -300,7 +300,7 @@ export const SYNTH_PRESETS = {
       trigger: { velocity: 0.35 } },
   },
   'preset-organ': {
-    name: 'ORGAN', type: 'chords', engine: 'synth',
+    name: 'Organ', type: 'chords', engine: 'synth',
     patch: { archetype: 'poly', volume: -18,
       oscillator: { shape: 'square' },
       envelope: { attack: 0.005, decay: 0.1, sustain: 1, release: 0.2 },
@@ -308,7 +308,7 @@ export const SYNTH_PRESETS = {
       trigger: { velocity: 0.3 } },
   },
   'preset-glass': {
-    name: 'GLASS', type: 'chords', engine: 'synth',
+    name: 'Glass', type: 'chords', engine: 'synth',
     patch: { archetype: 'poly', volume: -16,
       oscillator: { shape: 'sine' },
       envelope: { attack: 0.06, decay: 0.3, sustain: 0.25, release: 0.5 },
@@ -317,49 +317,49 @@ export const SYNTH_PRESETS = {
   },
   // Melody (poly)
   'preset-square-lead': {
-    name: 'SQUARE LEAD', type: 'melody', engine: 'synth',
+    name: 'Square Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -11,
       oscillator: { shape: 'square' },
       envelope: { attack: 0.004, decay: 0.16, sustain: 0.25, release: 0.18 },
       trigger: { velocity: 0.82 } },
   },
   'preset-saw-lead': {
-    name: 'SAW LEAD', type: 'melody', engine: 'synth',
+    name: 'Saw Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -12,
       oscillator: { shape: 'sawtooth' },
       envelope: { attack: 0.004, decay: 0.2, sustain: 0.3, release: 0.2 },
       trigger: { velocity: 0.82 } },
   },
   'preset-soft-pad': {
-    name: 'SOFT PAD', type: 'melody', engine: 'synth',
+    name: 'Soft Pad', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -12,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.07, decay: 0.4, sustain: 0.65, release: 0.5 },
       trigger: { velocity: 0.75 } },
   },
   'preset-pluck-lead': {
-    name: 'PLUCK LEAD', type: 'melody', engine: 'synth',
+    name: 'Pluck Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -11,
       oscillator: { shape: 'pulse', width: 0.25 },
       envelope: { attack: 0.004, decay: 0.08, sustain: 0, release: 0.12 },
       trigger: { velocity: 0.82 } },
   },
   'preset-fat-saw': {
-    name: 'FAT SAW', type: 'melody', engine: 'synth',
+    name: 'Fat Saw', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -12,
       oscillator: { shape: 'fatsawtooth' },
       envelope: { attack: 0.006, decay: 0.22, sustain: 0.35, release: 0.2 },
       trigger: { velocity: 0.82 } },
   },
   'preset-triangle-lead': {
-    name: 'TRIANGLE LEAD', type: 'melody', engine: 'synth',
+    name: 'Triangle Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -11,
       oscillator: { shape: 'triangle' },
       envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },
       trigger: { velocity: 0.82 } },
   },
   'preset-sine-lead': {
-    name: 'SINE LEAD', type: 'melody', engine: 'synth',
+    name: 'Sine Lead', type: 'melody', engine: 'synth',
     patch: { archetype: 'poly', volume: -10,
       oscillator: { shape: 'sine' },
       envelope: { attack: 0.004, decay: 0.18, sustain: 0.2, release: 0.2 },

--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -379,6 +379,64 @@ export const LEGACY_TONE_PRESET = {
   sine: 'preset-sine-lead',
 };
 
+// ─── Drum instrument presets (Slice 2) ────────────────────────────────────────
+// type:'drum' patches the kits below assemble. Kicks/toms = membrane (shaped via
+// pitch + trigger.dur + filter; no envelope). Snares/hats/crashes = noise (shaped
+// via envelope + filter). STARTER values — ear-test gated.
+export const DRUM_PRESETS = {
+  // 808 — deep sub kick, snappy snare, tight hats
+  'drum-808-kick':  { name: '808 Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -3, pitch: { pitchDecay: 0.45, octaves: 6 }, trigger: { note: 'C1', dur: '2n', velocity: 1 } } },
+  'drum-808-snare': { name: '808 Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -10, envelope: { attack: 0.001, decay: 0.2, sustain: 0 }, filter: { type: 'highpass', freq: 1400 }, trigger: { dur: '16n', velocity: 0.9 } } },
+  'drum-808-hat':   { name: '808 Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -18, envelope: { attack: 0.001, decay: 0.04, sustain: 0 }, filter: { type: 'highpass', freq: 9000 }, trigger: { dur: '32n', velocity: 0.6 } } },
+  // 909 — punchy kick, noisy snare, sizzly hats
+  'drum-909-kick':  { name: '909 Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -4, pitch: { pitchDecay: 0.06, octaves: 4 }, trigger: { note: 'C1', dur: '8n', velocity: 1 } } },
+  'drum-909-snare': { name: '909 Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -10, envelope: { attack: 0.001, decay: 0.18, sustain: 0 }, filter: { type: 'highpass', freq: 1800 }, trigger: { dur: '16n', velocity: 0.9 } } },
+  'drum-909-hat':   { name: '909 Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -17, envelope: { attack: 0.001, decay: 0.05, sustain: 0 }, filter: { type: 'highpass', freq: 8000 }, trigger: { dur: '32n', velocity: 0.65 } } },
+  // Acoustic — natural thud, fuller snare
+  'drum-acoustic-kick':  { name: 'Acoustic Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -5, pitch: { pitchDecay: 0.03, octaves: 3 }, trigger: { note: 'C1', dur: '8n', velocity: 0.9 } } },
+  'drum-acoustic-snare': { name: 'Acoustic Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -9, envelope: { attack: 0.001, decay: 0.22, sustain: 0 }, filter: { type: 'highpass', freq: 1100 }, trigger: { dur: '8n', velocity: 0.85 } } },
+  'drum-acoustic-hat':   { name: 'Acoustic Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -19, envelope: { attack: 0.001, decay: 0.05, sustain: 0 }, filter: { type: 'highpass', freq: 7500 }, trigger: { dur: '32n', velocity: 0.55 } } },
+  // Lo-Fi — soft warm kick (low-passed), dusty snare, muffled hat
+  'drum-lofi-kick':  { name: 'Lo-Fi Kick',  type: 'drum', engine: 'synth',
+    patch: { archetype: 'membrane', volume: -6, pitch: { pitchDecay: 0.05, octaves: 2.5 }, filter: { type: 'lowpass', freq: 2200 }, trigger: { note: 'C1', dur: '8n', velocity: 0.8 } } },
+  'drum-lofi-snare': { name: 'Lo-Fi Snare', type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -12, envelope: { attack: 0.002, decay: 0.25, sustain: 0 }, filter: { type: 'highpass', freq: 700 }, trigger: { dur: '8n', velocity: 0.7 } } },
+  'drum-lofi-hat':   { name: 'Lo-Fi Hat',   type: 'drum', engine: 'synth',
+    patch: { archetype: 'noise', volume: -22, envelope: { attack: 0.001, decay: 0.06, sustain: 0 }, filter: { type: 'highpass', freq: 5000 }, trigger: { dur: '32n', velocity: 0.5 } } },
+};
+
 // The full selectable set: stock defaults + preset banks. Engine inits
 // `_instruments` from this so every preset id resolves.
-export const ALL_INSTRUMENTS = { ...DEFAULT_INSTRUMENTS, ...SYNTH_PRESETS };
+export const ALL_INSTRUMENTS = { ...DEFAULT_INSTRUMENTS, ...SYNTH_PRESETS, ...DRUM_PRESETS };
+
+// ─── Drum kits (Slice 2) ──────────────────────────────────────────────────────
+// Each kit keeps the SAME GM notes/labels as DEFAULT_KIT (36/38/42/45/49) so the
+// drum grooves trigger the same slots; only the instrument per slot differs.
+// Tom + Crash reuse the Oyster voices for now.
+const kit = (name, kick, snare, hat) => ({
+  name,
+  slots: [
+    { note: 36, label: 'Kick',  instrument: kick },
+    { note: 38, label: 'Snare', instrument: snare },
+    { note: 42, label: 'HH',    instrument: hat },
+    { note: 45, label: 'Tom',   instrument: 'gb-tom', pitched: true },
+    { note: 49, label: 'Crash', instrument: 'gb-crash' },
+  ],
+});
+export const DRUM_KITS = {
+  'kit-808':      kit('808',      'drum-808-kick',      'drum-808-snare',      'drum-808-hat'),
+  'kit-909':      kit('909',      'drum-909-kick',      'drum-909-snare',      'drum-909-hat'),
+  'kit-acoustic': kit('Acoustic', 'drum-acoustic-kick', 'drum-acoustic-snare', 'drum-acoustic-hat'),
+  'kit-lofi':     kit('Lo-Fi',    'drum-lofi-kick',     'drum-lofi-snare',     'drum-lofi-hat'),
+};
+// Selectable kits: the Oyster default + the banks.
+export const ALL_KITS = { 'oyster-kit': DEFAULT_KIT, ...DRUM_KITS };

--- a/docs/arcade/groovebox/engine/lanes.js
+++ b/docs/arcade/groovebox/engine/lanes.js
@@ -2,6 +2,9 @@
 import { emptyBarFor } from './patterns.js';
 import { slotKey } from './instruments.js';
 
+// Default preset a new pitched lane starts on (drums use the kit, not this).
+export const DEFAULT_LANE_INSTRUMENT = { bass: 'gb-bass', chords: 'gb-chords', melody: 'gb-lead' };
+
 
 /**
  * uniqueLaneId(lanes, type) → collision-free id string.
@@ -39,7 +42,7 @@ export function addLane(song, type) {
     name: uniqueLaneName(lanes, type),
     muted: false,
     soloed: false,
-    ...(type === 'melody' ? { tone: 'pulse' } : {}),
+    ...(DEFAULT_LANE_INSTRUMENT[type] ? { instrument: DEFAULT_LANE_INSTRUMENT[type] } : {}),
   };
   lanes.push(lane);
   // New lane gets one 'empty' groove; every pattern picks it.

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -2,6 +2,7 @@
 // Single source of truth alongside DATA-MODEL.md and the spec
 // (po20/2026-06-06-share-registry-spec.md). Strict everywhere: unknown keys
 // rejected; the ONLY extension point is `extensions: {}` inside payloads.
+import { validateInstrument } from '../engine/instruments.js';
 
 export const KIND_VERSIONS = { song: 2, groove: 1 };
 export const LANE_TYPES = ['drums', 'bass', 'chords', 'melody'];
@@ -102,8 +103,16 @@ export function validateGroovePayload(p) {
 export function validateSongPayload(p) {
   if (!isObj(p)) return err('payload must be an object');
   const bad = strictKeys(p, ['version', 'title', 'artist', 'meter', 'bpm', 'lanes', 'grooves',
-    'patterns', 'chain', 'fills', 'transpose', 'key', 'extensions'], 'song payload');
+    'patterns', 'chain', 'fills', 'transpose', 'key', 'instruments', 'extensions'], 'song payload');
   if (bad) return err(bad);
+  // Song-local custom (forked) instruments travel inline with the song.
+  if (p.instruments !== undefined) {
+    if (!isObj(p.instruments)) return err('instruments must be an object');
+    for (const [iid, inst] of Object.entries(p.instruments)) {
+      if (typeof iid !== 'string' || !iid.length || iid.length > 64) return err('invalid instrument id');
+      if (!validateInstrument(inst)) return err(`invalid instrument "${iid}"`);
+    }
+  }
   if (p.key !== undefined && !(isObj(p.key) && typeof p.key.root === 'string' && typeof p.key.mode === 'string')) return err('invalid key');
   if (p.version !== 2) return err('song payload version must be 2');
   if (!meterValid(p.meter)) return err('invalid meter');

--- a/docs/arcade/groovebox/registry/validate.js
+++ b/docs/arcade/groovebox/registry/validate.js
@@ -105,11 +105,13 @@ export function validateSongPayload(p) {
   const bad = strictKeys(p, ['version', 'title', 'artist', 'meter', 'bpm', 'lanes', 'grooves',
     'patterns', 'chain', 'fills', 'transpose', 'key', 'instruments', 'extensions'], 'song payload');
   if (bad) return err(bad);
-  // Song-local custom (forked) instruments travel inline with the song.
+  // Song-local custom (forked) instruments travel inline with the song. Ids must
+  // carry the `custom-` prefix — this blocks special keys (__proto__) and stops a
+  // song shadowing a stock preset id (gb-*/preset-*/drum-*/kit-*).
   if (p.instruments !== undefined) {
     if (!isObj(p.instruments)) return err('instruments must be an object');
     for (const [iid, inst] of Object.entries(p.instruments)) {
-      if (typeof iid !== 'string' || !iid.length || iid.length > 64) return err('invalid instrument id');
+      if (!/^custom-[a-z0-9-]{1,48}$/i.test(iid)) return err('invalid instrument id');
       if (!validateInstrument(inst)) return err(`invalid instrument "${iid}"`);
     }
   }

--- a/docs/arcade/groovebox/songs/boo-waltz.js
+++ b/docs/arcade/groovebox/songs/boo-waltz.js
@@ -25,12 +25,12 @@ export const booWaltz = {
 
   grooves: {
     drums: {
-      // the ballroom: soft pulse on 1, brushes on 2 and 3
-      ballroom: [{ kick: [0], hat: [4, 8] }],
-      // footsteps: something walks on the off-16ths
-      footsteps: [{ kick: [0], hat: [4, 8], snare: [6] }],
-      // the chase: toms lurch through the bar
-      lurch: [{ kick: [0, 8], hat: [2, 6, 10], tom: [[4, 0], [10, -4]] }],
+      // the ballroom: soft pulse on 1, ride shimmer on 2 and 3
+      ballroom: [{ kick: [0], hat: [4, 8], ride: [4, 8] }],
+      // footsteps: something walks on the off-16ths, a creak before the loop
+      footsteps: [{ kick: [0], hat: [4, 8], snare: [6], openhat: [10] }],
+      // the chase: toms lurch through the bar, ride echoes the kick
+      lurch: [{ kick: [0, 8], hat: [2, 6, 10], tom: [[4, 0], [10, -4]], ride: [0, 8] }],
     },
     bass: {
       // oom-cha-cha: root on 1, fifth above on 2 and 3

--- a/docs/arcade/groovebox/songs/boo-waltz.js
+++ b/docs/arcade/groovebox/songs/boo-waltz.js
@@ -20,7 +20,7 @@ export const booWaltz = {
     { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
     { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
     { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
-    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'sine' },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, instrument: 'preset-sine-lead' },
   ],
 
   grooves: {

--- a/docs/arcade/groovebox/songs/first-roll.js
+++ b/docs/arcade/groovebox/songs/first-roll.js
@@ -20,7 +20,7 @@ export const firstRoll = {
     { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
     { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
     { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
-    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'pulse' },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, instrument: 'gb-lead' },
   ],
 
   grooves: {

--- a/docs/arcade/groovebox/songs/first-roll.js
+++ b/docs/arcade/groovebox/songs/first-roll.js
@@ -25,12 +25,12 @@ export const firstRoll = {
 
   grooves: {
     drums: {
-      // steady verse kit
-      four:        [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
-      // sparse intro/bridge kit
-      'half-time': [{ kick: [0], snare: [8], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
-      // busy chorus kit
-      breaks:      [{ kick: [0, 6, 10], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] }],
+      // steady verse kit — clap on the backbeat, open-hat lift
+      four:        [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14], clap: [4, 12], openhat: [14] }],
+      // sparse intro/bridge kit — clap doubles the half-time snare
+      'half-time': [{ kick: [0], snare: [8], hat: [0, 2, 4, 6, 8, 10, 12, 14], clap: [8], openhat: [14] }],
+      // busy chorus kit — clap reinforces the backbeat
+      breaks:      [{ kick: [0, 6, 10], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], clap: [4, 12] }],
     },
     bass: {
       // root/octave bounce — rides whatever chords the pattern carries

--- a/docs/arcade/groovebox/songs/press-start.js
+++ b/docs/arcade/groovebox/songs/press-start.js
@@ -26,12 +26,12 @@ export const pressStart = {
 
   grooves: {
     drums: {
-      // fanfare bed — sparse, big crash
-      fanfare: [{ kick: [0, 8], snare: [12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [0] }],
-      // main run — driving 16th hats, four on the floor
-      sprint:  [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] }],
-      // B section — syncopated kick, lighter hats
-      skip:    [{ kick: [0, 6, 8, 14], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      // fanfare bed — sparse, big crash, open-hat pickup
+      fanfare: [{ kick: [0, 8], snare: [12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [0], openhat: [14] }],
+      // main run — driving 16th hats, four on the floor, clap on the backbeat
+      sprint:  [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], clap: [4, 12] }],
+      // B section — syncopated kick, lighter hats, clap + open-hat lift
+      skip:    [{ kick: [0, 6, 8, 14], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14], clap: [4, 12], openhat: [14] }],
     },
     bass: {
       // THE game bass: root/fifth oom-pah in 8ths

--- a/docs/arcade/groovebox/songs/press-start.js
+++ b/docs/arcade/groovebox/songs/press-start.js
@@ -21,7 +21,7 @@ export const pressStart = {
     { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
     { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
     { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
-    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'square' },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, instrument: 'preset-square-lead' },
   ],
 
   grooves: {

--- a/docs/arcade/groovebox/songs/scallywag.js
+++ b/docs/arcade/groovebox/songs/scallywag.js
@@ -21,7 +21,7 @@ export const scallywag = {
     { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
     { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
     { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
-    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, tone: 'triangle' },
+    { id: 'melody', type: 'melody', name: 'melody', muted: false, soloed: false, instrument: 'preset-triangle-lead' },
   ],
 
   grooves: {

--- a/docs/arcade/groovebox/songs/scallywag.js
+++ b/docs/arcade/groovebox/songs/scallywag.js
@@ -26,12 +26,12 @@ export const scallywag = {
 
   grooves: {
     drums: {
-      // gentle ship-sway: pulses on the two dotted quarters
-      sway:  [{ kick: [0, 6], hat: [0, 2, 4, 6, 8, 10] }],
-      // tavern stomp: snare answers on the second pulse
-      stomp: [{ kick: [0, 6], snare: [6], hat: [0, 2, 4, 6, 8, 10] }],
-      // full sail: busier kick, crash to open
-      'full sail': [{ kick: [0, 3, 6, 9], snare: [6], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], crash: [0] }],
+      // gentle ship-sway: pulses on the two dotted quarters, open-hat lilt
+      sway:  [{ kick: [0, 6], hat: [0, 2, 4, 6, 8, 10], openhat: [10] }],
+      // tavern stomp: snare answers on the second pulse, clap-along
+      stomp: [{ kick: [0, 6], snare: [6], hat: [0, 2, 4, 6, 8, 10], clap: [6] }],
+      // full sail: busier kick, crash to open, ride the dotted quarters
+      'full sail': [{ kick: [0, 3, 6, 9], snare: [6], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], crash: [0], clap: [6], ride: [0, 3, 6, 9] }],
     },
     bass: {
       // lilting root → octave → fifth, the 6/8 sea-legs walk

--- a/docs/arcade/groovebox/tests/preset-picker.test.js
+++ b/docs/arcade/groovebox/tests/preset-picker.test.js
@@ -85,6 +85,16 @@ describe('per-lane instrument selection + fork-to-Custom', () => {
     eng.setLaneCustom('nope', VALID_BASS);
     expect(eng.getSong().instruments['custom-' + id].name).toBe('My Bass');
   });
+
+  test('type mismatch is rejected (a lane only takes its own type)', () => {
+    const eng = loaded(); const id = bassLane(eng);
+    const before = eng.getSong().lanes.find(l => l.id === id).instrument;
+    eng.setLaneInstrument(id, 'preset-square-lead');      // a melody preset on a bass lane
+    expect(eng.getSong().lanes.find(l => l.id === id).instrument).toBe(before);
+    const melodyPatch = { ...VALID_BASS, type: 'melody' };
+    eng.setLaneCustom(id, melodyPatch);                   // a melody patch on a bass lane
+    expect(eng.getSong().instruments?.['custom-' + id]).toBeUndefined();
+  });
 });
 
 describe('tone → instrument migration (load boundary)', () => {
@@ -112,5 +122,11 @@ describe('registry validation of song-local instruments', () => {
   });
   it('rejects a non-object instruments field', () => {
     expect(validateSongPayload({ ...SONG_PAYLOAD, instruments: [] }).ok).not.toBe(true);
+  });
+  it('rejects ids without the custom- prefix (stock shadowing / proto pollution)', () => {
+    expect(validateSongPayload({ ...SONG_PAYLOAD, instruments: { 'gb-bass': VALID_BASS } }).ok).not.toBe(true);
+    // __proto__ as an OWN key — how it arrives via JSON.parse on a real payload.
+    const proto = JSON.parse(`{"__proto__": ${JSON.stringify(VALID_BASS)}}`);
+    expect(validateSongPayload({ ...SONG_PAYLOAD, instruments: proto }).ok).not.toBe(true);
   });
 });

--- a/docs/arcade/groovebox/tests/preset-picker.test.js
+++ b/docs/arcade/groovebox/tests/preset-picker.test.js
@@ -1,0 +1,116 @@
+// tests/preset-picker.test.js — instrument/kit banks, per-lane selection,
+// fork-to-Custom, the tone→instrument migration, and registry validation.
+import { describe, it, test, expect } from 'vitest';
+import {
+  SYNTH_PRESETS, DRUM_PRESETS, ALL_INSTRUMENTS, ALL_KITS, DRUM_KITS,
+  LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit,
+} from '../engine/instruments.js';
+import { addLane, DEFAULT_LANE_INSTRUMENT } from '../engine/lanes.js';
+import { createEngine } from '../engine/index.js';
+import { kids } from '../songs/kids.js';
+import { validateSongPayload } from '../registry/validate.js';
+import { SONG_PAYLOAD } from './helpers/registry-fixtures.js';
+
+const VALID_BASS = {
+  name: 'My Bass', type: 'bass', engine: 'synth',
+  patch: { archetype: 'mono', volume: -8, oscillator: { shape: 'sawtooth' },
+    envelope: { attack: 0.01, decay: 0.2, sustain: 0.4, release: 0.2 }, trigger: { velocity: 0.8 } },
+};
+
+describe('preset banks', () => {
+  it('every synth + drum preset validates', () => {
+    for (const [id, inst] of Object.entries(SYNTH_PRESETS)) expect(validateInstrument(inst), id).toBe(true);
+    for (const [id, inst] of Object.entries(DRUM_PRESETS)) expect(validateInstrument(inst), id).toBe(true);
+  });
+  it('ALL_INSTRUMENTS contains the defaults + every preset', () => {
+    for (const id of Object.keys(SYNTH_PRESETS)) expect(ALL_INSTRUMENTS[id]).toBeDefined();
+    for (const id of Object.keys(DRUM_PRESETS)) expect(ALL_INSTRUMENTS[id]).toBeDefined();
+    expect(ALL_INSTRUMENTS['gb-bass']).toBeDefined();
+  });
+  it('every kit fills the canonical 8 slots and resolves', () => {
+    const notes = DEFAULT_KIT.slots.map(s => s.note);
+    expect(notes).toEqual([36, 38, 39, 42, 46, 45, 49, 51]);
+    for (const [id, k] of Object.entries(ALL_KITS)) {
+      expect(validateKit(k, ALL_INSTRUMENTS), id).toBe(true);
+      expect(k.slots.map(s => s.note), id).toEqual(notes);
+      for (const s of k.slots) expect(ALL_INSTRUMENTS[s.instrument], `${id}/${s.label}`).toBeDefined();
+    }
+  });
+  it('LEGACY_TONE_PRESET maps every old tone to a real melody preset', () => {
+    for (const presetId of Object.values(LEGACY_TONE_PRESET)) {
+      expect(ALL_INSTRUMENTS[presetId]).toBeDefined();
+      expect(ALL_INSTRUMENTS[presetId].type).toBe('melody');
+    }
+  });
+});
+
+describe('addLane seeds the default preset', () => {
+  it('seeds instrument per pitched type; drums use the kit', () => {
+    const eng = createEngine(); eng.load(kids);
+    const song = eng.getSong();   // v2: lanes array + grooves + patterns
+    expect(addLane(song, 'bass').instrument).toBe('gb-bass');
+    expect(addLane(song, 'melody').instrument).toBe('gb-lead');
+    expect(addLane(song, 'drums').instrument).toBeUndefined();
+    expect(DEFAULT_LANE_INSTRUMENT.chords).toBe('gb-chords');
+  });
+});
+
+function loaded() { const eng = createEngine(); eng.load(kids); return eng; }
+const bassLane = eng => eng.getLanes().find(l => l.type === 'bass').id;
+
+describe('per-lane instrument selection + fork-to-Custom', () => {
+  test('setLaneInstrument picks a stock preset; unknown id is a no-op', () => {
+    const eng = loaded(); const id = bassLane(eng);
+    eng.setLaneInstrument(id, 'preset-reese');
+    expect(eng.getSong().lanes.find(l => l.id === id).instrument).toBe('preset-reese');
+    eng.setLaneInstrument(id, 'does-not-exist');
+    expect(eng.getSong().lanes.find(l => l.id === id).instrument).toBe('preset-reese');
+  });
+
+  test('setLaneCustom forks to a SONG-LOCAL custom; stock is untouched', () => {
+    const eng = loaded(); const id = bassLane(eng);
+    eng.setLaneCustom(id, VALID_BASS);
+    const song = eng.getSong();
+    expect(song.lanes.find(l => l.id === id).instrument).toBe('custom-' + id);
+    expect(song.instruments['custom-' + id].name).toBe('My Bass');
+    expect(eng.resolveLaneInstrument(id).name).toBe('My Bass');
+    // the stock preset object is never mutated
+    expect(ALL_INSTRUMENTS['gb-bass'].name).toBe('Oyster Bass');
+  });
+
+  test('setLaneCustom rejects a bad patch / unknown lane (no-op)', () => {
+    const eng = loaded(); const id = bassLane(eng);
+    eng.setLaneCustom(id, VALID_BASS);
+    eng.setLaneCustom(id, { not: 'a patch' });
+    eng.setLaneCustom('nope', VALID_BASS);
+    expect(eng.getSong().instruments['custom-' + id].name).toBe('My Bass');
+  });
+});
+
+describe('tone → instrument migration (load boundary)', () => {
+  test('an old song with lane.tone upgrades to lane.instrument', () => {
+    const eng = createEngine(); eng.load(kids);
+    const v2 = JSON.parse(JSON.stringify(eng.getSong()));
+    const mel = v2.lanes.find(l => l.type === 'melody');
+    delete mel.instrument; mel.tone = 'square';
+    eng.load(v2);
+    const after = eng.getSong().lanes.find(l => l.type === 'melody');
+    expect(after.tone).toBeUndefined();
+    expect(after.instrument).toBe('preset-square-lead');
+  });
+});
+
+describe('registry validation of song-local instruments', () => {
+  it('accepts a song carrying a valid instruments map', () => {
+    const payload = { ...SONG_PAYLOAD, instruments: { 'custom-bass': VALID_BASS } };
+    expect(validateSongPayload(payload).ok).toBe(true);
+  });
+  it('rejects an out-of-range custom patch', () => {
+    const bad = JSON.parse(JSON.stringify({ ...SONG_PAYLOAD, instruments: { 'custom-bass': VALID_BASS } }));
+    bad.instruments['custom-bass'].patch.volume = 999;
+    expect(validateSongPayload(bad).ok).not.toBe(true);
+  });
+  it('rejects a non-object instruments field', () => {
+    expect(validateSongPayload({ ...SONG_PAYLOAD, instruments: [] }).ok).not.toBe(true);
+  });
+});

--- a/docs/arcade/groovebox/tests/song-switch.test.js
+++ b/docs/arcade/groovebox/tests/song-switch.test.js
@@ -78,7 +78,7 @@ test('load() never mutates the rich preset module object', () => {
   const eng = createEngine();
   eng.load(kids);
   eng.setTranspose(7);                         // writes to the FLATTENED song
-  eng.setTone('melody', 'sawtooth');           // writes lane.tone on flattened song
+  eng.setLaneInstrument('melody', 'preset-saw-lead');   // writes lane.instrument on flattened song
   eng.selectPattern(1);
   const after = JSON.stringify(kids, (k, v) => typeof v === 'function' ? '[fn]' : v);
   expect(after).toBe(before);
@@ -88,12 +88,12 @@ test('switching to a song and back gives an independent flattened object each ti
   const eng = createEngine();
   eng.load(kids);
   const first = eng.getSong();
-  eng.setTone('melody', 'sawtooth');           // mutate flattened lane.tone
-  expect(first.lanes.find(l => l.type === 'melody').tone).toBe('sawtooth');
+  eng.setLaneInstrument('melody', 'preset-saw-lead');   // mutate flattened lane.instrument
+  expect(first.lanes.find(l => l.type === 'melody').instrument).toBe('preset-saw-lead');
   switchTo(eng, risingSun);
   switchTo(eng, kids);
   const second = eng.getSong();
   expect(second).not.toBe(first);              // fresh flatten
-  // The new flatten must carry the preset's own tone (pulse), not the mutated one.
-  expect(second.lanes.find(l => l.type === 'melody').tone).toBe('pulse');
+  // The new flatten must NOT carry the runtime mutation — kids' melody has no override.
+  expect(second.lanes.find(l => l.type === 'melody').instrument).toBeUndefined();
 });

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1248,7 +1248,7 @@ input[type=range] {
 .mctl { display:flex; gap:8px; align-items:center; }
 .mctl select { width:auto; }
 .mctl select[data-lane] { flex:1; }
-.mctl select[data-tone] { flex:0 0 auto; color:var(--dim); }
+.mctl select[data-preset] { flex:1 1 auto; min-width:0; }
 
 /* ─── § 5 — knob groups ─────────────────────────────────────────────────── */
 .kgroup {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -23,9 +23,11 @@ import { openInstrumentEditor, isInstrumentEditorOpen } from './instrument-edito
 // carries no explicit lane.instrument).
 const LANE_INSTRUMENT = { bass: 'gb-bass', chords: 'gb-chords', melody: 'gb-lead' };
 import { DEFAULT_PRESETS } from '../engine/punch-presets.js';
-import { ALL_INSTRUMENTS } from '../engine/instruments.js';
+import { ALL_INSTRUMENTS, ALL_KITS } from '../engine/instruments.js';
 
 const eng = createEngine();
+// Selected drum kit (global for now — kit-per-song serialization is a follow-up).
+let currentKitId = 'oyster-kit';
 
 // ─── Knob info map (single source of truth) ───────────────────────────────────
 const KNOB_INFO = {
@@ -462,6 +464,11 @@ function renderStrips() {
         .filter(([, inst]) => inst.type === lane.type)
         .map(([id, inst]) => `<option value="${id}"${id === cur ? ' selected' : ''}>${esc(inst.name)}</option>`).join('');
       presetSel = `<select class="lane-preset" data-preset data-lane="${lane.id}" title="Instrument preset">${opts}</select>`;
+    } else {
+      // Drums pick a KIT (a composite of drum sounds).
+      const opts = Object.entries(ALL_KITS)
+        .map(([id, k]) => `<option value="${id}"${id === currentKitId ? ' selected' : ''}>${esc(k.name)}</option>`).join('');
+      presetSel = `<select class="lane-preset" data-kit data-lane="${lane.id}" title="Drum kit">${opts}</select>`;
     }
     const soundBtn = isPitched
       ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">EDIT</button>`
@@ -532,6 +539,10 @@ function renderStrips() {
 
   host.querySelectorAll('select[data-preset]').forEach(s => s.onchange = () => {
     eng.setLaneInstrument(s.dataset.lane, s.value);
+  });
+  host.querySelectorAll('select[data-kit]').forEach(s => s.onchange = () => {
+    currentKitId = s.value;
+    eng.setKit(ALL_KITS[currentKitId]);
   });
   host.querySelectorAll('.lane-sound').forEach(b => b.onclick = e => {
     e.stopPropagation();

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -19,13 +19,13 @@ import { listItems } from '../registry/client.js';
 import { openPunchEditor, isPunchEditorOpen } from './punch-editor.js';
 import { openInstrumentEditor, isInstrumentEditorOpen } from './instrument-editor.js';
 
-// Lane type → instrument id in the engine set (PR2 v1: one per type; per-lane
-// refs ride lane.instrument when the picker lands).
+// Lane type → default preset id (the instrument a lane falls back to when it
+// carries no explicit lane.instrument).
 const LANE_INSTRUMENT = { bass: 'gb-bass', chords: 'gb-chords', melody: 'gb-lead' };
 import { DEFAULT_PRESETS } from '../engine/punch-presets.js';
+import { ALL_INSTRUMENTS } from '../engine/instruments.js';
 
 const eng = createEngine();
-const TONES = ['pulse','square','sawtooth','fatsawtooth','triangle','sine'];
 
 // ─── Knob info map (single source of truth) ───────────────────────────────────
 const KNOB_INFO = {
@@ -452,13 +452,19 @@ function renderStrips() {
   const isLast = lanes.length === 1;
 
   host.innerHTML = lanes.map(lane => {
-    const tone = lane.type === 'melody'
-      ? `<select data-tone data-lane="${lane.id}">${TONES.map(t=>`<option value="${t}"${t===(lane.tone||'pulse')?' selected':''}>${t==='fatsawtooth'?'fat saw':t}</option>`).join('')}</select>`
-      : '';
-    // The strip selects the lane's SOUND (not the groove — the loop is chosen on
-    // the screen, in Grooves / Patterns).
-    const soundBtn = lane.type !== 'drums'
-      ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">SOUND</button>`
+    // Pitched lanes pick an instrument PRESET from a dropdown; EDIT opens the
+    // synth editor for the lane's current preset. (Drums = a kit, handled later.)
+    const isPitched = lane.type !== 'drums';
+    let presetSel = '';
+    if (isPitched) {
+      const cur = lane.instrument || LANE_INSTRUMENT[lane.type];
+      const opts = Object.entries(ALL_INSTRUMENTS)
+        .filter(([, inst]) => inst.type === lane.type)
+        .map(([id, inst]) => `<option value="${id}"${id === cur ? ' selected' : ''}>${esc(inst.name)}</option>`).join('');
+      presetSel = `<select class="lane-preset" data-preset data-lane="${lane.id}" title="Instrument preset">${opts}</select>`;
+    }
+    const soundBtn = isPitched
+      ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">EDIT</button>`
       : '';
     // Edit button — present for types with an editor (drums, melody, bass); skip chords.
     const hasEditor = lane.type !== 'chords';
@@ -469,7 +475,7 @@ function renderStrips() {
     return `<div class="lane" data-lane="${lane.id}" data-type="${lane.type}">
       <span class="lane-drag" title="Drag to reorder">⠿</span>
       <span class="name" title="double-click to rename">${esc(lane.name)}</span>
-      <div class="mctl">${tone}${soundBtn}</div>
+      <div class="mctl">${presetSel}${soundBtn}</div>
       <div class="lvl"><div class="lvl-fill"></div></div>
       <div class="msgroup">
         <button class="mute" data-lane="${lane.id}" aria-label="mute ${esc(lane.name)}" title="Mute">M</button>
@@ -524,10 +530,13 @@ function renderStrips() {
     renderStrips();
   });
 
-  host.querySelectorAll('select[data-tone]').forEach(s => s.onchange = e => eng.setTone(s.dataset.lane, e.target.value));
+  host.querySelectorAll('select[data-preset]').forEach(s => s.onchange = () => {
+    eng.setLaneInstrument(s.dataset.lane, s.value);
+  });
   host.querySelectorAll('.lane-sound').forEach(b => b.onclick = e => {
     e.stopPropagation();
-    const id = LANE_INSTRUMENT[b.dataset.type];
+    const lane = eng.getLanes().find(l => l.id === b.dataset.lane);
+    const id = lane?.instrument || LANE_INSTRUMENT[b.dataset.type];
     if (id) openInstrumentEditor({ id, eng, onSaved: renderStrips });
   });
   host.querySelectorAll('.mute').forEach(b => b.onclick = () => {

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -460,10 +460,12 @@ function renderStrips() {
     let presetSel = '';
     if (isPitched) {
       const cur = lane.instrument || LANE_INSTRUMENT[lane.type];
+      const isCustom = !ALL_INSTRUMENTS[cur];   // a song-local custom (forked) patch
       const opts = Object.entries(ALL_INSTRUMENTS)
         .filter(([, inst]) => inst.type === lane.type)
         .map(([id, inst]) => `<option value="${id}"${id === cur ? ' selected' : ''}>${esc(inst.name)}</option>`).join('');
-      presetSel = `<select class="lane-preset" data-preset data-lane="${lane.id}" title="Instrument preset">${opts}</select>`;
+      const customOpt = isCustom ? `<option value="${esc(cur)}" selected>Custom ✎</option>` : '';
+      presetSel = `<select class="lane-preset" data-preset data-lane="${lane.id}" title="Instrument preset">${customOpt}${opts}</select>`;
     } else {
       // Drums pick a KIT (a composite of drum sounds).
       const opts = Object.entries(ALL_KITS)
@@ -539,6 +541,7 @@ function renderStrips() {
 
   host.querySelectorAll('select[data-preset]').forEach(s => s.onchange = () => {
     eng.setLaneInstrument(s.dataset.lane, s.value);
+    renderStrips();   // a stock pick clears the "Custom" option from the list
   });
   host.querySelectorAll('select[data-kit]').forEach(s => s.onchange = () => {
     currentKitId = s.value;
@@ -547,8 +550,18 @@ function renderStrips() {
   host.querySelectorAll('.lane-sound').forEach(b => b.onclick = e => {
     e.stopPropagation();
     const lane = eng.getLanes().find(l => l.id === b.dataset.lane);
-    const id = lane?.instrument || LANE_INSTRUMENT[b.dataset.type];
-    if (id) openInstrumentEditor({ id, eng, onSaved: renderStrips });
+    if (!lane) return;
+    const patch = eng.resolveLaneInstrument(lane.id);
+    if (!patch) return;
+    // EDIT forks to a SONG-LOCAL Custom patch (per-lane hooks) — never mutates
+    // the shared stock preset.
+    openInstrumentEditor({
+      patch, eng,
+      onPreview: d => eng.previewLaneInstrument(lane.id, d),
+      onRestore: () => eng.clearLanePreview(lane.id),
+      onCommit:  d => eng.setLaneCustom(lane.id, d),
+      onSaved: renderStrips,
+    });
   });
   host.querySelectorAll('.mute').forEach(b => b.onclick = () => {
     eng.toggleMute(b.dataset.lane);

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -26,8 +26,6 @@ import { DEFAULT_PRESETS } from '../engine/punch-presets.js';
 import { ALL_INSTRUMENTS, ALL_KITS } from '../engine/instruments.js';
 
 const eng = createEngine();
-// Selected drum kit (global for now — kit-per-song serialization is a follow-up).
-let currentKitId = 'oyster-kit';
 
 // ─── Knob info map (single source of truth) ───────────────────────────────────
 const KNOB_INFO = {
@@ -467,10 +465,15 @@ function renderStrips() {
       const customOpt = isCustom ? `<option value="${esc(cur)}" selected>Custom ✎</option>` : '';
       presetSel = `<select class="lane-preset" data-preset data-lane="${lane.id}" title="Instrument preset">${customOpt}${opts}</select>`;
     } else {
-      // Drums pick a KIT (a composite of drum sounds).
+      // Drums pick a KIT. The selected id is derived from the engine's live kit
+      // (by reference) — so a saved global custom kit shows "Custom", not a wrong
+      // bank entry.
+      const curKit = eng.getKit();
+      const selId = Object.keys(ALL_KITS).find(k => ALL_KITS[k] === curKit);
       const opts = Object.entries(ALL_KITS)
-        .map(([id, k]) => `<option value="${id}"${id === currentKitId ? ' selected' : ''}>${esc(k.name)}</option>`).join('');
-      presetSel = `<select class="lane-preset" data-kit data-lane="${lane.id}" title="Drum kit">${opts}</select>`;
+        .map(([id, k]) => `<option value="${id}"${id === selId ? ' selected' : ''}>${esc(k.name)}</option>`).join('');
+      const customOpt = selId ? '' : `<option value="" selected>Custom</option>`;
+      presetSel = `<select class="lane-preset" data-kit data-lane="${lane.id}" title="Drum kit">${customOpt}${opts}</select>`;
     }
     const soundBtn = isPitched
       ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">EDIT</button>`
@@ -544,8 +547,8 @@ function renderStrips() {
     renderStrips();   // a stock pick clears the "Custom" option from the list
   });
   host.querySelectorAll('select[data-kit]').forEach(s => s.onchange = () => {
-    currentKitId = s.value;
-    eng.setKit(ALL_KITS[currentKitId]);
+    const k = ALL_KITS[s.value];
+    if (k) eng.setKit(k);   // ignore the display-only "Custom" entry
   });
   host.querySelectorAll('.lane-sound').forEach(b => b.onclick = e => {
     e.stopPropagation();

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -100,7 +100,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
   function save() {
     if (!validateInstrument(draft)) return;
     previewing = false;                     // a still-held TEST must not restore over the save
-    draft.name = (draft.name || 'SOUND').toUpperCase().slice(0, 24);
+    draft.name = (draft.name || 'Sound').trim().slice(0, 24) || 'Sound';
     const next = { ...stash, [id]: draft };
     eng.setInstruments(next);
     // Persist only non-stock-identical entries? v1: persist the whole user set.

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -54,8 +54,14 @@ let _open = false;
 export const isInstrumentEditorOpen = () => _open;
 
 /**
- * openInstrumentEditor({ id, eng, onSaved })
- * id — instrument id in the engine's set (e.g. 'gb-kick', 'gb-bass')
+ * openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRestore, onCommit })
+ *   id    — instrument id in the global set (e.g. 'gb-kick'); the draft source
+ *           and the default persistence target. Optional when `patch` is given.
+ *   patch — explicit starting patch (used by the lane EDIT, where the lane's
+ *           instrument may be a song-local custom not in the global set).
+ *   onPreview/onRestore/onCommit — optional hooks. Default persists to the global
+ *           instrument set + localStorage (drum-slot editor). The lane EDIT injects
+ *           per-lane hooks so SAVE forks to a song-local Custom patch.
  */
 export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRestore, onCommit }) {
   if (_open) return;
@@ -73,9 +79,14 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
   const restore = () => onRestore ? onRestore() : eng.setInstruments(stash);
   const persist = d => {
     if (onCommit) { onCommit(d); return; }
-    const next = { ...stash, [id]: d };
-    eng.setInstruments(next);
-    localStorage.setItem('gb-instruments', JSON.stringify(next));
+    eng.setInstruments({ ...stash, [id]: d });
+    // Persist ONLY this edited instrument as an override (not the whole bank) —
+    // otherwise localStorage freezes every stock preset at today's values and
+    // future preset updates would never reach the user.
+    let saved = {};
+    try { saved = JSON.parse(localStorage.getItem('gb-instruments') || '{}') || {}; } catch (_) { saved = {}; }
+    saved[id] = d;
+    localStorage.setItem('gb-instruments', JSON.stringify(saved));
   };
   function applyDraftLive() {
     if (!previewing) return;

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -57,18 +57,30 @@ export const isInstrumentEditorOpen = () => _open;
  * openInstrumentEditor({ id, eng, onSaved })
  * id — instrument id in the engine's set (e.g. 'gb-kick', 'gb-bass')
  */
-export function openInstrumentEditor({ id, eng, onSaved }) {
+export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRestore, onCommit }) {
   if (_open) return;
   const stash = eng.getInstruments();
-  if (!stash[id]) return;                   // stale/unknown id — never open broken
+  const startPatch = patch ?? stash[id];
+  if (!startPatch) return;                  // stale/unknown id — never open broken
   _open = true;
-  let draft = JSON.parse(JSON.stringify(stash[id]));
+  let draft = JSON.parse(JSON.stringify(startPatch));
   let previewing = false;
   let _tweakTimer = null, _tweakLast = 0;
+  // Persistence/preview hooks. Default = the global instrument set (+ localStorage)
+  // — used by the drum-slot editor. The lane EDIT injects per-lane (song-local)
+  // hooks so editing forks to a Custom patch instead of mutating the stock preset.
+  const preview = d => onPreview ? onPreview(d) : eng.setInstruments({ ...stash, [id]: d });
+  const restore = () => onRestore ? onRestore() : eng.setInstruments(stash);
+  const persist = d => {
+    if (onCommit) { onCommit(d); return; }
+    const next = { ...stash, [id]: d };
+    eng.setInstruments(next);
+    localStorage.setItem('gb-instruments', JSON.stringify(next));
+  };
   function applyDraftLive() {
     if (!previewing) return;
     const now = Date.now();
-    const run = () => { _tweakLast = Date.now(); if (previewing) eng.setInstruments({ ...stash, [id]: draft }); };
+    const run = () => { _tweakLast = Date.now(); if (previewing) preview(draft); };
     if (now - _tweakLast > 150) run();
     else { clearTimeout(_tweakTimer); _tweakTimer = setTimeout(run, 150 - (now - _tweakLast)); }
   }
@@ -83,7 +95,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
   function stopPreview() {
     if (!previewing) return;
     previewing = false;
-    eng.setInstruments(stash);              // restore the saved set
+    restore();                              // undo the live preview
   }
   function close() {
     stopPreview();
@@ -101,10 +113,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
     if (!validateInstrument(draft)) return;
     previewing = false;                     // a still-held TEST must not restore over the save
     draft.name = (draft.name || 'Sound').trim().slice(0, 24) || 'Sound';
-    const next = { ...stash, [id]: draft };
-    eng.setInstruments(next);
-    // Persist only non-stock-identical entries? v1: persist the whole user set.
-    localStorage.setItem('gb-instruments', JSON.stringify(next));
+    persist(draft);                         // global set (default) or song-local fork (lane EDIT)
     close();
     onSaved?.();
   }
@@ -135,7 +144,7 @@ export function openInstrumentEditor({ id, eng, onSaved }) {
       if (!validateInstrument(draft)) return;
       if (!eng.isPlaying()) { eng.auditionInstrument(draft); return; }   // one-shot, no transport needed
       previewing = true;
-      eng.setInstruments({ ...stash, [id]: draft });   // draft is live while held
+      preview(draft);                                  // draft is live while held
     });
     test.addEventListener('pointerup', stopPreview);
     test.addEventListener('pointercancel', stopPreview);


### PR DESCRIPTION
The song-editor "named preset picker everywhere" feature. Every pitched lane picks an instrument **preset**; drums pick a **kit**; **EDIT** forks to a song-local **Custom** patch (never mutates a shared preset). Arcade-only — no changelog.

## What's in it
- **Synth picker** — bass/chords/melody get a preset dropdown (`setLaneInstrument` + targeted voice rebuild). Banks: Sub Bass/Reese/Pluck/Moog · Poly Pad/Stab/Organ/Glass · Square/Saw/Soft/Pluck/Triangle/Sine/Fat leads.
- **Drum kits** — 9 kits (Oyster · 808 · 909 · Acoustic · Lo-Fi · Boom Bap · Techno · Electro · Brush), each filling a canonical **8-slot** layout (Kick · Snare · Clap · Closed Hat · Open Hat · Tom · Crash · Ride; GM 36/38/39/42/46/45/49/51). 72 drum presets. The drum editor auto-grows to 8 rows.
- **Fork-to-Custom** — EDIT writes a song-local patch (`song.instruments["custom-<lane>"]`), points the lane at it, shows **"Custom ✎"**. Stock presets are read-only; custom sounds **travel with the song** (serialized + registry-validated). The drum-slot ✎ editor keeps its existing global behavior.
- **`tone` fully retired** — migrated to `lane.instrument`. The four ★ cartridge songs ported; a load-boundary shim (`LEGACY_TONE_PRESET`) upgrades old/shared songs.
- **Naming** — Title Case everywhere; the editor no longer force-uppercases; defaults branded **Oyster X** (ids stay `gb-*`).
- **Songs** — the four ★ originals now use clap/open-hat/ride.

## Model
Read-only presets in code → **EDIT forks to a per-song Custom** copy. That's the no-footgun rule (editing your bass can't silently rewrite it in other songs), and it makes shared songs carry their exact custom sounds.

## Known limitation (deliberate — fast-follow)
**Kit choice is global**, not yet saved per song, and there's **no kit editor** (swap slots / Custom Kit). That's the next slice.

## Tests
**389 green** (+12 new: banks/kits validate, selection, fork-to-Custom, `tone`→instrument migration, registry validation of the instruments map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)