### PR TITLE
arcade: stop deploying groovebox node_modules to the edge

### DIFF
--- a/docs/arcade/.assetsignore
+++ b/docs/arcade/.assetsignore
@@ -1,0 +1,5 @@
+# Files in this directory are deployed as static assets by infra/oyster-arcade-site
+# (wrangler walks the whole tree and does NOT honour .gitignore). Keep dev-only
+# artefacts out of the edge upload. Same format as .gitignore.
+node_modules
+.DS_Store


### PR DESCRIPTION
## Problem

`infra/oyster-arcade-site` serves all of `docs/arcade/` as Workers static assets, and `wrangler deploy` walks the whole tree **without honouring `.gitignore`**. So groovebox's vendored `node_modules` (~5,813 files, including Vitest's incremental run-cache `node_modules/.vite/vitest/results.json`) was being uploaded and served at the edge — pure dev-only noise.

## Fix

Add `docs/arcade/.assetsignore` (same format as `.gitignore`, must live in the assets-dir root) excluding `node_modules` and `.DS_Store`.

## Verified (already deployed)

After `wrangler deploy` with the ignore in place:
- `arcade.oyster.to/groovebox/node_modules/...` → **404** (removed from manifest)
- `groovebox.oyster.to/` , `ui/app.js`, `ui/app.css`, `vendor/tone.js` → **200**
- arcade hub + space-jumper → **200**
- the LCD hover fix (#678) still live in the served CSS

Note: `wrangler`'s "Read N files from the assets directory" line is the raw filesystem walk (pre-ignore); the *deployed manifest* is what excludes the ignored files, so they stop being served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)