### PR TITLE
arcade(groovebox): Reso Saw lead — filter resonance + vibrato primitives

### DIFF
--- a/docs/arcade/groovebox/engine/instruments.js
+++ b/docs/arcade/groovebox/engine/instruments.js
@@ -38,7 +38,7 @@ export function gmName(note) { return GM_NAME_BY_NOTE[note] ?? null; }
 // ── neutral patch vocabulary ─────────────────────────────────────────────────
 // Versioned and deliberately small: exactly what today's eight voices need.
 // scale: 'linear' | 'log'. Compiled to Tone by ONE adapter (voices.js).
-export const PATCH_SCHEMA_VERSION = 1;
+export const PATCH_SCHEMA_VERSION = 2;   // v2 adds filter.Q (resonance) + vibrato
 
 export const ARCHETYPES = ['membrane', 'noise', 'mono', 'poly'];
 export const OSC_SHAPES = ['pulse', 'square', 'sawtooth', 'fatsawtooth', 'triangle', 'sine'];
@@ -52,6 +52,9 @@ export const PATCH_PARAMS = {
   'envelope.release':        { min: 0.01,  max: 8,     scale: 'log' },
   'oscillator.width':        { min: 0.05,  max: 0.95,  scale: 'linear' },  // pulse only
   'filter.freq':             { min: 40,    max: 20000, scale: 'log' },
+  'filter.Q':                { min: 0,     max: 20,    scale: 'linear' },  // resonance; ~self-oscillates near max
+  'vibrato.rate':            { min: 0.1,   max: 12,    scale: 'log' },     // Hz — pitch LFO speed
+  'vibrato.depth':           { min: 0,     max: 1,     scale: 'linear' },
   'filterEnvelope.attack':   { min: 0.001, max: 4,     scale: 'log' },
   'filterEnvelope.decay':    { min: 0.01,  max: 4,     scale: 'log' },
   'filterEnvelope.sustain':  { min: 0,     max: 1,     scale: 'linear' },
@@ -91,6 +94,10 @@ export function validateInstrument(inst) {
     if (!FILTER_TYPES.includes(p.filter.type)) return false;
     if (!inRange('filter.freq', p.filter.freq)) return false;
   }
+  // vibrato is an optional object; its rate/depth ranges are checked by the loop
+  // above, but a non-object (e.g. a stray scalar) must be rejected outright.
+  if (p.vibrato !== undefined &&
+      (typeof p.vibrato !== 'object' || p.vibrato === null || Array.isArray(p.vibrato))) return false;
   if (p.trigger !== undefined) {
     if (p.trigger.note !== undefined && typeof p.trigger.note !== 'string') return false;
     if (p.trigger.dur !== undefined && typeof p.trigger.dur !== 'string') return false;
@@ -376,6 +383,19 @@ export const SYNTH_PRESETS = {
       oscillator: { shape: 'fatsawtooth' },
       envelope: { attack: 0.006, decay: 0.22, sustain: 0.35, release: 0.2 },
       trigger: { velocity: 0.82 } },
+  },
+  'preset-reso-saw': {
+    // Quacky resonant saw lead (the MGMT "Kids" topline character): one bright
+    // detuned saw → resonant lowpass in the upper-mids (the nasal "quack") →
+    // wide ~4 Hz pitch vibrato (the wobble). fatsawtooth's unison detune stands
+    // in for the record's chorus/ensemble.
+    name: 'Reso Saw', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', volume: -11,
+      oscillator: { shape: 'fatsawtooth' },
+      envelope: { attack: 0.004, decay: 0.2, sustain: 0.55, release: 0.25 },
+      filter: { type: 'lowpass', freq: 1300, Q: 11 },
+      vibrato: { rate: 4.2, depth: 0.18 },
+      trigger: { velocity: 0.85 } },
   },
   'preset-triangle-lead': {
     name: 'Triangle Lead', type: 'melody', engine: 'synth',

--- a/docs/arcade/groovebox/engine/voices.js
+++ b/docs/arcade/groovebox/engine/voices.js
@@ -20,7 +20,7 @@ import { DEFAULT_INSTRUMENTS, DEFAULT_KIT, validateInstrument, slotKey } from '.
  * via voice.lead. disposeLane prefers voice.dispose().)
  */
 
-const BRIGHT_OPEN = 18000;   // transparent lowpass base for pitched brightness inserts
+export const BRIGHT_OPEN = 18000;   // transparent lowpass base for pitched brightness inserts
 
 const CTOR_BY_ARCHETYPE = {
   membrane: 'MembraneSynth',

--- a/docs/arcade/groovebox/engine/voices.js
+++ b/docs/arcade/groovebox/engine/voices.js
@@ -42,7 +42,12 @@ export function compileSynthPatch(inst) {
     ctor: CTOR_BY_ARCHETYPE[p.archetype],
     options: {},
     postVolume: undefined,
-    filter: p.filter ? { type: p.filter.type, freq: p.filter.freq } : null,
+    filter: p.filter
+      ? { type: p.filter.type, freq: p.filter.freq, ...(p.filter.Q !== undefined ? { Q: p.filter.Q } : {}) }
+      : null,
+    // vibrato is opt-in: the key is absent unless the patch declares one, so
+    // default voices compile to a byte-identical plan (parity preserved).
+    ...(p.vibrato ? { vibrato: { rate: p.vibrato.rate, depth: p.vibrato.depth } } : {}),
     trig: {
       sig: p.archetype === 'noise' ? 'noise' : 'note',
       note: p.trigger?.note,
@@ -81,18 +86,26 @@ export function compileSynthPatch(inst) {
   return plan;
 }
 
-// Build one connected voice from a plan. Returns { synth, filter }.
+// Build one connected voice from a plan. Returns { synth, filter, vibrato }.
 // openInsert: when the plan has no filter, add a transparent open lowpass so a
 // velocity lock has a cutoff to modulate (pitched brightness). Drums pass false
 // and keep using their plan filter (or none).
+// Chain: synth → [vibrato] → [filter] → bus. The filter is returned for the
+// velocity→brightness modulation; the vibrato is returned only for disposal.
 function buildFromPlan(plan, bus, openInsert = false) {
   let out = bus, filter = null;
   if (plan.filter) {
     filter = new Tone.Filter(plan.filter.freq, plan.filter.type).connect(bus);
+    if (plan.filter.Q !== undefined) filter.Q.value = plan.filter.Q;   // resonance (the "honk")
     out = filter;
   } else if (openInsert) {
     filter = new Tone.Filter(BRIGHT_OPEN, 'lowpass').connect(bus);
     out = filter;
+  }
+  let vibrato = null;
+  if (plan.vibrato) {   // pitch wobble — a delay-line vibrato works for mono OR poly
+    vibrato = new Tone.Vibrato({ frequency: plan.vibrato.rate ?? 5, depth: plan.vibrato.depth ?? 0 }).connect(out);
+    out = vibrato;
   }
   let synth;
   if (plan.ctor === 'PolySynth') {
@@ -102,7 +115,7 @@ function buildFromPlan(plan, bus, openInsert = false) {
     synth = new Tone[plan.ctor](plan.options).connect(out);
   }
   if (plan.postVolume !== undefined) synth.volume.value = plan.postVolume;
-  return { synth, filter };
+  return { synth, filter, vibrato };
 }
 
 // Resolve + validate an instrument ref; bad data falls back (never crashes).
@@ -140,7 +153,7 @@ export function createVoiceForType(type, bus, opts = {}) {
         filterBase: plan.filter ? plan.filter.freq : 0,
         filterType: plan.filter ? plan.filter.type : null,
       };
-      nodes.push(v.synth, v.filter);
+      nodes.push(v.synth, v.filter, v.vibrato);
     }
     return { byNote, dispose() { for (const n of nodes) { try { n?.dispose?.(); } catch (_) {} } } };
   }
@@ -149,7 +162,11 @@ export function createVoiceForType(type, bus, opts = {}) {
   const inst = resolveInstrument(opts.instrumentId ?? fallback, instruments, fallback);
   const plan = compileSynthPatch(inst);
   const v = buildFromPlan(plan, bus, true);   // openInsert: a cutoff for velocity to modulate
-  const dispose = () => { try { v.synth.dispose?.(); } catch (_) {} try { v.filter?.dispose?.(); } catch (_) {} };
+  const dispose = () => {
+    try { v.synth.dispose?.(); } catch (_) {}
+    try { v.filter?.dispose?.(); } catch (_) {}
+    try { v.vibrato?.dispose?.(); } catch (_) {}
+  };
   // Brightness modulates the character filter where one exists (chords @ 4200),
   // else the open insert (bass/melody @ BRIGHT_OPEN — transparent at rest).
   const tone = { toneFilter: v.filter, toneBase: plan.filter ? plan.filter.freq : BRIGHT_OPEN, toneType: plan.filter ? plan.filter.type : 'lowpass' };

--- a/docs/arcade/groovebox/songs/kids.js
+++ b/docs/arcade/groovebox/songs/kids.js
@@ -129,7 +129,7 @@ export const kids = {
                 },
               } },
     chords: { selection:'pad', muted:false },
-    melody: { selection:'hook', muted:false, pool:{
+    melody: { selection:'hook', muted:false, instrument:'preset-reso-saw', pool:{
       hook: RIFF,
       chopped: RIFF.map(bar => {
         if (!bar.length) return [];

--- a/docs/arcade/groovebox/tests/instruments.test.js
+++ b/docs/arcade/groovebox/tests/instruments.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   GM, slotKey, gmName, normalizeDrumBar, normalizeDrumGrooves,
   validateInstrument, validateKit, DEFAULT_INSTRUMENTS, DEFAULT_KIT,
-  PATCH_PARAMS, ARCHETYPES,
+  PATCH_PARAMS, ARCHETYPES, SYNTH_PRESETS,
 } from '../engine/instruments.js';
 
 describe('slotKey — names and numbers are both valid input, numbers canonical', () => {
@@ -161,5 +161,30 @@ describe('PATCH_PARAMS registry', () => {
   });
   it('archetypes are the four todays voices need', () => {
     expect(ARCHETYPES).toEqual(['membrane', 'noise', 'mono', 'poly']);
+  });
+});
+
+describe('schema v2 — filter resonance + vibrato', () => {
+  const resoSaw = () => JSON.parse(JSON.stringify(SYNTH_PRESETS['preset-reso-saw']));
+
+  it('declares filter.Q and vibrato rate/depth in PATCH_PARAMS', () => {
+    expect(PATCH_PARAMS['filter.Q']).toBeDefined();
+    expect(PATCH_PARAMS['vibrato.rate']).toBeDefined();
+    expect(PATCH_PARAMS['vibrato.depth']).toBeDefined();
+  });
+  it('accepts the Reso Saw preset (resonant lowpass + vibrato)', () => {
+    expect(validateInstrument(SYNTH_PRESETS['preset-reso-saw'])).toBe(true);
+  });
+  it('rejects out-of-range resonance', () => {
+    const inst = resoSaw(); inst.patch.filter.Q = 99;
+    expect(validateInstrument(inst)).toBe(false);
+  });
+  it('rejects out-of-range vibrato rate', () => {
+    const inst = resoSaw(); inst.patch.vibrato.rate = 50;
+    expect(validateInstrument(inst)).toBe(false);
+  });
+  it('rejects a malformed (non-object) vibrato block', () => {
+    const inst = resoSaw(); inst.patch.vibrato = 5;
+    expect(validateInstrument(inst)).toBe(false);
   });
 });

--- a/docs/arcade/groovebox/tests/preset-picker.test.js
+++ b/docs/arcade/groovebox/tests/preset-picker.test.js
@@ -42,6 +42,11 @@ describe('preset banks', () => {
       expect(ALL_INSTRUMENTS[presetId].type).toBe('melody');
     }
   });
+  it('the Kids song plays its own lead preset (not the stock default)', () => {
+    const eng = createEngine(); eng.load(kids);
+    const melody = eng.getSong().lanes.find(l => l.type === 'melody');
+    expect(melody.instrument).toBe('preset-reso-saw');
+  });
 });
 
 describe('addLane seeds the default preset', () => {

--- a/docs/arcade/groovebox/tests/song-switch.test.js
+++ b/docs/arcade/groovebox/tests/song-switch.test.js
@@ -94,6 +94,7 @@ test('switching to a song and back gives an independent flattened object each ti
   switchTo(eng, kids);
   const second = eng.getSong();
   expect(second).not.toBe(first);              // fresh flatten
-  // The new flatten must NOT carry the runtime mutation — kids' melody has no override.
-  expect(second.lanes.find(l => l.type === 'melody').instrument).toBeUndefined();
+  // The new flatten must NOT carry the runtime mutation — it reflects kids'
+  // SOURCE override (preset-reso-saw), not the runtime 'preset-saw-lead'.
+  expect(second.lanes.find(l => l.type === 'melody').instrument).toBe('preset-reso-saw');
 });

--- a/docs/arcade/groovebox/tests/voices-adapter.test.js
+++ b/docs/arcade/groovebox/tests/voices-adapter.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { compileSynthPatch } from '../engine/voices.js';
-import { DEFAULT_INSTRUMENTS } from '../engine/instruments.js';
+import { DEFAULT_INSTRUMENTS, SYNTH_PRESETS } from '../engine/instruments.js';
 
 // PARITY GATE: the adapter must reproduce the legacy hardcoded voices EXACTLY.
 // Expected values below are copied verbatim from the pre-instruments voices.js
@@ -84,5 +84,37 @@ describe('compileSynthPatch parity vs legacy hardcoded voices', () => {
       postVolume: -11, filter: null,
       trig: { sig: 'note', note: undefined, dur: undefined, velocity: 0.82 },
     });
+  });
+});
+
+// Schema v2 adds two expressive primitives: filter resonance (Q) and a
+// pitch-vibrato block. Both are OPT-IN — absent from a patch means absent from
+// the plan, so the default voices above stay byte-identical (parity preserved).
+describe('compileSynthPatch — filter resonance + vibrato (schema v2)', () => {
+  const melody = patch => ({ name: 'X', type: 'melody', engine: 'synth',
+    patch: { archetype: 'poly', oscillator: { shape: 'sawtooth' }, ...patch } });
+
+  it('carries filter.Q into the plan filter when present', () => {
+    const p = compileSynthPatch(melody({ filter: { type: 'lowpass', freq: 1700, Q: 8 } }));
+    expect(p.filter).toEqual({ type: 'lowpass', freq: 1700, Q: 8 });
+  });
+  it('omits Q from the plan filter when absent (default voices unchanged)', () => {
+    expect(plan('gb-chords').filter).toEqual({ type: 'lowpass', freq: 4200 });
+  });
+  it('carries vibrato {rate, depth} into the plan when present', () => {
+    expect(compileSynthPatch(melody({ vibrato: { rate: 4.2, depth: 0.18 } })).vibrato)
+      .toEqual({ rate: 4.2, depth: 0.18 });
+  });
+  it('has no vibrato key when the patch declares none', () => {
+    expect('vibrato' in plan('gb-lead')).toBe(false);
+  });
+  it('compiles the Reso Saw preset with a resonant lowpass + vibrato', () => {
+    // Tuning numbers are ear-gated — assert STRUCTURE (resonant lowpass + a
+    // vibrato block), not the exact freq/Q/rate so knob-turns don't churn tests.
+    const p = compileSynthPatch(SYNTH_PRESETS['preset-reso-saw']);
+    expect(p.filter.type).toBe('lowpass');
+    expect(p.filter.Q).toBeGreaterThan(0);
+    expect(p.vibrato.rate).toBeGreaterThan(0);
+    expect(p.vibrato.depth).toBeGreaterThan(0);
   });
 });

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -3,6 +3,7 @@
 // from the engine registry (PATCH_PARAMS), hold-to-TEST auditions the UNSAVED
 // draft live (the playing loop sounds it), SAVE persists to localStorage.
 import { PATCH_PARAMS, OSC_SHAPES, validateInstrument, DEFAULT_INSTRUMENTS } from '../engine/instruments.js';
+import { BRIGHT_OPEN } from '../engine/voices.js';
 
 // UI metadata only — ranges/scales live in PATCH_PARAMS (one source of truth).
 const PARAM_UI = {
@@ -184,12 +185,17 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
     }
 
     // Resonant filter + vibrato are general lead/pad primitives, not specific to
-    // any one preset. On a poly patch that ships without them, seed a NEUTRAL
-    // block (transparent lowpass / zero-depth wobble) so the knobs are always
-    // there and inaudible until moved. (mono keeps its own filterEnvelope path.)
+    // any one preset. On a poly patch, seed/complete a NEUTRAL block so the knobs
+    // are always present AND read their TRUE value, not the slider midpoint.
+    // freq = BRIGHT_OPEN and Q = 1 mirror the engine's transparent openInsert, so
+    // an edit→save round-trip never shifts the velocity→brightness base cutoff.
+    // (mono keeps its own filterEnvelope path.)
     if (draft.patch.archetype === 'poly') {
-      if (!draft.patch.filter)  draft.patch.filter  = { type: 'lowpass', freq: 20000, Q: 1 };
-      if (!draft.patch.vibrato) draft.patch.vibrato = { rate: 5, depth: 0 };
+      const f = draft.patch.filter ?? (draft.patch.filter = { type: 'lowpass', freq: BRIGHT_OPEN });
+      if (f.Q === undefined) f.Q = 1;
+      const vib = draft.patch.vibrato ?? (draft.patch.vibrato = {});
+      if (vib.rate === undefined) vib.rate = 5;
+      if (vib.depth === undefined) vib.depth = 0;
     }
 
     // param sliders — ranges/scales straight from the registry

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -13,6 +13,9 @@ const PARAM_UI = {
   'envelope.release':       { label: 'release',     fmt: v => `${(v * 1000).toFixed(0)} ms` },
   'oscillator.width':       { label: 'pulse width', fmt: v => v.toFixed(2) },
   'filter.freq':            { label: 'filter Hz',   fmt: v => `${Math.round(v)} Hz` },
+  'filter.Q':               { label: 'resonance',   fmt: v => v.toFixed(1) },
+  'vibrato.rate':           { label: 'vibrato Hz',  fmt: v => `${v.toFixed(1)} Hz` },
+  'vibrato.depth':          { label: 'vibrato amt', fmt: v => v.toFixed(2) },
   'filterEnvelope.baseFrequency': { label: 'flt base', fmt: v => `${Math.round(v)} Hz` },
   'filterEnvelope.octaves': { label: 'flt sweep',   fmt: v => v.toFixed(1) },
   'pitch.pitchDecay':       { label: 'pitch drop',  fmt: v => `${(v * 1000).toFixed(0)} ms` },
@@ -27,7 +30,7 @@ const ARCHETYPE_PARAMS = {
   mono:     ['volume', 'envelope.attack', 'envelope.decay', 'envelope.sustain', 'envelope.release',
              'filterEnvelope.baseFrequency', 'filterEnvelope.octaves', 'trigger.velocity'],
   poly:     ['volume', 'envelope.attack', 'envelope.decay', 'envelope.sustain', 'envelope.release',
-             'oscillator.width', 'trigger.velocity'],
+             'oscillator.width', 'filter.freq', 'filter.Q', 'vibrato.rate', 'vibrato.depth', 'trigger.velocity'],
 };
 
 // slider position (0..1) ↔ value, honouring the registry's scale
@@ -180,9 +183,19 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
       modal.appendChild(row);
     }
 
+    // Resonant filter + vibrato are general lead/pad primitives, not specific to
+    // any one preset. On a poly patch that ships without them, seed a NEUTRAL
+    // block (transparent lowpass / zero-depth wobble) so the knobs are always
+    // there and inaudible until moved. (mono keeps its own filterEnvelope path.)
+    if (draft.patch.archetype === 'poly') {
+      if (!draft.patch.filter)  draft.patch.filter  = { type: 'lowpass', freq: 20000, Q: 1 };
+      if (!draft.patch.vibrato) draft.patch.vibrato = { rate: 5, depth: 0 };
+    }
+
     // param sliders — ranges/scales straight from the registry
     for (const pid of ARCHETYPE_PARAMS[draft.patch.archetype] ?? []) {
-      if (pid === 'filter.freq' && !draft.patch.filter) continue;   // no filter on this patch
+      if (pid.startsWith('filter.') && !draft.patch.filter) continue;     // patch has no filter block
+      if (pid.startsWith('vibrato.') && !draft.patch.vibrato) continue;   // patch has no vibrato block
       const ui = PARAM_UI[pid];
       const cur = get(draft.patch, pid);
       const reg = PATCH_PARAMS[pid];


### PR DESCRIPTION
Stacked on #679 (base: `groovebox-preset-picker`). Gives leads two expressive primitives the v1 patch schema lacked, and ships a quacky resonant saw that the Kids song now plays.

## What's in it
- **Patch schema → v2**, two opt-in primitives:
  - **`filter.Q`** (resonance) — compiled onto the voice's `Tone.Filter` (the nasal "quack").
  - **`vibrato {rate, depth}`** — a `Tone.Vibrato` insert (`synth → vibrato → filter → bus`), mono or poly; disposed on both voice paths.
  - Both are **opt-in**: absent from a patch ⇒ absent from the compiled plan, so the default voices stay byte-identical (the `compileSynthPatch` parity gate proves it).
- **New `Reso Saw` melody preset** (`fatsawtooth` → resonant lowpass ~1.3 kHz / Q 11 → ~4 Hz vibrato) — tuned to the MGMT "Kids" topline character. The **Kids song** now plays it instead of the stock default lead (one line; `flattenSong` already passes `lane.instrument` through).
- **Editor** — EDIT on any **poly** lead/pad seeds a *neutral* (transparent lowpass / zero-depth vibrato) block so **resonance / filter Hz / vibrato Hz / vibrato amt** are always available, inaudible until moved. `mono` keeps its own filter-envelope path.

## Model
The two primitives aren't single-use — resonance + vibrato make every poly lead/pad more expressive. v2 is a considered bump to a deliberately-small versioned schema, not a one-off for this preset.

## Known limitation (deliberate)
Static resonant filter ⇒ a resonant **vowel** per note, not a moving per-note "wah." Genuine wah-sweep is the **mono filter-envelope** path — a clean fast-follow if wanted.

## Tests
**400 green** (+11 new/changed): Q + vibrato in the compile plan, parity gate intact, schema validation (range + malformed-vibrato rejection), preset validates, and the Kids song resolves to `preset-reso-saw`. Tuning numbers are asserted structurally (ear-gated), so knob-turns don't churn tests.

Arcade-only — no changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)