### PR TITLE
arcade(groovebox): visual instrument editor — envelope + filter graphs, knob layout

### DIFF
--- a/docs/arcade/groovebox/tests/curve-math.test.js
+++ b/docs/arcade/groovebox/tests/curve-math.test.js
@@ -1,0 +1,72 @@
+// tests/curve-math.test.js — the pure param↔geometry math behind the visual
+// instrument editor (envelope + filter graphs). DOM/drag lives in the widgets;
+// this is the testable core: scale-aware mapping, handle layout, drag inverse.
+import { describe, it, expect } from 'vitest';
+import {
+  posToVal, valToPos,
+  ENV_GEOM, envHandles, attackFromX, decayFromX, sustainFromY, releaseFromX,
+  FILT_GEOM, filterHandle, freqFromX, qFromY,
+} from '../ui/curve-math.js';
+
+describe('posToVal / valToPos — scale-aware, clamped', () => {
+  it('maps endpoints: pos 0 → min, pos 1 → max (log + linear)', () => {
+    expect(posToVal('filter.freq', 0)).toBeCloseTo(40, 5);
+    expect(posToVal('filter.freq', 1)).toBeCloseTo(20000, 5);
+    expect(posToVal('envelope.sustain', 0)).toBeCloseTo(0, 5);
+    expect(posToVal('envelope.sustain', 1)).toBeCloseTo(1, 5);
+  });
+  it('round-trips value → pos → value on a log scale', () => {
+    for (const v of [50, 200, 1300, 8000]) {
+      expect(posToVal('filter.freq', valToPos('filter.freq', v))).toBeCloseTo(v, 2);
+    }
+  });
+  it('round-trips on a linear scale', () => {
+    for (const v of [0, 0.18, 0.55, 1]) {
+      expect(posToVal('envelope.sustain', valToPos('envelope.sustain', v))).toBeCloseTo(v, 6);
+    }
+  });
+  it('clamps pos and value to [0,1] domain', () => {
+    expect(posToVal('filter.Q', -0.5)).toBeCloseTo(0, 6);    // Q min 0
+    expect(posToVal('filter.Q', 2)).toBeCloseTo(20, 6);      // Q max 20
+    expect(valToPos('filter.freq', 10)).toBe(0);             // below min
+    expect(valToPos('filter.freq', 99999)).toBe(1);          // above max
+  });
+});
+
+describe('ADSR envelope geometry', () => {
+  const env = { attack: 0.02, decay: 0.2, sustain: 0.55, release: 0.3 };
+
+  it('handles read left-to-right (A ≤ D/S ≤ R)', () => {
+    const h = envHandles(env);
+    expect(h.a.x).toBeLessThanOrEqual(h.ds.x);
+    expect(h.ds.x).toBeLessThanOrEqual(h.r.x);
+  });
+  it('sustain maps to height: 1 → top, 0 → bottom', () => {
+    expect(envHandles({ ...env, sustain: 1 }).ds.y).toBeCloseTo(ENV_GEOM.top, 5);
+    expect(envHandles({ ...env, sustain: 0 }).ds.y).toBeCloseTo(ENV_GEOM.bottom, 5);
+  });
+  it('drag inverse recovers each param', () => {
+    const h = envHandles(env);
+    expect(attackFromX(h.a.x)).toBeCloseTo(env.attack, 4);
+    expect(decayFromX(h.ds.x, env)).toBeCloseTo(env.decay, 4);
+    expect(sustainFromY(h.ds.y)).toBeCloseTo(env.sustain, 6);
+    expect(releaseFromX(h.r.x, env)).toBeCloseTo(env.release, 4);
+  });
+  it('clamps drags past the edges to the param range', () => {
+    expect(attackFromX(-9999)).toBeCloseTo(0.001, 6);   // envelope.attack min
+    expect(sustainFromY(-9999)).toBeCloseTo(1, 6);
+    expect(sustainFromY(99999)).toBeCloseTo(0, 6);
+  });
+});
+
+describe('lowpass filter geometry', () => {
+  const f = { freq: 1300, Q: 8 };
+  it('handle round-trips cutoff (x) and resonance (y)', () => {
+    const h = filterHandle(f);
+    expect(freqFromX(h.x)).toBeCloseTo(1300, 1);
+    expect(qFromY(h.y)).toBeCloseTo(8, 4);
+  });
+  it('higher resonance sits higher (smaller y)', () => {
+    expect(filterHandle({ freq: 1300, Q: 16 }).y).toBeLessThan(filterHandle({ freq: 1300, Q: 2 }).y);
+  });
+});

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1617,11 +1617,12 @@ body.gb-knob-values .knob-val { display: block; }
   letter-spacing: 0.06em; flex: 1; min-width: 0; text-transform: uppercase;
 }
 .ie-test {
-  margin-left: auto; border: 0; border-radius: 8px; padding: 6px 16px; cursor: pointer;
+  margin-left: auto; border: 0; border-radius: 8px; padding: 7px 18px 8px; cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; gap: 2px; line-height: 1.1;
   background: linear-gradient(180deg, #63f8d4, #3dd6b0); color: #04201a; font-weight: 700;
   box-shadow: 0 0 14px rgba(84, 240, 200, 0.4); user-select: none; touch-action: none;
 }
-.ie-test small { display: block; font-weight: 400; font-size: 9px; opacity: 0.7; }
+.ie-test small { font-weight: 400; font-size: 9px; opacity: 0.7; }
 .ie-test.idle { filter: grayscale(1); opacity: 0.5; box-shadow: none; }
 .ie-row { display: flex; align-items: center; gap: 10px; margin: 7px 0; }
 .ie-rl { width: 84px; flex: 0 0 84px; color: var(--faint); font-size: 11px; }
@@ -1636,6 +1637,32 @@ body.gb-knob-values .knob-val { display: block; }
   background: var(--acc); color: #04201a; font-weight: 700;
 }
 .ie-save:disabled { filter: grayscale(1); opacity: 0.5; cursor: default; }
+
+/* ─── visual editor: section headers + envelope/filter graphs ────────────── */
+.ie-sec { display: flex; align-items: center; gap: 8px; margin: 12px 0 6px; }
+.ie-sec b { font-size: 9px; font-weight: 700; letter-spacing: 0.13em; text-transform: uppercase; color: var(--faint); }
+.ie-sec i { flex: 1; height: 1px; background: var(--line); }
+.ie-graph { border: 1px solid var(--line); border-radius: 9px; padding: 5px 6px; margin: 2px 0;
+  background: color-mix(in srgb, var(--ink) 5%, transparent); touch-action: none; }
+.ie-graph-svg { display: block; width: 100%; overflow: visible; }
+.ie-axis { stroke: var(--line); stroke-width: 1; }
+.ie-stroke { fill: none; stroke: var(--acc); stroke-width: 2.5; stroke-linejoin: round; stroke-linecap: round; }
+.ie-fill { fill: color-mix(in srgb, var(--acc) 18%, transparent); stroke: none; }
+.ie-handle { fill: var(--acc); stroke: #fff; stroke-width: 1; cursor: grab; }
+.ie-handle:active { cursor: grabbing; }
+.ie-sec .ie-tag { font-size: 8px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--ink-on-acc); background: var(--acc); padding: 2px 6px; border-radius: 5px; }
+
+/* waveform icon picker */
+.ie-waves { display: flex; gap: 7px; margin: 4px 0 2px; }
+.ie-wv { width: 42px; height: 30px; border-radius: 8px; cursor: pointer; display: grid; place-items: center;
+  background: color-mix(in srgb, var(--ink) 6%, transparent); border: 1px solid var(--line); color: var(--dim); }
+.ie-wv svg { width: 20px; height: 13px; display: block; }
+.ie-wv.on { background: var(--acc); border-color: var(--acc); color: var(--ink-on-acc); }
+
+/* knob rows in the editor — show the persistent value readout under each dial */
+.ie-knobrow { display: flex; flex-wrap: wrap; gap: 14px 16px; margin: 2px 0 4px; }
+#inst-editor .knob-val { display: block; }
 
 /* ─── fills row (panel chrome via #fills) ───────────────────────────────── */
 .fillsrow {

--- a/docs/arcade/groovebox/ui/curve-math.js
+++ b/docs/arcade/groovebox/ui/curve-math.js
@@ -1,0 +1,79 @@
+// ui/curve-math.js — pure param↔geometry math for the visual instrument editor.
+// No DOM. The envelope/filter widgets own pointer handling and SVG; this owns
+// the mapping between a patch param and a handle coordinate (and back), honouring
+// the registry's per-param scale. Parity with the slider editor: posToVal/valToPos
+// are the same scale math the sliders used, lifted here as the single source.
+import { PATCH_PARAMS } from '../engine/instruments.js';
+
+const clamp01 = v => (v < 0 ? 0 : v > 1 ? 1 : v);
+
+/** posToVal(id, pos) — normalized slider/handle position (0..1) → param value. */
+export function posToVal(id, pos) {
+  const { min, max, scale } = PATCH_PARAMS[id];
+  const p = clamp01(pos);
+  return scale === 'log' ? min * Math.pow(max / min, p) : min + (max - min) * p;
+}
+
+/** valToPos(id, v) — param value → normalized position (0..1), clamped. */
+export function valToPos(id, v) {
+  const { min, max, scale } = PATCH_PARAMS[id];
+  const p = scale === 'log' ? Math.log(v / min) / Math.log(max / min) : (v - min) / (max - min);
+  return clamp01(p);
+}
+
+// ── ADSR envelope ────────────────────────────────────────────────────────────
+// Three handles for four params (decay + sustain share a handle, as in most
+// soft-synths): A controls attack (x only); D/S controls decay (x) + sustain (y);
+// R controls release (x only). Each time param is a horizontal lane; sustain is
+// the only vertical axis. Layout (in viewBox units): A lane, D lane, a fixed
+// sustain-hold gap, then the R lane.
+export const ENV_GEOM = { x0: 6, top: 8, bottom: 72, wA: 70, wD: 70, hold: 46, wR: 80 };
+
+export function envHandles(env, g = ENV_GEOM) {
+  const ax = g.x0 + valToPos('envelope.attack', env.attack) * g.wA;
+  const dx = ax + valToPos('envelope.decay', env.decay) * g.wD;
+  const sy = g.bottom - clamp01(env.sustain) * (g.bottom - g.top);
+  const rx = dx + g.hold + valToPos('envelope.release', env.release) * g.wR;
+  return { a: { x: ax, y: g.top }, ds: { x: dx, y: sy }, r: { x: rx, y: g.bottom } };
+}
+
+/** SVG path for the envelope outline (silence → peak → sustain → hold → silence). */
+export function envPath(env, g = ENV_GEOM) {
+  const h = envHandles(env, g);
+  return `M${g.x0},${g.bottom} L${h.a.x},${g.top} L${h.ds.x},${h.ds.y} L${h.ds.x + g.hold},${h.ds.y} L${h.r.x},${g.bottom}`;
+}
+
+// Drag inverses. Time handles need their left anchor (which depends on earlier
+// params), so the dependent ones take the current env.
+export function attackFromX(x, g = ENV_GEOM) {
+  return posToVal('envelope.attack', (x - g.x0) / g.wA);
+}
+export function decayFromX(x, env, g = ENV_GEOM) {
+  const ax = g.x0 + valToPos('envelope.attack', env.attack) * g.wA;
+  return posToVal('envelope.decay', (x - ax) / g.wD);
+}
+export function sustainFromY(y, g = ENV_GEOM) {
+  return clamp01((g.bottom - y) / (g.bottom - g.top));
+}
+export function releaseFromX(x, env, g = ENV_GEOM) {
+  const h = envHandles(env, g);
+  return posToVal('envelope.release', (x - h.ds.x - g.hold) / g.wR);
+}
+
+// ── lowpass filter (poly) ────────────────────────────────────────────────────
+// One handle: x = cutoff (filter.freq), y = resonance (filter.Q, higher = taller
+// peak = smaller y). The widget draws the response curve through it.
+export const FILT_GEOM = { x0: 6, x1: 294, top: 6, base: 30, bottom: 46 };
+
+export function filterHandle(f, g = FILT_GEOM) {
+  return {
+    x: g.x0 + valToPos('filter.freq', f.freq) * (g.x1 - g.x0),
+    y: g.base - valToPos('filter.Q', f.Q) * (g.base - g.top),
+  };
+}
+export function freqFromX(x, g = FILT_GEOM) {
+  return posToVal('filter.freq', (x - g.x0) / (g.x1 - g.x0));
+}
+export function qFromY(y, g = FILT_GEOM) {
+  return posToVal('filter.Q', (g.base - y) / (g.base - g.top));
+}

--- a/docs/arcade/groovebox/ui/env-graph.js
+++ b/docs/arcade/groovebox/ui/env-graph.js
@@ -34,21 +34,25 @@ export function makeEnvGraph(env, onInput) {
     hDS.setAttribute('cx', h.ds.x); hDS.setAttribute('cy', h.ds.y);
     hR.setAttribute('cx', h.r.x);   hR.setAttribute('cy', h.r.y);
   }
-  const toSvg = ev => {
-    const r = svg.getBoundingClientRect();
-    return { x: (ev.clientX - r.left) * (W / r.width), y: (ev.clientY - r.top) * (H / r.height) };
-  };
   const drag = which => ev => {
     ev.preventDefault(); ev.stopPropagation();
+    const r = svg.getBoundingClientRect();          // capture once per drag (not per move)
+    const sx = W / r.width, sy = H / r.height;
     const move = e => {
-      const p = toSvg(e);
-      if (which === 'a') env.attack = attackFromX(p.x, G);
-      else if (which === 'ds') { env.decay = decayFromX(p.x, env, G); env.sustain = sustainFromY(p.y, G); }
-      else env.release = releaseFromX(p.x, env, G);
+      const x = (e.clientX - r.left) * sx, y = (e.clientY - r.top) * sy;
+      if (which === 'a') env.attack = attackFromX(x, G);
+      else if (which === 'ds') { env.decay = decayFromX(x, env, G); env.sustain = sustainFromY(y, G); }
+      else env.release = releaseFromX(x, env, G);
       redraw(); onInput?.();
     };
-    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
-    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+    const end = () => {                             // clean up on cancel too, so an
+      window.removeEventListener('pointermove', move);   // interrupted gesture can't
+      window.removeEventListener('pointerup', end);      // leak listeners / keep editing
+      window.removeEventListener('pointercancel', end);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', end);
+    window.addEventListener('pointercancel', end);
   };
   hA.addEventListener('pointerdown', drag('a'));
   hDS.addEventListener('pointerdown', drag('ds'));

--- a/docs/arcade/groovebox/ui/env-graph.js
+++ b/docs/arcade/groovebox/ui/env-graph.js
@@ -1,0 +1,59 @@
+// ui/env-graph.js — draggable ADSR envelope. Three handles (A · D/S · R) over an
+// SVG outline. Mutates the passed `env` object in place and calls onInput after
+// each change (so the editor can live-preview + refresh SAVE), matching the
+// slider rows. Pure param↔geometry math lives in ./curve-math.js.
+import {
+  ENV_GEOM, envHandles, envPath, attackFromX, decayFromX, sustainFromY, releaseFromX,
+} from './curve-math.js';
+
+const NS = 'http://www.w3.org/2000/svg';
+const el = (t, a = {}) => { const e = document.createElementNS(NS, t); for (const k in a) e.setAttribute(k, a[k]); return e; };
+
+const W = 300, H = 80, G = ENV_GEOM;
+
+/** makeEnvGraph(env, onInput) → DOM element. `env` = draft.patch.envelope. */
+export function makeEnvGraph(env, onInput) {
+  const wrap = document.createElement('div');
+  wrap.className = 'ie-graph';
+  const svg = el('svg', { viewBox: `0 0 ${W} ${H}`, class: 'ie-graph-svg' });
+  const axis = el('line', { x1: 0, y1: G.bottom, x2: W, y2: G.bottom, class: 'ie-axis' });
+  const fill = el('path', { class: 'ie-fill' });
+  const line = el('path', { class: 'ie-stroke' });
+  const hA = el('circle', { r: 3.5, class: 'ie-handle' });
+  const hDS = el('circle', { r: 3.5, class: 'ie-handle' });
+  const hR = el('circle', { r: 3.5, class: 'ie-handle' });
+  svg.append(axis, fill, line, hA, hDS, hR);
+  wrap.appendChild(svg);
+
+  function redraw() {
+    const h = envHandles(env, G);
+    const d = envPath(env, G);
+    line.setAttribute('d', d);
+    fill.setAttribute('d', `${d} L${G.x0},${G.bottom} Z`);
+    hA.setAttribute('cx', h.a.x);   hA.setAttribute('cy', h.a.y);
+    hDS.setAttribute('cx', h.ds.x); hDS.setAttribute('cy', h.ds.y);
+    hR.setAttribute('cx', h.r.x);   hR.setAttribute('cy', h.r.y);
+  }
+  const toSvg = ev => {
+    const r = svg.getBoundingClientRect();
+    return { x: (ev.clientX - r.left) * (W / r.width), y: (ev.clientY - r.top) * (H / r.height) };
+  };
+  const drag = which => ev => {
+    ev.preventDefault(); ev.stopPropagation();
+    const move = e => {
+      const p = toSvg(e);
+      if (which === 'a') env.attack = attackFromX(p.x, G);
+      else if (which === 'ds') { env.decay = decayFromX(p.x, env, G); env.sustain = sustainFromY(p.y, G); }
+      else env.release = releaseFromX(p.x, env, G);
+      redraw(); onInput?.();
+    };
+    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  };
+  hA.addEventListener('pointerdown', drag('a'));
+  hDS.addEventListener('pointerdown', drag('ds'));
+  hR.addEventListener('pointerdown', drag('r'));
+
+  redraw();
+  return wrap;
+}

--- a/docs/arcade/groovebox/ui/filter-graph.js
+++ b/docs/arcade/groovebox/ui/filter-graph.js
@@ -1,0 +1,57 @@
+// ui/filter-graph.js — lowpass response curve with one cutoff/resonance handle
+// (x = cutoff, y = resonance). Mutates the passed `filter` object's freq + Q in
+// place and calls onInput after each change. Math lives in ./curve-math.js.
+import { FILT_GEOM, filterHandle, freqFromX, qFromY } from './curve-math.js';
+
+const NS = 'http://www.w3.org/2000/svg';
+const el = (t, a = {}) => { const e = document.createElementNS(NS, t); for (const k in a) e.setAttribute(k, a[k]); return e; };
+
+const W = 300, H = 52, G = FILT_GEOM;
+
+/** makeFilterGraph(filter, onInput) → DOM element. `filter` = draft.patch.filter. */
+export function makeFilterGraph(filter, onInput) {
+  const wrap = document.createElement('div');
+  wrap.className = 'ie-graph';
+  const svg = el('svg', { viewBox: `0 0 ${W} ${H}`, class: 'ie-graph-svg' });
+  const axis = el('line', { x1: 0, y1: G.bottom, x2: W, y2: G.bottom, class: 'ie-axis' });
+  const line = el('path', { class: 'ie-stroke' });
+  const handle = el('circle', { r: 3.5, class: 'ie-handle' });
+  svg.append(axis, line, handle);
+  wrap.appendChild(svg);
+
+  function redraw() {
+    const h = filterHandle(filter, G);
+    const hx = Math.max(G.x0, Math.min(G.x1, h.x));
+    const pass = G.base;                                   // flat passband level
+    const peak = h.y;                                      // resonance height
+    const fall = G.bottom - 2;                             // rolled-off floor
+    const kneeL = Math.max(G.x0, hx - 22);
+    // flat passband → resonant peak at cutoff → roll off. When the cutoff sits
+    // near the right edge (an open/transparent filter) there's no room to roll
+    // off, so the curve just stays flat to the edge — a clean "nothing filtered"
+    // line instead of a crammed kink running off-screen.
+    line.setAttribute('d', hx > G.x1 - 26
+      ? `M${G.x0},${pass} L${kneeL},${pass} Q${hx - 6},${pass} ${hx},${peak} L${G.x1},${peak}`
+      : `M${G.x0},${pass} L${kneeL},${pass} Q${hx - 6},${pass} ${hx},${peak} ` +
+        `Q${hx + 10},${peak} ${(hx + G.x1) / 2},${(peak + fall) / 2} L${G.x1},${fall}`);
+    handle.setAttribute('cx', hx); handle.setAttribute('cy', h.y);
+  }
+  const toSvg = ev => {
+    const r = svg.getBoundingClientRect();
+    return { x: (ev.clientX - r.left) * (W / r.width), y: (ev.clientY - r.top) * (H / r.height) };
+  };
+  handle.addEventListener('pointerdown', ev => {
+    ev.preventDefault(); ev.stopPropagation();
+    const move = e => {
+      const p = toSvg(e);
+      filter.freq = freqFromX(p.x, G);
+      filter.Q = qFromY(p.y, G);
+      redraw(); onInput?.();
+    };
+    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+  });
+
+  redraw();
+  return wrap;
+}

--- a/docs/arcade/groovebox/ui/filter-graph.js
+++ b/docs/arcade/groovebox/ui/filter-graph.js
@@ -36,20 +36,23 @@ export function makeFilterGraph(filter, onInput) {
         `Q${hx + 10},${peak} ${(hx + G.x1) / 2},${(peak + fall) / 2} L${G.x1},${fall}`);
     handle.setAttribute('cx', hx); handle.setAttribute('cy', h.y);
   }
-  const toSvg = ev => {
-    const r = svg.getBoundingClientRect();
-    return { x: (ev.clientX - r.left) * (W / r.width), y: (ev.clientY - r.top) * (H / r.height) };
-  };
   handle.addEventListener('pointerdown', ev => {
     ev.preventDefault(); ev.stopPropagation();
+    const r = svg.getBoundingClientRect();          // capture once per drag (not per move)
+    const sx = W / r.width, sy = H / r.height;
     const move = e => {
-      const p = toSvg(e);
-      filter.freq = freqFromX(p.x, G);
-      filter.Q = qFromY(p.y, G);
+      filter.freq = freqFromX((e.clientX - r.left) * sx, G);
+      filter.Q = qFromY((e.clientY - r.top) * sy, G);
       redraw(); onInput?.();
     };
-    const up = () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
-    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+    const end = () => {                             // clean up on cancel too (interrupted gesture)
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', end);
+      window.removeEventListener('pointercancel', end);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', end);
+    window.addEventListener('pointercancel', end);
   });
 
   redraw();

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -181,9 +181,13 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
     const curShape = draft.patch.oscillator?.shape ?? 'triangle';
     for (const sh of OSC_SHAPES) {
       const b = document.createElement('button');
+      b.type = 'button';
       b.className = 'ie-wv' + (sh === curShape ? ' on' : '');
-      b.title = sh === 'fatsawtooth' ? 'fat saw' : sh;
-      b.innerHTML = `<svg viewBox="0 0 20 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">${WAVE_ICON[sh]}</svg>`;
+      const wlabel = sh === 'fatsawtooth' ? 'fat saw' : sh;
+      b.title = wlabel;
+      b.setAttribute('aria-label', wlabel);                 // icon-only — announce the shape
+      b.setAttribute('aria-pressed', String(sh === curShape));
+      b.innerHTML = `<svg viewBox="0 0 20 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">${WAVE_ICON[sh]}</svg>`;
       b.onclick = () => { set(draft.patch, 'oscillator.shape', sh); refreshSave(); render(); };
       wrap.appendChild(b);
     }

--- a/docs/arcade/groovebox/ui/instrument-editor.js
+++ b/docs/arcade/groovebox/ui/instrument-editor.js
@@ -4,6 +4,26 @@
 // draft live (the playing loop sounds it), SAVE persists to localStorage.
 import { PATCH_PARAMS, OSC_SHAPES, validateInstrument, DEFAULT_INSTRUMENTS } from '../engine/instruments.js';
 import { BRIGHT_OPEN } from '../engine/voices.js';
+import { posToVal, valToPos } from './curve-math.js';
+import { makeEnvGraph } from './env-graph.js';
+import { makeFilterGraph } from './filter-graph.js';
+import { makeKnob } from './knob.js';
+
+// Short uppercase labels for the knob layout (the slider rows use PARAM_UI.label).
+const KNOB_LABEL = {
+  'volume': 'vol', 'trigger.velocity': 'hit',
+  'vibrato.rate': 'vib hz', 'vibrato.depth': 'amt', 'oscillator.width': 'width',
+  'filterEnvelope.baseFrequency': 'base', 'filterEnvelope.octaves': 'sweep',
+};
+// Waveform glyphs (20×13 viewBox, stroked with currentColor) for the icon picker.
+const WAVE_ICON = {
+  sawtooth:    '<polyline points="1,11 7,2 7,11 13,2 13,11 19,2 19,11"/>',
+  fatsawtooth: '<polyline points="2,11 8,3 8,11 14,3 14,11 19,3"/><polyline points="1,11 6,5 6,11 11,5" opacity=".45"/>',
+  square:      '<polyline points="1,11 1,3 10,3 10,11 19,11 19,3"/>',
+  pulse:       '<polyline points="1,11 1,3 5,3 5,11 19,11"/>',
+  triangle:    '<polyline points="1,11 6,2 11,11 16,2 20,9"/>',
+  sine:        '<path d="M1,7 Q6,0 11,7 T20,7"/>',
+};
 
 // UI metadata only — ranges/scales live in PATCH_PARAMS (one source of truth).
 const PARAM_UI = {
@@ -34,17 +54,8 @@ const ARCHETYPE_PARAMS = {
              'oscillator.width', 'filter.freq', 'filter.Q', 'vibrato.rate', 'vibrato.depth', 'trigger.velocity'],
 };
 
-// slider position (0..1) ↔ value, honouring the registry's scale
-function posToVal(id, pos) {
-  const { min, max, scale } = PATCH_PARAMS[id];
-  if (scale === 'log') return min * Math.pow(max / min, pos);
-  return min + (max - min) * pos;
-}
-function valToPos(id, v) {
-  const { min, max, scale } = PATCH_PARAMS[id];
-  if (scale === 'log') return Math.log(v / min) / Math.log(max / min);
-  return (v - min) / (max - min);
-}
+// slider position (0..1) ↔ value math now lives in ./curve-math.js (shared with
+// the envelope/filter graphs).
 
 const get = (o, p) => p.split('.').reduce((x, k) => (x == null ? x : x[k]), o);
 function set(o, p, v) {
@@ -135,6 +146,49 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
 
   const label = t => { const s = document.createElement('span'); s.className = 'ie-rl'; s.textContent = t; return s; };
   const value = t => { const s = document.createElement('span'); s.className = 'ie-val'; s.textContent = t; return s; };
+  const section = (t, tag) => {
+    const s = document.createElement('div'); s.className = 'ie-sec';
+    s.innerHTML = `<b>${t}</b><i></i>${tag ? `<span class="ie-tag">${tag}</span>` : ''}`;
+    return s;
+  };
+  // graphs + knobs mutate draft.patch in place; mirror the slider rows' live-preview + save-refresh
+  const onGraphInput = () => { applyDraftLive(); refreshSave(); };
+
+  // One knob bound to a registry param (normalized 0..1 in/out, value formatted
+  // back through PARAM_UI). onChange mutates the draft + live-previews like a row.
+  const paramKnob = pid => {
+    const reg = PATCH_PARAMS[pid], ui = PARAM_UI[pid];
+    const cur = get(draft.patch, pid) ?? (pid === 'trigger.velocity' ? 1 : (reg.min + reg.max) / 2);
+    return makeKnob({
+      label: KNOB_LABEL[pid] ?? ui.label, tip: ui.label,
+      value: valToPos(pid, cur),
+      fmt: norm => ui.fmt(posToVal(pid, norm)),
+      onChange: norm => {
+        set(draft.patch, pid, Math.round(posToVal(pid, norm) * 1000) / 1000);
+        applyDraftLive(); refreshSave();
+      },
+    });
+  };
+  const knobGroup = (title, pids, tag) => {
+    const row = document.createElement('div'); row.className = 'ie-knobrow';
+    for (const pid of pids) row.appendChild(paramKnob(pid));
+    return [section(title, tag), row];
+  };
+  // waveform icon picker (replaces the dropdown); re-renders on change so the
+  // pulse-width knob can appear/vanish with the shape.
+  const waveformButtons = () => {
+    const wrap = document.createElement('div'); wrap.className = 'ie-waves';
+    const curShape = draft.patch.oscillator?.shape ?? 'triangle';
+    for (const sh of OSC_SHAPES) {
+      const b = document.createElement('button');
+      b.className = 'ie-wv' + (sh === curShape ? ' on' : '');
+      b.title = sh === 'fatsawtooth' ? 'fat saw' : sh;
+      b.innerHTML = `<svg viewBox="0 0 20 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">${WAVE_ICON[sh]}</svg>`;
+      b.onclick = () => { set(draft.patch, 'oscillator.shape', sh); refreshSave(); render(); };
+      wrap.appendChild(b);
+    }
+    return wrap;
+  };
 
   function refreshSave() {
     const btn = modal.querySelector('.ie-save');
@@ -166,31 +220,21 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
     hd.append(name, test);
     modal.appendChild(hd);
 
-    // oscillator shape (mono/poly only)
-    if (draft.patch.archetype === 'mono' || draft.patch.archetype === 'poly') {
-      const row = document.createElement('div');
-      row.className = 'ie-row';
-      row.appendChild(label('waveform'));
-      const sel = document.createElement('select');
-      sel.className = 'ie-sel';
-      for (const sh of OSC_SHAPES) {
-        const o = document.createElement('option');
-        o.value = sh; o.textContent = sh === 'fatsawtooth' ? 'fat saw' : sh;
-        if ((draft.patch.oscillator?.shape ?? 'triangle') === sh) o.selected = true;
-        sel.appendChild(o);
-      }
-      sel.onchange = () => { set(draft.patch, 'oscillator.shape', sel.value); refreshSave(); };
-      row.appendChild(sel);
-      modal.appendChild(row);
+    // mono/poly get the graph + knob layout (matches the mock); membrane/noise
+    // keep the slider rows for now. Seed/complete the graphed blocks first.
+    const archetype = draft.patch.archetype;
+    const knobby = archetype === 'mono' || archetype === 'poly';
+    if (knobby) {
+      const e = draft.patch.envelope ?? (draft.patch.envelope = {});
+      if (e.attack === undefined) e.attack = 0.01;
+      if (e.decay === undefined) e.decay = 0.2;
+      if (e.sustain === undefined) e.sustain = 0.5;
+      if (e.release === undefined) e.release = 0.2;
     }
-
-    // Resonant filter + vibrato are general lead/pad primitives, not specific to
-    // any one preset. On a poly patch, seed/complete a NEUTRAL block so the knobs
-    // are always present AND read their TRUE value, not the slider midpoint.
-    // freq = BRIGHT_OPEN and Q = 1 mirror the engine's transparent openInsert, so
-    // an edit→save round-trip never shifts the velocity→brightness base cutoff.
-    // (mono keeps its own filterEnvelope path.)
-    if (draft.patch.archetype === 'poly') {
+    if (archetype === 'poly') {
+      // Seed a NEUTRAL filter + vibrato (freq = BRIGHT_OPEN, Q = 1 mirror the
+      // engine's transparent openInsert, so an edit→save round-trip never shifts
+      // the velocity→brightness base cutoff).
       const f = draft.patch.filter ?? (draft.patch.filter = { type: 'lowpass', freq: BRIGHT_OPEN });
       if (f.Q === undefined) f.Q = 1;
       const vib = draft.patch.vibrato ?? (draft.patch.vibrato = {});
@@ -198,30 +242,43 @@ export function openInstrumentEditor({ id, patch, eng, onSaved, onPreview, onRes
       if (vib.depth === undefined) vib.depth = 0;
     }
 
-    // param sliders — ranges/scales straight from the registry
-    for (const pid of ARCHETYPE_PARAMS[draft.patch.archetype] ?? []) {
-      if (pid.startsWith('filter.') && !draft.patch.filter) continue;     // patch has no filter block
-      if (pid.startsWith('vibrato.') && !draft.patch.vibrato) continue;   // patch has no vibrato block
-      const ui = PARAM_UI[pid];
-      const cur = get(draft.patch, pid);
-      const reg = PATCH_PARAMS[pid];
-      const shown = cur ?? (pid === 'trigger.velocity' ? 1 : (reg.min + reg.max) / 2);
-      const row = document.createElement('div');
-      row.className = 'ie-row';
-      const v = value(ui.fmt(shown));
-      const s = document.createElement('input');
-      s.type = 'range'; s.min = 0; s.max = 1000; s.step = 1;
-      s.className = 'ie-slider';
-      s.value = Math.round(valToPos(pid, shown) * 1000);
-      s.oninput = () => {
-        const nv = posToVal(pid, s.value / 1000);
-        set(draft.patch, pid, Math.round(nv * 1000) / 1000);
-        v.textContent = ui.fmt(get(draft.patch, pid));
-        applyDraftLive();                            // throttled — see above
-        refreshSave();
-      };
-      row.append(label(ui.label), s, v);
-      modal.appendChild(row);
+    if (knobby) {
+      modal.appendChild(waveformButtons());
+      modal.append(section('amp env'), makeEnvGraph(draft.patch.envelope, onGraphInput));
+      if (archetype === 'poly') {
+        modal.append(section('filter', 'cutoff + reso'), makeFilterGraph(draft.patch.filter, onGraphInput));
+        const mod = ['vibrato.rate', 'vibrato.depth'];
+        if (draft.patch.oscillator?.shape === 'pulse') mod.unshift('oscillator.width');
+        modal.append(...knobGroup('mod', mod));
+      } else {   // mono: filter-envelope as knobs (the sweep graph is a later slice)
+        modal.append(...knobGroup('filter', ['filterEnvelope.baseFrequency', 'filterEnvelope.octaves'], 'sweep'));
+      }
+      modal.append(...knobGroup('level', ['volume', 'trigger.velocity']));
+    } else {
+      // param sliders — ranges/scales straight from the registry (membrane/noise)
+      for (const pid of ARCHETYPE_PARAMS[archetype] ?? []) {
+        if (pid.startsWith('filter.') && !draft.patch.filter) continue;     // patch has no filter block
+        const ui = PARAM_UI[pid];
+        const cur = get(draft.patch, pid);
+        const reg = PATCH_PARAMS[pid];
+        const shown = cur ?? (pid === 'trigger.velocity' ? 1 : (reg.min + reg.max) / 2);
+        const row = document.createElement('div');
+        row.className = 'ie-row';
+        const v = value(ui.fmt(shown));
+        const s = document.createElement('input');
+        s.type = 'range'; s.min = 0; s.max = 1000; s.step = 1;
+        s.className = 'ie-slider';
+        s.value = Math.round(valToPos(pid, shown) * 1000);
+        s.oninput = () => {
+          const nv = posToVal(pid, s.value / 1000);
+          set(draft.patch, pid, Math.round(nv * 1000) / 1000);
+          v.textContent = ui.fmt(get(draft.patch, pid));
+          applyDraftLive();                            // throttled — see above
+          refreshSave();
+        };
+        row.append(label(ui.label), s, v);
+        modal.appendChild(row);
+      }
     }
 
     // footer


### PR DESCRIPTION
Turns the pitched-lane instrument editor (mono/poly) into a hardware-style panel — draggable envelope + filter graphs and knobs in grouped sections — instead of a flat slider list.

## What's in it
- **Envelope graph** — draggable ADSR (A · D/S · R handles) over an SVG outline.
- **Filter graph (poly)** — lowpass response curve with one cutoff/resonance handle; renders cleanly when the cutoff is fully open (no off-screen kink).
- **`curve-math.js`** — pure, scale-aware param↔geometry math (handle layout + drag inverses), **unit-tested**, and lifted to be the single source for the slider math too.
- **Knob layout** — scalars become `makeKnob` knobs grouped into **MOD / FILTER / LEVEL** with value readouts; **waveform icon picker** (pulse-width knob appears only for the `pulse` shape); section tags (`cutoff + reso`, `sweep`).
- **Mono** gets the amp-env graph too (its filter-envelope stays as knobs for now).
- **TEST button fix** — its two-line label had been clipping *under* the button since #666 (never changed since); now a flex column with breathing room.

## Scope
- `membrane`/`noise` (kick/snare/hat) still use the slider editor — their graphs (pitch-env, highpass) and the **kit editor** are the next slice.
- Both opt-in graph blocks seed *neutral* values (filter at `BRIGHT_OPEN`, vibrato depth 0) so an edit→save round-trip is sonically inert.

## Tests
**412 green** (+10 new `curve-math` tests: endpoint/round-trip/clamp on log & linear, handle ordering, sustain→height, drag-inverse recovery, resonance height). Verified live on poly (melody/chords) and mono (bass).

Arcade-only — no changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)