### PR TITLE
arcade(groovebox): kit-per-song — the drum kit travels with the song

### DIFF
--- a/docs/arcade/groovebox/engine/flatten.js
+++ b/docs/arcade/groovebox/engine/flatten.js
@@ -321,6 +321,7 @@ export function flattenSong(rich) {
     id: l.id, type: l.type, name: l.name || l.id,
     muted: !!l.muted, soloed: !!l.soloed,
     ...(l.instrument ? { instrument: l.instrument } : {}),
+    ...(l.type === 'drums' && l.kit ? { kit: l.kit } : {}),
   }));
 
   // Song key (for melody snap-to-scale + editor tinting). The chord progression

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -1,7 +1,7 @@
 import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
-import { normalizeSongDrums, DEFAULT_INSTRUMENTS, ALL_INSTRUMENTS, LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
+import { normalizeSongDrums, DEFAULT_INSTRUMENTS, ALL_INSTRUMENTS, ALL_KITS, LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
 import { laneByType, DEFAULT_LANE_INSTRUMENT, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
@@ -196,11 +196,19 @@ export function createEngine() {
   function instrumentSet() {
     return song?.instruments ? { ..._instruments, ...song.instruments } : _instruments;
   }
+  // The kit a drums lane sounds: its own `lane.kit` ref (so the kit travels with
+  // the song), else the global default. (song.kits is the future custom-kit hook.)
+  function resolveKit(kitId) {
+    return (kitId && ALL_KITS[kitId]) || (kitId && song?.kits?.[kitId]) || null;
+  }
+  function kitFor(lane) {
+    return resolveKit(lane?.kit) || _kit;
+  }
 
   function buildLane(lane) {
     fx[lane.id]     = _makeFX(_masterIn);
     voices[lane.id] = createVoiceForType(lane.type, fx[lane.id].input,
-      { instruments: instrumentSet(), kit: _kit, instrumentId: lane.instrument });
+      { instruments: instrumentSet(), kit: kitFor(lane), instrumentId: lane.instrument });
     // Per-lane scope analyser — lazy: created on first getScope(id) call.
     // scopeLane[lane.id] intentionally NOT created here.
     // Per-lane level meter
@@ -226,7 +234,7 @@ export function createEngine() {
     const v = voices[laneId];
     if (v?.dispose) { try { v.dispose(); } catch (_) {} }
     voices[laneId] = createVoiceForType(lane.type, fx[laneId].input,
-      { instruments: instrumentSet(), kit: _kit, instrumentId: lane.instrument });
+      { instruments: instrumentSet(), kit: kitFor(lane), instrumentId: lane.instrument });
   }
   function _rebuildVoices() {
     if (!started || !song) return;
@@ -701,6 +709,15 @@ export function createEngine() {
       const inst = instrumentSet()[instrumentId];
       if (!lane || lane.type === 'drums' || !inst || inst.type !== lane.type) return;
       lane.instrument = instrumentId;
+      _rebuildVoice(id);
+    },
+    // Choose a kit for a drums lane. The ref rides on the lane (so it serializes
+    // with the song); unknown kit / non-drums lane = no-op.
+    setLaneKit(id, kitId) {
+      if (!song) return;
+      const lane = song.lanes.find(l => l.id === id);
+      if (!lane || lane.type !== 'drums' || !resolveKit(kitId)) return;
+      lane.kit = kitId;
       _rebuildVoice(id);
     },
     // The resolved patch a lane currently sounds (stock preset or song-local

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -199,7 +199,10 @@ export function createEngine() {
   // The kit a drums lane sounds: its own `lane.kit` ref (so the kit travels with
   // the song), else the global default. (song.kits is the future custom-kit hook.)
   function resolveKit(kitId) {
-    return (kitId && ALL_KITS[kitId]) || (kitId && song?.kits?.[kitId]) || null;
+    if (!kitId) return null;
+    if (ALL_KITS[kitId]) return ALL_KITS[kitId];               // stock kits are trusted
+    const custom = song?.kits?.[kitId];                        // future song-local custom kits
+    return (custom && validateKit(custom, instrumentSet())) ? custom : null;   // bad data never crashes
   }
   function kitFor(lane) {
     return resolveKit(lane?.kit) || _kit;

--- a/docs/arcade/groovebox/engine/lanes.js
+++ b/docs/arcade/groovebox/engine/lanes.js
@@ -43,6 +43,7 @@ export function addLane(song, type) {
     muted: false,
     soloed: false,
     ...(DEFAULT_LANE_INSTRUMENT[type] ? { instrument: DEFAULT_LANE_INSTRUMENT[type] } : {}),
+    ...(type === 'drums' ? { kit: 'oyster-kit' } : {}),
   };
   lanes.push(lane);
   // New lane gets one 'empty' groove; every pattern picks it.

--- a/docs/arcade/groovebox/tests/preset-picker.test.js
+++ b/docs/arcade/groovebox/tests/preset-picker.test.js
@@ -135,3 +135,32 @@ describe('registry validation of song-local instruments', () => {
     expect(validateSongPayload({ ...SONG_PAYLOAD, instruments: proto }).ok).not.toBe(true);
   });
 });
+
+describe('kit-per-song (kit ref rides on the drums lane)', () => {
+  const drumsLane = eng => eng.getLanes().find(l => l.type === 'drums').id;
+
+  it('addLane(drums) seeds a kit ref', () => {
+    const eng = createEngine(); eng.load(kids);
+    expect(addLane(eng.getSong(), 'drums').kit).toBe('oyster-kit');
+  });
+
+  test('setLaneKit records the kit on the lane; unknown/non-drums = no-op', () => {
+    const eng = createEngine(); eng.load(kids); const id = drumsLane(eng);
+    eng.setLaneKit(id, 'kit-808');
+    expect(eng.getSong().lanes.find(l => l.id === id).kit).toBe('kit-808');
+    eng.setLaneKit(id, 'kit-nope');                       // unknown kit
+    expect(eng.getSong().lanes.find(l => l.id === id).kit).toBe('kit-808');
+    const bassId = eng.getLanes().find(l => l.type === 'bass').id;
+    eng.setLaneKit(bassId, 'kit-808');                    // not a drums lane
+    expect(eng.getSong().lanes.find(l => l.id === bassId).kit).toBeUndefined();
+  });
+
+  test('the kit ref serializes and round-trips through load', () => {
+    const eng = createEngine(); eng.load(kids); const id = drumsLane(eng);
+    eng.setLaneKit(id, 'kit-lofi');
+    const v2 = JSON.parse(JSON.stringify(eng.getSong()));
+    expect(v2.lanes.find(l => l.id === id).kit).toBe('kit-lofi');   // serialized
+    const eng2 = createEngine(); eng2.load(v2);
+    expect(eng2.getSong().lanes.find(l => l.id === id).kit).toBe('kit-lofi');   // restored
+  });
+});

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -465,15 +465,11 @@ function renderStrips() {
       const customOpt = isCustom ? `<option value="${esc(cur)}" selected>Custom ✎</option>` : '';
       presetSel = `<select class="lane-preset" data-preset data-lane="${lane.id}" title="Instrument preset">${customOpt}${opts}</select>`;
     } else {
-      // Drums pick a KIT. The selected id is derived from the engine's live kit
-      // (by reference) — so a saved global custom kit shows "Custom", not a wrong
-      // bank entry.
-      const curKit = eng.getKit();
-      const selId = Object.keys(ALL_KITS).find(k => ALL_KITS[k] === curKit);
+      // Drums pick a KIT — the ref rides on the lane so it travels with the song.
+      const selId = ALL_KITS[lane.kit] ? lane.kit : 'oyster-kit';
       const opts = Object.entries(ALL_KITS)
         .map(([id, k]) => `<option value="${id}"${id === selId ? ' selected' : ''}>${esc(k.name)}</option>`).join('');
-      const customOpt = selId ? '' : `<option value="" selected>Custom</option>`;
-      presetSel = `<select class="lane-preset" data-kit data-lane="${lane.id}" title="Drum kit">${customOpt}${opts}</select>`;
+      presetSel = `<select class="lane-preset" data-kit data-lane="${lane.id}" title="Drum kit">${opts}</select>`;
     }
     const soundBtn = isPitched
       ? `<button class="lane-sound" data-lane="${lane.id}" data-type="${lane.type}" title="Edit ${esc(lane.name)} sound">EDIT</button>`
@@ -547,8 +543,7 @@ function renderStrips() {
     renderStrips();   // a stock pick clears the "Custom" option from the list
   });
   host.querySelectorAll('select[data-kit]').forEach(s => s.onchange = () => {
-    const k = ALL_KITS[s.value];
-    if (k) eng.setKit(k);   // ignore the display-only "Custom" entry
+    if (ALL_KITS[s.value]) eng.setLaneKit(s.dataset.lane, s.value);
   });
   host.querySelectorAll('.lane-sound').forEach(b => b.onclick = e => {
     e.stopPropagation();


### PR DESCRIPTION
Follow-up to #679. The drum **kit choice now rides on the song** instead of being a global engine setting — mirroring how each pitched lane already carries its `instrument`.

## What changed
- The drums lane carries a **`kit`** id (`lane.kit`). The engine resolves the drums voice from it (`kitFor(lane)`), with the global `_kit` as the fallback default.
- **`setLaneKit(laneId, kitId)`** replaces the global `setKit` call from the kit dropdown.
- **Serializes** (`flatten` emits `kit` on drums lanes), so save / share / reload keep the kit.
- `addLane(drums)` seeds the default kit ref.

## Notes
- Bank kits travel as an **id ref** (e.g. `kit-808`) — the recipient resolves it from the bank. **Custom kits** (a future kit editor) will travel inline like `song.instruments`.
- Cartridge (Oyster-authored) songs don't set `lane.kit` yet, so they use the default kit; assigning kits to the demo songs is optional content follow-up.

## Tests
**415 green** (+3: seed, setLaneKit guards, save/load round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)