### PR TITLE
groovebox: start a song from scratch — blank templates, groove + progression library, focused loop editor

### DIFF
--- a/docs/arcade/groovebox/engine/groove-presets.js
+++ b/docs/arcade/groovebox/engine/groove-presets.js
@@ -11,20 +11,42 @@
 
 export function meterKey(meter) { return `${meter.beatsPerBar}/${meter.beatUnit}`; }
 
-// Curated chord progressions — famous, varied moods, one chord per bar.
-// Plain chord-symbol strings for the PATTERNS chord line parser; names teach
-// what they are. Meter-agnostic (a progression works in any meter). This list
+// Curated chord progressions — famous SHAPES, not fixed chords. Stored as
+// roman-numeral degrees (case = quality: I major, i minor; optional 'b'
+// prefix flattens) and resolved against a key at apply time — the schema
+// keeps storing the compiled concrete chords. Meter-agnostic. This list
 // doubles as the roll-a-progression pool for the future Generate feature.
 export const PROGRESSION_PRESETS = [
-  { name: 'axis of awesome', chords: 'C G Am F',           vibe: 'the 4-chord pop anthem (I–V–vi–IV)' },
-  { name: 'doo-wop',         chords: 'C Am F G',           vibe: "'50s heartthrob (I–vi–IV–V)" },
-  { name: "don't stop",      chords: 'Am F C G',           vibe: 'minor-leaning pop drive (vi–IV–I–V)' },
-  { name: 'andalusian',      chords: 'Am G F E',           vibe: 'flamenco descent (i–VII–VI–V)' },
-  { name: 'jazz turnaround', chords: 'Dm G C Am',          vibe: 'smooth cycle (ii–V–I–vi)' },
-  { name: 'creep',           chords: 'C E F Fm',           vibe: 'bittersweet lift and fall (I–III–IV–iv)' },
-  { name: 'simple blues',    chords: 'C F C G',            vibe: 'porch blues (I–IV–I–V)' },
-  { name: 'canon',           chords: 'C G Am Em F C F G',  vibe: "Pachelbel's 8-bar wedding classic" },
+  { name: 'axis of awesome', degrees: ['I', 'V', 'vi', 'IV'],  vibe: 'the 4-chord pop anthem' },
+  { name: 'doo-wop',         degrees: ['I', 'vi', 'IV', 'V'],  vibe: "'50s heartthrob" },
+  { name: "don't stop",      degrees: ['vi', 'IV', 'I', 'V'],  vibe: 'minor-leaning pop drive (Zombie, Kids)' },
+  { name: 'andalusian',      degrees: ['vi', 'V', 'IV', 'III'], vibe: 'flamenco descent' },
+  { name: 'jazz turnaround', degrees: ['ii', 'V', 'I', 'vi'],  vibe: 'smooth cycle' },
+  { name: 'creep',           degrees: ['I', 'III', 'IV', 'iv'], vibe: 'bittersweet lift and fall' },
+  { name: 'simple blues',    degrees: ['I', 'IV', 'I', 'V'],   vibe: 'porch blues' },
+  { name: 'canon',           degrees: ['I', 'V', 'vi', 'iii', 'IV', 'I', 'IV', 'V'], vibe: "Pachelbel's 8-bar classic" },
 ];
+
+// resolveProgression(degrees, keyRoot) → chord-symbol string for the chord
+// line parser (sharps-only spellings). 'vi' in A → 'F#m'. Pure + tested.
+const DEGREE_OFFSETS = { i: 0, ii: 2, iii: 4, iv: 5, v: 7, vi: 9, vii: 11 };
+const PC_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const LETTER_PC = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+export function resolveProgression(degrees, keyRoot) {
+  const m = /^([A-G])(#|b)?$/.exec(keyRoot);
+  if (!m) return null;
+  const base = (LETTER_PC[m[1]] + (m[2] === '#' ? 1 : m[2] === 'b' ? -1 : 0) + 12) % 12;
+  const out = [];
+  for (let d of degrees) {
+    let flat = 0;
+    while (d.startsWith('b')) { flat -= 1; d = d.slice(1); }   // ♭VII-style borrowings
+    const off = DEGREE_OFFSETS[d.toLowerCase()];
+    if (off === undefined) return null;
+    const minor = d === d.toLowerCase();
+    out.push(PC_NAMES[(base + off + flat + 12) % 12] + (minor ? 'm' : ''));
+  }
+  return out.join(' ');
+}
 
 export const GROOVE_PRESETS = {
   '4/4': {

--- a/docs/arcade/groovebox/engine/groove-presets.js
+++ b/docs/arcade/groovebox/engine/groove-presets.js
@@ -1,0 +1,91 @@
+// engine/groove-presets.js — the curated starter groove library, keyed by meter.
+//
+// Pure v2 data: 1-bar building blocks with human names, stocked into a New
+// song so its dropdowns aren't a one-trick pony. Curated by hand from the
+// bundled songs' pools (flatten-harvest loses unused pool entries, so these
+// are authored directly, not generated). Bass/chords are RELATIVE (R/V refs,
+// see DATA-MODEL.md) so they fit any key or progression; drums are pitchless
+// and portable by nature. This set doubles as registry seed content later.
+//
+// 4/4 → 16 steps/bar, beats at 0/4/8/12.  3/4 → 12 steps/bar, beats at 0/4/8.
+
+export function meterKey(meter) { return `${meter.beatsPerBar}/${meter.beatUnit}`; }
+
+// Curated chord progressions — famous, varied moods, one chord per bar.
+// Plain chord-symbol strings for the PATTERNS chord line parser; names teach
+// what they are. Meter-agnostic (a progression works in any meter). This list
+// doubles as the roll-a-progression pool for the future Generate feature.
+export const PROGRESSION_PRESETS = [
+  { name: 'axis of awesome', chords: 'C G Am F',           vibe: 'the 4-chord pop anthem (I–V–vi–IV)' },
+  { name: 'doo-wop',         chords: 'C Am F G',           vibe: "'50s heartthrob (I–vi–IV–V)" },
+  { name: "don't stop",      chords: 'Am F C G',           vibe: 'minor-leaning pop drive (vi–IV–I–V)' },
+  { name: 'andalusian',      chords: 'Am G F E',           vibe: 'flamenco descent (i–VII–VI–V)' },
+  { name: 'jazz turnaround', chords: 'Dm G C Am',          vibe: 'smooth cycle (ii–V–I–vi)' },
+  { name: 'creep',           chords: 'C E F Fm',           vibe: 'bittersweet lift and fall (I–III–IV–iv)' },
+  { name: 'simple blues',    chords: 'C F C G',            vibe: 'porch blues (I–IV–I–V)' },
+  { name: 'canon',           chords: 'C G Am Em F C F G',  vibe: "Pachelbel's 8-bar wedding classic" },
+];
+
+export const GROOVE_PRESETS = {
+  '4/4': {
+    drums: {
+      'four on the floor': [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      'backbeat':          [{ kick: [0, 8], snare: [4, 12], hat: [2, 6, 10, 14] }],
+      'boom-cha':          [{ kick: [0, 4, 8, 12], snare: [2, 6, 10, 14] }],
+      'boom-bap':          [{ kick: [0, 7, 10], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      // boom · cha · boom-boom · cha (lazy double — 8th apart)
+      'half-time':         [{ kick: [0, 8, 10], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      // quick 16th double ON beat 3: boom · cha · b-boom · cha
+      'half-time double':  [{ kick: [0, 8, 9], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      // quick 16th double driving INTO the back cha: boom · cha · …b-boom-CHA
+      'half-time drive':   [{ kick: [0, 10, 11], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }],
+      'house':             [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [2, 6, 10, 14] }],
+      'breaks':            [{ kick: [0, 6, 10], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] }],
+      'sprint':            [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], clap: [4, 12] }],
+      'tribal toms':       [{ kick: [0, 8], snare: [8], tom: [[2, 7], [4, 5], [6, 3], [10, 7], [12, 5], [14, 0]] }],
+      'fanfare':           [{ kick: [0, 8], snare: [12], hat: [0, 2, 4, 6, 8, 10, 12, 14], crash: [0], openhat: [14] }],
+    },
+    bass: {
+      'root quarters': { relative: true, bars: [[[0, 'R', 4], [4, 'R', 4], [8, 'R', 4], [12, 'R', 4]]] },
+      'eighths':       { relative: true, bars: [[[0, 'R', 2], [2, 'R', 2], [4, 'R', 2], [6, 'R', 2], [8, 'R', 2], [10, 'R', 2], [12, 'R', 2], [14, 'R', 2]]] },
+      '16ths':         { relative: true, bars: [[[0, 'R', 1], [1, 'R', 1], [2, 'R', 1], [3, 'R', 1], [4, 'R', 1], [5, 'R', 1], [6, 'R', 1], [7, 'R', 1], [8, 'R', 1], [9, 'R', 1], [10, 'R', 1], [11, 'R', 1], [12, 'R', 1], [13, 'R', 1], [14, 'R', 1], [15, 'R', 1]]] },
+      'octave bounce': { relative: true, bars: [[[0, 'R', 2], [2, 'R+12', 2], [4, 'R', 2], [6, 'R+12', 2], [8, 'R', 2], [10, 'R+12', 2], [12, 'R', 2], [14, 'R+12', 2]]] },
+      'oom-pah':       { relative: true, bars: [[[0, 'R', 2], [2, 'V2-12', 2], [4, 'R', 2], [6, 'V2-12', 2], [8, 'R', 2], [10, 'V2-12', 2], [12, 'R', 2], [14, 'V2-12', 2]]] },
+      'walking':       { relative: true, bars: [[[0, 'R', 4], [4, 'V1-12', 4], [8, 'V2-12', 4], [12, 'V1-12', 4]]] },
+      'offbeat':       { relative: true, bars: [[[2, 'R', 2], [6, 'R', 2], [10, 'R', 2], [14, 'R', 2]]] },
+      'whole note':    { relative: true, bars: [[[0, 'R', 16]]] },
+    },
+    chords: {
+      'pad':          { relative: true, bars: [[[0, 'V*', 'bar']]] },
+      'half pads':    { relative: true, bars: [[[0, 'V*', 8], [8, 'V*', 8]]] },
+      'stab':         { relative: true, bars: [[[0, 'V*', 2], [4, 'V*', 2], [8, 'V*', 2], [12, 'V*', 2]]] },
+      'offbeat stab': { relative: true, bars: [[[2, 'V*', 2], [6, 'V*', 2], [10, 'V*', 2], [14, 'V*', 2]]] },
+      'arp':          { relative: true, bars: [[[0, 'V0', 2], [2, 'V1', 2], [4, 'V2', 2], [6, 'V1', 2], [8, 'V0', 2], [10, 'V1', 2], [12, 'V2', 2], [14, 'V1', 2]]] },
+      'arp up':       { relative: true, bars: [[[0, 'V0', 2], [2, 'V1', 2], [4, 'V2', 2], [6, 'V0+12', 2], [8, 'V0', 2], [10, 'V1', 2], [12, 'V2', 2], [14, 'V0+12', 2]]] },
+    },
+  },
+
+  '3/4': {
+    drums: {
+      // oom-cha-cha — the waltz
+      'waltz':     [{ kick: [0], snare: [4, 8], hat: [0, 2, 4, 6, 8, 10] }],
+      'ballroom':  [{ kick: [0], hat: [4, 8], ride: [4, 8] }],
+      'footsteps': [{ kick: [0], hat: [4, 8], snare: [6], openhat: [10] }],
+      'lurch':     [{ kick: [0, 8], hat: [2, 6, 10], tom: [[4, 0], [10, -4]], ride: [0, 8] }],
+    },
+    bass: {
+      // root on 1, fifth above on 2 and 3
+      'oom-cha-cha':   { relative: true, bars: [[[0, 'R', 4], [4, 'V2-12', 4], [8, 'V2-12', 4]]] },
+      'root quarters': { relative: true, bars: [[[0, 'R', 4], [4, 'R', 4], [8, 'R', 4]]] },
+      'octave waltz':  { relative: true, bars: [[[0, 'R', 4], [4, 'R+12', 4], [8, 'R+12', 4]]] },
+      'whole note':    { relative: true, bars: [[[0, 'R', 12]]] },
+    },
+    chords: {
+      'pad':          { relative: true, bars: [[[0, 'V*', 'bar']]] },
+      // waltz comps on 2 and 3
+      'comp (2 & 3)': { relative: true, bars: [[[4, 'V*', 2], [8, 'V*', 2]]] },
+      'stab':         { relative: true, bars: [[[0, 'V*', 2], [4, 'V*', 2], [8, 'V*', 2]]] },
+      'arp':          { relative: true, bars: [[[0, 'V0', 4], [4, 'V1', 4], [8, 'V2', 4]]] },
+    },
+  },
+};

--- a/docs/arcade/groovebox/engine/index.js
+++ b/docs/arcade/groovebox/engine/index.js
@@ -1,7 +1,7 @@
 import * as Tone from 'tone';
 import { stepsPerBar } from './meter.js';
 import { createVoiceForType, trigger } from './voices.js';
-import { normalizeSongDrums, DEFAULT_INSTRUMENTS, ALL_INSTRUMENTS, LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
+import { normalizeSongDrums, normalizeDrumBar, DEFAULT_INSTRUMENTS, ALL_INSTRUMENTS, LEGACY_TONE_PRESET, DEFAULT_KIT, validateInstrument, validateKit } from './instruments.js';
 import { laneByType, DEFAULT_LANE_INSTRUMENT, toggleMute as _toggleMute, soloExclusive as _soloExclusive, toggleDrumMute as _toggleDrumMute, toggleDrumSolo as _toggleDrumSolo, addLane as _addLane, duplicateLane as _duplicateLane, removeLane as _removeLane, renameLane as _renameLane, moveLane as _moveLane } from './lanes.js';
 import { deriveKey } from './song.js';
 import { flattenSong } from './flatten.js';
@@ -647,7 +647,15 @@ export function createEngine() {
     addPattern()            { return song ? _addPattern(song, editIdx) : null; },
     duplicatePattern(i)     { return song ? _duplicatePattern(song, i) : null; },
     setLaneGroove(laneId, grooveName) { return song ? _setLaneGroove(song, editIdx, laneId, grooveName) : false; },
-    addGroove(laneId, name, value) { return song ? _addGroove(song, laneId, name, value) : false; },
+    addGroove(laneId, name, value) {
+      if (!song) return false;
+      // addGroove is an ingest point like load(): drum bars must cross the
+      // GM-numeric boundary here too, or named-key grooves play but render
+      // invisible in the step editor.
+      const lane = song.lanes.find(l => l.id === laneId);
+      const v = (lane?.type === 'drums' && Array.isArray(value)) ? value.map(normalizeDrumBar) : value;
+      return _addGroove(song, laneId, name, v);
+    },
     setGrooveBars(laneId, n) {
       if (!song) return null;
       const g = grooveFor(song, editIdx, laneId);

--- a/docs/arcade/groovebox/songs/blank.js
+++ b/docs/arcade/groovebox/songs/blank.js
@@ -1,0 +1,61 @@
+// songs/blank.js — the "＋ New" starters. Minimal *alive* skeletons (never an
+// empty grid), authored directly in the v2 schema (no rich/flatten dependency).
+//
+// Deliberate choices:
+//   - drums + bass + chords only; no melody lane. Melody is literal and
+//     key-bound (the song's identity) — you add it via ＋ add instrument when
+//     you have an idea, not before.
+//   - bass + chords are RELATIVE (R / V*) so they auto-fit whatever chords or
+//     key you change to — born portable, droppable into any progression.
+//   - boots playing a I–V–vi–IV in C major (all white keys): alive on hit,
+//     obviously yours to reshape.
+//   - meter is chosen at New (there is no meter editing at runtime); each
+//     template pins one meter and picks grooves authored for it. Groove names
+//     match engine/groove-presets.js — the New flow stocks the rest of the
+//     library around these picks, and addGroove skips names already present.
+
+const PROGRESSION = [   // I–V–vi–IV in C
+  { name: 'C',  root: 'C2', voicing: ['C3', 'E3', 'G3'] },
+  { name: 'G',  root: 'G2', voicing: ['G3', 'B3', 'D4'] },
+  { name: 'Am', root: 'A2', voicing: ['A3', 'C4', 'E4'] },
+  { name: 'F',  root: 'F2', voicing: ['F3', 'A3', 'C4'] },
+];
+
+function template({ meter, grooves, picks }) {
+  return {
+    version: 2,
+    title: 'Untitled', artist: '',
+    meter,
+    bpm: 120,
+    key: { root: 'C', mode: 'major' },
+    lanes: [
+      { id: 'drums',  type: 'drums',  name: 'drums',  muted: false, soloed: false },
+      { id: 'bass',   type: 'bass',   name: 'bass',   muted: false, soloed: false },
+      { id: 'chords', type: 'chords', name: 'chords', muted: false, soloed: false },
+    ],
+    grooves,
+    patterns: [{ lanes: picks, chords: PROGRESSION }],
+    chain: [0],
+    fills: {},
+  };
+}
+
+export const blank = template({
+  meter: { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },   // 4/4 → 16 steps/bar
+  grooves: {
+    drums:  { 'four on the floor': [{ kick: [0, 4, 8, 12], snare: [4, 12], hat: [0, 2, 4, 6, 8, 10, 12, 14] }] },
+    bass:   { 'root quarters': { relative: true, bars: [[[0, 'R', 4], [4, 'R', 4], [8, 'R', 4], [12, 'R', 4]]] } },
+    chords: { pad: { relative: true, bars: [[[0, 'V*', 'bar']]] } },
+  },
+  picks: { drums: 'four on the floor', bass: 'root quarters', chords: 'pad' },
+});
+
+export const blankWaltz = template({
+  meter: { beatsPerBar: 3, beatUnit: 4, stepsPerBeat: 4 },   // 3/4 → 12 steps/bar
+  grooves: {
+    drums:  { waltz: [{ kick: [0], snare: [4, 8], hat: [0, 2, 4, 6, 8, 10] }] },
+    bass:   { 'oom-cha-cha': { relative: true, bars: [[[0, 'R', 4], [4, 'V2-12', 4], [8, 'V2-12', 4]]] } },
+    chords: { pad: { relative: true, bars: [[[0, 'V*', 'bar']]] } },
+  },
+  picks: { drums: 'waltz', bass: 'oom-cha-cha', chords: 'pad' },
+});

--- a/docs/arcade/groovebox/tests/blank-loads.test.js
+++ b/docs/arcade/groovebox/tests/blank-loads.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine } from '../engine/index.js';
+import { blank, blankWaltz } from '../songs/blank.js';
+
+for (const [label, tpl, beats] of [['blank (4/4)', blank, 4], ['blankWaltz (3/4)', blankWaltz, 3]]) {
+  describe(`${label} "New" template`, () => {
+    it('loads without throwing and exposes the skeleton', () => {
+      const eng = createEngine();
+      expect(() => eng.load(structuredClone(tpl))).not.toThrow();
+      expect(eng.getLanes().map(l => l.type)).toEqual(['drums', 'bass', 'chords']);
+      expect(eng.getPatterns().length).toBe(1);
+      expect(eng.getChain()).toEqual([0]);
+      expect(eng.getSong().meter.beatsPerBar).toBe(beats);
+    });
+
+    it('every pattern pick resolves to an existing groove (valid-song invariant)', () => {
+      const eng = createEngine();
+      eng.load(structuredClone(tpl));
+      const grooves = eng.getGrooves();
+      for (const [laneId, name] of Object.entries(eng.getPatterns()[0].lanes)) {
+        expect(grooves[laneId]?.[name], `${laneId}:${name}`).toBeDefined();
+      }
+    });
+
+    it('relative bass/chords resolve against the pattern chords (4-bar pattern)', () => {
+      const eng = createEngine();
+      eng.load(structuredClone(tpl));
+      expect(eng.getPatternChords(0)?.length).toBe(4);   // I–V–vi–IV
+      expect(eng.getKey()).toMatchObject({ root: 'C', mode: 'major' });
+    });
+  });
+}

--- a/docs/arcade/groovebox/tests/groove-import.test.js
+++ b/docs/arcade/groovebox/tests/groove-import.test.js
@@ -11,11 +11,12 @@ const drumLaneId = (eng) => eng.getLanes().find((l) => l.type === 'drums').id;
 describe('eng.addGroove(laneId, name, value)', () => {
   const BARS = [{ kick: [0, 8], snare: [4, 12], hat: [], crash: [], tom: [] }];
 
-  it('adds a named groove to an existing lane', () => {
+  it('adds a named groove to an existing lane (drum bars normalized to GM numbers)', () => {
     const eng = engineWithSong();
     const laneId = drumLaneId(eng);
     expect(eng.addGroove(laneId, 'imported', BARS)).toBe(true);
-    expect(eng.getGrooves()[laneId].imported).toEqual(BARS);
+    // addGroove is an ingest boundary: named keys cross to the numeric contract.
+    expect(eng.getGrooves()[laneId].imported).toEqual([{ 36: [0, 8], 38: [4, 12], 42: [], 49: [], 45: [] }]);
   });
 
   it('refuses name collisions and unknown lanes', () => {

--- a/docs/arcade/groovebox/tests/groove-presets.test.js
+++ b/docs/arcade/groovebox/tests/groove-presets.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { GROOVE_PRESETS, meterKey } from '../engine/groove-presets.js';
+import { validateGroovePayload } from '../registry/validate.js';
+import { createEngine } from '../engine/index.js';
+import { blank, blankWaltz } from '../songs/blank.js';
+
+const METERS = {
+  '4/4': { beatsPerBar: 4, beatUnit: 4, stepsPerBeat: 4 },
+  '3/4': { beatsPerBar: 3, beatUnit: 4, stepsPerBeat: 4 },
+};
+
+describe('GROOVE_PRESETS', () => {
+  it('every preset in every meter passes the registry groove validator', () => {
+    for (const [mk, pool] of Object.entries(GROOVE_PRESETS)) {
+      for (const [laneType, presets] of Object.entries(pool)) {
+        for (const [name, value] of Object.entries(presets)) {
+          const payload = {
+            laneType, meter: METERS[mk],
+            bars: Array.isArray(value) ? value : value.bars,
+            ...(Array.isArray(value) ? {} : { relative: true }),
+          };
+          const res = validateGroovePayload(payload);
+          expect(res.ok, `${mk} ${laneType}/${name}: ${res.error || ''}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('bass/chords presets are all relative; drums all literal', () => {
+    for (const pool of Object.values(GROOVE_PRESETS)) {
+      for (const v of Object.values(pool.drums))  expect(Array.isArray(v)).toBe(true);
+      for (const v of Object.values(pool.bass))   expect(v.relative).toBe(true);
+      for (const v of Object.values(pool.chords)) expect(v.relative).toBe(true);
+    }
+  });
+
+  it('3/4 presets stay within the 12-step bar', () => {
+    for (const presets of Object.values(GROOVE_PRESETS['3/4'])) {
+      for (const value of Object.values(presets)) {
+        const bars = Array.isArray(value) ? value : value.bars;
+        for (const bar of bars) {
+          const steps = Array.isArray(bar)
+            ? bar.map(ev => ev[0])
+            : Object.values(bar).flat().map(s => Array.isArray(s) ? s[0] : s);
+          for (const s of steps) expect(s, 'step in 0..11').toBeLessThan(12);
+        }
+      }
+    }
+  });
+});
+
+describe('a New song stocked from the pool', () => {
+  for (const [label, tpl] of [['4/4', blank], ['3/4 waltz', blankWaltz]]) {
+    it(`${label}: accepts every preset via addGroove and can select each as the pick`, () => {
+      const eng = createEngine();
+      eng.load(structuredClone(tpl));
+      const pool = GROOVE_PRESETS[meterKey(tpl.meter)];
+      for (const lane of eng.getLanes()) {
+        for (const [name, value] of Object.entries(pool[lane.type] || {})) {
+          eng.addGroove(lane.id, name, structuredClone(value));
+          expect(!!eng.getGrooves()[lane.id][name], `${lane.id}/${name} present`).toBe(true);
+          expect(eng.setLaneGroove(lane.id, name), `${lane.id}/${name} selectable`).toBe(true);
+        }
+      }
+    });
+  }
+});
+
+describe('addGroove normalizes drum bars (the invisible-hits bug)', () => {
+  it('stocked drum grooves come out GM-numeric, not named-key', () => {
+    const eng = createEngine();
+    eng.load(structuredClone(blank));
+    const pool = GROOVE_PRESETS['4/4'];
+    const drumLane = eng.getLanes().find(l => l.type === 'drums');
+    for (const [name, value] of Object.entries(pool.drums)) {
+      eng.addGroove(drumLane.id, name, structuredClone(value));
+    }
+    const bar = eng.getGrooves()[drumLane.id]['half-time'][0];
+    expect(bar.kick, 'named keys gone').toBeUndefined();
+    expect(bar[36], 'kick → GM 36').toEqual([0, 8, 10]);
+    expect(bar[38], 'snare → GM 38').toEqual([4, 12]);
+  });
+});
+
+describe('PROGRESSION_PRESETS', () => {
+  it('every preset parses cleanly through the chord-line parser', async () => {
+    const { parseProgression } = await import('../engine/chords.js');
+    const { PROGRESSION_PRESETS } = await import('../engine/groove-presets.js');
+    for (const p of PROGRESSION_PRESETS) {
+      const { chords, errors } = parseProgression(p.chords);
+      expect(errors, `${p.name}: ${JSON.stringify(errors)}`).toEqual([]);
+      expect(chords.length, `${p.name} has chords`).toBeGreaterThanOrEqual(4);
+    }
+  });
+});

--- a/docs/arcade/groovebox/tests/groove-presets.test.js
+++ b/docs/arcade/groovebox/tests/groove-presets.test.js
@@ -82,14 +82,41 @@ describe('addGroove normalizes drum bars (the invisible-hits bug)', () => {
   });
 });
 
-describe('PROGRESSION_PRESETS', () => {
-  it('every preset parses cleanly through the chord-line parser', async () => {
-    const { parseProgression } = await import('../engine/chords.js');
-    const { PROGRESSION_PRESETS } = await import('../engine/groove-presets.js');
+describe('PROGRESSION_PRESETS (shapes × key)', () => {
+  it('resolving every shape in C reproduces the original fixed chords (parity)', async () => {
+    const { PROGRESSION_PRESETS, resolveProgression } = await import('../engine/groove-presets.js');
+    const IN_C = {
+      'axis of awesome': 'C G Am F',
+      'doo-wop':         'C Am F G',
+      "don't stop":      'Am F C G',
+      'andalusian':      'Am G F E',
+      'jazz turnaround': 'Dm G C Am',
+      'creep':           'C E F Fm',
+      'simple blues':    'C F C G',
+      'canon':           'C G Am Em F C F G',
+    };
     for (const p of PROGRESSION_PRESETS) {
-      const { chords, errors } = parseProgression(p.chords);
-      expect(errors, `${p.name}: ${JSON.stringify(errors)}`).toEqual([]);
-      expect(chords.length, `${p.name} has chords`).toBeGreaterThanOrEqual(4);
+      expect(resolveProgression(p.degrees, 'C'), p.name).toBe(IN_C[p.name]);
+    }
+  });
+
+  it('transposes shapes to other keys', async () => {
+    const { resolveProgression } = await import('../engine/groove-presets.js');
+    expect(resolveProgression(['vi', 'IV', 'I', 'V'], 'G')).toBe('Em C G D');        // Zombie
+    expect(resolveProgression(['vi', 'IV', 'I', 'V'], 'A')).toBe('F#m D A E');       // Kids
+    expect(resolveProgression(['I', 'III', 'IV', 'iv'], 'A')).toBe('A C# D Dm');     // creep in A
+    expect(resolveProgression(['I', 'bVII', 'IV', 'I'], 'C')).toBe('C A# F C');      // borrowed ♭VII
+  });
+
+  it('every resolved preset parses cleanly through the chord-line parser, in all 12 keys', async () => {
+    const { parseProgression } = await import('../engine/chords.js');
+    const { PROGRESSION_PRESETS, resolveProgression } = await import('../engine/groove-presets.js');
+    for (const k of ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']) {
+      for (const p of PROGRESSION_PRESETS) {
+        const { chords, errors } = parseProgression(resolveProgression(p.degrees, k));
+        expect(errors, `${p.name} in ${k}: ${JSON.stringify(errors)}`).toEqual([]);
+        expect(chords.length, `${p.name} in ${k}`).toBeGreaterThanOrEqual(4);
+      }
     }
   });
 });

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1799,6 +1799,11 @@ body.gb-knob-values .knob-val { display: block; }
 }
 .h-edit:focus { outline: 2px solid var(--screen-acc); outline-offset: -1px; }
 .h-edit.invalid { border-color: var(--screen-hot); outline-color: var(--screen-hot); }
+/* Progression starters shown under the chord line while editing. */
+.h-edit-wrap { display: flex; flex-direction: column; gap: 5px; margin-left: auto; min-width: 0; }
+.prog-presets { display: flex; flex-wrap: wrap; gap: 4px; }
+.prog-preset { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 5px; cursor: pointer; color: var(--screen-ink); background: color-mix(in srgb, var(--screen-ink) 8%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); box-shadow: none; }
+.prog-preset:hover { background: color-mix(in srgb, var(--screen-ink) 16%, transparent); }
 
 /* Snap-to-scale toggle — mirror .roll-mode-btn / .glen-btn look. */
 .snap-btn {
@@ -4628,6 +4633,7 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 .panes.two { display: grid; grid-template-columns: 200px 1fr; gap: 12px; align-items: start; }
 .pane-ttl { font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--screen-dim); font-weight: 700; margin: 2px 2px 8px; }
 .pane-ttl small { text-transform: none; letter-spacing: 0; font-weight: 500; }
+.used-by { font-size: 10px; color: var(--screen-dim); margin: 8px 2px 0; }
 .pane-back { display: none; background: none; box-shadow: none; border: none; color: var(--screen-acc); font-weight: 700; font-size: 12px; cursor: pointer; margin-bottom: 8px; padding: 0; }
 .pane-back:hover { background-color: transparent; text-decoration: underline; }
 .mini-btn { background: none; box-shadow: none; text-transform: none; letter-spacing: 0; border: 1px solid color-mix(in srgb, var(--screen-ink) 28%, transparent); color: var(--screen-dim); border-radius: 5px; font-size: 10px; padding: 2px 8px; cursor: pointer; font-weight: 700; margin-left: 6px; vertical-align: middle; }
@@ -4655,7 +4661,15 @@ body.hide-k-hi   .knob[data-k="hi"]   { display: none; }
 /* ── Compose rows (swap a loop per instrument) ───────────────────────────── */
 .crow { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; padding: 8px 10px; border-radius: 8px; background: color-mix(in srgb, #fff 26%, var(--screen-bg)); border: 1px solid color-mix(in srgb, var(--screen-ink) 12%, transparent); box-shadow: 0 1px 2px rgba(0,0,0,.07); }
 .crow-fl { font-size: 12px; font-weight: 700; color: var(--screen-ink); min-width: 84px; }
-select.gpick { margin-left: auto; background: color-mix(in srgb, var(--screen-ink) 8%, transparent); color: var(--screen-ink); border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent); border-radius: 6px; padding: 4px 8px; font-size: 12px; font-weight: 700; font-family: inherit; cursor: pointer; }
+select.gpick {
+  margin-left: auto; background: color-mix(in srgb, var(--screen-ink) 8%, transparent); color: var(--screen-ink); border: 1px solid color-mix(in srgb, var(--screen-ink) 30%, transparent); border-radius: 6px; padding: 4px 22px 4px 8px; font-size: 12px; font-weight: 700; font-family: inherit; cursor: pointer;
+  /* Unmistakable dropdown affordance: explicit ▾ caret (the chip look hides the native arrow). */
+  appearance: none; -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5'%3E%3Cpath d='M0 0l4 5 4-5z' fill='%23667'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 7px center;
+}
+.crow-link { cursor: pointer; }
+.crow-link:hover { background: color-mix(in srgb, var(--screen-ink) 6%, transparent); border-radius: 8px; }
 .prog { margin-left: auto; display: inline-flex; gap: 4px; cursor: pointer; }
 .progc { font-family: ui-monospace, Menlo, monospace; font-weight: 800; font-size: 11px; background: color-mix(in srgb, var(--screen-ink) 8%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); border-radius: 5px; padding: 2px 7px; color: var(--screen-ink); }
 .progc-empty { color: var(--screen-dim); border-style: dashed; }

--- a/docs/arcade/groovebox/ui/app.css
+++ b/docs/arcade/groovebox/ui/app.css
@@ -1803,6 +1803,7 @@ body.gb-knob-values .knob-val { display: block; }
 .h-edit-wrap { display: flex; flex-direction: column; gap: 5px; margin-left: auto; min-width: 0; }
 .prog-presets { display: flex; flex-wrap: wrap; gap: 4px; }
 .prog-preset { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 5px; cursor: pointer; color: var(--screen-ink); background: color-mix(in srgb, var(--screen-ink) 8%, transparent); border: 1px solid color-mix(in srgb, var(--screen-ink) 25%, transparent); box-shadow: none; }
+.prog-deg { font-family: ui-monospace, Menlo, monospace; font-size: 9px; font-weight: 600; color: var(--screen-dim); margin-left: 3px; }
 .prog-preset:hover { background: color-mix(in srgb, var(--screen-ink) 16%, transparent); }
 
 /* Snap-to-scale toggle — mirror .roll-mode-btn / .glen-btn look. */

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -13,7 +13,7 @@ import { pressStart } from '../songs/press-start.js';
 import { scallywag } from '../songs/scallywag.js';
 import { booWaltz } from '../songs/boo-waltz.js';
 import { blank, blankWaltz } from '../songs/blank.js';
-import { GROOVE_PRESETS, PROGRESSION_PRESETS, meterKey } from '../engine/groove-presets.js';
+import { GROOVE_PRESETS, PROGRESSION_PRESETS, resolveProgression, meterKey } from '../engine/groove-presets.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 import { initShare, maybeLoadShared, loadSharedSong, clearLoadedFrom } from './share.js';
@@ -1100,7 +1100,6 @@ function renderGroovesEditor(body) {
   };
 }
 
-
 // ─── Patterns composer — sections list + compose (swap a loop per instrument) ─
 function renderPatternsComposer(body) {
   const patterns = eng.getPatterns();
@@ -1383,16 +1382,23 @@ function openComposerChordEdit(idx, anchor) {
   input.value = formatProgression(chords);
   input.placeholder = 'e.g. F#m D A E/G#';
   wrap.appendChild(input);
-  // Curated starters: tap one to fill + commit. pointerdown (not click) so the
-  // input's blur-commit doesn't fire first with the stale value.
+  // Curated starters: famous SHAPES resolved in the song's current key, tap to
+  // fill + commit. pointerdown (not click) so the input's blur-commit doesn't
+  // fire first with the stale value.
+  const starterKey = () => eng.getKey()?.root || 'C';
   const row = document.createElement('span');
   row.className = 'prog-presets';
   for (const p of PROGRESSION_PRESETS) {
     const b = document.createElement('button');
     b.className = 'prog-preset';
-    b.textContent = p.name;
-    b.title = `${p.chords} — ${p.vibe}`;
-    b.onpointerdown = (e) => { e.preventDefault(); input.value = p.chords; commit(); };
+    // The shape is the point — show the numerals, don't hide them in a tooltip.
+    b.innerHTML = `${esc(p.name)} <span class="prog-deg">${esc(p.degrees.join('·'))}</span>`;
+    b.title = p.vibe;
+    b.onpointerdown = (e) => {
+      e.preventDefault();
+      input.value = resolveProgression(p.degrees, starterKey()) || input.value;
+      commit();
+    };
     row.appendChild(b);
   }
   wrap.appendChild(row);
@@ -1417,7 +1423,12 @@ function openComposerChordEdit(idx, anchor) {
     if (e.key === 'Enter') { e.preventDefault(); commit(); }
     else if (e.key === 'Escape') { e.preventDefault(); if (!done) { done = true; finish(); } }
   };
-  input.onblur = commit;
+  // Commit only when focus leaves the editor for good — keep it open while
+  // focus moves to a starter button inside the wrap.
+  input.addEventListener('blur', (e) => {
+    if (e.relatedTarget && wrap.contains(e.relatedTarget)) return;
+    commit();
+  });
 }
 
 // Tell the viz the edit pattern changed (rebuilds the open editor).

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -242,6 +242,9 @@ let _drilled = false;       // mobile: show the detail pane instead of the list
 let _scopeOpen = false;     // scope monitor overlay (Story 6) — independent of route
 const isWide = () => matchMedia('(min-width: 901px)').matches;   // complements the 900px mobile breakpoint
 const LANE_ICONS = { drums: '🥁', bass: '🎸', melody: '🎹', chords: '🎵' };
+// Deep-clone pure-JSON song/groove data — matches the JSON-clone convention
+// used across the engine (lanes.js, patterns.js); no structuredClone dependency.
+const clone = (x) => JSON.parse(JSON.stringify(x));
 const patLabel = i => { const p = eng.getPatterns()[i]; return p && p.name ? p.name : `P${i + 1}`; };
 
 // Open a lane's editor in the viz (no route change) + highlight its strip.
@@ -1078,9 +1081,11 @@ function renderGroovesEditor(body) {
   const opts = Object.keys(laneGrooves).map(n =>
     `<option value="${esc(n)}"${n === picked ? ' selected' : ''}>${esc(n)}</option>`).join('');
   // Blast radius: every section whose pick is this groove changes with it.
-  const usedBy = patterns
-    .map((p, i) => (p.lanes?.[lane.id] === picked ? patLabel(i) : null))
-    .filter(Boolean);
+  // Guard on `picked` — otherwise an unpicked lane (undefined) would match
+  // every other unpicked section and claim "used everywhere".
+  const usedBy = picked
+    ? patterns.map((p, i) => (p.lanes?.[lane.id] === picked ? patLabel(i) : null)).filter(Boolean)
+    : [];
   body.innerHTML =
     `<div class="pane-list"><div class="pane-ttl">${LANE_ICONS[lane.type] || '🎛'} ${esc(lane.name)}</div>` +
     `<div class="crow"><select class="gpick" data-swap="${lane.id}">${opts}</select>` +
@@ -1094,7 +1099,7 @@ function renderGroovesEditor(body) {
     if (!picked) return;
     let name = `${picked} (copy)`, n = 2;
     while (laneGrooves[name]) name = `${picked} (copy ${n++})`;
-    eng.addGroove(lane.id, name, structuredClone(laneGrooves[picked]));
+    eng.addGroove(lane.id, name, clone(laneGrooves[picked]));
     eng.setLaneGroove(lane.id, name);
     setRoute('grooves', { laneId: lane.id, drilled: true });
   };
@@ -1178,9 +1183,15 @@ function renderPatternsComposer(body) {
     setRoute('grooves', { laneId: row.dataset.row, drilled: true });
   });
   const prog = body.querySelector('[data-chords]');
-  if (prog) prog.onclick = () => openComposerChordEdit(editIdx, prog);
+  // Resolve the live [data-chords] node at click time — the edit replaces it,
+  // so a captured reference goes stale (and re-clicking ✎ mid-edit would no-op).
+  const openChordEdit = () => {
+    const cur = body.querySelector('[data-chords]');
+    if (cur) openComposerChordEdit(editIdx, cur);
+  };
+  if (prog) prog.onclick = openChordEdit;
   const progEdit = body.querySelector('[data-chords-edit]');
-  if (progEdit && prog) progEdit.onclick = () => openComposerChordEdit(editIdx, prog);
+  if (progEdit) progEdit.onclick = openChordEdit;
 }
 
 function renameSectionInline(idx, anchor) {
@@ -1383,8 +1394,7 @@ function openComposerChordEdit(idx, anchor) {
   input.placeholder = 'e.g. F#m D A E/G#';
   wrap.appendChild(input);
   // Curated starters: famous SHAPES resolved in the song's current key, tap to
-  // fill + commit. pointerdown (not click) so the input's blur-commit doesn't
-  // fire first with the stale value.
+  // fill + commit.
   const starterKey = () => eng.getKey()?.root || 'C';
   const row = document.createElement('span');
   row.className = 'prog-presets';
@@ -1394,11 +1404,13 @@ function openComposerChordEdit(idx, anchor) {
     // The shape is the point — show the numerals, don't hide them in a tooltip.
     b.innerHTML = `${esc(p.name)} <span class="prog-deg">${esc(p.degrees.join('·'))}</span>`;
     b.title = p.vibe;
-    b.onpointerdown = (e) => {
+    const apply = (e) => {
       e.preventDefault();
       input.value = resolveProgression(p.degrees, starterKey()) || input.value;
-      commit();
+      commit();   // commit() is idempotent (done-guard), so pointer+click can't double-apply
     };
+    b.onpointerdown = apply;   // mouse/touch: beats the input's blur-commit race
+    b.onclick = apply;         // keyboard (Enter/Space) fires click, not pointerdown
     row.appendChild(b);
   }
   wrap.appendChild(row);
@@ -1507,7 +1519,7 @@ function afterSongLoad() {
 }
 
 // ─── Start a fresh song from a blank template ─────────────────────────────────
-// structuredClone each time: load() mutates the song in place AND retains the
+// clone each time: load() mutates the song in place AND retains the
 // reference, so a shared template would accumulate edits across News.
 function newSong(tpl) {
   eng.stop();
@@ -1515,7 +1527,7 @@ function newSong(tpl) {
   const play = document.getElementById('play');
   play.classList.remove('on');
   play.textContent = '▶ play';
-  eng.load(structuredClone(tpl));
+  eng.load(clone(tpl));
   // Stock the lanes from the curated starter library (matched to the
   // template's meter) so the dropdowns aren't a one-trick pony. addGroove
   // harmlessly refuses names already present (the template's own picks),
@@ -1523,7 +1535,7 @@ function newSong(tpl) {
   const pool = GROOVE_PRESETS[meterKey(tpl.meter)] || {};
   for (const lane of eng.getLanes()) {
     for (const [name, value] of Object.entries(pool[lane.type] || {})) {
-      eng.addGroove(lane.id, name, structuredClone(value));
+      eng.addGroove(lane.id, name, clone(value));
     }
   }
   clearLoadedFrom();

--- a/docs/arcade/groovebox/ui/app.js
+++ b/docs/arcade/groovebox/ui/app.js
@@ -12,6 +12,8 @@ import { firstRoll } from '../songs/first-roll.js';
 import { pressStart } from '../songs/press-start.js';
 import { scallywag } from '../songs/scallywag.js';
 import { booWaltz } from '../songs/boo-waltz.js';
+import { blank, blankWaltz } from '../songs/blank.js';
+import { GROOVE_PRESETS, PROGRESSION_PRESETS, meterKey } from '../engine/groove-presets.js';
 import { makeViz } from './viz.js';
 import { makeKnob } from './knob.js';
 import { initShare, maybeLoadShared, loadSharedSong, clearLoadedFrom } from './share.js';
@@ -378,6 +380,22 @@ function renderPicker() {
       onPick: () => { closePicker(); loadSong(key); },
     }));
   };
+
+  // ＋ New — start from a blank template. Top of the rack: the first thing
+  // you reach for when you open the drawer. Meter is chosen here (there is
+  // no meter editing at runtime), so the waltz gets its own cartridge.
+  host.appendChild(cartEl({
+    cls: 'new',
+    title: '＋ Start a new song',
+    author: '4/4',
+    onPick: () => { closePicker(); newSong(blank); },
+  }));
+  host.appendChild(cartEl({
+    cls: 'new',
+    title: '＋ Start a new waltz',
+    author: '3/4',
+    onPick: () => { closePicker(); newSong(blankWaltz); },
+  }));
 
   sect('BUILT-IN');
   for (const key of PRESET_ORDER) if (AI_PRESETS.has(key)) presetCart(key);
@@ -1045,43 +1063,43 @@ function homecard(route, ic, t, s) {
 }
 
 // ─── Grooves editor — instrument list (here) + the step editor (in #lcd-viz) ──
+// The loop editor's side pane is about ONE groove: the lane's pick for the
+// edit pattern. It carries the groove switcher (audition-and-choose without
+// leaving the editor), the blast radius ("used by ..."), and a ⧉ duplicate
+// for making a private variant. Song-level furniture (instrument list,
+// ＋ add instrument) deliberately does NOT live here — that's Home/Patterns.
 function renderGroovesEditor(body) {
-  const lanes = eng.getLanes().filter(l => l.type !== 'chords');
-  const editPat = eng.getPatterns()[eng.getEditPatternIndex()];
-  let h = `<div class="pane-list"><div class="pane-ttl">instruments</div>`;
-  lanes.forEach(l => {
-    const g = (editPat && editPat.lanes && editPat.lanes[l.id]) || '—';
-    h += `<button class="li ${l.id === _editingLaneId ? 'sel' : ''}" data-lane="${l.id}">` +
-      `<span class="li-ic">${LANE_ICONS[l.type] || '🎛'}</span>` +
-      `<span class="li-nm">${esc(l.name)}</span>` +
-      `<span class="li-sub">${esc(g)}</span><span class="li-chev">›</span></button>`;
-  });
-  h += `<button class="li li-add" data-addinstr="1">＋ add instrument</button></div>`;
-  body.innerHTML = h;
-  body.querySelectorAll('.li[data-lane]').forEach(b =>
-    b.onclick = () => setRoute('grooves', { laneId: b.dataset.lane, drilled: true }));
-  wireAddInstr(body.querySelector('[data-addinstr]'));
-}
-
-// Inline 4-type instrument picker (mirrors the strips add-lane menu).
-function wireAddInstr(btn) {
-  if (!btn) return;
-  btn.onclick = () => {
-    const menu = document.createElement('div');
-    menu.className = 'addinstr-menu';
-    menu.innerHTML = ['drums', 'bass', 'melody', 'chords']
-      .map(t => `<button data-t="${t}">${LANE_ICONS[t]} ${t[0].toUpperCase() + t.slice(1)}</button>`).join('');
-    btn.replaceWith(menu);
-    menu.querySelectorAll('[data-t]').forEach(b => b.onclick = () => {
-      eng.addLane(b.dataset.t);
-      renderStrips();
-      const ls = eng.getLanes().filter(l => l.type !== 'chords');
-      const last = ls[ls.length - 1];
-      if (b.dataset.t !== 'chords' && last) setRoute('grooves', { laneId: last.id, drilled: true });
-      else renderScreen();
-    });
+  const lane = eng.getLanes().find(l => l.id === _editingLaneId);
+  if (!lane) { body.innerHTML = ''; return; }
+  const patterns = eng.getPatterns();
+  const editIdx = eng.getEditPatternIndex();
+  const picked = patterns[editIdx]?.lanes?.[lane.id];
+  const laneGrooves = eng.getGrooves()[lane.id] || {};
+  const opts = Object.keys(laneGrooves).map(n =>
+    `<option value="${esc(n)}"${n === picked ? ' selected' : ''}>${esc(n)}</option>`).join('');
+  // Blast radius: every section whose pick is this groove changes with it.
+  const usedBy = patterns
+    .map((p, i) => (p.lanes?.[lane.id] === picked ? patLabel(i) : null))
+    .filter(Boolean);
+  body.innerHTML =
+    `<div class="pane-list"><div class="pane-ttl">${LANE_ICONS[lane.type] || '🎛'} ${esc(lane.name)}</div>` +
+    `<div class="crow"><select class="gpick" data-swap="${lane.id}">${opts}</select>` +
+    `<button class="mini-btn" data-dup="1" title="Duplicate this loop and edit the copy">⧉</button></div>` +
+    `<div class="used-by">used by ${usedBy.map(esc).join(' · ') || '—'}</div></div>`;
+  body.querySelector('select[data-swap]').onchange = (e) => {
+    eng.setLaneGroove(lane.id, e.target.value);
+    setRoute('grooves', { laneId: lane.id, drilled: true });   // re-render pane + grid
+  };
+  body.querySelector('[data-dup]').onclick = () => {
+    if (!picked) return;
+    let name = `${picked} (copy)`, n = 2;
+    while (laneGrooves[name]) name = `${picked} (copy ${n++})`;
+    eng.addGroove(lane.id, name, structuredClone(laneGrooves[picked]));
+    eng.setLaneGroove(lane.id, name);
+    setRoute('grooves', { laneId: lane.id, drilled: true });
   };
 }
+
 
 // ─── Patterns composer — sections list + compose (swap a loop per instrument) ─
 function renderPatternsComposer(body) {
@@ -1104,23 +1122,34 @@ function renderPatternsComposer(body) {
   let detail = `<button class="pane-back" data-back="1">‹ sections</button>` +
     `<div class="pane-ttl">compose “${s && s.name ? esc(s.name) : 'P' + (editIdx + 1)}” — swap a loop` +
     ` <button class="mini-btn" data-ren="1">✎ rename</button></div>`;
-  lanes.filter(l => l.type !== 'chords').forEach(l => {
-    const laneGrooves = grooves[l.id] || {};
-    const picked = s && s.lanes ? s.lanes[l.id] : undefined;
-    const opts = Object.keys(laneGrooves).map(n =>
-      `<option value="${esc(n)}"${n === picked ? ' selected' : ''}>${esc(n)}</option>`).join('');
-    detail += `<div class="crow"><span class="crow-fl">${LANE_ICONS[l.type] || '🎛'} ${esc(l.name)}</span>` +
-      `<select class="gpick" data-swap="${l.id}">${opts}</select></div>`;
-  });
-  const chordLane = lanes.find(l => l.type === 'chords');
-  if (chordLane) {
+  // The PROGRESSION is section-owned harmony (pattern.chords): it steers every
+  // chord-relative loop — bass R/V refs, chord voicings, future arps. It is
+  // NOT the chords lane's content, so it gets its own row above the
+  // instruments, not a seat on the chords lane.
+  {
     const chords = eng.getPatternChords(editIdx) || [];
     const chips = chords.length
       ? chords.map(c => `<span class="progc">${esc(c.name)}</span>`).join('')
       : `<span class="progc progc-empty">＋ chords</span>`;
-    detail += `<div class="crow crow-chords"><span class="crow-fl">🎵 ${esc(chordLane.name)}</span>` +
-      `<span class="prog" data-chords="1">${chips}</span></div>`;
+    detail += `<div class="crow crow-harmony"><span class="crow-fl">🎼 progression</span>` +
+      `<span class="prog" data-chords="1" title="The section's chord loop — steers bass and chords">${chips}</span>` +
+      `<button class="mini-btn" data-chords-edit="1" title="Edit the progression — or pick a famous one">✎</button></div>`;
   }
+  // Every lane is an ordinary instrument row: groove dropdown + drill into the
+  // editor (row click or ✎). Chords loops are chord-relative and the engine
+  // can't step-edit those yet, so the chords row swaps loops but doesn't drill.
+  lanes.forEach(l => {
+    const laneGrooves = grooves[l.id] || {};
+    const picked = s && s.lanes ? s.lanes[l.id] : undefined;
+    const opts = Object.keys(laneGrooves).map(n =>
+      `<option value="${esc(n)}"${n === picked ? ' selected' : ''}>${esc(n)}</option>`).join('');
+    const editable = l.type !== 'chords';
+    detail += `<div class="crow${editable ? ' crow-link' : ''}"${editable ? ` data-row="${l.id}"` : ''}>` +
+      `<span class="crow-fl">${LANE_ICONS[l.type] || '🎛'} ${esc(l.name)}</span>` +
+      `<select class="gpick" data-swap="${l.id}">${opts}</select>` +
+      (editable ? `<button class="mini-btn" data-edit="${l.id}" title="Edit this loop's steps">✎</button>` : '') +
+      `</div>`;
+  });
 
   body.innerHTML = `<div class="panes two"><div class="pane-list">${list}</div><div class="pane-detail">${detail}</div></div>`;
 
@@ -1139,8 +1168,20 @@ function renderPatternsComposer(body) {
     eng.setLaneGroove(sel.dataset.swap, sel.value);
     refreshVizPattern();
   });
+  // ✎ or anywhere on the row → jump straight into the step editor for that
+  // lane's picked loop. Clicks on the dropdown itself don't drill.
+  body.querySelectorAll('[data-edit]').forEach(b => b.onclick = (e) => {
+    e.stopPropagation();
+    setRoute('grooves', { laneId: b.dataset.edit, drilled: true });
+  });
+  body.querySelectorAll('.crow[data-row]').forEach(row => row.onclick = (e) => {
+    if (e.target.closest('select, button')) return;
+    setRoute('grooves', { laneId: row.dataset.row, drilled: true });
+  });
   const prog = body.querySelector('[data-chords]');
   if (prog) prog.onclick = () => openComposerChordEdit(editIdx, prog);
+  const progEdit = body.querySelector('[data-chords-edit]');
+  if (progEdit && prog) progEdit.onclick = () => openComposerChordEdit(editIdx, prog);
 }
 
 function renameSectionInline(idx, anchor) {
@@ -1241,20 +1282,23 @@ function renderLcdBar() {
     crumb.appendChild(crumbSep());
     if (_route === 'song') {
       crumb.appendChild(crumbSeg('Song', null, true));
+    } else if (_route === 'grooves') {
+      // The loop editor is always scoped to the edit pattern's pick, so the
+      // honest trail is Patterns › P<n> › lane — and it navigates back the
+      // way you came.
+      const lane = eng.getLanes().find(l => l.id === _editingLaneId);
+      crumb.appendChild(crumbSeg('Patterns', () => setRoute('patterns')));
+      crumb.appendChild(crumbSep());
+      crumb.appendChild(crumbSeg(patLabel(eng.getEditPatternIndex()),
+        () => setRoute('patterns', { drilled: true })));
+      crumb.appendChild(crumbSep());
+      crumb.appendChild(crumbSeg(lane ? lane.name : '—', null, true));
     } else {
-      const ed = _route === 'grooves' ? 'Grooves' : 'Patterns';
       const showItem = isWide() || _drilled;
-      crumb.appendChild(crumbSeg(ed, showItem ? () => { _drilled = false; renderScreen(); } : null, !showItem));
+      crumb.appendChild(crumbSeg('Patterns', showItem ? () => { _drilled = false; renderScreen(); } : null, !showItem));
       if (showItem) {
         crumb.appendChild(crumbSep());
-        let item;
-        if (_route === 'grooves') {
-          const lane = eng.getLanes().find(l => l.id === _editingLaneId);
-          item = lane ? lane.name : '—';
-        } else {
-          item = patLabel(eng.getEditPatternIndex());
-        }
-        crumb.appendChild(crumbSeg(item, null, true));
+        crumb.appendChild(crumbSeg(patLabel(eng.getEditPatternIndex()), null, true));
       }
     }
   }
@@ -1332,11 +1376,27 @@ function updateLcdBar(target) {
 // (parser-backed). Enter / blur commit; Escape cancels; invalid stays editing.
 function openComposerChordEdit(idx, anchor) {
   const chords = eng.getPatternChords(idx) || [];
+  const wrap = document.createElement('span');
+  wrap.className = 'h-edit-wrap';
   const input = document.createElement('input');
   input.className = 'h-edit';
   input.value = formatProgression(chords);
   input.placeholder = 'e.g. F#m D A E/G#';
-  anchor.replaceWith(input);
+  wrap.appendChild(input);
+  // Curated starters: tap one to fill + commit. pointerdown (not click) so the
+  // input's blur-commit doesn't fire first with the stale value.
+  const row = document.createElement('span');
+  row.className = 'prog-presets';
+  for (const p of PROGRESSION_PRESETS) {
+    const b = document.createElement('button');
+    b.className = 'prog-preset';
+    b.textContent = p.name;
+    b.title = `${p.chords} — ${p.vibe}`;
+    b.onpointerdown = (e) => { e.preventDefault(); input.value = p.chords; commit(); };
+    row.appendChild(b);
+  }
+  wrap.appendChild(row);
+  anchor.replaceWith(wrap);
   input.focus();
   input.select();
   let done = false;
@@ -1433,6 +1493,32 @@ function afterSongLoad() {
   eng.setTranspose(0);
   resetFX();
   mount();
+}
+
+// ─── Start a fresh song from a blank template ─────────────────────────────────
+// structuredClone each time: load() mutates the song in place AND retains the
+// reference, so a shared template would accumulate edits across News.
+function newSong(tpl) {
+  eng.stop();
+  stopMeterLoop();
+  const play = document.getElementById('play');
+  play.classList.remove('on');
+  play.textContent = '▶ play';
+  eng.load(structuredClone(tpl));
+  // Stock the lanes from the curated starter library (matched to the
+  // template's meter) so the dropdowns aren't a one-trick pony. addGroove
+  // harmlessly refuses names already present (the template's own picks),
+  // so those stay selected.
+  const pool = GROOVE_PRESETS[meterKey(tpl.meter)] || {};
+  for (const lane of eng.getLanes()) {
+    for (const [name, value] of Object.entries(pool[lane.type] || {})) {
+      eng.addGroove(lane.id, name, structuredClone(value));
+    }
+  }
+  clearLoadedFrom();
+  _currentSongKey = 'new';
+  songButtonLabel('Untitled');
+  afterSongLoad();
 }
 
 // ─── Transport ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Start-from-scratch flow for Groovebox: a New song you can build from a reusable library, plus a coherent edit surface. Two commits.

## What's new
- **＋ Start a new song / waltz** cartridges (4/4 and 3/4) — minimal *alive* v2 templates (drums/bass/chords, relative bass+chords, I–V–vi–IV in C, playing on load). No empty canvas.
- **Curated starter groove library** (`engine/groove-presets.js`) — meter-keyed drums/bass/chords (incl. 3 half-time variants); a New song is stocked from it so the lane dropdowns aren't a one-trick pony. Every preset passes the registry groove validator.
- **Progression presets** as key-relative **shapes** (roman numerals `vi–IV–I–V`), resolved to concrete chords in the song's key at apply time; the schema still stores compiled chords (parity-tested). Shapes shown inline on each starter chip.
- **Focused loop editor** — single-groove pane (instrument rail + add-instrument removed), groove dropdown, **used-by blast radius**, ⧉ duplicate; honest breadcrumb `Patterns › P‹n› › lane`.
- **Patterns composer** — section-owned 🎼 progression row (chords decoupled from the chords *instrument*), chords lane demoted to an ordinary row, rows click through to the editor, dropdowns get explicit ▾ carets.

## Bugfix
- `addGroove` now normalizes drum bars to GM note numbers at ingest (matching `load()`). Named-key grooves previously **played but rendered invisible** in the step editor.

## Tests
406 green (28 files). New coverage: blank templates load + invariants, every preset registry-valid + addable/selectable, 3/4 stays in the 12-step bar, the addGroove normalization regression, and progression shape×key resolution across all 12 keys (incl. parity with the prior fixed chords). Legacy flatten-parity suite unchanged.

## Scope
Layer-3 arcade/groovebox only — no changes to the Oyster product, server, or `main` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)