### PR TITLE
Open arcade: data-driven registry + author credit + /install

### DIFF
--- a/docs/arcade/covers/coming-soon.svg
+++ b/docs/arcade/covers/coming-soon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges" viewBox="0 0 22 30" aria-hidden="true">
+    <rect width="22" height="30" fill="#1a1535"/>
+    <rect x="7"  y="6"  width="8" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="5"  y="8"  width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="15" y="8"  width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="15" y="10" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="13" y="12" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="11" y="14" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="9"  y="16" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="9"  y="18" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="9"  y="22" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
+    <rect x="2"  y="3"  width="1" height="1" fill="#fff" opacity="0.25"/>
+    <rect x="18" y="2"  width="1" height="1" fill="#fff" opacity="0.25"/>
+    <rect x="3"  y="14" width="1" height="1" fill="#fff" opacity="0.25"/>
+    <rect x="19" y="22" width="1" height="1" fill="#fff" opacity="0.25"/>
+    <rect x="14" y="27" width="1" height="1" fill="#fff" opacity="0.25"/>
+  </svg>

--- a/docs/arcade/covers/invaders.svg
+++ b/docs/arcade/covers/invaders.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges" viewBox="0 0 32 32" aria-hidden="true">
+    <rect width="32" height="32" fill="#04050f"/>
+    <!-- Starfield -->
+    <rect x="4"  y="3" width="1" height="1" fill="#fff"/>
+    <rect x="22" y="2" width="1" height="1" fill="#fff"/>
+    <rect x="27" y="7" width="1" height="1" fill="#fff"/>
+    <!-- UFO band — single purple saucer with cyan glint -->
+    <rect x="13" y="5" width="6" height="2" fill="#a855f7"/>
+    <rect x="15" y="4" width="2" height="1" fill="#a855f7"/>
+    <rect x="14" y="6" width="1" height="1" fill="#2dd4ff"/>
+    <rect x="17" y="6" width="1" height="1" fill="#2dd4ff"/>
+    <!-- Invader row 1 (cyan squids) -->
+    <rect x="6"  y="11" width="3" height="2" fill="#2dd4ff"/>
+    <rect x="14" y="11" width="3" height="2" fill="#2dd4ff"/>
+    <rect x="22" y="11" width="3" height="2" fill="#2dd4ff"/>
+    <!-- Invader row 2 (pink crabs) -->
+    <rect x="6"  y="15" width="3" height="2" fill="#ff3aa1"/>
+    <rect x="14" y="15" width="3" height="2" fill="#ff3aa1"/>
+    <rect x="22" y="15" width="3" height="2" fill="#ff3aa1"/>
+    <!-- Invader row 3 (green octopi) -->
+    <rect x="6"  y="19" width="3" height="2" fill="#4ade80"/>
+    <rect x="14" y="19" width="3" height="2" fill="#4ade80"/>
+    <rect x="22" y="19" width="3" height="2" fill="#4ade80"/>
+    <!-- Shields (purple) -->
+    <rect x="5"  y="24" width="4" height="2" fill="#a855f7"/>
+    <rect x="14" y="24" width="4" height="2" fill="#a855f7"/>
+    <rect x="23" y="24" width="4" height="2" fill="#a855f7"/>
+    <!-- Player ship (cyan) -->
+    <rect x="15" y="28" width="2" height="2" fill="#2dd4ff"/>
+    <rect x="14" y="29" width="4" height="1" fill="#2dd4ff"/>
+    <rect x="15" y="27" width="2" height="1" fill="#2dd4ff"/>
+  </svg>

--- a/docs/arcade/covers/rocket-ship.svg
+++ b/docs/arcade/covers/rocket-ship.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges" viewBox="0 0 22 30" aria-hidden="true">
+    <rect x="10" y="0" width="2" height="2" fill="#ff4444"/>
+    <rect x="9"  y="2" width="4" height="2" fill="#ff4444"/>
+    <rect x="8"  y="4" width="6" height="2" fill="#ff4444"/>
+    <rect x="7"  y="6"  width="8"  height="8" fill="#ffffff"/>
+    <rect x="13" y="6"  width="2"  height="8" fill="#c8c8c8"/>
+    <rect x="6"  y="14" width="10" height="4" fill="#ffffff"/>
+    <rect x="14" y="14" width="2"  height="4" fill="#c8c8c8"/>
+    <rect x="9"  y="8"  width="4" height="4" fill="#2dd4ff"/>
+    <rect x="10" y="9"  width="2" height="1" fill="#aef0ff"/>
+    <rect x="6"  y="16" width="10" height="1" fill="#ff3aa1"/>
+    <rect x="3"  y="14" width="3" height="2" fill="#ff4444"/>
+    <rect x="2"  y="16" width="4" height="2" fill="#ff4444"/>
+    <rect x="0"  y="18" width="4" height="2" fill="#ff4444"/>
+    <rect x="16" y="14" width="3" height="2" fill="#ff4444"/>
+    <rect x="16" y="16" width="4" height="2" fill="#ff4444"/>
+    <rect x="18" y="18" width="4" height="2" fill="#ff4444"/>
+    <rect x="7"  y="18" width="8" height="2" fill="#555555"/>
+    <rect x="8"  y="20" width="6" height="1" fill="#333333"/>
+    <rect x="8"  y="21" width="6" height="2" fill="#ffd84a"/>
+    <rect x="9"  y="23" width="4" height="2" fill="#ff8800"/>
+    <rect x="9"  y="25" width="4" height="2" fill="#ffd84a"/>
+    <rect x="10" y="27" width="2" height="2" fill="#ffffff"/>
+  </svg>

--- a/docs/arcade/covers/space-jumper.svg
+++ b/docs/arcade/covers/space-jumper.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges" viewBox="0 0 32 32" aria-hidden="true">
+    <rect width="32" height="32" fill="#1a1535"/>
+    <rect x="4"  y="3" width="1" height="1" fill="#fff"/>
+    <rect x="11" y="6" width="1" height="1" fill="#fff"/>
+    <rect x="22" y="2" width="1" height="1" fill="#fff"/>
+    <rect x="27" y="7" width="1" height="1" fill="#fff"/>
+    <rect x="0" y="26" width="32" height="6" fill="#3b2f1a"/>
+    <rect x="0" y="26" width="32" height="1" fill="#5a4a2a"/>
+    <rect x="0" y="26" width="32" height="1" fill="#2dd4ff" opacity="0.65"/>
+    <rect x="13" y="18" width="7" height="3" fill="#3b2f1a"/>
+    <rect x="13" y="18" width="7" height="1" fill="#2dd4ff" opacity="0.6"/>
+    <!-- Alien — green critter with antennae, on the right side of the floor -->
+    <rect x="22" y="19" width="1" height="1" fill="#ff3aa1"/>
+    <rect x="25" y="19" width="1" height="1" fill="#ff3aa1"/>
+    <rect x="22" y="20" width="1" height="1" fill="#22c55e"/>
+    <rect x="25" y="20" width="1" height="1" fill="#22c55e"/>
+    <rect x="21" y="21" width="6" height="2" fill="#4ade80"/>
+    <rect x="22" y="22" width="1" height="1" fill="#0a0a14"/>
+    <rect x="25" y="22" width="1" height="1" fill="#0a0a14"/>
+    <rect x="22" y="23" width="4" height="2" fill="#22c55e"/>
+    <rect x="21" y="25" width="2" height="1" fill="#0f5132"/>
+    <rect x="25" y="25" width="2" height="1" fill="#0f5132"/>
+    <!-- Steve — chunky pixel hero. Cap + face + shirt + belt + legs. -->
+    <!-- Cap (red): crown + overhanging brim + peak fringe -->
+    <rect x="5"  y="13" width="6" height="2" fill="#a855f7"/>
+    <rect x="4"  y="15" width="8" height="1" fill="#a855f7"/>
+    <rect x="9"  y="16" width="2" height="1" fill="#a855f7"/>
+    <!-- Face (skin) -->
+    <rect x="5"  y="16" width="6" height="3" fill="#ffd6c8"/>
+    <!-- Eye + mouth -->
+    <rect x="8"  y="17" width="2" height="1" fill="#0a0a0a"/>
+    <rect x="6"  y="19" width="3" height="1" fill="#0a0a0a"/>
+    <!-- Shirt (pink) -->
+    <rect x="5"  y="20" width="6" height="3" fill="#ff3aa1"/>
+    <!-- Shoulder shading + arms (darker pink) + skin hands -->
+    <rect x="5"  y="20" width="6" height="1" fill="#c92670"/>
+    <rect x="3"  y="20" width="2" height="2" fill="#c92670"/>
+    <rect x="11" y="20" width="2" height="2" fill="#c92670"/>
+    <rect x="3"  y="22" width="2" height="1" fill="#ffd6c8"/>
+    <rect x="11" y="22" width="2" height="1" fill="#ffd6c8"/>
+    <!-- Belt + brass buckle -->
+    <rect x="5"  y="22" width="6" height="1" fill="#ffd84a"/>
+    <rect x="7"  y="22" width="2" height="1" fill="#c79b00"/>
+    <!-- Legs (cyan) + feet (dark) -->
+    <rect x="5"  y="23" width="2" height="3" fill="#2dd4ff"/>
+    <rect x="9"  y="23" width="2" height="3" fill="#2dd4ff"/>
+    <rect x="4"  y="25" width="3" height="1" fill="#0a0a0a"/>
+    <rect x="9"  y="25" width="3" height="1" fill="#0a0a0a"/>
+    <circle cx="16" cy="14" r="1.6" fill="#ffd84a"/>
+    <circle cx="16" cy="14" r="0.7" fill="#c79b00"/>
+    <rect x="28" y="14" width="1" height="12" fill="#fff"/>
+    <polygon points="29,15 32,16.5 29,18" fill="#2dd4ff"/>
+  </svg>

--- a/docs/arcade/games.json
+++ b/docs/arcade/games.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "rocket-ship",
+    "name": "ROCKET SHIP",
+    "url": "https://oyster.to/rocket-ship.html",
+    "cover": "covers/rocket-ship.svg",
+    "author": "Oyster"
+  },
+  {
+    "id": "space-jumper",
+    "name": "SPACE JUMPER",
+    "url": "space-jumper/",
+    "cover": "covers/space-jumper.svg",
+    "author": "Oyster"
+  },
+  {
+    "id": "invaders",
+    "name": "INVADERS",
+    "url": "invaders/",
+    "cover": "covers/invaders.svg",
+    "author": "Oyster"
+  },
+  {
+    "id": "black-hole-fishing",
+    "name": "BLACK HOLE FISHING",
+    "comingSoon": true,
+    "tagline": "Reel in space junk through warped gravity",
+    "features": [
+      "Cast a gravity hook into deep space",
+      "Time slingshots around black holes",
+      "Watch out for hungry star-fish"
+    ],
+    "palette": {
+      "bg1": "#1a0c3a",
+      "bg2": "#04081f",
+      "accent": "#2dd4ff",
+      "neon": "#a855f7"
+    },
+    "cover": "covers/coming-soon.svg"
+  },
+  {
+    "id": "comet-race",
+    "name": "COMET RACE",
+    "comingSoon": true,
+    "tagline": "Burn neon trails through asteroid lanes",
+    "features": [
+      "Ride a comet down a winding lane",
+      "Drift around moons for a speed boost",
+      "Outrun a rival rocket on every lap"
+    ],
+    "palette": {
+      "bg1": "#3a0d22",
+      "bg2": "#0c0418",
+      "accent": "#ff8800",
+      "neon": "#ffd84a"
+    },
+    "cover": "covers/coming-soon.svg"
+  },
+  {
+    "id": "star-fight",
+    "name": "STAR FIGHT",
+    "comingSoon": true,
+    "tagline": "Side-scrolling shmup against the alien armada",
+    "features": [
+      "Pilot a fighter through enemy waves",
+      "Power up your weapons between bosses",
+      "Memorise bullet patterns to survive"
+    ],
+    "palette": {
+      "bg1": "#2a0822",
+      "bg2": "#04050f",
+      "accent": "#ff3aa1",
+      "neon": "#2dd4ff"
+    },
+    "cover": "covers/coming-soon.svg"
+  },
+  {
+    "id": "zero-g-trainer",
+    "name": "ZERO-G TRAINER",
+    "comingSoon": true,
+    "tagline": "Pump iron in low gravity",
+    "features": [
+      "Rhythm-press lifts in slow-mo",
+      "Heavier plates = more drift to wrestle",
+      "Don’t let the dumbbells float away"
+    ],
+    "palette": {
+      "bg1": "#0c1438",
+      "bg2": "#020414",
+      "accent": "#2dd4ff",
+      "neon": "#a855f7"
+    },
+    "cover": "covers/coming-soon.svg"
+  },
+  {
+    "id": "dead-station",
+    "name": "DEAD STATION",
+    "comingSoon": true,
+    "tagline": "Explore an abandoned space station",
+    "features": [
+      "A torchlight is all you have",
+      "Listen for the things that listen back",
+      "Find out what happened to the crew"
+    ],
+    "palette": {
+      "bg1": "#0a1a14",
+      "bg2": "#020806",
+      "accent": "#4ade80",
+      "neon": "#a855f7"
+    },
+    "cover": "covers/coming-soon.svg"
+  },
+  {
+    "id": "star-troopers",
+    "name": "STAR TROOPERS",
+    "comingSoon": true,
+    "tagline": "Run and gun across alien battlefields",
+    "features": [
+      "Storm enemy strongholds on foot",
+      "Pick up weapon power-ups mid-mission",
+      "Take down massive end-of-level bosses"
+    ],
+    "palette": {
+      "bg1": "#1c2a0c",
+      "bg2": "#04080a",
+      "accent": "#a3e635",
+      "neon": "#ffd84a"
+    },
+    "cover": "covers/coming-soon.svg"
+  },
+  {
+    "id": "astro-courier",
+    "name": "ASTRO COURIER",
+    "comingSoon": true,
+    "tagline": "Deliver packages between tiny planets",
+    "features": [
+      "Ration fuel like your life depends on it",
+      "Slingshot around moons for speed",
+      "Outrun — or outgun — space pirates"
+    ],
+    "palette": {
+      "bg1": "#1a0d3a",
+      "bg2": "#050a25",
+      "accent": "#ffd84a",
+      "neon": "#ff3aa1"
+    },
+    "cover": "covers/coming-soon.svg"
+  }
+]

--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -808,7 +808,11 @@ function buildCard(game, realIdx, isClone) {
 
   const name = document.createElement('div');
   name.className = 'game-name';
-  name.innerHTML = '<span class="br">[</span> ' + game.name + ' <span class="br">]</span>';
+  // Brackets as elements + the name as a text node — never innerHTML, so a
+  // contributed game's name can't inject markup into the cabinet.
+  const lb = document.createElement('span'); lb.className = 'br'; lb.textContent = '[';
+  const rb = document.createElement('span'); rb.className = 'br'; rb.textContent = ']';
+  name.append(lb, ` ${game.name ?? ''} `, rb);
   card.appendChild(name);
 
   if (game.author) {
@@ -919,7 +923,7 @@ function paintHi() {
 // we only normalize silently when about to overflow the strip.
 // ============================================
 function navigate(delta) {
-  if (launched) return;
+  if (launched || !N) return;
   // Pre-empt overflow: if the next step would walk off the strip, jump
   // silently to the middle copy first. Content at every visible offset
   // is identical across copies, so the user doesn't see the jump.
@@ -937,7 +941,7 @@ function navigate(delta) {
 // copy of `newSel` closest to the current stripPos so the slide is the
 // shortest path.
 function navigateTo(newSel) {
-  if (launched) return;
+  if (launched || !N) return;
   if (newSel === sel) { launch(); return; }
   let target = canonicalStripFor(newSel);
   for (let c = 0; c < COPIES; c++) {
@@ -1227,7 +1231,14 @@ window.addEventListener('resize', () => {
   try {
     GAMES = await (await fetch('games.json')).json();
   } catch (e) {
+    // A failed catalogue fetch must not leave a silent blank screen.
     console.error('[arcade] failed to load games.json', e);
+    const msg = document.createElement('div');
+    msg.textContent = "Couldn't load the arcade — please refresh.";
+    msg.style.cssText = 'position:fixed;inset:0;display:flex;align-items:center;' +
+      'justify-content:center;text-align:center;padding:24px;color:#ff3aa1;' +
+      'font-size:14px;letter-spacing:0.12em;';
+    document.body.appendChild(msg);
     return;
   }
   N = GAMES.length;

--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -209,11 +209,10 @@
     justify-content: center;
     padding: clamp(14px, 2vw, 24px);
   }
-  .game-thumb svg {
+  .game-thumb img {
     width: 85%;
     height: 85%;
     image-rendering: pixelated;
-    shape-rendering: crispEdges;
   }
   .game-name {
     font-size: clamp(15px, 2.6vw, 24px);
@@ -743,233 +742,16 @@
 <audio id="sfx-game-intro" src="sfx-oyster.wav"     preload="auto"></audio>
 
 <!-- Pixel-art previews. -->
-<template id="preview-rocket-ship">
-  <svg viewBox="0 0 22 30" aria-hidden="true">
-    <rect x="10" y="0" width="2" height="2" fill="#ff4444"/>
-    <rect x="9"  y="2" width="4" height="2" fill="#ff4444"/>
-    <rect x="8"  y="4" width="6" height="2" fill="#ff4444"/>
-    <rect x="7"  y="6"  width="8"  height="8" fill="#ffffff"/>
-    <rect x="13" y="6"  width="2"  height="8" fill="#c8c8c8"/>
-    <rect x="6"  y="14" width="10" height="4" fill="#ffffff"/>
-    <rect x="14" y="14" width="2"  height="4" fill="#c8c8c8"/>
-    <rect x="9"  y="8"  width="4" height="4" fill="#2dd4ff"/>
-    <rect x="10" y="9"  width="2" height="1" fill="#aef0ff"/>
-    <rect x="6"  y="16" width="10" height="1" fill="#ff3aa1"/>
-    <rect x="3"  y="14" width="3" height="2" fill="#ff4444"/>
-    <rect x="2"  y="16" width="4" height="2" fill="#ff4444"/>
-    <rect x="0"  y="18" width="4" height="2" fill="#ff4444"/>
-    <rect x="16" y="14" width="3" height="2" fill="#ff4444"/>
-    <rect x="16" y="16" width="4" height="2" fill="#ff4444"/>
-    <rect x="18" y="18" width="4" height="2" fill="#ff4444"/>
-    <rect x="7"  y="18" width="8" height="2" fill="#555555"/>
-    <rect x="8"  y="20" width="6" height="1" fill="#333333"/>
-    <rect x="8"  y="21" width="6" height="2" fill="#ffd84a"/>
-    <rect x="9"  y="23" width="4" height="2" fill="#ff8800"/>
-    <rect x="9"  y="25" width="4" height="2" fill="#ffd84a"/>
-    <rect x="10" y="27" width="2" height="2" fill="#ffffff"/>
-  </svg>
-</template>
-<template id="preview-coming-soon">
-  <svg viewBox="0 0 22 30" aria-hidden="true">
-    <rect width="22" height="30" fill="#1a1535"/>
-    <rect x="7"  y="6"  width="8" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="5"  y="8"  width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="15" y="8"  width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="15" y="10" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="13" y="12" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="11" y="14" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="9"  y="16" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="9"  y="18" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="9"  y="22" width="2" height="2" fill="#2dd4ff" opacity="0.75"/>
-    <rect x="2"  y="3"  width="1" height="1" fill="#fff" opacity="0.25"/>
-    <rect x="18" y="2"  width="1" height="1" fill="#fff" opacity="0.25"/>
-    <rect x="3"  y="14" width="1" height="1" fill="#fff" opacity="0.25"/>
-    <rect x="19" y="22" width="1" height="1" fill="#fff" opacity="0.25"/>
-    <rect x="14" y="27" width="1" height="1" fill="#fff" opacity="0.25"/>
-  </svg>
-</template>
-<template id="preview-space-jumper">
-  <svg viewBox="0 0 32 32" aria-hidden="true">
-    <rect width="32" height="32" fill="#1a1535"/>
-    <rect x="4"  y="3" width="1" height="1" fill="#fff"/>
-    <rect x="11" y="6" width="1" height="1" fill="#fff"/>
-    <rect x="22" y="2" width="1" height="1" fill="#fff"/>
-    <rect x="27" y="7" width="1" height="1" fill="#fff"/>
-    <rect x="0" y="26" width="32" height="6" fill="#3b2f1a"/>
-    <rect x="0" y="26" width="32" height="1" fill="#5a4a2a"/>
-    <rect x="0" y="26" width="32" height="1" fill="#2dd4ff" opacity="0.65"/>
-    <rect x="13" y="18" width="7" height="3" fill="#3b2f1a"/>
-    <rect x="13" y="18" width="7" height="1" fill="#2dd4ff" opacity="0.6"/>
-    <!-- Alien — green critter with antennae, on the right side of the floor -->
-    <rect x="22" y="19" width="1" height="1" fill="#ff3aa1"/>
-    <rect x="25" y="19" width="1" height="1" fill="#ff3aa1"/>
-    <rect x="22" y="20" width="1" height="1" fill="#22c55e"/>
-    <rect x="25" y="20" width="1" height="1" fill="#22c55e"/>
-    <rect x="21" y="21" width="6" height="2" fill="#4ade80"/>
-    <rect x="22" y="22" width="1" height="1" fill="#0a0a14"/>
-    <rect x="25" y="22" width="1" height="1" fill="#0a0a14"/>
-    <rect x="22" y="23" width="4" height="2" fill="#22c55e"/>
-    <rect x="21" y="25" width="2" height="1" fill="#0f5132"/>
-    <rect x="25" y="25" width="2" height="1" fill="#0f5132"/>
-    <!-- Steve — chunky pixel hero. Cap + face + shirt + belt + legs. -->
-    <!-- Cap (red): crown + overhanging brim + peak fringe -->
-    <rect x="5"  y="13" width="6" height="2" fill="#a855f7"/>
-    <rect x="4"  y="15" width="8" height="1" fill="#a855f7"/>
-    <rect x="9"  y="16" width="2" height="1" fill="#a855f7"/>
-    <!-- Face (skin) -->
-    <rect x="5"  y="16" width="6" height="3" fill="#ffd6c8"/>
-    <!-- Eye + mouth -->
-    <rect x="8"  y="17" width="2" height="1" fill="#0a0a0a"/>
-    <rect x="6"  y="19" width="3" height="1" fill="#0a0a0a"/>
-    <!-- Shirt (pink) -->
-    <rect x="5"  y="20" width="6" height="3" fill="#ff3aa1"/>
-    <!-- Shoulder shading + arms (darker pink) + skin hands -->
-    <rect x="5"  y="20" width="6" height="1" fill="#c92670"/>
-    <rect x="3"  y="20" width="2" height="2" fill="#c92670"/>
-    <rect x="11" y="20" width="2" height="2" fill="#c92670"/>
-    <rect x="3"  y="22" width="2" height="1" fill="#ffd6c8"/>
-    <rect x="11" y="22" width="2" height="1" fill="#ffd6c8"/>
-    <!-- Belt + brass buckle -->
-    <rect x="5"  y="22" width="6" height="1" fill="#ffd84a"/>
-    <rect x="7"  y="22" width="2" height="1" fill="#c79b00"/>
-    <!-- Legs (cyan) + feet (dark) -->
-    <rect x="5"  y="23" width="2" height="3" fill="#2dd4ff"/>
-    <rect x="9"  y="23" width="2" height="3" fill="#2dd4ff"/>
-    <rect x="4"  y="25" width="3" height="1" fill="#0a0a0a"/>
-    <rect x="9"  y="25" width="3" height="1" fill="#0a0a0a"/>
-    <circle cx="16" cy="14" r="1.6" fill="#ffd84a"/>
-    <circle cx="16" cy="14" r="0.7" fill="#c79b00"/>
-    <rect x="28" y="14" width="1" height="12" fill="#fff"/>
-    <polygon points="29,15 32,16.5 29,18" fill="#2dd4ff"/>
-  </svg>
-</template>
-<template id="preview-invaders">
-  <svg viewBox="0 0 32 32" aria-hidden="true">
-    <rect width="32" height="32" fill="#04050f"/>
-    <!-- Starfield -->
-    <rect x="4"  y="3" width="1" height="1" fill="#fff"/>
-    <rect x="22" y="2" width="1" height="1" fill="#fff"/>
-    <rect x="27" y="7" width="1" height="1" fill="#fff"/>
-    <!-- UFO band — single purple saucer with cyan glint -->
-    <rect x="13" y="5" width="6" height="2" fill="#a855f7"/>
-    <rect x="15" y="4" width="2" height="1" fill="#a855f7"/>
-    <rect x="14" y="6" width="1" height="1" fill="#2dd4ff"/>
-    <rect x="17" y="6" width="1" height="1" fill="#2dd4ff"/>
-    <!-- Invader row 1 (cyan squids) -->
-    <rect x="6"  y="11" width="3" height="2" fill="#2dd4ff"/>
-    <rect x="14" y="11" width="3" height="2" fill="#2dd4ff"/>
-    <rect x="22" y="11" width="3" height="2" fill="#2dd4ff"/>
-    <!-- Invader row 2 (pink crabs) -->
-    <rect x="6"  y="15" width="3" height="2" fill="#ff3aa1"/>
-    <rect x="14" y="15" width="3" height="2" fill="#ff3aa1"/>
-    <rect x="22" y="15" width="3" height="2" fill="#ff3aa1"/>
-    <!-- Invader row 3 (green octopi) -->
-    <rect x="6"  y="19" width="3" height="2" fill="#4ade80"/>
-    <rect x="14" y="19" width="3" height="2" fill="#4ade80"/>
-    <rect x="22" y="19" width="3" height="2" fill="#4ade80"/>
-    <!-- Shields (purple) -->
-    <rect x="5"  y="24" width="4" height="2" fill="#a855f7"/>
-    <rect x="14" y="24" width="4" height="2" fill="#a855f7"/>
-    <rect x="23" y="24" width="4" height="2" fill="#a855f7"/>
-    <!-- Player ship (cyan) -->
-    <rect x="15" y="28" width="2" height="2" fill="#2dd4ff"/>
-    <rect x="14" y="29" width="4" height="1" fill="#2dd4ff"/>
-    <rect x="15" y="27" width="2" height="1" fill="#2dd4ff"/>
-  </svg>
-</template>
-
 <script src="shared/touch.js"></script>
 <script src="shared/leaderboard.js"></script>
 <script src="shared/audio.js"></script>
 <script>
 // ============================================
-// CATALOGUE — add a new game here + its preview <template> above.
+// CATALOGUE — games live in games.json (fetched at boot, see boot() below).
+// Add a game there + a cover image under covers/; this file isn't touched.
 // ============================================
-const GAMES = [
-  { id: 'rocket-ship', name: 'ROCKET SHIP', url: 'https://oyster.to/rocket-ship.html', preview: 'preview-rocket-ship' },
-  { id: 'space-jumper', name: 'SPACE JUMPER', url: 'space-jumper/',                      preview: 'preview-space-jumper' },
-  { id: 'invaders', name: 'INVADERS', url: 'invaders/', preview: 'preview-invaders' },
-  {
-    id: 'black-hole-fishing', name: 'BLACK HOLE FISHING',
-    preview: 'preview-coming-soon', comingSoon: true,
-    tagline: 'Reel in space junk through warped gravity',
-    features: [
-      'Cast a gravity hook into deep space',
-      'Time slingshots around black holes',
-      'Watch out for hungry star-fish',
-    ],
-    palette: { bg1: '#1a0c3a', bg2: '#04081f', accent: '#2dd4ff', neon: '#a855f7' },
-  },
-  {
-    id: 'comet-race', name: 'COMET RACE',
-    preview: 'preview-coming-soon', comingSoon: true,
-    tagline: 'Burn neon trails through asteroid lanes',
-    features: [
-      'Ride a comet down a winding lane',
-      'Drift around moons for a speed boost',
-      'Outrun a rival rocket on every lap',
-    ],
-    palette: { bg1: '#3a0d22', bg2: '#0c0418', accent: '#ff8800', neon: '#ffd84a' },
-  },
-  {
-    id: 'star-fight', name: 'STAR FIGHT',
-    preview: 'preview-coming-soon', comingSoon: true,
-    tagline: 'Side-scrolling shmup against the alien armada',
-    features: [
-      'Pilot a fighter through enemy waves',
-      'Power up your weapons between bosses',
-      'Memorise bullet patterns to survive',
-    ],
-    palette: { bg1: '#2a0822', bg2: '#04050f', accent: '#ff3aa1', neon: '#2dd4ff' },
-  },
-  {
-    id: 'zero-g-trainer', name: 'ZERO-G TRAINER',
-    preview: 'preview-coming-soon', comingSoon: true,
-    tagline: 'Pump iron in low gravity',
-    features: [
-      'Rhythm-press lifts in slow-mo',
-      'Heavier plates = more drift to wrestle',
-      'Don’t let the dumbbells float away',
-    ],
-    palette: { bg1: '#0c1438', bg2: '#020414', accent: '#2dd4ff', neon: '#a855f7' },
-  },
-  {
-    id: 'dead-station', name: 'DEAD STATION',
-    preview: 'preview-coming-soon', comingSoon: true,
-    tagline: 'Explore an abandoned space station',
-    features: [
-      'A torchlight is all you have',
-      'Listen for the things that listen back',
-      'Find out what happened to the crew',
-    ],
-    palette: { bg1: '#0a1a14', bg2: '#020806', accent: '#4ade80', neon: '#a855f7' },
-  },
-  {
-    id: 'star-troopers', name: 'STAR TROOPERS',
-    preview: 'preview-coming-soon', comingSoon: true,
-    tagline: 'Run and gun across alien battlefields',
-    features: [
-      'Storm enemy strongholds on foot',
-      'Pick up weapon power-ups mid-mission',
-      'Take down massive end-of-level bosses',
-    ],
-    palette: { bg1: '#1c2a0c', bg2: '#04080a', accent: '#a3e635', neon: '#ffd84a' },
-  },
-  {
-    id: 'astro-courier',
-    name: 'ASTRO COURIER',
-    preview: 'preview-coming-soon',
-    comingSoon: true,
-    tagline: 'Deliver packages between tiny planets',
-    features: [
-      'Ration fuel like your life depends on it',
-      'Slingshot around moons for speed',
-      'Outrun — or outgun — space pirates',
-    ],
-    palette: { bg1: '#1a0d3a', bg2: '#050a25', accent: '#ffd84a', neon: '#ff3aa1' },
-  },
-];
-const N = GAMES.length;
+let GAMES = [];
+let N = 0;
 const TRANSITION_MS = 400;
 
 let sel = 0;
@@ -1011,8 +793,10 @@ function buildCard(game, realIdx, isClone) {
 
   const thumb = document.createElement('div');
   thumb.className = 'game-thumb';
-  const tpl = document.getElementById(game.preview);
-  if (tpl) thumb.appendChild(tpl.content.cloneNode(true));
+  const img = document.createElement('img');
+  img.src = game.cover;
+  img.alt = '';
+  thumb.appendChild(img);
   card.appendChild(thumb);
 
   const name = document.createElement('div');
@@ -1417,19 +1201,27 @@ Arcade.Touch.bind(document.getElementById('tc-select'), launch, () => {});
 // copy. On resize, re-translate (card widths are clamp() and change
 // with viewport width, so the centre offset shifts).
 // ============================================
-mountStrip();
-stripPos = canonicalStripFor(sel);
-// Defer to the next frame so card layout (clamp() widths, flex gap)
-// is fully resolved before we measure offsetWidth — measuring during
-// the synchronous post-mount window can return 0 / stale values and
-// leave the strip translated to the wrong x.
-requestAnimationFrame(() => translateStripTo(stripPos, false));
 window.addEventListener('resize', () => {
   stripPos = canonicalStripFor(sel);
   translateStripTo(stripPos, false);
 });
 
-(async () => {
+// Catalogue lives in games.json so adding a game never touches this file.
+// Fetch it, then mount. Splash / launch timing is user-triggered, so the
+// one-tick fetch delay before first paint doesn't affect them.
+(async function boot() {
+  try {
+    GAMES = await (await fetch('games.json')).json();
+  } catch (e) {
+    console.error('[arcade] failed to load games.json', e);
+    return;
+  }
+  N = GAMES.length;
+  mountStrip();
+  stripPos = canonicalStripFor(sel);
+  // Defer to the next frame so card layout (clamp() widths, flex gap) is
+  // resolved before we measure offsetWidth.
+  requestAnimationFrame(() => translateStripTo(stripPos, false));
   for (const g of GAMES) {
     if (g.comingSoon) continue;
     Arcade.Leaderboard.init({ game: g.id, max: 10 });

--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -233,6 +233,12 @@
   }
   .game-hi .hi-val { color: #ffd84a; }
   .game-hi .hi-initials { color: #2dd4ff; }
+  .game-by {
+    font-size: clamp(8px, 1.2vw, 11px);
+    letter-spacing: 0.18em;
+    color: rgba(170, 196, 224, 0.6);
+    display: none;
+  }
   .game-prompt {
     font-size: clamp(10px, 1.6vw, 14px);
     letter-spacing: 0.18em;
@@ -242,6 +248,7 @@
     display: none;
   }
   .game-card.is-focused .game-hi,
+  .game-card.is-focused .game-by,
   .game-card.is-focused .game-prompt { display: block; }
 
   /* Coming-soon placeholder card — desaturated, distinct prompt. */
@@ -803,6 +810,13 @@ function buildCard(game, realIdx, isClone) {
   name.className = 'game-name';
   name.innerHTML = '<span class="br">[</span> ' + game.name + ' <span class="br">]</span>';
   card.appendChild(name);
+
+  if (game.author) {
+    const by = document.createElement('div');
+    by.className = 'game-by';
+    by.textContent = 'BY ' + game.author.toUpperCase();
+    card.appendChild(by);
+  }
 
   if (!game.comingSoon) {
     const hi = document.createElement('div');

--- a/docs/plans/arcade-framework-roadmap.md
+++ b/docs/plans/arcade-framework-roadmap.md
@@ -6,6 +6,11 @@
 > The canonical reference for where the arcade framework is going and why.
 > Individual sub-projects get their own design spec + plan. This doc pins the
 > shape so they stay coherent.
+>
+> **Scope:** this doc is the *authoring substrate* (how to build a game easily).
+> For the *distribution boundary* — how an outside contributor's game gets
+> packaged, sandboxed, and listed — see
+> [`arcade-open-contribution.md`](arcade-open-contribution.md).
 
 ## The goal
 

--- a/docs/plans/arcade-open-contribution.md
+++ b/docs/plans/arcade-open-contribution.md
@@ -138,7 +138,7 @@ arcade-games/
   <game-id>/
     game.json        ← manifest (required)
     index.html       ← entry point (required; overridable via manifest.entry)
-    thumb.png        ← carousel thumbnail (required; 480×480 recommended)
+    cover.svg        ← carousel card art (required; SVG or PNG, ~square)
     ...              ← any other assets the game references (relative paths only)
 ```
 
@@ -172,7 +172,7 @@ these, so adding a game never touches chrome code.
 | `tagline` | ✓ | string | One line for the card / coming-soon flyer. |
 | `description` |  | string | Longer blurb. |
 | `entry` |  | string | Defaults to `index.html`. |
-| `thumbnail` |  | string | Defaults to `thumb.png`. |
+| `cover` | ✓ | string | Carousel card art. Image file (SVG or PNG) in the game folder; defaults to `cover.svg`. Rendered via `<img>` (so SVG can't script). |
 | `palette` |  | object | `{ bg1, bg2, accent, neon }` hex — themes the card, matches today's `GAMES` palette. |
 | `controls` |  | string[] | e.g. `["arrows","tap"]` — drives touch hints + a controls badge. |
 | `orientation` |  | `any\|portrait\|landscape` | Default `any`. |

--- a/docs/plans/arcade-open-contribution.md
+++ b/docs/plans/arcade-open-contribution.md
@@ -1,0 +1,435 @@
+# Open Arcade — Contribution & Game Contract (design)
+
+**Date:** 2026-06-28
+**Status:** Design draft, rev 2 — incorporates external security review at the
+"foundation-right" rigor level. Not yet an implementation spec.
+
+> How *anyone* (a friend, a kid, a kid's AI agent) gets a game onto
+> `arcade.oyster.to` — safely, with you in control of what runs on your domain.
+>
+> **Sibling doc:** [`arcade-framework-roadmap.md`](arcade-framework-roadmap.md)
+> covers the *authoring substrate* — making it easy to *build* a game (cabinet
+> chrome, sim contract, MP substrate). **This doc covers the *distribution*
+> boundary** — how a *third-party* game gets *packaged, isolated, and listed*.
+> They meet at "the game contract" but answer different questions:
+> *"how do I write a game easily?"* vs *"how does my game get in, without
+> being able to break the arcade?"*
+
+---
+
+## North star & the staircase
+
+The end state (call it **self-serve**) is: a kid's agent runs one command, and a
+sandboxed game appears on the live arcade with no human in the loop. We are
+**not** building that first. We're building its *bones* now and keeping a manual
+gate, so the journey is switches flipping — not rewrites.
+
+The only throwaway piece is the PR/merge mechanism itself. Everything else —
+the game contract, the `/install` guide, the sandbox, the data-driven registry —
+is identical at every stage:
+
+| Stage | Registry source | Add-a-game = | Gate | Game hosting (isolation is day-one) |
+|---|---|---|---|---|
+| **Now** | checked-in `games.json` | PR to `arcade-games` + manifest | **you merge** | per-game origin, immutable release |
+| **Public-gated** | same | same (repo is public) | **you merge** | same |
+| **Self-serve** | D1 table | `POST` bundle to upload API | auto-validate | same, bundle in R2 |
+
+## Repo topology (decided)
+
+Two boundaries get conflated — keep them distinct:
+
+- **Governance / contribution boundary = the repo.** First-party code you can
+  change vs third-party games outsiders PR — different repos.
+- **Runtime isolation boundary = serving origin + response headers + iframe
+  policy.** This — *not* the repo — is what actually stops a game touching the
+  cabinet, and it must hold even for a game living in your own repo. (See §3.)
+
+The repos:
+
+```
+oyster-to/oyster          first-party, trusted: cabinet chrome, shared/ framework,
+                          groovebox, the deploy worker, the registry API, this contract
+oyster-to/arcade-games    third-party, untrusted: one folder per contributed game
+   (later, optional) oyster-to/arcade   extract chrome here only if it ever wants its own identity
+```
+
+- Chrome **stays in `oyster`** — it already deploys via its own worker, and moving
+  groovebox + the worker + the `/assets/*` proxy buys nothing toward self-serve.
+  Extraction to `oyster-to/arcade` is a deferrable, reversible-later (`git
+  filter-repo`) cosmetic move; never a prerequisite.
+- Games get **`oyster-to/arcade-games`** so contributors don't fork the product
+  and game history doesn't pollute product CI.
+- The two are joined by a **registry + sandboxed iframes**, *not* a git submodule
+  or build-time fetch — because the registry is the literal spine of self-serve,
+  so the connecting mechanism pays for itself instead of being scaffolding.
+
+---
+
+## The game contract
+
+A "game" is the smallest thing the cabinet can list, launch, isolate, and trust
+nothing about. Adopting the Oyster framework is **strongly suggested — but never
+forced**: the `/install` flow actively *coaches an agent up the ladder* rather
+than just accepting whatever it's handed, while always leaving a working
+lower-effort path. **The port itself is part of the install.**
+
+### Two tiers of polish (progressive adoption)
+
+A submission lands somewhere on a spectrum; the install flow's job is to push it
+toward the top:
+
+- **Tier 1 — Drop-in (the floor).** Any self-contained HTML game. Sandboxed,
+  listed, playable — but *frozen*: it shares nothing with the cabinet, so it
+  neither looks native nor inherits future improvements. The "I just want my POC
+  up" path, and the always-available fallback when a port is too hard.
+- **Tier 2 — Adopted (the target).** The agent ports the POC *onto* the cabinet:
+  the shared `window.Arcade.*` libs (CRT chrome, splash/attract, audio, touch,
+  pause, leaderboard, pixel font) loaded from a **hosted, versioned cabinet
+  bundle**, plus a port that follows the **design guide**. The payoff is the whole
+  point of this feature:
+  - it **looks native** — same CRT cabinet, pixel font, neon-on-dark feel;
+  - it gets **leaderboard / touch / splash / pause for free**, not hand-rolled;
+  - it **inherits cabinet upgrades automatically** — because it *references* the
+    shared bundle instead of vendoring a copy, a better CRT shader or smoother
+    touch shipped to the cabinet lifts every adopted game with no re-submit.
+
+So a kid's rough POC doesn't just get *hosted* — it gets *upgraded on the way in*,
+and keeps improving as the cabinet does. (This is also exactly the
+`arcade-framework-roadmap.md` PROOF test, arriving via real outside games rather
+than a purpose-built demo.)
+
+### How "upgrades when it pulls in" works
+
+Adopted games reference the shared libs by a **versioned URL on a dedicated static
+origin** (kept off the privileged cabinet origin on purpose):
+
+```html
+<script src="https://shared.arcade.oyster.to/v1/audio.js"></script>
+```
+
+- Pinned to a **major** (`v1`) → backwards-compatible improvements flow to every
+  adopted game automatically. Breaking changes bump to `v2`; games opt in.
+- The game's CSP allow-lists **exactly** `shared.arcade.oyster.to` for scripts —
+  *our* audited code, never arbitrary third-party JS, and never the whole arcade
+  origin.
+- The shared libs must work under the game's locked-down CSP (no cross-origin
+  network). Concretely, `leaderboard.js` (today it `fetch`es the registry) needs a
+  **sandboxed mode** that posts scores to the host over `postMessage` instead (see
+  the host protocol). Tracked in the build steps.
+- A moving `v1` alias is a *fleet-wide* dependency: changes ship via **canary +
+  cross-game regression test + instant rollback** — never validate-after-release.
+
+### The design guide (loose by design)
+
+A short, example-driven **arcade design guide** lives with the framework and is
+handed to the agent by `/install`. Deliberately *loose* — principles + do/don't +
+a couple of worked examples, not a rigid pixel spec — so games keep their own
+character (Crossy Road, Among Us, and Roblox don't look alike, and shouldn't)
+while sharing the cabinet frame. Roughly: the CRT/neon-on-dark palette idiom (and
+how to pick a tasteful per-game `palette`); the Press Start 2P pixel font and
+chunky retro "feel"; splash/pause/end-initials conventions (use the shared ones);
+reach for the shared `sfx-*` cues before inventing audio; phone touch-control
+conventions.
+
+### 1. Packaging
+
+```
+arcade-games/
+  <game-id>/
+    game.json        ← manifest (required)
+    index.html       ← entry point (required; overridable via manifest.entry)
+    thumb.png        ← carousel thumbnail (required; 480×480 recommended)
+    ...              ← any other assets the game references (relative paths only)
+```
+
+Rules:
+
+- **Self-contained.** Everything the game needs lives in its folder, referenced by
+  **relative path** — loaded from the game's *own* origin, so `localStorage` and
+  same-origin `fetch` work normally. The only off-origin reference allowed is the
+  shared cabinet bundle from `shared.arcade.oyster.to` (Tier 2). No other external
+  scripts/connections — CSP-enforced (see §3).
+- **One folder = one game = one `game-id`.** The folder name is the id.
+- **Size budget.** Soft caps on folder size, file count, and individual +
+  decompressed sizes (so the edge upload stays sane and zip-bombs can't land);
+  enforced by the validator.
+- **No bundler required** — but `file://` won't reproduce the production headers,
+  sandbox, or origin, so authoring is verified with **`arcade-games preview`**,
+  which serves the game under the *exact* prod iframe + CSP config. The "open it
+  and it works" simplicity stays; the preview just makes it truthful.
+
+### 2. Manifest — `game.json`
+
+Replaces the hand-maintained `GAMES` array entry. The registry is *derived* from
+these, so adding a game never touches chrome code.
+
+| Field | Req | Type | Notes |
+|---|---|---|---|
+| `schemaVersion` | ✓ | `1` | Lets the contract evolve without breaking old games. |
+| `id` | ✓ | string | `^[a-z0-9](?:[a-z0-9-]{1,38}[a-z0-9])$`. Must equal folder name. |
+| `name` | ✓ | string | Display name on the marquee/card (e.g. `NUCLEAR TESTING FACILITY`). |
+| `author` | ✓ | string | **Rendered on the game-select screen** (a "by &lt;author&gt;" credit). An **alias/handle**, never identifying info — especially for kids. Length + control-char limited. |
+| `tagline` | ✓ | string | One line for the card / coming-soon flyer. |
+| `description` |  | string | Longer blurb. |
+| `entry` |  | string | Defaults to `index.html`. |
+| `thumbnail` |  | string | Defaults to `thumb.png`. |
+| `palette` |  | object | `{ bg1, bg2, accent, neon }` hex — themes the card, matches today's `GAMES` palette. |
+| `controls` |  | string[] | e.g. `["arrows","tap"]` — drives touch hints + a controls badge. |
+| `orientation` |  | `any\|portrait\|landscape` | Default `any`. |
+| `capabilities` |  | string[] | Permissions the game needs (`pointer-lock`, `fullscreen`, `gamepad`, `autoplay`). Host grants **only** these — least privilege, not all-on. |
+
+`name` / `author` / `tagline` are length-capped and control-char-stripped.
+**Trust tier is not a manifest field** — it's assigned server-side in the registry,
+so a manifest can never claim first-party privileges.
+
+Example:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "nuclear-testing-facility",
+  "name": "NUCLEAR TESTING FACILITY",
+  "author": "Henry",
+  "tagline": "Contain the meltdown before the timer hits zero",
+  "controls": ["arrows", "tap"],
+  "orientation": "landscape",
+  "palette": { "bg1": "#1a0c3a", "bg2": "#04081f", "accent": "#2dd4ff", "neon": "#a855f7" }
+}
+```
+
+### 3. The runtime boundary (the firewall)
+
+Games already boot in `<iframe id="game-frame">` with a parent-owned exit button
+and a `postMessage` close bridge. The firewall is **three enforced layers** — none
+of them the repo, all of them runtime:
+
+**(a) Per-game origin.** Each game is served from its own subdomain under an
+immutable release path:
+
+```
+https://<game-id>.arcade-games.oyster.to/<release-id>/index.html
+```
+
+A separate origin is what actually isolates a game from the cabinet (the
+same-origin policy does the work); per-game subdomains also isolate games *from
+each other* (no shared storage). This is **day one**, not deferred —
+retrofitting origins/CSP/caching later lands exactly when the system is most
+exposed.
+
+**(b) Sandboxed iframe — with `allow-same-origin`, deliberately:**
+
+```html
+<iframe
+  sandbox="allow-scripts allow-same-origin allow-pointer-lock"
+  allow="autoplay; fullscreen; gamepad"
+  src="https://<game-id>.arcade-games.oyster.to/<release-id>/index.html"></iframe>
+```
+
+- `allow-scripts allow-same-origin` is only dangerous when the iframe shares the
+  *parent's* origin. On a separate subdomain it merely lets the game keep its
+  **own** origin — normal `localStorage` / `fetch` for *its* assets — while the
+  same-origin policy still walls it off from `arcade.oyster.to`. This is the
+  standard user-code-hosting pattern (CodePen/JSFiddle), and it's what makes
+  Tier 1 genuinely "any self-contained HTML game."
+- **Omitted on purpose:** `allow-top-navigation` (can't hijack the cabinet),
+  `allow-popups`, `allow-modals` (no `alert()` freeze / popup abuse). Capabilities
+  in `allow=` are granted **per game from its validated `capabilities`**, not
+  blanket. (The `allow-fullscreen` *sandbox token* is dropped — fullscreen rides
+  the `allow=` / Permissions-Policy mechanism, not a sandbox flag.)
+
+**(c) Server-imposed CSP** (response headers from the serving worker — *not* a
+meta tag, which can't express `frame-ancestors`):
+
+```
+default-src 'none';
+script-src  'self' https://shared.arcade.oyster.to 'wasm-unsafe-eval';
+style-src   'self' 'unsafe-inline';
+img-src     'self' data: blob:;
+media-src   'self' data: blob:;
+font-src    'self' https://shared.arcade.oyster.to;
+connect-src 'self';            /* own-origin asset/WASM fetch only — no calling home */
+worker-src  'self' blob:;
+frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';
+frame-ancestors https://arcade.oyster.to;
+```
+
+`connect-src 'self'` (not `'none'`) so games that load level JSON / WASM via
+`fetch` work, while external exfiltration stays blocked. `frame-ancestors` locks
+embedding to the cabinet. (First-party games like invaders MP, which need
+WebRTC/DO, live in `oyster` under their own looser policy — the trust tier, set in
+the registry, decides the CSP.)
+
+**Invariant — the close button is host-owned and unsuppressable.** The exit `×`
+lives in the *parent* DOM, stacked above the iframe; a frozen or hostile game
+cannot paint over it or swallow its click. A game ignoring `arcade-close` can
+never trap the player. *(Already true in the cabinet today — codified here.)*
+
+### 4. Host ↔ game protocol (`postMessage`)
+
+The cabinet surface splits in two:
+
+- **Local libs (in-iframe, harmless).** `Arcade.Audio / Music / Splash / Pause /
+  Touch / Engine` — the game loads these itself; they only touch the game's *own*
+  document. Safe under sandbox, optional to use.
+- **Host services (mediated by the trusted parent).** Anything that touches shared
+  backend state or the cabinet — leaderboard writes, close, persistence — goes
+  over `postMessage` so the game *cannot spoof another game's data*. The host owns
+  the real `game-id`; the game never asserts it.
+
+**Game → host** (`window.parent.postMessage(msg, '*')`):
+
+| `type` | Payload | Effect |
+|---|---|---|
+| `arcade-ready` | — | Game booted; host may fade the splash. |
+| `arcade-close` | — | Return to the cabinet (today's behaviour). |
+| `arcade-score` | `{ value:number }` | Host records under the real game-id leaderboard. |
+| `arcade-state` | `{ blob:string }` | Optional host-persisted save state (for cross-device; purely-local saves can use the game's own `localStorage`). |
+| `arcade-error` | `{ message }` | Host can surface a friendly "this game crashed". |
+
+**Host → game** (`iframe.contentWindow.postMessage(msg, '*')`):
+
+| `type` | Payload | Effect |
+|---|---|---|
+| `arcade-init` | `{ embedded:true, muted, state? }` | Sent on load; richer successor to `?embedded=1`. |
+| `arcade-pause` / `arcade-resume` | — | Cabinet-driven pause (e.g. tab hidden). |
+
+`?embedded=1` stays for back-compat; `arcade-init` is the structured path forward.
+
+**Message security.** Because each game has a real subdomain origin (not the
+opaque `null` an originless sandbox would produce), **both sides authenticate by
+`event.origin`** — the host checks a message came from the launched game's
+subdomain, the game checks host→game came from `arcade.oyster.to`. Day-one shape:
+a versioned envelope `{ protocol:"oyster-arcade", v:1, type, payload }`, scores
+validated as finite numbers, game-supplied error text rendered with `textContent`
+(never HTML). *Designed-in now, built before opening up:* per-launch session
+nonce, payload schemas + size/rate limits, and a dedicated `MessageChannel` port
+handed over at `arcade-init` (retiring the global listener).
+
+### 5. Identity, trust & releases
+
+- **`gameId` vs `releaseId`.** `gameId` is the stable identity (folder name now;
+  registry-assigned opaque id at self-serve). Each publish mints a fresh immutable
+  `releaseId` (content hash) — that's what's in the served URL, so assets cache
+  forever and rollback is instant.
+- **Trust tier is server-assigned.** First-party vs contributed lives in the
+  trusted registry, **never** in the author-controlled manifest — a manifest can't
+  claim first-party to win the looser policy.
+- **Collisions.** Now / gated: PR review + a validator uniqueness check on the
+  folder name. Self-serve: the registry namespaces ids (the proven groovebox
+  share-id pattern) so two `nuclear-testing-facility` submissions can't fight;
+  `author` becomes a verified handle.
+
+### 6. Publishing (atomic & immutable)
+
+A merged manifest goes live through a defined transaction — no build-time fetch,
+no half-published state:
+
+1. **Validate** (compatibility lint + supply-chain hygiene — see below).
+2. **Publish** the bundle under its immutable `releaseId` path.
+3. **Verify** it loads under the real prod headers + sandbox.
+4. **Flip** the registry pointer to the new `releaseId` atomically.
+5. **Retain** the prior release for instant rollback.
+
+Assets cache immutable (the `releaseId` is in the path); the registry is served
+with ETags / short revalidation so a pointer flip is seen quickly. A **kill
+switch** disables a game by flipping a registry flag — no delete, no redeploy.
+
+---
+
+## The `/install` flow
+
+`arcade.oyster.to/install` is an **agent-readable contribution guide at a
+well-known URL** (an `llms.txt`/`AGENTS.md` for the arcade) that hands over both
+the **contract and the design guide**, and *strongly suggests* the agent port the
+POC up to Tier 2 — with Tier 1 drop-in as an explicit, always-available fallback,
+never a block. It's orthogonal to the backend — same URL at every stage:
+
+- **Now / gated** → *"clone `oyster-to/arcade-games`, adopt the cabinet + design
+  guide, scaffold the manifest, run `npx arcade-games validate <id>`, open a PR."*
+- **Self-serve** → *"POST your validated bundle to `/api/games`."*
+
+The intended loop, from a kid's machine:
+
+```
+kid: "put my game on the arcade"
+agent: fetch arcade.oyster.to/install          → contract + design guide
+       → PORT the POC up to Tier 2 (strongly suggested): adopt Arcade.* libs +
+         design guide; fall back to Tier 1 drop-in only if a port is blocked
+       → scaffold game.json (author → shown on the select screen) + thumb
+       → run the validator (same checks the gate/upload API runs)
+       → open the PR (or POST the bundle)
+```
+
+## Validation — compatibility lint + supply-chain hygiene (not the security layer)
+
+Enforcement of no-network / no-cabinet-access is the **headers + sandbox**, not
+the validator — static analysis can't *prove* runtime behaviour. `validate` is
+**compatibility lint + supply-chain hygiene**, run identically by the author
+locally, PR CI, and (later) the upload API, so "passes locally" = "will be
+accepted." It checks:
+
+- **Manifest:** schema, id format + folder-name match, length/control-char limits,
+  entry + thumbnail exist, thumbnail well-formed and sized.
+- **Compatibility:** loads under the prod preview; uses only its declared
+  `capabilities`.
+- **Supply-chain:** reject symlinks, submodules, Git-LFS pointers, zip/encoded
+  path traversal, `<base>` elements, case-colliding filenames, wrong MIME types,
+  excessive file counts / individual + decompressed sizes (zip-bomb guard).
+
+**CI safety:** never run contributed code with secrets or via `pull_request_target`.
+Run the *trusted* validator from the default branch with a read-only token, then
+browser-smoke-test in the **production sandbox** with no privileged credentials.
+
+---
+
+## What to build first (foundation-right; gate stays manual)
+
+Ordered; each a small, durable PR. The retrofit-expensive isolation is day-one;
+the *additive* hardening is designed-in now, built before the gate opens.
+
+1. **Data-driven registry.** Replace the hardcoded `GAMES` array with a
+   `games.json` the cabinet fetches and renders — cards derived from manifests,
+   including the **"by &lt;author&gt;" credit on the select screen** — not inline
+   `<template>` previews. *Pure refactor of `index.html`.*
+2. **Serving worker: per-game origin + CSP + immutable releases.** Stand up
+   `*.arcade-games.oyster.to` serving `<release-id>/…` with the full CSP header
+   set, the publish→verify→flip→rollback transaction, and the kill switch. *The
+   isolation foundation — the thing you don't want to retrofit later.*
+3. **Sandbox the iframe + host-mediate the leaderboard.** Apply the `sandbox` /
+   `allow` policy and the host-owned-close invariant; give `shared/leaderboard.js`
+   a sandboxed mode that posts scores over the bridge. *First-party games keep
+   working through it.*
+4. **Shared bundle (`shared.arcade.oyster.to/v1/…`) + design guide.** With canary +
+   cross-game regression + rollback for the moving `v1` alias. *Makes Tier 2
+   adoption + upgrades-on-pull possible.*
+5. **Contract + `validate` + `arcade-games preview`, proven on Henry's game.** Take
+   his POC all the way to **Tier 2** → manifest (with his author credit) → sandbox
+   → validated → listed. First real end-to-end run; the framework PROOF in
+   miniature.
+6. **`/install` guide + `arcade-games` repo + PR CI** (read-only token, no
+   `pull_request_target`). Wire the registry to read first-party + games-repo
+   manifests.
+
+**Designed-in now, built before opening past the trusted circle:** the message
+hardening (nonce / schemas / rate-limits / `MessageChannel`), the deep
+supply-chain lint, and **content moderation / reporting / takedown** — sandboxing
+stops bad *code*, not bad *content*. The upload API + opaque self-serve ids come
+with the self-serve flip.
+
+## Open questions (for review)
+
+- **Thumbnail vs live preview.** Today's cards use rich inline `<template>`
+  previews; the portable contract is a static `thumb.png`. Anything we'd miss for
+  contributed games? (First-party games could keep bespoke previews.)
+- **Score trust.** Even host-mediated, a game reports its own score — cheatable.
+  Fine for a family arcade; flag if leaderboards ever need to be real.
+- **Upgrade pinning.** Major-pin (`v1`, auto-upgrade — recommended) vs exact-pin
+  (frozen). Major-pin delivers "gets better over time"; the guardrail is canary +
+  cross-game regression + instant rollback (§"How upgrades when it pulls in works").
+- **First-party stays first-party.** Confirm invaders (WebRTC/DO) + groovebox
+  simply remain first-party in `oyster`, served under their own looser policy,
+  never subject to the contributed-game CSP.
+- **Subdomain ops.** Per-game `*.arcade-games.oyster.to` needs wildcard DNS + cert
+  + a routing worker. Confirm that's acceptable vs a single games origin with
+  per-game *path* isolation (simpler, but games then share storage with each other
+  — cabinet stays protected either way).

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -84,17 +84,24 @@ export default {
     // arcade-games repo so it's a single source of truth. Lets a contributor's
     // agent do exactly: "read arcade.oyster.to/install and follow it".
     if (url.pathname === '/install' || url.pathname === '/install/') {
-      const upstream = await fetch(
-        'https://raw.githubusercontent.com/oyster-to/arcade-games/main/AGENTS.md',
-      );
-      const body = upstream.ok
-        ? await upstream.text()
-        : '# Oyster Arcade — add a game\n\nGuide temporarily unavailable. See https://github.com/oyster-to/arcade-games';
+      // Proxy the guide; tolerate upstream network errors (fetch can throw) and
+      // never cache a failure — caching a 502 would prolong an outage.
+      let body = '';
+      let ok = false;
+      try {
+        const upstream = await fetch(
+          'https://raw.githubusercontent.com/oyster-to/arcade-games/main/AGENTS.md',
+        );
+        if (upstream.ok) { body = await upstream.text(); ok = true; }
+      } catch { /* fall through to the fallback body */ }
+      if (!ok) {
+        body = '# Oyster Arcade — add a game\n\nGuide temporarily unavailable. See https://github.com/oyster-to/arcade-games';
+      }
       return new Response(body, {
-        status: upstream.ok ? 200 : 502,
+        status: ok ? 200 : 502,
         headers: {
           'content-type': 'text/markdown; charset=utf-8',
-          'cache-control': 'public, max-age=300',
+          'cache-control': ok ? 'public, max-age=300' : 'no-store',
         },
       });
     }

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -80,6 +80,25 @@ export default {
       return handleRegistry(req, d1Db(env.DB), env.EDIT_KEY_SECRET);
     }
 
+    // ─── /install — agent-readable "how to add a game" guide, proxied from the
+    // arcade-games repo so it's a single source of truth. Lets a contributor's
+    // agent do exactly: "read arcade.oyster.to/install and follow it".
+    if (url.pathname === '/install' || url.pathname === '/install/') {
+      const upstream = await fetch(
+        'https://raw.githubusercontent.com/oyster-to/arcade-games/main/AGENTS.md',
+      );
+      const body = upstream.ok
+        ? await upstream.text()
+        : '# Oyster Arcade — add a game\n\nGuide temporarily unavailable. See https://github.com/oyster-to/arcade-games';
+      return new Response(body, {
+        status: upstream.ok ? 200 : 502,
+        headers: {
+          'content-type': 'text/markdown; charset=utf-8',
+          'cache-control': 'public, max-age=300',
+        },
+      });
+    }
+
     // ─── Pretty share links: /s/<id>[@rev] → groovebox app with ?s=<id> ───────
     // Redirect (not rewrite): index.html uses all-relative asset refs, so
     // serving the app AT /s/<id> would break them. On groovebox.oyster.to the


### PR DESCRIPTION
Foundation for letting anyone contribute games to **arcade.oyster.to**. Design: `docs/plans/arcade-open-contribution.md`.

## What's here

- **Data-driven registry** — the hardcoded `GAMES` array + inline `<template>` previews in `docs/arcade/index.html` are replaced by a fetched `games.json` plus per-game cover files under `docs/arcade/covers/`. **Adding a game no longer touches `index.html`.** Covers were extracted verbatim from the old inline SVGs (no visual change); cards render via `<img>` (an `<img>`-loaded SVG can't run scripts — matters once games are untrusted).
- **Author credit** — a dim `BY <AUTHOR>` line on the focused card, from `games.json` `author`.
- **`/install`** — `arcade.oyster.to/install` proxies the contribution guide (`AGENTS.md`) from the new [`oyster-to/arcade-games`](https://github.com/oyster-to/arcade-games) repo, so a contributor's agent can literally *"read arcade.oyster.to/install and follow it"*. 502 + repo-link fallback if upstream fetch fails.
- **Design doc** — `docs/plans/arcade-open-contribution.md` (+ a cross-link from the framework roadmap).

## Verified

- Carousel renders + navigates identically (parity), covers crisp, console clean, games launch.
- `/install` source guide returns 200; handler proxies it as `text/markdown`.

## Deploy

Arcade is a manual `wrangler deploy` (no CI). One deploy ships both the data-driven arcade and `/install` live.

## Deferred (not in this PR)

Hardened isolation (per-game origin + server CSP + immutable releases) — only needed before *untrusted* outside games. For the trusted/family phase the loop is: PR → you approve → host (Pages) → add a `games.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
