### PR TITLE
arcade: list Carrier Defense (by Henry) on the carousel

### DIFF
--- a/docs/arcade/games.json
+++ b/docs/arcade/games.json
@@ -21,6 +21,13 @@
     "author": "Oyster"
   },
   {
+    "id": "carrier-defense",
+    "name": "CARRIER DEFENSE",
+    "author": "Henry",
+    "url": "https://oyster-to.github.io/arcade-games/games/carrier-defense/",
+    "cover": "https://oyster-to.github.io/arcade-games/games/carrier-defense/cover.svg"
+  },
+  {
     "id": "black-hole-fishing",
     "name": "BLACK HOLE FISHING",
     "comingSoon": true,


### PR DESCRIPTION
Henry's first community game, contributed via [arcade-games#1](https://github.com/oyster-to/arcade-games/pull/1). Hosted on GitHub Pages; the games.json entry points `url`/`cover` at the Pages URLs.

Already playable at https://oyster-to.github.io/arcade-games/games/carrier-defense/ — this just puts it on the carousel. Needs a `wrangler deploy` to go live (games.json is a static asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)