### PR TITLE
arcade: dynamic /games.json (contributed games appear with no redeploy)

### DIFF
--- a/docs/arcade/games.first-party.json
+++ b/docs/arcade/games.first-party.json
@@ -21,13 +21,6 @@
     "author": "Oyster"
   },
   {
-    "id": "carrier-defense",
-    "name": "CARRIER DEFENSE",
-    "author": "Henry",
-    "url": "https://oyster-to.github.io/arcade-games/games/carrier-defense/",
-    "cover": "https://oyster-to.github.io/arcade-games/games/carrier-defense/cover.svg"
-  },
-  {
     "id": "black-hole-fishing",
     "name": "BLACK HOLE FISHING",
     "comingSoon": true,

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -106,6 +106,39 @@ export default {
       });
     }
 
+    // ─── /games.json — dynamic catalogue = curated first-party games (static,
+    // from games.first-party.json) + contributed games pulled live from the
+    // arcade-games repo's Pages-hosted index.json. So a merged game appears on
+    // the carousel within the cache window — no redeploy. If the contributed
+    // list can't be fetched, the arcade still works on first-party alone.
+    if (url.pathname === '/games.json' && url.hostname !== 'groovebox.oyster.to') {
+      const fpRes = await env.ASSETS.fetch(
+        new Request(new URL('/games.first-party.json', req.url)),
+      );
+      const firstParty = (fpRes.ok ? await fpRes.json() : []) as Array<{ id: string; comingSoon?: boolean }>;
+      let contributed: Array<{ id: string }> = [];
+      try {
+        const r = await fetch('https://oyster-to.github.io/arcade-games/index.json');
+        if (r.ok) contributed = (await r.json()) as Array<{ id: string }>;
+      } catch { /* arcade still works on first-party alone */ }
+
+      const seen = new Set(firstParty.map((g) => g.id));
+      const extra = contributed.filter((g) => g && g.id && !seen.has(g.id));
+      // Keep curated order: first-party playable, then contributed, then
+      // first-party coming-soon.
+      const soonIdx = firstParty.findIndex((g) => g.comingSoon);
+      const merged = soonIdx < 0
+        ? [...firstParty, ...extra]
+        : [...firstParty.slice(0, soonIdx), ...extra, ...firstParty.slice(soonIdx)];
+
+      return new Response(JSON.stringify(merged), {
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'public, max-age=60',
+        },
+      });
+    }
+
     // ─── Pretty share links: /s/<id>[@rev] → groovebox app with ?s=<id> ───────
     // Redirect (not rewrite): index.html uses all-relative asset refs, so
     // serving the app AT /s/<id> would break them. On groovebox.oyster.to the


### PR DESCRIPTION
Makes the arcade carousel pull contributed games live from `arcade-games`, so **merging a game PR puts it on the arcade within ~60s — no `wrangler deploy` per game**.

**How:** the worker serves `/games.json` as first-party (static `games.first-party.json`) **+** contributed games fetched from `arcade-games`'s Pages-hosted `index.json` (regenerated by CI on every merge). Dedupes by id, keeps curated order, and falls back to first-party alone if the fetch fails (no blank arcade).

Deploying this once brings **Carrier Defense** live (currently merged but not shown) *and* makes every future game auto-appear. Supersedes the manual per-game entry from #694 (carrier-defense moved out of first-party into the dynamic index).

Verified: merge-logic simulation produces the right order + entry; Pages `index.json` is live (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)