### PR TITLE
arcade: harden dynamic /games.json + refresh before arcade-init

### DIFF
--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -1177,13 +1177,17 @@ window.addEventListener('message', e => {
   // real best (instead of a private localStorage value).
   if (t === 'arcade-ready') {
     Arcade.Leaderboard.init({ game: g.id, max: 10 });
-    const top = Arcade.Leaderboard.getHighScore();
-    try {
-      frame.contentWindow.postMessage({
-        protocol: 'oyster-arcade', v: 1, type: 'arcade-init',
-        payload: { embedded: true, highScore: top ? { score: top.score, initials: top.initials } : null },
-      }, '*');
-    } catch (_) {}
+    // Refresh from the backend first so the game gets the *current* shared top,
+    // not just this browser's possibly-stale localStorage mirror.
+    Arcade.Leaderboard.refresh().catch(() => {}).then(() => {
+      const top = Arcade.Leaderboard.getHighScore();
+      try {
+        frame.contentWindow.postMessage({
+          protocol: 'oyster-arcade', v: 1, type: 'arcade-init',
+          payload: { embedded: true, highScore: top ? { score: top.score, initials: top.initials } : null },
+        }, '*');
+      } catch (_) {}
+    });
     return;
   }
 

--- a/docs/arcade/index.html
+++ b/docs/arcade/index.html
@@ -1176,13 +1176,19 @@ window.addEventListener('message', e => {
   // Game booted → hand it the current shared high score so it can display the
   // real best (instead of a private localStorage value).
   if (t === 'arcade-ready') {
-    Arcade.Leaderboard.init({ game: g.id, max: 10 });
+    const readyId = g.id;
+    const target = e.source;            // the game's window at ready time
+    Arcade.Leaderboard.init({ game: readyId, max: 10 });
     // Refresh from the backend first so the game gets the *current* shared top,
     // not just this browser's possibly-stale localStorage mirror.
     Arcade.Leaderboard.refresh().catch(() => {}).then(() => {
+      // The player may have closed / switched games during the async refresh —
+      // only reply if the same game is still running in the same frame.
+      if (!launched || !GAMES[sel] || GAMES[sel].id !== readyId || !frame || frame.contentWindow !== target) return;
+      Arcade.Leaderboard.init({ game: readyId, max: 10 });
       const top = Arcade.Leaderboard.getHighScore();
       try {
-        frame.contentWindow.postMessage({
+        target.postMessage({
           protocol: 'oyster-arcade', v: 1, type: 'arcade-init',
           payload: { embedded: true, highScore: top ? { score: top.score, initials: top.initials } : null },
         }, '*');

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -115,15 +115,32 @@ export default {
       const fpRes = await env.ASSETS.fetch(
         new Request(new URL('/games.first-party.json', req.url)),
       );
-      const firstParty = (fpRes.ok ? await fpRes.json() : []) as Array<{ id: string; comingSoon?: boolean }>;
-      let contributed: Array<{ id: string }> = [];
+      const fpJson = fpRes.ok ? await fpRes.json().catch(() => []) : [];
+      const firstParty = (Array.isArray(fpJson) ? fpJson : []) as Array<{ id: string; comingSoon?: boolean }>;
+
+      // Contributed games from the arcade-games Pages index. Time-boxed so a
+      // slow / down Pages can't hang the catalogue; falls back to first-party.
+      let contributedRaw: unknown = [];
       try {
-        const r = await fetch('https://oyster-to.github.io/arcade-games/index.json');
-        if (r.ok) contributed = (await r.json()) as Array<{ id: string }>;
+        const ctl = new AbortController();
+        const timer = setTimeout(() => ctl.abort(), 3000);
+        try {
+          const r = await fetch('https://oyster-to.github.io/arcade-games/index.json', { signal: ctl.signal });
+          if (r.ok) contributedRaw = await r.json().catch(() => []);
+        } finally { clearTimeout(timer); }
       } catch { /* arcade still works on first-party alone */ }
 
+      // Validate each contributed entry has the fields the cabinet renders, and
+      // dedupe (within the contributed list and against first-party) — a
+      // malformed index.json must never break the carousel.
       const seen = new Set(firstParty.map((g) => g.id));
-      const extra = contributed.filter((g) => g && g.id && !seen.has(g.id));
+      const str = (v: unknown) => typeof v === 'string' && v.length > 0;
+      const extra = (Array.isArray(contributedRaw) ? contributedRaw : []).filter((g: any) => {
+        if (!g || !str(g.id) || !str(g.name) || !str(g.url) || !str(g.cover)) return false;
+        if (seen.has(g.id)) return false;
+        seen.add(g.id);
+        return true;
+      });
       // Keep curated order: first-party playable, then contributed, then
       // first-party coming-soon.
       const soonIdx = firstParty.findIndex((g) => g.comingSoon);

--- a/infra/oyster-arcade-site/src/worker.ts
+++ b/infra/oyster-arcade-site/src/worker.ts
@@ -116,7 +116,10 @@ export default {
         new Request(new URL('/games.first-party.json', req.url)),
       );
       const fpJson = fpRes.ok ? await fpRes.json().catch(() => []) : [];
-      const firstParty = (Array.isArray(fpJson) ? fpJson : []) as Array<{ id: string; comingSoon?: boolean }>;
+      // Validate elements too (not just Array-ness) so a bad/partial first-party
+      // file can't throw on .map/.findIndex and take down the whole catalogue.
+      const firstParty = (Array.isArray(fpJson) ? fpJson : [])
+        .filter((g: any) => g && typeof g.id === 'string') as Array<{ id: string; comingSoon?: boolean }>;
 
       // Contributed games from the arcade-games Pages index. Time-boxed so a
       // slow / down Pages can't hang the catalogue; falls back to first-party.


### PR DESCRIPTION
Follow-up addressing Copilot's review on #695 and #696.

**#695 — `/games.json` robustness:** `Array.isArray` guards on both payloads; validate each contributed entry has `id`/`name`/`url`/`cover` (a malformed `index.json` must never feed broken entries that crash the carousel); dedupe within the contributed list and against first-party; 3s `AbortController` timeout on the Pages fetch (always cleared) so a slow/down Pages can't hang the catalogue.

**#696 — accurate high score:** `arcade-ready` now `refresh()`es from the backend before `getHighScore()`, so the game receives the *current* shared top rather than a stale localStorage mirror.

Verified the merge/validation logic against malformed inputs (non-array, missing fields, dup vs first-party, dup within contributed, null entries) — all dropped/deduped, list never breaks.

(Deferred, lower priority: edge-caching the merged response via `caches.default` — the response already sets `max-age=60` and the Pages subrequest is CF-cached.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)